### PR TITLE
Add stack display and slider

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -347,9 +347,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
-                            ],
+                              Padding(
+                                padding: const EdgeInsets.only(top: 2.0),
+                                child: Text(
+                                  'Stack: \$${stackSizes[index] ?? 0}',
+                                  style: TextStyle(
+                                    color: isFolded ? Colors.white38 : Colors.white,
+                                    fontSize: 11,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                              ],
+                            ),
                           ),
-                        ),
                       ),
                       if (lastAction != null)
                         Positioned(


### PR DESCRIPTION
## Summary
- show remaining stack below each player
- revamp `ActionDialog` to add simple slider for bet/raise/call amounts

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684256a6c49c832abd893278f8e8bb28