### PR TITLE
Refactor stack logic into service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -53,7 +53,7 @@ import '../widgets/action_timeline_widget.dart';
 import '../models/street_investments.dart';
 import '../helpers/pot_calculator.dart';
 import '../widgets/chip_moving_widget.dart';
-import '../helpers/stack_manager.dart';
+import '../services/stack_manager_service.dart';
 import '../helpers/date_utils.dart';
 import '../widgets/evaluation_request_tile.dart';
 import '../helpers/debug_helpers.dart';
@@ -99,8 +99,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     8: 105,
     9: 100,
   };
-  final Map<int, int> stackSizes = {};
-  late StackManager _stackManager;
+  late StackManagerService _stackService;
   final TextEditingController _commentController = TextEditingController();
   final TextEditingController _tagsController = TextEditingController();
   Set<String> get allTags =>
@@ -956,7 +955,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               if (c2 != null) cards.add(c2);
               playerCards[index] = cards;
             }
-            _stackManager = StackManager(Map<int, int>.from(_initialStacks));
+            _stackService =
+                StackManagerService(Map<int, int>.from(_initialStacks));
             _updatePlaybackState();
           });
         },
@@ -972,8 +972,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    _stackManager = StackManager(Map<int, int>.from(_initialStacks));
-    stackSizes.addAll(_stackManager.currentStacks);
+    _stackService = StackManagerService(Map<int, int>.from(_initialStacks));
     playerPositions = Map.fromIterables(
       List.generate(numberOfPlayers, (i) => i),
       getPositionList(numberOfPlayers),
@@ -1107,63 +1106,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
-  int _calculateEffectiveStack({List<ActionEntry>? fromActions}) {
-    final list = fromActions ?? actions;
-    int? minStack;
-    for (final entry in stackSizes.entries) {
-      final index = entry.key;
-      final folded = list.any((a) =>
-          a.playerIndex == index && a.action == 'fold' && a.street <= currentStreet);
-      if (folded) continue;
-      final stack = entry.value;
-      if (minStack == null || stack < minStack) {
-        minStack = stack;
-      }
-    }
-    return minStack ?? 0;
-  }
 
-  /// Calculates the effective stack size at the end of [street].
-  ///
-  /// For each active player their initial stack is reduced by the total
-  /// amount invested up to and including the given [street]. Folded players
-  /// (before or on this street) are ignored. The smallest remaining stack
-  /// among all active players is returned.
-  int _calculateEffectiveStackForStreet(int street) {
-    final visibleActions = actions.take(_playbackIndex).toList();
-    int? minStack;
-    for (int index = 0; index < numberOfPlayers; index++) {
-      final folded = visibleActions.any((a) =>
-          a.playerIndex == index && a.action == 'fold' && a.street <= street);
-      if (folded) continue;
-
-      final initial = _initialStacks[index] ?? 0;
-      int invested = 0;
-      for (int s = 0; s <= street; s++) {
-        invested += _stackManager.getInvestmentForStreet(index, s);
-      }
-      final remaining = initial - invested;
-
-      if (minStack == null || remaining < minStack) {
-        minStack = remaining;
-      }
-    }
-    return minStack ?? 0;
-  }
-
-  /// Calculates the effective stack size for every street and returns a map
-  /// with human-readable street names as keys.
-  ///
-  /// This helper does not update any UI and can be used for exporting data or
-  /// further analytics.
-  Map<String, int> calculateEffectiveStacksPerStreet() {
-    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
-    final Map<String, int> stacks = {};
-    for (int street = 0; street < streetNames.length; street++) {
-      stacks[streetNames[street]] = _calculateEffectiveStackForStreet(street);
-    }
-    return stacks;
-  }
 
 
   void _updatePlaybackState() {
@@ -1171,10 +1114,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (_playbackIndex == 0) {
       _animatedPlayersPerStreet.clear();
     }
-    _stackManager.applyActions(subset);
-    stackSizes
-      ..clear()
-      ..addAll(_stackManager.currentStacks);
+    _stackService.applyActions(subset);
     _updatePots(fromActions: subset);
     lastActionPlayerIndex =
         subset.isNotEmpty ? subset.last.playerIndex : null;
@@ -1712,7 +1652,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       if (_playbackIndex > actions.length) {
         _playbackIndex = actions.length;
       }
-      _stackManager = StackManager(Map<int, int>.from(_initialStacks));
+      _stackService = StackManagerService(Map<int, int>.from(_initialStacks));
       _updatePlaybackState();
     });
   }
@@ -1752,7 +1692,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _animatedPlayersPerStreet.clear();
         lastActionPlayerIndex = null;
         _playbackIndex = 0;
-        _stackManager = StackManager(Map<int, int>.from(_initialStacks));
+        _stackService = StackManagerService(Map<int, int>.from(_initialStacks));
         _updatePlaybackState();
         playerTypes.clear();
         for (int i = 0; i < _showActionHints.length; i++) {
@@ -2888,13 +2828,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
 
   SavedHand _currentSavedHand({String? name}) {
-    final stacks = calculateEffectiveStacksPerStreet();
+    final stacks =
+        _stackService.calculateEffectiveStacksPerStreet(actions, numberOfPlayers);
     Map<String, String>? notes;
     if (_savedEffectiveStacks != null) {
       const names = ['Preflop', 'Flop', 'Turn', 'River'];
       notes = {};
       for (int s = 0; s < names.length; s++) {
-        final live = _calculateEffectiveStackForStreet(s);
+        final live = _stackService.calculateEffectiveStackForStreet(
+            s, actions, numberOfPlayers);
         final exported = _savedEffectiveStacks![names[s]];
         if (exported != live) {
           notes![names[s]] = 'live $live vs saved ${exported ?? 'N/A'}';
@@ -2925,7 +2867,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       stackSizes: Map<int, int>.from(_initialStacks),
       remainingStacks: {
         for (int i = 0; i < numberOfPlayers; i++)
-          i: _stackManager.getStackForPlayer(i)
+          i: _stackService.getStackForPlayer(i)
       },
       playerPositions: Map<int, String>.from(playerPositions),
       playerTypes: Map<int, PlayerType>.from(playerTypes),
@@ -2992,13 +2934,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _initialStacks
         ..clear()
         ..addAll(hand.stackSizes);
-      _stackManager = StackManager(
+      _stackService = StackManagerService(
         Map<int, int>.from(_initialStacks),
         remainingStacks: hand.remainingStacks,
       );
-      stackSizes
-        ..clear()
-        ..addAll(_stackManager.currentStacks);
       playerPositions
         ..clear()
         ..addAll(hand.playerPositions);
@@ -3621,8 +3560,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
     final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
 
-    final effectiveStack = _calculateEffectiveStack(fromActions: visibleActions);
-    final currentStreetEffectiveStack = _calculateEffectiveStackForStreet(currentStreet);
+    final effectiveStack =
+        _stackService.calculateEffectiveStack(currentStreet, visibleActions);
+    final currentStreetEffectiveStack = _stackService
+        .calculateEffectiveStackForStreet(currentStreet, visibleActions, numberOfPlayers);
     final pot = _pots[currentStreet];
     final double? sprValue =
         pot > 0 ? effectiveStack / pot : null;
@@ -3748,7 +3689,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             street: i,
             actions: savedActions,
             pots: _pots,
-            stackSizes: stackSizes,
+            stackSizes: _stackService.stackSizes,
             playerPositions: playerPositions,
             onEdit: _editAction,
             onDelete: _deleteAction,
@@ -3762,7 +3703,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       actions: visibleActions,
       playerPositions: playerPositions,
       pots: _pots,
-      stackSizes: stackSizes,
+      stackSizes: _stackService.stackSizes,
       onEdit: _editAction,
       onDelete: _deleteAction,
       visibleCount: _playbackIndex,
@@ -3837,7 +3778,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 currentStreet: currentStreet,
                 actions: actions,
                 pots: _pots,
-                stackSizes: stackSizes,
+                stackSizes: _stackService.stackSizes,
                 onEdit: _editAction,
                 onDelete: _deleteAction,
                 visibleCount: _playbackIndex,
@@ -3932,7 +3873,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final bias = _verticalBiasFromAngle(angle) * scale;
 
     final String position = playerPositions[index] ?? '';
-    final int stack = stackSizes[index] ?? 0;
+    final int stack = _stackService.stackSizes[index] ?? 0;
     final String tag = _actionTags[index] ?? '';
     final bool isActive = activePlayerIndex == index;
     final bool isFolded = visibleActions.any((a) =>
@@ -3964,7 +3905,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final int currentBet = lastAmountAction?.amount ?? 0;
 
     final invested =
-        _stackManager.getInvestmentForStreet(index, currentStreet);
+        _stackService.getInvestmentForStreet(index, currentStreet);
 
     final Color? actionColor =
         (lastAction?.action == 'bet' || lastAction?.action == 'raise')
@@ -4037,7 +3978,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     .whereType<CardModel>()
                     .toList()
                 : playerCards[index],
-            remainingStack: _stackManager.getStackForPlayer(index),
+            remainingStack: _stackService.getStackForPlayer(index),
             streetInvestment: invested,
             currentBet: currentBet,
             lastAction: lastAction?.action,
@@ -4065,7 +4006,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             onEdit: () => _editPlayerInfo(index),
             onStackTap: (value) => setState(() {
               _initialStacks[index] = value;
-              _stackManager = StackManager(Map<int, int>.from(_initialStacks));
+              _stackService =
+                  StackManagerService(Map<int, int>.from(_initialStacks));
               _updatePlaybackState();
             }),
             onRemove: numberOfPlayers > 2 ? () {
@@ -4247,7 +4189,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
 
     final invested =
-        _stackManager.getInvestmentForStreet(index, currentStreet);
+        _stackService.getInvestmentForStreet(index, currentStreet);
 
     final Color? actionColor =
         (lastAction?.action == 'bet' || lastAction?.action == 'raise')
@@ -6008,8 +5950,8 @@ class _HudOverlayDiagnosticsSection extends StatelessWidget {
     final _PokerAnalyzerScreenState s = state.s;
     final hudStreetName = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][s.currentStreet];
     final hudPotText = s._formatAmount(s._pots[s.currentStreet]);
-    final int hudEffStack =
-        s._calculateEffectiveStackForStreet(s.currentStreet);
+    final int hudEffStack = s._stackService.calculateEffectiveStackForStreet(
+        s.currentStreet, s.actions, s.numberOfPlayers);
     final double? hudSprValue = s._pots[s.currentStreet] > 0
         ? hudEffStack / s._pots[s.currentStreet]
         : null;
@@ -6293,8 +6235,8 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
               debugDiag(
                 'Player ${i + 1}',
                 'Initial ${s._initialStacks[i] ?? 0}, '
-                'Invested ${s._stackManager.getTotalInvested(i)}, '
-                'Remaining ${s._stackManager.getStackForPlayer(i)}',
+                'Invested ${s._stackService.getTotalInvested(i)}, '
+                'Remaining ${s._stackService.getStackForPlayer(i)}',
               ),
             _vGap,
             if (hand.remainingStacks != null) ...[
@@ -6374,7 +6316,8 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
                   'Turn',
                   'River',
                 ][street],
-                s._calculateEffectiveStackForStreet(street),
+                s._stackService.calculateEffectiveStackForStreet(
+                    street, s.actions, s.numberOfPlayers),
               ),
             _vGap,
             const Text('Effective Stacks (from export data):'),
@@ -6390,7 +6333,8 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
                 () {
                   const names = ['Preflop', 'Flop', 'Turn', 'River'];
                   final name = names[st];
-                  final live = s._calculateEffectiveStackForStreet(st);
+                  final live = s._stackService.calculateEffectiveStackForStreet(
+                      st, s.actions, s.numberOfPlayers);
                   final exported = s._savedEffectiveStacks![name];
                   final ok = exported == live;
                   return debugDiag(
@@ -6432,7 +6376,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
             for (int i = 0; i < s.numberOfPlayers; i++) ...[
               debugDiag(
                 'Player $i StackManager',
-                'current ${s._stackManager.getStackForPlayer(i)}, invested ${s._stackManager.getTotalInvested(i)}',
+                'current ${s._stackService.getStackForPlayer(i)}, invested ${s._stackService.getTotalInvested(i)}',
               ),
               _vGap,
             ],

--- a/lib/services/stack_manager_service.dart
+++ b/lib/services/stack_manager_service.dart
@@ -1,0 +1,96 @@
+import '../helpers/stack_manager.dart';
+import '../models/action_entry.dart';
+
+/// Service that manages stack sizes and investments based on actions.
+class StackManagerService {
+  final Map<int, int> _initialStacks;
+  late StackManager _manager;
+  final Map<int, int> stackSizes = {};
+
+  StackManagerService(Map<int, int> initialStacks, {Map<int, int>? remainingStacks})
+      : _initialStacks = Map<int, int>.from(initialStacks) {
+    _manager = StackManager(_initialStacks, remainingStacks: remainingStacks);
+    stackSizes.addAll(_manager.currentStacks);
+  }
+
+  /// Re-initialize with a new set of initial stacks.
+  void reset(Map<int, int> stacks, {Map<int, int>? remainingStacks}) {
+    _initialStacks
+      ..clear()
+      ..addAll(stacks);
+    _manager = StackManager(Map<int, int>.from(_initialStacks),
+        remainingStacks: remainingStacks);
+    stackSizes
+      ..clear()
+      ..addAll(_manager.currentStacks);
+  }
+
+  /// Apply [actions] and update current stack sizes.
+  void applyActions(List<ActionEntry> actions) {
+    _manager.applyActions(actions);
+    stackSizes
+      ..clear()
+      ..addAll(_manager.currentStacks);
+  }
+
+  int getStackForPlayer(int playerIndex) =>
+      _manager.getStackForPlayer(playerIndex);
+
+  int getInvestmentForStreet(int playerIndex, int street) =>
+      _manager.getInvestmentForStreet(playerIndex, street);
+
+  int getTotalInvested(int playerIndex) =>
+      _manager.getTotalInvested(playerIndex);
+
+  /// Calculates the effective stack size using [actions] visible up to the
+  /// current point in the hand.
+  int calculateEffectiveStack(int currentStreet, List<ActionEntry> actions) {
+    int? minStack;
+    for (final entry in stackSizes.entries) {
+      final index = entry.key;
+      final folded = actions.any((a) =>
+          a.playerIndex == index && a.action == 'fold' && a.street <= currentStreet);
+      if (folded) continue;
+      final stack = entry.value;
+      if (minStack == null || stack < minStack) {
+        minStack = stack;
+      }
+    }
+    return minStack ?? 0;
+  }
+
+  /// Calculates the effective stack size at the end of [street].
+  int calculateEffectiveStackForStreet(
+      int street, List<ActionEntry> visibleActions, int numberOfPlayers) {
+    int? minStack;
+    for (int index = 0; index < numberOfPlayers; index++) {
+      final folded = visibleActions.any((a) =>
+          a.playerIndex == index && a.action == 'fold' && a.street <= street);
+      if (folded) continue;
+
+      final initial = _initialStacks[index] ?? 0;
+      int invested = 0;
+      for (int s = 0; s <= street; s++) {
+        invested += _manager.getInvestmentForStreet(index, s);
+      }
+      final remaining = initial - invested;
+
+      if (minStack == null || remaining < minStack) {
+        minStack = remaining;
+      }
+    }
+    return minStack ?? 0;
+  }
+
+  /// Calculates effective stack sizes for every street.
+  Map<String, int> calculateEffectiveStacksPerStreet(
+      List<ActionEntry> actions, int numberOfPlayers) {
+    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+    final Map<String, int> stacks = {};
+    for (int street = 0; street < streetNames.length; street++) {
+      stacks[streetNames[street]] =
+          calculateEffectiveStackForStreet(street, actions, numberOfPlayers);
+    }
+    return stacks;
+  }
+}


### PR DESCRIPTION
## Summary
- create `StackManagerService` to encapsulate stack operations
- delegate stack calculations from `PokerAnalyzerScreen` to the new service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dbdd5d5d8832aa90400a2f8161aa1