### PR TITLE
Improve action list UI

### DIFF
--- a/lib/widgets/street_action_list_simple.dart
+++ b/lib/widgets/street_action_list_simple.dart
@@ -14,31 +14,66 @@ class StreetActionListSimple extends StatelessWidget {
     final Map<String, List<ActionEntry>> actions =
         context.watch<ActionSyncService>().actions;
     final list = actions[street] ?? [];
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+
+    Color _cardColor() => isDark ? Colors.grey[800]! : Colors.grey[100]!;
+    Color _textColor() => isDark ? Colors.white : Colors.black87;
+
+    String _iconForAction(String action) {
+      switch (action) {
+        case 'fold':
+          return '❌';
+        case 'bet':
+          return '💰';
+        case 'raise':
+          return '⬆';
+        case 'call':
+          return '📞';
+        default:
+          return '';
+      }
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           street,
-          style: const TextStyle(
-            color: Colors.white,
+          style: TextStyle(
+            color: _textColor(),
             fontWeight: FontWeight.bold,
           ),
         ),
         if (list.isEmpty)
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 2),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
             child: Text(
               'No actions',
-              style: TextStyle(color: Colors.white54),
+              style: TextStyle(color: _textColor().withOpacity(0.6)),
             ),
           )
         else
           for (final a in list)
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 2),
-              child: Text(
-                '${a.playerName}: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
-                style: const TextStyle(color: Colors.white),
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Card(
+                color: _cardColor(),
+                elevation: 2,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
+                    children: [
+                      Text(_iconForAction(a.action)),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          '${a.playerName}: ${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+                          style: TextStyle(color: _textColor()),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
         Row(


### PR DESCRIPTION
## Summary
- render StreetActionListSimple actions inside Cards
- show icons for folds, bets, raises and calls
- adapt card and text colors to light/dark theme

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_6847ad320ebc832a999981c5a6f19656