### PR TITLE
Add active player action timer

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -552,6 +552,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
   }
 
+  void _onPlayerTimeExpired(int index) {
+    if (activePlayerIndex == index) {
+      setState(() => activePlayerIndex = null);
+    }
+  }
+
   void selectBoardCard(int index, CardModel card) {
     setState(() {
       for (final cards in playerCards) {
@@ -2323,6 +2329,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             onRemove: numberOfPlayers > 2 ? () {
               _removePlayer(index);
             } : null,
+            onTimeExpired: () => _onPlayerTimeExpired(index),
           ),
         ),
       ),

--- a/lib/widgets/action_timer_ring.dart
+++ b/lib/widgets/action_timer_ring.dart
@@ -1,0 +1,124 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+/// Animated ring that counts down over [duration] when [isActive] is true.
+/// Calls [onTimeExpired] when the countdown completes.
+class ActionTimerRing extends StatefulWidget {
+  final Widget child;
+  final bool isActive;
+  final Duration duration;
+  final VoidCallback? onTimeExpired;
+  final double thickness;
+
+  const ActionTimerRing({
+    super.key,
+    required this.child,
+    required this.isActive,
+    this.duration = const Duration(seconds: 10),
+    this.onTimeExpired,
+    this.thickness = 4,
+  });
+
+  @override
+  State<ActionTimerRing> createState() => _ActionTimerRingState();
+}
+
+class _ActionTimerRingState extends State<ActionTimerRing>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Color?> _color;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _color = TweenSequence<Color?>([
+      TweenSequenceItem(
+        tween: ColorTween(begin: Colors.green, end: Colors.yellow),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: ColorTween(begin: Colors.yellow, end: Colors.red),
+        weight: 50,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onTimeExpired?.call();
+      }
+    });
+    if (widget.isActive) {
+      _controller.forward();
+    }
+  }
+
+  @override
+  void didUpdateWidget(ActionTimerRing oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isActive && !oldWidget.isActive) {
+      _controller
+        ..reset()
+        ..forward();
+    } else if (!widget.isActive && oldWidget.isActive) {
+      _controller.reset();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final progress = 1.0 - _controller.value;
+        final color = _color.value ?? Colors.green;
+        return CustomPaint(
+          foregroundPainter: _RingPainter(
+            progress: progress,
+            color: color,
+            thickness: widget.thickness,
+          ),
+          child: child,
+        );
+      },
+      child: widget.child,
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  final double progress;
+  final Color color;
+  final double thickness;
+
+  _RingPainter({
+    required this.progress,
+    required this.color,
+    required this.thickness,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius =
+        math.min(size.width, size.height) / 2 - thickness / 2;
+    final rect = Rect.fromCircle(center: size.center(Offset.zero), radius: radius);
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = thickness
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(rect, -math.pi / 2, 2 * math.pi * progress, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.color != color ||
+        oldDelegate.thickness != thickness;
+  }
+}

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/card_model.dart';
+import 'action_timer_ring.dart';
 
 /// Compact display for a player's position, stack, tag and last action.
 /// Optionally shows a simplified position label as a badge.
@@ -32,6 +33,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final ValueChanged<int>? onStackTap;
   /// Called when the remove icon is tapped.
   final VoidCallback? onRemove;
+  /// Called when the active timer finishes.
+  final VoidCallback? onTimeExpired;
   /// Called when a card slot is tapped. The index corresponds to 0 or 1.
   final void Function(int index)? onCardTap;
 
@@ -55,6 +58,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.onEdit,
     this.onStackTap,
     this.onRemove,
+    this.onTimeExpired,
     this.onCardTap,
     this.showLastIndicator = false,
   });
@@ -338,6 +342,11 @@ class PlayerInfoWidget extends StatelessWidget {
 
     if (isActive) {
       clickable = _ActivePlayerGlow(child: clickable);
+      clickable = ActionTimerRing(
+        child: clickable,
+        isActive: true,
+        onTimeExpired: onTimeExpired,
+      );
     }
 
     Widget withBadge = clickable;


### PR DESCRIPTION
## Summary
- create `ActionTimerRing` widget for countdown ring
- integrate timer ring into `PlayerInfoWidget`
- trigger callback when timer ends
- expose timer callback in PokerAnalyzerScreen

## Testing
- `dart` command unavailable so formatting skipped
- No tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_6848373cef78832aaa56f5fae013e2a9