### PR TITLE
Add folded player persistence

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -28,6 +28,7 @@ class SavedHand {
   final Map<String, String>? validationNotes;
   final List<int>? collapsedHistoryStreets;
   final List<int>? firstActionTaken;
+  final List<int>? foldedPlayers;
   final Map<int, String?>? actionTags;
   /// Pending action evaluation requests queued when the hand was saved.
   final List<ActionEvaluationRequest>? pendingEvaluations;
@@ -56,6 +57,7 @@ class SavedHand {
     this.validationNotes,
     this.collapsedHistoryStreets,
     this.firstActionTaken,
+    this.foldedPlayers,
     this.actionTags,
     this.pendingEvaluations,
   })  : tags = tags ?? [],
@@ -87,6 +89,7 @@ class SavedHand {
     Map<String, String>? validationNotes,
     List<int>? collapsedHistoryStreets,
     List<int>? firstActionTaken,
+    List<int>? foldedPlayers,
     Map<int, String?>? actionTags,
     List<ActionEvaluationRequest>? pendingEvaluations,
   }) {
@@ -121,6 +124,10 @@ class SavedHand {
       collapsedHistoryStreets:
           collapsedHistoryStreets ?? this.collapsedHistoryStreets,
       firstActionTaken: firstActionTaken ?? this.firstActionTaken,
+      foldedPlayers: foldedPlayers ??
+          (this.foldedPlayers == null
+              ? null
+              : List<int>.from(this.foldedPlayers!)),
       actionTags: actionTags ??
           (this.actionTags == null
               ? null
@@ -193,6 +200,7 @@ class SavedHand {
           'collapsedHistoryStreets': collapsedHistoryStreets,
         if (firstActionTaken != null)
           'firstActionTaken': firstActionTaken,
+        if (foldedPlayers != null) 'foldedPlayers': foldedPlayers,
         if (actionTags != null)
           'actionTags':
               actionTags!.map((k, v) => MapEntry(k.toString(), v)),
@@ -272,6 +280,10 @@ class SavedHand {
     if (json['firstActionTaken'] != null) {
       firsts = [for (final i in (json['firstActionTaken'] as List)) i as int];
     }
+    List<int>? folded;
+    if (json['foldedPlayers'] != null) {
+      folded = [for (final i in (json['foldedPlayers'] as List)) i as int];
+    }
     Map<int, String?>? aTags;
     if (json['actionTags'] != null) {
       aTags = <int, String?>{};
@@ -325,6 +337,7 @@ class SavedHand {
       validationNotes: notes,
       collapsedHistoryStreets: collapsed,
       firstActionTaken: firsts,
+      foldedPlayers: folded,
       actionTags: aTags,
       pendingEvaluations: pending,
     );

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2173,6 +2173,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       date: DateTime.now(),
       effectiveStacksPerStreet: stacks,
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
+      foldedPlayers:
+          _foldedPlayers.isEmpty ? null : List<int>.from(_foldedPlayers),
       actionTags:
           _actionTags.isEmpty ? null : Map<int, String?>.from(_actionTags),
       pendingEvaluations:
@@ -2242,6 +2244,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _pendingEvaluations
         ..clear()
         ..addAll(hand.pendingEvaluations ?? []);
+      _foldedPlayers
+        ..clear()
+        ..addAll(hand.foldedPlayers ??
+            [for (final a in hand.actions) if (a.action == 'fold') a.playerIndex]);
       _expandedHistoryStreets
         ..clear()
         ..addAll([
@@ -2255,7 +2261,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _playbackManager.animatedPlayersPerStreet.clear();
       _playbackManager.updatePlaybackState();
       _playerManager.updatePositions();
-      _recomputeFoldedPlayers();
+      if (hand.foldedPlayers == null) {
+        _recomputeFoldedPlayers();
+      }
     });
     _queueService.persist();
   }


### PR DESCRIPTION
## Summary
- persist folded players in `SavedHand`
- restore folded players when loading a hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684df1ef88ec832a8cd282940e9ef570