### PR TITLE
Implement correctness feedback in RetryTrainingScreen

### DIFF
--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -97,6 +97,17 @@ class _RetryTrainingScreenState extends State<RetryTrainingScreen> {
                     ),
                     const SizedBox(height: 4),
                     Text(
+                      _selectedAction == error.correctAction
+                          ? '✅ Correct'
+                          : '❌ Mistake',
+                      style: TextStyle(
+                        color: _selectedAction == error.correctAction
+                            ? Colors.green
+                            : Colors.red,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
                       'Correct Action: ${error.correctAction}',
                       style: const TextStyle(color: Colors.green),
                     ),


### PR DESCRIPTION
## Summary
- compare the user's selected action with the correct one
- show a green `✅ Correct` or red `❌ Mistake` message when revealing the answer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684778686094832a95b354d9a3898ff8