### PR TITLE
Add summary banner on sessions screen

### DIFF
--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -1092,17 +1092,58 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
             ),
           if (_allEntries.isNotEmpty)
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text('Сессий: $_filteredCount',
-                      style: const TextStyle(color: Colors.white)),
-                  Text('Средний %: ${_averagePercent.toStringAsFixed(0)}',
-                      style: const TextStyle(color: Colors.white)),
-                  Text('Успешных: $_successCount, Неуспешных: $_failCount',
-                      style: const TextStyle(color: Colors.white)),
-                ],
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF2A2B2E),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Сессий: $_filteredCount',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        'Успешных: $_successCount',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        'Неуспешных: $_failCount',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        'Средний %: ${_averagePercent.toStringAsFixed(0)}',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           if (_entries.isNotEmpty)


### PR DESCRIPTION
## Summary
- style the sessions stats row as a banner with dark background and bold white text
- show total sessions, successful and unsuccessful counts, and average accuracy

## Testing
- `git commit -m "Add summary banner on sessions screen"`

------
https://chatgpt.com/codex/tasks/task_e_684756766474832ab06589c80f02f5a2