### PR TITLE
Add centered Pot display widget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/bet_chips_on_table.dart';
 import '../widgets/invested_chip_tokens.dart';
 import '../widgets/central_pot_widget.dart';
 import '../widgets/central_pot_chips.dart';
+import '../widgets/pot_display_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -919,6 +920,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 amount: pot,
                 scale: 1.2 * scale,
               ),
+            ),
+          ),
+        ),
+      ));
+      items.add(Positioned.fill(
+        child: IgnorePointer(
+          child: Align(
+            alignment: const Alignment(0, -0.25),
+            child: PotDisplayWidget(
+              text: 'Pot ${_formatAmount(pot)}',
+              scale: scale,
             ),
           ),
         ),

--- a/lib/widgets/pot_display_widget.dart
+++ b/lib/widgets/pot_display_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+/// Displays the current pot amount with a label.
+class PotDisplayWidget extends StatelessWidget {
+  final String text;
+  final double scale;
+
+  const PotDisplayWidget({
+    Key? key,
+    required this.text,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Container(
+        key: ValueKey(text),
+        padding: EdgeInsets.symmetric(horizontal: 12 * scale, vertical: 6 * scale),
+        decoration: BoxDecoration(
+          color: Colors.black45,
+          borderRadius: BorderRadius.circular(12 * scale),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 16 * scale,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show pot information on the table with new `PotDisplayWidget`
- overlay pot display in the center of the table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684487997c04832aa28b5df30721050a