### PR TITLE
Add timestamps to actions list

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -14,9 +14,13 @@ class ActionEntry {
   /// Флаг, указывающий, что запись сгенерирована автоматически
   final bool generated;
 
+  /// Время, когда было совершено действие
+  final DateTime timestamp;
+
   /// Создает запись о действии игрока на определенной улице.
   /// [amount] заполняется только для действий bet, raise или call.
   /// [generated] помечает автоматически добавленные действия.
   ActionEntry(this.street, this.playerIndex, this.action,
-      {this.amount, this.generated = false});
+      {this.amount, this.generated = false, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
 }

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -115,6 +115,7 @@ class SavedHand {
               'action': a.action,
               'amount': a.amount,
               'generated': a.generated,
+              'timestamp': a.timestamp.toIso8601String(),
             }
         ],
         'stackSizes': stackSizes.map((k, v) => MapEntry(k.toString(), v)),
@@ -152,8 +153,15 @@ class SavedHand {
     final oppIndex = json['opponentIndex'] as int?;
     final acts = [
       for (final a in (json['actions'] as List? ?? []))
-        ActionEntry(a['street'] as int, a['playerIndex'] as int, a['action'] as String,
-            amount: a['amount'] as int?, generated: a['generated'] as bool? ?? false)
+        ActionEntry(
+          a['street'] as int,
+          a['playerIndex'] as int,
+          a['action'] as String,
+          amount: a['amount'] as int?,
+          generated: a['generated'] as bool? ?? false,
+          timestamp:
+              DateTime.tryParse(a['timestamp'] as String? ?? '') ?? DateTime.now(),
+        )
     ];
     final stack = <int, int>{};
     (json['stackSizes'] as Map? ?? {}).forEach((key, value) {

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'detailed_action_bottom_sheet.dart';
+import 'package:intl/intl.dart';
 
 /// Список действий на конкретной улице
 class StreetActionsList extends StatelessWidget {
@@ -118,6 +119,14 @@ class StreetActionsList extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
+          if (!a.generated)
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: Text(
+                _formatTimestamp(globalIndex, a),
+                style: const TextStyle(color: Colors.white54, fontSize: 12),
+              ),
+            ),
           if (qualityText != null)
             Padding(
               padding: const EdgeInsets.only(right: 8.0),
@@ -133,6 +142,17 @@ class StreetActionsList extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _formatTimestamp(int index, ActionEntry a) {
+    if (index > 0) {
+      final prev = actions[index - 1];
+      final diff = a.timestamp.difference(prev.timestamp).inSeconds;
+      if (diff > 0 && diff < 60) {
+        return '+${diff}s';
+      }
+    }
+    return '⏱ ${DateFormat('HH:mm').format(a.timestamp)}';
   }
 
   @override


### PR DESCRIPTION
## Summary
- capture when every action happens via a new `timestamp` field in `ActionEntry`
- persist timestamps inside `SavedHand`
- show elapsed time or clock icon in `StreetActionsList`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848b18995d0832a9472cd09ca621657