### PR TITLE
Centralize stack calculations

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -119,6 +119,9 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                 handContext: CurrentHandContextService(),
                                 playbackManager:
                                     context.read<PlaybackManagerService>(),
+                                stackService: context
+                                    .read<PlaybackManagerService>()
+                                    .stackService,
                               ),
                             ),
                           ),
@@ -161,6 +164,9 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                 handContext: CurrentHandContextService(),
                                 playbackManager:
                                     context.read<PlaybackManagerService>(),
+                                stackService: context
+                                    .read<PlaybackManagerService>()
+                                    .stackService,
                               ),
                             ),
                           ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -617,6 +617,9 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                           handContext: CurrentHandContextService(),
                           playbackManager:
                               context.read<PlaybackManagerService>(),
+                          stackService: context
+                              .read<PlaybackManagerService>()
+                              .stackService,
                         ),
                       ),
                     ),

--- a/lib/services/stack_manager_service.dart
+++ b/lib/services/stack_manager_service.dart
@@ -13,6 +13,9 @@ class StackManagerService {
     stackSizes.addAll(_manager.currentStacks);
   }
 
+  /// Current initial stack sizes.
+  Map<int, int> get initialStacks => Map<int, int>.from(_initialStacks);
+
   /// Re-initialize with a new set of initial stacks.
   void reset(Map<int, int> stacks, {Map<int, int>? remainingStacks}) {
     _initialStacks


### PR DESCRIPTION
## Summary
- add `initialStacks` getter in `StackManagerService`
- inject `StackManagerService` into `PokerAnalyzerScreen`
- reset stacks via service instead of recreating
- pass stack service when constructing `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f26718044832aa9d42d26dc9dacf8