### PR TITLE
Add per street effective stack info

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1335,6 +1335,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   'Invested ${_stackManager.getTotalInvested(i)}, '
                   'Remaining ${_stackManager.getStackForPlayer(i)}',
                 ),
+              const SizedBox(height: 12),
+              const Text('Effective Stacks:'),
+              for (int s = 0; s < 4; s++)
+                Text([
+                      'Preflop',
+                      'Flop',
+                      'Turn',
+                      'River',
+                    ][s] + ': ${_calculateEffectiveStackForStreet(s)}'),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- show effective stack sizes for each street in debug panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ebfbbc50832ab7ce06eb9473d99e