### PR TITLE
Refactor board cards rendering

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -77,6 +77,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   int numberOfPlayers = 6;
   final List<List<CardModel>> playerCards = List.generate(10, (_) => []);
   final List<CardModel> boardCards = [];
+  final List<CardModel> revealedBoardCards = [];
   final List<PlayerModel> players =
       List.generate(10, (i) => PlayerModel(name: 'Player ${i + 1}'));
   int? opponentIndex;
@@ -3807,6 +3808,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     scale: scale,
                     currentStreet: currentStreet,
                     boardCards: boardCards,
+                    revealedBoardCards: revealedBoardCards,
                     onCardSelected: selectBoardCard,
                     visibleActions: visibleActions,
                   ),
@@ -4876,6 +4878,7 @@ class _BoardCardsSection extends StatelessWidget {
   final double scale;
   final int currentStreet;
   final List<CardModel> boardCards;
+  final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
 
@@ -4883,6 +4886,7 @@ class _BoardCardsSection extends StatelessWidget {
     required this.scale,
     required this.currentStreet,
     required this.boardCards,
+    required this.revealedBoardCards,
     required this.onCardSelected,
     required this.visibleActions,
   });
@@ -4893,6 +4897,7 @@ class _BoardCardsSection extends StatelessWidget {
       scale: scale,
       currentStreet: currentStreet,
       boardCards: boardCards,
+      revealedBoardCards: revealedBoardCards,
       onCardSelected: onCardSelected,
       visibleActions: visibleActions,
     );

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -8,6 +8,7 @@ import 'pot_over_board_widget.dart';
 class BoardDisplay extends StatelessWidget {
   final int currentStreet;
   final List<CardModel> boardCards;
+  final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
   final double scale;
@@ -16,6 +17,7 @@ class BoardDisplay extends StatelessWidget {
     Key? key,
     required this.currentStreet,
     required this.boardCards,
+    required this.revealedBoardCards,
     required this.visibleActions,
     required this.onCardSelected,
     this.scale = 1.0,
@@ -28,7 +30,7 @@ class BoardDisplay extends StatelessWidget {
         BoardCardsWidget(
           scale: scale,
           currentStreet: currentStreet,
-          boardCards: boardCards,
+          boardCards: revealedBoardCards,
           onCardSelected: onCardSelected,
         ),
         PotOverBoardWidget(


### PR DESCRIPTION
## Summary
- include `revealedBoardCards` state in `PokerAnalyzerScreen`
- pass it to a new `_BoardCardsSection`
- update `BoardDisplay` widget to accept and render revealed cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d7d3a74e4832a9d69059769fa04c0