### PR TITLE
Add tags to saved hands

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -13,6 +13,7 @@ class SavedHand {
   final Map<int, String> playerPositions;
   final Map<int, String>? playerTypes;
   final String? comment;
+  final List<String> tags;
 
   SavedHand({
     required this.name,
@@ -26,7 +27,8 @@ class SavedHand {
     required this.playerPositions,
     this.playerTypes,
     this.comment,
-  });
+    List<String>? tags,
+  }) : tags = tags ?? [];
 
   Map<String, dynamic> toJson() => {
         'name': name,
@@ -53,6 +55,7 @@ class SavedHand {
         if (playerTypes != null)
           'playerTypes': playerTypes!.map((k, v) => MapEntry(k.toString(), v)),
         if (comment != null) 'comment': comment,
+        'tags': tags,
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -80,6 +83,7 @@ class SavedHand {
     (json['playerPositions'] as Map? ?? {}).forEach((key, value) {
       positions[int.parse(key as String)] = value as String;
     });
+    final tags = [for (final t in (json['tags'] as List? ?? [])) t as String];
     Map<int, String> types = {};
     if (json['playerTypes'] != null) {
       (json['playerTypes'] as Map).forEach((key, value) {
@@ -102,6 +106,7 @@ class SavedHand {
       playerPositions: positions,
       playerTypes: types,
       comment: json['comment'] as String?,
+      tags: tags,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -66,6 +66,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     9: 100,
   };
   final TextEditingController _commentController = TextEditingController();
+  final TextEditingController _tagsController = TextEditingController();
   final List<bool> _showActionHints = List.filled(10, true);
   final Set<int> _firstActionTaken = {};
   int? activePlayerIndex;
@@ -1059,6 +1060,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         for (int i = 0; i < _showActionHints.length; i++) {
           _showActionHints[i] = true;
         }
+        _commentController.clear();
+        _tagsController.clear();
       });
     }
   }
@@ -1087,6 +1090,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       playerPositions: Map<int, String>.from(playerPositions),
       playerTypes: Map<int, String>.from(playerTypes),
       comment: _commentController.text.isNotEmpty ? _commentController.text : null,
+      tags: _tagsController.text
+          .split(',')
+          .map((t) => t.trim())
+          .where((t) => t.isNotEmpty)
+          .toList(),
     );
   }
 
@@ -1127,6 +1135,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         ..addAll(hand.playerTypes ??
             {for (final k in hand.playerPositions.keys) k: 'standard'});
       _commentController.text = hand.comment ?? '';
+      _tagsController.text = hand.tags.join(', ');
       _recalculatePots();
       _recalculateStreetInvestments();
       currentStreet = 0;
@@ -1239,6 +1248,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                                 playerPositions: Map<int, String>.from(old.playerPositions),
                                 playerTypes: Map<int, String>.from(old.playerTypes),
                                 comment: old.comment,
+                                tags: List<String>.from(old.tags),
                               );
                             });
                             setStateDialog(() {});
@@ -1373,6 +1383,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _activeTimer?.cancel();
     _playbackTimer?.cancel();
     _commentController.dispose();
+    _tagsController.dispose();
     super.dispose();
   }
 
@@ -1908,6 +1919,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         style: const TextStyle(color: Colors.white),
                         decoration: const InputDecoration(
                           labelText: 'Комментарий к раздаче',
+                          labelStyle: TextStyle(color: Colors.white),
+                          filled: true,
+                          fillColor: Colors.white12,
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: TextField(
+                        controller: _tagsController,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: const InputDecoration(
+                          labelText: 'Теги (через запятую)',
                           labelStyle: TextStyle(color: Colors.white),
                           filled: true,
                           fillColor: Colors.white12,


### PR DESCRIPTION
## Summary
- extend `SavedHand` model with `tags` list
- add tag input field in analyzer screen
- persist tag data when saving/loading hands
- clear tag field when resetting

## Testing
- `dart`/`flutter` not installed, so skipped formatting and tests

------
https://chatgpt.com/codex/tasks/task_e_6845e0aed4e4832aab5021a0ac100b09