### PR TITLE
Add board transition loading overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3207,6 +3207,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         ? 'SPR: ${sprValue.toStringAsFixed(1)}'
                         : null,
                   ),
+                  if (_boardTransitioning)
+                    const _BoardTransitionBusyIndicator(),
                 _RevealAllCardsButton(
                   showAllRevealedCards: _showAllRevealedCards,
                   onToggle: () => setState(
@@ -4419,6 +4421,26 @@ class _HudOverlaySection extends StatelessWidget {
         potText: potText,
         stackText: stackText,
         sprText: sprText,
+      ),
+    );
+  }
+}
+
+class _BoardTransitionBusyIndicator extends StatelessWidget {
+  const _BoardTransitionBusyIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: ColoredBox(
+        color: Colors.black38,
+        child: const Center(
+          child: SizedBox(
+            width: 40,
+            height: 40,
+            child: CircularProgressIndicator(),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- show busy overlay with spinner when board transition is active
- implement `_BoardTransitionBusyIndicator` widget

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e9feb3268832a9bc338aa16b85a63