### PR TITLE
Enhance action arrow rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ class InputScreen extends StatelessWidget {
     );
   }
 }
+\n## Future Improvements\nTo show a chain of action arrows without cluttering the interface, consider rendering semi-transparent arrows for past actions and fading them out over time or collapsing them into a small history panel.

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -513,6 +513,43 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                         : 'stack';
 
                     return [
+                      // action arrow behind player widgets
+                      Positioned(
+                        left: centerX + dx,
+                        top: centerY + dy + bias + 12,
+                        child: IgnorePointer(
+                          child: AnimatedOpacity(
+                            opacity: (lastStreetAction != null &&
+                                    lastStreetAction!.playerIndex == index &&
+                                    (lastStreetAction!.action == 'bet' ||
+                                        lastStreetAction!.action == 'raise' ||
+                                        lastStreetAction!.action == 'call'))
+                                ? 1.0
+                                : 0.0,
+                            duration: const Duration(milliseconds: 300),
+                            child: Transform.rotate(
+                              angle: atan2(
+                                  centerY - (centerY + dy + bias + 12),
+                                  centerX - (centerX + dx)),
+                              alignment: Alignment.topLeft,
+                              child: Container(
+                                width: sqrt(pow(centerX - (centerX + dx), 2) +
+                                    pow(centerY - (centerY + dy + bias + 12), 2)),
+                                height: 1,
+                                decoration: BoxDecoration(
+                                  color: Colors.orangeAccent.withOpacity(0.9),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.orangeAccent.withOpacity(0.6),
+                                      blurRadius: 4,
+                                    )
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
                       Positioned(
                         left: centerX + dx - 55 * scale,
                         top: centerY + dy + bias - 55 * scale,
@@ -641,31 +678,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                               key: ValueKey(invested),
                               amount: invested,
                               chipType: chipType,
-                            ),
-                          ),
-                        ),
-                      if (lastStreetAction != null &&
-                          lastStreetAction!.playerIndex == index &&
-                          (lastStreetAction!.action == 'bet' ||
-                              lastStreetAction!.action == 'raise' ||
-                              lastStreetAction!.action == 'call'))
-                        Positioned(
-                          left: centerX + dx,
-                          top: centerY + dy + bias,
-                          child: AnimatedOpacity(
-                            opacity: 1.0,
-                            duration: const Duration(milliseconds: 300),
-                            child: Transform.rotate(
-                              angle: atan2(centerY - (centerY + dy + bias),
-                                  centerX - (centerX + dx)),
-                              alignment: Alignment.topLeft,
-                              child: Container(
-                                width: sqrt(pow(centerX - (centerX + dx), 2) +
-                                    pow(centerY - (centerY + dy + bias), 2)),
-                                height: 2,
-                                color:
-                                    Colors.orangeAccent.withOpacity(0.7),
-                              ),
                             ),
                           ),
                         ),


### PR DESCRIPTION
## Summary
- make the action arrow thinner and apply glow
- draw the arrow below other player widgets
- fade the arrow out when not the last action
- document a potential solution for rendering a chain of arrows

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d8f7d00832a9ad31e2530eec1ef