### PR TITLE
Finalize chip display cleanup

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -406,7 +406,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           _streetInvestments[index]! > 0)
                         Positioned(
                           left: centerX + dx - 20,
-                          top: centerY + dy + 85,
+                          top: centerY + dy + 110,
                           child:
                               ChipWidget(amount: _streetInvestments[index]!),
                         ),

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -16,11 +16,6 @@ class StreetActionsList extends StatelessWidget {
   Widget build(BuildContext context) {
     final streetActions =
         actions.where((a) => a.street == street).toList(growable: false);
-    final pot = actions
-        .where((a) => a.street <= street)
-        .where((a) => ['call', 'bet', 'raise'].contains(a.action))
-        .fold<int>(0, (sum, a) => sum + (a.amount ?? 0));
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -67,13 +62,6 @@ class StreetActionsList extends StatelessWidget {
               },
             ),
           ),
-        Padding(
-          padding: const EdgeInsets.only(top: 4.0),
-          child: Text(
-            'Пот: $pot',
-            style: const TextStyle(color: Colors.white),
-          ),
-        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- remove legacy pot label from action list
- drop unused pot calculation
- adjust player bet chip position

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425bd49c84832aa65f4e0dbd4d49ac