### PR TITLE
Add CurrentHandContextService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -4,6 +4,7 @@ import 'settings_screen.dart';
 import 'training_packs_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/action_sync_service.dart';
+import '../services/current_hand_context_service.dart';
 
 class PlayerInputScreen extends StatefulWidget {
   const PlayerInputScreen({super.key});
@@ -97,6 +98,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                       builder: (_) => PokerAnalyzerScreen(
                         key: key,
                         actionSync: context.read<ActionSyncService>(),
+                        handContext: CurrentHandContextService(),
                       ),
                     ),
                   );
@@ -117,6 +119,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                     MaterialPageRoute(
                       builder: (context) => PokerAnalyzerScreen(
                         actionSync: context.read<ActionSyncService>(),
+                        handContext: CurrentHandContextService(),
                       ),
                     ),
                   );

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -18,6 +18,7 @@ import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/action_sync_service.dart';
+import '../services/current_hand_context_service.dart';
 
 class _ResultEntry {
   final String name;
@@ -597,6 +598,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                   key: _analyzerKey,
                   initialHand: hands[_currentIndex],
                   actionSync: context.read<ActionSyncService>(),
+                  handContext: CurrentHandContextService(),
                 ),
               ),
             ),

--- a/lib/services/current_hand_context_service.dart
+++ b/lib/services/current_hand_context_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class CurrentHandContextService {
+  String? _currentHandName;
+  String? get currentHandName => _currentHandName;
+  set currentHandName(String? value) => _currentHandName = value;
+
+  final TextEditingController commentController = TextEditingController();
+  final TextEditingController tagsController = TextEditingController();
+  final Map<int, String?> actionTags = {};
+
+  void clear() {
+    _currentHandName = null;
+    commentController.clear();
+    tagsController.clear();
+    actionTags.clear();
+  }
+
+  void dispose() {
+    commentController.dispose();
+    tagsController.dispose();
+  }
+}

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -13,6 +13,7 @@ import 'stack_manager_service.dart';
 import 'backup_manager_service.dart';
 import 'debug_preferences_service.dart';
 import 'transition_lock_service.dart';
+import 'current_hand_context_service.dart';
 
 class HandRestoreService {
   HandRestoreService({
@@ -23,9 +24,7 @@ class HandRestoreService {
     required this.backupManager,
     required this.debugPrefs,
     required this.lockService,
-    required this.commentController,
-    required this.tagsController,
-    required this.actionTags,
+    required this.handContext,
     required this.pendingEvaluations,
     required this.foldedPlayers,
     required this.revealedBoardCards,
@@ -40,9 +39,7 @@ class HandRestoreService {
   final BackupManagerService backupManager;
   final DebugPreferencesService debugPrefs;
   final TransitionLockService lockService;
-  final TextEditingController commentController;
-  final TextEditingController tagsController;
-  final Map<int, String?> actionTags;
+  final CurrentHandContextService handContext;
   final List<ActionEvaluationRequest> pendingEvaluations;
   final Set<int> foldedPlayers;
   final List<CardModel> revealedBoardCards;
@@ -92,18 +89,18 @@ class HandRestoreService {
       ..clear()
       ..addAll(hand.playerTypes ??
           {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
-    commentController.text = hand.comment ?? '';
-    tagsController.text = hand.tags.join(', ');
-    commentController.selection = TextSelection.collapsed(
+    handContext.commentController.text = hand.comment ?? '';
+    handContext.tagsController.text = hand.tags.join(', ');
+    handContext.commentController.selection = TextSelection.collapsed(
         offset: hand.commentCursor != null &&
-                hand.commentCursor! <= commentController.text.length
+                hand.commentCursor! <= handContext.commentController.text.length
             ? hand.commentCursor!
-            : commentController.text.length);
-    tagsController.selection = TextSelection.collapsed(
-        offset: hand.tagsCursor != null && hand.tagsCursor! <= tagsController.text.length
+            : handContext.commentController.text.length);
+    handContext.tagsController.selection = TextSelection.collapsed(
+        offset: hand.tagsCursor != null && hand.tagsCursor! <= handContext.tagsController.text.length
             ? hand.tagsCursor!
-            : tagsController.text.length);
-    actionTags
+            : handContext.tagsController.text.length);
+    handContext.actionTags
       ..clear()
       ..addAll(hand.actionTags ?? {});
     pendingEvaluations


### PR DESCRIPTION
## Summary
- create `CurrentHandContextService` to manage comment, tag and hand name state
- inject this service into `PokerAnalyzerScreen`
- update `HandRestoreService` to use `CurrentHandContextService`
- pass the service from player and training screens

## Testing
- `dart` and `flutter` not available, so no formatting or analysis was run

------
https://chatgpt.com/codex/tasks/task_e_684f14a6bb20832aa3ba46268be4b2a9