### PR TITLE
Implement auto fold generation

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -11,7 +11,12 @@ class ActionEntry {
   /// Размер ставки в фишках, если применимо
   final int? amount;
 
+  /// Флаг, указывающий, что запись сгенерирована автоматически
+  final bool generated;
+
   /// Создает запись о действии игрока на определенной улице.
   /// [amount] заполняется только для действий bet, raise или call.
-  ActionEntry(this.street, this.playerIndex, this.action, [this.amount]);
+  /// [generated] помечает автоматически добавленные действия.
+  ActionEntry(this.street, this.playerIndex, this.action,
+      {this.amount, this.generated = false});
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -198,9 +198,31 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     }
   }
 
+  void _addAutoFolds(ActionEntry entry) {
+    final street = entry.street;
+    final playerIndex = entry.playerIndex;
+    int insertPos = actions.length - 1; // position before the new entry
+    for (int i = 0; i < numberOfPlayers; i++) {
+      if (i == playerIndex) continue;
+      if (i >= playerIndex) continue; // earlier in simple index order
+      final hasActionThisStreet =
+          actions.any((a) => a.playerIndex == i && a.street == street);
+      if (hasActionThisStreet) continue;
+      final foldedEarlier = actions.any((a) =>
+          a.playerIndex == i && a.action == 'fold' && a.street < street);
+      if (foldedEarlier) continue;
+      final autoFold =
+          ActionEntry(street, i, 'fold', generated: true);
+      actions.insert(insertPos, autoFold);
+      insertPos++;
+      _actionTags[i] = 'fold';
+    }
+  }
+
   void onActionSelected(ActionEntry entry) {
     setState(() {
       actions.add(entry);
+      _addAutoFolds(entry);
       lastActionPlayerIndex = entry.playerIndex;
       _actionTags[entry.playerIndex] =
           '${entry.action}${entry.amount != null ? ' ${entry.amount}' : ''}';

--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -37,7 +37,8 @@ class _ActionDialogState extends State<ActionDialog> {
     if (action == 'fold' || action == 'check' || action == 'call') {
       Navigator.pop(
         context,
-        ActionEntry(widget.street, widget.playerIndex, action, null),
+        ActionEntry(widget.street, widget.playerIndex, action,
+            amount: null),
       );
     } else {
       setState(() => _selectedAction = action);
@@ -73,7 +74,8 @@ class _ActionDialogState extends State<ActionDialog> {
   void _onBetSelected(int amount) {
     Navigator.pop(
       context,
-      ActionEntry(widget.street, widget.playerIndex, _selectedAction!, amount),
+      ActionEntry(widget.street, widget.playerIndex, _selectedAction!,
+          amount: amount),
     );
   }
 

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -35,12 +35,18 @@ class StreetActionsList extends StatelessWidget {
       default:
         color = Colors.white;
     }
+    final title = a.generated
+        ? 'Игрок ${a.playerIndex + 1}: ${a.action}$amountStr (auto)'
+        : 'Игрок ${a.playerIndex + 1}: ${a.action}$amountStr';
     return ListTile(
       dense: true,
       contentPadding: EdgeInsets.zero,
       title: Text(
-        'Игрок ${a.playerIndex + 1}: ${a.action}$amountStr',
-        style: TextStyle(color: color),
+        title,
+        style: TextStyle(
+          color: color,
+          fontStyle: a.generated ? FontStyle.italic : FontStyle.normal,
+        ),
       ),
       onTap: () => onEdit(globalIndex),
       trailing: IconButton(


### PR DESCRIPTION
## Summary
- add `generated` flag to `ActionEntry`
- mark auto-added folds in the action list UI
- generate auto fold actions when a player is skipped on a street

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843708f96f8832a80eb96a650278d61