### PR TITLE
Add board consistency validation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2830,6 +2830,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     boardCards: boardCards,
                     revealedBoardCards: revealedBoardCards,
                     onCardSelected: selectBoardCard,
+                    canEditBoard: _canEditBoard,
                     visibleActions: visibleActions,
                   ),
                   _PlayerZonesSection(
@@ -3957,6 +3958,7 @@ class _BoardCardsSection extends StatelessWidget {
   final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
+  final bool Function(int index)? canEditBoard;
 
   const _BoardCardsSection({
     required this.scale,
@@ -3965,6 +3967,7 @@ class _BoardCardsSection extends StatelessWidget {
     required this.revealedBoardCards,
     required this.onCardSelected,
     required this.visibleActions,
+    this.canEditBoard,
   });
 
   @override
@@ -3982,6 +3985,7 @@ class _BoardCardsSection extends StatelessWidget {
         boardCards: boardCards,
         revealedBoardCards: revealedBoardCards,
         onCardSelected: onCardSelected,
+        canEditBoard: canEditBoard,
         visibleActions: visibleActions,
       ),
     );

--- a/lib/widgets/board_cards_widget.dart
+++ b/lib/widgets/board_cards_widget.dart
@@ -6,6 +6,7 @@ class BoardCardsWidget extends StatelessWidget {
   final int currentStreet;
   final List<CardModel> boardCards;
   final void Function(int, CardModel) onCardSelected;
+  final bool Function(int index)? canEditBoard;
   final double scale;
 
   const BoardCardsWidget({
@@ -13,6 +14,7 @@ class BoardCardsWidget extends StatelessWidget {
     required this.currentStreet,
     required this.boardCards,
     required this.onCardSelected,
+    this.canEditBoard,
     this.scale = 1.0,
   }) : super(key: key);
 
@@ -32,6 +34,7 @@ class BoardCardsWidget extends StatelessWidget {
             return GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () async {
+                if (canEditBoard != null && !canEditBoard!(index)) return;
                 final selected = await showCardSelector(context);
                 if (selected != null) {
                   onCardSelected(index, selected);

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -11,6 +11,7 @@ class BoardDisplay extends StatelessWidget {
   final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
+  final bool Function(int index)? canEditBoard;
   final double scale;
 
   const BoardDisplay({
@@ -20,6 +21,7 @@ class BoardDisplay extends StatelessWidget {
     required this.revealedBoardCards,
     required this.visibleActions,
     required this.onCardSelected,
+    this.canEditBoard,
     this.scale = 1.0,
   }) : super(key: key);
 
@@ -32,6 +34,7 @@ class BoardDisplay extends StatelessWidget {
           currentStreet: currentStreet,
           boardCards: revealedBoardCards,
           onCardSelected: onCardSelected,
+          canEditBoard: canEditBoard,
         ),
         PotOverBoardWidget(
           visibleActions: visibleActions,


### PR DESCRIPTION
## Summary
- ensure board stages can't be skipped when editing
- pass board validation callback through board widgets

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_684e1e1a6858832a8581b8c6604afd71