### PR TITLE
Add global undo to ActionSyncService

### DIFF
--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -60,6 +60,11 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
                       padding: const EdgeInsets.only(bottom: 12.0),
                       child: StreetActionListSimple(street: s),
                     ),
+                  TextButton(
+                    onPressed: () =>
+                        context.read<ActionSyncService>().undoLastGlobal(),
+                    child: const Text('Undo Global'),
+                  ),
                 ],
               ),
             ),

--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -10,6 +10,8 @@ class ActionSyncService extends ChangeNotifier {
     'River': [],
   };
 
+  final List<ActionEntry> _history = [];
+
   void addOrUpdate(ActionEntry entry) {
     final list = actions[entry.street]!;
     final index = list.indexWhere((e) => e.playerName == entry.playerName);
@@ -17,6 +19,7 @@ class ActionSyncService extends ChangeNotifier {
       list[index] = entry;
     } else {
       list.add(entry);
+      _history.add(entry);
     }
     notifyListeners();
   }
@@ -25,7 +28,18 @@ class ActionSyncService extends ChangeNotifier {
   void undoLastAction(String street) {
     final list = actions[street];
     if (list != null && list.isNotEmpty) {
-      list.removeLast();
+      final removed = list.removeLast();
+      _history.remove(removed);
+      notifyListeners();
+    }
+  }
+
+  /// Removes the last added action across all streets, if any.
+  void undoLastGlobal() {
+    if (_history.isNotEmpty) {
+      final last = _history.removeLast();
+      final list = actions[last.street];
+      list?.remove(last);
       notifyListeners();
     }
   }
@@ -34,6 +48,9 @@ class ActionSyncService extends ChangeNotifier {
   void clearStreet(String street) {
     final list = actions[street];
     if (list != null && list.isNotEmpty) {
+      for (final a in list) {
+        _history.remove(a);
+      }
       list.clear();
       notifyListeners();
     }


### PR DESCRIPTION
## Summary
- support undoing last action across all streets
- remove actions from history when undoing or clearing a street
- expose global undo button in demo screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847ac3481c8832abbf95591fcc05940