### PR TITLE
Add collapsible street summary

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -9,7 +9,7 @@ import '../widgets/board_cards_widget.dart';
 import '../widgets/action_dialog.dart';
 import '../widgets/chip_widget.dart';
 import '../widgets/street_actions_list.dart';
-import '../widgets/street_action_summary_bar.dart';
+import '../widgets/collapsible_street_summary.dart';
 import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
 
@@ -810,6 +810,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
             ),
           ),
         ),
+            CollapsibleStreetSummary(
+              actions: actions,
+              playerPositions: playerPositions,
+              onEdit: _editAction,
+              onDelete: _deleteAction,
+            ),
             StreetActionsWidget(
               currentStreet: currentStreet,
               onStreetChanged: (index) {
@@ -820,12 +826,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                   _actionTags.clear();
                 });
               },
-            ),
-            StreetActionSummaryBar(
-              street: currentStreet,
-              actions: actions,
-              playerPositions: playerPositions,
-              onActionTap: _showStreetActionsDetails,
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+import 'street_actions_list.dart';
+
+class CollapsibleStreetSummary extends StatefulWidget {
+  final List<ActionEntry> actions;
+  final Map<int, String> playerPositions;
+  final void Function(int) onEdit;
+  final void Function(int) onDelete;
+
+  const CollapsibleStreetSummary({
+    super.key,
+    required this.actions,
+    required this.playerPositions,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  @override
+  State<CollapsibleStreetSummary> createState() => _CollapsibleStreetSummaryState();
+}
+
+class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
+  int? _expandedStreet;
+
+  String _summaryForStreet(int street) {
+    final streetActions = widget.actions.where((a) => a.street == street).toList();
+    if (streetActions.isEmpty) return 'Нет действий';
+    final parts = streetActions.map((a) {
+      final pos = widget.playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
+      final act = '${a.action}${a.amount != null ? ' ${a.amount}' : ''}';
+      return '$act $pos';
+    }).toList();
+    return parts.join(' → ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
+    return Column(
+      children: List.generate(4, (i) {
+        final expanded = _expandedStreet == i;
+        final summary = _summaryForStreet(i);
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Container(
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.4),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                InkWell(
+                  onTap: () {
+                    setState(() {
+                      _expandedStreet = expanded ? null : i;
+                    });
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      '${streetNames[i]}: $summary',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+                ClipRect(
+                  child: AnimatedAlign(
+                    alignment: Alignment.topCenter,
+                    duration: const Duration(milliseconds: 300),
+                    heightFactor: expanded ? 1 : 0,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                      child: StreetActionsList(
+                        street: i,
+                        actions: widget.actions,
+                        onEdit: widget.onEdit,
+                        onDelete: widget.onDelete,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `CollapsibleStreetSummary` widget for per-street expandable summaries
- integrate the new component into `PokerAnalyzerScreen` below the table

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6010f54832a9715c83119bf48a6