### PR TITLE
Add errorType field and filter errors

### DIFF
--- a/lib/models/error_entry.dart
+++ b/lib/models/error_entry.dart
@@ -5,6 +5,7 @@ class ErrorEntry {
   final String userAction;
   final String correctAction;
   final String aiExplanation;
+  final String errorType;
 
   ErrorEntry({
     required this.street,
@@ -13,5 +14,6 @@ class ErrorEntry {
     required this.userAction,
     required this.correctAction,
     required this.aiExplanation,
+    required this.errorType,
   });
 }

--- a/lib/screens/session_review_screen.dart
+++ b/lib/screens/session_review_screen.dart
@@ -2,36 +2,70 @@ import 'package:flutter/material.dart';
 
 import '../models/error_entry.dart';
 
-class SessionReviewScreen extends StatelessWidget {
+const _filterOptions = [
+  'All',
+  'Aggressive',
+  'Passive',
+  'Sizing',
+  'Other'
+];
+class SessionReviewScreen extends StatefulWidget {
   final List<ErrorEntry> errors;
 
   const SessionReviewScreen({super.key, required this.errors});
 
   @override
+  State<SessionReviewScreen> createState() => _SessionReviewScreenState();
+}
+
+class _SessionReviewScreenState extends State<SessionReviewScreen> {
+  String _selectedType = 'All';
+
+  @override
   Widget build(BuildContext context) {
+    final filtered = _selectedType == 'All'
+        ? widget.errors
+        : widget.errors
+            .where((e) => e.errorType == _selectedType)
+            .toList();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Ошибки сессии'),
         centerTitle: true,
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (v) {
+              setState(() {
+                _selectedType = v;
+              });
+            },
+            icon: const Icon(Icons.filter_list),
+            itemBuilder: (_) => [
+              for (final option in _filterOptions)
+                PopupMenuItem(value: option, child: Text(option))
+            ],
+          )
+        ],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
-      body: errors.isEmpty
+      body: filtered.isEmpty
           ? const Center(
               child: Text(
                 'Ошибок нет',
                 style: TextStyle(color: Colors.white70),
               ),
             )
-          : _buildGroupedList(),
+          : _buildGroupedList(filtered),
     );
   }
 
-  Widget _buildGroupedList() {
+  Widget _buildGroupedList(List<ErrorEntry> entries) {
     const streets = ['Preflop', 'Flop', 'Turn', 'River'];
     final Map<String, List<ErrorEntry>> grouped = {
       for (final s in streets) s: []
     };
-    for (final e in errors) {
+    for (final e in entries) {
       if (grouped.containsKey(e.street)) {
         grouped[e.street]!.add(e);
       } else {


### PR DESCRIPTION
## Summary
- extend `ErrorEntry` with new required `errorType` field
- convert `SessionReviewScreen` to `StatefulWidget`
- add popup menu filter in the AppBar to filter by error type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476b349ae0832a846f8d3c1975b05e