### PR TITLE
Add street action chip summary

### DIFF
--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'street_actions_list.dart';
+import 'street_action_chip_row.dart';
 
 class CollapsibleStreetSummary extends StatefulWidget {
   final List<ActionEntry> actions;
@@ -31,23 +32,14 @@ class CollapsibleStreetSummary extends StatefulWidget {
 class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
   int? _expandedStreet;
 
-  String _summaryForStreet(int street) {
-    final streetActions =
-        widget.actions.where((a) => a.street == street).toList(growable: false);
-    if (streetActions.isEmpty) return 'Нет действий';
-    final last = streetActions.last;
-    final pos = widget.playerPositions[last.playerIndex] ?? 'P${last.playerIndex + 1}';
-    final act = '${last.action}${last.amount != null ? ' ${last.amount}' : ''}';
-    return '$act $pos';
-  }
-
   @override
   Widget build(BuildContext context) {
     const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
     return Column(
       children: List.generate(4, (i) {
         final expanded = _expandedStreet == i;
-        final summary = _summaryForStreet(i);
+        final streetActions =
+            widget.actions.where((a) => a.street == i).toList(growable: false);
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: Container(
@@ -66,9 +58,16 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                   },
                   child: Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: Text(
-                      '${streetNames[i]}: $summary',
-                      style: const TextStyle(color: Colors.white),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          streetNames[i],
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        const SizedBox(height: 4),
+                        StreetActionChipRow(actions: streetActions),
+                      ],
                     ),
                   ),
                 ),

--- a/lib/widgets/street_action_chip_row.dart
+++ b/lib/widgets/street_action_chip_row.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+
+class StreetActionChipRow extends StatelessWidget {
+  final List<ActionEntry> actions;
+  const StreetActionChipRow({super.key, required this.actions});
+
+  Color _colorForAction(String action) {
+    switch (action) {
+      case 'fold':
+        return Colors.grey;
+      case 'call':
+        return Colors.blue;
+      case 'bet':
+        return Colors.green;
+      case 'raise':
+        return Colors.orange;
+      default:
+        return Colors.white;
+    }
+  }
+
+  String _labelForAction(String action) {
+    switch (action) {
+      case 'fold':
+        return 'F';
+      case 'call':
+        return 'C';
+      case 'bet':
+        return 'B';
+      case 'raise':
+        return 'R';
+      default:
+        return action.isNotEmpty ? action[0].toUpperCase() : '?';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (actions.isEmpty) {
+      return const Text(
+        'Нет действий',
+        style: TextStyle(color: Colors.white54),
+      );
+    }
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (final a in actions)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2.0),
+              child: Container(
+                width: 20,
+                height: 20,
+                decoration: BoxDecoration(
+                  color: _colorForAction(a.action),
+                  shape: BoxShape.circle,
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  _labelForAction(a.action),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show chip-based street action summaries
- tap chip row to expand the street's action list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445583709c832a9cf6454ee510ed41