### PR TITLE
Visual chip placeholders

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -362,6 +362,31 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             ),
                           ),
                         ),
+                      if (_streetInvestments[index] != null &&
+                          _streetInvestments[index]! > 0)
+                        Positioned(
+                          left: centerX + dx - 25,
+                          top: centerY + dy + 85,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 4),
+                            decoration: BoxDecoration(
+                              gradient: const LinearGradient(
+                                colors: [Colors.black54, Colors.black87],
+                                begin: Alignment.topCenter,
+                                end: Alignment.bottomCenter,
+                              ),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(
+                              '\$${_streetInvestments[index]}',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                        ),
                     ];
                   }).expand((w) => w)
                 ],


### PR DESCRIPTION
## Summary
- show chip containers for bets, raises or calls

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68421f38ec6c832abf2327af045c6a4d