### PR TITLE
Add explanation text label in retry screen

### DIFF
--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -168,9 +168,22 @@ class _RetryTrainingScreenState extends State<RetryTrainingScreen> {
                     style: const TextStyle(color: Colors.green),
                   ),
                   const SizedBox(height: 4),
-                  Text(
-                    error.aiExplanation,
-                    style: const TextStyle(color: Colors.white70),
+                  Text.rich(
+                    TextSpan(
+                      children: [
+                        const TextSpan(
+                          text: 'Explanation: ',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        TextSpan(
+                          text: error.aiExplanation,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
                   ),
                 ],
               ],


### PR DESCRIPTION
## Summary
- update RetryTrainingScreen to show AI explanations with a bold `Explanation:` label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68478466db2c832ab03af06a16c4d567