### PR TITLE
Extract action formatting helper

### DIFF
--- a/lib/helpers/action_formatting_helper.dart
+++ b/lib/helpers/action_formatting_helper.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../models/action_entry.dart';
+
+/// Utility methods for formatting poker actions and related data.
+class ActionFormattingHelper {
+  /// Formats [amount] with spaces as thousand separators.
+  static String formatAmount(int amount) {
+    final digits = amount.toString();
+    final buffer = StringBuffer();
+    for (int i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) {
+        buffer.write(' ');
+      }
+      buffer.write(digits[i]);
+    }
+    return buffer.toString();
+  }
+
+  /// Returns a color representing the given [action].
+  static Color actionColor(String action) {
+    switch (action) {
+      case 'fold':
+        return Colors.red[700]!;
+      case 'call':
+        return Colors.blue[700]!;
+      case 'raise':
+        return Colors.green[600]!;
+      case 'bet':
+        return Colors.amber[700]!;
+      case 'all-in':
+        return Colors.purpleAccent;
+      case 'check':
+        return Colors.grey[700]!;
+      default:
+        return Colors.black;
+    }
+  }
+
+  /// Returns the text color for the given [action].
+  static Color actionTextColor(String action) {
+    switch (action) {
+      case 'bet':
+        return Colors.black;
+      default:
+        return Colors.white;
+    }
+  }
+
+  /// Returns an icon representing the given [action], if any.
+  static IconData? actionIcon(String action) {
+    switch (action) {
+      case 'fold':
+        return Icons.close;
+      case 'call':
+        return Icons.call;
+      case 'raise':
+        return Icons.arrow_upward;
+      case 'bet':
+        return Icons.trending_up;
+      case 'all-in':
+        return Icons.flash_on;
+      case 'check':
+        return Icons.remove;
+      default:
+        return null;
+    }
+  }
+
+  /// Formats the last action label for display.
+  static String formatLastAction(ActionEntry entry) {
+    final a = entry.action;
+    final cap = a.isNotEmpty ? a[0].toUpperCase() + a.substring(1) : a;
+    return entry.amount != null ? '$cap ${entry.amount}' : cap;
+  }
+}

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -60,6 +60,7 @@ import '../helpers/date_utils.dart';
 import '../widgets/evaluation_request_tile.dart';
 import '../helpers/debug_helpers.dart';
 import '../helpers/table_geometry_helper.dart';
+import '../helpers/action_formatting_helper.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
   final SavedHand? initialHand;
@@ -702,64 +703,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     overlay.insert(overlayEntry);
   }
 
-  String _formatAmount(int amount) {
-    final digits = amount.toString();
-    final buffer = StringBuffer();
-    for (int i = 0; i < digits.length; i++) {
-      if (i > 0 && (digits.length - i) % 3 == 0) {
-        buffer.write(' ');
-      }
-      buffer.write(digits[i]);
-    }
-    return buffer.toString();
-  }
-
-  Color _actionColor(String action) {
-    switch (action) {
-      case 'fold':
-        return Colors.red[700]!;
-      case 'call':
-        return Colors.blue[700]!;
-      case 'raise':
-        return Colors.green[600]!;
-      case 'bet':
-        return Colors.amber[700]!;
-      case 'all-in':
-        return Colors.purpleAccent;
-      case 'check':
-        return Colors.grey[700]!;
-      default:
-        return Colors.black;
-    }
-  }
-
-  Color _actionTextColor(String action) {
-    switch (action) {
-      case 'bet':
-        return Colors.black;
-      default:
-        return Colors.white;
-    }
-  }
-
-  IconData? _actionIcon(String action) {
-    switch (action) {
-      case 'fold':
-        return Icons.close;
-      case 'call':
-        return Icons.call;
-      case 'raise':
-        return Icons.arrow_upward;
-      case 'bet':
-        return Icons.trending_up;
-      case 'all-in':
-        return Icons.flash_on;
-      case 'check':
-        return Icons.remove;
-      default:
-        return null;
-    }
-  }
+  // Formatting helpers moved to [ActionFormattingHelper].
 
   String _actionLabel(ActionEntry entry) {
     return entry.amount != null
@@ -767,11 +711,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         : entry.action;
   }
 
-  String _formatLastAction(ActionEntry entry) {
-    final a = entry.action;
-    final cap = a.isNotEmpty ? a[0].toUpperCase() + a.substring(1) : a;
-    return entry.amount != null ? '$cap ${entry.amount}' : cap;
-  }
+
 
   String _cardToDebugString(CardModel card) {
     const suits = {'♠': 's', '♥': 'h', '♦': 'd', '♣': 'c'};
@@ -1375,8 +1315,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         '${entry.action}${entry.amount != null ? ' ${entry.amount}' : ''}';
     setPlayerLastAction(
       players[entry.playerIndex].name,
-      _formatLastAction(entry),
-      _actionColor(entry.action),
+      ActionFormattingHelper.formatLastAction(entry),
+      ActionFormattingHelper.actionColor(entry.action),
       entry.amount,
     );
     _triggerCenterChip(entry);
@@ -1401,8 +1341,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         '${entry.action}${entry.amount != null ? ' ${entry.amount}' : ''}';
     setPlayerLastAction(
       players[entry.playerIndex].name,
-      _formatLastAction(entry),
-      _actionColor(entry.action),
+      ActionFormattingHelper.formatLastAction(entry),
+      ActionFormattingHelper.actionColor(entry.action),
       entry.amount,
     );
     _triggerCenterChip(entry);
@@ -3558,7 +3498,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     centerChipAction: _centerChipAction,
                     showCenterChip: _showCenterChip,
                     centerChipController: _centerChipController,
-                    actionColor: _actionColor,
+                    actionColor: ActionFormattingHelper.actionColor,
                   ),
                   _ActionHistorySection(
                     actions: actions,
@@ -3583,8 +3523,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   _HudOverlaySection(
                     streetName:
                         ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
-                    potText: _formatAmount(_pots[currentStreet]),
-                    stackText: _formatAmount(effectiveStack),
+                    potText:
+                        ActionFormattingHelper.formatAmount(_pots[currentStreet]),
+                    stackText:
+                        ActionFormattingHelper.formatAmount(effectiveStack),
                     sprText: sprValue != null
                         ? 'SPR: ${sprValue.toStringAsFixed(1)}'
                         : null,
@@ -3947,7 +3889,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           top: centerY + dy + bias - 80 * scale,
           child: ChipAmountWidget(
             amount: lastAmountAction!.amount!.toDouble(),
-            color: _actionColor(lastAmountAction!.action),
+            color: ActionFormattingHelper.actionColor(
+                lastAmountAction!.action),
             scale: scale,
           ),
         ),
@@ -4524,7 +4467,8 @@ class _InvestedChipsOverlaySection extends StatelessWidget {
             .toList();
         final lastAction =
             playerActions.isNotEmpty ? playerActions.last : null;
-        final color = state._actionColor(lastAction?.action ?? 'bet');
+        final color =
+            ActionFormattingHelper.actionColor(lastAction?.action ?? 'bet');
         final start =
             Offset(centerX + dx, centerY + dy + bias + 92 * scale);
         final end = Offset.lerp(start, Offset(centerX, centerY), 0.2)!;
@@ -5857,7 +5801,8 @@ class _HudOverlayDiagnosticsSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final _PokerAnalyzerScreenState s = state.s;
     final hudStreetName = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][s.currentStreet];
-    final hudPotText = s._formatAmount(s._pots[s.currentStreet]);
+    final hudPotText =
+        ActionFormattingHelper.formatAmount(s._pots[s.currentStreet]);
     final int hudEffStack = s._stackService.calculateEffectiveStackForStreet(
         s.currentStreet, s.actions, s.numberOfPlayers);
     final double? hudSprValue = s._pots[s.currentStreet] > 0

--- a/lib/widgets/action_history_overlay.dart
+++ b/lib/widgets/action_history_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/action_entry.dart';
+import '../helpers/action_formatting_helper.dart';
 
 class ActionHistoryOverlay extends StatelessWidget {
   final List<ActionEntry> actions;
@@ -18,31 +19,7 @@ class ActionHistoryOverlay extends StatelessWidget {
     this.onToggleStreet,
   }) : super(key: key);
 
-  Color _actionColor(String action) {
-    switch (action) {
-      case 'fold':
-        return Colors.red[700]!;
-      case 'call':
-        return Colors.blue[700]!;
-      case 'raise':
-        return Colors.green[600]!;
-      case 'bet':
-        return Colors.amber[700]!;
-      case 'check':
-        return Colors.grey[700]!;
-      default:
-        return Colors.black;
-    }
-  }
-
-  Color _actionTextColor(String action) {
-    switch (action) {
-      case 'bet':
-        return Colors.black;
-      default:
-        return Colors.white;
-    }
-  }
+  // Color helpers moved to [ActionFormattingHelper].
 
   @override
   Widget build(BuildContext context) {
@@ -63,13 +40,13 @@ class ActionHistoryOverlay extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 3 * scale),
         margin: const EdgeInsets.only(right: 4, bottom: 4),
         decoration: BoxDecoration(
-          color: _actionColor(a.action).withOpacity(0.8),
+          color: ActionFormattingHelper.actionColor(a.action).withOpacity(0.8),
           borderRadius: BorderRadius.circular(12),
         ),
         child: Text(
           text,
           style: TextStyle(
-            color: _actionTextColor(a.action),
+            color: ActionFormattingHelper.actionTextColor(a.action),
             fontSize: 11 * scale,
           ),
         ),


### PR DESCRIPTION
## Summary
- add `ActionFormattingHelper` with static formatting methods
- remove old helper methods from `PokerAnalyzerScreen`
- switch screen and `ActionHistoryOverlay` to the new utility

## Testing
- `flutter format lib/helpers/action_formatting_helper.dart lib/screens/poker_analyzer_screen.dart lib/widgets/action_history_overlay.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc6777570832aacc00feaf0296599