### PR TITLE
Refactor pot overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3959,125 +3959,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     return Stack(children: chips);
   }
 
-  Widget _buildPotAndBetsOverlay(double scale) {
-    final screenSize = MediaQuery.of(context).size;
-    final tableWidth = screenSize.width * 0.9;
-    final tableHeight = tableWidth * 0.55;
-    final centerX = screenSize.width / 2 + 10;
-    final centerY = screenSize.height / 2 - _centerYOffset(scale);
-    final radiusMod = _radiusModifier();
-    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
-    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
-
-    final List<Widget> items = [];
-
-    final pot = _pots[currentStreet];
-    if (pot > 0) {
-      items.add(Positioned.fill(
-        child: IgnorePointer(
-          child: Align(
-            alignment: const Alignment(0, -0.05),
-            child: Transform.translate(
-              offset: Offset(0, -12 * scale),
-              child: CentralPotChips(
-                amount: pot,
-                scale: scale,
-              ),
-            ),
-          ),
-        ),
-      ));
-      items.add(Positioned.fill(
-        child: IgnorePointer(
-          child: Align(
-            alignment: Alignment.center,
-            child: PotDisplayWidget(
-              amount: pot,
-              scale: scale,
-            ),
-          ),
-        ),
-      ));
-    }
-
-    if (_centerChipAction != null) {
-      items.add(Positioned.fill(
-        child: IgnorePointer(
-          child: Align(
-            alignment: Alignment.center,
-            child: AnimatedOpacity(
-              opacity: _showCenterChip ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 300),
-              child: ScaleTransition(
-                scale: _centerChipController,
-                child: ChipAmountWidget(
-                  amount: _centerChipAction!.amount!.toDouble(),
-                  color: _actionColor(_centerChipAction!.action),
-                  scale: scale,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ));
-    }
-
-    for (int i = 0; i < numberOfPlayers; i++) {
-      final index = (i + _viewIndex()) % numberOfPlayers;
-      final playerActions = actions
-          .where((a) => a.playerIndex == index && a.street == currentStreet)
-          .toList();
-      if (playerActions.isEmpty) continue;
-      final lastAction = playerActions.last;
-      if (['bet', 'raise', 'call'].contains(lastAction.action) &&
-          lastAction.amount != null) {
-        final angle = 2 * pi * i / numberOfPlayers + pi / 2;
-        final dx = radiusX * cos(angle);
-        final dy = radiusY * sin(angle);
-        final bias = _verticalBiasFromAngle(angle) * scale;
-        final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
-        final end = Offset(centerX, centerY);
-        final streetSet =
-            _animatedPlayersPerStreet.putIfAbsent(currentStreet, () => <int>{});
-        final animate = !streetSet.contains(index);
-        if (animate) {
-          streetSet.add(index);
-        }
-        items.add(Positioned.fill(
-          child: BetChipsOnTable(
-            start: start,
-            end: end,
-            chipCount: (lastAction.amount! / 20).clamp(1, 5).round(),
-            color: _actionColor(lastAction.action),
-            scale: scale,
-            animate: animate,
-          ),
-        ));
-        items.add(Positioned(
-          left: centerX + dx + 40 * scale,
-          top: centerY + dy + bias - 40 * scale,
-          child: PlayerBetIndicator(
-            action: lastAction.action,
-            amount: lastAction.amount!,
-            scale: scale,
-          ),
-        ));
-        final stackPos = Offset.lerp(start, end, 0.15)!;
-        final stackScale = scale * 0.7;
-        items.add(Positioned(
-          left: stackPos.dx - 6 * stackScale,
-          top: stackPos.dy - 12 * stackScale,
-          child: ChipStackWidget(
-            amount: lastAction.amount!,
-            scale: stackScale,
-            color: _actionColor(lastAction.action),
-          ),
-        ));
-      }
-    }
-
-    return Stack(children: items);
-  }
 
   Widget _buildOpponentCardRow(double scale) {
     return Positioned.fill(
@@ -4136,6 +4017,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final visibleActions = actions.take(_playbackIndex).toList();
     final savedActions = _currentSavedHand().actions;
     final double scale = _tableScale();
+    final viewIndex = _viewIndex();
     final double infoScale = numberOfPlayers > 8 ? 0.85 : 1.0;
     final tableWidth = screenSize.width * 0.9;
     final tableHeight = tableWidth * 0.55;
@@ -4225,7 +4107,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                   _buildBetStacksOverlay(scale),
                   _buildInvestedChipsOverlay(scale),
-                  _buildPotAndBetsOverlay(scale),
+                  _PotAndBetsOverlaySection(
+                    scale: scale,
+                    numberOfPlayers: numberOfPlayers,
+                    currentStreet: currentStreet,
+                    viewIndex: viewIndex,
+                    actions: actions,
+                    pots: _pots,
+                    animatedPlayersPerStreet: _animatedPlayersPerStreet,
+                    centerChipAction: _centerChipAction,
+                    showCenterChip: _showCenterChip,
+                    centerChipController: _centerChipController,
+                    actionColor: _actionColor,
+                  ),
                   ActionHistoryOverlay(
                     actions: actions,
                     playbackIndex: _playbackIndex,
@@ -4936,6 +4830,183 @@ class _PlayerZonesSection extends StatelessWidget {
         for (int i = 0; i < numberOfPlayers; i++) ...chipTrailBuilder(i, scale),
       ],
     );
+  }
+}
+
+class _PotAndBetsOverlaySection extends StatelessWidget {
+  final double scale;
+  final int numberOfPlayers;
+  final int currentStreet;
+  final int viewIndex;
+  final List<ActionEntry> actions;
+  final List<int> pots;
+  final Map<int, Set<int>> animatedPlayersPerStreet;
+  final ActionEntry? centerChipAction;
+  final bool showCenterChip;
+  final Animation<double> centerChipController;
+  final Color Function(String) actionColor;
+
+  const _PotAndBetsOverlaySection({
+    required this.scale,
+    required this.numberOfPlayers,
+    required this.currentStreet,
+    required this.viewIndex,
+    required this.actions,
+    required this.pots,
+    required this.animatedPlayersPerStreet,
+    required this.centerChipAction,
+    required this.showCenterChip,
+    required this.centerChipController,
+    required this.actionColor,
+  });
+
+  double _centerYOffset() {
+    double base;
+    if (numberOfPlayers > 6) {
+      base = 200.0 + (numberOfPlayers - 6) * 10.0;
+    } else {
+      base = 140.0 - (6 - numberOfPlayers) * 10.0;
+    }
+    return base * scale;
+  }
+
+  double _radiusModifier() {
+    return (1 + (6 - numberOfPlayers) * 0.05).clamp(0.8, 1.2);
+  }
+
+  double _verticalBiasFromAngle(double angle) {
+    return 90 + 20 * sin(angle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final tableWidth = screenSize.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screenSize.width / 2 + 10;
+    final centerY = screenSize.height / 2 - _centerYOffset();
+    final radiusMod = _radiusModifier();
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    final List<Widget> items = [];
+
+    final pot = pots[currentStreet];
+    if (pot > 0) {
+      items.add(
+        Positioned.fill(
+          child: IgnorePointer(
+            child: Align(
+              alignment: const Alignment(0, -0.05),
+              child: Transform.translate(
+                offset: Offset(0, -12 * scale),
+                child: CentralPotChips(
+                  amount: pot,
+                  scale: scale,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      items.add(
+        Positioned.fill(
+          child: IgnorePointer(
+            child: Align(
+              alignment: Alignment.center,
+              child: PotDisplayWidget(
+                amount: pot,
+                scale: scale,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (centerChipAction != null) {
+      items.add(
+        Positioned.fill(
+          child: IgnorePointer(
+            child: Align(
+              alignment: Alignment.center,
+              child: AnimatedOpacity(
+                opacity: showCenterChip ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 300),
+                child: ScaleTransition(
+                  scale: centerChipController,
+                  child: ChipAmountWidget(
+                    amount: centerChipAction!.amount!.toDouble(),
+                    color: actionColor(centerChipAction!.action),
+                    scale: scale,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    for (int i = 0; i < numberOfPlayers; i++) {
+      final index = (i + viewIndex) % numberOfPlayers;
+      final playerActions =
+          actions.where((a) => a.playerIndex == index && a.street == currentStreet).toList();
+      if (playerActions.isEmpty) continue;
+      final lastAction = playerActions.last;
+      if (['bet', 'raise', 'call'].contains(lastAction.action) && lastAction.amount != null) {
+        final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+        final dx = radiusX * cos(angle);
+        final dy = radiusY * sin(angle);
+        final bias = _verticalBiasFromAngle(angle) * scale;
+        final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+        final end = Offset(centerX, centerY);
+        final streetSet =
+            animatedPlayersPerStreet.putIfAbsent(currentStreet, () => <int>{});
+        final animate = !streetSet.contains(index);
+        if (animate) {
+          streetSet.add(index);
+        }
+        items.add(
+          Positioned.fill(
+            child: BetChipsOnTable(
+              start: start,
+              end: end,
+              chipCount: (lastAction.amount! / 20).clamp(1, 5).round(),
+              color: actionColor(lastAction.action),
+              scale: scale,
+              animate: animate,
+            ),
+          ),
+        );
+        items.add(
+          Positioned(
+            left: centerX + dx + 40 * scale,
+            top: centerY + dy + bias - 40 * scale,
+            child: PlayerBetIndicator(
+              action: lastAction.action,
+              amount: lastAction.amount!,
+              scale: scale,
+            ),
+          ),
+        );
+        final stackPos = Offset.lerp(start, end, 0.15)!;
+        final stackScale = scale * 0.7;
+        items.add(
+          Positioned(
+            left: stackPos.dx - 6 * stackScale,
+            top: stackPos.dy - 12 * stackScale,
+            child: ChipStackWidget(
+              amount: lastAction.amount!,
+              scale: stackScale,
+              color: actionColor(lastAction.action),
+            ),
+          ),
+        );
+      }
+    }
+
+    return Stack(children: items);
   }
 }
 


### PR DESCRIPTION
## Summary
- factor pot and bets overlay from `PokerAnalyzerScreen` into new `_PotAndBetsOverlaySection`
- use the new widget inside the screen build method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cc87f9a78832a9cc9ab5233fb29c0