### PR TITLE
Refactor playback controls into service

### DIFF
--- a/lib/services/playback_service.dart
+++ b/lib/services/playback_service.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+class PlaybackService extends ChangeNotifier {
+  int _playbackIndex = 0;
+  bool _isPlaying = false;
+  Timer? _playbackTimer;
+  final Duration stepDuration;
+
+  PlaybackService({this.stepDuration = const Duration(seconds: 1)});
+
+  int get playbackIndex => _playbackIndex;
+  bool get isPlaying => _isPlaying;
+
+  void updatePlaybackState() {
+    notifyListeners();
+  }
+
+  void _playStepForward(int actionCount) {
+    if (_playbackIndex < actionCount) {
+      _playbackIndex++;
+      updatePlaybackState();
+    } else {
+      pausePlayback();
+    }
+  }
+
+  void startPlayback(int actionCount) {
+    pausePlayback();
+    _isPlaying = true;
+    if (_playbackIndex == actionCount) {
+      _playbackIndex = 0;
+    }
+    updatePlaybackState();
+    _playbackTimer =
+        Timer.periodic(stepDuration, (_) => _playStepForward(actionCount));
+  }
+
+  void pausePlayback() {
+    _playbackTimer?.cancel();
+    _isPlaying = false;
+    notifyListeners();
+  }
+
+  void stepForward(int actionCount) {
+    pausePlayback();
+    _playStepForward(actionCount);
+  }
+
+  void stepBackward() {
+    pausePlayback();
+    if (_playbackIndex > 0) {
+      _playbackIndex--;
+      updatePlaybackState();
+    }
+  }
+
+  void seek(int index) {
+    pausePlayback();
+    _playbackIndex = index;
+    updatePlaybackState();
+  }
+
+  void resetHand() {
+    pausePlayback();
+    _playbackIndex = 0;
+    updatePlaybackState();
+  }
+
+  @override
+  void dispose() {
+    _playbackTimer?.cancel();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PlaybackService` to manage playback state
- update `PokerAnalyzerScreen` to use the new service
- hook playback state updates through a listener

## Testing
- `dart` and `flutter` commands were unavailable, so no formatting or tests were run

------
https://chatgpt.com/codex/tasks/task_e_684dc00a666c832a99b612ba35925a0e