### PR TITLE
Introduce transition lock service

### DIFF
--- a/lib/services/transition_lock_service.dart
+++ b/lib/services/transition_lock_service.dart
@@ -1,0 +1,15 @@
+import "package:flutter/widgets.dart";
+class TransitionLockService {
+  bool boardTransitioning = false;
+  bool undoRedoTransitionLock = false;
+
+  void safeSetState(
+    State state,
+    VoidCallback fn, {
+    bool ignoreTransitionLock = false,
+  }) {
+    if (!state.mounted) return;
+    if (boardTransitioning && !ignoreTransitionLock) return;
+    state.setState(fn);
+  }
+}


### PR DESCRIPTION
## Summary
- add `TransitionLockService` to centralize transition lock logic
- refactor `PokerAnalyzerScreen` to use `lockService.safeSetState`
- update `StreetActionInputWidget` to access the lock service via context

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684ecfadfda8832abab00c27427e6348