### PR TITLE
Add progress chart to training history

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fl_chart/fl_chart.dart';
 
 import '../models/training_result.dart';
 
@@ -65,6 +66,94 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     });
   }
 
+  Widget _buildAccuracyChart() {
+    if (_history.length < 2) return const SizedBox.shrink();
+
+    final sessions = [..._history]..sort((a, b) => a.date.compareTo(b.date));
+    final spots = <FlSpot>[];
+    for (var i = 0; i < sessions.length; i++) {
+      spots.add(FlSpot(i.toDouble(), sessions[i].accuracy));
+    }
+    final step = (sessions.length / 6).ceil();
+
+    final barData = LineChartBarData(
+      spots: spots,
+      color: Colors.greenAccent,
+      barWidth: 2,
+      isCurved: true,
+      dotData: FlDotData(show: false),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFF2A2B2E),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= sessions.length) {
+                      return const SizedBox.shrink();
+                    }
+                    if (index % step != 0 && index != sessions.length - 1) {
+                      return const SizedBox.shrink();
+                    }
+                    final d = sessions[index].date;
+                    final label =
+                        '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                    return Text(label,
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 10));
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            lineBarsData: [barData],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -95,6 +184,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                     style: const TextStyle(color: Colors.white),
                   ),
                 ),
+                _buildAccuracyChart(),
                 Expanded(
                   child: ListView.separated(
                     padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- show training progress line chart when viewing history
- plot accuracy trend over time using `fl_chart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684780da2864832aa8d1300a5fbc3eaf