### PR TITLE
Display bets as chips

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/player_zone_widget.dart';
 import '../widgets/street_actions_widget.dart';
 import '../widgets/board_cards_widget.dart';
 import '../widgets/action_dialog.dart';
+import '../widgets/chip_widget.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   const PokerAnalyzerScreen({super.key});
@@ -257,21 +258,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     boardCards: boardCards,
                     onCardSelected: selectBoardCard,
                   ),
-                  Positioned(
-                    left: centerX - 40,
-                    top: centerY - 20,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                      decoration: BoxDecoration(
-                        color: Colors.black54,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        'Pot: \$${_pots[currentStreet]}',
-                        style: const TextStyle(color: Colors.white, fontSize: 15),
-                      ),
+                  if (_pots[currentStreet] > 0)
+                    Positioned(
+                      left: centerX - 20,
+                      top: centerY - 10,
+                      child: ChipWidget(amount: _pots[currentStreet]),
                     ),
-                  ),
                   ...List.generate(numberOfPlayers, (i) {
                     final index = (i + heroIndex) % numberOfPlayers;
                     final angle =
@@ -331,7 +323,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                 isActive: index == activePlayerIndex,
                                 showHint: _showActionHints[index],
                                 actionTagText: actionTag,
-                                chipAmount: _streetInvestments[index],
                                 stackSize: stackSizes[index],
                                 onCardsSelected: (card) => selectCard(index, card),
                               ),
@@ -414,27 +405,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       if (_streetInvestments[index] != null &&
                           _streetInvestments[index]! > 0)
                         Positioned(
-                          left: centerX + dx - 25,
+                          left: centerX + dx - 20,
                           top: centerY + dy + 85,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              gradient: const LinearGradient(
-                                colors: [Colors.black54, Colors.black87],
-                                begin: Alignment.topCenter,
-                                end: Alignment.bottomCenter,
-                              ),
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Text(
-                              '\$${_streetInvestments[index]}',
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ),
+                          child:
+                              ChipWidget(amount: _streetInvestments[index]!),
                         ),
                     ];
                   }).expand((w) => w)

--- a/lib/widgets/chip_widget.dart
+++ b/lib/widgets/chip_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class ChipWidget extends StatelessWidget {
+  final int amount;
+
+  const ChipWidget({Key? key, required this.amount}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: const LinearGradient(
+          colors: [Color(0xFF8B0000), Colors.black],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+        border: Border.all(color: Colors.black87, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.5),
+            blurRadius: 4,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Text(
+        '\$${amount}',
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 13,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ChipWidget` for stylized chip display
- show `ChipWidget` in the center for the pot
- show each player's investment using `ChipWidget`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format lib/widgets/chip_widget.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425ad39b2c832a836f00d3747a6c5c