### PR TITLE
Implement PlayerInfoWidget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1055,11 +1055,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     final dy = radiusY * sin(angle);
                     final bias = _verticalBiasFromAngle(angle) * scale;
 
-                    final isFolded = visibleActions.any((a) =>
+                    final String position = playerPositions[index] ?? '';
+                    final int stack = stackSizes[index] ?? 0;
+                    final String tag = _actionTags[index] ?? '';
+                    final bool isActive = activePlayerIndex == index;
+                    final bool isFolded = visibleActions.any((a) =>
                         a.playerIndex == index &&
                         a.action == 'fold' &&
                         a.street <= currentStreet);
-                    final actionTag = _actionTags[index];
 
                     ActionEntry? lastAction;
                     for (final a in visibleActions.reversed) {
@@ -1164,62 +1167,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         left: centerX + dx - 55 * scale,
                         top: centerY + dy + bias - 55 * scale,
                         child: PlayerInfoWidget(
-                          scale: scale,
-                          playerName: 'Player ${index + 1}',
-                          position: playerPositions[index],
-                          cards: playerCards[index],
-                          isHero: index == heroIndex,
+                          position: position,
+                          stack: stack,
+                          tag: tag,
+                          isActive: isActive,
                           isFolded: isFolded,
-                          isActive: index == activePlayerIndex,
-                          highlightLastAction: index == lastActionPlayerIndex,
-                          showHint: _showActionHints[index],
-                          actionTagText: actionTag,
-                          onCardsSelected: (card) => selectCard(index, card),
-                          playerTypeIcon: _playerTypeIcon(playerTypes[index]),
-                          stack: stackSizes[index] ?? 0,
-                          lastAction: lastAction,
-                          onTap: () async {
-                            setState(() {
-                              activePlayerIndex = index;
-                            });
-                            final result = await showDetailedActionBottomSheet(
-                              context,
-                              potSizeBB: _pots[currentStreet],
-                              stackSizeBB: stackSizes[index] ?? 0,
-                              currentStreet: currentStreet,
-                            );
-                            if (result != null) {
-                              final street = result['street'] as int? ?? currentStreet;
-                              final entry = ActionEntry(
-                                street,
-                                index,
-                                result['action'] as String,
-                                amount: result['amount'] as int?,
-                              );
-                              final existingIndex = actions.lastIndexWhere(
-                                  (a) => a.playerIndex == index && a.street == street);
-                              setState(() {
-                                if (existingIndex != -1) {
-                                  _updateAction(existingIndex, entry);
-                                } else {
-                                  _addAction(entry);
-                                }
-                              });
-                            }
-                            setState(() {
-                              if (activePlayerIndex == index) {
-                                activePlayerIndex = null;
-                              }
-                            });
-                          },
-                          onDoubleTap: () {
-                            setState(() {
-                              heroIndex = index;
-                              _updatePositions();
-                            });
-                          },
-                          onLongPress: () => _selectPlayerType(index),
-                          onStackTap: () => _editStackSize(index),
                         ),
                       ),
                       if (invested > 0) ...[

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,224 +1,68 @@
 import 'package:flutter/material.dart';
-import '../models/card_model.dart';
-import '../models/action_entry.dart';
-import 'player_zone_widget.dart';
 
+/// Compact display for a player's position, stack and last action tag.
 class PlayerInfoWidget extends StatelessWidget {
-  final String playerName;
-  final String? position;
-  final List<CardModel> cards;
-  final bool isHero;
-  final bool isFolded;
-  final bool isActive;
-  final bool highlightLastAction;
-  final bool showHint;
-  final String? actionTagText;
-  final Function(CardModel) onCardsSelected;
-  final double scale;
-  final String playerTypeIcon;
+  final String position;
   final int stack;
-  final ActionEntry? lastAction;
-  final VoidCallback? onTap;
-  final VoidCallback? onDoubleTap;
-  final VoidCallback? onLongPress;
-  final VoidCallback? onStackTap;
+  final String tag;
+  final bool isActive;
+  final bool isFolded;
 
   const PlayerInfoWidget({
     super.key,
-    required this.playerName,
-    this.position,
-    required this.cards,
-    required this.isHero,
-    required this.isFolded,
-    required this.onCardsSelected,
+    required this.position,
     required this.stack,
+    required this.tag,
     this.isActive = false,
-    this.highlightLastAction = false,
-    this.showHint = false,
-    this.actionTagText,
-    this.scale = 1.0,
-    this.playerTypeIcon = '🔘',
-    this.lastAction,
-    this.onTap,
-    this.onDoubleTap,
-    this.onLongPress,
-    this.onStackTap,
+    this.isFolded = false,
   });
 
-  Color _actionColor(String action) {
-    switch (action) {
-      case 'fold':
-        return Colors.red[700]!;
-      case 'call':
-        return Colors.blue[700]!;
-      case 'raise':
-        return Colors.green[600]!;
-      case 'bet':
-        return Colors.amber[700]!;
-      case 'check':
-        return Colors.grey[700]!;
-      default:
-        return Colors.black;
-    }
-  }
-
-  Color _actionTextColor(String action) {
-    return action == 'bet' ? Colors.black : Colors.white;
-  }
-
-  IconData? _actionIcon(String action) {
-    switch (action) {
-      case 'fold':
-        return Icons.close;
-      case 'call':
-        return Icons.call;
-      case 'raise':
-        return Icons.arrow_upward;
-      case 'bet':
-        return Icons.trending_up;
-      case 'check':
-        return Icons.remove;
-      default:
-        return null;
-    }
-  }
-
-  String _actionLabel(ActionEntry entry) {
-    return entry.amount != null
-        ? '${entry.action} ${entry.amount}'
-        : entry.action;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final zone = GestureDetector(
-      onTap: onTap,
-      onDoubleTap: onDoubleTap,
-      onLongPress: onLongPress,
-      child: Row(
+    Widget box = Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(8),
+        border: isActive ? Border.all(color: Colors.orangeAccent, width: 2) : null,
+      ),
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          PlayerZoneWidget(
-            scale: scale,
-            playerName: playerName,
-            position: position,
-            cards: cards,
-            isHero: isHero,
-            isFolded: isFolded,
-            isActive: isActive,
-            highlightLastAction: highlightLastAction,
-            showHint: showHint,
-            actionTagText: actionTagText,
-            onCardsSelected: onCardsSelected,
+          Text(
+            position,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
           ),
-          SizedBox(width: 4 * scale),
-          Text(playerTypeIcon, style: TextStyle(fontSize: 18 * scale)),
+          const SizedBox(height: 4),
+          Text(
+            'Stack: \$stack',
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+          if (tag.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.grey[800],
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                tag,
+                style: const TextStyle(color: Colors.white, fontSize: 10),
+              ),
+            ),
+          ],
         ],
       ),
     );
 
-    final actionWidget = (lastAction != null &&
-            (lastAction!.action == 'bet' ||
-                lastAction!.action == 'raise' ||
-                lastAction!.action == 'call') &&
-            lastAction!.amount != null)
-        ? Container(
-            key: ValueKey('${lastAction!.action}_${lastAction!.amount}'),
-            padding: EdgeInsets.symmetric(
-                horizontal: 10 * scale, vertical: 6 * scale),
-            decoration: BoxDecoration(
-              color: _actionColor(lastAction!.action),
-              borderRadius: BorderRadius.circular(14),
-              boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (_actionIcon(lastAction!.action) != null) ...[
-                  Icon(
-                    _actionIcon(lastAction!.action),
-                    size: 14 * scale,
-                    color: _actionTextColor(lastAction!.action),
-                  ),
-                  SizedBox(width: 4 * scale),
-                ],
-                Text(
-                  _actionLabel(lastAction!),
-                  style: TextStyle(
-                    color: _actionTextColor(lastAction!.action),
-                    fontSize: 13 * scale,
-                  ),
-                ),
-              ],
-            ),
-          )
-        : const SizedBox.shrink();
+    if (isFolded) {
+      box = Opacity(opacity: 0.5, child: box);
+    }
 
-    final stackChip = GestureDetector(
-      onTap: onStackTap,
-      child: _StackChip(key: ValueKey(stack), amount: stack, scale: scale),
-    );
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        zone,
-        AnimatedSwitcher(
-          duration: const Duration(milliseconds: 300),
-          transitionBuilder: (child, animation) => FadeTransition(
-            opacity: animation,
-            child: ScaleTransition(scale: animation, child: child),
-          ),
-          child: actionWidget,
-        ),
-        SizedBox(height: 4 * scale),
-        AnimatedSwitcher(
-          duration: const Duration(milliseconds: 300),
-          transitionBuilder: (child, animation) => FadeTransition(
-            opacity: animation,
-            child: ScaleTransition(scale: animation, child: child),
-          ),
-          child: stackChip,
-        ),
-      ],
-    );
-  }
-}
-
-class _StackChip extends StatelessWidget {
-  final int amount;
-  final double scale;
-
-  const _StackChip({super.key, required this.amount, this.scale = 1.0});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 32 * scale,
-      height: 32 * scale,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          colors: [Colors.orangeAccent, Colors.deepOrange.shade700],
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.6),
-            blurRadius: 4 * scale,
-          ),
-        ],
-      ),
-      child: Text(
-        '$amount',
-        style: TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
-          fontSize: 14 * scale,
-        ),
-      ),
-    );
+    return box;
   }
 }


### PR DESCRIPTION
## Summary
- create a compact `PlayerInfoWidget` to show position, stack and action tag
- simplify `PokerAnalyzerScreen` to use new widget for each player
- remove old detailed player widget and update zone widget comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68448e30f5cc832a82798ddda871e0eb