### PR TITLE
Prevent active timer during board transitions

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1005,6 +1005,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void _onPlayerTimeExpired(int index) {
+    if (_boardTransitioning) return;
     if (activePlayerIndex == index) {
       setState(() => activePlayerIndex = null);
     }
@@ -3625,6 +3626,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     _playerManager.playerPositions[index] == 'BB')
                 ? _playerManager.playerPositions[index]
                 : null,
+            timersDisabled: _boardTransitioning,
             onCardTap: _boardTransitioning
                 ? null
                 : (cardIndex) => _onPlayerCardTap(index, cardIndex),

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -45,6 +45,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final int currentBet;
   /// Remaining stack after subtracting investments.
   final int? remainingStack;
+  /// Disables the active timer when true.
+  final bool timersDisabled;
 
   const PlayerInfoWidget({
     super.key,
@@ -73,6 +75,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.currentBet = 0,
     this.showLastIndicator = false,
     this.remainingStack,
+    this.timersDisabled = false,
   });
 
   String _format(int value) => NumberFormat.decimalPattern().format(value);
@@ -427,8 +430,8 @@ class PlayerInfoWidget extends StatelessWidget {
       clickable = _ActivePlayerGlow(child: clickable);
       clickable = ActionTimerRing(
         child: clickable,
-        isActive: true,
-        onTimeExpired: onTimeExpired,
+        isActive: !timersDisabled,
+        onTimeExpired: timersDisabled ? null : onTimeExpired,
       );
     }
 


### PR DESCRIPTION
## Summary
- add `timersDisabled` flag to `PlayerInfoWidget`
- disable countdown and callback when board transition animation runs
- pass board transition status from `PokerAnalyzerScreen`
- ignore timer expiration during transitions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ebc09f2d8832abd0b4951488feb55