### PR TITLE
Add chip tokens and pot widget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -14,6 +14,8 @@ import '../widgets/street_actions_list.dart';
 import '../widgets/collapsible_street_summary.dart';
 import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
+import '../widgets/invested_chip_tokens.dart';
+import '../widgets/central_pot_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -723,17 +725,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       child: IgnorePointer(
                         child: Align(
                           alignment: const Alignment(0, 0.4),
-                          child: Text(
-                            'Pot: ${_formatAmount(_pots[currentStreet])}',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
+                          child: CentralPotWidget(
+                            text: 'Pot: ${_formatAmount(_pots[currentStreet])}',
+                            scale: scale,
                           ),
                         ),
                       ),
-                    ),
                     ),
                   for (int i = 0; i < numberOfPlayers; i++) {
                     final index = (i + heroIndex) % numberOfPlayers;
@@ -761,13 +758,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                         _streetInvestments[currentStreet]?[index] ?? 0;
 
                     final Color? actionColor =
-                        lastAction?.action == 'bet'
-                            ? const Color(0xFFFFA500)
-                            : lastAction?.action == 'raise'
-                                ? const Color(0xFFFF6347)
-                                : lastAction?.action == 'call'
-                                    ? const Color(0xFF00BFFF)
-                                    : null;
+                        (lastAction?.action == 'bet' ||
+                                lastAction?.action == 'raise')
+                            ? Colors.green
+                            : lastAction?.action == 'call'
+                                ? Colors.blue
+                                : null;
                     final double maxRadius = 36 * scale;
                     final double radius = (_pots[currentStreet] > 0)
                         ? min(
@@ -793,7 +789,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           chipCount: trailCount,
                           visible: showTrail,
                           scale: scale,
-                          color: actionColor ?? Colors.orangeAccent,
+                          color: actionColor ?? Colors.green,
                         ),
                       ));
                     }
@@ -1006,19 +1002,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                         Positioned(
                           left: centerX + dx - 20 * scale,
                           top: centerY + dy + bias + 92 * scale,
-                          child: AnimatedSwitcher(
-                            duration: const Duration(milliseconds: 300),
-                            transitionBuilder: (child, animation) => ScaleTransition(
-                              scale: animation,
-                              child: FadeTransition(
-                                opacity: animation,
-                                child: child,
-                              ),
-                            ),
-                            child: ChipWidget(
-                              key: ValueKey(invested),
-                              amount: invested,
-                            ),
+                          child: InvestedChipTokens(
+                            amount: invested,
+                            color: actionColor ?? Colors.green,
+                            scale: scale,
                           ),
                         ),
                       ],

--- a/lib/widgets/central_pot_widget.dart
+++ b/lib/widgets/central_pot_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+/// Pot display widget positioned in the middle of the table.
+class CentralPotWidget extends StatelessWidget {
+  final String text;
+  final double scale;
+
+  const CentralPotWidget({
+    Key? key,
+    required this.text,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Container(
+        key: ValueKey(text),
+        padding: EdgeInsets.symmetric(horizontal: 12 * scale, vertical: 6 * scale),
+        decoration: BoxDecoration(
+          color: Colors.black54,
+          borderRadius: BorderRadius.circular(12 * scale),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 16 * scale,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/invested_chip_tokens.dart
+++ b/lib/widgets/invested_chip_tokens.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'chip_trail.dart';
+
+/// Displays a short row of mini chips representing the
+/// amount invested by a player on the current street.
+class InvestedChipTokens extends StatelessWidget {
+  final int amount;
+  final Color color;
+  final double scale;
+
+  const InvestedChipTokens({
+    Key? key,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (amount <= 0) return const SizedBox.shrink();
+    final chipCount = (amount / 10).clamp(1, 5).round();
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Row(
+        key: ValueKey(amount),
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(
+          chipCount,
+          (index) => Padding(
+            padding: EdgeInsets.symmetric(horizontal: 2 * scale),
+            child: MiniChip(color: color, size: 12 * scale),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show central pot with fade/scale animation
- color player chip trails
- show invested chip tokens per player

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844285c2004832a84db88acfc1df6ab