### PR TITLE
Add hero badge to player info

### DIFF
--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -95,13 +95,32 @@ class PlayerInfoWidget extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (isHero) const Text('🦸', style: TextStyle(fontSize: 12)),
-          Text(
-            position,
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                position,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              if (isHero)
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[700],
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text(
+                      '🧙‍♂️ Hero',
+                      style: TextStyle(color: Colors.white, fontSize: 10),
+                    ),
+                  ),
+                ),
+            ],
           ),
           if (positionLabel != null)
             Padding(


### PR DESCRIPTION
## Summary
- display a "🧙‍♂️ Hero" badge next to the position text when the player is hero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844ab2c9d60832aa2ec5c409611f3d5