### PR TITLE
Add training pack progress display

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -45,6 +45,18 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> clear() async {
+    _packs.clear();
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> removePack(TrainingPack pack) async {
+    _packs.remove(pack);
+    await _persist();
+    notifyListeners();
+  }
+
   Future<File?> exportPack(TrainingPack pack) async {
     final dir = await getDownloadsDirectory() ??
         await getApplicationDocumentsDirectory();


### PR DESCRIPTION
## Summary
- show progress for training packs using latest session accuracy
- filter packs by status (All/Started/Completed)
- use `TrainingPackStorageService` through Provider
- support removing and clearing packs in storage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68479c13caf4832aa3070c10663361c6