### PR TITLE
Preserve chip display after fold

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -204,9 +204,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
         final streetMap = _streetInvestments.putIfAbsent(a.street, () => {});
         streetMap[a.playerIndex] =
             (streetMap[a.playerIndex] ?? 0) + (a.amount ?? 0);
-      } else if (a.action == 'fold') {
-        _streetInvestments[a.street]?.remove(a.playerIndex);
       }
+      // Do not remove chip contributions on "fold" so that
+      // folded players still display their invested amount
     }
   }
 


### PR DESCRIPTION
## Summary
- show invested chips even after a player folds

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684409a039e0832a96d99f9618eb2652