### PR TITLE
Add player zone action sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'screens/main_menu_screen.dart';
 import 'services/saved_hand_storage_service.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/daily_hand_service.dart';
+import 'services/action_sync_service.dart';
 
 void main() {
   runApp(
@@ -14,6 +15,7 @@ void main() {
         ChangeNotifierProvider(create: (_) => SavedHandStorageService()..load()),
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
+        ChangeNotifierProvider(create: (_) => ActionSyncService()),
       ],
       child: const PokerAIAnalyzerApp(),
     ),

--- a/lib/models/player_zone_action_entry.dart
+++ b/lib/models/player_zone_action_entry.dart
@@ -1,0 +1,13 @@
+class ActionEntry {
+  final String playerName;
+  final String street;
+  final String action;
+  final int? amount;
+
+  ActionEntry({
+    required this.playerName,
+    required this.street,
+    required this.action,
+    this.amount,
+  });
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -5,6 +5,7 @@ import 'saved_hands_screen.dart';
 import 'training_packs_screen.dart';
 import 'all_sessions_screen.dart';
 import 'training_history_screen.dart';
+import 'player_zone_demo_screen.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -70,6 +71,17 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('🗓️ Training History'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const PlayerZoneDemoScreen()),
+                );
+              },
+              child: const Text('🧪 Player Zone Demo'),
             ),
           ],
         ),

--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../widgets/player_zone_widget.dart';
+import '../widgets/street_tabs.dart';
+import '../widgets/street_action_list_simple.dart';
+import '../models/card_model.dart';
+import '../services/action_sync_service.dart';
+
+class PlayerZoneDemoScreen extends StatefulWidget {
+  const PlayerZoneDemoScreen({super.key});
+
+  @override
+  State<PlayerZoneDemoScreen> createState() => _PlayerZoneDemoScreenState();
+}
+
+class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
+  int _street = 0;
+  final List<String> _streetNames = const ['Preflop', 'Flop', 'Turn', 'River'];
+  final List<String> _players = const ['Alice', 'Bob', 'Carol'];
+  final List<List<CardModel>> _cards = [[], [], []];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Player Zone Demo')),
+      body: Column(
+        children: [
+          StreetTabs(
+            currentStreet: _street,
+            onStreetChanged: (i) => setState(() => _street = i),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _players.length,
+              itemBuilder: (context, index) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16),
+                  child: PlayerZoneWidget(
+                    playerName: _players[index],
+                    street: _streetNames[_street],
+                    position: null,
+                    cards: _cards[index],
+                    isHero: index == 0,
+                    isFolded: false,
+                    onCardsSelected: (i, c) {},
+                  ),
+                );
+              },
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final s in _streetNames)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 12.0),
+                      child: StreetActionListSimple(street: s),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/player_zone_action_entry.dart';
+
+class ActionSyncService extends ChangeNotifier {
+  final Map<String, List<ActionEntry>> actions = {
+    'Preflop': [],
+    'Flop': [],
+    'Turn': [],
+    'River': [],
+  };
+
+  void addOrUpdate(ActionEntry entry) {
+    final list = actions[entry.street]!;
+    final index = list.indexWhere((e) => e.playerName == entry.playerName);
+    if (index >= 0) {
+      list[index] = entry;
+    } else {
+      list.add(entry);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../models/card_model.dart';
 import '../models/player_model.dart';
+import '../models/player_zone_action_entry.dart' as pz;
+import '../services/action_sync_service.dart';
 import 'card_selector.dart';
 import 'chip_widget.dart';
 
 class PlayerZoneWidget extends StatefulWidget {
   final String playerName;
+  final String street;
   final String? position;
   final List<CardModel> cards;
   final bool isHero;
@@ -25,6 +29,7 @@ class PlayerZoneWidget extends StatefulWidget {
   const PlayerZoneWidget({
     Key? key,
     required this.playerName,
+    required this.street,
     this.position,
     required this.cards,
     required this.isHero,
@@ -433,6 +438,13 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
         _currentBet = amount;
       }
     });
+    final sync = context.read<ActionSyncService>();
+    sync.addOrUpdate(pz.ActionEntry(
+      playerName: widget.playerName,
+      street: widget.street,
+      action: action,
+      amount: amount,
+    ));
   }
 
   Future<Map<String, dynamic>?> _showActionSheet() {

--- a/lib/widgets/street_action_list_simple.dart
+++ b/lib/widgets/street_action_list_simple.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/action_sync_service.dart';
+import '../models/player_zone_action_entry.dart';
+
+class StreetActionListSimple extends StatelessWidget {
+  final String street;
+
+  const StreetActionListSimple({super.key, required this.street});
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, List<ActionEntry>> actions =
+        context.watch<ActionSyncService>().actions;
+    final list = actions[street] ?? [];
+    if (list.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          street,
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        for (final a in list)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Text(
+              '${a.playerName}: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ActionSyncService` for centralized action storage
- integrate service with `PlayerZoneWidget`
- display actions via new `StreetActionListSimple`
- add demo screen to interact with player zones
- wire up provider and menu entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847aa1d505c832ab7112426547cdfa5