### PR TITLE
Introduce StreetInvestments model

### DIFF
--- a/lib/models/street_investments.dart
+++ b/lib/models/street_investments.dart
@@ -1,0 +1,35 @@
+import "action_entry.dart";
+
+class StreetInvestments {
+  final Map<int, Map<int, int>> _investments = {};
+  int _currentStreet = 0;
+
+  /// Adds an action's investment to the totals if applicable.
+  void addAction(ActionEntry entry) {
+    if (entry.action == 'call' ||
+        entry.action == 'bet' ||
+        entry.action == 'raise') {
+      final streetMap = _investments.putIfAbsent(entry.street, () => {});
+      streetMap[entry.playerIndex] =
+          (streetMap[entry.playerIndex] ?? 0) + (entry.amount ?? 0);
+    }
+  }
+
+  /// Clears data for [street] and sets it as the current street.
+  void resetForNewStreet(int street) {
+    _currentStreet = street;
+    _investments[street] = {};
+  }
+
+  /// Returns the invested chips for [playerIndex] on [street] or
+  /// the current street if [street] is omitted.
+  int getInvestment(int playerIndex, [int? street]) {
+    final s = street ?? _currentStreet;
+    return _investments[s]?[playerIndex] ?? 0;
+  }
+
+  /// Utility to clear all stored investments.
+  void clear() => _investments.clear();
+
+  Map<int, Map<int, int>> get data => _investments;
+}


### PR DESCRIPTION
## Summary
- add `StreetInvestments` class to track player investments per street
- refactor `PokerAnalyzerScreen` to use the new class for investment recalculation
- update stack info dialog and chip drawing logic to query through `StreetInvestments`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d3f88234832ab5334600f70889fd