### PR TITLE
Add category filter to training packs

### DIFF
--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -4,8 +4,15 @@ import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import 'training_pack_screen.dart';
 
-class TrainingPacksScreen extends StatelessWidget {
+class TrainingPacksScreen extends StatefulWidget {
   const TrainingPacksScreen({super.key});
+
+  @override
+  State<TrainingPacksScreen> createState() => _TrainingPacksScreenState();
+}
+
+class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
+  String _selectedCategory = 'All';
 
   SavedHand _placeholderHand(String name) {
     return SavedHand(
@@ -43,48 +50,80 @@ class TrainingPacksScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final packs = _packs();
+    final categories = ['All', ...{for (final p in packs) p.category}];
+    final visible = _selectedCategory == 'All'
+        ? packs
+        : packs.where((p) => p.category == _selectedCategory).toList();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Тренировочные пакеты'),
         centerTitle: true,
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.all(16),
-        itemCount: packs.length,
-        itemBuilder: (context, index) {
-          final pack = packs[index];
-          return Card(
-            color: const Color(0xFF2A2B2E),
-            child: ListTile(
-              title: Text(pack.name, style: const TextStyle(color: Colors.white)),
-              subtitle: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(pack.description,
-                      style: const TextStyle(color: Colors.white70)),
-                  const SizedBox(height: 4),
-                  Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFF3A3B3E),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Text(pack.category,
-                        style: const TextStyle(color: Colors.white70)),
-                  ),
-                ],
-              ),
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => TrainingPackScreen(pack: pack),
-                ),
-              ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: DropdownButton<String>(
+              value: _selectedCategory,
+              dropdownColor: const Color(0xFF2A2B2E),
+              style: const TextStyle(color: Colors.white),
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedCategory = value);
+                }
+              },
+              items: [
+                for (final c in categories)
+                  DropdownMenuItem(
+                    value: c,
+                    child: Text(c),
+                  )
+              ],
             ),
-          );
-        },
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: visible.length,
+              itemBuilder: (context, index) {
+                final pack = visible[index];
+                return Card(
+                  color: const Color(0xFF2A2B2E),
+                  child: ListTile(
+                    title: Text(pack.name,
+                        style: const TextStyle(color: Colors.white)),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(pack.description,
+                            style: const TextStyle(color: Colors.white70)),
+                        const SizedBox(height: 4),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF3A3B3E),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(pack.category,
+                              style: const TextStyle(color: Colors.white70)),
+                        ),
+                      ],
+                    ),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TrainingPackScreen(pack: pack),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
     );


### PR DESCRIPTION
## Summary
- convert `TrainingPacksScreen` to `StatefulWidget`
- add dropdown filter for training pack categories

## Testing
- `flutter --version`

------
https://chatgpt.com/codex/tasks/task_e_6846e3b1a52c832ab66e4a0bfe1f3aa5