### PR TITLE
Enhance pot overlay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class PokerAIAnalyzerApp extends StatelessWidget {
               displayColor: Colors.white,
             ),
       ),
-      home: const PokerAnalyzerScreen(potAmount: 0),
+      home: const PokerAnalyzerScreen(),
     );
   }
 }

--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -72,7 +72,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                 if (text.isNotEmpty) {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (context) => const PokerAnalyzerScreen(potAmount: 0),
+                      builder: (context) => const PokerAnalyzerScreen(),
                     ),
                   );
                 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1492,7 +1492,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     boardCards: boardCards,
                     onCardSelected: selectBoardCard,
                   ),
-                  PotOverBoardWidget(potAmount: widget.potAmount, scale: scale),
+                  PotOverBoardWidget(
+                    visibleActions: visibleActions,
+                    currentStreet: currentStreet,
+                    scale: scale,
+                  ),
                   for (int i = 0; i < numberOfPlayers; i++) {
                     final index = (i + heroIndex) % numberOfPlayers;
                     final angle =

--- a/lib/widgets/pot_over_board_widget.dart
+++ b/lib/widgets/pot_over_board_widget.dart
@@ -1,21 +1,38 @@
 import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
 
 /// Displays current pot size above the board cards.
 class PotOverBoardWidget extends StatelessWidget {
-  /// Current pot size in big blinds.
-  final double potAmount;
+  /// Visible actions up to the current playback index.
+  final List<ActionEntry> visibleActions;
+
+  /// Current street index. 0 = preflop, 1 = flop, ...
+  final int currentStreet;
 
   /// Scale factor to adapt to table size.
   final double scale;
 
   const PotOverBoardWidget({
     Key? key,
-    required this.potAmount,
+    required this.visibleActions,
+    required this.currentStreet,
     this.scale = 1.0,
   }) : super(key: key);
 
+  double _calculatePot() {
+    return visibleActions
+        .where((a) =>
+            a.street <= currentStreet &&
+            (a.action == 'call' || a.action == 'bet' || a.action == 'raise'))
+        .fold<double>(0, (sum, a) => sum + (a.amount ?? 0).toDouble());
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (currentStreet < 1) {
+      return const SizedBox.shrink();
+    }
+    final potAmount = _calculatePot();
     return Positioned.fill(
       child: IgnorePointer(
         child: Align(


### PR DESCRIPTION
## Summary
- compute pot within `PotOverBoardWidget`
- embed overlay in `PokerAnalyzerScreen`
- remove unused `potAmount` parameter

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844b30e99cc832ab5ace594f19667e1