### PR TITLE
Refactor analyzer UI pieces and share utilities

### DIFF
--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -10,6 +10,7 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../helpers/date_utils.dart';
+import '../helpers/accuracy_utils.dart';
 
 import '../models/training_pack.dart';
 import 'session_detail_screen.dart';
@@ -207,7 +208,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     if (_minPercent != null && _maxPercent != null) {
       filtered = filtered.where((e) {
         final percent = e.result.total > 0
-            ? e.result.correct * 100 / e.result.total
+            ? calculateAccuracy(e.result.correct, e.result.total)
             : 0.0;
         return percent >= _minPercent! && percent <= _maxPercent!;
       }).toList();
@@ -257,7 +258,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     final double avg = filtered.isNotEmpty
         ? filtered
                 .map((e) => e.result.total > 0
-                    ? e.result.correct * 100 / e.result.total
+                    ? calculateAccuracy(e.result.correct, e.result.total)
                     : 0.0)
                 .reduce((a, b) => a + b) /
             filtered.length
@@ -292,7 +293,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     final buffer = StringBuffer()..writeln('## $title')..writeln();
     for (final e in _entries) {
       final percent = e.result.total > 0
-          ? (e.result.correct * 100 / e.result.total).toStringAsFixed(0)
+          ? (calculateAccuracy(e.result.correct, e.result.total)).toStringAsFixed(0)
           : '0';
       buffer.writeln(
           '- ${e.packName} — ${formatDateTime(e.result.date)} — ${e.result.correct}/${e.result.total} (${percent}%)');
@@ -336,7 +337,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     for (final e in _entries) {
       final date = formatDateTime(e.result.date);
       final percent = e.result.total > 0
-          ? (e.result.correct * 100 / e.result.total).round()
+          ? (calculateAccuracy(e.result.correct, e.result.total)).round()
           : 0;
       buffer.writeln(
           '"$date","${e.packName}",${e.result.correct},${e.result.total},$percent');
@@ -468,7 +469,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
                   ...groups[name]!.map(
                     (e) {
                       final percent = e.result.total > 0
-                          ? e.result.correct * 100 / e.result.total
+                          ? calculateAccuracy(e.result.correct, e.result.total)
                           : 0.0;
                       final color = percent >= 80
                           ? PdfColors.lightGreen
@@ -503,7 +504,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
                             padding: const pw.EdgeInsets.all(4),
                             child: pw.Text(
                               e.result.total > 0
-                                  ? '${(e.result.correct * 100 / e.result.total).toStringAsFixed(0)}%'
+                                  ? '${(calculateAccuracy(e.result.correct, e.result.total)).toStringAsFixed(0)}%'
                                   : '0%',
                               style: pw.TextStyle(font: regularFont),
                             ),
@@ -560,7 +561,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
                             var sum = 0.0;
                             for (final e in groups[name]!) {
                               sum += e.result.total > 0
-                                  ? e.result.correct * 100 / e.result.total
+                                  ? calculateAccuracy(e.result.correct, e.result.total)
                                   : 0.0;
                             }
                             final avg = sum / groups[name]!.length;
@@ -1452,7 +1453,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
                                 const SizedBox(height: 4),
                                 Text(
                                   e.result.total > 0
-                                      ? '${(e.result.correct * 100 / e.result.total).toStringAsFixed(0)}%'
+                                      ? '${(calculateAccuracy(e.result.correct, e.result.total)).toStringAsFixed(0)}%'
                                       : '0%',
                                   style: const TextStyle(color: Colors.white),
                                 ),

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_service.dart';
+import '../theme/constants.dart';
 
 class SavedHandsScreen extends StatelessWidget {
   const SavedHandsScreen({super.key});
@@ -19,11 +20,13 @@ class SavedHandsScreen extends StatelessWidget {
           ? const Center(
               child: Text(
                 'Нет сохранённых раздач.',
-                style: TextStyle(fontSize: 16, color: Colors.white54),
+                style: TextStyle(
+                    fontSize: AppConstants.fontSize16,
+                    color: Colors.white54),
               ),
             )
           : ListView.separated(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(AppConstants.padding16),
               itemCount: savedHands.length,
               separatorBuilder: (_, __) => const Divider(color: Colors.white12),
               itemBuilder: (context, index) {

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -8,6 +8,7 @@ import 'package:open_file/open_file.dart';
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import 'training_pack_screen.dart';
+import '../theme/constants.dart';
 import 'create_pack_screen.dart';
 
 class TrainingPacksScreen extends StatefulWidget {
@@ -168,7 +169,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(AppConstants.padding16),
             child: DropdownButton<String>(
               value: _selectedCategory,
               dropdownColor: const Color(0xFF2A2B2E),
@@ -189,7 +190,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           ),
           Expanded(
             child: ListView.builder(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(AppConstants.padding16),
               itemCount: visible.length,
               itemBuilder: (context, index) {
                 final pack = visible[index];

--- a/lib/services/saved_hand_service.dart
+++ b/lib/services/saved_hand_service.dart
@@ -37,4 +37,11 @@ class SavedHandService extends ChangeNotifier {
     await _persist();
     notifyListeners();
   }
+
+  Future<void> update(int index, SavedHand hand) async {
+    if (index < 0 || index >= _hands.length) return;
+    _hands[index] = hand;
+    await _persist();
+    notifyListeners();
+  }
 }

--- a/lib/theme/constants.dart
+++ b/lib/theme/constants.dart
@@ -1,0 +1,7 @@
+class AppConstants {
+  static const double padding16 = 16.0;
+  static const double radius8 = 8.0;
+  static const double fontSize14 = 14.0;
+  static const double fontSize16 = 16.0;
+  static const double fontSize20 = 20.0;
+}

--- a/lib/widgets/action_history_overlay.dart
+++ b/lib/widgets/action_history_overlay.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+import '../models/action_entry.dart';
+
+class ActionHistoryOverlay extends StatelessWidget {
+  final List<ActionEntry> actions;
+  final int playbackIndex;
+  final Map<int, String> playerPositions;
+  final Set<int> expandedStreets;
+  final ValueChanged<int>? onToggleStreet;
+
+  const ActionHistoryOverlay({
+    Key? key,
+    required this.actions,
+    required this.playbackIndex,
+    required this.playerPositions,
+    required this.expandedStreets,
+    this.onToggleStreet,
+  }) : super(key: key);
+
+  Color _actionColor(String action) {
+    switch (action) {
+      case 'fold':
+        return Colors.red[700]!;
+      case 'call':
+        return Colors.blue[700]!;
+      case 'raise':
+        return Colors.green[600]!;
+      case 'bet':
+        return Colors.amber[700]!;
+      case 'check':
+        return Colors.grey[700]!;
+      default:
+        return Colors.black;
+    }
+  }
+
+  Color _actionTextColor(String action) {
+    switch (action) {
+      case 'bet':
+        return Colors.black;
+      default:
+        return Colors.white;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = actions.take(playbackIndex).toList();
+    final Map<int, List<ActionEntry>> grouped =
+        {for (var i = 0; i < 4; i++) i: <ActionEntry>[]};
+    for (final a in visible) {
+      grouped[a.street]?.add(a);
+    }
+    final screenWidth = MediaQuery.of(context).size.width;
+    final double scale = screenWidth < 350 ? 0.8 : 1.0;
+    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
+
+    Widget buildChip(ActionEntry a) {
+      final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
+      final text = '$pos: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}';
+      return Container(
+        padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 3 * scale),
+        margin: const EdgeInsets.only(right: 4, bottom: 4),
+        decoration: BoxDecoration(
+          color: _actionColor(a.action).withOpacity(0.8),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            color: _actionTextColor(a.action),
+            fontSize: 11 * scale,
+          ),
+        ),
+      );
+    }
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        color: Colors.black38,
+        height: 70 * scale,
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          itemCount: 4,
+          itemBuilder: (context, index) {
+            final list = grouped[index] ?? [];
+            if (list.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            final expanded = expandedStreets.contains(index);
+            final visibleList = expanded || list.length <= 5
+                ? list
+                : list.sublist(list.length - 5);
+            return GestureDetector(
+              onTap: () => onToggleStreet?.call(index),
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 6),
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: Colors.black54,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      streetNames[index],
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 12 * scale,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: Row(
+                          children: [for (final a in visibleList) buildChip(a)],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../models/card_model.dart';
+import '../models/action_entry.dart';
+import 'board_cards_widget.dart';
+import 'pot_over_board_widget.dart';
+
+class BoardDisplay extends StatelessWidget {
+  final int currentStreet;
+  final List<CardModel> boardCards;
+  final List<ActionEntry> visibleActions;
+  final void Function(int, CardModel) onCardSelected;
+  final double scale;
+
+  const BoardDisplay({
+    Key? key,
+    required this.currentStreet,
+    required this.boardCards,
+    required this.visibleActions,
+    required this.onCardSelected,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        BoardCardsWidget(
+          scale: scale,
+          currentStreet: currentStreet,
+          boardCards: boardCards,
+          onCardSelected: onCardSelected,
+        ),
+        PotOverBoardWidget(
+          visibleActions: visibleActions,
+          currentStreet: currentStreet,
+          scale: scale,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AppConstants` for padding/font constants
- add persistent editing via `SavedHandService.update`
- split board and history views into `BoardDisplay` and `ActionHistoryOverlay`
- use provider-based service in `PokerAnalyzerScreen`
- clean up padding constants in a few screens
- replace manual accuracy math with `calculateAccuracy`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684790e96828832a86ec80ec5acb0719