### PR TITLE
Refactor playback manager

### DIFF
--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -131,7 +131,6 @@ class HandRestoreService {
     final seekIndex =
         hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
     playbackManager.seek(seekIndex);
-    actionSync.updatePlaybackIndex(seekIndex);
     playbackManager.animatedPlayersPerStreet.clear();
     playbackManager.updatePlaybackState();
     playerManager.updatePositions();

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../helpers/pot_calculator.dart';
 import '../models/action_entry.dart';
 import '../models/street_investments.dart';
+import 'action_sync_service.dart';
 import 'playback_service.dart';
 import 'stack_manager_service.dart';
 
@@ -12,6 +13,7 @@ class PlaybackManagerService extends ChangeNotifier {
   final List<ActionEntry> actions;
   StackManagerService stackService;
   final PotCalculator _potCalculator;
+  final ActionSyncService actionSync;
 
   /// Current pot size for each street.
   final List<int> pots = List.filled(4, 0);
@@ -25,6 +27,7 @@ class PlaybackManagerService extends ChangeNotifier {
     PlaybackService? playbackService,
     required this.actions,
     required this.stackService,
+    required this.actionSync,
     PotCalculator? potCalculator,
   })  : _playbackService = playbackService ?? PlaybackService(),
         _potCalculator = potCalculator ?? PotCalculator() {
@@ -46,6 +49,7 @@ class PlaybackManagerService extends ChangeNotifier {
 
   void resetHand() {
     _playbackService.resetHand();
+    actionSync.updatePlaybackIndex(_playbackService.playbackIndex);
     updatePlaybackState();
   }
 
@@ -74,6 +78,7 @@ class PlaybackManagerService extends ChangeNotifier {
   }
 
   void _onPlaybackChanged() {
+    actionSync.updatePlaybackIndex(_playbackService.playbackIndex);
     updatePlaybackState();
   }
 


### PR DESCRIPTION
## Summary
- wire `ActionSyncService` into `PlaybackManagerService`
- keep playback index synced from the service
- inject `PlaybackManagerService` into `PokerAnalyzerScreen`
- remove manual playback index updates after seeking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f201496d4832aba0aaf0cdef69ec1