### PR TITLE
Add current pot display to action dialog

### DIFF
--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -130,6 +130,10 @@ class _ActionDialogState extends State<ActionDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            Text(
+              'Текущий пот: ${widget.pot}',
+              style: textStyle.copyWith(fontWeight: FontWeight.bold),
+            ),
             DropdownButtonFormField<PlayerAction>(
               value: _action,
               dropdownColor: Colors.black87,


### PR DESCRIPTION
## Summary
- show current pot value at the top of the action dialog

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684415e795bc832ab583344881b6a6af