### PR TITLE
Enhance bet display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -381,6 +381,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                         child: ChipWidget(
                           key: ValueKey(_pots[currentStreet]),
                           amount: _pots[currentStreet],
+                          chipType: 'bet',
                         ),
                       ),
                     ),
@@ -438,6 +439,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             children: [
                               PlayerZoneWidget(
                                 playerName: 'Player ${index + 1}',
+                                position: playerPositions[index],
                                 cards: playerCards[index],
                                 isHero: index == heroIndex,
                                 isFolded: isFolded,
@@ -448,21 +450,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                 actionTagText: actionTag,
                                 onCardsSelected: (card) => selectCard(index, card),
                               ),
-                              if (playerPositions[index] != null)
-                                Padding(
-                                  padding: const EdgeInsets.only(top: 2.0),
-                                  child: Text(
-                                    playerPositions[index]!,
-                                    style: const TextStyle(
-                                      color: Colors.white70,
-                                      fontSize: 11,
-                                    ),
-                                    textAlign: TextAlign.center,
-                                  ),
+                              AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 300),
+                                transitionBuilder: (child, animation) => ScaleTransition(
+                                  scale: animation,
+                                  child: FadeTransition(opacity: animation, child: child),
                                 ),
-                              Padding(
-                                padding: const EdgeInsets.only(top: 2.0),
-                                child: ChipWidget(amount: stackSizes[index] ?? 0),
+                                child: ChipWidget(
+                                  key: ValueKey(stackSizes[index] ?? 0),
+                                  amount: stackSizes[index] ?? 0,
+                                  chipType: 'stack',
+                                ),
                               ),
                               ],
                             ),
@@ -471,7 +469,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       if (lastAction != null)
                         Positioned(
                           left: centerX + dx - 30,
-                          top: centerY + dy + 60,
+                          top: centerY + dy + 50,
                           child: Container(
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),
@@ -481,8 +479,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             ),
                             child: Text(
                               '${lastAction!.action}${lastAction!.amount != null ? ' ${lastAction!.amount}' : ''}',
-                              style:
-                                  const TextStyle(color: Colors.white, fontSize: 12),
+                              style: const TextStyle(color: Colors.white, fontSize: 12),
+                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
                         ),
@@ -493,7 +491,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           lastAction!.amount != null)
                         Positioned(
                           left: centerX + dx - 20,
-                          top: centerY + dy + 80,
+                          top: centerY + dy + 70,
                           child: Container(
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),
@@ -521,14 +519,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           _streetInvestments[index]! > 0)
                         Positioned(
                           left: centerX + dx - 20,
-                          top: centerY + dy + 110,
+                          top: centerY + dy + 100,
                           child: AnimatedSwitcher(
                             duration: const Duration(milliseconds: 300),
-                            transitionBuilder: (child, animation) => SlideTransition(
-                              position: Tween<Offset>(
-                                      begin: const Offset(0, 0.2),
-                                      end: Offset.zero)
-                                  .animate(animation),
+                            transitionBuilder: (child, animation) => ScaleTransition(
+                              scale: animation,
                               child: FadeTransition(
                                 opacity: animation,
                                 child: child,
@@ -537,6 +532,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             child: ChipWidget(
                               key: ValueKey(_streetInvestments[index]),
                               amount: _streetInvestments[index]!,
+                              chipType: 'bet',
                             ),
                           ),
                         ),

--- a/lib/widgets/chip_widget.dart
+++ b/lib/widgets/chip_widget.dart
@@ -2,30 +2,36 @@ import 'package:flutter/material.dart';
 
 class ChipWidget extends StatelessWidget {
   final int amount;
+  final String chipType; // "bet" or "stack"
 
-  const ChipWidget({Key? key, required this.amount}) : super(key: key);
+  const ChipWidget({Key? key, required this.amount, this.chipType = 'stack'})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final isBet = chipType == 'bet';
+    final gradientColors = isBet
+        ? const [Color(0xFFB22222), Colors.black]
+        : const [Color(0xFF4A4A4A), Colors.black];
+    final shadow = BoxShadow(
+      color: Colors.black.withOpacity(isBet ? 0.6 : 0.3),
+      blurRadius: isBet ? 6 : 4,
+      offset: const Offset(0, 2),
+    );
+
     return Container(
       width: 40,
       height: 40,
       alignment: Alignment.center,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        gradient: const LinearGradient(
-          colors: [Color(0xFF8B0000), Colors.black],
+        gradient: LinearGradient(
+          colors: gradientColors,
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
         ),
         border: Border.all(color: Colors.black87, width: 1),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.5),
-            blurRadius: 4,
-            offset: Offset(0, 2),
-          ),
-        ],
+        boxShadow: [shadow],
       ),
       child: Text(
         '\$${amount}',

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -29,6 +29,15 @@ class PlayerZoneWidget extends StatelessWidget {
     this.actionTagText,
   }) : super(key: key);
 
+  static const TextStyle _captionStyle = TextStyle(
+    color: Colors.white70,
+    fontSize: 12,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle _tagStyle =
+      TextStyle(color: Colors.white, fontSize: 12);
+
   @override
   Widget build(BuildContext context) {
     final column = Column(
@@ -56,11 +65,7 @@ class PlayerZoneWidget extends StatelessWidget {
                 padding: const EdgeInsets.only(left: 4.0),
                 child: Text(
                   position!,
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: _captionStyle,
                 ),
               ),
             if (showHint)
@@ -77,21 +82,6 @@ class PlayerZoneWidget extends StatelessWidget {
               ),
           ],
         ),
-        if (actionTagText != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 4.0),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: Colors.grey.withOpacity(0.6),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Text(
-                actionTagText!,
-                style: const TextStyle(color: Colors.white, fontSize: 12),
-              ),
-            ),
-          ),
         const SizedBox(height: 4),
         GestureDetector(
           onTap: () async {
@@ -139,6 +129,22 @@ class PlayerZoneWidget extends StatelessWidget {
             ),
           ),
         ),
+        if (actionTagText != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.grey.withOpacity(0.6),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                actionTagText!,
+                style: _tagStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
       ],
     );
 


### PR DESCRIPTION
## Summary
- style chips by type to distinguish bets from stacks
- unify player caption styles and reposition action tags
- show player position within PlayerZoneWidget
- add animations for stack updates and make bet chips red
- tweak last action label positioning

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b990e81c832aa9970f7f4f046c67