### PR TITLE
Add stack display under player labels

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -633,6 +633,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                 showHint: _showActionHints[index],
                                 actionTagText: actionTag,
                                 onCardsSelected: (card) => selectCard(index, card),
+                                stack: stackSizes[index] ?? 0,
                               ),
                               AnimatedSwitcher(
                                 duration: const Duration(milliseconds: 300),
@@ -645,21 +646,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                   key: ValueKey(stackSizes[index] ?? 0),
                                   amount: stackSizes[index] ?? 0,
                                   chipType: 'stack',
-                                ),
-                              ),
-                              AnimatedSwitcher(
-                                duration: const Duration(milliseconds: 300),
-                                transitionBuilder: (child, animation) => FadeTransition(
-                                  opacity: animation,
-                                  child: ScaleTransition(scale: animation, child: child),
-                                ),
-                                child: Text(
-                                  'Stack: ${_formatAmount(stackSizes[index] ?? 0)}',
-                                  key: ValueKey('t${stackSizes[index] ?? 0}'),
-                                  style: TextStyle(
-                                    color: isFolded ? Colors.grey : Colors.white,
-                                    fontSize: 14 * scale,
-                                  ),
                                 ),
                               ),
                               ],

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -3,6 +3,18 @@ import 'package:flutter/material.dart';
 import '../models/card_model.dart';
 import 'card_selector.dart';
 
+String _formatAmount(int amount) {
+  final digits = amount.toString();
+  final buffer = StringBuffer();
+  for (int i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) {
+      buffer.write(' ');
+    }
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}
+
 class PlayerZoneWidget extends StatelessWidget {
   final String playerName;
   final String? position;
@@ -15,6 +27,7 @@ class PlayerZoneWidget extends StatelessWidget {
   final String? actionTagText;
   final Function(CardModel) onCardsSelected;
   final double scale;
+  final int stack;
 
   const PlayerZoneWidget({
     Key? key,
@@ -29,6 +42,7 @@ class PlayerZoneWidget extends StatelessWidget {
     this.showHint = false,
     this.actionTagText,
     this.scale = 1.0,
+    required this.stack,
   }) : super(key: key);
 
 
@@ -83,6 +97,33 @@ class PlayerZoneWidget extends StatelessWidget {
                   position!,
                   style: captionStyle,
                   textAlign: TextAlign.center,
+                ),
+              ),
+            if (stack > 0)
+              Padding(
+                padding: EdgeInsets.only(top: 2.0 * scale),
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 300),
+                  transitionBuilder: (child, animation) => FadeTransition(
+                    opacity: animation,
+                    child: ScaleTransition(scale: animation, child: child),
+                  ),
+                  child: Container(
+                    key: ValueKey(stack),
+                    padding: EdgeInsets.symmetric(
+                        horizontal: 6 * scale, vertical: 2 * scale),
+                    decoration: BoxDecoration(
+                      color: Colors.black54,
+                      borderRadius: BorderRadius.circular(8 * scale),
+                    ),
+                    child: Text(
+                      _formatAmount(stack),
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 12 * scale,
+                      ),
+                    ),
+                  ),
                 ),
               ),
           ],


### PR DESCRIPTION
## Summary
- show each player's stack size below the name/position label
- animate the label when stack changes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d58211fc832a92a237a22b0d78d3