### PR TITLE
Add stack size display for players

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -24,6 +24,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
   final List<ActionEntry> actions = [];
   final List<int> _pots = List.filled(4, 0);
   final Map<int, int> _streetInvestments = {};
+  final Map<int, int> stackSizes = {
+    0: 120,
+    1: 80,
+    2: 100,
+    3: 90,
+    4: 110,
+    5: 70,
+    6: 130,
+    7: 95,
+    8: 105,
+  };
   final TextEditingController _commentController = TextEditingController();
   final List<bool> _showActionHints = List.filled(9, true);
   final Set<int> _firstActionTaken = {};
@@ -251,6 +262,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                               showHint: _showActionHints[index],
                               actionTagText: actionTag,
                               chipAmount: _streetInvestments[index],
+                              stackSize: stackSizes[index],
                               onCardsSelected: (card) => selectCard(index, card),
                             ),
                             if (lastAction != null)

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -13,6 +13,7 @@ class PlayerZoneWidget extends StatelessWidget {
   final bool showHint;
   final String? actionTagText;
   final int? chipAmount;
+  final int? stackSize;
   final Function(CardModel) onCardsSelected;
 
   const PlayerZoneWidget({
@@ -27,6 +28,7 @@ class PlayerZoneWidget extends StatelessWidget {
     this.showHint = false,
     this.actionTagText,
     this.chipAmount,
+    this.stackSize,
   }) : super(key: key);
 
   @override
@@ -50,11 +52,11 @@ class PlayerZoneWidget extends StatelessWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-            ),
-            if (showHint)
-              Padding(
-                padding: const EdgeInsets.only(left: 4.0),
-                child: Tooltip(
+        ),
+        if (showHint)
+          Padding(
+            padding: const EdgeInsets.only(left: 4.0),
+            child: Tooltip(
                   message: 'Нажмите, чтобы ввести действие',
                   child: const Icon(
                     Icons.edit,
@@ -65,6 +67,18 @@ class PlayerZoneWidget extends StatelessWidget {
             ),
           ],
         ),
+        if (stackSize != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2.0),
+            child: Text(
+              '$stackSize',
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.orangeAccent,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
         if (position != null)
           Padding(
             padding: const EdgeInsets.only(top: 2.0),


### PR DESCRIPTION
## Summary
- show each player's stack below their name
- pass fixed stack sizes from `PokerAnalyzerScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421277e438832abb2415c823f4a6c9