### PR TITLE
Add manual backup button

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3165,6 +3165,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   child: const Text('Export Snapshot Now'),
                 ),
               ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton(
+                  onPressed: _processingEvaluations
+                      ? null
+                      : () async {
+                          await _backupEvaluationQueue();
+                          _debugPanelSetState?.call(() {});
+                        },
+                  child: const Text('Backup Queue Now'),
+                ),
+              ),
               const SizedBox(height: 12),
               Row(
                 children: [


### PR DESCRIPTION
## Summary
- add a `Backup Queue Now` button to the debug panel
- allow quickly backing up evaluation queues from the UI

## Testing
- `dart` command not found
- `flutter` command not found

------
https://chatgpt.com/codex/tasks/task_e_684c23abd45c832aae1189f58e3ddd94