### PR TITLE
Improve board skip message

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -804,12 +804,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final prevName = _stageNames[prevStage];
     final nextName = _stageNames[nextStage];
     final count = _stageCardCounts[prevStage];
+    final cardWord = count == 1 ? 'card' : 'cards';
     ScaffoldMessenger.of(context)
       ..clearSnackBars()
       ..showSnackBar(
         SnackBar(
           content: Text(
-            'Please complete the $prevName by adding $count cards before editing the $nextName.',
+            'Please complete the $prevName by adding $count $cardWord before editing the $nextName.',
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- refine user-facing warning when skipping streets while editing the board

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e487dcb80832ab8b5d1d5b2ba04fc