### PR TITLE
Refactor transition lock management

### DIFF
--- a/lib/services/transition_lock_service.dart
+++ b/lib/services/transition_lock_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+/// Centralizes board and undo/redo transition locks.
+class TransitionLockService extends ChangeNotifier {
+  bool _boardTransitioning = false;
+  bool _undoRedoTransitionLock = false;
+
+  bool get boardTransitioning => _boardTransitioning;
+  bool get undoRedoTransitionLock => _undoRedoTransitionLock;
+
+  set boardTransitioning(bool value) {
+    if (_boardTransitioning == value) return;
+    _boardTransitioning = value;
+    notifyListeners();
+  }
+
+  set undoRedoTransitionLock(bool value) {
+    if (_undoRedoTransitionLock == value) return;
+    _undoRedoTransitionLock = value;
+    notifyListeners();
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize board and undo/redo transition locks in new `TransitionLockService`
- inject `TransitionLockService` into `PokerAnalyzerScreen`
- pass universal `_safeSetState` and lock service to `StreetActionInputWidget`

## Testing
- `dart` and `flutter` were not available so formatting/tests could not run

------
https://chatgpt.com/codex/tasks/task_e_684ecd8ea134832ab0530937386e5a24