### PR TITLE
Fix inline chip variable error

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -487,6 +487,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       }
                     }
 
+                    final invested =
+                        _streetInvestments[currentStreet]?[index] ?? 0;
+                    final chipType = (lastAction != null &&
+                            (lastAction!.action == 'bet' ||
+                                lastAction!.action == 'raise' ||
+                                lastAction!.action == 'call'))
+                        ? lastAction!.action
+                        : 'stack';
+
                     return [
                       Positioned(
                         left: centerX + dx - 55,
@@ -598,12 +607,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             ),
                           ),
                         ),
-                      final invested =
-                          _streetInvestments[currentStreet]?[index] ?? 0;
                       if (invested > 0)
                         Positioned(
                           left: centerX + dx - 20,
-                          top: centerY + dy + 90,
+                          top: centerY + dy + 92,
                           child: AnimatedSwitcher(
                             duration: const Duration(milliseconds: 300),
                             transitionBuilder: (child, animation) => ScaleTransition(
@@ -617,7 +624,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                               scale: scale,
                               key: ValueKey(invested),
                               amount: invested,
-                              chipType: 'stack',
+                              chipType: chipType,
                             ),
                           ),
                         ),


### PR DESCRIPTION
## Summary
- fix Dart error by moving `invested` variable outside of widget list
- animate investment chips only when value is >0 and update chip style based on last action
- tweak chip vertical offset for better alignment

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec26ef10832a9a348dd845c74e43