### PR TITLE
Fix mutating final ActionEntry fields

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -938,9 +938,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       heroIndex = updatedHeroIndex;
       // Remove actions for this player and adjust indices
       actions.removeWhere((a) => a.playerIndex == index);
-      for (final a in actions) {
+      for (int i = 0; i < actions.length; i++) {
+        final a = actions[i];
         if (a.playerIndex > index) {
-          a.playerIndex -= 1;
+          actions[i] = ActionEntry(
+            a.street,
+            a.playerIndex - 1,
+            a.action,
+            amount: a.amount,
+            generated: a.generated,
+          );
         }
       }
       // Shift player-specific data


### PR DESCRIPTION
## Summary
- update player removal logic to rebuild ActionEntry entries instead of mutating

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844bcb6a938832a9be7ebcd539959c2