### PR TITLE
Enable editing street actions

### DIFF
--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -24,6 +24,14 @@ class ActionSyncService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates an existing action entry at the given index for the street.
+  void updateAction(String street, int index, ActionEntry newEntry) {
+    final list = actions[street];
+    if (list == null || index < 0 || index >= list.length) return;
+    list[index] = newEntry;
+    notifyListeners();
+  }
+
   /// Removes the most recently added action for the given street, if any.
   void undoLastAction(String street) {
     final list = actions[street];


### PR DESCRIPTION
## Summary
- allow editing street actions via a modal sheet
- update action entries through ActionSyncService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847f67a6b64832aa823e0301fcbd2b9