### PR TITLE
Implement PotCalculator and refactor pot logic

### DIFF
--- a/lib/helpers/pot_calculator.dart
+++ b/lib/helpers/pot_calculator.dart
@@ -1,0 +1,17 @@
+import '../models/action_entry.dart';
+import '../models/street_investments.dart';
+
+/// Utility for computing pot sizes for each street.
+class PotCalculator {
+  /// Returns the cumulative pot for each street based on [investments].
+  List<int> calculatePots(
+      List<ActionEntry> actions, StreetInvestments investments) {
+    final pots = List<int>.filled(4, 0);
+    int cumulative = 0;
+    for (int s = 0; s < pots.length; s++) {
+      cumulative += investments.getTotalInvestedOnStreet(s);
+      pots[s] = cumulative;
+    }
+    return pots;
+  }
+}

--- a/lib/models/street_investments.dart
+++ b/lib/models/street_investments.dart
@@ -28,6 +28,20 @@ class StreetInvestments {
     return _investments[s]?[playerIndex] ?? 0;
   }
 
+  /// Returns total chips invested by [playerIndex] across all streets.
+  int getTotalInvestment(int playerIndex) {
+    int total = 0;
+    for (final streetMap in _investments.values) {
+      total += streetMap[playerIndex] ?? 0;
+    }
+    return total;
+  }
+
+  /// Returns total chips invested by all players on [street].
+  int getTotalInvestedOnStreet(int street) {
+    return _investments[street]?.values.fold<int>(0, (sum, v) => sum + v) ?? 0;
+  }
+
   /// Utility to clear all stored investments.
   void clear() => _investments.clear();
 


### PR DESCRIPTION
## Summary
- extend `StreetInvestments` with total investment helpers
- add reusable `PotCalculator` utility
- integrate new pot calculation in `PokerAnalyzerScreen`
- remove old pot recalculation logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848d57c66b4832a961cf4c4ab8ede00