### PR TITLE
Improve street action history display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1387,6 +1387,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         actions: actions,
                         pots: _pots,
                         stackSizes: stackSizes,
+                        playerPositions: playerPositions,
                         onEdit: _editAction,
                         onDelete: _deleteAction,
                         visibleCount: _playbackIndex,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'street_actions_list.dart';
-import 'street_action_chip_row.dart';
 
 class CollapsibleStreetSummary extends StatefulWidget {
   final List<ActionEntry> actions;
@@ -31,6 +30,41 @@ class CollapsibleStreetSummary extends StatefulWidget {
 
 class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
   int? _expandedStreet;
+
+  Color _colorForAction(String action) {
+    switch (action) {
+      case 'fold':
+        return Colors.red;
+      case 'call':
+        return Colors.blue;
+      case 'raise':
+      case 'bet':
+        return Colors.green;
+      default:
+        return Colors.white;
+    }
+  }
+
+  String _capitalize(String s) =>
+      s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
+
+  Widget _buildHeaderSummary(List<ActionEntry> actions) {
+    if (actions.isEmpty) {
+      return const Text(
+        'Нет действий',
+        style: TextStyle(color: Colors.white54),
+      );
+    }
+    final last = actions.last;
+    final pos =
+        widget.playerPositions[last.playerIndex] ?? 'P${last.playerIndex + 1}';
+    final actionText =
+        '${_capitalize(last.action)}${last.amount != null ? ' ${last.amount}' : ''}';
+    return Text(
+      '$pos $actionText',
+      style: TextStyle(color: _colorForAction(last.action)),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +100,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                           style: const TextStyle(color: Colors.white),
                         ),
                         const SizedBox(height: 4),
-                        StreetActionChipRow(actions: streetActions),
+                        _buildHeaderSummary(streetActions),
                       ],
                     ),
                   ),
@@ -83,6 +117,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                         actions: widget.actions,
                         pots: widget.pots,
                         stackSizes: widget.stackSizes,
+                        playerPositions: widget.playerPositions,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -8,6 +8,7 @@ class StreetActionsList extends StatelessWidget {
   final List<ActionEntry> actions;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final int? visibleCount;
@@ -19,6 +20,7 @@ class StreetActionsList extends StatelessWidget {
     required this.actions,
     required this.pots,
     required this.stackSizes,
+    required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
     this.visibleCount,
@@ -44,9 +46,11 @@ class StreetActionsList extends StatelessWidget {
       default:
         color = Colors.white;
     }
+    final pos =
+        playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
     final title = a.generated
-        ? 'Игрок ${a.playerIndex + 1}: ${a.action}$amountStr (auto)'
-        : 'Игрок ${a.playerIndex + 1}: ${a.action}$amountStr';
+        ? '$pos — ${a.action}$amountStr (auto)'
+        : '$pos — ${a.action}$amountStr';
 
     String? icon;
     if (evaluateActionQuality != null && visibleCount != null) {


### PR DESCRIPTION
## Summary
- show last action summary for each street in CollapsibleStreetSummary
- color code headers by action
- show position in StreetActionsList and wire through playerPositions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68449a0555f8832a9f53e8e203594dcc