### PR TITLE
Refactor loadQueueSnapshot with async stat

### DIFF
--- a/lib/services/evaluation_queue_manager.dart
+++ b/lib/services/evaluation_queue_manager.dart
@@ -312,17 +312,19 @@ class EvaluationQueueManager {
           .cast<File>()
           .toList();
       if (files.isEmpty) return;
-      final entries = <MapEntry<File, DateTime>>[];
-      for (final f in files) {
+      final results = await Future.wait(files.map((f) async {
         try {
           final stat = await f.stat();
-          entries.add(MapEntry(f, stat.modified));
+          return MapEntry(f, stat.modified);
         } catch (e) {
           if (kDebugMode) {
             debugPrint('Failed to stat ${f.path}: $e');
           }
+          return null;
         }
-      }
+      }));
+      final entries =
+          results.whereType<MapEntry<File, DateTime>>().toList();
       if (entries.isEmpty) return;
       entries.sort((a, b) => b.value.compareTo(a.value));
       final file = entries.first.key;


### PR DESCRIPTION
## Summary
- avoid UI blocking when loading queue snapshot
- gather file stats concurrently via `Future.wait`
- sort snapshot files by modification date using async data

## Testing
- `git log -1 --oneline`

------
https://chatgpt.com/codex/tasks/task_e_684d77196680832aa8dd9961d89372a4