### PR TITLE
Add visual bet size input

### DIFF
--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -121,6 +121,7 @@ class _ActionDialogState extends State<ActionDialog> {
                 pot: widget.pot,
                 stackSize: widget.stackSize,
                 onSelected: _onBetSelected,
+                initialAmount: widget.initialAmount,
               ),
             ),
         ],

--- a/lib/widgets/bet_sizer.dart
+++ b/lib/widgets/bet_sizer.dart
@@ -5,49 +5,93 @@ class BetSizer extends StatefulWidget {
   final int pot;
   final int stackSize;
   final ValueChanged<int> onSelected;
+  final int? initialAmount;
 
   const BetSizer({
     Key? key,
     required this.pot,
     required this.stackSize,
     required this.onSelected,
+    this.initialAmount,
   }) : super(key: key);
 
   @override
   State<BetSizer> createState() => _BetSizerState();
 }
 
+String _formatWithSpaces(String digits) {
+  final buffer = StringBuffer();
+  for (int i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) {
+      buffer.write(' ');
+    }
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}
+
+class _ThousandsFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    final digits = newValue.text.replaceAll(RegExp(r'\D'), '');
+    final formatted = _formatWithSpaces(digits);
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
+  }
+}
+
 class _BetSizerState extends State<BetSizer> {
-  double _value = 0;
   final TextEditingController _controller = TextEditingController();
   final FocusNode _focusNode = FocusNode();
 
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() => setState(() {}));
+    if (widget.initialAmount != null) {
+      final formatted = _formatWithSpaces(widget.initialAmount!.toString());
+      _controller.text = formatted;
+    }
+  }
+
+  int? get _currentAmount {
+    final digits = _controller.text.replaceAll(RegExp(r'\D'), '');
+    final int? value = int.tryParse(digits);
+    if (value == null || value <= 0) return null;
+    return value.clamp(1, widget.stackSize);
+  }
+
+  void _setAmount(int amount) {
+    final clamped = amount.clamp(1, widget.stackSize);
+    final formatted = _formatWithSpaces(clamped.toString());
+    _controller.value = TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
+  }
+
   Widget _quickButton(String label, double fraction) {
-    final int amount = (widget.pot * fraction).round().clamp(0, widget.stackSize);
-    return ElevatedButton(
-      style: ElevatedButton.styleFrom(
-        backgroundColor: Colors.grey[850],
+    final int amount = (widget.pot * fraction).round();
+    return OutlinedButton(
+      style: OutlinedButton.styleFrom(
         foregroundColor: Colors.white,
+        side: const BorderSide(color: Colors.white54),
       ),
-      onPressed: () => widget.onSelected(amount),
+      onPressed: () => _setAmount(amount),
       child: Text(label),
     );
   }
 
-  void _handleEnd(double val) {
-    if (val > 0) {
-      widget.onSelected(val.round());
-      setState(() => _value = 0);
+  void _submit() {
+    final int? amount = _currentAmount;
+    if (amount != null) {
+      widget.onSelected(amount);
+      _controller.clear();
+      _focusNode.unfocus();
     }
-  }
-
-  void _submitManual() {
-    final int? input = int.tryParse(_controller.text);
-    if (input == null || input <= 0) return;
-    final int amount = input.clamp(1, widget.stackSize);
-    widget.onSelected(amount);
-    _controller.clear();
-    _focusNode.unfocus();
   }
 
   @override
@@ -59,6 +103,7 @@ class _BetSizerState extends State<BetSizer> {
 
   @override
   Widget build(BuildContext context) {
+    final bool valid = _currentAmount != null;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -66,9 +111,8 @@ class _BetSizerState extends State<BetSizer> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            _quickButton('⅓ Pot', 0.33),
             _quickButton('½ Pot', 0.5),
-            _quickButton('¾ Pot', 0.75),
+            _quickButton('⅔ Pot', 2 / 3),
             _quickButton('Pot', 1.0),
           ],
         ),
@@ -80,7 +124,10 @@ class _BetSizerState extends State<BetSizer> {
             focusNode: _focusNode,
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.done,
-            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+              _ThousandsFormatter(),
+            ],
             style: const TextStyle(color: Colors.white),
             decoration: InputDecoration(
               filled: true,
@@ -92,24 +139,22 @@ class _BetSizerState extends State<BetSizer> {
               hintText: 'Введите ставку',
               hintStyle: const TextStyle(color: Colors.white70),
             ),
-            onSubmitted: (_) => _submitManual(),
+            onSubmitted: (_) => _submit(),
           ),
         ),
-        const SizedBox(height: 12),
-        Slider(
-          value: _value,
-          min: 0,
-          max: widget.stackSize.toDouble(),
-          divisions: widget.stackSize > 0 ? widget.stackSize : 1,
-          label: _value.round().toString(),
-          onChanged: (v) => setState(() => _value = v),
-          onChangeEnd: _handleEnd,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          _value.round().toString(),
-          textAlign: TextAlign.center,
-          style: const TextStyle(color: Colors.white),
+        const SizedBox(height: 16),
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 200),
+          opacity: valid ? 1.0 : 0.6,
+          child: ElevatedButton(
+            onPressed: valid ? _submit : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blueGrey,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+            child: const Text('OK'),
+          ),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- add numeric bet amount input with preset buttons
- support editing existing bet amounts
- wire up new bet size chooser in `ActionDialog`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843810aabf0832a852ee02f882b718c