### PR TITLE
Improve PokerAnalyzer UI layout

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -121,8 +121,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   double _centerYOffset(double scale) {
-    final base = numberOfPlayers > 6 ? 180.0 : 140.0;
-    final extra = numberOfPlayers > 7 ? (numberOfPlayers - 7) * 15.0 : 0.0;
+    final base = numberOfPlayers > 6 ? 200.0 : 140.0;
+    final extra = numberOfPlayers > 7 ? (numberOfPlayers - 7) * 20.0 : 0.0;
     return (base + extra) * scale;
   }
 
@@ -1515,6 +1515,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             ),
           ),
         ),
+            StreetActionsWidget(
+              currentStreet: currentStreet,
+              onStreetChanged: (index) {
+                setState(() {
+                  currentStreet = index;
+                  _pots[currentStreet] = _calculatePotForStreet(currentStreet);
+                  _recalculateStreetInvestments();
+                  _actionTags.clear();
+                  _animatedPlayersPerStreet.clear();
+                });
+              },
+            ),
             ActionTimelineWidget(
               actions: visibleActions,
               playbackIndex: _playbackIndex,
@@ -1578,19 +1590,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       visibleCount: _playbackIndex,
                       evaluateActionQuality: _evaluateActionQuality,
                     ),
-                    StreetActionsWidget(
-                      currentStreet: currentStreet,
-                      onStreetChanged: (index) {
-                        setState(() {
-                          currentStreet = index;
-                          _pots[currentStreet] =
-                              _calculatePotForStreet(currentStreet);
-                          _recalculateStreetInvestments();
-                          _actionTags.clear();
-                          _animatedPlayersPerStreet.clear();
-                        });
-                      },
-                    ),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16.0),
                       child: StreetActionsList(
@@ -1614,6 +1613,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                           labelText: 'Комментарий к раздаче',
                         ),
                       ),
+                    ),
+                    const SizedBox(height: 10),
+                    TextButton(
+                      onPressed: () {},
+                      child: const Text('🔍 Проанализировать'),
                     ),
                     const SizedBox(height: 10),
                     TextButton(
@@ -1750,6 +1754,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             position: position,
             stack: stack,
             tag: tag,
+            cards: playerCards[index],
             lastAction: lastAction?.action,
             showLastIndicator: lastStreetAction?.playerIndex == index,
             isActive: isActive,

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../models/card_model.dart';
 
 /// Compact display for a player's position, stack, tag and last action.
 /// Optionally shows a simplified position label as a badge.
@@ -7,6 +8,7 @@ class PlayerInfoWidget extends StatelessWidget {
   final String position;
   final int stack;
   final String tag;
+  final List<CardModel> cards;
   /// Last action taken by the player ('fold', 'call', 'bet', 'raise', 'check').
   final String? lastAction;
   final bool isActive;
@@ -34,6 +36,7 @@ class PlayerInfoWidget extends StatelessWidget {
     required this.position,
     required this.stack,
     required this.tag,
+    this.cards = const [],
     this.lastAction,
     this.isActive = false,
     this.isFolded = false,
@@ -90,13 +93,12 @@ class PlayerInfoWidget extends StatelessWidget {
     }
 
     Widget box = Container(
-      padding: const EdgeInsets.all(8),
+      padding: const EdgeInsets.all(6),
       decoration: BoxDecoration(
-        color: Colors.black87,
+        color: Colors.black.withOpacity(0.6),
         borderRadius: BorderRadius.circular(8),
-        border: borderColor != null
-            ? Border.all(color: borderColor, width: 2)
-            : null,
+        border: Border.all(
+            color: borderColor ?? Colors.white24, width: borderColor != null ? 2 : 1),
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -143,6 +145,37 @@ class PlayerInfoWidget extends StatelessWidget {
                   style:
                       const TextStyle(color: Colors.white, fontSize: 10),
                 ),
+              ),
+            ),
+          if (cards.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(2, (idx) {
+                  final card = idx < cards.length ? cards[idx] : null;
+                  final isRed = card?.suit == '♥' || card?.suit == '♦';
+                  return Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 2),
+                    width: 22,
+                    height: 30,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    alignment: Alignment.center,
+                    child: card != null
+                        ? Text(
+                            '${card.rank}${card.suit}',
+                            style: TextStyle(
+                              color: isRed ? Colors.red : Colors.black,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  );
+                }),
               ),
             ),
           const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- adjust PlayerInfoWidget style and allow showing player cards
- tweak table center offset for many players
- show StreetActionsWidget above the timeline
- render player cards in player info
- add placeholder hand analysis button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844d865a90c832a958678a114bf9a5b