### PR TITLE
Add current street info to debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1431,6 +1431,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 ),
                 const SizedBox(height: 12),
               ],
+              Text(
+                  'Current Street: ${['Preflop', 'Flop', 'Turn', 'River'][currentStreet]}'),
+              const SizedBox(height: 12),
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- show the active street name in PokerAnalyzerScreen's debug panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aab4dc67c832aba727a547a10d829