### PR TITLE
Implement evaluation backup cleanup and queue controls

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -899,7 +899,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   void _clearEvaluationQueue() {
     setState(() {
       _pendingEvaluations.clear();
+      _completedEvaluations.clear();
     });
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Evaluation queue cleared')),
+      );
+    }
   }
 
   void _playStepForward() {
@@ -1423,6 +1429,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           await files[i].delete();
         } catch (_) {}
       }
+
+      await _cleanupOldEvaluationBackups();
 
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -1996,6 +2004,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ElevatedButton(
                     onPressed: _pendingEvaluations.isEmpty || _processingEvaluations ? null : _processEvaluationQueue,
                     child: const Text('Start Evaluation Processing'),
+                  ),
+                  ElevatedButton(
+                    onPressed: _pendingEvaluations.isEmpty && _completedEvaluations.isEmpty
+                        ? null
+                        : _clearEvaluationQueue,
+                    child: const Text('Clear Evaluation Queue'),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- clear completed evaluation queue items and show confirmation
- purge old backups when creating a new evaluation queue backup
- add `Clear Evaluation Queue` button to debug tools

## Testing
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_684b64fafe10832a9e63f4eacb47d5d1