### PR TITLE
UI improvements for betting

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -516,7 +516,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       if (lastAction != null)
                         Positioned(
                           left: centerX + dx - 30,
-                          top: centerY + dy + 50,
+                          top: centerY + dy + 60,
                           child: Container(
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),
@@ -538,7 +538,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           lastAction!.amount != null)
                         Positioned(
                           left: centerX + dx - 20,
-                          top: centerY + dy + 70,
+                          top: centerY + dy + 85,
                           child: Container(
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),

--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -66,6 +66,7 @@ class _ActionDialogState extends State<ActionDialog> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
+              _buildSizingButton('1/3 Пот', (widget.pot / 3).round()),
               _buildSizingButton('1/2 Пот', (widget.pot / 2).round()),
               _buildSizingButton('Пот', widget.pot),
               _buildSizingButton('Олл-ин', widget.stackSize),


### PR DESCRIPTION
## Summary
- add 1/3 pot quick sizing option to betting dialog
- shift bet display text down to avoid overlapping

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4a26c9c832a948018d23daf0b0e