### PR TITLE
Refactor async snapshot loading

### DIFF
--- a/lib/services/evaluation_queue_manager.dart
+++ b/lib/services/evaluation_queue_manager.dart
@@ -312,8 +312,11 @@ class EvaluationQueueManager {
           .cast<File>()
           .toList();
       if (files.isEmpty) return;
-      files.sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
-      final decoded = await _readJson(files.first);
+      final entries = await Future.wait(
+        files.map((f) async => MapEntry(f, (await f.stat()).modified)),
+      );
+      entries.sort((a, b) => b.value.compareTo(a.value));
+      final decoded = await _readJson(entries.first.key);
       final queues = _decodeQueues(decoded);
       await _queueLock.synchronized(() {
         pending


### PR DESCRIPTION
## Summary
- refactor `EvaluationQueueManager.loadQueueSnapshot` to fetch file metadata asynchronously and sort by modification time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d709f9f7c832ab29f1f3559253532