### PR TITLE
Implement animated pot chip display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -371,17 +371,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       top: centerY - 10,
                       child: AnimatedSwitcher(
                         duration: const Duration(milliseconds: 300),
-                        transitionBuilder: (child, animation) =>
-                            SlideTransition(
-                          position: Tween<Offset>(
-                                  begin: const Offset(0, 0.2), end: Offset.zero)
-                              .animate(animation),
+                        transitionBuilder: (child, animation) => ScaleTransition(
+                          scale: animation,
                           child: FadeTransition(opacity: animation, child: child),
                         ),
                         child: ChipWidget(
                           key: ValueKey(_pots[currentStreet]),
                           amount: _pots[currentStreet],
-                          chipType: 'bet',
+                          chipType: 'stack',
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- center pot uses chipType `stack`
- same transition animation for pot chip as other chip widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb35d934832a8c846b5a6f08bf9e