### PR TITLE
Use transition-safe state updates in action dialog

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -5357,7 +5357,9 @@ class _StreetActionInputWidgetState extends State<StreetActionInputWidget> {
                             'Player ${i + 1}'),
                       )
                   ],
-                  onChanged: (v) => setState(() => p = v ?? p),
+                  onChanged: (v) =>
+                      ctx.findAncestorStateOfType<_PokerAnalyzerScreenState>()?
+                          ._safeSetState(() => setState(() => p = v ?? p)),
                 ),
                 const SizedBox(height: 8),
                 DropdownButton<String>(
@@ -5369,7 +5371,9 @@ class _StreetActionInputWidgetState extends State<StreetActionInputWidget> {
                     DropdownMenuItem(value: 'bet', child: Text('bet')),
                     DropdownMenuItem(value: 'raise', child: Text('raise')),
                   ],
-                  onChanged: (v) => setState(() => act = v ?? act),
+                  onChanged: (v) =>
+                      ctx.findAncestorStateOfType<_PokerAnalyzerScreenState>()?
+                          ._safeSetState(() => setState(() => act = v ?? act)),
                 ),
                 if (need)
                   TextField(


### PR DESCRIPTION
## Summary
- ensure the edit action dialog in `PokerAnalyzerScreen` uses `_safeSetState`

## Testing
- `git commit -m "Use _safeSetState in action edit dialog"`


------
https://chatgpt.com/codex/tasks/task_e_684ec6df5a64832a97bd85a2c524f449