### PR TITLE
Add poker position helper

### DIFF
--- a/lib/helpers/poker_position_helper.dart
+++ b/lib/helpers/poker_position_helper.dart
@@ -1,0 +1,22 @@
+/// Returns the list of position names for a given number of players.
+///
+/// The list is ordered from UTG to BB and supports tables with 2 to 9 players.
+/// Throws an [ArgumentError] if the provided [playerCount] is outside this range.
+List<String> getPositionList(int playerCount) {
+  if (playerCount < 2 || playerCount > 9) {
+    throw ArgumentError('Supported range: 2 to 9 players');
+  }
+
+  final Map<int, List<String>> positionsByCount = {
+    2: ['SB', 'BB'],
+    3: ['BTN', 'SB', 'BB'],
+    4: ['CO', 'BTN', 'SB', 'BB'],
+    5: ['MP', 'CO', 'BTN', 'SB', 'BB'],
+    6: ['UTG', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+    7: ['UTG', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+    8: ['UTG', 'UTG+1', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+    9: ['UTG', 'UTG+1', 'UTG+2', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+  };
+
+  return positionsByCount[playerCount]!;
+}


### PR DESCRIPTION
## Summary
- add a helper to compute poker positions for different table sizes

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843fb0ca798832a85d841c9eb858191