### PR TITLE
Add ability to reset debug panel preferences

### DIFF
--- a/lib/helpers/debug_panel_preferences.dart
+++ b/lib/helpers/debug_panel_preferences.dart
@@ -84,5 +84,16 @@ class DebugPanelPreferences {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_searchQueryKey, value);
   }
+
+  /// Clears all stored debug panel preferences.
+  Future<void> clearAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_snapshotRetentionKey);
+    await prefs.remove(_processingDelayKey);
+    await prefs.remove(_queueFilterKey);
+    await prefs.remove(_advancedFilterKey);
+    await prefs.remove(_sortBySprKey);
+    await prefs.remove(_searchQueryKey);
+  }
 }
 

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -402,6 +402,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _debugPanelSetState?.call(() {});
   }
 
+  Future<void> _resetDebugPanelPreferences() async {
+    await _prefs.clearAll();
+    await _loadSnapshotRetentionPreference();
+    await _loadProcessingDelayPreference();
+    await _loadQueueFilterPreference();
+    await _loadAdvancedFilterPreference();
+    await _loadSortBySprPreference();
+    await _loadSearchQueryPreference();
+    _debugPanelSetState?.call(() {});
+  }
+
   List<ActionEvaluationRequest> _applyAdvancedFilters(
       List<ActionEvaluationRequest> list) {
     final filters = _advancedFilters;
@@ -3715,6 +3726,7 @@ class _DebugPanelState extends State<_DebugPanel> {
         _dialogBtn('Export All Snapshots', s._exportAllEvaluationSnapshots),
         _dialogBtn('Close', () => Navigator.pop(context)),
         _dialogBtn('Clear Evaluation Queue', s._clearEvaluationQueue),
+        _dialogBtn('Reset Debug Panel Settings', s._resetDebugPanelPreferences),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- centralize clearing of debug panel settings in `DebugPanelPreferences`
- expose `_resetDebugPanelPreferences` in `PokerAnalyzerScreen`
- add "Reset Debug Panel Settings" action in debug dialog

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c9b9c79a8832aa8b8002848f30b32