### PR TITLE
Refactor folded players service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -454,10 +454,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     overlay.insert(overlayEntry);
   }
 
-  void _recomputeFoldedPlayers() {
-    _foldedPlayers.recompute(actions);
-  }
-
   void _autoCollapseStreets() {
     for (int i = 0; i < 4; i++) {
       if (!actions.any((a) => a.street == i)) {
@@ -1413,7 +1409,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     } catch (_) {
       _handContext.actionTags.remove(playerIndex);
     }
-    _recomputeFoldedPlayers();
     _playbackManager.updatePlaybackState();
   }
 
@@ -1469,9 +1464,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         prevStreet: prevStreet,
         newStreet: currentStreet);
     _actionSync.addExpandedStreet(entry.street);
-    if (entry.action == 'fold') {
-      _foldedPlayers.add(entry.playerIndex);
-    }
     _handContext.actionTags[entry.playerIndex] =
         '${entry.action}${entry.amount != null ? ' ${entry.amount}' : ''}';
     setPlayerLastAction(
@@ -1484,7 +1476,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _triggerCenterChip(entry);
       _playUnifiedChipAnimation(entry);
     }
-    _recomputeFoldedPlayers();
     if (_playbackManager.playbackIndex > actions.length) {
       _playbackManager.seek(actions.length);
     }
@@ -1512,7 +1503,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
     _actionSync.updateAnalyzerAction(index, entry,
         recordHistory: recordHistory, street: currentStreet);
-    _recomputeFoldedPlayers();
     _handContext.actionTags[entry.playerIndex] =
         '${entry.action}${entry.amount != null ? ' ${entry.amount}' : ''}';
     setPlayerLastAction(
@@ -1559,7 +1549,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       } catch (_) {
         _handContext.actionTags.remove(removed.playerIndex);
       }
-      _recomputeFoldedPlayers();
       _autoCollapseStreets();
       _playbackManager.updatePlaybackState();
     }
@@ -2223,8 +2212,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       actions
         ..clear()
         ..addAll(newActions);
-
-      _recomputeFoldedPlayers();
 
       playerPositions
         ..clear()

--- a/lib/services/folded_players_service.dart
+++ b/lib/services/folded_players_service.dart
@@ -1,8 +1,20 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/action_entry.dart';
+import 'action_sync_service.dart';
 
 /// Manages the set of folded players and provides helpers to update it.
 class FoldedPlayersService {
   final Set<int> _foldedPlayers = {};
+
+  ActionSyncService? _actionSync;
+  VoidCallback? _listener;
+
+  FoldedPlayersService({ActionSyncService? actionSync}) {
+    if (actionSync != null) {
+      attach(actionSync);
+    }
+  }
 
   Set<int> get players => _foldedPlayers;
   bool get isEmpty => _foldedPlayers.isEmpty;
@@ -32,4 +44,22 @@ class FoldedPlayersService {
           if (a.action == 'fold') a.playerIndex
       });
   }
+
+  void attach(ActionSyncService actionSync) {
+    _actionSync?.removeListener(_listener!);
+    _actionSync = actionSync;
+    _listener = () => recompute(_actionSync!.analyzerActions);
+    _actionSync!.addListener(_listener!);
+    recompute(_actionSync!.analyzerActions);
+  }
+
+  void detach() {
+    if (_actionSync != null && _listener != null) {
+      _actionSync!.removeListener(_listener!);
+      _listener = null;
+      _actionSync = null;
+    }
+  }
+
+  void dispose() => detach();
 }

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -31,7 +31,9 @@ class HandRestoreService {
     required this.revealedBoardCards,
     required this.setCurrentHandName,
     required this.setActivePlayerIndex,
-  });
+  }) {
+    foldedPlayers.attach(actionSync);
+  }
 
   final PlayerManagerService playerManager;
   final ActionSyncService actionSync;
@@ -133,9 +135,7 @@ class HandRestoreService {
     playbackManager.animatedPlayersPerStreet.clear();
     playbackManager.updatePlaybackState();
     playerManager.updatePositions();
-    if (hand.foldedPlayers == null) {
-      _recomputeFoldedPlayers();
-    }
+    // foldedPlayers recomputes automatically when actions change
     queueService.persist();
     backupManager.startAutoBackupTimer();
     unawaited(debugPrefs.setEvaluationQueueResumed(false));
@@ -171,10 +171,6 @@ class HandRestoreService {
     revealedBoardCards
       ..clear()
       ..addAll(playerManager.boardCards.take(visible));
-  }
-
-  void _recomputeFoldedPlayers() {
-    foldedPlayers.recompute(actionSync.analyzerActions);
   }
 }
 


### PR DESCRIPTION
## Summary
- manage folded player state in `FoldedPlayersService`
- wire `FoldedPlayersService` into `HandRestoreService` and `PokerAnalyzerScreen`
- recompute folded players automatically from `ActionSyncService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f1df43ec4832ab8ae3fa49bcd3681