### PR TITLE
Implement bulk backup import

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2913,6 +2913,77 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  Future<void> _bulkImportEvaluationBackups() async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final backupDir = Directory('${dir.path}/evaluation_backups');
+      if (!await backupDir.exists()) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('No backup files found')),
+          );
+        }
+        return;
+      }
+
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+        allowMultiple: true,
+        initialDirectory: backupDir.path,
+      );
+      if (result == null || result.files.isEmpty) return;
+
+      final importedPending = <ActionEvaluationRequest>[];
+      final importedFailed = <ActionEvaluationRequest>[];
+      final importedCompleted = <ActionEvaluationRequest>[];
+      int skipped = 0;
+
+      for (final f in result.files) {
+        final path = f.path;
+        if (path == null) {
+          skipped++;
+          continue;
+        }
+        try {
+          final content = await File(path).readAsString();
+          final decoded = jsonDecode(content);
+          final queues = _decodeBackupQueues(decoded);
+          importedPending.addAll(queues['pending']!);
+          importedFailed.addAll(queues['failed']!);
+          importedCompleted.addAll(queues['completed']!);
+        } catch (_) {
+          skipped++;
+        }
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _pendingEvaluations.addAll(importedPending);
+        _failedEvaluations.addAll(importedFailed);
+        _completedEvaluations.addAll(importedCompleted);
+      });
+      _debugPanelSetState?.call(() {});
+      _persistEvaluationQueue();
+      unawaited(_setEvaluationQueueResumed(false));
+
+      final total =
+          importedPending.length + importedFailed.length + importedCompleted.length;
+      final msg = skipped == 0
+          ? 'Imported $total evaluations from ${result.files.length} files'
+          : 'Imported $total evaluations, $skipped files skipped';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(msg)),
+      );
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to import backups')),
+        );
+      }
+    }
+  }
+
   Future<void> _importEvaluationQueueSnapshot() async {
     try {
       final dir = await getApplicationDocumentsDirectory();
@@ -3442,6 +3513,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ElevatedButton(
                     onPressed: _bulkImportEvaluationQueue,
                     child: const Text('Bulk Import Evaluation Queue'),
+                  ),
+                  ElevatedButton(
+                    onPressed: _bulkImportEvaluationBackups,
+                    child: const Text('Bulk Import Backups'),
                   ),
                   ElevatedButton(
                     onPressed: _importEvaluationQueueSnapshot,


### PR DESCRIPTION
## Summary
- add `_bulkImportEvaluationBackups` to merge multiple backups
- expose new debug button **Bulk Import Backups**

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ce26ef4832a93efd9e5804d8bac