### PR TITLE
Add stack-to-pot ratio to HUD

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -425,6 +425,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     final radiusY = (tableHeight / 2 + 90) * scale;
 
     final effectiveStack = _calculateEffectiveStack();
+    final pot = _pots[currentStreet];
+    final double? sprValue =
+        pot > 0 ? effectiveStack / pot : null;
 
     ActionEntry? lastStreetAction;
     for (final a in actions.reversed) {
@@ -772,6 +775,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     streetName: ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
                     potText: _formatAmount(_pots[currentStreet]),
                     stackText: _formatAmount(effectiveStack),
+                    sprText: sprValue != null
+                        ? 'SPR: ${sprValue.toStringAsFixed(1)}'
+                        : null,
                   ),
                 )
               ],

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -5,12 +5,14 @@ class HudOverlay extends StatelessWidget {
   final String streetName;
   final String potText;
   final String stackText;
+  final String? sprText;
 
   const HudOverlay({
     Key? key,
     required this.streetName,
     required this.potText,
     required this.stackText,
+    this.sprText,
   }) : super(key: key);
 
   @override
@@ -18,7 +20,7 @@ class HudOverlay extends StatelessWidget {
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
       child: Container(
-        key: ValueKey('$streetName-$potText-$stackText'),
+        key: ValueKey('$streetName-$potText-$stackText-${sprText ?? ''}'),
         margin: const EdgeInsets.all(8),
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
@@ -36,7 +38,28 @@ class HudOverlay extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(streetName),
-              Text('Pot: $potText'),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('Pot: $potText'),
+                  if (sprText != null) ...[
+                    const SizedBox(width: 4),
+                    Text(
+                      sprText!,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        shadows: [
+                          Shadow(
+                            color: Colors.black54,
+                            offset: Offset(1, 1),
+                            blurRadius: 2,
+                          )
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
               Text('Eff: $stackText'),
             ],
           ),


### PR DESCRIPTION
## Summary
- enhance `HudOverlay` to optionally display SPR
- compute hero SPR in `PokerAnalyzerScreen`
- show the ratio next to the pot with shadowed text

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ec36e9e0832a9b6b3803eabfff22