### PR TITLE
Refactor queue clipboard operations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1941,6 +1941,24 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  Future<void> _exportQueueToClipboard() async {
+    await _queueManager.exportToClipboard();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Queue copied to clipboard')),
+    );
+  }
+
+  Future<void> _importQueueFromClipboard() async {
+    await _queueManager.importFromClipboard();
+    if (!mounted) return;
+    setState(() {});
+    _debugPanelSetState?.call(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Queue imported from clipboard')),
+    );
+  }
+
   Future<void> _exportFullEvaluationQueueState() async {
     try {
       final exportDir = await _getBackupDirectory(_exportsFolder);

--- a/lib/services/evaluation_queue_manager.dart
+++ b/lib/services/evaluation_queue_manager.dart
@@ -216,6 +216,7 @@ class EvaluationQueueManager {
     await _persist();
   }
 
+  /// Replace the current evaluation queue with data taken from the clipboard.
   Future<void> importFromClipboard() async {
     try {
       final data = await Clipboard.getData('text/plain');
@@ -235,6 +236,7 @@ class EvaluationQueueManager {
     } catch (_) {}
   }
 
+  /// Copy the current evaluation queue state to the clipboard as JSON.
   Future<void> exportToClipboard() async {
     final jsonStr = jsonEncode(_state());
     await Clipboard.setData(ClipboardData(text: jsonStr));

--- a/lib/widgets/debug_panel.dart
+++ b/lib/widgets/debug_panel.dart
@@ -70,6 +70,8 @@ class _QueueTools extends StatelessWidget {
       'Import Full Queue State': s._importFullEvaluationQueueState,
       'Restore Full Queue State': s._restoreFullEvaluationQueueState,
       'Export Full Queue State': s._exportFullEvaluationQueueState,
+      'Export Queue To Clipboard': s._exportQueueToClipboard,
+      'Import Queue From Clipboard': s._importQueueFromClipboard,
       'Export Current Queue Snapshot': s._exportEvaluationQueueSnapshot,
       'Quick Backup': s._quickBackupEvaluationQueue,
       'Import Quick Backups': s._importQuickBackups,
@@ -848,6 +850,8 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
       actions: [
         _dialogBtn('Export Evaluation Queue', s._exportEvaluationQueue),
         _dialogBtn('Export Full Queue State', s._exportFullEvaluationQueueState),
+        _dialogBtn('Export Queue To Clipboard', s._exportQueueToClipboard),
+        _dialogBtn('Import Queue From Clipboard', s._importQueueFromClipboard),
         _dialogBtn('Backup Evaluation Queue', s._backupEvaluationQueue),
         _dialogBtn('Export All Backups', s._exportAllEvaluationBackups),
         _dialogBtn('Export Auto-Backups', s._exportAutoBackups),


### PR DESCRIPTION
## Summary
- manage queue clipboard operations in `EvaluationQueueManager`
- delegate import/export clipboard actions from `PokerAnalyzerScreen`
- expose the new actions via DebugPanel buttons

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d599e128c832a9d4d5e6605ec90b3