### PR TITLE
Refactor table background widget

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3939,13 +3939,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 padding: const EdgeInsets.only(bottom: 8.0),
                 child: Stack(
                   children: [
-                  Center(
-                    child: Image.asset(
-                      'assets/table.png',
-                      width: tableWidth,
-                      fit: BoxFit.contain,
-                    ),
-                  ),
+                  _TableBackgroundSection(scale: scale),
                   _BoardCardsSection(
                     scale: scale,
                     currentStreet: currentStreet,
@@ -4751,6 +4745,28 @@ class _OpponentCardRowSection extends StatelessWidget {
             );
           }),
         ),
+      ),
+    );
+  }
+}
+
+class _TableBackgroundSection extends StatelessWidget {
+  final double scale;
+
+  const _TableBackgroundSection({
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final tableWidth = screenSize.width * 0.9;
+
+    return Center(
+      child: Image.asset(
+        'assets/table.png',
+        width: tableWidth,
+        fit: BoxFit.contain,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- extract table background rendering into private widget `_TableBackgroundSection`
- replace inline table image in `build` method with the new widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cda4ef310832ab6f63a76d87be976