### PR TITLE
Show comment and tags in debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1369,6 +1369,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   Text('Player ${entry.key + 1}: ${entry.value.name}'),
                 const SizedBox(height: 12),
               ],
+              if (hand.comment != null) ...[
+                const Text('Comment:'),
+                Text(hand.comment!),
+                const SizedBox(height: 12),
+              ],
+              if (hand.tags.isNotEmpty) ...[
+                const Text('Tags:'),
+                for (final tag in hand.tags) Text(tag),
+                const SizedBox(height: 12),
+              ],
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- show SavedHand comment and tags in `_showDebugPanel` of `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a450074d0832aba348b6ecb59e952