### PR TITLE
Add evaluation processing cancellation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -140,6 +140,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   /// True when a pause of the evaluation processing loop has been requested.
   bool _pauseProcessingRequested = false;
 
+  /// True when a cancellation of the evaluation processing loop has been requested.
+  bool _cancelProcessingRequested = false;
+
   /// Whether the evaluation queue was restored from disk on startup.
   bool _evaluationQueueResumed = false;
 
@@ -927,6 +930,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  void _cancelEvaluationProcessing() {
+    setState(() {
+      _cancelProcessingRequested = true;
+      _pauseProcessingRequested = false;
+      _pendingEvaluations.clear();
+      _processingEvaluations = false;
+    });
+    _persistEvaluationQueue();
+    _debugPanelSetState?.call(() {});
+  }
+
   void _playStepForward() {
     if (_playbackIndex < actions.length) {
       setState(() {
@@ -1519,7 +1533,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
     _debugPanelSetState?.call(() {});
     while (_pendingEvaluations.isNotEmpty) {
-      if (_pauseProcessingRequested) {
+      if (_pauseProcessingRequested || _cancelProcessingRequested) {
         break;
       }
       final req = _pendingEvaluations.first;
@@ -1529,6 +1543,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _persistEvaluationQueue();
         return;
       }
+      if (_cancelProcessingRequested) {
+        break;
+      }
+      if (_pendingEvaluations.isEmpty) break;
       setState(() {
         _pendingEvaluations.removeAt(0);
         _completedEvaluations.add(req);
@@ -1536,18 +1554,22 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _persistEvaluationQueue();
       // Update debug panel if it's currently visible.
       _debugPanelSetState?.call(() {});
-      if (_pauseProcessingRequested) {
+      if (_pauseProcessingRequested || _cancelProcessingRequested) {
         break;
       }
     }
     if (mounted) {
       setState(() {
         _processingEvaluations = false;
+        _pauseProcessingRequested = false;
+        _cancelProcessingRequested = false;
       });
       _persistEvaluationQueue();
       _debugPanelSetState?.call(() {});
     } else {
       _processingEvaluations = false;
+      _pauseProcessingRequested = false;
+      _cancelProcessingRequested = false;
       _persistEvaluationQueue();
     }
   }
@@ -2105,6 +2127,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     child: Text(_pauseProcessingRequested
                         ? 'Resume Evaluation Processing'
                         : 'Pause Evaluation Processing'),
+                  ),
+                  ElevatedButton(
+                    onPressed: !_processingEvaluations && _pendingEvaluations.isEmpty
+                        ? null
+                        : _cancelEvaluationProcessing,
+                    child: const Text('Cancel Evaluation Processing'),
                   ),
                   ElevatedButton(
                     onPressed: _pendingEvaluations.isEmpty && _completedEvaluations.isEmpty


### PR DESCRIPTION
## Summary
- allow cancelling ongoing evaluation processing
- support cancellation inside processing loop
- expose 'Cancel Evaluation Processing' in debug panel

## Testing
- `dart` and `flutter` commands were unavailable in the environment

------
https://chatgpt.com/codex/tasks/task_e_684b6abcb110832ab2953c318a649ccf