### PR TITLE
Enable board card removal via long press

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -849,6 +849,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
   }
 
+  void _removeBoardCard(int index) {
+    if (index >= boardCards.length) return;
+    setState(() {
+      _recordSnapshot();
+      _playerManager.removeBoardCard(index);
+      _ensureBoardStreetConsistent();
+      _updateRevealedBoardCards();
+    });
+  }
+
   Future<Map<String, dynamic>?> _showActionPicker() {
     final bool hasBet = _streetHasBet();
     final bool betEnabled = !hasBet;
@@ -2861,6 +2871,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     boardCards: boardCards,
                     revealedBoardCards: revealedBoardCards,
                     onCardSelected: selectBoardCard,
+                    onCardLongPress: _removeBoardCard,
                     canEditBoard: _canEditBoard,
                     visibleActions: visibleActions,
                   ),
@@ -3989,6 +4000,7 @@ class _BoardCardsSection extends StatelessWidget {
   final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
+  final void Function(int) onCardLongPress;
   final bool Function(int index)? canEditBoard;
 
   const _BoardCardsSection({
@@ -3997,6 +4009,7 @@ class _BoardCardsSection extends StatelessWidget {
     required this.boardCards,
     required this.revealedBoardCards,
     required this.onCardSelected,
+    required this.onCardLongPress,
     required this.visibleActions,
     this.canEditBoard,
   });
@@ -4016,6 +4029,7 @@ class _BoardCardsSection extends StatelessWidget {
         boardCards: boardCards,
         revealedBoardCards: revealedBoardCards,
         onCardSelected: onCardSelected,
+        onCardLongPress: onCardLongPress,
         canEditBoard: canEditBoard,
         visibleActions: visibleActions,
       ),

--- a/lib/services/player_manager_service.dart
+++ b/lib/services/player_manager_service.dart
@@ -161,6 +161,12 @@ class PlayerManagerService extends ChangeNotifier {
     notifyListeners();
   }
 
+  void removeBoardCard(int index) {
+    if (index < 0 || index >= boardCards.length) return;
+    boardCards.removeAt(index);
+    notifyListeners();
+  }
+
   void _removeFromRevealedCards(CardModel card) {
     for (final player in players) {
       for (int i = 0; i < player.revealedCards.length; i++) {

--- a/lib/widgets/board_cards_widget.dart
+++ b/lib/widgets/board_cards_widget.dart
@@ -6,6 +6,7 @@ class BoardCardsWidget extends StatelessWidget {
   final int currentStreet;
   final List<CardModel> boardCards;
   final void Function(int, CardModel) onCardSelected;
+  final void Function(int index)? onCardLongPress;
   final bool Function(int index)? canEditBoard;
   final double scale;
 
@@ -14,6 +15,7 @@ class BoardCardsWidget extends StatelessWidget {
     required this.currentStreet,
     required this.boardCards,
     required this.onCardSelected,
+    this.onCardLongPress,
     this.canEditBoard,
     this.scale = 1.0,
   }) : super(key: key);
@@ -38,6 +40,11 @@ class BoardCardsWidget extends StatelessWidget {
                 final selected = await showCardSelector(context);
                 if (selected != null) {
                   onCardSelected(index, selected);
+                }
+              },
+              onLongPress: () {
+                if (onCardLongPress != null && index < boardCards.length) {
+                  onCardLongPress!(index);
                 }
               },
               child: Container(

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -11,6 +11,7 @@ class BoardDisplay extends StatelessWidget {
   final List<CardModel> revealedBoardCards;
   final List<ActionEntry> visibleActions;
   final void Function(int, CardModel) onCardSelected;
+  final void Function(int index)? onCardLongPress;
   final bool Function(int index)? canEditBoard;
   final double scale;
 
@@ -21,6 +22,7 @@ class BoardDisplay extends StatelessWidget {
     required this.revealedBoardCards,
     required this.visibleActions,
     required this.onCardSelected,
+    this.onCardLongPress,
     this.canEditBoard,
     this.scale = 1.0,
   }) : super(key: key);
@@ -34,6 +36,7 @@ class BoardDisplay extends StatelessWidget {
           currentStreet: currentStreet,
           boardCards: revealedBoardCards,
           onCardSelected: onCardSelected,
+          onCardLongPress: onCardLongPress,
           canEditBoard: canEditBoard,
         ),
         PotOverBoardWidget(


### PR DESCRIPTION
## Summary
- allow removing a board card with long press
- wire removal through BoardDisplay and _BoardCardsSection
- keep board street in sync via PlayerManagerService

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e84786418832aa61e91a93b038a9a