### PR TITLE
Add pack import/export service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,12 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'screens/main_menu_screen.dart';
 import 'services/saved_hand_storage_service.dart';
+import 'services/training_pack_storage_service.dart';
 
 void main() {
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => SavedHandStorageService()..load()),
+        ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
       ],
       child: const PokerAIAnalyzerApp(),
     ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -4,6 +4,7 @@ import 'package:open_file/open_file.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:file_picker/file_picker.dart';
 import '../helpers/date_utils.dart';
+import 'package:provider/provider.dart';
 
 import 'dart:convert';
 import 'dart:io';
@@ -14,6 +15,7 @@ import '../models/saved_hand.dart';
 import '../models/session_task_result.dart';
 import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
+import '../services/training_pack_storage_service.dart';
 
 class _ResultEntry {
   final String name;
@@ -295,6 +297,22 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
             },
           ),
         ),
+      );
+    }
+  }
+
+  Future<void> _importPackFromFile() async {
+    final service =
+        Provider.of<TrainingPackStorageService>(context, listen: false);
+    final pack = await service.importPack();
+    if (!mounted) return;
+    if (pack == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Ошибка загрузки пакета')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Пакет "${pack.name}" загружен')),
       );
     }
   }
@@ -607,6 +625,11 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
             IconButton(
               icon: const Icon(Icons.edit),
               onPressed: _editPack,
+            ),
+            IconButton(
+              icon: const Icon(Icons.file_download),
+              tooltip: 'Импорт пакета',
+              onPressed: _importPackFromFile,
             ),
           ],
         ),

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/training_pack.dart';
+
+class TrainingPackStorageService extends ChangeNotifier {
+  static const _storageFile = 'training_packs.json';
+
+  final List<TrainingPack> _packs = [];
+  List<TrainingPack> get packs => List.unmodifiable(_packs);
+
+  Future<File> _getStorageFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_storageFile');
+  }
+
+  Future<void> load() async {
+    final file = await _getStorageFile();
+    if (!await file.exists()) return;
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is List) {
+        _packs
+          ..clear()
+          ..addAll(data.whereType<Map>().map((e) =>
+              TrainingPack.fromJson(Map<String, dynamic>.from(e))));
+      }
+    } catch (_) {}
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    final file = await _getStorageFile();
+    await file.writeAsString(jsonEncode([for (final p in _packs) p.toJson()]));
+  }
+
+  Future<void> addPack(TrainingPack pack) async {
+    _packs.add(pack);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<File?> exportPack(TrainingPack pack) async {
+    final dir = await getDownloadsDirectory() ??
+        await getApplicationDocumentsDirectory();
+    final safeName = pack.name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    final file = File('${dir.path}/$safeName.json');
+    await file.writeAsString(jsonEncode(pack.toJson()));
+    return file;
+  }
+
+  Future<TrainingPack?> importPack() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final path = result.files.single.path;
+    if (path == null) return null;
+    final file = File(path);
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is! Map<String, dynamic>) return null;
+      if (!data.containsKey('name') || !data.containsKey('hands')) return null;
+      var pack = TrainingPack.fromJson(Map<String, dynamic>.from(data));
+      String baseName = pack.name;
+      String name = baseName;
+      int idx = 1;
+      while (_packs.any((p) => p.name == name)) {
+        name = '$baseName-copy${idx > 1 ? idx : ''}';
+        idx++;
+      }
+      if (name != pack.name) {
+        pack = TrainingPack(
+          name: name,
+          description: pack.description,
+          category: pack.category,
+          hands: pack.hands,
+          history: pack.history,
+        );
+      }
+      _packs.add(pack);
+      await _persist();
+      notifyListeners();
+      return pack;
+    } catch (_) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrainingPackStorageService` for JSON import/export of packs
- provide the new service in `main.dart`
- enable importing packs from file in `TrainingPackScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68479a174700832aa261379480cc91ed