### PR TITLE
Add TrainingHistoryScreen

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -4,6 +4,7 @@ import 'player_input_screen.dart';
 import 'saved_hands_screen.dart';
 import 'training_packs_screen.dart';
 import 'all_sessions_screen.dart';
+import 'training_history_screen.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -58,6 +59,17 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('📈 История тренировок'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingHistoryScreen()),
+                );
+              },
+              child: const Text('🗓️ Training History'),
             ),
           ],
         ),

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/training_result.dart';
+
+class TrainingHistoryScreen extends StatefulWidget {
+  const TrainingHistoryScreen({super.key});
+
+  @override
+  State<TrainingHistoryScreen> createState() => _TrainingHistoryScreenState();
+}
+
+class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
+  final List<TrainingResult> _history = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHistory();
+  }
+
+  String _formatDate(DateTime d) {
+    final day = d.day.toString().padLeft(2, '0');
+    final month = d.month.toString().padLeft(2, '0');
+    final year = d.year.toString();
+    final hour = d.hour.toString().padLeft(2, '0');
+    final minute = d.minute.toString().padLeft(2, '0');
+    return '$day.$month.$year $hour:$minute';
+  }
+
+  Future<void> _loadHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getStringList('training_history') ?? [];
+    final List<TrainingResult> loaded = [];
+    for (final item in stored) {
+      try {
+        final data = jsonDecode(item);
+        if (data is Map<String, dynamic>) {
+          loaded.add(TrainingResult.fromJson(Map<String, dynamic>.from(data)));
+        }
+      } catch (_) {}
+    }
+    setState(() => _history
+      ..clear()
+      ..addAll(loaded.reversed));
+  }
+
+  Future<void> _clearHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('training_history');
+    setState(() => _history.clear());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Training History'),
+        centerTitle: true,
+        actions: [
+          TextButton(
+            onPressed: _clearHistory,
+            child: const Text('Clear History'),
+          ),
+        ],
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: _history.isEmpty
+          ? const Center(
+              child: Text(
+                'No history available.',
+                style: TextStyle(color: Colors.white54),
+              ),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemBuilder: (context, index) {
+                final result = _history[index];
+                final accuracy = result.accuracy.toStringAsFixed(1);
+                return Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF2A2B2E),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: ListTile(
+                    title: Text(
+                      _formatDate(result.date),
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    subtitle: Text(
+                      'Correct: ${result.correct} / ${result.total}',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                    trailing: Text(
+                      '$accuracy%',
+                      style: const TextStyle(color: Colors.greenAccent),
+                    ),
+                  ),
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemCount: _history.length,
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `TrainingHistoryScreen` for viewing saved `TrainingResult` items
- wire up new screen from main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68477e5e6944832a9638f5c2e0d1e77a