### PR TITLE
Refactor player state to service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -92,7 +92,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   Map<int, int> get _initialStacks => _playerManager.initialStacks;
   List<bool> get _showActionHints => _playerManager.showActionHints;
   final List<CardModel> revealedBoardCards = [];
-  int? opponentIndex;
+  int? get opponentIndex => _playerManager.opponentIndex;
+  set opponentIndex(int? v) => _playerManager.opponentIndex = v;
   int currentStreet = 0;
   final List<ActionEntry> actions = [];
   late PlaybackManagerService _playbackManager;
@@ -1376,14 +1377,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     );
     if (confirm == true) {
       setState(() {
-        for (final list in _playerManager.playerCards) {
-          list.clear();
-        }
-        _playerManager.boardCards.clear();
-        for (final p in _playerManager.players) {
-          p.revealedCards.fillRange(0, p.revealedCards.length, null);
-        }
-        opponentIndex = null;
+        _playerManager.reset();
         actions.clear();
         currentStreet = 0;
         _actionTags.clear();
@@ -1393,10 +1387,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             StackManagerService(Map<int, int>.from(_playerManager.initialStacks));
         _playbackManager.stackService = _stackService;
         _playbackManager.resetHand();
-        _playerManager.playerTypes.clear();
-        for (int i = 0; i < _playerManager.showActionHints.length; i++) {
-          _playerManager.showActionHints[i] = true;
-        }
         _commentController.clear();
         _tagsController.clear();
       });

--- a/lib/services/player_manager_service.dart
+++ b/lib/services/player_manager_service.dart
@@ -173,10 +173,10 @@ class PlayerManagerService extends ChangeNotifier {
 
   void removePlayer(
     int index, {
-    required int heroIndexOverride,
-    required List<ActionEntry> actions,
-    required Map<int, String?> actionTags,
-    required List<bool> hintFlags,
+      required int heroIndexOverride,
+      required List<ActionEntry> actions,
+      required Map<int, String?> actionTags,
+      required List<bool> hintFlags,
   }) {
     if (numberOfPlayers <= 2) return;
 
@@ -229,6 +229,23 @@ class PlayerManagerService extends ChangeNotifier {
 
     numberOfPlayers--;
     updatePositions();
+  }
+
+  /// Reset all player-related state to defaults while preserving stack sizes.
+  void reset() {
+    for (final list in playerCards) {
+      list.clear();
+    }
+    boardCards.clear();
+    for (final p in players) {
+      p.revealedCards.fillRange(0, p.revealedCards.length, null);
+    }
+    opponentIndex = null;
+    playerTypes.clear();
+    for (int i = 0; i < showActionHints.length; i++) {
+      showActionHints[i] = true;
+    }
+    notifyListeners();
   }
 }
 


### PR DESCRIPTION
## Summary
- move opponentIndex and reset logic into PlayerManagerService
- expose opponentIndex through getters in PokerAnalyzerScreen
- call PlayerManagerService.reset when resetting a hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd201ca70832aa5b35600d6485150