### PR TITLE
Add retry mistakes screen

### DIFF
--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../models/error_entry.dart';
+
+class RetryTrainingScreen extends StatelessWidget {
+  final List<ErrorEntry> errors;
+
+  const RetryTrainingScreen({super.key, required this.errors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Retry Mistakes'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Mistakes to retry: ${errors.length}',
+              style: const TextStyle(color: Colors.white, fontSize: 16),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Coming Soon',
+              style: TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/session_review_screen.dart
+++ b/lib/screens/session_review_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/error_entry.dart';
+import 'retry_training_screen.dart';
 
 const _filterOptions = [
   'All',
@@ -107,6 +108,21 @@ class _SessionReviewScreenState extends State<SessionReviewScreen> {
                   padding: const EdgeInsets.all(16),
                   child: _buildSummary(),
                 ),
+                if (filtered.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                    child: ElevatedButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => RetryTrainingScreen(errors: filtered),
+                          ),
+                        );
+                      },
+                      child: const Text('Retry Mistakes'),
+                    ),
+                  ),
                 Expanded(child: _buildGroupedList(filtered)),
               ],
             ),


### PR DESCRIPTION
## Summary
- add placeholder `RetryTrainingScreen`
- show `Retry Mistakes` button in `SessionReviewScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847732a4ccc832aa0933b1e6fbf34cb