### PR TITLE
Add session detail screen

### DIFF
--- a/lib/models/session_task_result.dart
+++ b/lib/models/session_task_result.dart
@@ -1,0 +1,27 @@
+class SessionTaskResult {
+  final String question;
+  final String selectedAnswer;
+  final String correctAnswer;
+  final bool correct;
+
+  SessionTaskResult({
+    required this.question,
+    required this.selectedAnswer,
+    required this.correctAnswer,
+    required this.correct,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'question': question,
+        'selectedAnswer': selectedAnswer,
+        'correctAnswer': correctAnswer,
+        'correct': correct,
+      };
+
+  factory SessionTaskResult.fromJson(Map<String, dynamic> json) => SessionTaskResult(
+        question: json['question'] as String? ?? '',
+        selectedAnswer: json['selectedAnswer'] as String? ?? '',
+        correctAnswer: json['correctAnswer'] as String? ?? '',
+        correct: json['correct'] as bool? ?? false,
+      );
+}

--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -1,20 +1,24 @@
 import 'saved_hand.dart';
+import 'session_task_result.dart';
 
 class TrainingSessionResult {
   final DateTime date;
   final int total;
   final int correct;
+  final List<SessionTaskResult> tasks;
 
   TrainingSessionResult({
     required this.date,
     required this.total,
     required this.correct,
-  });
+    List<SessionTaskResult>? tasks,
+  }) : tasks = tasks ?? [];
 
   Map<String, dynamic> toJson() => {
         'date': date.toIso8601String(),
         'total': total,
         'correct': correct,
+        'tasks': [for (final t in tasks) t.toJson()],
       };
 
   static TrainingSessionResult fromJson(Map<String, dynamic> json) {
@@ -22,6 +26,10 @@ class TrainingSessionResult {
       date: DateTime.parse(json['date']),
       total: json['total'],
       correct: json['correct'],
+      tasks: [
+        for (final t in (json['tasks'] as List? ?? []))
+          SessionTaskResult.fromJson(Map<String, dynamic>.from(t))
+      ],
     );
   }
 }

--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -7,6 +7,7 @@ import 'package:open_file/open_file.dart';
 import 'package:file_picker/file_picker.dart';
 
 import '../models/training_pack.dart';
+import 'session_detail_screen.dart';
 
 class AllSessionsScreen extends StatefulWidget {
   const AllSessionsScreen({super.key});
@@ -223,15 +224,27 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
                     itemCount: _entries.length,
                     itemBuilder: (context, index) {
                       final e = _entries[index];
-                      return Container(
-                        margin: const EdgeInsets.symmetric(vertical: 4),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFF2A2B2E),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          children: [
+                      return GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => SessionDetailScreen(
+                                packName: e.packName,
+                                result: e.result,
+                              ),
+                            ),
+                          );
+                        },
+                        child: Container(
+                          margin: const EdgeInsets.symmetric(vertical: 4),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF2A2B2E),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            children: [
                             Expanded(
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack.dart';
+
+class SessionDetailScreen extends StatelessWidget {
+  final String packName;
+  final TrainingSessionResult result;
+
+  const SessionDetailScreen({
+    super.key,
+    required this.packName,
+    required this.result,
+  });
+
+  String _formatDate(DateTime d) {
+    final day = d.day.toString().padLeft(2, '0');
+    final month = d.month.toString().padLeft(2, '0');
+    final year = d.year.toString();
+    final hour = d.hour.toString().padLeft(2, '0');
+    final minute = d.minute.toString().padLeft(2, '0');
+    return '$day.$month.$year $hour:$minute';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(packName),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  packName,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _formatDate(result.date),
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+          const Divider(color: Colors.white12, height: 1),
+          Expanded(
+            child: result.tasks.isEmpty
+                ? const Center(
+                    child: Text(
+                      'Нет данных по задачам',
+                      style: TextStyle(color: Colors.white70),
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: result.tasks.length,
+                    itemBuilder: (context, index) {
+                      final t = result.tasks[index];
+                      return Container(
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF2A2B2E),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              t.question,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Ваш ответ: ${t.selectedAnswer}',
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                            Text(
+                              'Правильный ответ: ${t.correctAnswer}',
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              t.correct ? 'Верно' : 'Неверно',
+                              style: TextStyle(
+                                color: t.correct ? Colors.green : Colors.red,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -10,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
+import '../models/session_task_result.dart';
 import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
 
@@ -318,10 +319,20 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
   Future<void> _completeSession() async {
     final total = _results.length;
     final correct = _results.where((r) => r.correct).length;
+    final tasks = [
+      for (final r in _results)
+        SessionTaskResult(
+          question: r.name,
+          selectedAnswer: r.userAction,
+          correctAnswer: r.expected,
+          correct: r.correct,
+        )
+    ];
     final result = TrainingSessionResult(
       date: DateTime.now(),
       total: total,
       correct: correct,
+      tasks: tasks,
     );
 
     widget.pack.history.add(result);


### PR DESCRIPTION
## Summary
- track per-hand results with `SessionTaskResult`
- extend `TrainingSessionResult` to store task list
- capture task details when completing a session
- add SessionDetailScreen to show a single session
- open SessionDetailScreen from AllSessionsScreen on tap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68470c3fc054832ab9439b6e41431822