### PR TITLE
Refactor action sync flow

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'poker_analyzer_screen.dart';
 import 'settings_screen.dart';
 import 'training_packs_screen.dart';
+import 'package:provider/provider.dart';
+import '../services/action_sync_service.dart';
 
 class PlayerInputScreen extends StatefulWidget {
   const PlayerInputScreen({super.key});
@@ -92,7 +94,10 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) => PokerAnalyzerScreen(key: key),
+                      builder: (_) => PokerAnalyzerScreen(
+                        key: key,
+                        actionSync: context.read<ActionSyncService>(),
+                      ),
                     ),
                   );
                   WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -110,7 +115,9 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                 if (text.isNotEmpty) {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (context) => const PokerAnalyzerScreen(),
+                      builder: (context) => PokerAnalyzerScreen(
+                        actionSync: context.read<ActionSyncService>(),
+                      ),
                     ),
                   );
                 }

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -17,6 +17,7 @@ import '../models/session_task_result.dart';
 import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
 import '../services/training_pack_storage_service.dart';
+import '../services/action_sync_service.dart';
 
 class _ResultEntry {
   final String name;
@@ -595,6 +596,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                 child: PokerAnalyzerScreen(
                   key: _analyzerKey,
                   initialHand: hands[_currentIndex],
+                  actionSync: context.read<ActionSyncService>(),
                 ),
               ),
             ),

--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -74,6 +74,26 @@ class ActionSyncService extends ChangeNotifier {
   final List<ActionSnapshot> _undoSnapshots = [];
   final List<ActionSnapshot> _redoSnapshots = [];
 
+  void setAnalyzerActions(List<ActionEntry> entries) {
+    analyzerActions
+      ..clear()
+      ..addAll(entries);
+    _undoStack.clear();
+    _redoStack.clear();
+    _undoSnapshots.clear();
+    _redoSnapshots.clear();
+    notifyListeners();
+  }
+
+  void clearAnalyzerActions() {
+    analyzerActions.clear();
+    _undoStack.clear();
+    _redoStack.clear();
+    _undoSnapshots.clear();
+    _redoSnapshots.clear();
+    notifyListeners();
+  }
+
   void recordSnapshot(ActionSnapshot snap) {
     _undoSnapshots.add(snap);
     _redoSnapshots.clear();


### PR DESCRIPTION
## Summary
- centralize analyzer action handling in `ActionSyncService`
- inject `ActionSyncService` into `PokerAnalyzerScreen`
- remove direct list manipulations from analyzer screen
- pass the service from training and player screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eeb474754832ab851445a8c9bc44d