### PR TITLE
Add pot indicator at table center

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -170,22 +170,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     boardCards: boardCards,
                     onCardSelected: selectBoardCard,
                   ),
-                  Positioned.fill(
-                    child: Align(
-                      alignment: const Alignment(0, -0.25),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withOpacity(0.6),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          'Pot: ${_pots[currentStreet]}',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 16,
-                          ),
-                        ),
+                  Positioned(
+                    left: centerX - 40,
+                    top: centerY - 20,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: Colors.white10,
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: Colors.white30),
+                      ),
+                      child: Text(
+                        'Pot: ${_pots[currentStreet]}',
+                        style: const TextStyle(color: Colors.white, fontSize: 14),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- display pot amount in the middle of the poker table

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842042361f0832aba68156408ab7243