### PR TITLE
Refactor to use BackupManager for quick backup imports

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2083,11 +2083,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _debugPanelSetState?.call(() {});
   }
 
-  Future<void> _importQuickBackups() async {
-    await _backupManager.importQuickBackups(context);
-    _debugPanelSetState?.call(() {});
-  }
-
   Future<void> _bulkImportAutoBackups() async {
     await _backupManager.bulkImportAutoBackups(context);
     if (mounted) setState(() {});


### PR DESCRIPTION
## Summary
- remove duplicate `_importQuickBackups` wrapper in `PokerAnalyzerScreen`
- keep single wrapper calling `BackupManagerService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ee2c936e4832abe1af920ba63ab71