### PR TITLE
Add playback index to debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1434,6 +1434,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               Text(
                   'Current Street: ${['Preflop', 'Flop', 'Turn', 'River'][currentStreet]}'),
               const SizedBox(height: 12),
+              Text('Playback Index: $_playbackIndex / ${actions.length}'),
+              const SizedBox(height: 12),
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- show `_playbackIndex` and total `actions` count in PokerAnalyzerScreen debug panel

## Testing
- `git diff --color -- lib/screens/poker_analyzer_screen.dart | sed -n '1,20p'`


------
https://chatgpt.com/codex/tasks/task_e_684aadb223fc832a8c2b2a2e7d986d96