### PR TITLE
Add chip trail visualization

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/chip_widget.dart';
 import '../widgets/street_actions_list.dart';
 import '../widgets/street_action_summary_bar.dart';
 import '../widgets/hud_overlay.dart';
+import '../widgets/chip_trail.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   const PokerAnalyzerScreen({super.key});
@@ -436,6 +437,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
         break;
       }
     }
+    final List<Widget> chipTrails = [];
+    final List<Widget> playerWidgets = [];
     return Scaffold(
       backgroundColor: Colors.black,
       resizeToAvoidBottomInset: true,
@@ -508,7 +511,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                         ),
                       ),
                     ),
-                  ...List.generate(numberOfPlayers, (i) {
+                  for (int i = 0; i < numberOfPlayers; i++) {
                     final index = (i + heroIndex) % numberOfPlayers;
                     final angle =
                         2 * pi * (i - heroIndex) / numberOfPlayers + pi / 2;
@@ -555,7 +558,29 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           )
                         : 0.0;
 
-                    return [
+                    final bool showTrail = invested > 0 &&
+                        (lastAction != null &&
+                            (lastAction!.action == 'bet' ||
+                                lastAction!.action == 'raise' ||
+                                lastAction!.action == 'call'));
+                    if (showTrail) {
+                      final fraction = _pots[currentStreet] > 0
+                          ? invested / _pots[currentStreet]
+                          : 0.0;
+                      final trailCount = 3 + (fraction * 2).clamp(0, 2).round();
+                      chipTrails.add(Positioned.fill(
+                        child: ChipTrail(
+                          start: Offset(centerX + dx, centerY + dy + bias + 92 * scale),
+                          end: Offset(centerX, centerY),
+                          chipCount: trailCount,
+                          visible: showTrail,
+                          scale: scale,
+                          color: actionColor ?? Colors.orangeAccent,
+                        ),
+                      ));
+                    }
+
+                    playerWidgets.addAll([
                       // action arrow behind player widgets
                       Positioned(
                         left: centerX + dx,
@@ -651,9 +676,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                                   chipType: 'stack',
                                 ),
                               ),
-                              ],
-                            ),
+                            ],
                           ),
+                        ),
                       ),
                       if (lastAction != null)
                         Positioned(
@@ -766,10 +791,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                             ),
                           ),
                         ),
-                  ];
-                }).expand((w) => w)
-                ,
-                Align(
+                    ]);
+                  }
+                    ...chipTrails,
+                    ...playerWidgets,
+                  Align(
                   alignment: Alignment.topRight,
                   child: HudOverlay(
                     streetName: ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],

--- a/lib/widgets/chip_trail.dart
+++ b/lib/widgets/chip_trail.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+class MiniChip extends StatelessWidget {
+  final Color color;
+  final double size;
+  const MiniChip({Key? key, required this.color, this.size = 12}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          colors: [color, Colors.black],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.6),
+            blurRadius: 4,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ChipTrail extends StatelessWidget {
+  final Offset start;
+  final Offset end;
+  final int chipCount;
+  final bool visible;
+  final double scale;
+  final Color color;
+
+  const ChipTrail({
+    Key? key,
+    required this.start,
+    required this.end,
+    this.chipCount = 3,
+    this.visible = false,
+    this.scale = 1.0,
+    this.color = const Color(0xFFB22222),
+  }) : super(key: key);
+
+  Offset _bezier(Offset p0, Offset p1, Offset p2, double t) {
+    final u = 1 - t;
+    return Offset(
+      u * u * p0.dx + 2 * u * t * p1.dx + t * t * p2.dx,
+      u * u * p0.dy + 2 * u * t * p1.dy + t * t * p2.dy,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final control = Offset((start.dx + end.dx) / 2, (start.dy + end.dy) / 2 - 40 * scale);
+    return IgnorePointer(
+      child: Stack(
+        children: List.generate(chipCount, (i) {
+          final t = (i + 1) / (chipCount + 1);
+          final pos = _bezier(start, control, end, t);
+          return Positioned(
+            left: pos.dx - 6 * scale,
+            top: pos.dy - 6 * scale,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 300),
+              opacity: visible ? 1.0 : 0.0,
+              child: MiniChip(color: color, size: 12 * scale),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show chips moving from player to pot as a visual bet indicator
- implement `ChipTrail` widget for curved mini chip paths
- wire new widget into `PokerAnalyzerScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f08668c4832abdb3097eaf5035d2