### PR TITLE
Show current bet below cards

### DIFF
--- a/lib/widgets/current_bet_label.dart
+++ b/lib/widgets/current_bet_label.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Displays the player's current bet as an icon and amount text.
+class CurrentBetLabel extends StatelessWidget {
+  /// Current bet amount to show.
+  final int bet;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const CurrentBetLabel({
+    Key? key,
+    required this.bet,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (bet <= 0) return const SizedBox.shrink();
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white;
+    return Padding(
+      padding: EdgeInsets.only(top: 4.0 * scale),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            '🪙',
+            style: TextStyle(fontSize: 12 * scale),
+          ),
+          SizedBox(width: 4 * scale),
+          Text(
+            '$bet',
+            style: TextStyle(
+              color: textColor,
+              fontSize: 12 * scale,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -6,6 +6,7 @@ import '../models/player_zone_action_entry.dart' as pz;
 import '../services/action_sync_service.dart';
 import 'card_selector.dart';
 import 'chip_widget.dart';
+import 'current_bet_label.dart';
 
 class PlayerZoneWidget extends StatefulWidget {
   final String playerName;
@@ -289,6 +290,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
             }),
           ),
         ),
+        CurrentBetLabel(bet: _currentBet, scale: widget.scale),
         if (_actionTagText != null)
           Padding(
             padding: EdgeInsets.only(top: 4.0 * widget.scale),


### PR DESCRIPTION
## Summary
- add `CurrentBetLabel` widget for displaying bet with a chip icon
- show the current bet amount under the player's cards

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684812486c84832a83ba0b67b0210031