### PR TITLE
Add training results export

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.0
+  path_provider: ^2.0.15
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- let users export training results to a JSON file
- show button to save results after finishing a pack
- add path_provider dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846db370b08832abaf1b1c740e0a70b