### PR TITLE
Refactor HUD overlay section

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4147,17 +4147,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       ),
                     ),
                   ),
-                  Align(
-                  alignment: Alignment.topRight,
-                  child: HudOverlay(
-                    streetName: ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
+                  _HudOverlaySection(
+                    streetName:
+                        ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
                     potText: _formatAmount(_pots[currentStreet]),
                     stackText: _formatAmount(effectiveStack),
-                sprText: sprValue != null
-                    ? 'SPR: ${sprValue.toStringAsFixed(1)}'
-                    : null,
+                    sprText: sprValue != null
+                        ? 'SPR: ${sprValue.toStringAsFixed(1)}'
+                        : null,
                   ),
-                ),
                 Align(
                   alignment: Alignment.bottomCenter,
                   child: Padding(
@@ -5060,6 +5058,33 @@ class _BoardCardsSection extends StatelessWidget {
       boardCards: boardCards,
       onCardSelected: onCardSelected,
       visibleActions: visibleActions,
+    );
+  }
+}
+
+class _HudOverlaySection extends StatelessWidget {
+  final String streetName;
+  final String potText;
+  final String stackText;
+  final String? sprText;
+
+  const _HudOverlaySection({
+    required this.streetName,
+    required this.potText,
+    required this.stackText,
+    this.sprText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: HudOverlay(
+        streetName: streetName,
+        potText: potText,
+        stackText: stackText,
+        sprText: sprText,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- extract `HudOverlay` call into new `_HudOverlaySection`
- use the new widget in `PokerAnalyzerScreen`

## Testing
- `flutter format lib/screens/poker_analyzer_screen.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ccbbc6370832aa9e4177965bd8a3f