### PR TITLE
Add undo and clear street actions

### DIFF
--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -20,4 +20,22 @@ class ActionSyncService extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  /// Removes the most recently added action for the given street, if any.
+  void undoLastAction(String street) {
+    final list = actions[street];
+    if (list != null && list.isNotEmpty) {
+      list.removeLast();
+      notifyListeners();
+    }
+  }
+
+  /// Clears all actions for the specified street.
+  void clearStreet(String street) {
+    final list = actions[street];
+    if (list != null && list.isNotEmpty) {
+      list.clear();
+      notifyListeners();
+    }
+  }
 }

--- a/lib/widgets/street_action_list_simple.dart
+++ b/lib/widgets/street_action_list_simple.dart
@@ -14,9 +14,6 @@ class StreetActionListSimple extends StatelessWidget {
     final Map<String, List<ActionEntry>> actions =
         context.watch<ActionSyncService>().actions;
     final list = actions[street] ?? [];
-    if (list.isEmpty) {
-      return const SizedBox.shrink();
-    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -27,14 +24,38 @@ class StreetActionListSimple extends StatelessWidget {
             fontWeight: FontWeight.bold,
           ),
         ),
-        for (final a in list)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2),
+        if (list.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 2),
             child: Text(
-              '${a.playerName}: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
-              style: const TextStyle(color: Colors.white),
+              'No actions',
+              style: TextStyle(color: Colors.white54),
             ),
-          ),
+          )
+        else
+          for (final a in list)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text(
+                '${a.playerName}: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
+        Row(
+          children: [
+            TextButton(
+              onPressed: () =>
+                  context.read<ActionSyncService>().undoLastAction(street),
+              child: const Text('Undo Last Action'),
+            ),
+            const SizedBox(width: 8),
+            TextButton(
+              onPressed: () =>
+                  context.read<ActionSyncService>().clearStreet(street),
+              child: const Text('Clear Street'),
+            ),
+          ],
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- support undoLastAction and clearStreet in ActionSyncService
- show undo and clear buttons in StreetActionListSimple

## Testing
- `No tests run due to instructions`

------
https://chatgpt.com/codex/tasks/task_e_6847ab65743c832aa93c9dc53c5ce54c