### PR TITLE
Add stack label under player avatars

### DIFF
--- a/lib/widgets/player_stack_label.dart
+++ b/lib/widgets/player_stack_label.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Displays the player's remaining stack as a small label.
+class PlayerStackLabel extends StatelessWidget {
+  /// Current stack value to display.
+  final int? stack;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const PlayerStackLabel({
+    Key? key,
+    required this.stack,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (stack == null || stack! <= 0) return const SizedBox.shrink();
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color textColor = isDark ? Colors.white : Colors.black;
+    final Color backgroundColor = isDark ? Colors.white24 : Colors.black26;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: Container(
+        key: ValueKey(stack),
+        padding: EdgeInsets.symmetric(
+          horizontal: 6 * scale,
+          vertical: 2 * scale,
+        ),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(8 * scale),
+        ),
+        child: Text(
+          'Stack: $stack',
+          style: TextStyle(
+            color: textColor,
+            fontSize: 12 * scale,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -7,6 +7,7 @@ import '../services/action_sync_service.dart';
 import 'card_selector.dart';
 import 'chip_widget.dart';
 import 'current_bet_label.dart';
+import 'player_stack_label.dart';
 
 class PlayerZoneWidget extends StatefulWidget {
   final String playerName;
@@ -290,6 +291,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
             }),
           ),
         ),
+        PlayerStackLabel(stack: widget.stackSize, scale: widget.scale),
         CurrentBetLabel(bet: _currentBet, scale: widget.scale),
         if (_actionTagText != null)
           Padding(


### PR DESCRIPTION
## Summary
- create `PlayerStackLabel` widget for displaying remaining chips
- show the stack below the cards in `PlayerZoneWidget`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684821bb1cf4832aab6f451b2a1f2a66