### PR TITLE
Add active player info to debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1436,6 +1436,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               const SizedBox(height: 12),
               Text('Playback Index: $_playbackIndex / ${actions.length}'),
               const SizedBox(height: 12),
+              Text('Active Player Index: ${activePlayerIndex ?? 'None'}'),
+              const SizedBox(height: 12),
+              Text('Last Action Player Index: ${lastActionPlayerIndex ?? 'None'}'),
+              const SizedBox(height: 12),
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- show activePlayerIndex and lastActionPlayerIndex in PokerAnalyzerScreen debug panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aaecdfdfc832a948b64dfbeb41f44