### PR TITLE
Refactor queue export backup dir

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1996,7 +1996,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   Future<void> _exportEvaluationQueue() async {
     if (_pendingEvaluations.isEmpty) return;
     try {
-      final dir = await getApplicationDocumentsDirectory();
+      final dir = await _getBackupDirectory(_exportsFolder);
       final fileName = 'evaluation_queue_${_timestamp()}.json';
       final file = File('${dir.path}/$fileName');
       final data = [for (final e in _pendingEvaluations) e.toJson()];


### PR DESCRIPTION
## Summary
- unify exportEvaluationQueue with new backup helper functions

## Testing
- `dart format -o none lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6fc40590832abd6fcaccd2303252