### PR TITLE
Add delete option on long press for training packs

### DIFF
--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -134,6 +134,29 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                         }
                       }
                     },
+                    onLongPress: () async {
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: Text('Удалить пакет «${pack.name}»?'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: const Text('Отмена'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: const Text('Удалить'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirm == true) {
+                        setState(() {
+                          _packsList.remove(pack);
+                        });
+                      }
+                    },
                   ),
                 );
               },


### PR DESCRIPTION
## Summary
- add long-press handler on training pack list items
- confirm deletion via dialog and remove pack when accepted

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6846e76c9e68832a9f315f13dee30ca7