### PR TITLE
Add ActionHistoryOverlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -63,6 +63,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
   Map<int, String> playerTypes = {};
 
   bool debugLayout = false;
+  final Set<int> _expandedHistoryStreets = {};
 
   List<String> _positionsForPlayers(int count) {
     return getPositionList(count);
@@ -824,6 +825,101 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
     return Stack(children: chips);
   }
 
+  Widget _buildActionHistoryOverlay() {
+    final visible = actions.take(_playbackIndex).toList();
+    final Map<int, List<ActionEntry>> grouped = {for (var i = 0; i < 4; i++) i: []};
+    for (final a in visible) {
+      grouped[a.street]?.add(a);
+    }
+    final screenWidth = MediaQuery.of(context).size.width;
+    final double scale = screenWidth < 350 ? 0.8 : 1.0;
+    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
+
+    Widget buildChip(ActionEntry a) {
+      final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
+      final text = '$pos: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}';
+      return Container(
+        padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 3 * scale),
+        margin: const EdgeInsets.only(right: 4, bottom: 4),
+        decoration: BoxDecoration(
+          color: _actionColor(a.action).withOpacity(0.8),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            color: _actionTextColor(a.action),
+            fontSize: 11 * scale,
+          ),
+        ),
+      );
+    }
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        color: Colors.black38,
+        height: 70 * scale,
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          itemCount: 4,
+          itemBuilder: (context, index) {
+            final list = grouped[index] ?? [];
+            if (list.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            final expanded = _expandedHistoryStreets.contains(index);
+            final visibleList = expanded || list.length <= 5
+                ? list
+                : list.sublist(list.length - 5);
+            return GestureDetector(
+              onTap: () {
+                setState(() {
+                  if (expanded) {
+                    _expandedHistoryStreets.remove(index);
+                  } else {
+                    _expandedHistoryStreets.add(index);
+                  }
+                });
+              },
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 6),
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: Colors.black54,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      streetNames[index],
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 12 * scale,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: Row(
+                          children: [for (final a in visibleList) buildChip(a)],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
@@ -1254,6 +1350,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
                     _buildBetChipsOverlay(),
                     _buildInvestedChipsOverlay(),
                     _buildStackDisplayOverlay(),
+                    _buildActionHistoryOverlay(),
                   Align(
                   alignment: Alignment.topRight,
                   child: HudOverlay(


### PR DESCRIPTION
## Summary
- add a `Set` to track expanded streets
- implement `_buildActionHistoryOverlay` for compact action history display
- include the overlay under the table in PokerAnalyzerScreen

## Testing
- `flutter format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684449c5787c832a99c6323fcf0f9afd