### PR TITLE
Show street investment per player

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2552,6 +2552,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         .whereType<CardModel>()
                         .toList()
                     : [],
+            streetInvestment: invested,
             lastAction: lastAction?.action,
             showLastIndicator: lastStreetAction?.playerIndex == index,
             isActive: isActive,

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -38,6 +38,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final VoidCallback? onTimeExpired;
   /// Called when a card slot is tapped. The index corresponds to 0 or 1.
   final void Function(int index)? onCardTap;
+  /// Amount invested by the player on the current street.
+  final int streetInvestment;
 
   const PlayerInfoWidget({
     super.key,
@@ -62,6 +64,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.onRemove,
     this.onTimeExpired,
     this.onCardTap,
+    this.streetInvestment = 0,
     this.showLastIndicator = false,
   });
 
@@ -224,6 +227,28 @@ class PlayerInfoWidget extends StatelessWidget {
               }),
             ),
           ),
+          if (streetInvestment > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.circle,
+                    size: 12,
+                    color: Colors.orangeAccent.withOpacity(0.8),
+                  ),
+                  const SizedBox(width: 2),
+                  Text(
+                    '$streetInvestment',
+                    style: TextStyle(
+                      color: Colors.orangeAccent.withOpacity(0.8),
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           const SizedBox(height: 4),
           GestureDetector(
             onTap: () async {


### PR DESCRIPTION
## Summary
- add `streetInvestment` field to `PlayerInfoWidget`
- display an invested chip indicator under the player's cards
- pass current street investment when building each player's info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68487606185c832a853c0435530fc93a