### PR TITLE
Add player card counts to debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1440,6 +1440,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               const SizedBox(height: 12),
               Text('Last Action Player Index: ${lastActionPlayerIndex ?? 'None'}'),
               const SizedBox(height: 12),
+              for (int i = 0; i < numberOfPlayers; i++) ...[
+                Text('Player ${i + 1} Cards: ${playerCards[i].length}'),
+                const SizedBox(height: 12),
+              ],
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- display number of cards for each player in debug dialog of `PokerAnalyzerScreen`

## Testing
- `dartfmt --version`

------
https://chatgpt.com/codex/tasks/task_e_684ab18456d8832aacc766113705e047