### PR TITLE
Implement one-time chip animations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -69,6 +69,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   bool debugLayout = false;
   final Set<int> _expandedHistoryStreets = {};
+  final Set<int> _animatedPlayersPerStreet = {};
 
 
   List<String> _positionsForPlayers(int count) {
@@ -386,6 +387,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   void _updatePlaybackState() {
     final subset = actions.take(_playbackIndex).toList();
+    if (_playbackIndex == 0) {
+      _animatedPlayersPerStreet.clear();
+    }
     _recalculatePots(fromActions: subset);
     _recalculateStreetInvestments(fromActions: subset);
     lastActionPlayerIndex =
@@ -681,6 +685,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _streetInvestments.clear();
         _actionTags.clear();
         _firstActionTaken.clear();
+        _animatedPlayersPerStreet.clear();
         lastActionPlayerIndex = null;
         _playbackIndex = 0;
         _updatePlaybackState();
@@ -747,6 +752,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _recalculateStreetInvestments();
       currentStreet = 0;
       _playbackIndex = 0;
+      _animatedPlayersPerStreet.clear();
       _updatePlaybackState();
       _updatePositions();
     });
@@ -840,6 +846,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         final start =
             Offset(centerX + dx, centerY + dy + bias + 92 * scale);
         final end = Offset.lerp(start, Offset(centerX, centerY), 0.2)!;
+        final animate = !_animatedPlayersPerStreet.contains(index);
+        if (animate) {
+          _animatedPlayersPerStreet.add(index);
+        }
         chips.add(Positioned.fill(
           child: BetChipsOnTable(
             start: start,
@@ -847,6 +857,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             chipCount: (invested / 20).clamp(1, 5).round(),
             color: color,
             scale: scale,
+            animate: animate,
           ),
         ));
       }
@@ -913,6 +924,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         final bias = _verticalBiasFromAngle(angle) * scale;
         final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
         final end = Offset(centerX, centerY);
+        final animate = !_animatedPlayersPerStreet.contains(index);
+        if (animate) {
+          _animatedPlayersPerStreet.add(index);
+        }
         items.add(Positioned.fill(
           child: BetChipsOnTable(
             start: start,
@@ -920,6 +935,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             chipCount: (lastAction.amount! / 20).clamp(1, 5).round(),
             color: _actionColor(lastAction.action),
             scale: scale,
+            animate: animate,
           ),
         ));
         items.add(Positioned(
@@ -1395,6 +1411,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                               _calculatePotForStreet(currentStreet);
                           _recalculateStreetInvestments();
                           _actionTags.clear();
+                          _animatedPlayersPerStreet.clear();
                         });
                       },
                     ),

--- a/lib/widgets/bet_chips_on_table.dart
+++ b/lib/widgets/bet_chips_on_table.dart
@@ -19,6 +19,9 @@ class BetChipsOnTable extends StatelessWidget {
   /// Scale factor to adapt to table scaling.
   final double scale;
 
+  /// Whether to animate the chip appearance.
+  final bool animate;
+
   const BetChipsOnTable({
     Key? key,
     required this.start,
@@ -26,6 +29,7 @@ class BetChipsOnTable extends StatelessWidget {
     required this.chipCount,
     required this.color,
     this.scale = 1.0,
+    this.animate = true,
   }) : super(key: key);
 
   @override
@@ -49,7 +53,8 @@ class BetChipsOnTable extends StatelessWidget {
             child: Transform.rotate(
               angle: angle,
               child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
+                duration:
+                    animate ? const Duration(milliseconds: 300) : Duration.zero,
                 transitionBuilder: (child, animation) => FadeTransition(
                   opacity: animation,
                   child: ScaleTransition(scale: animation, child: child),


### PR DESCRIPTION
## Summary
- add an `animate` flag to `BetChipsOnTable`
- add `_animatedPlayersPerStreet` tracker
- animate chips only the first time per street in overlays
- clear animation state on street or playback reset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68449fb16294832abf0aadeeea351331