### PR TITLE
Add firstActionTaken persistence

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -26,6 +26,7 @@ class SavedHand {
   final Map<String, int>? effectiveStacksPerStreet;
   final Map<String, String>? validationNotes;
   final List<int>? collapsedHistoryStreets;
+  final List<int>? firstActionTaken;
 
   SavedHand({
     required this.name,
@@ -50,6 +51,7 @@ class SavedHand {
     this.effectiveStacksPerStreet,
     this.validationNotes,
     this.collapsedHistoryStreets,
+    this.firstActionTaken,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
@@ -78,6 +80,7 @@ class SavedHand {
     Map<String, int>? effectiveStacksPerStreet,
     Map<String, String>? validationNotes,
     List<int>? collapsedHistoryStreets,
+    List<int>? firstActionTaken,
   }) {
     return SavedHand(
       name: name ?? this.name,
@@ -109,6 +112,7 @@ class SavedHand {
       validationNotes: validationNotes ?? this.validationNotes,
       collapsedHistoryStreets:
           collapsedHistoryStreets ?? this.collapsedHistoryStreets,
+      firstActionTaken: firstActionTaken ?? this.firstActionTaken,
     );
   }
 
@@ -157,6 +161,8 @@ class SavedHand {
         if (validationNotes != null) 'validationNotes': validationNotes,
         if (collapsedHistoryStreets != null)
           'collapsedHistoryStreets': collapsedHistoryStreets,
+        if (firstActionTaken != null)
+          'firstActionTaken': firstActionTaken,
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -227,6 +233,10 @@ class SavedHand {
     if (json['collapsedHistoryStreets'] != null) {
       collapsed = [for (final i in (json['collapsedHistoryStreets'] as List)) i as int];
     }
+    List<int>? firsts;
+    if (json['firstActionTaken'] != null) {
+      firsts = [for (final i in (json['firstActionTaken'] as List)) i as int];
+    }
     Map<int, PlayerType> types = {};
     if (json['playerTypes'] != null) {
       (json['playerTypes'] as Map).forEach((key, value) {
@@ -264,6 +274,7 @@ class SavedHand {
       effectiveStacksPerStreet: effStacks,
       validationNotes: notes,
       collapsedHistoryStreets: collapsed,
+      firstActionTaken: firsts,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1727,6 +1727,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       effectiveStacksPerStreet: stacks,
       validationNotes: notes,
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
+      firstActionTaken:
+          _firstActionTaken.isEmpty ? null : _firstActionTaken.toList(),
     );
   }
 
@@ -1791,6 +1793,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _validationNotes = hand.validationNotes;
       _expectedAction = hand.expectedAction;
       _feedbackText = hand.feedbackText;
+      _firstActionTaken
+        ..clear()
+        ..addAll(hand.firstActionTaken ?? []);
       _expandedHistoryStreets
         ..clear()
         ..addAll([


### PR DESCRIPTION
## Summary
- add `firstActionTaken` field to `SavedHand`
- include `firstActionTaken` when saving a hand
- restore `_firstActionTaken` when applying a saved hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b437c9d20832a84deac51e3f13c3f