### PR TITLE
Add clipboard export/import for last saved hand

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1184,6 +1184,32 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
   }
 
+  Future<void> exportLastSavedHand() async {
+    if (savedHands.isEmpty) return;
+    final jsonStr = jsonEncode(savedHands.last.toJson());
+    await Clipboard.setData(ClipboardData(text: jsonStr));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Раздача скопирована.')),
+    );
+  }
+
+  Future<void> importHandFromClipboard() async {
+    final data = await Clipboard.getData('text/plain');
+    if (data == null || data.text == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Неверный формат данных.')),
+      );
+      return;
+    }
+    try {
+      loadHand(data.text!);
+    } catch (_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Неверный формат данных.')),
+      );
+    }
+  }
+
 
 
   @override
@@ -1664,6 +1690,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   IconButton(
                     icon: const Icon(Icons.folder_open, color: Colors.white),
                     onPressed: loadLastSavedHand,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.upload, color: Colors.white),
+                    onPressed: exportLastSavedHand,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.download, color: Colors.white),
+                    onPressed: importHandFromClipboard,
                   ),
                   Expanded(
                     child: Slider(


### PR DESCRIPTION
## Summary
- add clipboard import/export logic for saved hands
- add upload/download icon buttons to UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845945362b4832a84288e3d4bdfa0c5