### PR TITLE
Add category to TrainingPack and use in UI

### DIFF
--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -1,13 +1,32 @@
-import 'saved_hand.dart'
+import 'saved_hand.dart';
 
 class TrainingPack {
   final String name;
   final String description;
+  final String category;
   final List<SavedHand> hands;
 
   TrainingPack({
     required this.name,
     required this.description,
+    this.category = 'Uncategorized',
     required this.hands,
   });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'description': description,
+        'category': category,
+        'hands': [for (final h in hands) h.toJson()],
+      };
+
+  factory TrainingPack.fromJson(Map<String, dynamic> json) => TrainingPack(
+        name: json['name'] as String? ?? '',
+        description: json['description'] as String? ?? '',
+        category: json['category'] as String? ?? 'Uncategorized',
+        hands: [
+          for (final h in (json['hands'] as List? ?? []))
+            SavedHand.fromJson(h as Map<String, dynamic>)
+        ],
+      );
 }

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -272,6 +272,22 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
             value: _currentIndex / hands.length,
           ),
           const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                color: const Color(0xFF3A3B3E),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                widget.pack.category,
+                style: const TextStyle(color: Colors.white70),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
           Expanded(
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 300),

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -28,11 +28,13 @@ class TrainingPacksScreen extends StatelessWidget {
       TrainingPack(
         name: 'Push/Fold 10BB',
         description: 'Решения при стеке 10BB',
+        category: 'Preflop',
         hands: [_placeholderHand('Push/Fold 10BB')],
       ),
       TrainingPack(
         name: '3-bet без позиции',
         description: 'Тренировка игры без позиции',
+        category: 'Preflop',
         hands: [_placeholderHand('3-bet без позиции')],
       ),
     ];
@@ -55,8 +57,25 @@ class TrainingPacksScreen extends StatelessWidget {
             color: const Color(0xFF2A2B2E),
             child: ListTile(
               title: Text(pack.name, style: const TextStyle(color: Colors.white)),
-              subtitle: Text(pack.description,
-                  style: const TextStyle(color: Colors.white70)),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(pack.description,
+                      style: const TextStyle(color: Colors.white70)),
+                  const SizedBox(height: 4),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF3A3B3E),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(pack.category,
+                        style: const TextStyle(color: Colors.white70)),
+                  ),
+                ],
+              ),
               onTap: () => Navigator.push(
                 context,
                 MaterialPageRoute(


### PR DESCRIPTION
## Summary
- extend `TrainingPack` model with `category`
- show pack categories on the list screen
- display category badge on the training screen

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846e289c048832a851e36ca75861f46