### PR TITLE
Add playback index persistence

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -39,6 +39,8 @@ class SavedHand {
   final Map<int, String?>? actionTags;
   /// Pending action evaluation requests queued when the hand was saved.
   final List<ActionEvaluationRequest>? pendingEvaluations;
+  /// Index in the action list used when the hand was last viewed.
+  final int playbackIndex;
 
   SavedHand({
     required this.name,
@@ -71,6 +73,7 @@ class SavedHand {
     this.foldedPlayers,
     this.actionTags,
     this.pendingEvaluations,
+    this.playbackIndex = 0,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
@@ -107,6 +110,7 @@ class SavedHand {
     List<int>? foldedPlayers,
     Map<int, String?>? actionTags,
     List<ActionEvaluationRequest>? pendingEvaluations,
+    int? playbackIndex,
   }) {
     return SavedHand(
       name: name ?? this.name,
@@ -169,6 +173,7 @@ class SavedHand {
                           attempts: e.attempts,
                         )
                     ]),
+      playbackIndex: playbackIndex ?? this.playbackIndex,
     );
   }
 
@@ -229,6 +234,7 @@ class SavedHand {
               actionTags!.map((k, v) => MapEntry(k.toString(), v)),
         if (pendingEvaluations != null)
           'pendingEvaluations': [for (final e in pendingEvaluations!) e.toJson()],
+        'playbackIndex': playbackIndex,
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -324,6 +330,7 @@ class SavedHand {
               Map<String, dynamic>.from(e as Map))
       ];
     }
+    final playbackIndex = json['playbackIndex'] as int? ?? 0;
     final commentCursor = json['commentCursor'] as int?;
     final tagsCursor = json['tagsCursor'] as int?;
     Map<int, PlayerType> types = {};
@@ -371,6 +378,7 @@ class SavedHand {
       foldedPlayers: folded,
       actionTags: aTags,
       pendingEvaluations: pending,
+      playbackIndex: playbackIndex,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2187,6 +2187,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           _actionTags.isEmpty ? null : Map<int, String?>.from(_actionTags),
       pendingEvaluations:
           _pendingEvaluations.isEmpty ? null : List<ActionEvaluationRequest>.from(_pendingEvaluations),
+      playbackIndex: _playbackManager.playbackIndex,
     );
   }
 
@@ -2276,7 +2277,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               i
         ]);
       currentStreet = hand.boardStreet;
-      _playbackManager.seek(hand.actions.length);
+      final seekIndex =
+          hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
+      _playbackManager.seek(seekIndex);
       _playbackManager.animatedPlayersPerStreet.clear();
       _playbackManager.updatePlaybackState();
       _playerManager.updatePositions();


### PR DESCRIPTION
## Summary
- store the current playback index in `SavedHand`
- restore playback position when loading hands
- include playback index in JSON serialization

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_684df79d6670832a9acce5db09539f65