### PR TITLE
Enable card editing in player info

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/invested_chip_tokens.dart';
 import '../widgets/central_pot_widget.dart';
 import '../widgets/central_pot_chips.dart';
 import '../widgets/pot_display_widget.dart';
+import '../widgets/card_selector.dart';
 import '../widgets/player_bet_indicator.dart';
 import '../widgets/player_stack_chips.dart';
 import '../widgets/bet_stack_chips.dart';
@@ -481,6 +482,22 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       boardCards.removeWhere((c) => c == card);
       if (playerCards[index].length < 2) {
         playerCards[index].add(card);
+      }
+    });
+  }
+
+  Future<void> _onPlayerCardTap(int index, int cardIndex) async {
+    final selectedCard = await showCardSelector(context);
+    if (selectedCard == null) return;
+    setState(() {
+      for (final cards in playerCards) {
+        cards.removeWhere((c) => c == selectedCard);
+      }
+      boardCards.removeWhere((c) => c == selectedCard);
+      if (playerCards[index].length > cardIndex) {
+        playerCards[index][cardIndex] = selectedCard;
+      } else if (playerCards[index].length == cardIndex) {
+        playerCards[index].add(selectedCard);
       }
     });
   }
@@ -1783,6 +1800,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     playerPositions[index] == 'BB')
                 ? playerPositions[index]
                 : null,
+            onCardTap: (cardIndex) => _onPlayerCardTap(index, cardIndex),
             onTap: () => setState(() => activePlayerIndex = index),
             onDoubleTap: () => setState(() {
               heroIndex = index;

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -32,6 +32,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final ValueChanged<int>? onStackTap;
   /// Called when the remove icon is tapped.
   final VoidCallback? onRemove;
+  /// Called when a card slot is tapped. The index corresponds to 0 or 1.
+  final void Function(int index)? onCardTap;
 
   const PlayerInfoWidget({
     super.key,
@@ -53,6 +55,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.onEdit,
     this.onStackTap,
     this.onRemove,
+    this.onCardTap,
     this.showLastIndicator = false,
   });
 
@@ -166,15 +169,17 @@ class PlayerInfoWidget extends StatelessWidget {
                 ),
               ),
             ),
-          if (cards.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: List.generate(2, (idx) {
-                  final card = idx < cards.length ? cards[idx] : null;
-                  final isRed = card?.suit == '♥' || card?.suit == '♦';
-                  return Container(
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(2, (idx) {
+                final card = idx < cards.length ? cards[idx] : null;
+                final isRed = card?.suit == '♥' || card?.suit == '♦';
+                return GestureDetector(
+                  onTap: onCardTap != null ? () => onCardTap!(idx) : null,
+                  behavior: HitTestBehavior.opaque,
+                  child: Container(
                     margin: const EdgeInsets.symmetric(horizontal: 2),
                     width: 22,
                     height: 30,
@@ -192,11 +197,12 @@ class PlayerInfoWidget extends StatelessWidget {
                               fontSize: 12,
                             ),
                           )
-                        : const SizedBox.shrink(),
-                  );
-                }),
-              ),
+                        : const Icon(Icons.add, size: 14, color: Colors.grey),
+                  ),
+                );
+              }),
             ),
+          ),
           const SizedBox(height: 4),
           GestureDetector(
             onTap: () async {


### PR DESCRIPTION
## Summary
- pass card tap callback into `PlayerInfoWidget`
- allow selecting a new card for a player via card selector
- show empty card slots with add icons for editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844e05d06cc832aa6ff0987b5673d41