### PR TITLE
Add snapshot retention limit

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -162,6 +162,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   StateSetter? _debugPanelSetState;
 
   static const _snapshotRetentionKey = 'snapshot_retention_enabled';
+  static const int _snapshotRetentionLimit = 50;
   bool _snapshotRetentionEnabled = true;
 
   static const _processingDelayKey = 'evaluation_processing_delay';
@@ -2206,7 +2207,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       final ordered = stats.entries.toList()
         ..sort((a, b) => b.value.compareTo(a.value));
 
-      for (final entry in ordered.skip(20)) {
+      for (final entry in ordered.skip(_snapshotRetentionLimit)) {
         try {
           await entry.key.delete();
         } catch (_) {}


### PR DESCRIPTION
## Summary
- add `_snapshotRetentionLimit` constant
- retain only the 50 most recent evaluation snapshots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c1a0d22d8832aa9e4d85fce3f8d1c