### PR TITLE
Add player type badge icon

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -175,7 +175,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       case 'station':
         return '📞';
       default:
-        return '🔘';
+        return '';
     }
   }
 

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -27,7 +27,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.isActive = false,
     this.isFolded = false,
     this.isHero = false,
-    this.playerTypeIcon = '🔘',
+    this.playerTypeIcon = '',
     this.playerTypeLabel,
     this.onTap,
     this.onDoubleTap,
@@ -120,7 +120,8 @@ class PlayerInfoWidget extends StatelessWidget {
             padding: const EdgeInsets.only(top: 2),
             child: Column(
               children: [
-                Text(playerTypeIcon, style: const TextStyle(fontSize: 14)),
+                if (playerTypeIcon.isNotEmpty)
+                  Text(playerTypeIcon, style: const TextStyle(fontSize: 14)),
                 if (playerTypeLabel != null)
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
@@ -192,7 +193,27 @@ class PlayerInfoWidget extends StatelessWidget {
       clickable = _ActivePlayerGlow(child: clickable);
     }
 
-    return clickable;
+    Widget withBadge = clickable;
+    if (playerTypeIcon.isNotEmpty) {
+      withBadge = Stack(
+        clipBehavior: Clip.none,
+        children: [
+          clickable,
+          Positioned(
+            top: -6,
+            right: -6,
+            child: IgnorePointer(
+              child: Text(
+                playerTypeIcon,
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return withBadge;
   }
 }
 


### PR DESCRIPTION
## Summary
- show player type badge on PlayerInfoWidget
- hide badge when player type is standard

## Testing
- `dart` is not installed so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_6844a10752e8832aacb5cc3fd918ada9