### PR TITLE
Enforce board stage order when editing

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -775,9 +775,30 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void selectBoardCard(int index, CardModel card) {
+    final count = boardCards.length;
+    if (index == 3 && count < 3) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('Add Flop cards before adding the Turn')),
+        );
+      }
+      return;
+    }
+    if (index == 4 && count < 4) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('Add the Turn before adding the River')),
+        );
+      }
+      return;
+    }
     setState(() {
       _recordSnapshot();
       _playerManager.selectBoardCard(index, card);
+      boardStreet = _inferBoardStreet();
+      currentStreet = boardStreet;
       _updateRevealedBoardCards();
     });
   }


### PR DESCRIPTION
## Summary
- prevent skipping Flop or Turn when selecting board cards
- sync `boardStreet` and `currentStreet` after manual board edits

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e077fd36c832a9ce6b87cb095dda2