### PR TITLE
Add training pack import

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   shared_preferences: ^2.2.0
   path_provider: ^2.0.15
   open_file: ^3.5.10
+  file_picker: ^5.2.10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- enable importing training packs from a JSON file
- wire up import button in TrainingPacksScreen
- include file_picker dependency

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846ed924044832aa828f9ab8927b053