### PR TITLE
Add collapsed streets section in debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1520,6 +1520,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               const SizedBox(height: 12),
               Text('Show All Revealed Cards: $_showAllRevealedCards'),
               const SizedBox(height: 12),
+              const Text('Collapsed Streets State:'),
+              for (int street = 0; street < 4; street++) ...[
+                Text(
+                  'Street $street Collapsed: '
+                  '${!_expandedHistoryStreets.contains(street)}',
+                ),
+                const SizedBox(height: 12),
+              ],
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- extend debug panel on `PokerAnalyzerScreen` with new 'Collapsed Streets State' section
- display collapsed state for each street using `_expandedHistoryStreets`

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_684b2a4ef074832a9bff51e28b1c4a89