### PR TITLE
Add RetryEvaluationService

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1440,17 +1440,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void _retryFailedEvaluations() {
-    setState(() {
-      if (_failedEvaluations.isNotEmpty) {
-        for (final r in _failedEvaluations) {
-          r.attempts = 0;
-        }
-        _pendingEvaluations.insertAll(0, _failedEvaluations);
-        _failedEvaluations.clear();
+    _queueManager.retryFailedEvaluations().then((_) {
+      if (mounted) {
+        setState(() {});
       }
+      _persistEvaluationQueue();
+      _debugPanelSetState?.call(() {});
     });
-    _persistEvaluationQueue();
-    _debugPanelSetState?.call(() {});
   }
 
   void _playStepForward() {

--- a/lib/services/retry_evaluation_service.dart
+++ b/lib/services/retry_evaluation_service.dart
@@ -1,0 +1,41 @@
+import '../models/action_evaluation_request.dart';
+import 'evaluation_queue_manager.dart';
+
+/// Handles retry operations for evaluation requests.
+class RetryEvaluationService {
+  /// Attempts to execute [executor] for [req] until it succeeds or
+  /// [maxAttempts] is reached. The [req]'s `attempts` field will be updated
+  /// on each failure.
+  Future<bool> processEvaluation(
+    ActionEvaluationRequest req,
+    Future<void> Function(ActionEvaluationRequest) executor, {
+    int maxAttempts = 3,
+    Duration retryDelay = const Duration(milliseconds: 200),
+  }) async {
+    var success = false;
+    while (!success && req.attempts < maxAttempts) {
+      try {
+        await executor(req);
+        success = true;
+      } catch (_) {
+        req.attempts++;
+        if (req.attempts < maxAttempts) {
+          await Future.delayed(retryDelay);
+        }
+      }
+    }
+    return success;
+  }
+
+  /// Moves all failed evaluations back to the pending queue and resets their
+  /// attempt counters.
+  Future<void> retryFailedEvaluations(EvaluationQueueManager manager) async {
+    if (manager.failed.isEmpty) return;
+    for (final r in manager.failed) {
+      r.attempts = 0;
+    }
+    manager.pending.insertAll(0, manager.failed);
+    manager.failed.clear();
+    await manager.persist();
+  }
+}


### PR DESCRIPTION
## Summary
- extract retry logic to new `RetryEvaluationService`
- wire `EvaluationQueueManager` to use the service
- delegate retry button in `PokerAnalyzerScreen` to the manager

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684dbc305398832ab7c25a5770509070