### PR TITLE
Add street navigation controls

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1706,6 +1706,34 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _debugPanelSetState?.call(() {});
   }
 
+  void _previousStreet() {
+    if (currentStreet <= 0) return;
+    setState(() {
+      _recordSnapshot();
+      currentStreet--;
+      _actionTags.clear();
+      _playbackManager.animatedPlayersPerStreet
+          .putIfAbsent(currentStreet, () => <int>{});
+      _updateRevealedBoardCards();
+      _playbackManager.updatePlaybackState();
+    });
+    _debugPanelSetState?.call(() {});
+  }
+
+  void _nextStreet() {
+    if (currentStreet >= boardStreet) return;
+    setState(() {
+      _recordSnapshot();
+      currentStreet++;
+      _actionTags.clear();
+      _playbackManager.animatedPlayersPerStreet
+          .putIfAbsent(currentStreet, () => <int>{});
+      _updateRevealedBoardCards();
+      _playbackManager.updatePlaybackState();
+    });
+    _debugPanelSetState?.call(() {});
+  }
+
   Future<void> _removePlayer(int index) async {
     if (_playerManager.numberOfPlayers <= 2) return;
 
@@ -5768,7 +5796,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
 
 
 
-  TextButton _dialogBtn(String label, VoidCallback onPressed) {
+  TextButton _dialogBtn(String label, VoidCallback? onPressed) {
     return TextButton(onPressed: onPressed, child: Text(label));
   }
 
@@ -5971,6 +5999,13 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
         _dialogBtn('Export Auto-Backups', s._exportAutoBackups),
         _dialogBtn('Export Snapshots', s._exportSnapshots),
         _dialogBtn('Export All Snapshots', s._exportAllEvaluationSnapshots),
+        _dialogBtn('Previous Street',
+            s.currentStreet <= 0 ? null : s._previousStreet),
+        _dialogBtn(
+            'Next Street',
+            s.currentStreet >= s.boardStreet
+                ? null
+                : s._nextStreet),
         _dialogBtn('Undo', s._undoAction),
         _dialogBtn('Redo', s._redoAction),
         _dialogBtn('Close', () => Navigator.pop(context)),


### PR DESCRIPTION
## Summary
- support navigating streets backward and forward
- add Previous/Next Street buttons to debug panel
- disable the buttons when navigation reaches the street limits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e91139af4832a95f3daa525262d85