### PR TITLE
Add hero action helpers

### DIFF
--- a/lib/helpers/action_utils.dart
+++ b/lib/helpers/action_utils.dart
@@ -1,0 +1,17 @@
+// Helper utilities for working with ActionEntry lists.
+import '../models/action_entry.dart';
+
+/// Returns true if [action] was performed by the hero at [heroIndex].
+bool isHeroAction(ActionEntry action, int heroIndex) {
+  return action.playerIndex == heroIndex;
+}
+
+/// Returns true if [action] was performed by an opponent of the hero.
+bool isOpponentAction(ActionEntry action, int heroIndex) {
+  return action.playerIndex != heroIndex;
+}
+
+/// Filters [actions] to only those taken by opponents of the hero.
+List<ActionEntry> actionsAgainstHero(List<ActionEntry> actions, int heroIndex) {
+  return actions.where((a) => isOpponentAction(a, heroIndex)).toList();
+}

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -4,6 +4,7 @@ import 'package:open_file/open_file.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:file_picker/file_picker.dart';
 import '../helpers/date_utils.dart';
+import '../helpers/action_utils.dart';
 import 'package:provider/provider.dart';
 
 import 'dart:convert';
@@ -102,7 +103,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     String userAct = '-';
     if (played != null) {
       for (final a in played.actions) {
-        if (a.playerIndex == played.heroIndex) {
+        if (isHeroAction(a, played.heroIndex)) {
           userAct = a.action;
           break;
         }

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../helpers/action_utils.dart';
 
 class CollapsibleActionHistory extends StatefulWidget {
   final List<ActionEntry> actions;
@@ -76,7 +77,7 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
         final style = TextStyle(
           color: Colors.white,
           fontWeight:
-              a.playerIndex == widget.heroIndex ? FontWeight.bold : null,
+              isHeroAction(a, widget.heroIndex) ? FontWeight.bold : null,
         );
         return Row(
           children: [


### PR DESCRIPTION
## Summary
- add `action_utils` helpers for hero vs. opponent actions
- highlight hero actions in history using new helper
- detect hero move during training using new helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68485117c474832abf157c04a502af4f