### PR TITLE
Add position labels around player widgets

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -260,7 +260,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           children: [
                             PlayerZoneWidget(
                               playerName: 'Player ${index + 1}',
-                              position: playerPositions[index],
                               cards: playerCards[index],
                               isHero: index == heroIndex,
                               isFolded: isFolded,
@@ -271,6 +270,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                               stackSize: stackSizes[index],
                               onCardsSelected: (card) => selectCard(index, card),
                             ),
+                            if (playerPositions[index] != null)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 2.0),
+                                child: Text(
+                                  playerPositions[index]!,
+                                  style: const TextStyle(
+                                    color: Colors.white70,
+                                    fontSize: 11,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
                             if (lastAction != null)
                               Padding(
                                 padding: const EdgeInsets.only(top: 4.0),


### PR DESCRIPTION
## Summary
- show each seat's position label just below PlayerZoneWidget in the analyzer screen

## Testing
- `flutter analyze --no-pub` *(fails: Analyzing Poker_Analyzer...)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68421903b4d0832abc890a86c125e7b9