### PR TITLE
Add comment persistence and UI field

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1138,7 +1138,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       stackSizes: Map<int, int>.from(stackSizes),
       playerPositions: Map<int, String>.from(playerPositions),
       playerTypes: Map<int, String>.from(playerTypes),
-      comment: null,
+      comment:
+          _commentController.text.isNotEmpty ? _commentController.text : null,
     );
     setState(() {
       savedHands.add(hand);
@@ -1734,6 +1735,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     ),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: TextField(
+                        controller: _commentController,
+                        maxLines: 3,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: const InputDecoration(
+                          labelText: 'Комментарий к раздаче',
+                          labelStyle: TextStyle(color: Colors.white),
+                          filled: true,
+                          fillColor: Colors.white12,
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
                       child: StreetActionsList(
                         street: currentStreet,
                         actions: actions,
@@ -1744,16 +1760,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         onDelete: _deleteAction,
                         visibleCount: _playbackIndex,
                         evaluateActionQuality: _evaluateActionQuality,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: TextField(
-                        controller: _commentController,
-                        style: const TextStyle(color: Colors.white),
-                        decoration: const InputDecoration(
-                          labelText: 'Комментарий к раздаче',
-                        ),
                       ),
                     ),
                     const SizedBox(height: 10),


### PR DESCRIPTION
## Summary
- add comment field styling and reposition it under CollapsibleStreetSummary
- persist comment in SavedHand when saving
- restore comment text when loading hands

## Testing
- `dart` or `flutter` not available, so no checks were run

------
https://chatgpt.com/codex/tasks/task_e_68459c7af868832aae5c8aa8d663c3ff