### PR TITLE
Add board stage consistency checks

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -816,8 +816,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   /// warning and returns `false`.
   bool _canAddBoardCard(int index) {
     final stage = _stageForBoardIndex(index);
-    final inferredStage = _inferBoardStreet();
-    if (stage > inferredStage + 1) {
+    if (!_isBoardStageComplete(stage - 1)) {
       _showBoardSkipWarning(_stageNames[stage - 1], _stageNames[stage]);
       return false;
     }


### PR DESCRIPTION
## Summary
- enforce board stage order when editing community cards
- show an error if the user tries to skip a stage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e3788cf8c832ab5085ab70d1fea10