### PR TITLE
Prevent board edits during transitions

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3199,6 +3199,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       onCardLongPress: _removeBoardCard,
                       canEditBoard: _canEditBoard,
                       usedCards: _usedCardKeys(),
+                      editingDisabled: _boardTransitioning,
                       visibleActions: visibleActions,
                     ),
                   ),
@@ -4359,6 +4360,7 @@ class _BoardCardsSection extends StatefulWidget {
   final void Function(int) onCardLongPress;
   final bool Function(int index)? canEditBoard;
   final Set<String> usedCards;
+  final bool editingDisabled;
 
   const _BoardCardsSection({
     Key? key,
@@ -4371,6 +4373,7 @@ class _BoardCardsSection extends StatefulWidget {
     required this.visibleActions,
     this.canEditBoard,
     this.usedCards = const {},
+    this.editingDisabled = false,
   }) : super(key: key);
 
   @override
@@ -4484,6 +4487,7 @@ class _BoardCardsSectionState extends State<_BoardCardsSection>
         onCardLongPress: widget.onCardLongPress,
         canEditBoard: widget.canEditBoard,
         usedCards: widget.usedCards,
+        editingDisabled: widget.editingDisabled,
         visibleActions: widget.visibleActions,
       ),
     );

--- a/lib/widgets/board_cards_widget.dart
+++ b/lib/widgets/board_cards_widget.dart
@@ -11,6 +11,7 @@ class BoardCardsWidget extends StatelessWidget {
   final Set<String> usedCards;
   final double scale;
   final List<Animation<double>>? revealAnimations;
+  final bool editingDisabled;
 
   const BoardCardsWidget({
     Key? key,
@@ -22,6 +23,7 @@ class BoardCardsWidget extends StatelessWidget {
     this.usedCards = const {},
     this.scale = 1.0,
     this.revealAnimations,
+    this.editingDisabled = false,
   }) : super(key: key);
 
   @override
@@ -63,21 +65,25 @@ class BoardCardsWidget extends StatelessWidget {
                 opacity: animation,
                 child: GestureDetector(
                   behavior: HitTestBehavior.opaque,
-                  onTap: () async {
-                    if (canEditBoard != null && !canEditBoard!(index)) return;
-                    final disabled = Set<String>.from(usedCards);
-                    if (card != null) disabled.remove('${card.rank}${card.suit}');
-                    final selected =
-                        await showCardSelector(context, disabledCards: disabled);
-                    if (selected != null) {
-                      onCardSelected(index, selected);
-                    }
-                  },
-                  onLongPress: () {
-                    if (onCardLongPress != null && index < boardCards.length) {
-                      onCardLongPress!(index);
-                    }
-                  },
+                  onTap: editingDisabled
+                      ? null
+                      : () async {
+                          if (canEditBoard != null && !canEditBoard!(index)) return;
+                          final disabled = Set<String>.from(usedCards);
+                          if (card != null) disabled.remove('${card.rank}${card.suit}');
+                          final selected =
+                              await showCardSelector(context, disabledCards: disabled);
+                          if (selected != null) {
+                            onCardSelected(index, selected);
+                          }
+                        },
+                  onLongPress: editingDisabled
+                      ? null
+                      : () {
+                          if (onCardLongPress != null && index < boardCards.length) {
+                            onCardLongPress!(index);
+                          }
+                        },
                   child: Container(
                     margin: const EdgeInsets.symmetric(horizontal: 4),
                     width: 36 * scale,

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -16,6 +16,7 @@ class BoardDisplay extends StatelessWidget {
   final Set<String> usedCards;
   final double scale;
   final List<Animation<double>>? revealAnimations;
+  final bool editingDisabled;
 
   const BoardDisplay({
     Key? key,
@@ -29,6 +30,7 @@ class BoardDisplay extends StatelessWidget {
     this.usedCards = const {},
     this.scale = 1.0,
     this.revealAnimations,
+    this.editingDisabled = false,
   }) : super(key: key);
 
   @override
@@ -44,6 +46,7 @@ class BoardDisplay extends StatelessWidget {
           onCardLongPress: onCardLongPress,
           canEditBoard: canEditBoard,
           usedCards: usedCards,
+          editingDisabled: editingDisabled,
         ),
         PotOverBoardWidget(
           visibleActions: visibleActions,


### PR DESCRIPTION
## Summary
- add `editingDisabled` option to BoardCardsWidget and BoardDisplay
- pass edit disable flag in PokerAnalyzerScreen while board transition is active
- disable board card selection and removal when transitioning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eb7138008832a8558880498933f1f