### PR TITLE
Add bet chips visualization

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/street_actions_list.dart';
 import '../widgets/collapsible_street_summary.dart';
 import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
+import '../widgets/bet_chips_on_table.dart';
 import '../widgets/invested_chip_tokens.dart';
 import '../widgets/central_pot_widget.dart';
 import '../helpers/poker_position_helper.dart';
@@ -790,6 +791,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                           visible: showTrail,
                           scale: scale,
                           color: actionColor ?? Colors.green,
+                        ),
+                      ));
+                      final tableChipCount =
+                          (invested / 20).clamp(1, 5).round();
+                      chipTrails.add(Positioned.fill(
+                        child: BetChipsOnTable(
+                          start: Offset(centerX + dx, centerY + dy + bias + 92 * scale),
+                          end: Offset(centerX, centerY),
+                          chipCount: tableChipCount,
+                          color: lastAction!.action == 'call'
+                              ? Colors.blue
+                              : Colors.green,
+                          scale: scale,
                         ),
                       ));
                     }

--- a/lib/widgets/bet_chips_on_table.dart
+++ b/lib/widgets/bet_chips_on_table.dart
@@ -1,0 +1,75 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'chip_trail.dart';
+
+/// Displays a small row of chips on the table along the betting trail.
+class BetChipsOnTable extends StatelessWidget {
+  /// Starting point of the trail (from player).
+  final Offset start;
+
+  /// Ending point of the trail (towards the pot).
+  final Offset end;
+
+  /// Number of chips to show.
+  final int chipCount;
+
+  /// Color of the chips.
+  final Color color;
+
+  /// Scale factor to adapt to table scaling.
+  final double scale;
+
+  const BetChipsOnTable({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.chipCount,
+    required this.color,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (chipCount <= 0) return const SizedBox.shrink();
+
+    final mid = Offset.lerp(start, end, 0.5)!;
+    final dx = end.dx - start.dx;
+    final dy = end.dy - start.dy;
+    final angle = atan2(dy, dx);
+    final len = sqrt(dx * dx + dy * dy);
+    final perp = len == 0 ? Offset.zero : Offset(dy / len, -dx / len);
+    final pos = mid + perp * 14 * scale;
+
+    return IgnorePointer(
+      child: Stack(
+        children: [
+          Positioned(
+            left: pos.dx - chipCount * 7 * scale,
+            top: pos.dy - 7 * scale,
+            child: Transform.rotate(
+              angle: angle,
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                transitionBuilder: (child, animation) => FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(scale: animation, child: child),
+                ),
+                child: Row(
+                  key: ValueKey(chipCount),
+                  mainAxisSize: MainAxisSize.min,
+                  children: List.generate(
+                    chipCount,
+                    (index) => Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 1 * scale),
+                      child: MiniChip(color: color, size: 14 * scale),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show betting chips on the table during bet/call/raise
- build new `BetChipsOnTable` widget for drawing mini chip rows
- integrate widget into the analyzer screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68442acc8ad0832ab0c5bb0c2e5c2e35