### PR TITLE
Show tags in saved hand selector

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1199,7 +1199,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 final title =
                     hand.name.isNotEmpty ? hand.name : 'Без названия';
                 return ListTile(
-                  title: Text(title),
+                  dense: true,
+                  title: Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  subtitle: hand.tags.isNotEmpty
+                      ? Text(
+                          hand.tags.join(', '),
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 12,
+                          ),
+                        )
+                      : null,
                   onTap: () => Navigator.pop(context, hand),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- display tags alongside saved hand names in `loadHandByName`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e1f38aac832ab1477e10d8275885