### PR TITLE
Refactor loadQueueSnapshot to async

### DIFF
--- a/lib/services/evaluation_queue_manager.dart
+++ b/lib/services/evaluation_queue_manager.dart
@@ -312,8 +312,12 @@ class EvaluationQueueManager {
           .cast<File>()
           .toList();
       if (files.isEmpty) return;
-      files.sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
-      final decoded = await _readJson(files.first);
+
+      final fileStats = await Future.wait(
+        files.map((f) async => MapEntry(f, await f.stat())),
+      );
+      fileStats.sort((a, b) => b.value.modified.compareTo(a.value.modified));
+      final decoded = await _readJson(fileStats.first.key);
       final queues = _decodeQueues(decoded);
       await _queueLock.synchronized(() {
         pending


### PR DESCRIPTION
## Summary
- avoid blocking UI in `loadQueueSnapshot`
- use asynchronous `stat()` and sort with modification date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d723e1240832a949225237707cf49