### PR TITLE
Show stack size with ChipWidget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -323,7 +323,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                 isActive: index == activePlayerIndex,
                                 showHint: _showActionHints[index],
                                 actionTagText: actionTag,
-                                stackSize: stackSizes[index],
                                 onCardsSelected: (card) => selectCard(index, card),
                               ),
                               if (playerPositions[index] != null)
@@ -340,14 +339,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                 ),
                               Padding(
                                 padding: const EdgeInsets.only(top: 2.0),
-                                child: Text(
-                                  'Stack: \$${stackSizes[index] ?? 0}',
-                                  style: TextStyle(
-                                    color: isFolded ? Colors.white38 : Colors.white,
-                                    fontSize: 11,
-                                  ),
-                                  textAlign: TextAlign.center,
-                                ),
+                                child: ChipWidget(amount: stackSizes[index] ?? 0),
                               ),
                               ],
                             ),

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -12,7 +12,6 @@ class PlayerZoneWidget extends StatelessWidget {
   final bool isActive;
   final bool showHint;
   final String? actionTagText;
-  final int? stackSize;
   final Function(CardModel) onCardsSelected;
 
   const PlayerZoneWidget({
@@ -26,7 +25,6 @@ class PlayerZoneWidget extends StatelessWidget {
     this.isActive = false,
     this.showHint = false,
     this.actionTagText,
-    this.stackSize,
   }) : super(key: key);
 
   @override
@@ -65,18 +63,6 @@ class PlayerZoneWidget extends StatelessWidget {
             ),
           ],
         ),
-        if (stackSize != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 2.0),
-            child: Text(
-              '$stackSize',
-              style: const TextStyle(
-                fontSize: 12,
-                color: Colors.orangeAccent,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ),
         if (position != null)
           Padding(
             padding: const EdgeInsets.only(top: 2.0),
@@ -158,6 +144,7 @@ class PlayerZoneWidget extends StatelessWidget {
       children: [
         column,
       ],
+    );
 
     Widget result = content;
 


### PR DESCRIPTION
## Summary
- remove `stackSize` field from `PlayerZoneWidget`
- display each player's stack using `ChipWidget`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f80a3b0832a9492346e55036779