### PR TITLE
Add manual snapshot export button

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3132,6 +3132,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                 ],
               ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton(
+                  onPressed: _processingEvaluations
+                      ? null
+                      : () =>
+                          _exportEvaluationQueueSnapshot(showNotification: true),
+                  child: const Text('Export Snapshot Now'),
+                ),
+              ),
               const SizedBox(height: 12),
               Row(
                 children: [


### PR DESCRIPTION
## Summary
- add a button to export an evaluation queue snapshot from the debug panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c1ba78074832a8ada92fe65e229c5