### PR TITLE
Add processing delay value display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3317,6 +3317,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       },
                     ),
                   ),
+                  const SizedBox(width: 8),
+                  Text('${_evaluationProcessingDelay} ms'),
                 ],
               ),
               const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- show current processing delay next to slider in debug panel

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3883e060832a8dd88eace35c2f78