### PR TITLE
Add bottom sheet player type selector

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -176,6 +176,23 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  String _playerTypeLabel(String? type) {
+    switch (type) {
+      case 'shark':
+        return 'Shark';
+      case 'fish':
+        return 'Fish';
+      case 'nit':
+        return 'Nit';
+      case 'maniac':
+        return 'Maniac';
+      case 'station':
+        return 'Calling Station';
+      default:
+        return 'Standard';
+    }
+  }
+
   String _evaluateActionQuality(ActionEntry entry) {
     switch (entry.action) {
       case 'raise':
@@ -192,32 +209,28 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   Future<void> _selectPlayerType(int index) async {
-    const types = {
-      'shark': '🦈',
-      'fish': '🐟',
-      'nit': '🧊',
-      'maniac': '🔥',
-      'station': '📞',
-      'standard': '🔘',
-    };
-    final result = await showDialog<String>(
+    const types = [
+      {'key': 'fish', 'icon': '🐟', 'label': 'Fish'},
+      {'key': 'shark', 'icon': '🦈', 'label': 'Shark'},
+      {'key': 'station', 'icon': '☎️', 'label': 'Calling Station'},
+      {'key': 'maniac', 'icon': '🔥', 'label': 'Maniac'},
+      {'key': 'nit', 'icon': '🧊', 'label': 'Nit'},
+      {'key': 'standard', 'icon': '🔘', 'label': 'Standard'},
+    ];
+    final result = await showModalBottomSheet<String>(
       context: context,
-      builder: (context) => SimpleDialog(
-        title: const Text('Тип игрока'),
-        children: [
-          for (final entry in types.entries)
-            SimpleDialogOption(
-              onPressed: () => Navigator.pop(context, entry.key),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(entry.value, style: const TextStyle(fontSize: 20)),
-                  const SizedBox(width: 8),
-                  Text(entry.key),
-                ],
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final t in types)
+              ListTile(
+                leading: Text(t['icon']!, style: const TextStyle(fontSize: 24)),
+                title: Text(t['label']!),
+                onTap: () => Navigator.pop(context, t['key']),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
     if (result != null) {
@@ -1208,6 +1221,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           isFolded: isFolded,
                           isHero: index == heroIndex,
                           playerTypeIcon: _playerTypeIcon(playerTypes[index]),
+                          playerTypeLabel: _playerTypeLabel(playerTypes[index]),
                           onTap: () => setState(() => activePlayerIndex = index),
                           onDoubleTap: () => setState(() {
                             heroIndex = index;

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -11,6 +11,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final bool isFolded;
   final bool isHero;
   final String playerTypeIcon;
+  /// Text label describing the player's type.
+  final String? playerTypeLabel;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
   final VoidCallback? onLongPress;
@@ -26,6 +28,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.isFolded = false,
     this.isHero = false,
     this.playerTypeIcon = '🔘',
+    this.playerTypeLabel,
     this.onTap,
     this.onDoubleTap,
     this.onLongPress,
@@ -115,7 +118,19 @@ class PlayerInfoWidget extends StatelessWidget {
           ],
           Padding(
             padding: const EdgeInsets.only(top: 2),
-            child: Text(playerTypeIcon, style: const TextStyle(fontSize: 14)),
+            child: Column(
+              children: [
+                Text(playerTypeIcon, style: const TextStyle(fontSize: 14)),
+                if (playerTypeLabel != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      playerTypeLabel!,
+                      style: const TextStyle(color: Colors.white60, fontSize: 10),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add optional label to `PlayerInfoWidget`
- show chosen type label next to icon
- open bottom sheet when long pressing a player to pick the type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684499041cf0832a9caed7a45524e387