### PR TITLE
Add All-in quick sizing button

### DIFF
--- a/lib/widgets/detailed_action_bottom_sheet.dart
+++ b/lib/widgets/detailed_action_bottom_sheet.dart
@@ -203,6 +203,7 @@ class _DetailedActionSheetState extends State<_DetailedActionSheet> {
                 _quickSizeButton('1/3 pot', 1 / 3),
                 _quickSizeButton('1/2 pot', 1 / 2),
                 _quickSizeButton('pot', 1),
+                _quickSizeButton('All-in', widget.stackSizeBB / widget.potSizeBB),
               ],
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- add "All-in" button to quick sizing options in `DetailedActionBottomSheet`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844b072c808832abe0679f848583c62