### PR TITLE
Add bet animation

### DIFF
--- a/lib/widgets/bet_chip_animation.dart
+++ b/lib/widgets/bet_chip_animation.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'chip_widget.dart';
+
+/// Animation of chips flying from a start point to an end point.
+class BetChipAnimation extends StatefulWidget {
+  /// Global start position of the chip stack.
+  final Offset start;
+
+  /// Global end position (usually the center of the table).
+  final Offset end;
+
+  /// Amount displayed on the chips.
+  final int amount;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  /// Called when the animation completes.
+  final VoidCallback? onCompleted;
+
+  const BetChipAnimation({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<BetChipAnimation> createState() => _BetChipAnimationState();
+}
+
+class _BetChipAnimationState extends State<BetChipAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0).chain(
+          CurveTween(curve: Curves.easeIn),
+        ),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0).chain(
+          CurveTween(curve: Curves.easeOut),
+        ),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pos = Offset.lerp(widget.start, widget.end, _controller.value)!;
+        return Positioned(
+          left: pos.dx,
+          top: pos.dy,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: child,
+          ),
+        );
+      },
+      child: ChipWidget(amount: widget.amount, scale: widget.scale),
+    );
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -9,6 +9,7 @@ import 'chip_widget.dart';
 import 'current_bet_label.dart';
 import 'player_stack_label.dart';
 import 'stack_bar_widget.dart';
+import 'bet_chip_animation.dart';
 
 class PlayerZoneWidget extends StatefulWidget {
   final String playerName;
@@ -64,6 +65,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
   late PlayerType _playerType;
   late int _currentBet;
   String? _actionTagText;
+  OverlayEntry? _betEntry;
 
   @override
   void initState() {
@@ -96,6 +98,9 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     }
     if (widget.currentBet != oldWidget.currentBet) {
       _currentBet = widget.currentBet;
+      if (widget.currentBet > 0 && widget.currentBet > oldWidget.currentBet) {
+        _playBetAnimation(widget.currentBet);
+      }
     }
     if (widget.actionTagText != oldWidget.actionTagText) {
       _actionTagText = widget.actionTagText;
@@ -107,8 +112,30 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     setState(() => _currentBet = bet);
   }
 
+  void _playBetAnimation(int amount) {
+    final overlay = Overlay.of(context);
+    final box = context.findRenderObject() as RenderBox?;
+    if (overlay == null || box == null) return;
+    final start = box.localToGlobal(box.size.center(Offset.zero));
+    final media = MediaQuery.of(context).size;
+    final end = Offset(media.width / 2, media.height / 2 - 60 * widget.scale);
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (_) => BetChipAnimation(
+        start: start,
+        end: end,
+        amount: amount,
+        scale: widget.scale,
+        onCompleted: () => entry.remove(),
+      ),
+    );
+    overlay.insert(entry);
+    _betEntry = entry;
+  }
+
   @override
   void dispose() {
+    _betEntry?.remove();
     _controller.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- add BetChipAnimation widget to display flying chips
- play animation from PlayerZoneWidget when bet increases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483fad2d4c832a8815c4f9eb5778af