### PR TITLE
Extract evaluation queue logic into service

### DIFF
--- a/lib/services/evaluation_queue_service.dart
+++ b/lib/services/evaluation_queue_service.dart
@@ -15,7 +15,7 @@ import 'snapshot_service.dart';
 import 'retry_evaluation_service.dart';
 import 'evaluation_executor_service.dart';
 
-class EvaluationQueueManager {
+class EvaluationQueueService {
   final List<ActionEvaluationRequest> pending = [];
   final List<ActionEvaluationRequest> completed = [];
   final List<ActionEvaluationRequest> failed = [];
@@ -47,7 +47,7 @@ class EvaluationQueueManager {
   late final RetryEvaluationService _retryService;
   late final Future<void> _initFuture;
 
-  EvaluationQueueManager({
+  EvaluationQueueService({
     EvaluationExecutorService? executorService,
     RetryEvaluationService? retryService,
   }) {

--- a/lib/services/retry_evaluation_service.dart
+++ b/lib/services/retry_evaluation_service.dart
@@ -1,6 +1,6 @@
 import '../models/action_evaluation_request.dart';
 import 'evaluation_executor_service.dart';
-import 'evaluation_queue_manager.dart';
+import 'evaluation_queue_service.dart';
 
 /// Handles retry operations for evaluation requests.
 class RetryEvaluationService {
@@ -33,7 +33,7 @@ class RetryEvaluationService {
 
   /// Moves all failed evaluations back to the pending queue and resets their
   /// attempt counters.
-  Future<void> retryFailedEvaluations(EvaluationQueueManager manager) async {
+  Future<void> retryFailedEvaluations(EvaluationQueueService manager) async {
     if (manager.failed.isEmpty) return;
     for (final r in manager.failed) {
       r.attempts = 0;


### PR DESCRIPTION
## Summary
- introduce `EvaluationQueueService` from existing queue manager
- update retry logic to use the new service
- delegate queue handling in `PokerAnalyzerScreen` to `EvaluationQueueService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dcd076c9c832ab197a96b1ffd191d