### PR TITLE
Block board taps during transitions

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3138,17 +3138,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 child: Stack(
                   children: [
                   _TableBackgroundSection(scale: scale),
-                  _BoardCardsSection(
-                    key: _boardKey,
-                    scale: scale,
-                    currentStreet: currentStreet,
-                    boardCards: boardCards,
-                    revealedBoardCards: revealedBoardCards,
-                    onCardSelected: selectBoardCard,
-                    onCardLongPress: _removeBoardCard,
-                    canEditBoard: _canEditBoard,
-                    usedCards: _usedCardKeys(),
-                    visibleActions: visibleActions,
+                  AbsorbPointer(
+                    absorbing: _boardTransitioning,
+                    child: _BoardCardsSection(
+                      key: _boardKey,
+                      scale: scale,
+                      currentStreet: currentStreet,
+                      boardCards: boardCards,
+                      revealedBoardCards: revealedBoardCards,
+                      onCardSelected: selectBoardCard,
+                      onCardLongPress: _removeBoardCard,
+                      canEditBoard: _canEditBoard,
+                      usedCards: _usedCardKeys(),
+                      visibleActions: visibleActions,
+                    ),
                   ),
                   _PlayerZonesSection(
                     numberOfPlayers: numberOfPlayers,


### PR DESCRIPTION
## Summary
- disable board card selection during board transition animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ea33a0608832aa5459fdeb881322b