### PR TITLE
Add chip stack display for bets

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/card_selector.dart';
 import '../widgets/player_bet_indicator.dart';
 import '../widgets/player_stack_chips.dart';
 import '../widgets/bet_stack_chips.dart';
+import '../widgets/chip_stack_widget.dart';
 import '../widgets/chip_amount_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
@@ -1863,6 +1864,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             action: lastAction.action,
             amount: lastAction.amount!,
             scale: scale,
+          ),
+        ));
+        final stackPos = Offset.lerp(start, end, 0.15)!;
+        final stackScale = scale * 0.7;
+        items.add(Positioned(
+          left: stackPos.dx - 6 * stackScale,
+          top: stackPos.dy - 12 * stackScale,
+          child: ChipStackWidget(
+            amount: lastAction.amount!,
+            scale: stackScale,
+            color: _actionColor(lastAction.action),
           ),
         ));
       }

--- a/lib/widgets/chip_stack_widget.dart
+++ b/lib/widgets/chip_stack_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'chip_trail.dart';
+
+/// Column of small chip icons representing a bet stack.
+class ChipStackWidget extends StatelessWidget {
+  /// Amount of chips to visualize.
+  final int amount;
+
+  /// Scale factor depending on table size.
+  final double scale;
+
+  /// Color of the chips.
+  final Color color;
+
+  const ChipStackWidget({
+    Key? key,
+    required this.amount,
+    this.scale = 1.0,
+    this.color = Colors.amber,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (amount <= 0) return const SizedBox.shrink();
+    final chipCount = (amount / 20).clamp(1, 8).round();
+    final chipSize = 12 * scale;
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Column(
+        key: ValueKey(amount),
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(
+          chipCount,
+          (i) => Padding(
+            padding: EdgeInsets.only(bottom: 2 * scale),
+            child: MiniChip(color: color, size: chipSize),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- visualize a column of chips using new `ChipStackWidget`
- show animated stack next to players after bets

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_68481cb383ec832aa99405f3001e732f