### PR TITLE
Add position labels to table HUD

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -96,6 +96,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  String _positionLabelForIndex(int index) {
+    final pos = playerPositions[index];
+    if (pos == null) return '';
+    if (pos.startsWith('UTG')) return 'UTG';
+    if (pos == 'HJ' || pos == 'MP') return 'MP';
+    return pos;
+  }
+
 
   double _verticalBiasFromAngle(double angle) {
     return 90 + 20 * sin(angle);
@@ -1308,6 +1316,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           playerTypeLabel: numberOfPlayers > 9
                               ? null
                               : _playerTypeLabel(playerTypes[index]),
+                          positionLabel: numberOfPlayers <= 9
+                              ? _positionLabelForIndex(index)
+                              : null,
                           onTap: () => setState(() => activePlayerIndex = index),
                           onDoubleTap: () => setState(() {
                             heroIndex = index;

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Compact display for a player's position, stack, tag and last action.
+/// Optionally shows a simplified position label as a badge.
 class PlayerInfoWidget extends StatelessWidget {
   final String position;
   final int stack;
@@ -13,6 +14,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final String playerTypeIcon;
   /// Text label describing the player's type.
   final String? playerTypeLabel;
+  /// Simplified position label shown as a badge.
+  final String? positionLabel;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
   final VoidCallback? onLongPress;
@@ -29,6 +32,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.isHero = false,
     this.playerTypeIcon = '',
     this.playerTypeLabel,
+    this.positionLabel,
     this.onTap,
     this.onDoubleTap,
     this.onLongPress,
@@ -94,6 +98,23 @@ class PlayerInfoWidget extends StatelessWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
+          if (positionLabel != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.grey[700],
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  positionLabel!,
+                  style:
+                      const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
           const SizedBox(height: 4),
           GestureDetector(
             onTap: onStackTap,


### PR DESCRIPTION
## Summary
- support a `positionLabel` badge in `PlayerInfoWidget`
- map player positions to simplified labels in PokerAnalyzerScreen
- show labels under each player's seat when there are nine or fewer players

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a45c2550832a8580257042089a3f