### PR TITLE
Display first-action set in debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1444,6 +1444,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 Text('Player ${i + 1} Cards: ${playerCards[i].length}'),
                 const SizedBox(height: 12),
               ],
+              Text(
+                _firstActionTaken.isNotEmpty
+                    ? 'First Action Taken: ' +
+                        (_firstActionTaken.toList()..sort()).join(', ')
+                    : 'First Action Taken: (none)',
+              ),
+              const SizedBox(height: 12),
               const Text('Effective Stacks:'),
               for (int s = 0; s < 4; s++)
                 Text([


### PR DESCRIPTION
## Summary
- show `_firstActionTaken` values on the Poker Analyzer debug panel

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_684ab37d6db8832aa4600354d10234cc