### PR TITLE
Add retry failed evaluations control

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3039,6 +3039,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                 ],
               ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton(
+                  onPressed:
+                      _failedEvaluations.isEmpty ? null : _retryFailedEvaluations,
+                  child: const Text('Retry Failed Evaluations'),
+                ),
+              ),
               const SizedBox(height: 12),
               const Text('Evaluation Queue Tools:'),
               Wrap(


### PR DESCRIPTION
## Summary
- show *Retry Failed Evaluations* button directly under evaluation processing controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c153db53c832aa3c910ae8cf1290b