### PR TITLE
Add dynamic queue stats update

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1205,6 +1205,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         const SnackBar(content: Text('Evaluation queue cleared')),
       );
     }
+    _debugPanelSetState?.call(() {});
   }
 
   void _clearPendingQueue() {
@@ -1218,6 +1219,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         const SnackBar(content: Text('Pending queue cleared')),
       );
     }
+    _debugPanelSetState?.call(() {});
   }
 
   void _clearFailedQueue() {
@@ -1231,6 +1233,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         const SnackBar(content: Text('Failed queue cleared')),
       );
     }
+    _debugPanelSetState?.call(() {});
   }
 
   void _clearCompletedQueue() {
@@ -1244,6 +1247,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         const SnackBar(content: Text('Completed queue cleared')),
       );
     }
+    _debugPanelSetState?.call(() {});
   }
 
   void _clearCompletedEvaluations() {


### PR DESCRIPTION
## Summary
- refresh debug stats when clearing evaluation queues

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c26e11b30832a9b90344df466ab07