### PR TITLE
Enable editing via detailed sheet

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -8,7 +8,6 @@ import '../models/action_entry.dart';
 import '../widgets/player_zone_widget.dart';
 import '../widgets/street_actions_widget.dart';
 import '../widgets/board_cards_widget.dart';
-import '../widgets/action_dialog.dart';
 import '../widgets/detailed_action_bottom_sheet.dart';
 import '../widgets/chip_widget.dart';
 import '../widgets/street_actions_list.dart';
@@ -484,26 +483,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     _updatePlaybackState();
   }
 
-  Future<void> _editAction(int index) async {
-    final action = actions[index];
-    final result = await showDialog<ActionEntry>(
-      context: context,
-      builder: (context) => ActionDialog(
-        playerIndex: action.playerIndex,
-        street: action.street,
-        position: playerPositions[action.playerIndex] ?? '',
-        pot: _pots[action.street],
-        stackSize: stackSizes[action.playerIndex] ?? 0,
-        initialAction: action.action,
-        initialAmount: action.amount,
-        actions: actions.take(index).toList(),
-      ),
-    );
-    if (result != null) {
-      setState(() {
-        _updateAction(index, result);
-      });
-    }
+  void _editAction(int index, ActionEntry entry) {
+    setState(() {
+      _updateAction(index, entry);
+    });
   }
 
   Future<void> _editStackSize(int index) async {
@@ -1212,6 +1195,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     CollapsibleStreetSummary(
                       actions: actions,
                       playerPositions: playerPositions,
+                      pots: _pots,
+                      stackSizes: stackSizes,
                       onEdit: _editAction,
                       onDelete: _deleteAction,
                       visibleCount: _playbackIndex,
@@ -1234,6 +1219,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                       child: StreetActionsList(
                         street: currentStreet,
                         actions: actions,
+                        pots: _pots,
+                        stackSizes: stackSizes,
                         onEdit: _editAction,
                         onDelete: _deleteAction,
                         visibleCount: _playbackIndex,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -5,7 +5,9 @@ import 'street_actions_list.dart';
 class CollapsibleStreetSummary extends StatefulWidget {
   final List<ActionEntry> actions;
   final Map<int, String> playerPositions;
-  final void Function(int) onEdit;
+  final List<int> pots;
+  final Map<int, int> stackSizes;
+  final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
@@ -14,6 +16,8 @@ class CollapsibleStreetSummary extends StatefulWidget {
     super.key,
     required this.actions,
     required this.playerPositions,
+    required this.pots,
+    required this.stackSizes,
     required this.onEdit,
     required this.onDelete,
     this.visibleCount,
@@ -78,6 +82,8 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                       child: StreetActionsList(
                         street: i,
                         actions: widget.actions,
+                        pots: widget.pots,
+                        stackSizes: widget.stackSizes,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/detailed_action_bottom_sheet.dart
+++ b/lib/widgets/detailed_action_bottom_sheet.dart
@@ -5,6 +5,8 @@ Future<Map<String, dynamic>?> showDetailedActionBottomSheet(
   required int potSizeBB,
   required int stackSizeBB,
   required int currentStreet,
+  String? initialAction,
+  int? initialAmount,
 }) {
   return showModalBottomSheet<Map<String, dynamic>>(
     context: context,
@@ -17,6 +19,8 @@ Future<Map<String, dynamic>?> showDetailedActionBottomSheet(
       potSizeBB: potSizeBB,
       stackSizeBB: stackSizeBB,
       currentStreet: currentStreet,
+      initialAction: initialAction,
+      initialAmount: initialAmount,
     ),
   );
 }
@@ -25,11 +29,15 @@ class _DetailedActionSheet extends StatefulWidget {
   final int potSizeBB;
   final int stackSizeBB;
   final int currentStreet;
+  final String? initialAction;
+  final int? initialAmount;
 
   const _DetailedActionSheet({
     required this.potSizeBB,
     required this.stackSizeBB,
     required this.currentStreet,
+    this.initialAction,
+    this.initialAmount,
   });
 
   @override
@@ -47,6 +55,13 @@ class _DetailedActionSheetState extends State<_DetailedActionSheet> {
     super.initState();
     _controller.addListener(_onTextChanged);
     _street = widget.currentStreet;
+    if (widget.initialAction != null) {
+      _action = widget.initialAction;
+      if (widget.initialAmount != null) {
+        _amount = widget.initialAmount!.toDouble();
+        _controller.text = widget.initialAmount!.toString();
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- call `showDetailedActionBottomSheet` when tapping an action tile
- pre-fill the sheet with action data
- update players' action when sheet is confirmed
- plumb pot and stack info down to the list
- remove old dialog-based editing

## Testing
- `flutter format lib/screens/poker_analyzer_screen.dart lib/widgets/collapsible_street_summary.dart lib/widgets/detailed_action_bottom_sheet.dart lib/widgets/street_actions_list.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68443e113810832aa20a2374fda136a8