### PR TITLE
Add pot overlay widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class PokerAIAnalyzerApp extends StatelessWidget {
               displayColor: Colors.white,
             ),
       ),
-      home: const PokerAnalyzerScreen(),
+      home: const PokerAnalyzerScreen(potAmount: 0),
     );
   }
 }

--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -72,7 +72,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                 if (text.isNotEmpty) {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (context) => const PokerAnalyzerScreen(),
+                      builder: (context) => const PokerAnalyzerScreen(potAmount: 0),
                     ),
                   );
                 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -7,7 +7,8 @@ import '../models/card_model.dart';
 import '../models/action_entry.dart';
 import '../widgets/player_zone_widget.dart';
 import '../widgets/street_actions_widget.dart';
-import '../widgets/board_cards_widget.dart';
+
+import '../widgets/pot_over_board_widget.dart';
 import '../widgets/detailed_action_bottom_sheet.dart';
 import '../widgets/chip_widget.dart';
 import '../widgets/player_info_widget.dart';
@@ -1491,6 +1492,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     boardCards: boardCards,
                     onCardSelected: selectBoardCard,
                   ),
+                  PotOverBoardWidget(potAmount: widget.potAmount, scale: scale),
                   for (int i = 0; i < numberOfPlayers; i++) {
                     final index = (i + heroIndex) % numberOfPlayers;
                     final angle =

--- a/lib/widgets/pot_over_board_widget.dart
+++ b/lib/widgets/pot_over_board_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+/// Displays current pot size above the board cards.
+class PotOverBoardWidget extends StatelessWidget {
+  /// Current pot size in big blinds.
+  final double potAmount;
+
+  /// Scale factor to adapt to table size.
+  final double scale;
+
+  const PotOverBoardWidget({
+    Key? key,
+    required this.potAmount,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: Align(
+          alignment: const Alignment(0, -0.05),
+          child: Transform.translate(
+            offset: Offset(0, -15 * scale),
+            child: Opacity(
+              opacity: 0.7,
+              child: Text(
+                'Pot: ${potAmount.toStringAsFixed(1)} BB',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14 * scale,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- display the current pot over the board
- pass potAmount into PokerAnalyzerScreen
- expose PotOverBoardWidget

## Testing
- `dart` or `flutter` commands not available to run formatting


------
https://chatgpt.com/codex/tasks/task_e_6844b1fc8198832abd04a9db11dff4a7