### PR TITLE
Add HUD overlay state to debug panel

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1353,6 +1353,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   Future<void> _showDebugPanel() async {
     final hand = _currentSavedHand();
+    final hudStreetName = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet];
+    final hudPotText = _formatAmount(_pots[currentStreet]);
+    final int hudEffStack = _calculateEffectiveStackForStreet(currentStreet);
+    final double? hudSprValue =
+        _pots[currentStreet] > 0 ? hudEffStack / _pots[currentStreet] : null;
+    final String? hudSprText =
+        hudSprValue != null ? 'SPR: ${hudSprValue.toStringAsFixed(1)}' : null;
     await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
@@ -1565,6 +1572,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               const SizedBox(height: 12),
               const Text('Action Evaluation Queue:'),
               Text('Pending Action Evaluations: ${_pendingEvaluations.length}'),
+              const SizedBox(height: 12),
+              const Text('HUD Overlay State:'),
+              Text('HUD Street Name: $hudStreetName'),
+              const SizedBox(height: 12),
+              Text('HUD Pot Text: $hudPotText'),
+              const SizedBox(height: 12),
+              Text('HUD SPR Text: ${hudSprText ?? '(none)'}'),
               const SizedBox(height: 12),
             ],
           ),


### PR DESCRIPTION
## Summary
- compute HUD overlay values in `_showDebugPanel`
- display HUD street name, pot and SPR in debug panel

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b338d1a34832ab195e4d1963ae3da