### PR TITLE
Add export all snapshots button

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3872,6 +3872,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     child: const Text('Bulk Import Snapshots'),
                   ),
                   ElevatedButton(
+                    onPressed: _exportAllEvaluationSnapshots,
+                    child: const Text('Export All Snapshots'),
+                  ),
+                  ElevatedButton(
                     onPressed: _importFullEvaluationQueueState,
                     child: const Text('Import Full Queue State'),
                   ),


### PR DESCRIPTION
## Summary
- add `Export All Snapshots` button to the debug panel
- existing logic zips `evaluation_snapshots` directory and saves via file picker

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c64ef4960832a8e4687cb9f1ba90a