### PR TITLE
Add last action badge to PlayerInfoWidget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1170,6 +1170,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           position: position,
                           stack: stack,
                           tag: tag,
+                          lastAction: lastAction?.action,
                           isActive: isActive,
                           isFolded: isFolded,
                           isHero: index == heroIndex,

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
-/// Compact display for a player's position, stack and last action tag.
+/// Compact display for a player's position, stack, tag and last action.
 class PlayerInfoWidget extends StatelessWidget {
   final String position;
   final int stack;
   final String tag;
+  /// Last action taken by the player ('fold', 'call', 'bet', 'raise', 'check').
+  final String? lastAction;
   final bool isActive;
   final bool isFolded;
   final bool isHero;
@@ -19,6 +21,7 @@ class PlayerInfoWidget extends StatelessWidget {
     required this.position,
     required this.stack,
     required this.tag,
+    this.lastAction,
     this.isActive = false,
     this.isFolded = false,
     this.isHero = false,
@@ -36,6 +39,37 @@ class PlayerInfoWidget extends StatelessWidget {
         : isHero
             ? Colors.purpleAccent
             : null;
+
+    Color? actionColor;
+    String? actionIcon;
+    String? actionLabel;
+    switch (lastAction) {
+      case 'fold':
+        actionColor = Colors.red;
+        actionIcon = '❌';
+        actionLabel = 'Fold';
+        break;
+      case 'call':
+        actionColor = Colors.blue;
+        actionIcon = '📞';
+        actionLabel = 'Call';
+        break;
+      case 'bet':
+        actionColor = Colors.amber;
+        actionIcon = '💰';
+        actionLabel = 'Bet';
+        break;
+      case 'raise':
+        actionColor = Colors.green;
+        actionIcon = '⬆️';
+        actionLabel = 'Raise';
+        break;
+      case 'check':
+        actionColor = Colors.grey;
+        actionIcon = '✔️';
+        actionLabel = 'Check';
+        break;
+    }
 
     Widget box = Container(
       padding: const EdgeInsets.all(8),
@@ -87,19 +121,50 @@ class PlayerInfoWidget extends StatelessWidget {
       ),
     );
 
+    Widget result = box;
+
+    if (actionColor != null && actionLabel != null) {
+      final badge = Container(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+        decoration: BoxDecoration(
+          color: actionColor,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (actionIcon != null)
+              Text(actionIcon!, style: const TextStyle(fontSize: 10)),
+            if (actionIcon != null) const SizedBox(width: 2),
+            Text(
+              actionLabel!,
+              style: const TextStyle(color: Colors.white, fontSize: 10),
+            ),
+          ],
+        ),
+      );
+      result = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(padding: const EdgeInsets.only(bottom: 4), child: badge),
+          box,
+        ],
+      );
+    }
+
     if (isFolded) {
-      box = Opacity(opacity: 0.5, child: box);
+      result = Opacity(opacity: 0.5, child: result);
     }
 
     if (onLongPress != null) {
-      box = Tooltip(message: 'Change player type', child: box);
+      result = Tooltip(message: 'Change player type', child: result);
     }
 
     return GestureDetector(
       onTap: onTap,
       onDoubleTap: onDoubleTap,
       onLongPress: onLongPress,
-      child: box,
+      child: result,
     );
   }
 }


### PR DESCRIPTION
## Summary
- expand `PlayerInfoWidget` with `lastAction` parameter
- display a color-coded badge showing the last action
- propagate the new parameter from `PokerAnalyzerScreen`

## Testing
- `dart format lib/widgets/player_info_widget.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*
- `flutter format lib/widgets/player_info_widget.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684493500970832a8df0f1d86166f876