### PR TITLE
Use temp file when persisting queue

### DIFF
--- a/lib/services/evaluation_queue_manager.dart
+++ b/lib/services/evaluation_queue_manager.dart
@@ -177,8 +177,16 @@ class EvaluationQueueManager {
     try {
       await _initFuture;
       final file = File('$_documentsDirPath/evaluation_current_queue.json');
+      final tmpFile = File('${file.path}.tmp');
       final state = await _state();
-      await _writeJson(file, state);
+      await _writeJson(tmpFile, state);
+      try {
+        await tmpFile.rename(file.path);
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint('Failed to replace ${file.path}: $e');
+        }
+      }
 
       final pendingIds = await _queueLock
           .synchronized(() => [for (final e in pending) _queueEntryId(e)]);


### PR DESCRIPTION
## Summary
- improve `_persist` in `EvaluationQueueManager` to write JSON state to a temporary file first
- rename the temporary file to the live queue file after a successful write

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d7c605b8c832abea5fbff47d332a6