### PR TITLE
Add action editing modal

### DIFF
--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -1,131 +1,112 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
-import 'bet_sizer.dart';
 
 class ActionDialog extends StatefulWidget {
   final int playerIndex;
   final int street;
-  final int pot;
+  final String position;
   final int stackSize;
+  final int pot;
   final String? initialAction;
   final int? initialAmount;
 
   const ActionDialog({
-    Key? key,
+    super.key,
     required this.playerIndex,
     required this.street,
-    required this.pot,
+    required this.position,
     required this.stackSize,
+    required this.pot,
     this.initialAction,
     this.initialAmount,
-  }) : super(key: key);
+  });
 
   @override
   State<ActionDialog> createState() => _ActionDialogState();
 }
 
 class _ActionDialogState extends State<ActionDialog> {
-  String? _selectedAction;
+  late String _action;
+  late TextEditingController _controller;
 
   @override
   void initState() {
     super.initState();
-    _selectedAction = widget.initialAction;
+    _action = widget.initialAction ?? 'fold';
+    _controller = TextEditingController(
+        text: widget.initialAmount != null ? widget.initialAmount.toString() : '');
   }
 
-  void _onActionPressed(String action) {
-    if (action == 'fold' || action == 'check' || action == 'call') {
-      Navigator.pop(
-        context,
-        ActionEntry(widget.street, widget.playerIndex, action,
-            amount: null),
-      );
-    } else {
-      setState(() => _selectedAction = action);
-    }
+  bool get _needsAmount =>
+      _action == 'bet' || _action == 'raise' || _action == 'call';
+
+  int? get _amount {
+    final digits = _controller.text.replaceAll(RegExp(r'\D'), '');
+    return int.tryParse(digits);
   }
 
-  Widget _actionButton(String label, String action, IconData icon) {
-    final bool active = _selectedAction == action;
-    final double scale = active ? 1.05 : 1.0;
-    return AnimatedOpacity(
-      duration: const Duration(milliseconds: 200),
-      opacity: active || _selectedAction == null ? 1.0 : 0.6,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        transform: Matrix4.identity()..scale(scale),
-        child: SizedBox(
-          width: 110,
-          child: ElevatedButton.icon(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: active ? Colors.blueGrey : Colors.grey[850],
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 18),
-            ),
-            onPressed: () => _onActionPressed(action),
-            icon: Icon(icon),
-            label: Text(label, style: const TextStyle(fontSize: 19)),
-          ),
-        ),
-      ),
-    );
-  }
-
-  void _onBetSelected(int amount) {
+  void _confirm() {
     Navigator.pop(
       context,
-      ActionEntry(widget.street, widget.playerIndex, _selectedAction!,
-          amount: amount),
+      ActionEntry(widget.street, widget.playerIndex, _action,
+          amount: _needsAmount ? _amount : null),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final textStyle = const TextStyle(color: Colors.white);
+    final actions = ['fold', 'check', 'call', 'bet', 'raise'];
     return AlertDialog(
-      backgroundColor: Colors.black,
-      titlePadding: const EdgeInsets.only(left: 24, right: 8, top: 20, bottom: 8),
-      title: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Text(
-              'Выберите действие игрока ${widget.playerIndex + 1}',
-              style: const TextStyle(color: Colors.white, fontSize: 20),
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.close, color: Colors.white),
-            onPressed: () => Navigator.pop(context),
-          ),
-        ],
+      backgroundColor: Colors.black87,
+      title: Text(
+        'Игрок ${widget.playerIndex + 1} (${widget.position})',
+        style: textStyle,
       ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Wrap(
-            alignment: WrapAlignment.center,
-            spacing: 12,
-            runSpacing: 12,
-            children: [
-              _actionButton('Fold', 'fold', Icons.close),
-              _actionButton('Check', 'check', Icons.remove),
-              _actionButton('Call', 'call', Icons.call),
-              _actionButton('Bet', 'bet', Icons.south),
-              _actionButton('Raise', 'raise', Icons.north),
+          DropdownButtonFormField<String>(
+            value: _action,
+            dropdownColor: Colors.black87,
+            decoration: const InputDecoration(
+              labelText: 'Действие',
+              labelStyle: TextStyle(color: Colors.white70),
+            ),
+            items: [
+              for (final a in actions)
+                DropdownMenuItem(
+                  value: a,
+                  child: Text(a, style: textStyle),
+                )
             ],
+            onChanged: (value) => setState(() => _action = value!),
           ),
-          if (_selectedAction == 'bet' || _selectedAction == 'raise')
+          if (_needsAmount)
             Padding(
-              padding: const EdgeInsets.all(16),
-              child: BetSizer(
-                pot: widget.pot,
-                stackSize: widget.stackSize,
-                onSelected: _onBetSelected,
-                initialAmount: widget.initialAmount,
+              padding: const EdgeInsets.only(top: 12.0),
+              child: TextField(
+                controller: _controller,
+                keyboardType: TextInputType.number,
+                style: textStyle,
+                decoration: const InputDecoration(
+                  labelText: 'Размер',
+                  labelStyle: TextStyle(color: Colors.white70),
+                ),
               ),
             ),
         ],
       ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Отмена'),
+        ),
+        TextButton(
+          onPressed: !_needsAmount || _amount != null ? _confirm : null,
+          child: const Text('OK'),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- open a modal when tapping player zone with existing action data if available
- new action dialog allows selecting action type and entering amounts
- update stack sizes when actions are added, edited or deleted
- recalc pots and investments after modifications

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440f56e318832aab18950e1af23d0c