### PR TITLE
Fix multiple bet actions

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -678,6 +678,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   Future<Map<String, dynamic>?> _showActionPicker() {
+    final bool hasBet = _streetHasBet();
+    final bool betEnabled = !hasBet;
+    final bool raiseEnabled = hasBet;
     final TextEditingController controller = TextEditingController();
     String? selected;
     return showModalBottomSheet<Map<String, dynamic>>(
@@ -715,7 +718,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
-                  onPressed: () => setModal(() => selected = 'bet'),
+                  onPressed: betEnabled
+                      ? () => setModal(() => selected = 'bet')
+                      : null,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.black87,
                     foregroundColor: Colors.white,
@@ -724,7 +729,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
-                  onPressed: () => setModal(() => selected = 'raise'),
+                  onPressed: raiseEnabled
+                      ? () => setModal(() => selected = 'raise')
+                      : null,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.black87,
                     foregroundColor: Colors.white,


### PR DESCRIPTION
## Summary
- disable Bet button when a bet/raise already exists in the current street
- disable Raise button before the first bet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684deeed8f00832a976ba37df0c8bf81