### PR TITLE
Add collapsible action history

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/street_actions_widget.dart';
 import '../widgets/board_display.dart';
 import '../widgets/action_history_overlay.dart';
 import '../widgets/collapsible_action_history.dart';
+import '../widgets/action_history_expansion_tile.dart';
 import 'package:provider/provider.dart';
 import '../services/saved_hand_storage_service.dart';
 import '../theme/constants.dart';
@@ -2374,14 +2375,24 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                 )
               ],
-            ),
-          ),
         ),
-            StreetActionsWidget(
-              currentStreet: currentStreet,
-              onStreetChanged: (index) {
-                setState(() {
-                  currentStreet = index;
+      ),
+    ),
+    ActionHistoryExpansionTile(
+      actions: visibleActions,
+      playerPositions: playerPositions,
+      pots: _pots,
+      stackSizes: stackSizes,
+      onEdit: _editAction,
+      onDelete: _deleteAction,
+      visibleCount: _playbackIndex,
+      evaluateActionQuality: _evaluateActionQuality,
+    ),
+    StreetActionsWidget(
+      currentStreet: currentStreet,
+      onStreetChanged: (index) {
+        setState(() {
+          currentStreet = index;
                   _pots[currentStreet] = _calculatePotForStreet(currentStreet);
                   _recalculateStreetInvestments();
                   _actionTags.clear();

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import '../models/action_entry.dart';
+import 'street_actions_list.dart';
+
+class ActionHistoryExpansionTile extends StatefulWidget {
+  final List<ActionEntry> actions;
+  final Map<int, String> playerPositions;
+  final List<int> pots;
+  final Map<int, int> stackSizes;
+  final void Function(int, ActionEntry) onEdit;
+  final void Function(int) onDelete;
+  final int visibleCount;
+  final String Function(ActionEntry)? evaluateActionQuality;
+
+  const ActionHistoryExpansionTile({
+    super.key,
+    required this.actions,
+    required this.playerPositions,
+    required this.pots,
+    required this.stackSizes,
+    required this.onEdit,
+    required this.onDelete,
+    required this.visibleCount,
+    this.evaluateActionQuality,
+  });
+
+  @override
+  State<ActionHistoryExpansionTile> createState() =>
+      _ActionHistoryExpansionTileState();
+}
+
+class _ActionHistoryExpansionTileState
+    extends State<ActionHistoryExpansionTile> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black45,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: ExpansionTile(
+        initiallyExpanded: _expanded,
+        onExpansionChanged: (v) => setState(() => _expanded = v),
+        title: const Text(
+          'Show Action History',
+          style: TextStyle(color: Colors.white),
+        ),
+        textColor: Colors.white,
+        iconColor: Colors.white,
+        collapsedIconColor: Colors.white,
+        collapsedTextColor: Colors.white,
+        collapsedBackgroundColor: Colors.black45,
+        backgroundColor: Colors.black54,
+        childrenPadding: const EdgeInsets.only(bottom: 8),
+        children: [
+          for (int i = 0; i < 4; i++)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    streetNames[i],
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  StreetActionsList(
+                    street: i,
+                    actions: widget.actions,
+                    pots: widget.pots,
+                    stackSizes: widget.stackSizes,
+                    playerPositions: widget.playerPositions,
+                    onEdit: widget.onEdit,
+                    onDelete: widget.onDelete,
+                    visibleCount: widget.visibleCount,
+                    evaluateActionQuality: widget.evaluateActionQuality,
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create `ActionHistoryExpansionTile` widget using `StreetActionsList`
- show the tile below board cards in `PokerAnalyzerScreen`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68489eb7477c832a9a99ee846491de31