### PR TITLE
Adjust board reveal timing

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -268,8 +268,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   static const List<int> _stageCardCounts = [0, 3, 4, 5];
   static const double _timelineExtent = 80.0;
   static const List<String> _stageNames = ['Preflop', 'Flop', 'Turn', 'River'];
-  static const Duration _boardRevealDuration = Duration(milliseconds: 300);
-  static const Duration _boardRevealStagger = Duration(milliseconds: 100);
+  static const Duration _boardRevealDuration = Duration(milliseconds: 250);
+  static const Duration _boardRevealStagger = Duration(milliseconds: 50);
 
   /// Determine which board stage a particular card index belongs to.
   int _stageForBoardIndex(int index) {
@@ -653,7 +653,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   void _startBoardTransition() {
     _boardTransitionTimer?.cancel();
     _boardTransitioning = true;
-    _boardTransitionTimer = Timer(const Duration(milliseconds: 300), () {
+    _boardTransitionTimer = Timer(_boardRevealDuration, () {
       if (mounted) {
         setState(() => _boardTransitioning = false);
       } else {


### PR DESCRIPTION
## Summary
- shorten board reveal duration
- shorten stagger delay between cards
- use reveal duration for board transition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e9af5ad54832a86ac2c5f51025c6b