### PR TITLE
Fix bottom player visibility and hero highlight

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -361,7 +361,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     final tableWidth = screenSize.width * 0.9;
     final tableHeight = tableWidth * 0.55;
     final centerX = screenSize.width / 2 + 10;
-    final centerY = screenSize.height / 2 - 120;
+    final centerY =
+        (numberOfPlayers > 6 ? screenSize.height / 2 - 160 : screenSize.height / 2 - 120);
     final radiusX = (tableWidth / 2 - 50) * scale;
     final radiusY = (tableHeight / 2 + 100) * scale;
     return Scaffold(
@@ -399,8 +400,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
             ),
             Expanded(
               flex: 7,
-              child: Stack(
-                children: [
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 40.0),
+                child: Stack(
+                  children: [
                   Center(
                     child: Image.asset(
                       'assets/table.png',
@@ -589,6 +592,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                 ],
               ),
             ),
+          ),
             StreetActionsWidget(
               currentStreet: currentStreet,
               onStreetChanged: (index) {

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -155,6 +155,16 @@ class PlayerZoneWidget extends StatelessWidget {
       clipBehavior: Clip.none,
       children: [
         column,
+        if (isHero)
+          Positioned(
+            right: -4 * scale,
+            top: -4 * scale,
+            child: Icon(
+              Icons.star,
+              color: Colors.orangeAccent,
+              size: 12 * scale,
+            ),
+          ),
       ],
     );
 


### PR DESCRIPTION
## Summary
- keep bottom player visible by moving table center up when crowded
- add bottom padding around the table Stack
- give Hero players a subtle star highlight

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c6190d84832ab945ac4226386337