### PR TITLE
Make queue thread safe

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   archive: ^4.0.0
   share_plus: ^7.0.0
   uuid: ^3.0.0
+  synchronized: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `synchronized` package
- protect pending queue with `_queueLock`
- update queue persistence and snapshot helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d64e0b390832ab0e26d5428318f36