### PR TITLE
Add pot display overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1817,7 +1817,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       items.add(Positioned.fill(
         child: IgnorePointer(
           child: Align(
-            alignment: const Alignment(0, -0.25),
+            alignment: Alignment.center,
             child: PotDisplayWidget(
               amount: pot,
               scale: scale,

--- a/lib/widgets/pot_display_widget.dart
+++ b/lib/widgets/pot_display_widget.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
-import 'chip_widget.dart';
 
-/// Displays the current pot amount with a label and animates changes.
-class PotDisplayWidget extends StatefulWidget {
-  /// Current pot amount.
+/// Simple widget that displays the current pot amount.
+///
+/// Shows a rounded semi-transparent background with a white label
+/// "Pot: X" where `X` is the amount. When the amount changes the
+/// label fades between the values.
+class PotDisplayWidget extends StatelessWidget {
+  /// Amount of chips currently in the pot.
   final int amount;
 
-  /// Scale factor to adapt to table size.
+  /// Scale factor for the text and padding.
   final double scale;
 
   const PotDisplayWidget({
@@ -16,71 +19,34 @@ class PotDisplayWidget extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<PotDisplayWidget> createState() => _PotDisplayWidgetState();
-}
-
-class _PotDisplayWidgetState extends State<PotDisplayWidget>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _scaleController;
-
-  @override
-  void initState() {
-    super.initState();
-    _scaleController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 150),
-    )..addStatusListener((status) {
-        if (status == AnimationStatus.completed) {
-          _scaleController.reverse();
-        }
-      });
-  }
-
-  @override
-  void didUpdateWidget(covariant PotDisplayWidget oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.amount > oldWidget.amount) {
-      _scaleController.forward(from: 0);
-    }
-  }
-
-  @override
-  void dispose() {
-    _scaleController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (widget.amount <= 0) return const SizedBox.shrink();
-
-    return ScaleTransition(
-      scale: Tween<double>(begin: 1, end: 1.1).animate(
-        CurvedAnimation(parent: _scaleController, curve: Curves.easeOut),
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: child,
       ),
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 300),
-        transitionBuilder: (child, animation) => FadeTransition(
-          opacity: animation,
-          child: ScaleTransition(scale: animation, child: child),
-        ),
-        child: Column(
-          key: ValueKey(widget.amount),
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ChipWidget(amount: widget.amount, scale: widget.scale * 1.3),
-            SizedBox(height: 4 * widget.scale),
-            Text(
-              'Pot',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 14 * widget.scale,
-                fontWeight: FontWeight.bold,
+      child: amount > 0
+          ? Container(
+              key: ValueKey(amount),
+              padding: EdgeInsets.symmetric(
+                horizontal: 12 * scale,
+                vertical: 6 * scale,
               ),
-            ),
-          ],
-        ),
-      ),
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                borderRadius: BorderRadius.circular(12 * scale),
+              ),
+              child: Text(
+                'Pot: $amount',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 16 * scale,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- redesign `PotDisplayWidget` to show text label with fade animation
- center the pot display in `_buildPotAndBetsOverlay`

## Testing
- `bash: flutter: command not found` when attempting to run `flutter format`

------
https://chatgpt.com/codex/tasks/task_e_68481b07a628832aa51f1d852e03cb36