### PR TITLE
Add default path to full queue state restore

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2086,9 +2086,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   Future<void> _restoreFullEvaluationQueueState() async {
     try {
+      final dir = await getApplicationDocumentsDirectory();
+      final exportDir = Directory('${dir.path}/evaluation_exports');
+      if (!await exportDir.exists()) {
+        await exportDir.create(recursive: true);
+      }
+
       final result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['json'],
+        initialDirectory: exportDir.path,
       );
       if (result == null || result.files.isEmpty) return;
       final path = result.files.single.path;


### PR DESCRIPTION
## Summary
- improve queue state restore by using the evaluation exports folder as default

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c581b8d8c832a8586ea904f84644c