### PR TITLE
Inject DebugPreferencesService

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -104,8 +104,14 @@ class _StateSnapshot {
 class PokerAnalyzerScreen extends StatefulWidget {
   final SavedHand? initialHand;
   final EvaluationQueueService? queueService;
+  final DebugPreferencesService? debugPrefsService;
 
-  const PokerAnalyzerScreen({super.key, this.initialHand, this.queueService});
+  const PokerAnalyzerScreen({
+    super.key,
+    this.initialHand,
+    this.queueService,
+    this.debugPrefsService,
+  });
 
   @override
   State<PokerAnalyzerScreen> createState() => _PokerAnalyzerScreenState();
@@ -261,7 +267,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   static const int _backupRetentionLimit = 30;
   /// Number of automatic queue backups to retain.
   static const int _autoBackupRetentionLimit = 50;
-  final DebugPreferencesService _debugPrefs = DebugPreferencesService();
+  late final DebugPreferencesService _debugPrefs;
 
   /// Evaluation processing delay, snapshot retention and other debug
   /// preferences are managed by [_debugPrefs].
@@ -897,6 +903,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   void initState() {
     super.initState();
     _queueService = widget.queueService ?? EvaluationQueueService();
+    _debugPrefs = widget.debugPrefsService ?? DebugPreferencesService();
     _backupManager = BackupManagerService(
       queueService: _queueService,
       debugPrefs: _debugPrefs,


### PR DESCRIPTION
## Summary
- add optional DebugPreferencesService injection for PokerAnalyzerScreen
- initialize the debug preferences service in initState

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eda4b6960832a948513f7ebd29164