### PR TITLE
Add StackWithInvestments helper

### DIFF
--- a/lib/helpers/stack_with_investments.dart
+++ b/lib/helpers/stack_with_investments.dart
@@ -1,0 +1,30 @@
+/// Helper for tracking a player's stack along with investments per street.
+class StackWithInvestments {
+  /// The starting stack size.
+  final int initialStack;
+
+  final Map<int, int> _investments = {};
+
+  StackWithInvestments(this.initialStack);
+
+  /// Remaining stack after subtracting all investments.
+  int get remainingStack {
+    int total = 0;
+    for (final v in _investments.values) {
+      total += v;
+    }
+    return initialStack - total;
+  }
+
+  /// Returns the invested chips for [street].
+  int getInvestmentForStreet(int street) => _investments[street] ?? 0;
+
+  /// Adds [amount] chips to the investment on [street].
+  void addInvestment(int street, int amount) {
+    if (amount == 0) return;
+    _investments[street] = (_investments[street] ?? 0) + amount;
+  }
+
+  /// Clears all investments.
+  void clear() => _investments.clear();
+}


### PR DESCRIPTION
## Summary
- add StackWithInvestments helper class for tracking initial and remaining stacks with per-street investments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684978f43ce0832aa24cc9d033b78e49