### PR TITLE
Add editable player stacks

### DIFF
--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -28,6 +28,7 @@ class PlayerZoneWidget extends StatelessWidget {
   final Function(CardModel) onCardsSelected;
   final double scale;
   final int stack;
+  final VoidCallback? onStackTap;
 
   const PlayerZoneWidget({
     Key? key,
@@ -43,6 +44,7 @@ class PlayerZoneWidget extends StatelessWidget {
     this.actionTagText,
     this.scale = 1.0,
     required this.stack,
+    this.onStackTap,
   }) : super(key: key);
 
 
@@ -99,9 +101,10 @@ class PlayerZoneWidget extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
               ),
-            if (stack > 0)
-              Padding(
-                padding: EdgeInsets.only(top: 2.0 * scale),
+            Padding(
+              padding: EdgeInsets.only(top: 2.0 * scale),
+              child: GestureDetector(
+                onTap: onStackTap,
                 child: AnimatedSwitcher(
                   duration: const Duration(milliseconds: 300),
                   transitionBuilder: (child, animation) => FadeTransition(
@@ -126,6 +129,7 @@ class PlayerZoneWidget extends StatelessWidget {
                   ),
                 ),
               ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- make stack label tappable by adding `onStackTap` to `PlayerZoneWidget`
- implement `_editStackSize` dialog in `PokerAnalyzerScreen`
- allow long press on a player or tapping stack to edit stack size
- always display stack size for players

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f7954fe4832a9a97d1344757fa2f