### PR TITLE
fix: show full action history on load

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1647,7 +1647,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _expectedAction = hand.expectedAction;
       _feedbackText = hand.feedbackText;
       currentStreet = 0;
-      _playbackIndex = 0;
+      _playbackIndex = hand.actions.length;
       _animatedPlayersPerStreet.clear();
       _updatePlaybackState();
       _updatePositions();


### PR DESCRIPTION
## Summary
- ensure history overlay shows complete actions when loading a saved hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b28693b78832aa59e48d7046b18c9