### PR TITLE
Add player stack/invested display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -809,6 +809,22 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           ),
                         ),
                       ],
+                      if (!isFolded && !((stackSizes[index] ?? 0) == 0 && invested == 0))
+                        Positioned(
+                          left: centerX + dx - 50 * scale,
+                          top: centerY + dy + bias + 124 * scale,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              'S: ${_formatAmount(stackSizes[index] ?? 0)}   I: ${_formatAmount(invested)}',
+                              style: TextStyle(color: Colors.white, fontSize: 11 * scale),
+                            ),
+                          ),
+                        ),
                       if (debugLayout)
                         Positioned(
                           left: centerX + dx - 40 * scale,


### PR DESCRIPTION
## Summary
- show stack and invested amount below each active player

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441b909554832a8de4137fc446c351