### PR TITLE
Add pot transfer animation

### DIFF
--- a/lib/widgets/move_pot_animation.dart
+++ b/lib/widgets/move_pot_animation.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+/// Animation of a small "Pot" label flying to the winning player.
+class MovePotAnimation extends StatefulWidget {
+  /// Global start position (usually the center of the screen).
+  final Offset start;
+
+  /// Global end position of the player.
+  final Offset end;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  /// Callback invoked when the animation completes.
+  final VoidCallback? onCompleted;
+
+  const MovePotAnimation({
+    Key? key,
+    required this.start,
+    required this.end,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<MovePotAnimation> createState() => _MovePotAnimationState();
+}
+
+class _MovePotAnimationState extends State<MovePotAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fade;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+    _fade = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.7, 1.0)),
+    );
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pos = Offset.lerp(widget.start, widget.end, _controller.value)!;
+        return Positioned(
+          left: pos.dx,
+          top: pos.dy,
+          child: FadeTransition(
+            opacity: _fade,
+            child: child,
+          ),
+        );
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: 8 * widget.scale,
+          vertical: 4 * widget.scale,
+        ),
+        decoration: BoxDecoration(
+          color: Colors.black54,
+          borderRadius: BorderRadius.circular(12 * widget.scale),
+        ),
+        child: Text(
+          'Pot',
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 14 * widget.scale,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays a [MovePotAnimation] above the current overlay.
+void showMovePotAnimation({
+  required BuildContext context,
+  required Offset start,
+  required Offset end,
+  double scale = 1.0,
+}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => MovePotAnimation(
+      start: start,
+      end: end,
+      scale: scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -12,6 +12,7 @@ import 'current_bet_label.dart';
 import 'player_stack_label.dart';
 import 'stack_bar_widget.dart';
 import 'bet_chip_animation.dart';
+import 'move_pot_animation.dart';
 
 final Map<String, _PlayerZoneWidgetState> _playerZoneRegistry = {};
 
@@ -709,5 +710,30 @@ void showOpponentCards(
   for (final entry in cardsByPlayer.entries) {
     revealOpponentCards(entry.key, entry.value);
   }
+}
+
+/// Animates the central pot moving to the specified player's zone.
+void movePotToWinner(BuildContext context, String playerName) {
+  final overlay = Overlay.of(context);
+  final state = _playerZoneRegistry[playerName];
+  if (overlay == null || state == null) return;
+
+  final box = state.context.findRenderObject() as RenderBox?;
+  if (box == null) return;
+
+  final end = box.localToGlobal(box.size.center(Offset.zero));
+  final media = MediaQuery.of(context).size;
+  final start = Offset(media.width / 2, media.height / 2);
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => MovePotAnimation(
+      start: start,
+      end: end,
+      scale: state.widget.scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
 }
 


### PR DESCRIPTION
## Summary
- animate pot movement using MovePotAnimation overlay
- expose `movePotToWinner` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68484548f9a8832a95ed8afde38659e1