### PR TITLE
Add central pot chips visualization

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/chip_trail.dart';
 import '../widgets/bet_chips_on_table.dart';
 import '../widgets/invested_chip_tokens.dart';
 import '../widgets/central_pot_widget.dart';
+import '../widgets/central_pot_chips.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -726,9 +727,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       child: IgnorePointer(
                         child: Align(
                           alignment: const Alignment(0, 0.4),
-                          child: CentralPotWidget(
-                            text: 'Pot: ${_formatAmount(_pots[currentStreet])}',
-                            scale: scale,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              CentralPotChips(
+                                amount: _pots[currentStreet],
+                                scale: scale,
+                              ),
+                              SizedBox(height: 4 * scale),
+                              CentralPotWidget(
+                                text:
+                                    'Pot: ${_formatAmount(_pots[currentStreet])}',
+                                scale: scale,
+                              ),
+                            ],
                           ),
                         ),
                       ),

--- a/lib/widgets/central_pot_chips.dart
+++ b/lib/widgets/central_pot_chips.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'chip_trail.dart';
+
+/// Visual representation of the central pot using chip icons.
+class CentralPotChips extends StatelessWidget {
+  /// Total amount currently in the pot.
+  final int amount;
+
+  /// Scale factor to adapt to table size.
+  final double scale;
+
+  const CentralPotChips({
+    Key? key,
+    required this.amount,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (amount <= 0) return const SizedBox.shrink();
+    final chipCount = (amount / 20).clamp(1, 10).round();
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Row(
+        key: ValueKey(chipCount),
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(
+          chipCount,
+          (index) => Padding(
+            padding: EdgeInsets.symmetric(horizontal: 2 * scale),
+            child: MiniChip(color: Colors.orangeAccent, size: 16 * scale),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show chips in the middle of the table with `CentralPotChips`
- animate chips according to the street's pot amount
- integrate chips widget beside existing pot text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68442be249bc832a896e97734e543350