### PR TITLE
Add evaluation queue reset button

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -880,6 +880,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _updatePlaybackState();
   }
 
+  void _clearEvaluationQueue() {
+    setState(() {
+      _pendingEvaluations.clear();
+    });
+  }
+
   void _playStepForward() {
     if (_playbackIndex < actions.length) {
       setState(() {
@@ -1665,6 +1671,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: const Text('Close'),
+          ),
+          TextButton(
+            onPressed: _clearEvaluationQueue,
+            child: const Text('Clear Evaluation Queue'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- allow clearing `_pendingEvaluations` from PokerAnalyzer debug panel
- add `_clearEvaluationQueue` helper for wiping the list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b50080f9c832aad7081af83b82cd9