### PR TITLE
Refactor opponent card handling

### DIFF
--- a/lib/models/player_model.dart
+++ b/lib/models/player_model.dart
@@ -1,4 +1,5 @@
 import 'action_model.dart';
+import 'card_model.dart';
 
 /// Different types of players at the table.
 enum PlayerType {
@@ -24,10 +25,12 @@ enum PlayerType {
 class PlayerModel {
   final String name;
   final List<String> cards;
+  /// Known revealed cards for this player, if any.
+  List<CardModel>? revealedCards;
   final Map<String, List<PlayerActionModel>> actions;
   PlayerType type;
 
-  PlayerModel({required this.name, this.type = PlayerType.unknown})
+  PlayerModel({required this.name, this.type = PlayerType.unknown, this.revealedCards})
       : cards = [],
         actions = {
           'Preflop': [],


### PR DESCRIPTION
## Summary
- add `revealedCards` field to `PlayerModel`
- store revealed player cards inside `SavedHand`
- replace `opponentCards` logic in analyzer screen with per-player `revealedCards`
- allow tapping any non-hero card slots to set revealed cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848642c5e98832ab6975ffe828b9a7c