### PR TITLE
Show bet chip tokens above players

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/pot_display_widget.dart';
 import '../widgets/player_bet_indicator.dart';
 import '../widgets/player_stack_chips.dart';
 import '../widgets/bet_stack_chips.dart';
+import '../widgets/chip_amount_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 
@@ -1522,6 +1523,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       }
                     }
 
+                    ActionEntry? lastAmountAction;
+                    for (final a in visibleActions.reversed) {
+                      if (a.playerIndex == index &&
+                          a.street == currentStreet &&
+                          (a.action == 'bet' ||
+                              a.action == 'raise' ||
+                              a.action == 'call') &&
+                          a.amount != null) {
+                        lastAmountAction = a;
+                        break;
+                      }
+                    }
+
                     final invested =
                         _streetInvestments[currentStreet]?[index] ?? 0;
 
@@ -1637,6 +1651,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           ),
                         ),
                       ),
+                      if (lastAmountAction != null)
+                        Positioned(
+                          left: centerX + dx - 24 * scale,
+                          top: centerY + dy + bias - 80 * scale,
+                          child: ChipAmountWidget(
+                            amount: lastAmountAction!.amount!.toDouble(),
+                            color: _actionColor(lastAmountAction!.action),
+                            scale: scale,
+                          ),
+                        ),
                       Positioned(
                         left: centerX + dx - 12 * scale,
                         top: centerY + dy + bias + 70 * scale,

--- a/lib/widgets/chip_amount_widget.dart
+++ b/lib/widgets/chip_amount_widget.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Displays a small chip-like label with amount in big blinds.
+class ChipAmountWidget extends StatelessWidget {
+  /// Amount in big blinds.
+  final double amount;
+
+  /// Background color of the chip label.
+  final Color color;
+
+  /// Scale factor for size.
+  final double scale;
+
+  const ChipAmountWidget({
+    Key? key,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  String _format(double value) {
+    if (value % 1 == 0) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = '${_format(amount)} BB';
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Container(
+        key: ValueKey(text),
+        padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 4 * scale),
+        decoration: BoxDecoration(
+          color: color.withOpacity(0.9),
+          borderRadius: BorderRadius.circular(12 * scale),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(color: Colors.white, fontSize: 12 * scale),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ChipAmountWidget` to display bet amounts in BB
- show chip amount animations above each active player in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844b440b7e4832aa499e08b3262418a