### PR TITLE
Implement async snapshot export after each evaluation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1941,6 +1941,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  /// Schedule snapshot export without awaiting the result.
+  void _scheduleSnapshotExport() {
+    unawaited(_exportEvaluationQueueSnapshot(showNotification: false));
+  }
+
   /// Persist the current evaluation queue to disk.
   Future<void> _persistEvaluationQueue() async {
     try {
@@ -2086,7 +2091,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         (success ? _completedEvaluations : _failedEvaluations).add(req);
       }
       if (success) {
-        _exportEvaluationQueueSnapshot(showNotification: false);
+        _scheduleSnapshotExport();
       }
       _persistEvaluationQueue();
       // Update debug panel if it's currently visible.
@@ -2149,7 +2154,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
     _persistEvaluationQueue();
     if (success) {
-      _exportEvaluationQueueSnapshot(showNotification: false);
+      _scheduleSnapshotExport();
     }
     _debugPanelSetState?.call(() {});
   }


### PR DESCRIPTION
## Summary
- add `_scheduleSnapshotExport` helper to wrap snapshot creation
- export snapshot asynchronously whenever an evaluation succeeds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c187264f4832ab39c12185d1555ba