### PR TITLE
Add board card reveal animations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4232,13 +4232,25 @@ class _BoardCardsSection extends StatefulWidget {
   State<_BoardCardsSection> createState() => _BoardCardsSectionState();
 }
 
-class _BoardCardsSectionState extends State<_BoardCardsSection> {
+class _BoardCardsSectionState extends State<_BoardCardsSection>
+    with TickerProviderStateMixin {
   late int _prevStreet;
+  late final List<AnimationController> _controllers;
+  late final List<Animation<double>> _animations;
+  List<CardModel> _prevCards = [];
 
   @override
   void initState() {
     super.initState();
     _prevStreet = widget.currentStreet;
+    _controllers =
+        List.generate(5, (_) => AnimationController(vsync: this, duration: const Duration(milliseconds: 300)));
+    _animations =
+        _controllers.map((c) => CurvedAnimation(parent: c, curve: Curves.easeIn)).toList();
+    _prevCards = List<CardModel>.from(widget.revealedBoardCards);
+    for (int i = 0; i < _prevCards.length; i++) {
+      _controllers[i].value = 1;
+    }
   }
 
   @override
@@ -4247,6 +4259,35 @@ class _BoardCardsSectionState extends State<_BoardCardsSection> {
     if (oldWidget.currentStreet != widget.currentStreet) {
       _prevStreet = oldWidget.currentStreet;
     }
+    _updateAnimations(oldWidget.revealedBoardCards);
+  }
+
+  void _updateAnimations(List<CardModel> oldCards) {
+    final visible = _stageCardCounts[widget.currentStreet];
+    for (int i = 0; i < 5; i++) {
+      final oldCard = i < oldCards.length ? oldCards[i] : null;
+      final newCard = i < widget.revealedBoardCards.length ? widget.revealedBoardCards[i] : null;
+      final shouldShow = i < visible && newCard != null;
+      if (shouldShow && oldCard == null) {
+        _controllers[i].forward(from: 0);
+      } else if (!shouldShow) {
+        _controllers[i].value = 0;
+      } else if (oldCard != null && newCard != null &&
+          (oldCard.rank != newCard.rank || oldCard.suit != newCard.suit)) {
+        _controllers[i].forward(from: 0);
+      } else if (shouldShow) {
+        _controllers[i].value = 1;
+      }
+    }
+    _prevCards = List<CardModel>.from(widget.revealedBoardCards);
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers) {
+      c.dispose();
+    }
+    super.dispose();
   }
 
   @override
@@ -4270,6 +4311,7 @@ class _BoardCardsSectionState extends State<_BoardCardsSection> {
         currentStreet: widget.currentStreet,
         boardCards: widget.boardCards,
         revealedBoardCards: widget.revealedBoardCards,
+        revealAnimations: _animations,
         onCardSelected: widget.onCardSelected,
         onCardLongPress: widget.onCardLongPress,
         canEditBoard: widget.canEditBoard,

--- a/lib/widgets/board_cards_widget.dart
+++ b/lib/widgets/board_cards_widget.dart
@@ -10,6 +10,7 @@ class BoardCardsWidget extends StatelessWidget {
   final bool Function(int index)? canEditBoard;
   final Set<String> usedCards;
   final double scale;
+  final List<Animation<double>>? revealAnimations;
 
   const BoardCardsWidget({
     Key? key,
@@ -20,6 +21,7 @@ class BoardCardsWidget extends StatelessWidget {
     this.canEditBoard,
     this.usedCards = const {},
     this.scale = 1.0,
+    this.revealAnimations,
   }) : super(key: key);
 
   @override
@@ -50,54 +52,61 @@ class BoardCardsWidget extends StatelessWidget {
             key: ValueKey('$keyString-$visibleCount'),
             mainAxisSize: MainAxisSize.min,
             children: List.generate(visibleCount, (index) {
-            final card = index < boardCards.length ? boardCards[index] : null;
-            final isRed = card?.suit == '♥' || card?.suit == '♦';
+              final card = index < boardCards.length ? boardCards[index] : null;
+              final isRed = card?.suit == '♥' || card?.suit == '♦';
 
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () async {
-                if (canEditBoard != null && !canEditBoard!(index)) return;
-                final disabled = Set<String>.from(usedCards);
-                if (card != null) disabled.remove('${card.rank}${card.suit}');
-                final selected =
-                    await showCardSelector(context, disabledCards: disabled);
-                if (selected != null) {
-                  onCardSelected(index, selected);
-                }
-              },
-              onLongPress: () {
-                if (onCardLongPress != null && index < boardCards.length) {
-                  onCardLongPress!(index);
-                }
-              },
-              child: Container(
-                margin: const EdgeInsets.symmetric(horizontal: 4),
-                width: 36 * scale,
-                height: 52 * scale,
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(card == null ? 0.3 : 1),
-                  borderRadius: BorderRadius.circular(6),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.25),
-                      blurRadius: 3,
-                      offset: const Offset(1, 2),
-                    )
-                  ],
+              final animation = revealAnimations != null &&
+                      index < revealAnimations!.length
+                  ? revealAnimations![index]
+                  : const AlwaysStoppedAnimation(1.0);
+              return FadeTransition(
+                opacity: animation,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () async {
+                    if (canEditBoard != null && !canEditBoard!(index)) return;
+                    final disabled = Set<String>.from(usedCards);
+                    if (card != null) disabled.remove('${card.rank}${card.suit}');
+                    final selected =
+                        await showCardSelector(context, disabledCards: disabled);
+                    if (selected != null) {
+                      onCardSelected(index, selected);
+                    }
+                  },
+                  onLongPress: () {
+                    if (onCardLongPress != null && index < boardCards.length) {
+                      onCardLongPress!(index);
+                    }
+                  },
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 4),
+                    width: 36 * scale,
+                    height: 52 * scale,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+                      borderRadius: BorderRadius.circular(6),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.25),
+                          blurRadius: 3,
+                          offset: const Offset(1, 2),
+                        )
+                      ],
+                    ),
+                    alignment: Alignment.center,
+                    child: card != null
+                        ? Text(
+                            '${card.rank}${card.suit}',
+                            style: TextStyle(
+                              color: isRed ? Colors.red : Colors.black,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18 * scale,
+                            ),
+                          )
+                        : const Icon(Icons.add, color: Colors.grey),
+                  ),
                 ),
-                alignment: Alignment.center,
-                child: card != null
-                    ? Text(
-                        '${card.rank}${card.suit}',
-                        style: TextStyle(
-                          color: isRed ? Colors.red : Colors.black,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 18 * scale,
-                        ),
-                      )
-                    : const Icon(Icons.add, color: Colors.grey),
-              ),
-            );
+              );
             }),
           ),
         ),

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -15,6 +15,7 @@ class BoardDisplay extends StatelessWidget {
   final bool Function(int index)? canEditBoard;
   final Set<String> usedCards;
   final double scale;
+  final List<Animation<double>>? revealAnimations;
 
   const BoardDisplay({
     Key? key,
@@ -27,6 +28,7 @@ class BoardDisplay extends StatelessWidget {
     this.canEditBoard,
     this.usedCards = const {},
     this.scale = 1.0,
+    this.revealAnimations,
   }) : super(key: key);
 
   @override
@@ -37,6 +39,7 @@ class BoardDisplay extends StatelessWidget {
           scale: scale,
           currentStreet: currentStreet,
           boardCards: revealedBoardCards,
+          revealAnimations: revealAnimations,
           onCardSelected: onCardSelected,
           onCardLongPress: onCardLongPress,
           canEditBoard: canEditBoard,


### PR DESCRIPTION
## Summary
- animate newly revealed board cards with fade-in
- track board card state to replay animations when undoing or navigating streets

## Testing
- `flutter --version`

------
https://chatgpt.com/codex/tasks/task_e_684e95fe47e4832aae2635db67f3814d