### PR TITLE
Implement pending evaluation persistence

### DIFF
--- a/lib/models/action_evaluation_request.dart
+++ b/lib/models/action_evaluation_request.dart
@@ -1,0 +1,36 @@
+class ActionEvaluationRequest {
+  final int street;
+  final int playerIndex;
+  final String action;
+  final int? amount;
+  final Map<String, dynamic>? metadata;
+
+  ActionEvaluationRequest({
+    required this.street,
+    required this.playerIndex,
+    required this.action,
+    this.amount,
+    this.metadata,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'street': street,
+        'playerIndex': playerIndex,
+        'action': action,
+        if (amount != null) 'amount': amount,
+        if (metadata != null) 'metadata': metadata,
+      };
+
+  factory ActionEvaluationRequest.fromJson(Map<String, dynamic> json) {
+    return ActionEvaluationRequest(
+      street: json['street'] as int? ?? 0,
+      playerIndex: json['playerIndex'] as int? ?? 0,
+      action: json['action'] as String? ?? '',
+      amount: json['amount'] as int?,
+      metadata: json['metadata'] != null
+          ? Map<String, dynamic>.from(json['metadata'] as Map)
+          : null,
+    );
+  }
+}
+

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -1,6 +1,7 @@
 import 'card_model.dart';
 import 'action_entry.dart';
 import 'player_model.dart';
+import 'action_evaluation_request.dart';
 
 class SavedHand {
   final String name;
@@ -28,6 +29,7 @@ class SavedHand {
   final List<int>? collapsedHistoryStreets;
   final List<int>? firstActionTaken;
   final Map<int, String?>? actionTags;
+  final List<ActionEvaluationRequest>? pendingEvaluations;
 
   SavedHand({
     required this.name,
@@ -54,6 +56,7 @@ class SavedHand {
     this.collapsedHistoryStreets,
     this.firstActionTaken,
     this.actionTags,
+    this.pendingEvaluations,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
@@ -84,6 +87,7 @@ class SavedHand {
     List<int>? collapsedHistoryStreets,
     List<int>? firstActionTaken,
     Map<int, String?>? actionTags,
+    List<ActionEvaluationRequest>? pendingEvaluations,
   }) {
     return SavedHand(
       name: name ?? this.name,
@@ -120,6 +124,22 @@ class SavedHand {
           (this.actionTags == null
               ? null
               : Map<int, String?>.from(this.actionTags!)),
+      pendingEvaluations:
+          pendingEvaluations ??
+              (this.pendingEvaluations == null
+                  ? null
+                  : [
+                      for (final e in this.pendingEvaluations!)
+                        ActionEvaluationRequest(
+                          street: e.street,
+                          playerIndex: e.playerIndex,
+                          action: e.action,
+                          amount: e.amount,
+                          metadata: e.metadata == null
+                              ? null
+                              : Map<String, dynamic>.from(e.metadata!),
+                        )
+                    ]),
     );
   }
 
@@ -173,6 +193,8 @@ class SavedHand {
         if (actionTags != null)
           'actionTags':
               actionTags!.map((k, v) => MapEntry(k.toString(), v)),
+        if (pendingEvaluations != null)
+          'pendingEvaluations': [for (final e in pendingEvaluations!) e.toJson()],
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -254,6 +276,14 @@ class SavedHand {
         aTags![int.parse(key as String)] = value as String?;
       });
     }
+    List<ActionEvaluationRequest>? pending;
+    if (json['pendingEvaluations'] != null) {
+      pending = [
+        for (final e in (json['pendingEvaluations'] as List))
+          ActionEvaluationRequest.fromJson(
+              Map<String, dynamic>.from(e as Map))
+      ];
+    }
     Map<int, PlayerType> types = {};
     if (json['playerTypes'] != null) {
       (json['playerTypes'] as Map).forEach((key, value) {
@@ -293,6 +323,7 @@ class SavedHand {
       collapsedHistoryStreets: collapsed,
       firstActionTaken: firsts,
       actionTags: aTags,
+      pendingEvaluations: pending,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -37,6 +37,7 @@ import '../widgets/mini_stack_widget.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 import '../models/player_model.dart';
+import '../models/action_evaluation_request.dart';
 import '../widgets/action_timeline_widget.dart';
 import '../models/street_investments.dart';
 import '../helpers/pot_calculator.dart';
@@ -122,7 +123,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   String? _feedbackText;
 
   /// Queue of pending action evaluation tasks.
-  final List<dynamic> _pendingEvaluations = [];
+  final List<ActionEvaluationRequest> _pendingEvaluations = [];
 
 
   List<String> _positionsForPlayers(int count) {
@@ -1731,6 +1732,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           _firstActionTaken.isEmpty ? null : _firstActionTaken.toList(),
       actionTags:
           _actionTags.isEmpty ? null : Map<int, String?>.from(_actionTags),
+      pendingEvaluations:
+          _pendingEvaluations.isEmpty ? null : List<ActionEvaluationRequest>.from(_pendingEvaluations),
     );
   }
 
@@ -1801,6 +1804,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _actionTags
         ..clear()
         ..addAll(hand.actionTags ?? {});
+      _pendingEvaluations
+        ..clear()
+        ..addAll(hand.pendingEvaluations ?? []);
       _expandedHistoryStreets
         ..clear()
         ..addAll([


### PR DESCRIPTION
## Summary
- track queue of pending action evaluations with new `ActionEvaluationRequest` model
- export/import pending evaluations in `SavedHand`
- persist queue when saving or loading hands

## Testing
- `dart` or `flutter` not available so formatting/checks skipped

------
https://chatgpt.com/codex/tasks/task_e_684b46e57c18832a8f0733a63d1f3668