### PR TITLE
Implement StackManager for consistent stack tracking

### DIFF
--- a/lib/helpers/stack_manager.dart
+++ b/lib/helpers/stack_manager.dart
@@ -1,0 +1,32 @@
+import '../models/action_entry.dart';
+
+/// Manages stack recalculations based solely on actions.
+class StackManager {
+  final Map<int, int> _initialStacks;
+  final Map<int, int> _currentStacks = {};
+
+  StackManager(Map<int, int> initialStacks)
+      : _initialStacks = Map<int, int>.from(initialStacks) {
+    _currentStacks.addAll(_initialStacks);
+  }
+
+  /// Replays [actions] from the beginning and updates current stacks.
+  void applyActions(List<ActionEntry> actions) {
+    _currentStacks
+      ..clear()
+      ..addAll(_initialStacks);
+    for (final a in actions) {
+      if (a.action == 'call' || a.action == 'bet' || a.action == 'raise') {
+        final amount = a.amount ?? 0;
+        _currentStacks[a.playerIndex] =
+            (_currentStacks[a.playerIndex] ?? 0) - amount;
+      }
+    }
+  }
+
+  /// The latest stack sizes after applying actions.
+  Map<int, int> get currentStacks => _currentStacks;
+
+  /// Returns the stack for a specific [playerIndex].
+  int getStackForPlayer(int playerIndex) => _currentStacks[playerIndex] ?? 0;
+}


### PR DESCRIPTION
## Summary
- add new `StackManager` helper to recalc stacks from actions
- integrate `StackManager` into `PokerAnalyzerScreen`
- update stack editing and reset logic to use the manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496e4dfce4832aa5ecb9c8e832145c