### PR TITLE
Improve evaluation queue viewer

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -51,6 +51,7 @@ import '../helpers/pot_calculator.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../helpers/stack_manager.dart';
 import '../helpers/date_utils.dart';
+import '../widgets/evaluation_request_tile.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   final SavedHand? initialHand;
@@ -1761,6 +1762,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           ..clear()
           ..addAll(completed);
       });
+      _debugPanelSetState?.call(() {});
       _persistEvaluationQueue();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -2313,6 +2315,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           ..clear()
           ..addAll(completed);
       });
+      _debugPanelSetState?.call(() {});
       _persistEvaluationQueue();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -2406,6 +2409,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           ..addAll(items);
         _failedEvaluations.clear();
       });
+      _debugPanelSetState?.call(() {});
       _persistEvaluationQueue();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Imported ${items.length} evaluations')),
@@ -2530,6 +2534,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           ..clear()
           ..addAll(completed);
       });
+      _debugPanelSetState?.call(() {});
       _persistEvaluationQueue();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -2586,6 +2591,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           ..addAll(allItems);
         _failedEvaluations.clear();
       });
+      _debugPanelSetState?.call(() {});
       _persistEvaluationQueue();
 
       final msg = failed == 0
@@ -2959,14 +2965,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   }
                   final display =
                       list.length > 50 ? list.sublist(list.length - 50) : list;
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      for (final r in display)
-                        Text(
-                          'Player ${r.playerIndex}, Street ${r.street}, Action ${r.action}${r.amount != null ? ' ${r.amount}' : ''}',
-                        ),
-                    ],
+                  return ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 300),
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: display.length,
+                      itemBuilder: (context, index) {
+                        final r = display[index];
+                        return EvaluationRequestTile(request: r);
+                      },
+                    ),
                   );
                 },
               ),

--- a/lib/widgets/evaluation_request_tile.dart
+++ b/lib/widgets/evaluation_request_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../models/action_evaluation_request.dart';
+
+class EvaluationRequestTile extends StatelessWidget {
+  final ActionEvaluationRequest request;
+  const EvaluationRequestTile({super.key, required this.request});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = Map<String, dynamic>.from(request.toJson());
+    final metadata = data.remove('metadata') as Map<String, dynamic>?;
+    final extras = <String, dynamic>{
+      if (metadata != null) ...metadata,
+      ...data,
+    }..removeWhere((key, value) =>
+        key == 'playerIndex' ||
+        key == 'street' ||
+        key == 'action' ||
+        key == 'amount');
+
+    final expected = metadata?['expectedAction'] ?? data['expectedAction'];
+    final feedback = metadata?['feedbackText'] ?? data['feedbackText'];
+
+    return Card(
+      child: ExpansionTile(
+        title: Text(
+          'Player ${request.playerIndex}, Street ${request.street}, '
+          '${request.action}${request.amount != null ? ' ${request.amount}' : ''}',
+        ),
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('playerIndex: ${request.playerIndex}'),
+                Text('street: ${request.street}'),
+                Text('action: ${request.action}'),
+                if (request.amount != null) Text('amount: ${request.amount}'),
+                if (expected != null) Text('expectedAction: $expected'),
+                if (feedback != null) Text('feedbackText: $feedback'),
+                for (final entry in extras.entries)
+                  Text('${entry.key}: ${entry.value}')
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add EvaluationRequestTile widget
- show queue items with ExpansionTile in debug panel
- refresh debug panel after queue imports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf0fd09c8832abf604688d9811bce