### PR TITLE
Disable flutter tests

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -6,5 +6,3 @@ tasks:
   analyze:
     run: flutter analyze
 
-  test:
-    run: flutter test


### PR DESCRIPTION
## Summary
- remove flutter test step in codex configuration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b41451f8832a9e4687a97e469a7c