### PR TITLE
Add effective stack info to main screen

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2328,6 +2328,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
 
     final effectiveStack = _calculateEffectiveStack(fromActions: visibleActions);
+    final currentStreetEffectiveStack = _calculateEffectiveStackForStreet(currentStreet);
     final pot = _pots[currentStreet];
     final double? sprValue =
         pot > 0 ? effectiveStack / pot : null;
@@ -2368,6 +2369,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 });
               }
             },
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              child: Text(
+                'Effective Stack (Current Street): $currentStreetEffectiveStack BB',
+                style: const TextStyle(color: Colors.white, fontSize: 16),
+              ),
             ),
             Expanded(
               flex: 7,


### PR DESCRIPTION
## Summary
- display effective stack for the current street in PokerAnalyzerScreen

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849ed198ae4832aba5e6a76a05189fb