### PR TITLE
Add stack bar under player avatar

### DIFF
--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -8,6 +8,7 @@ import 'card_selector.dart';
 import 'chip_widget.dart';
 import 'current_bet_label.dart';
 import 'player_stack_label.dart';
+import 'stack_bar_widget.dart';
 
 class PlayerZoneWidget extends StatefulWidget {
   final String playerName;
@@ -27,6 +28,8 @@ class PlayerZoneWidget extends StatefulWidget {
   final bool showHint;
   final String? actionTagText;
   final void Function(int, CardModel) onCardsSelected;
+  /// Starting stack value representing 100% for the stack bar.
+  final int maxStackSize;
   final double scale;
   // Stack editing is handled by PlayerInfoWidget
 
@@ -47,6 +50,7 @@ class PlayerZoneWidget extends StatefulWidget {
     this.highlightLastAction = false,
     this.showHint = false,
     this.actionTagText,
+    this.maxStackSize = 100,
     this.scale = 1.0,
   }) : super(key: key);
 
@@ -289,9 +293,14 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                 ),
               );
             }),
-          ),
         ),
+      ),
         PlayerStackLabel(stack: widget.stackSize, scale: widget.scale),
+        StackBarWidget(
+          stack: widget.stackSize,
+          maxStack: widget.maxStackSize,
+          scale: widget.scale,
+        ),
         CurrentBetLabel(bet: _currentBet, scale: widget.scale),
         if (_actionTagText != null)
           Padding(

--- a/lib/widgets/stack_bar_widget.dart
+++ b/lib/widgets/stack_bar_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Displays player's remaining stack as a thin progress bar.
+class StackBarWidget extends StatelessWidget {
+  /// Current stack size. If null, the bar is hidden.
+  final int? stack;
+
+  /// Starting stack value representing 100% of the bar.
+  final int maxStack;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const StackBarWidget({
+    Key? key,
+    required this.stack,
+    this.maxStack = 100,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  Color _barColor(int stack) {
+    if (stack > 50) {
+      return Colors.green;
+    } else if (stack >= 20) {
+      return Colors.yellow;
+    }
+    return Colors.red;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (stack == null) return SizedBox(height: 4 * scale);
+    final double progress = (stack! / maxStack).clamp(0.0, 1.0);
+    final color = _barColor(stack!);
+    return SizedBox(
+      height: 4 * scale,
+      child: TweenAnimationBuilder<double>(
+        tween: Tween<double>(begin: 0, end: progress),
+        duration: const Duration(milliseconds: 300),
+        builder: (context, value, child) {
+          return ClipRRect(
+            borderRadius: BorderRadius.circular(2 * scale),
+            child: LinearProgressIndicator(
+              value: value,
+              backgroundColor: Colors.black26,
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+              minHeight: 4 * scale,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `StackBarWidget` to show stack as an animated progress bar
- display the new widget in `PlayerZoneWidget`
- allow configuring `maxStackSize` for progress calculations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483d2752d4832ab535fb82f2670550