### PR TITLE
Open exported pack file

### DIFF
--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:open_file/open_file.dart';
 
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
@@ -67,6 +68,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     final file = File('${dir.path}/$fileName');
     final data = [for (final p in _packsList) p.toJson()];
     await file.writeAsString(jsonEncode(data));
+    await OpenFile.open(file.path);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Экспорт завершён: \$fileName')),


### PR DESCRIPTION
## Summary
- integrate `open_file` package in TrainingPacksScreen
- automatically open exported JSON file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ef2ffd50832ab9de54fb33e9ca63