### PR TITLE
Add StreetActionSummaryBar widget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/board_cards_widget.dart';
 import '../widgets/action_dialog.dart';
 import '../widgets/chip_widget.dart';
 import '../widgets/street_actions_list.dart';
+import '../widgets/street_action_summary_bar.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   const PokerAnalyzerScreen({super.key});
@@ -246,6 +247,44 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
             'Позиция: ${pos ?? '-'}\n'
             'Карты: $cardsText\n\n'
             'Действия:\n$actionsText'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showStreetActionsDetails() {
+    final streetActions =
+        actions.where((a) => a.street == currentStreet).toList(growable: false);
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Colors.black87,
+        title: Text(
+          ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
+          style: const TextStyle(color: Colors.white),
+        ),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              for (final a in streetActions)
+                ListTile(
+                  dense: true,
+                  title: Text(
+                    '${playerPositions[a.playerIndex] ?? 'Player ${a.playerIndex + 1}'} '
+                    '— ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+            ],
+          ),
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
@@ -548,6 +587,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                   _actionTags.clear();
                 });
               },
+            ),
+            StreetActionSummaryBar(
+              street: currentStreet,
+              actions: actions,
+              playerPositions: playerPositions,
+              onActionTap: _showStreetActionsDetails,
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/widgets/street_action_summary_bar.dart
+++ b/lib/widgets/street_action_summary_bar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+
+/// Horizontal bar showing brief actions for the current street.
+class StreetActionSummaryBar extends StatelessWidget {
+  final int street;
+  final List<ActionEntry> actions;
+  final Map<int, String> playerPositions;
+  final VoidCallback onActionTap;
+
+  const StreetActionSummaryBar({
+    super.key,
+    required this.street,
+    required this.actions,
+    required this.playerPositions,
+    required this.onActionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final streetActions =
+        actions.where((a) => a.street == street).toList(growable: false);
+    if (streetActions.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+      color: Colors.black.withOpacity(0.3),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (final a in streetActions)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: GestureDetector(
+                  onTap: onActionTap,
+                  child: Chip(
+                    backgroundColor: Colors.black54,
+                    label: Text(
+                      '${playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}'}: '
+                      '${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+                      style: const TextStyle(color: Colors.white, fontSize: 12),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `StreetActionSummaryBar` widget to show compact street action history
- display history bar in `PokerAnalyzerScreen`
- show full street details on tap

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6842bc6c0e60832a963accb38a0286a7