### PR TITLE
Implement history street collapse export

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -25,6 +25,7 @@ class SavedHand {
   final String? feedbackText;
   final Map<String, int>? effectiveStacksPerStreet;
   final Map<String, String>? validationNotes;
+  final List<int>? collapsedHistoryStreets;
 
   SavedHand({
     required this.name,
@@ -48,6 +49,7 @@ class SavedHand {
     this.feedbackText,
     this.effectiveStacksPerStreet,
     this.validationNotes,
+    this.collapsedHistoryStreets,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
@@ -75,6 +77,7 @@ class SavedHand {
     String? feedbackText,
     Map<String, int>? effectiveStacksPerStreet,
     Map<String, String>? validationNotes,
+    List<int>? collapsedHistoryStreets,
   }) {
     return SavedHand(
       name: name ?? this.name,
@@ -104,6 +107,8 @@ class SavedHand {
       effectiveStacksPerStreet:
           effectiveStacksPerStreet ?? this.effectiveStacksPerStreet,
       validationNotes: validationNotes ?? this.validationNotes,
+      collapsedHistoryStreets:
+          collapsedHistoryStreets ?? this.collapsedHistoryStreets,
     );
   }
 
@@ -150,6 +155,8 @@ class SavedHand {
         if (effectiveStacksPerStreet != null)
           'effectiveStacksPerStreet': effectiveStacksPerStreet,
         if (validationNotes != null) 'validationNotes': validationNotes,
+        if (collapsedHistoryStreets != null)
+          'collapsedHistoryStreets': collapsedHistoryStreets,
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -216,6 +223,10 @@ class SavedHand {
         notes![key as String] = value as String;
       });
     }
+    List<int>? collapsed;
+    if (json['collapsedHistoryStreets'] != null) {
+      collapsed = [for (final i in (json['collapsedHistoryStreets'] as List)) i as int];
+    }
     Map<int, PlayerType> types = {};
     if (json['playerTypes'] != null) {
       (json['playerTypes'] as Map).forEach((key, value) {
@@ -252,6 +263,7 @@ class SavedHand {
       feedbackText: json['feedbackText'] as String?,
       effectiveStacksPerStreet: effStacks,
       validationNotes: notes,
+      collapsedHistoryStreets: collapsed,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1687,6 +1687,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       }
       if (notes.isEmpty) notes = null;
     }
+    final collapsed = [
+      for (int i = 0; i < 4; i++)
+        if (!_expandedHistoryStreets.contains(i)) i
+    ];
     return SavedHand(
       name: name ?? _defaultHandName(),
       heroIndex: heroIndex,
@@ -1722,6 +1726,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       feedbackText: _feedbackText,
       effectiveStacksPerStreet: stacks,
       validationNotes: notes,
+      collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
     );
   }
 
@@ -1786,6 +1791,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _validationNotes = hand.validationNotes;
       _expectedAction = hand.expectedAction;
       _feedbackText = hand.feedbackText;
+      _expandedHistoryStreets
+        ..clear()
+        ..addAll([
+          for (int i = 0; i < 4; i++)
+            if (hand.collapsedHistoryStreets == null ||
+                !hand.collapsedHistoryStreets!.contains(i))
+              i
+        ]);
       currentStreet = 0;
       _playbackIndex = hand.actions.length;
       _animatedPlayersPerStreet.clear();


### PR DESCRIPTION
## Summary
- extend `SavedHand` with `collapsedHistoryStreets`
- export collapsed streets from PokerAnalyzerScreen
- restore expanded streets when loading a saved hand

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b422a6f94832abf1fbe6ced678cf4