### PR TITLE
Refactor stack handling into StackManagerService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -101,27 +101,30 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                       builder: (_) => ChangeNotifierProvider(
                         create: (_) => PlayerManagerService(),
                         child: Builder(
-                          builder: (context) => ChangeNotifierProvider(
-                            create: (_) => PlaybackManagerService(
-                              actions: context
-                                  .read<ActionSyncService>()
-                                  .analyzerActions,
-                              stackService: StackManagerService(
-                                Map<int, int>.from(
-                                    context.read<PlayerManagerService>().initialStacks),
-                              ),
-                              actionSync: context.read<ActionSyncService>(),
-                            ),
-                            child: Builder(
-                              builder: (context) => PokerAnalyzerScreen(
-                                key: key,
+                          builder: (context) {
+                            final stackService = StackManagerService(
+                              Map<int, int>.from(
+                                  context.read<PlayerManagerService>().initialStacks),
+                            );
+                            return ChangeNotifierProvider(
+                              create: (_) => PlaybackManagerService(
+                                actions:
+                                    context.read<ActionSyncService>().analyzerActions,
+                                stackService: stackService,
                                 actionSync: context.read<ActionSyncService>(),
-                                handContext: CurrentHandContextService(),
-                                playbackManager:
-                                    context.read<PlaybackManagerService>(),
                               ),
-                            ),
-                          ),
+                              child: Builder(
+                                builder: (context) => PokerAnalyzerScreen(
+                                  key: key,
+                                  actionSync: context.read<ActionSyncService>(),
+                                  handContext: CurrentHandContextService(),
+                                  playbackManager:
+                                      context.read<PlaybackManagerService>(),
+                                  stackService: stackService,
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ),
@@ -144,26 +147,29 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                       builder: (context) => ChangeNotifierProvider(
                         create: (_) => PlayerManagerService(),
                         child: Builder(
-                          builder: (context) => ChangeNotifierProvider(
-                            create: (_) => PlaybackManagerService(
-                              actions: context
-                                  .read<ActionSyncService>()
-                                  .analyzerActions,
-                              stackService: StackManagerService(
-                                Map<int, int>.from(
-                                    context.read<PlayerManagerService>().initialStacks),
-                              ),
-                              actionSync: context.read<ActionSyncService>(),
-                            ),
-                            child: Builder(
-                              builder: (context) => PokerAnalyzerScreen(
+                          builder: (context) {
+                            final stackService = StackManagerService(
+                              Map<int, int>.from(
+                                  context.read<PlayerManagerService>().initialStacks),
+                            );
+                            return ChangeNotifierProvider(
+                              create: (_) => PlaybackManagerService(
+                                actions:
+                                    context.read<ActionSyncService>().analyzerActions,
+                                stackService: stackService,
                                 actionSync: context.read<ActionSyncService>(),
-                                handContext: CurrentHandContextService(),
-                                playbackManager:
-                                    context.read<PlaybackManagerService>(),
                               ),
-                            ),
-                          ),
+                              child: Builder(
+                                builder: (context) => PokerAnalyzerScreen(
+                                  actionSync: context.read<ActionSyncService>(),
+                                  handContext: CurrentHandContextService(),
+                                  playbackManager:
+                                      context.read<PlaybackManagerService>(),
+                                  stackService: stackService,
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ),

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -75,6 +75,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final CurrentHandContextService? handContext;
   final FoldedPlayersService? foldedPlayersService;
   final PlaybackManagerService playbackManager;
+  final StackManagerService stackService;
 
   const PokerAnalyzerScreen({
     super.key,
@@ -85,6 +86,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     this.handContext,
     this.foldedPlayersService,
     required this.playbackManager,
+    required this.stackService,
   });
 
   @override
@@ -107,7 +109,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   List<PlayerModel> get players => _playerManager.players;
   Map<int, String> get playerPositions => _playerManager.playerPositions;
   Map<int, PlayerType> get playerTypes => _playerManager.playerTypes;
-  Map<int, int> get _initialStacks => _playerManager.initialStacks;
   List<bool> get _showActionHints => _playerManager.showActionHints;
   final List<CardModel> revealedBoardCards = [];
   int? get opponentIndex => _playerManager.opponentIndex;
@@ -722,7 +723,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     await showDialog(
       context: context,
       builder: (context) => _PlayerEditorSection(
-        initialStack: _playerManager.initialStacks[index] ?? 0,
+        initialStack: _stackService.initialStacks[index] ?? 0,
         initialType: _playerManager.playerTypes[index] ?? PlayerType.unknown,
         isHeroSelected: index == _playerManager.heroIndex,
         card1: _playerManager.playerCards[index].isNotEmpty
@@ -746,9 +747,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               cards: cards,
               disableCards: disableCards,
             );
-            _stackService = StackManagerService(
-                Map<int, int>.from(_playerManager.initialStacks));
-            _playbackManager.stackService = _stackService;
+            _stackService.setInitialStack(index, stack);
             _playbackManager.updatePlaybackState();
           });
         },
@@ -775,8 +774,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _timelineController = ScrollController();
     _playerManager = context.read<PlayerManagerService>()
       ..addListener(_onPlayerManagerChanged);
-    _stackService =
-        StackManagerService(Map<int, int>.from(_playerManager.initialStacks));
+    _stackService = widget.stackService;
     _playbackManager = widget.playbackManager;
     _playbackManager
       ..stackService = _stackService
@@ -1742,9 +1740,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       if (_playbackManager.playbackIndex > actions.length) {
         _playbackManager.seek(actions.length);
       }
-      _stackService =
-          StackManagerService(Map<int, int>.from(_playerManager.initialStacks));
-      _playbackManager.stackService = _stackService;
+      _stackService.removePlayer(index);
       _playbackManager.updatePlaybackState();
     });
   }
@@ -1777,9 +1773,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _startBoardTransition();
         _handContext.actionTags.clear();
         _playbackManager.animatedPlayersPerStreet.clear();
-        _stackService =
-            StackManagerService(Map<int, int>.from(_playerManager.initialStacks));
-        _playbackManager.stackService = _stackService;
+        _stackService.reset(_stackService.initialStacks);
         _playbackManager.resetHand();
         _handContext.commentController.clear();
         _handContext.tagsController.clear();
@@ -2074,7 +2068,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       opponentIndex: opponentIndex,
       activePlayerIndex: activePlayerIndex,
       actions: List<ActionEntry>.from(actions),
-      stackSizes: Map<int, int>.from(_playerManager.initialStacks),
+      stackSizes: Map<int, int>.from(_stackService.initialStacks),
       remainingStacks: {
         for (int i = 0; i < _playerManager.numberOfPlayers; i++)
           i: _stackService.getStackForPlayer(i)
@@ -2833,9 +2827,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 ? null
                 : (value) => lockService.safeSetState(this, () {
                       _playerManager.setInitialStack(index, value);
-                      _stackService = StackManagerService(
-                          Map<int, int>.from(_playerManager.initialStacks));
-                      _playbackManager.stackService = _stackService;
+                      _stackService.setInitialStack(index, value);
                       _playbackManager.updatePlaybackState();
                     }),
             onRemove: _playerManager.numberOfPlayers > 2 && !lockService.boardTransitioning
@@ -5216,8 +5208,10 @@ class _ExportConsistencySection extends StatelessWidget {
             mapEquals(hand.playerPositions, s.playerPositions),
             hand.playerPositions.toString(),
             s.playerPositions.toString()),
-        debugCheck('stackSizes', mapEquals(hand.stackSizes, s._initialStacks),
-            hand.stackSizes.toString(), s._initialStacks.toString()),
+        debugCheck('stackSizes',
+            mapEquals(hand.stackSizes, s._stackService.initialStacks),
+            hand.stackSizes.toString(),
+            s._stackService.initialStacks.toString()),
         debugCheck('actions.length', hand.actions.length == s.actions.length,
             '${hand.actions.length}', '${s.actions.length}'),
         debugCheck(
@@ -5385,7 +5379,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
             for (int i = 0; i < s.numberOfPlayers; i++)
               debugDiag(
                 'Player ${i + 1}',
-                'Initial ${s._initialStacks[i] ?? 0}, '
+                'Initial ${s._stackService.initialStacks[i] ?? 0}, '
                 'Invested ${s._stackService.getTotalInvested(i)}, '
                 'Remaining ${s._stackService.getStackForPlayer(i)}',
               ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -600,26 +600,31 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                 child: ChangeNotifierProvider(
                   create: (_) => PlayerManagerService(),
                   child: Builder(
-                    builder: (context) => ChangeNotifierProvider(
-                      create: (_) => PlaybackManagerService(
-                        actions: context.read<ActionSyncService>().analyzerActions,
-                        stackService: StackManagerService(
-                          Map<int, int>.from(
-                              context.read<PlayerManagerService>().initialStacks),
-                        ),
-                        actionSync: context.read<ActionSyncService>(),
-                      ),
-                      child: Builder(
-                        builder: (context) => PokerAnalyzerScreen(
-                          key: _analyzerKey,
-                          initialHand: hands[_currentIndex],
+                    builder: (context) {
+                      final stackService = StackManagerService(
+                        Map<int, int>.from(
+                            context.read<PlayerManagerService>().initialStacks),
+                      );
+                      return ChangeNotifierProvider(
+                        create: (_) => PlaybackManagerService(
+                          actions:
+                              context.read<ActionSyncService>().analyzerActions,
+                          stackService: stackService,
                           actionSync: context.read<ActionSyncService>(),
-                          handContext: CurrentHandContextService(),
-                          playbackManager:
-                              context.read<PlaybackManagerService>(),
                         ),
-                      ),
-                    ),
+                        child: Builder(
+                          builder: (context) => PokerAnalyzerScreen(
+                            key: _analyzerKey,
+                            initialHand: hands[_currentIndex],
+                            actionSync: context.read<ActionSyncService>(),
+                            handContext: CurrentHandContextService(),
+                            playbackManager:
+                                context.read<PlaybackManagerService>(),
+                            stackService: stackService,
+                          ),
+                        ),
+                      );
+                    },
                   ),
                 ),
               ),

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -80,11 +80,11 @@ class HandRestoreService {
     playerManager.initialStacks
       ..clear()
       ..addAll(hand.stackSizes);
-    final stackService = StackManagerService(
+    final stackService = playbackManager.stackService;
+    stackService.reset(
       Map<int, int>.from(playerManager.initialStacks),
       remainingStacks: hand.remainingStacks,
     );
-    playbackManager.stackService = stackService;
     playerManager.playerPositions
       ..clear()
       ..addAll(hand.playerPositions);

--- a/lib/services/stack_manager_service.dart
+++ b/lib/services/stack_manager_service.dart
@@ -7,6 +7,8 @@ class StackManagerService {
   late StackManager _manager;
   final Map<int, int> stackSizes = {};
 
+  Map<int, int> get initialStacks => Map<int, int>.from(_initialStacks);
+
   StackManagerService(Map<int, int> initialStacks, {Map<int, int>? remainingStacks})
       : _initialStacks = Map<int, int>.from(initialStacks) {
     _manager = StackManager(_initialStacks, remainingStacks: remainingStacks);
@@ -23,6 +25,29 @@ class StackManagerService {
     stackSizes
       ..clear()
       ..addAll(_manager.currentStacks);
+  }
+
+  /// Update a single player's starting stack and reinitialize manager.
+  void setInitialStack(int index, int stack, {Map<int, int>? remainingStacks}) {
+    _initialStacks[index] = stack;
+    _manager = StackManager(Map<int, int>.from(_initialStacks),
+        remainingStacks: remainingStacks);
+    stackSizes
+      ..clear()
+      ..addAll(_manager.currentStacks);
+  }
+
+  /// Remove a player from [_initialStacks] and reindex subsequent players.
+  void removePlayer(int index) {
+    final newStacks = <int, int>{};
+    for (final entry in _initialStacks.entries) {
+      if (entry.key < index) {
+        newStacks[entry.key] = entry.value;
+      } else if (entry.key > index) {
+        newStacks[entry.key - 1] = entry.value;
+      }
+    }
+    reset(newStacks);
   }
 
   /// Apply [actions] and update current stack sizes.


### PR DESCRIPTION
## Summary
- expose stack data and mutation helpers in `StackManagerService`
- inject a shared `StackManagerService` into `PokerAnalyzerScreen`
- reset and update stacks via service when editing players or restoring hands
- propagate stack service through `PlayerInputScreen` and `TrainingPackScreen`
- reuse existing service when restoring hands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2452420c832ab771b3bcb589b6b7