### PR TITLE
Refactor hand restoration service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -53,6 +53,7 @@ import '../helpers/pot_calculator.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
+import '../services/hand_restore_service.dart';
 import '../helpers/date_utils.dart';
 import '../widgets/evaluation_request_tile.dart';
 import '../helpers/debug_helpers.dart';
@@ -111,6 +112,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late PlaybackManagerService _playbackManager;
   final PotCalculator _potCalculator = PotCalculator();
   late StackManagerService _stackService;
+  late HandRestoreService _handRestore;
   final TextEditingController _commentController = TextEditingController();
   final TextEditingController _tagsController = TextEditingController();
   Set<String> get allTags => _handManager.allTags;
@@ -784,6 +786,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       stackService: _stackService,
       potCalculator: _potCalculator,
     )..addListener(_onPlaybackManagerChanged);
+    _handRestore = HandRestoreService(
+      playerManager: _playerManager,
+      actionSync: _actionSync,
+      playbackManager: _playbackManager,
+      queueService: _queueService,
+    );
     _playerManager.updatePositions();
     _actionSync.setBoardStreet(_inferBoardStreet());
     _actionSync.changeStreet(boardStreet);
@@ -791,7 +799,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _playbackManager.updatePlaybackState();
     _updateRevealedBoardCards();
     if (widget.initialHand != null) {
-      _applySavedHand(widget.initialHand!);
+      _stackService = _handRestore.restoreHand(
+        widget.initialHand!,
+        commentController: _commentController,
+        tagsController: _tagsController,
+        actionTags: _actionTags,
+        pendingEvaluations: _pendingEvaluations,
+        foldedPlayers: _foldedPlayers,
+        revealedBoardCards: revealedBoardCards,
+        setCurrentHandName: (name) => _currentHandName = name,
+        setActivePlayerIndex: (i) => activePlayerIndex = i,
+      );
+      _startBoardTransition();
     }
     Future(() => _cleanupOldEvaluationBackups());
     Future(() => _initializeDebugPreferences());
@@ -2110,98 +2129,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   void loadHand(String jsonStr) {
     final hand = SavedHand.fromJson(jsonDecode(jsonStr));
-    _applySavedHand(hand);
+    _stackService = _handRestore.restoreHand(
+      hand,
+      commentController: _commentController,
+      tagsController: _tagsController,
+      actionTags: _actionTags,
+      pendingEvaluations: _pendingEvaluations,
+      foldedPlayers: _foldedPlayers,
+      revealedBoardCards: revealedBoardCards,
+      setCurrentHandName: (name) => _currentHandName = name,
+      setActivePlayerIndex: (i) => activePlayerIndex = i,
+    );
+    _startBoardTransition();
   }
 
-  void _applySavedHand(SavedHand hand) {
-    lockService.safeSetState(this, () {
-      _currentHandName = hand.name;
-      _playerManager.heroIndex = hand.heroIndex;
-      _playerManager.heroPosition = hand.heroPosition;
-      _playerManager.numberOfPlayers = hand.numberOfPlayers;
-      for (int i = 0; i < _playerManager.playerCards.length; i++) {
-        _playerManager.playerCards[i]
-          ..clear()
-          ..addAll(i < hand.playerCards.length ? hand.playerCards[i] : []);
-      }
-      _playerManager.boardCards
-        ..clear()
-        ..addAll(hand.boardCards);
-      for (int i = 0; i < _playerManager.players.length; i++) {
-        final list = _playerManager.players[i].revealedCards;
-        list.fillRange(0, list.length, null);
-        if (i < hand.revealedCards.length) {
-          final from = hand.revealedCards[i];
-          for (int j = 0; j < list.length && j < from.length; j++) {
-            list[j] = from[j];
-          }
-        }
-      }
-      opponentIndex = hand.opponentIndex;
-      activePlayerIndex = hand.activePlayerIndex;
-      _actionSync.setAnalyzerActions(hand.actions);
-      _playerManager.initialStacks
-        ..clear()
-        ..addAll(hand.stackSizes);
-      _stackService = StackManagerService(
-        Map<int, int>.from(_playerManager.initialStacks),
-        remainingStacks: hand.remainingStacks,
-      );
-      _playbackManager.stackService = _stackService;
-      _playerManager.playerPositions
-        ..clear()
-        ..addAll(hand.playerPositions);
-      _playerManager.playerTypes
-        ..clear()
-        ..addAll(hand.playerTypes ??
-            {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
-      _commentController.text = hand.comment ?? '';
-      _tagsController.text = hand.tags.join(', ');
-      _commentController.selection = TextSelection.collapsed(
-          offset: hand.commentCursor != null &&
-                  hand.commentCursor! <= _commentController.text.length
-              ? hand.commentCursor!
-              : _commentController.text.length);
-      _tagsController.selection = TextSelection.collapsed(
-          offset:
-              hand.tagsCursor != null && hand.tagsCursor! <= _tagsController.text.length
-                  ? hand.tagsCursor!
-                  : _tagsController.text.length);
-      _actionTags
-        ..clear()
-        ..addAll(hand.actionTags ?? {});
-      _pendingEvaluations
-        ..clear()
-        ..addAll(hand.pendingEvaluations ?? []);
-      _foldedPlayers
-        ..clear()
-        ..addAll(hand.foldedPlayers ??
-            [for (final a in hand.actions) if (a.action == 'fold') a.playerIndex]);
-      _actionSync.setExpandedStreets([
-        for (int i = 0; i < 4; i++)
-          if (hand.collapsedHistoryStreets == null ||
-              !hand.collapsedHistoryStreets!.contains(i))
-            i
-      ]);
-      _autoCollapseStreets();
-      _actionSync.setBoardStreet(hand.boardStreet);
-      _actionSync.changeStreet(hand.boardStreet);
-      _ensureBoardStreetConsistent();
-      _updateRevealedBoardCards();
-      final seekIndex =
-          hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
-      _playbackManager.seek(seekIndex);
-      _actionSync.updatePlaybackIndex(seekIndex);
-      _playbackManager.animatedPlayersPerStreet.clear();
-      _playbackManager.updatePlaybackState();
-      _playerManager.updatePositions();
-      if (hand.foldedPlayers == null) {
-        _recomputeFoldedPlayers();
-      }
-    });
-    _startBoardTransition();
-    _queueService.persist();
-  }
 
   /// Load a training spot represented as a JSON-like map.
   ///
@@ -2342,14 +2283,36 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (lockService.undoRedoTransitionLock || lockService.boardTransitioning) return;
     if (savedHands.isEmpty) return;
     final hand = savedHands.last;
-    _applySavedHand(hand);
+    _stackService = _handRestore.restoreHand(
+      hand,
+      commentController: _commentController,
+      tagsController: _tagsController,
+      actionTags: _actionTags,
+      pendingEvaluations: _pendingEvaluations,
+      foldedPlayers: _foldedPlayers,
+      revealedBoardCards: revealedBoardCards,
+      setCurrentHandName: (name) => _currentHandName = name,
+      setActivePlayerIndex: (i) => activePlayerIndex = i,
+    );
+    _startBoardTransition();
   }
 
   Future<void> loadHandByName() async {
     if (lockService.undoRedoTransitionLock || lockService.boardTransitioning) return;
     final selected = await _handManager.selectHand(context);
     if (selected != null) {
-      _applySavedHand(selected);
+      _stackService = _handRestore.restoreHand(
+        selected,
+        commentController: _commentController,
+        tagsController: _tagsController,
+        actionTags: _actionTags,
+        pendingEvaluations: _pendingEvaluations,
+        foldedPlayers: _foldedPlayers,
+        revealedBoardCards: revealedBoardCards,
+        setCurrentHandName: (name) => _currentHandName = name,
+        setActivePlayerIndex: (i) => activePlayerIndex = i,
+      );
+      _startBoardTransition();
     }
   }
 
@@ -2368,7 +2331,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (lockService.undoRedoTransitionLock || lockService.boardTransitioning) return;
     final hand = await _handManager.importHandFromClipboard(context);
     if (hand != null) {
-      _applySavedHand(hand);
+      _stackService = _handRestore.restoreHand(
+        hand,
+        commentController: _commentController,
+        tagsController: _tagsController,
+        actionTags: _actionTags,
+        pendingEvaluations: _pendingEvaluations,
+        foldedPlayers: _foldedPlayers,
+        revealedBoardCards: revealedBoardCards,
+        setCurrentHandName: (name) => _currentHandName = name,
+        setActivePlayerIndex: (i) => activePlayerIndex = i,
+      );
+      _startBoardTransition();
     }
   }
 

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+
+import '../models/saved_hand.dart';
+import '../models/action_evaluation_request.dart';
+import '../models/card_model.dart';
+import '../models/player_model.dart';
+import 'action_sync_service.dart';
+import 'evaluation_queue_service.dart';
+import 'player_manager_service.dart';
+import 'playback_manager_service.dart';
+import 'stack_manager_service.dart';
+
+class HandRestoreService {
+  HandRestoreService({
+    required this.playerManager,
+    required this.actionSync,
+    required this.playbackManager,
+    required this.queueService,
+  });
+
+  final PlayerManagerService playerManager;
+  final ActionSyncService actionSync;
+  final PlaybackManagerService playbackManager;
+  final EvaluationQueueService queueService;
+
+  static const List<int> _stageCardCounts = [0, 3, 4, 5];
+
+  StackManagerService restoreHand(
+    SavedHand hand, {
+    required TextEditingController commentController,
+    required TextEditingController tagsController,
+    required Map<int, String?> actionTags,
+    required List<ActionEvaluationRequest> pendingEvaluations,
+    required Set<int> foldedPlayers,
+    required List<CardModel> revealedBoardCards,
+    required void Function(String) setCurrentHandName,
+    required void Function(int?) setActivePlayerIndex,
+  }) {
+    setCurrentHandName(hand.name);
+    playerManager.heroIndex = hand.heroIndex;
+    playerManager.heroPosition = hand.heroPosition;
+    playerManager.numberOfPlayers = hand.numberOfPlayers;
+    for (int i = 0; i < playerManager.playerCards.length; i++) {
+      playerManager.playerCards[i]
+        ..clear()
+        ..addAll(i < hand.playerCards.length ? hand.playerCards[i] : []);
+    }
+    playerManager.boardCards
+      ..clear()
+      ..addAll(hand.boardCards);
+    for (int i = 0; i < playerManager.players.length; i++) {
+      final list = playerManager.players[i].revealedCards;
+      list.fillRange(0, list.length, null);
+      if (i < hand.revealedCards.length) {
+        final from = hand.revealedCards[i];
+        for (int j = 0; j < list.length && j < from.length; j++) {
+          list[j] = from[j];
+        }
+      }
+    }
+    playerManager.opponentIndex = hand.opponentIndex;
+    setActivePlayerIndex(hand.activePlayerIndex);
+    actionSync.setAnalyzerActions(hand.actions);
+    playerManager.initialStacks
+      ..clear()
+      ..addAll(hand.stackSizes);
+    final stackService = StackManagerService(
+      Map<int, int>.from(playerManager.initialStacks),
+      remainingStacks: hand.remainingStacks,
+    );
+    playbackManager.stackService = stackService;
+    playerManager.playerPositions
+      ..clear()
+      ..addAll(hand.playerPositions);
+    playerManager.playerTypes
+      ..clear()
+      ..addAll(hand.playerTypes ??
+          {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
+    commentController.text = hand.comment ?? '';
+    tagsController.text = hand.tags.join(', ');
+    commentController.selection = TextSelection.collapsed(
+        offset: hand.commentCursor != null &&
+                hand.commentCursor! <= commentController.text.length
+            ? hand.commentCursor!
+            : commentController.text.length);
+    tagsController.selection = TextSelection.collapsed(
+        offset: hand.tagsCursor != null && hand.tagsCursor! <= tagsController.text.length
+            ? hand.tagsCursor!
+            : tagsController.text.length);
+    actionTags
+      ..clear()
+      ..addAll(hand.actionTags ?? {});
+    pendingEvaluations
+      ..clear()
+      ..addAll(hand.pendingEvaluations ?? []);
+    foldedPlayers
+      ..clear()
+      ..addAll(hand.foldedPlayers ??
+          [for (final a in hand.actions) if (a.action == 'fold') a.playerIndex]);
+    actionSync.setExpandedStreets([
+      for (int i = 0; i < 4; i++)
+        if (hand.collapsedHistoryStreets == null ||
+            !hand.collapsedHistoryStreets!.contains(i))
+          i
+    ]);
+    _autoCollapseStreets();
+    actionSync.setBoardStreet(hand.boardStreet);
+    actionSync.changeStreet(hand.boardStreet);
+    _ensureBoardStreetConsistent();
+    _updateRevealedBoardCards(revealedBoardCards);
+    final seekIndex =
+        hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
+    playbackManager.seek(seekIndex);
+    actionSync.updatePlaybackIndex(seekIndex);
+    playbackManager.animatedPlayersPerStreet.clear();
+    playbackManager.updatePlaybackState();
+    playerManager.updatePositions();
+    if (hand.foldedPlayers == null) {
+      _recomputeFoldedPlayers(foldedPlayers);
+    }
+    queueService.persist();
+    return stackService;
+  }
+
+  void _autoCollapseStreets() {
+    for (int i = 0; i < 4; i++) {
+      if (!actionSync.analyzerActions.any((a) => a.street == i)) {
+        actionSync.removeExpandedStreet(i);
+      }
+    }
+  }
+
+  int _inferBoardStreet() {
+    final count = playerManager.boardCards.length;
+    if (count >= _stageCardCounts[3]) return 3;
+    if (count >= _stageCardCounts[2]) return 2;
+    if (count >= _stageCardCounts[1]) return 1;
+    return 0;
+  }
+
+  void _ensureBoardStreetConsistent() {
+    final inferred = _inferBoardStreet();
+    if (inferred != actionSync.boardStreet) {
+      actionSync.setBoardStreet(inferred);
+      actionSync.changeStreet(inferred);
+    }
+  }
+
+  void _updateRevealedBoardCards(List<CardModel> revealedBoardCards) {
+    final visible = _stageCardCounts[actionSync.currentStreet];
+    revealedBoardCards
+      ..clear()
+      ..addAll(playerManager.boardCards.take(visible));
+  }
+
+  void _recomputeFoldedPlayers(Set<int> foldedPlayers) {
+    foldedPlayers
+      ..clear()
+      ..addAll({
+        for (final a in actionSync.analyzerActions)
+          if (a.action == 'fold') a.playerIndex
+      });
+  }
+}
+


### PR DESCRIPTION
## Summary
- move saved hand restoration logic to new `HandRestoreService`
- wire `PokerAnalyzerScreen` to use the service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef5e4df28832abf73c19bf600ca69