### PR TITLE
Add bet indicator display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/invested_chip_tokens.dart';
 import '../widgets/central_pot_widget.dart';
 import '../widgets/central_pot_chips.dart';
 import '../widgets/pot_display_widget.dart';
+import '../widgets/player_bet_indicator.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -899,11 +900,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         final dy = radiusY * sin(angle);
         final bias = _verticalBiasFromAngle(angle) * scale;
         items.add(Positioned(
-          left: centerX + dx - 10 * scale,
-          top: centerY + dy + bias - 80 * scale,
-          child: ChipWidget(
+          left: centerX + dx + 40 * scale,
+          top: centerY + dy + bias - 40 * scale,
+          child: PlayerBetIndicator(
+            action: lastAction.action,
             amount: lastAction.amount!,
-            scale: 0.8 * scale,
+            scale: scale,
           ),
         ));
       }

--- a/lib/widgets/player_bet_indicator.dart
+++ b/lib/widgets/player_bet_indicator.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'chip_trail.dart';
+
+/// Small chip icon with amount text representing a bet, raise or call.
+class PlayerBetIndicator extends StatelessWidget {
+  final String action;
+  final int amount;
+  final double scale;
+
+  const PlayerBetIndicator({
+    Key? key,
+    required this.action,
+    required this.amount,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  Color _color() {
+    switch (action) {
+      case 'raise':
+        return Colors.green;
+      case 'call':
+        return Colors.blue;
+      case 'bet':
+      default:
+        return Colors.amber;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (amount <= 0) return const SizedBox.shrink();
+    final color = _color();
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Container(
+        key: ValueKey('$action-$amount'),
+        padding: EdgeInsets.symmetric(horizontal: 4 * scale, vertical: 2 * scale),
+        decoration: BoxDecoration(
+          color: Colors.black45,
+          borderRadius: BorderRadius.circular(8 * scale),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            MiniChip(color: color, size: 12 * scale),
+            SizedBox(width: 4 * scale),
+            Text(
+              '$amount',
+              style: TextStyle(color: Colors.white, fontSize: 12 * scale),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show mini chip display for bet/raise/call actions
- place indicator beside each player's info and color by action

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68449b0961bc832a80392697c9c68038