### PR TITLE
Add chip stack visualization for players

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -21,6 +21,7 @@ import '../widgets/central_pot_widget.dart';
 import '../widgets/central_pot_chips.dart';
 import '../widgets/pot_display_widget.dart';
 import '../widgets/player_bet_indicator.dart';
+import '../widgets/player_stack_chips.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -1552,7 +1553,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       Positioned(
                         left: centerX + dx - 55 * scale * infoScale,
                         top: centerY + dy + bias - 55 * scale * infoScale,
-                        child: Transform.scale(
+                      child: Transform.scale(
                           scale: infoScale,
                           child: PlayerInfoWidget(
                           position: position,
@@ -1582,6 +1583,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           onRemove:
                               numberOfPlayers > 2 ? () { _removePlayer(index); } : null,
                           ),
+                        ),
+                      ),
+                      Positioned(
+                        left: centerX + dx - 12 * scale,
+                        top: centerY + dy + bias + 70 * scale,
+                        child: PlayerStackChips(
+                          stack: stack,
+                          scale: scale * 0.9,
                         ),
                       ),
                       if (lastAction != null)

--- a/lib/widgets/player_stack_chips.dart
+++ b/lib/widgets/player_stack_chips.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+/// Displays a small pile of chips representing the player's remaining stack.
+class PlayerStackChips extends StatelessWidget {
+  /// Player stack in big blinds or chip units.
+  final int stack;
+
+  /// Scale factor depending on table size.
+  final double scale;
+
+  const PlayerStackChips({
+    Key? key,
+    required this.stack,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  Color _colorForStack() {
+    if (stack >= 50) return Colors.redAccent;
+    if (stack >= 10) return Colors.orangeAccent;
+    return Colors.blueAccent;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (stack <= 0) return const SizedBox.shrink();
+    final chipCount = (stack / 10).clamp(1, 10).round();
+    final double size = 10 * scale;
+    final color = _colorForStack();
+
+    return SizedBox(
+      width: size * 2,
+      height: size + chipCount * size * 0.35,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          for (int i = 0; i < chipCount; i++)
+            Positioned(
+              bottom: i * size * 0.35,
+              child: Container(
+                width: size * 2,
+                height: size,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: LinearGradient(
+                    colors: [color, Colors.black],
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.6),
+                      blurRadius: 3,
+                      offset: const Offset(1, 2),
+                    )
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `PlayerStackChips` widget for visualizing remaining stack as chips
- import and render `PlayerStackChips` for each player on `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844acff5d80832aa39ae80e2a01e7d9