### PR TITLE
Update chip and info widget styling

### DIFF
--- a/lib/widgets/chip_widget.dart
+++ b/lib/widgets/chip_widget.dart
@@ -13,16 +13,21 @@ class ChipWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final double size = 30 * scale;
     return Container(
-      padding:
-          EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 5 * scale),
-      decoration: BoxDecoration(
-        color: Colors.green.shade700.withOpacity(0.8),
-        borderRadius: BorderRadius.circular(12),
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: Colors.black38,
+        border: Border.all(color: Colors.white, width: 1),
+        boxShadow: [BoxShadow(color: Colors.black45, blurRadius: 2)],
       ),
       child: Text(
         '\$${amount}',
-        style: TextStyle(color: Colors.white, fontSize: 14 * scale),
+        style: TextStyle(color: Colors.white, fontSize: 12 * scale),
+        textAlign: TextAlign.center,
       ),
     );
   }

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -98,10 +98,11 @@ class PlayerInfoWidget extends StatelessWidget {
     Widget box = Container(
       padding: const EdgeInsets.all(6),
       decoration: BoxDecoration(
-        color: Colors.black.withOpacity(0.6),
+        color: Colors.black.withOpacity(0.3),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
             color: borderColor ?? Colors.white24, width: borderColor != null ? 2 : 1),
+        boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 2)],
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -207,7 +208,7 @@ class PlayerInfoWidget extends StatelessWidget {
                 builder: (context) => StatefulBuilder(
                   builder: (context, setState) {
                     return AlertDialog(
-                      backgroundColor: Colors.black87,
+                      backgroundColor: Colors.black.withOpacity(0.3),
                       title: const Text(
                         'Edit Stack',
                         style: TextStyle(color: Colors.white),


### PR DESCRIPTION
## Summary
- lighten PlayerInfoWidget background and add subtle shadow
- lighten edit stack dialog background
- redesign ChipWidget to be a circular chip icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844dbeca854832abbaf1e32dcaede61