### PR TITLE
Add pot size display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -263,13 +263,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     child: Container(
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                       decoration: BoxDecoration(
-                        color: Colors.white10,
-                        borderRadius: BorderRadius.circular(20),
-                        border: Border.all(color: Colors.white30),
+                        color: Colors.black54,
+                        borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(
-                        'Pot: ${_pots[currentStreet]}',
-                        style: const TextStyle(color: Colors.white, fontSize: 14),
+                        'Pot: \$${_pots[currentStreet]}',
+                        style: const TextStyle(color: Colors.white, fontSize: 15),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- show current pot size centered on the table

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425582eff8832a83b21dea41336931