### PR TITLE
Disable player edits during board transitions

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3588,12 +3588,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         top: centerY + dy + bias - 55 * scale * infoScale,
         child: Transform.scale(
           scale: infoScale,
-          child: AbsorbPointer(
-            absorbing: _boardTransitioning,
-            child: PlayerInfoWidget(
-            position: position,
-            stack: stack,
-            tag: tag,
+          child: PlayerInfoWidget(
+              editingDisabled: _boardTransitioning,
+              position: position,
+              stack: stack,
+              tag: tag,
             cards: _showAllRevealedCards &&
                     players[index]
                         .revealedCards
@@ -3634,11 +3633,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 : () => setState(() {
                     _playerManager.setHeroIndex(index);
                   }),
-            onLongPress: _boardTransitioning ? null : () => _editPlayerInfo(index),
-            onEdit: _boardTransitioning ? null : () => _editPlayerInfo(index),
-            onStackTap: _boardTransitioning
-                ? null
-                : (value) => setState(() {
+            onLongPress: () => _editPlayerInfo(index),
+            onEdit: () => _editPlayerInfo(index),
+            onStackTap: (value) => setState(() {
                       _playerManager.setInitialStack(index, value);
                       _stackService = StackManagerService(
                           Map<int, int>.from(_playerManager.initialStacks));

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -45,6 +45,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final int currentBet;
   /// Remaining stack after subtracting investments.
   final int? remainingStack;
+  /// Disable stack and type edits when true.
+  final bool editingDisabled;
 
   const PlayerInfoWidget({
     super.key,
@@ -73,6 +75,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.currentBet = 0,
     this.showLastIndicator = false,
     this.remainingStack,
+    this.editingDisabled = false,
   });
 
   String _format(int value) => NumberFormat.decimalPattern().format(value);
@@ -288,7 +291,7 @@ class PlayerInfoWidget extends StatelessWidget {
           const SizedBox(height: 4),
           GestureDetector(
             onTap: () async {
-              if (onStackTap == null) return;
+              if (onStackTap == null || editingDisabled) return;
               final controller = TextEditingController(text: stack.toString());
               int? value = stack;
               final result = await showDialog<int>(
@@ -417,7 +420,7 @@ class PlayerInfoWidget extends StatelessWidget {
       child: InkWell(
         onTap: onTap,
         onDoubleTap: onDoubleTap,
-        onLongPress: onLongPress ?? onEdit,
+        onLongPress: editingDisabled ? null : (onLongPress ?? onEdit),
         borderRadius: BorderRadius.circular(8),
         child: result,
       ),
@@ -452,7 +455,7 @@ class PlayerInfoWidget extends StatelessWidget {
           top: 0,
           left: 0,
           child: GestureDetector(
-            onTap: onEdit,
+            onTap: editingDisabled ? null : onEdit,
             child: const Text('✏️', style: TextStyle(fontSize: 12)),
           ),
         ));
@@ -462,7 +465,7 @@ class PlayerInfoWidget extends StatelessWidget {
           top: 0,
           right: 0,
           child: GestureDetector(
-            onTap: onRemove,
+            onTap: editingDisabled ? null : onRemove,
             child: const Text('❌', style: TextStyle(fontSize: 12)),
           ),
         ));


### PR DESCRIPTION
## Summary
- avoid stack/type edits while board transition is active
- propagate editingDisabled flag to PlayerInfoWidget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eba627460832ab8d13c69fb406a66