### PR TITLE
Add stack overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -789,6 +789,41 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     return Stack(children: chips);
   }
 
+  Widget _buildStackDisplayOverlay() {
+    final screenSize = MediaQuery.of(context).size;
+    final crowded = numberOfPlayers > 6;
+    final scale = crowded ? (screenSize.height < 700 ? 0.8 : 0.9) : 1.0;
+    final tableWidth = screenSize.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screenSize.width / 2 + 10;
+    final extraOffset = numberOfPlayers > 7 ? (numberOfPlayers - 7) * 15.0 : 0.0;
+    final centerY =
+        screenSize.height / 2 - (numberOfPlayers > 6 ? 160 + extraOffset : 120);
+    final radiusX = (tableWidth / 2 - 60) * scale;
+    final radiusY = (tableHeight / 2 + 90) * scale;
+
+    final List<Widget> chips = [];
+    for (int i = 0; i < numberOfPlayers; i++) {
+      final index = (i + heroIndex) % numberOfPlayers;
+      final stack = stackSizes[index] ?? 0;
+      if (stack > 0) {
+        final angle = 2 * pi * (i - heroIndex) / numberOfPlayers + pi / 2;
+        final dx = radiusX * cos(angle);
+        final dy = radiusY * sin(angle);
+        final bias = _verticalBiasFromAngle(angle) * scale;
+        chips.add(Positioned(
+          left: centerX + dx - 10 * scale,
+          top: centerY + dy + bias - 140 * scale,
+          child: ChipWidget(
+            amount: stack,
+            scale: 0.6 * scale,
+          ),
+        ));
+      }
+    }
+    return Stack(children: chips);
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
@@ -1218,6 +1253,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     ...chipTrails,
                     _buildBetChipsOverlay(),
                     _buildInvestedChipsOverlay(),
+                    _buildStackDisplayOverlay(),
                   Align(
                   alignment: Alignment.topRight,
                   child: HudOverlay(


### PR DESCRIPTION
## Summary
- add helper method to render stack sizes above players
- show overlay above bet and investment chips in analyzer screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684448bfb22c832a8270718a379d48a7