### PR TITLE
Fix unmatched parenthesis in build method

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -631,6 +631,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
               child: const Text('Сбросить раздачу'),
             ),
           ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- fix missing parenthesis near end of `PokerAnalyzerScreen.build`

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842c2d985a8832a90e89a912fe99d51