### PR TITLE
Add static player position display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -30,10 +30,22 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
   int? activePlayerIndex;
   Timer? _activeTimer;
   final Map<int, String?> _actionTags = {};
+  Map<int, String> playerPositions = {};
+
+  void setPosition(int playerIndex, String position) {
+    setState(() {
+      playerPositions[playerIndex] = position;
+    });
+  }
 
   @override
   void initState() {
     super.initState();
+    playerPositions = {
+      heroIndex: 'BTN',
+      (heroIndex + 1) % numberOfPlayers: 'SB',
+      (heroIndex + 2) % numberOfPlayers: 'BB',
+    };
   }
 
   void selectCard(int index, CardModel card) {
@@ -226,6 +238,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           children: [
                             PlayerZoneWidget(
                               playerName: 'Player ${index + 1}',
+                              position: playerPositions[index],
                               cards: playerCards[index],
                               isHero: index == heroIndex,
                               isFolded: isFolded,

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -5,6 +5,7 @@ import 'card_selector.dart';
 
 class PlayerZoneWidget extends StatelessWidget {
   final String playerName;
+  final String? position;
   final List<CardModel> cards;
   final bool isHero;
   final bool isFolded;
@@ -17,6 +18,7 @@ class PlayerZoneWidget extends StatelessWidget {
   const PlayerZoneWidget({
     Key? key,
     required this.playerName,
+    this.position,
     required this.cards,
     required this.isHero,
     required this.isFolded,
@@ -60,9 +62,20 @@ class PlayerZoneWidget extends StatelessWidget {
                     color: Colors.white,
                   ),
                 ),
-              ),
+            ),
           ],
         ),
+        if (position != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2.0),
+            child: Text(
+              position!,
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 12,
+              ),
+            ),
+          ),
         if (actionTagText != null)
           Padding(
             padding: const EdgeInsets.only(top: 4.0),


### PR DESCRIPTION
## Summary
- store player positions and add setter
- display position under player name when provided
- preset BTN, SB and BB indices on startup

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420904e4b4832aaf6544d189314e7b