### PR TITLE
Show central pot chips

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -835,22 +835,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     onCardSelected: selectBoardCard,
                   ),
                   // Pot display in the center of the table
-                  if (_pots[currentStreet] > 0)
+                  if (pot > 0)
                     Positioned.fill(
                       child: IgnorePointer(
                         child: Align(
-                          alignment: const Alignment(0, 0.4),
+                          alignment: Alignment.center,
                           child: Column(
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               CentralPotChips(
-                                amount: _pots[currentStreet],
-                                scale: scale,
+                                amount: pot,
+                                scale: 1.3 * scale,
                               ),
                               SizedBox(height: 4 * scale),
                               CentralPotWidget(
-                                text:
-                                    'Pot: ${_formatAmount(_pots[currentStreet])}',
+                                text: 'Pot: ${_formatAmount(pot)}',
                                 scale: scale,
                               ),
                             ],

--- a/lib/widgets/central_pot_chips.dart
+++ b/lib/widgets/central_pot_chips.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'chip_trail.dart';
+import 'chip_widget.dart';
 
 /// Visual representation of the central pot using chip icons.
 class CentralPotChips extends StatelessWidget {
@@ -18,22 +18,23 @@ class CentralPotChips extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (amount <= 0) return const SizedBox.shrink();
-    final chipCount = (amount / 20).clamp(1, 10).round();
+    final double chipScale = 1.3 * scale;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
       transitionBuilder: (child, animation) => FadeTransition(
         opacity: animation,
         child: ScaleTransition(scale: animation, child: child),
       ),
-      child: Row(
-        key: ValueKey(chipCount),
-        mainAxisSize: MainAxisSize.min,
-        children: List.generate(
-          chipCount,
-          (index) => Padding(
-            padding: EdgeInsets.symmetric(horizontal: 2 * scale),
-            child: MiniChip(color: Colors.orangeAccent, size: 16 * scale),
-          ),
+      child: Container(
+        key: ValueKey(amount),
+        padding: EdgeInsets.all(4 * scale),
+        decoration: BoxDecoration(
+          color: Colors.black45,
+          borderRadius: BorderRadius.circular(12 * scale),
+        ),
+        child: ChipWidget(
+          amount: amount,
+          scale: chipScale,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- display pot visually with CentralPotChips
- style CentralPotChips using ChipWidget with translucent background

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444291611c832a9123e52a796d99f9