### PR TITLE
Add action timeline widget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -27,6 +27,7 @@ import '../widgets/bet_stack_chips.dart';
 import '../widgets/chip_amount_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
+import '../widgets/action_timeline_widget.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   const PokerAnalyzerScreen({super.key});
@@ -564,6 +565,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _recalculateStreetInvestments(fromActions: subset);
     lastActionPlayerIndex =
         subset.isNotEmpty ? subset.last.playerIndex : null;
+  }
+
+  void _updateVisibleActions() {
+    _updatePlaybackState();
   }
 
   void _playStepForward() {
@@ -1756,6 +1761,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             ),
           ),
         ),
+            ActionTimelineWidget(
+              actions: visibleActions,
+              playbackIndex: _playbackIndex,
+              onTap: (index) {
+                setState(() {
+                  _playbackIndex = index;
+                  _updateVisibleActions(); // Перестраиваем экран
+                });
+              },
+              scale: scale,
+            ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: Row(

--- a/lib/widgets/action_timeline_widget.dart
+++ b/lib/widgets/action_timeline_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+
+/// Displays a timeline of all visible actions with interaction support.
+class ActionTimelineWidget extends StatelessWidget {
+  final List<ActionEntry> actions;
+  final int playbackIndex;
+  final Function(int index) onTap;
+  final double scale;
+
+  const ActionTimelineWidget({
+    Key? key,
+    required this.actions,
+    required this.playbackIndex,
+    required this.onTap,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 48 * scale,
+      padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 4 * scale),
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: actions.length,
+        itemBuilder: (context, index) {
+          final action = actions[index];
+          final isSelected = index == playbackIndex;
+
+          return GestureDetector(
+            onTap: () => onTap(index),
+            child: Container(
+              margin: EdgeInsets.symmetric(horizontal: 4 * scale),
+              padding: EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 6 * scale),
+              decoration: BoxDecoration(
+                color: isSelected ? Colors.deepPurple : Colors.grey[800],
+                borderRadius: BorderRadius.circular(8 * scale),
+                border: Border.all(color: Colors.white24),
+              ),
+              child: Text(
+                '${action.position} ${action.action} ${action.amount ?? ''}',
+                style: TextStyle(
+                  color: isSelected ? Colors.white : Colors.white70,
+                  fontSize: 12 * scale,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ActionTimelineWidget` for scrolling action list
- integrate timeline with playback controls in `PokerAnalyzerScreen`
- support rebuilding visible actions via `_updateVisibleActions`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844b5a2afc0832a9b0c602e26945c6d