### PR TITLE
Remove duplicate param

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -46,7 +46,6 @@ class SavedHand {
     this.expectedAction,
     this.feedbackText,
     this.effectiveStacksPerStreet,
-    revealedCards,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),


### PR DESCRIPTION
## Summary
- clean up `SavedHand` constructor by removing stray `revealedCards` entry

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684a2bd84f28832a84bb133ff5d67c5c