### PR TITLE
Fix PlayerZoneWidget syntax

### DIFF
--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -158,6 +158,7 @@ class PlayerZoneWidget extends StatelessWidget {
       children: [
         column,
       ],
+    );
 
     Widget result = content;
 


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `PlayerZoneWidget`

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68425f80a3b0832a9492346e55036779