### PR TITLE
Add collapsible history tabs

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/player_zone_widget.dart';
 import '../widgets/street_actions_widget.dart';
 import '../widgets/board_display.dart';
 import '../widgets/action_history_overlay.dart';
+import '../widgets/collapsible_action_history.dart';
 import 'package:provider/provider.dart';
 import '../services/saved_hand_storage_service.dart';
 import '../theme/constants.dart';
@@ -2153,6 +2154,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                 ],
               ),
+            ),
+            CollapsibleActionHistory(
+              actions: visibleActions,
+              playerPositions: playerPositions,
             ),
             Expanded(
               child: SingleChildScrollView(

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+
+class CollapsibleActionHistory extends StatefulWidget {
+  final List<ActionEntry> actions;
+  final Map<int, String> playerPositions;
+
+  const CollapsibleActionHistory({
+    super.key,
+    required this.actions,
+    required this.playerPositions,
+  });
+
+  @override
+  State<CollapsibleActionHistory> createState() => _CollapsibleActionHistoryState();
+}
+
+class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
+    with SingleTickerProviderStateMixin {
+  bool _open = false;
+  late TabController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  List<ActionEntry> _forStreet(int street) {
+    return widget.actions
+        .where((a) => a.street == street && !a.generated)
+        .toList();
+  }
+
+  Widget _buildList(int street) {
+    final list = _forStreet(street);
+    if (list.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('No actions', style: TextStyle(color: Colors.white70)),
+        ),
+      );
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(12),
+      itemCount: list.length,
+      itemBuilder: (_, i) {
+        final a = list[i];
+        final pos = widget.playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
+        final size = a.amount != null ? ' ${a.amount}' : '';
+        return Text('$pos ${a.action}$size', style: const TextStyle(color: Colors.white));
+      },
+      separatorBuilder: (_, __) => const Divider(height: 1, color: Colors.white24),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        GestureDetector(
+          onTap: () => setState(() => _open = !_open),
+          child: Container(
+            color: Colors.black45,
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Action History', style: TextStyle(color: Colors.white)),
+                Icon(_open ? Icons.expand_less : Icons.expand_more, color: Colors.white),
+              ],
+            ),
+          ),
+        ),
+        if (_open)
+          Container(
+            color: Colors.black54,
+            height: 200,
+            child: Column(
+              children: [
+                TabBar(
+                  controller: _controller,
+                  labelColor: Colors.white,
+                  unselectedLabelColor: Colors.white70,
+                  indicatorColor: Colors.white,
+                  tabs: const [
+                    Tab(text: 'Preflop'),
+                    Tab(text: 'Flop'),
+                    Tab(text: 'Turn'),
+                    Tab(text: 'River'),
+                  ],
+                ),
+                const Divider(height: 1, color: Colors.white24),
+                Expanded(
+                  child: TabBarView(
+                    controller: _controller,
+                    children: [
+                      _buildList(0),
+                      _buildList(1),
+                      _buildList(2),
+                      _buildList(3),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- display collapsible action history tabs
- include the widget below the table on the analyzer screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68484f2dd0f0832ab1753fd64b73123b