### PR TITLE
Add pack creation UI

### DIFF
--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack.dart';
+
+class CreatePackScreen extends StatefulWidget {
+  const CreatePackScreen({super.key});
+
+  @override
+  State<CreatePackScreen> createState() => _CreatePackScreenState();
+}
+
+class _CreatePackScreenState extends State<CreatePackScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _categoryController = TextEditingController();
+
+  void _save() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    final category = _categoryController.text.trim();
+    final pack = TrainingPack(
+      name: name,
+      description: _descriptionController.text.trim(),
+      category: category.isEmpty ? 'Uncategorized' : category,
+      hands: const [],
+    );
+    Navigator.pop(context, pack);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Новый пакет'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              style: const TextStyle(color: Colors.white),
+              decoration: const InputDecoration(
+                labelText: 'Название',
+                labelStyle: TextStyle(color: Colors.white),
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _descriptionController,
+              style: const TextStyle(color: Colors.white),
+              decoration: const InputDecoration(
+                labelText: 'Описание',
+                labelStyle: TextStyle(color: Colors.white),
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _categoryController,
+              style: const TextStyle(color: Colors.white),
+              decoration: const InputDecoration(
+                labelText: 'Категория',
+                labelStyle: TextStyle(color: Colors.white),
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Сохранить'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import 'training_pack_screen.dart';
+import 'create_pack_screen.dart';
 
 class TrainingPacksScreen extends StatefulWidget {
   const TrainingPacksScreen({super.key});
@@ -13,6 +14,13 @@ class TrainingPacksScreen extends StatefulWidget {
 
 class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
   String _selectedCategory = 'All';
+  final List<TrainingPack> _packsList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _packsList.addAll(_defaultPacks());
+  }
 
   SavedHand _placeholderHand(String name) {
     return SavedHand(
@@ -30,7 +38,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     );
   }
 
-  List<TrainingPack> _packs() {
+  List<TrainingPack> _defaultPacks() {
     return [
       TrainingPack(
         name: 'Push/Fold 10BB',
@@ -49,7 +57,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final packs = _packs();
+    final packs = _packsList;
     final categories = ['All', ...{for (final p in packs) p.category}];
     final visible = _selectedCategory == 'All'
         ? packs
@@ -126,6 +134,18 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
         ],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final pack = await Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const CreatePackScreen()),
+          );
+          if (pack is TrainingPack) {
+            setState(() => _packsList.add(pack));
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a screen to create training packs
- store packs in memory in `TrainingPacksScreen`
- add floating action button to open create screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e4c66958832a86a134748a900439