### PR TITLE
Refactor board editing logic

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -774,26 +774,31 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _playerManager.setRevealedCard(playerIndex, cardIndex, selected));
   }
 
-  void selectBoardCard(int index, CardModel card) {
+  bool _canAddBoardCard(int index) {
     final count = boardCards.length;
     if (index == 3 && count < 3) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-              content: Text('Add Flop cards before adding the Turn')),
-        );
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(const SnackBar(
+              content: Text('Add Flop cards before adding the Turn')));
       }
-      return;
+      return false;
     }
     if (index == 4 && count < 4) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-              content: Text('Add the Turn before adding the River')),
-        );
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(const SnackBar(
+              content: Text('Add the Turn before adding the River')));
       }
-      return;
+      return false;
     }
+    return true;
+  }
+
+  void selectBoardCard(int index, CardModel card) {
+    if (!_canAddBoardCard(index)) return;
     setState(() {
       _recordSnapshot();
       _playerManager.selectBoardCard(index, card);


### PR DESCRIPTION
## Summary
- add helper `_canAddBoardCard` in `PokerAnalyzerScreen`
- show message if user tries to add Turn or River before prior streets
- use helper in `selectBoardCard` to enforce consistent board state

## Testing
- `dartfmt` (not run)


------
https://chatgpt.com/codex/tasks/task_e_684e0a52cbf8832aaf264e0c20c20e1a