### PR TITLE
Add reverse street navigation

### DIFF
--- a/lib/widgets/street_actions_widget.dart
+++ b/lib/widgets/street_actions_widget.dart
@@ -9,11 +9,15 @@ import 'package:flutter/material.dart';
 class StreetActionsWidget extends StatelessWidget {
   final int currentStreet;
   final Function(int) onStreetChanged;
+  final VoidCallback? onPrevStreet;
+  final bool canGoPrev;
 
   const StreetActionsWidget({
     Key? key,
     required this.currentStreet,
     required this.onStreetChanged,
+    this.onPrevStreet,
+    this.canGoPrev = false,
   }) : super(key: key);
 
   @override
@@ -24,24 +28,31 @@ class StreetActionsWidget extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: List.generate(streets.length, (index) {
-          final isSelected = index == currentStreet;
-          return ElevatedButton(
-            onPressed: () => onStreetChanged(index),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isSelected ? Colors.amber : Colors.grey[800],
-              foregroundColor: isSelected ? Colors.black : Colors.white,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            color: Colors.white,
+            onPressed: canGoPrev ? onPrevStreet : null,
+          ),
+          ...List.generate(streets.length, (index) {
+            final isSelected = index == currentStreet;
+            return ElevatedButton(
+              onPressed: () => onStreetChanged(index),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: isSelected ? Colors.amber : Colors.grey[800],
+                foregroundColor: isSelected ? Colors.black : Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
-            ),
-            child: Text(
-              streets[index],
-              style: const TextStyle(fontSize: 16),
-            ),
-          );
-        }),
+              child: Text(
+                streets[index],
+                style: const TextStyle(fontSize: 16),
+              ),
+            );
+          }),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow StreetActionsWidget to navigate backward with a new prev button
- animate board when moving to earlier streets
- enable manual reverse navigation with `_reverseStreet`

## Testing
- `dart format lib/widgets/street_actions_widget.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8fa856f0832ab0d43a9c9bde25de