### PR TITLE
Add training pack screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 // lib/main.dart
 
 import 'package:flutter/material.dart';
-import 'screens/poker_analyzer_screen.dart';
+import 'screens/main_menu_screen.dart';
 
 void main() {
   runApp(const PokerAIAnalyzerApp());
@@ -24,7 +24,7 @@ class PokerAIAnalyzerApp extends StatelessWidget {
               displayColor: Colors.white,
             ),
       ),
-      home: const PokerAnalyzerScreen(),
+      home: const MainMenuScreen(),
     );
   }
 }

--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -1,0 +1,13 @@
+import 'saved_hand.dart'
+
+class TrainingPack {
+  final String name;
+  final String description;
+  final List<SavedHand> hands;
+
+  TrainingPack({
+    required this.name,
+    required this.description,
+    required this.hands,
+  });
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import 'player_input_screen.dart';
+import 'saved_hands_screen.dart';
+import 'training_packs_screen.dart';
+
+class MainMenuScreen extends StatelessWidget {
+  const MainMenuScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Poker AI Analyzer'),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const PlayerInputScreen()),
+                );
+              },
+              child: const Text('➕ Новая раздача'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SavedHandsScreen()),
+                );
+              },
+              child: const Text('📂 Сохранённые раздачи'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingPacksScreen()),
+                );
+              },
+              child: const Text('🎯 Тренировка'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -33,7 +33,9 @@ import '../models/saved_hand.dart';
 import '../widgets/action_timeline_widget.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
-  const PokerAnalyzerScreen({super.key});
+  final SavedHand? initialHand;
+
+  const PokerAnalyzerScreen({super.key, this.initialHand});
 
   @override
   State<PokerAnalyzerScreen> createState() => _PokerAnalyzerScreenState();
@@ -500,6 +502,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     );
     _updatePositions();
     _updatePlaybackState();
+    if (widget.initialHand != null) {
+      _applySavedHand(widget.initialHand!);
+    }
   }
 
   void selectCard(int index, CardModel card) {

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack.dart';
+import 'poker_analyzer_screen.dart';
+
+class TrainingPackScreen extends StatelessWidget {
+  final TrainingPack pack;
+
+  const TrainingPackScreen({super.key, required this.pack});
+
+  @override
+  Widget build(BuildContext context) {
+    final firstHand = pack.hands.isNotEmpty ? pack.hands.first : null;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(pack.name),
+        centerTitle: true,
+      ),
+      body: firstHand == null
+          ? const Center(child: Text('Нет раздач'))
+          : PokerAnalyzerScreen(initialHand: firstHand),
+      backgroundColor: const Color(0xFF1B1C1E),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack.dart';
+import '../models/saved_hand.dart';
+import 'training_pack_screen.dart';
+
+class TrainingPacksScreen extends StatelessWidget {
+  const TrainingPacksScreen({super.key});
+
+  SavedHand _placeholderHand(String name) {
+    return SavedHand(
+      name: name,
+      heroIndex: 0,
+      heroPosition: 'BTN',
+      numberOfPlayers: 6,
+      playerCards: List.generate(6, (_) => []),
+      boardCards: [],
+      actions: [],
+      stackSizes: const {},
+      playerPositions: const {},
+    );
+  }
+
+  List<TrainingPack> _packs() {
+    return [
+      TrainingPack(
+        name: 'Push/Fold 10BB',
+        description: 'Решения при стеке 10BB',
+        hands: [_placeholderHand('Push/Fold 10BB')],
+      ),
+      TrainingPack(
+        name: '3-bet без позиции',
+        description: 'Тренировка игры без позиции',
+        hands: [_placeholderHand('3-bet без позиции')],
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final packs = _packs();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Тренировочные пакеты'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: packs.length,
+        itemBuilder: (context, index) {
+          final pack = packs[index];
+          return Card(
+            color: const Color(0xFF2A2B2E),
+            child: ListTile(
+              title: Text(pack.name, style: const TextStyle(color: Colors.white)),
+              subtitle: Text(pack.description,
+                  style: const TextStyle(color: Colors.white70)),
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TrainingPackScreen(pack: pack),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrainingPack` model
- add `TrainingPackScreen` and `TrainingPacksScreen`
- add `MainMenuScreen` with new **🎯 Тренировка** option
- allow `PokerAnalyzerScreen` to take an optional `initialHand`
- set `MainMenuScreen` as the app entry point

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d3177440832a989be38a6bf22892