### PR TITLE
Fix validation notes visibility in debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1386,8 +1386,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     return '$name: ❌ live $live vs export ${exported ?? 'N/A'}';
                   }()),
               ],
-              if (_savedEffectiveStacks != null &&
-                  _validationNotes != null &&
+              if (_validationNotes != null &&
                   _validationNotes!.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 const Text('Validation Notes:'),


### PR DESCRIPTION
## Summary
- show `validationNotes` block in debug panel even when export data isn't loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a3c289df4832aa6e51f5e802210b8