### PR TITLE
Show pot size after each street

### DIFF
--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -3,6 +3,7 @@ import '../models/action_entry.dart';
 import 'detailed_action_bottom_sheet.dart';
 import 'package:intl/intl.dart';
 
+import 'street_pot_widget.dart';
 /// Whether action hints (tooltips) should be shown. TODO: load from preferences.
 const bool kShowActionHints = true;
 
@@ -221,6 +222,10 @@ class StreetActionsList extends StatelessWidget {
               ],
             ),
           ),
+        StreetPotWidget(
+          streetIndex: street,
+          potSize: pots[street],
+        ),
       ],
     );
   }

--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Displays pot size for a specific street in the history panel.
+class StreetPotWidget extends StatelessWidget {
+  final int streetIndex;
+  final int potSize;
+
+  const StreetPotWidget({
+    super.key,
+    required this.streetIndex,
+    required this.potSize,
+  });
+
+  String get _streetName {
+    const names = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
+    if (streetIndex >= 0 && streetIndex < names.length) {
+      return names[streetIndex];
+    }
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (potSize <= 0) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0),
+      child: Text(
+        '$_streetName пот: $potSize',
+        style: const TextStyle(color: Colors.white70, fontSize: 12),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `StreetPotWidget` to display pot size per street
- integrate it into `StreetActionsList` so each street block shows pot information

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68497559bd88832ab7cdde216f6e3675