### PR TITLE
Add advanced saved hands system

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,13 +3,13 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'screens/main_menu_screen.dart';
-import 'services/saved_hand_service.dart';
+import 'services/saved_hand_storage_service.dart';
 
 void main() {
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => SavedHandService()..load()),
+        ChangeNotifierProvider(create: (_) => SavedHandStorageService()..load()),
       ],
       child: const PokerAIAnalyzerApp(),
     ),

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -15,6 +15,8 @@ class SavedHand {
   final Map<int, PlayerType>? playerTypes;
   final String? comment;
   final List<String> tags;
+  final bool isFavorite;
+  final DateTime date;
   final String? expectedAction;
   final String? feedbackText;
 
@@ -31,9 +33,51 @@ class SavedHand {
     this.playerTypes,
     this.comment,
     List<String>? tags,
+    this.isFavorite = false,
+    DateTime? date,
     this.expectedAction,
     this.feedbackText,
-  }) : tags = tags ?? [];
+  })  : tags = tags ?? [],
+        date = date ?? DateTime.now();
+
+  SavedHand copyWith({
+    String? name,
+    int? heroIndex,
+    String? heroPosition,
+    int? numberOfPlayers,
+    List<List<CardModel>>? playerCards,
+    List<CardModel>? boardCards,
+    List<ActionEntry>? actions,
+    Map<int, int>? stackSizes,
+    Map<int, String>? playerPositions,
+    Map<int, PlayerType>? playerTypes,
+    String? comment,
+    List<String>? tags,
+    bool? isFavorite,
+    DateTime? date,
+    String? expectedAction,
+    String? feedbackText,
+  }) {
+    return SavedHand(
+      name: name ?? this.name,
+      heroIndex: heroIndex ?? this.heroIndex,
+      heroPosition: heroPosition ?? this.heroPosition,
+      numberOfPlayers: numberOfPlayers ?? this.numberOfPlayers,
+      playerCards: playerCards ??
+          [for (final list in this.playerCards) List<CardModel>.from(list)],
+      boardCards: boardCards ?? List<CardModel>.from(this.boardCards),
+      actions: actions ?? List<ActionEntry>.from(this.actions),
+      stackSizes: stackSizes ?? Map<int, int>.from(this.stackSizes),
+      playerPositions: playerPositions ?? Map<int, String>.from(this.playerPositions),
+      playerTypes: playerTypes ?? this.playerTypes,
+      comment: comment ?? this.comment,
+      tags: tags ?? List<String>.from(this.tags),
+      isFavorite: isFavorite ?? this.isFavorite,
+      date: date ?? this.date,
+      expectedAction: expectedAction ?? this.expectedAction,
+      feedbackText: feedbackText ?? this.feedbackText,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'name': name,
@@ -62,6 +106,8 @@ class SavedHand {
               playerTypes!.map((k, v) => MapEntry(k.toString(), v.name)),
         if (comment != null) 'comment': comment,
         'tags': tags,
+        'isFavorite': isFavorite,
+        'date': date.toIso8601String(),
         if (expectedAction != null) 'expectedAction': expectedAction,
         if (feedbackText != null) 'feedbackText': feedbackText,
       };
@@ -92,6 +138,8 @@ class SavedHand {
       positions[int.parse(key as String)] = value as String;
     });
     final tags = [for (final t in (json['tags'] as List? ?? [])) t as String];
+    final isFavorite = json['isFavorite'] as bool? ?? false;
+    final date = DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now();
     Map<int, PlayerType> types = {};
     if (json['playerTypes'] != null) {
       (json['playerTypes'] as Map).forEach((key, value) {
@@ -119,6 +167,8 @@ class SavedHand {
       playerTypes: types,
       comment: json['comment'] as String?,
       tags: tags,
+      isFavorite: isFavorite,
+      date: date,
       expectedAction: json['expectedAction'] as String?,
       feedbackText: json['feedbackText'] as String?,
     );

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -11,7 +11,7 @@ import '../widgets/street_actions_widget.dart';
 import '../widgets/board_display.dart';
 import '../widgets/action_history_overlay.dart';
 import 'package:provider/provider.dart';
-import '../services/saved_hand_service.dart';
+import '../services/saved_hand_storage_service.dart';
 import '../theme/constants.dart';
 import '../widgets/detailed_action_bottom_sheet.dart';
 import '../widgets/chip_widget.dart';
@@ -46,7 +46,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
 
 class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     with TickerProviderStateMixin {
-  late SavedHandService _savedHandService;
+  late SavedHandStorageService _savedHandService;
   List<SavedHand> get savedHands => _savedHandService.hands;
   int heroIndex = 0;
   String _heroPosition = 'BTN';
@@ -520,7 +520,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _savedHandService = context.read<SavedHandService>();
+    _savedHandService = context.read<SavedHandStorageService>();
   }
 
   void selectCard(int index, CardModel card) {
@@ -1142,6 +1142,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           .map((t) => t.trim())
           .where((t) => t.isNotEmpty)
           .toList(),
+      isFavorite: false,
+      date: DateTime.now(),
     );
   }
 
@@ -1505,10 +1507,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                                     Map<int, String>.from(old.playerPositions),
                                 playerTypes: old.playerTypes == null
                                     ? null
-                                    : Map<int, String>.from(old.playerTypes!),
+                                    : Map<int, PlayerType>.from(old.playerTypes!),
                                 comment:
                                     newComment.isNotEmpty ? newComment : null,
                                 tags: newTags,
+                                isFavorite: old.isFavorite,
+                                date: old.date,
                               );
                             await _savedHandService.update(savedIndex, updated);
                             setStateDialog(() {});

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -1,58 +1,193 @@
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../models/saved_hand.dart';
-import '../services/saved_hand_service.dart';
-import '../theme/constants.dart';
+import 'dart:convert';
+import 'dart:io';
 
-class SavedHandsScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:open_file/open_file.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/saved_hand_storage_service.dart';
+import '../theme/constants.dart';
+import '../widgets/saved_hand_tile.dart';
+import '../widgets/saved_hand_detail_sheet.dart';
+
+class SavedHandsScreen extends StatefulWidget {
   const SavedHandsScreen({super.key});
 
   @override
+  State<SavedHandsScreen> createState() => _SavedHandsScreenState();
+}
+
+class _SavedHandsScreenState extends State<SavedHandsScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  String _tagFilter = 'Все';
+  String _positionFilter = 'Все';
+  String _dateFilter = 'Все';
+  bool _onlyFavorites = false;
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final service = context.watch<SavedHandService>();
-    final savedHands = service.hands;
+    final storage = context.watch<SavedHandStorageService>();
+    final allHands = storage.hands;
+    final tags = <String>{for (final h in allHands) ...h.tags};
+    final positions = <String>{for (final h in allHands) h.heroPosition};
+
+    List<SavedHand> visible = allHands.where((hand) {
+      if (_onlyFavorites && !hand.isFavorite) return false;
+      if (_tagFilter != 'Все' && !hand.tags.contains(_tagFilter)) return false;
+      if (_positionFilter != 'Все' && hand.heroPosition != _positionFilter) {
+        return false;
+      }
+      final now = DateTime.now();
+      if (_dateFilter == 'Сегодня' && !_sameDay(hand.date, now)) return false;
+      if (_dateFilter == '7 дней' && hand.date.isBefore(now.subtract(const Duration(days: 7)))) {
+        return false;
+      }
+      if (_dateFilter == '30 дней' && hand.date.isBefore(now.subtract(const Duration(days: 30)))) {
+        return false;
+      }
+      final query = _searchController.text.toLowerCase();
+      if (query.isNotEmpty) {
+        final inTags = hand.tags.any((t) => t.toLowerCase().contains(query));
+        final inComment = hand.comment?.toLowerCase().contains(query) ?? false;
+        final inPos = hand.heroPosition.toLowerCase().contains(query);
+        if (!(inTags || inComment || inPos)) return false;
+      }
+      return true;
+    }).toList();
+
+    visible.sort((a, b) => b.date.compareTo(a.date));
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Сохранённые раздачи'),
         centerTitle: true,
       ),
-      body: savedHands.isEmpty
-          ? const Center(
-              child: Text(
-                'Нет сохранённых раздач.',
-                style: TextStyle(
-                    fontSize: AppConstants.fontSize16,
-                    color: Colors.white54),
-              ),
-            )
-          : ListView.separated(
-              padding: const EdgeInsets.all(AppConstants.padding16),
-              itemCount: savedHands.length,
-              separatorBuilder: (_, __) => const Divider(color: Colors.white12),
-              itemBuilder: (context, index) {
-                final hand = savedHands[index];
-                final title = hand.comment ?? 'Раздача ${index + 1}';
-                return Dismissible(
-                  key: ValueKey(index),
-                  direction: DismissDirection.endToStart,
-                  background: Container(
-                    alignment: Alignment.centerRight,
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    color: Colors.red,
-                    child: const Icon(Icons.delete, color: Colors.white),
-                  ),
-                  onDismissed: (_) => service.removeAt(index),
-                  child: ListTile(
-                    tileColor: const Color(0xFF2A2B2E),
-                    title: Text(
-                      title,
-                      style: const TextStyle(color: Colors.white),
-                    ),
-                  ),
-                );
-              },
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppConstants.padding16),
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(hintText: 'Поиск'),
+              onChanged: (_) => setState(() {}),
             ),
-      backgroundColor: const Color(0xFF1B1C1E),
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: AppConstants.padding16),
+            child: Row(
+              children: [
+                DropdownButton<String>(
+                  value: _tagFilter,
+                  dropdownColor: const Color(0xFF2A2B2E),
+                  onChanged: (v) => setState(() => _tagFilter = v ?? 'Все'),
+                  items: ['Все', ...tags]
+                      .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                      .toList(),
+                ),
+                const SizedBox(width: 12),
+                DropdownButton<String>(
+                  value: _positionFilter,
+                  dropdownColor: const Color(0xFF2A2B2E),
+                  onChanged: (v) => setState(() => _positionFilter = v ?? 'Все'),
+                  items: ['Все', ...positions]
+                      .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                      .toList(),
+                ),
+                const SizedBox(width: 12),
+                DropdownButton<String>(
+                  value: _dateFilter,
+                  dropdownColor: const Color(0xFF2A2B2E),
+                  onChanged: (v) => setState(() => _dateFilter = v ?? 'Все'),
+                  items: ['Все', 'Сегодня', '7 дней', '30 дней']
+                      .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+                      .toList(),
+                ),
+                IconButton(
+                  onPressed: () => setState(() => _onlyFavorites = !_onlyFavorites),
+                  icon: Icon(_onlyFavorites ? Icons.star : Icons.star_border),
+                  color: _onlyFavorites ? Colors.amber : Colors.white,
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: visible.isEmpty
+                ? const Center(
+                    child: Text('Нет сохранённых раздач.',
+                        style: TextStyle(color: Colors.white54)),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.all(AppConstants.padding16),
+                    itemCount: visible.length,
+                    itemBuilder: (context, index) {
+                      final hand = visible[index];
+                      final originalIndex = allHands.indexOf(hand);
+                      return SavedHandTile(
+                        hand: hand,
+                        onFavoriteToggle: () {
+                          final updated = hand.copyWith(isFavorite: !hand.isFavorite);
+                          storage.update(originalIndex, updated);
+                        },
+                        onTap: () async {
+                          await showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            backgroundColor: Colors.grey[900],
+                            shape: const RoundedRectangleBorder(
+                              borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                            ),
+                            builder: (_) => SavedHandDetailSheet(
+                              hand: hand,
+                              onDelete: () {
+                                Navigator.pop(context);
+                                storage.removeAt(originalIndex);
+                              },
+                              onExportJson: () => _exportJson(hand),
+                              onExportCsv: () => _exportCsv(hand),
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
     );
+  }
+
+  Future<void> _exportJson(SavedHand hand) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final fileName = '${hand.name}_${hand.date.millisecondsSinceEpoch}.json';
+    final file = File('${dir.path}/$fileName');
+    await file.writeAsString(jsonEncode(hand.toJson()));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Файл сохранён: $fileName')),
+    );
+    OpenFile.open(file.path);
+  }
+
+  Future<void> _exportCsv(SavedHand hand) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final fileName = '${hand.name}_${hand.date.millisecondsSinceEpoch}.csv';
+    final file = File('${dir.path}/$fileName');
+    final buffer = StringBuffer()
+      ..writeln('name,heroPosition,date,isFavorite,tags,comment')
+      ..writeln(
+          '${hand.name},${hand.heroPosition},${hand.date.toIso8601String()},${hand.isFavorite},"${hand.tags.join('|')}","${hand.comment ?? ''}"');
+    await file.writeAsString(buffer.toString());
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Файл сохранён: $fileName')),
+    );
+    OpenFile.open(file.path);
   }
 }

--- a/lib/services/saved_hand_storage_service.dart
+++ b/lib/services/saved_hand_storage_service.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/saved_hand.dart';
+
+class SavedHandStorageService extends ChangeNotifier {
+  static const _storageKey = 'saved_hands';
+
+  final List<SavedHand> _hands = [];
+  List<SavedHand> get hands => List.unmodifiable(_hands);
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_storageKey) ?? [];
+    _hands
+      ..clear()
+      ..addAll(raw.map((e) => SavedHand.fromJson(jsonDecode(e) as Map<String, dynamic>)));
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = _hands.map((e) => jsonEncode(e.toJson())).toList();
+    await prefs.setStringList(_storageKey, data);
+  }
+
+  Future<void> add(SavedHand hand) async {
+    _hands.add(hand);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> removeAt(int index) async {
+    if (index < 0 || index >= _hands.length) return;
+    _hands.removeAt(index);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> update(int index, SavedHand hand) async {
+    if (index < 0 || index >= _hands.length) return;
+    _hands[index] = hand;
+    await _persist();
+    notifyListeners();
+  }
+}

--- a/lib/widgets/saved_hand_detail_sheet.dart
+++ b/lib/widgets/saved_hand_detail_sheet.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../models/saved_hand.dart';
+
+class SavedHandDetailSheet extends StatelessWidget {
+  final SavedHand hand;
+  final VoidCallback onDelete;
+  final Future<void> Function() onExportJson;
+  final Future<void> Function() onExportCsv;
+
+  const SavedHandDetailSheet({
+    super.key,
+    required this.hand,
+    required this.onDelete,
+    required this.onExportJson,
+    required this.onExportCsv,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    hand.name,
+                    style: const TextStyle(color: Colors.white, fontSize: 18),
+                  ),
+                ),
+                IconButton(
+                  onPressed: onDelete,
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('Позиция: ${hand.heroPosition}',
+                style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 4),
+            Text('Стек: ${hand.stackSizes[hand.heroIndex] ?? '-'}',
+                style: const TextStyle(color: Colors.white70)),
+            if (hand.comment != null) ...[
+              const SizedBox(height: 12),
+              const Text('Комментарий:',
+                  style: TextStyle(color: Colors.white)),
+              Text(hand.comment!, style: const TextStyle(color: Colors.white70)),
+            ],
+            if (hand.tags.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                children: [
+                  for (final t in hand.tags)
+                    Chip(
+                      label: Text(t),
+                      backgroundColor: const Color(0xFF3A3B3E),
+                      labelStyle: const TextStyle(color: Colors.white),
+                    ),
+                ],
+              ),
+            ],
+            if (hand.actions.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const Text('Действия:',
+                  style: TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              for (final a in hand.actions)
+                Text(
+                  'S${a.street}: P${a.playerIndex} ${a.action}${a.amount != null ? ' • ${a.amount}' : ''}',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+            ],
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: onExportJson,
+                  child: const Text('Экспорт JSON'),
+                ),
+                const SizedBox(width: 12),
+                ElevatedButton(
+                  onPressed: onExportCsv,
+                  child: const Text('Экспорт CSV'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/saved_hand_tile.dart
+++ b/lib/widgets/saved_hand_tile.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/saved_hand.dart';
+
+class SavedHandTile extends StatelessWidget {
+  final SavedHand hand;
+  final VoidCallback onTap;
+  final VoidCallback? onFavoriteToggle;
+
+  const SavedHandTile({
+    super.key,
+    required this.hand,
+    required this.onTap,
+    this.onFavoriteToggle,
+  });
+
+  String _formatDate(DateTime date) {
+    final d = date.day.toString().padLeft(2, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    final y = date.year.toString();
+    return '$d.$m.$y';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: const Color(0xFF2A2B2E),
+      child: ListTile(
+        onTap: onTap,
+        leading: IconButton(
+          icon: Icon(hand.isFavorite ? Icons.star : Icons.star_border),
+          color: hand.isFavorite ? Colors.amber : Colors.white54,
+          onPressed: onFavoriteToggle,
+        ),
+        title: Text(hand.name, style: const TextStyle(color: Colors.white)),
+        subtitle: Text(
+          '${hand.heroPosition} • ${_formatDate(hand.date)}',
+          style: const TextStyle(color: Colors.white70),
+        ),
+        trailing: const Icon(Icons.chevron_right, color: Colors.white),
+      ),
+    );
+  }
+}

--- a/test/saved_hand_service_test.dart
+++ b/test/saved_hand_service_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:poker_ai_analyzer/services/saved_hand_service.dart';
+import 'package:poker_ai_analyzer/services/saved_hand_storage_service.dart';
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import 'package:poker_ai_analyzer/models/card_model.dart';
 import 'package:poker_ai_analyzer/models/action_entry.dart';
@@ -12,7 +12,7 @@ void main() {
 
   test('saved hand service persists hands', () async {
     SharedPreferences.setMockInitialValues({});
-    final service = SavedHandService();
+    final service = SavedHandStorageService();
     await service.load();
     final hand = SavedHand(
       name: 'Test',
@@ -33,7 +33,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getStringList('saved_hands');
     expect(raw, isNotNull);
-    final loadedService = SavedHandService();
+    final loadedService = SavedHandStorageService();
     await loadedService.load();
     expect(loadedService.hands.length, 1);
     expect(loadedService.hands.first.name, 'Test');


### PR DESCRIPTION
## Summary
- update `SavedHand` model with favorites and date
- implement `SavedHandStorageService` for persistence
- overhaul saved hands screen with search and filters
- add widgets for hand preview and detail sheet
- integrate storage service through the app

## Testing
- `flutter analyze` *(fails: user requested not to run)*

------
https://chatgpt.com/codex/tasks/task_e_68479822dbec832a8c30b17a2b1d97e5