### PR TITLE
Refactor action history section

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4066,7 +4066,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 onReset: _resetHand,
               ),
             ),
-            CollapsibleActionHistory(
+            _CollapsibleActionHistorySection(
               actions: visibleActions,
               playerPositions: playerPositions,
               heroIndex: heroIndex,
@@ -5159,6 +5159,27 @@ class _PlaybackAndHandControls extends StatelessWidget {
           child: const Text('Сбросить раздачу'),
         ),
       ],
+    );
+  }
+}
+
+class _CollapsibleActionHistorySection extends StatelessWidget {
+  final List<ActionEntry> actions;
+  final Map<int, String> playerPositions;
+  final int heroIndex;
+
+  const _CollapsibleActionHistorySection({
+    required this.actions,
+    required this.playerPositions,
+    required this.heroIndex,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CollapsibleActionHistory(
+      actions: actions,
+      playerPositions: playerPositions,
+      heroIndex: heroIndex,
     );
   }
 }


### PR DESCRIPTION
## Summary
- move CollapsibleActionHistory usage into new `_CollapsibleActionHistorySection`
- keep poker analyzer screen functionality intact

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d413b8b1c832a837575693f14fd74