### PR TITLE
Introduce BoardManagerService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -8,6 +8,8 @@ import '../services/current_hand_context_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
+import '../services/board_manager_service.dart';
+import '../services/transition_lock_service.dart';
 
 class PlayerInputScreen extends StatefulWidget {
   const PlayerInputScreen({super.key});
@@ -113,6 +115,16 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                               actionSync: context.read<ActionSyncService>(),
                             ),
                             child: Builder(
+                          builder: (context) => ChangeNotifierProvider(
+                            create: (_) => BoardManagerService(
+                              playerManager:
+                                  context.read<PlayerManagerService>(),
+                              actionSync: context.read<ActionSyncService>(),
+                              playbackManager:
+                                  context.read<PlaybackManagerService>(),
+                              lockService: TransitionLockService(),
+                            ),
+                            child: Builder(
                               builder: (context) => PokerAnalyzerScreen(
                                 key: key,
                                 actionSync: context.read<ActionSyncService>(),
@@ -122,7 +134,11 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                 stackService: context
                                     .read<PlaybackManagerService>()
                                     .stackService,
+                                boardManager:
+                                    context.read<BoardManagerService>(),
                               ),
+                            ),
+                          ),
                             ),
                           ),
                         ),
@@ -159,6 +175,16 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                               actionSync: context.read<ActionSyncService>(),
                             ),
                             child: Builder(
+                          builder: (context) => ChangeNotifierProvider(
+                            create: (_) => BoardManagerService(
+                              playerManager:
+                                  context.read<PlayerManagerService>(),
+                              actionSync: context.read<ActionSyncService>(),
+                              playbackManager:
+                                  context.read<PlaybackManagerService>(),
+                              lockService: TransitionLockService(),
+                            ),
+                            child: Builder(
                               builder: (context) => PokerAnalyzerScreen(
                                 actionSync: context.read<ActionSyncService>(),
                                 handContext: CurrentHandContextService(),
@@ -167,7 +193,11 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                 stackService: context
                                     .read<PlaybackManagerService>()
                                     .stackService,
+                                boardManager:
+                                    context.read<BoardManagerService>(),
                               ),
+                            ),
+                          ),
                             ),
                           ),
                         ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -18,6 +18,8 @@ import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/action_sync_service.dart';
+import '../services/board_manager_service.dart';
+import '../services/transition_lock_service.dart';
 import '../services/current_hand_context_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/playback_manager_service.dart';
@@ -610,16 +612,27 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                         actionSync: context.read<ActionSyncService>(),
                       ),
                       child: Builder(
-                        builder: (context) => PokerAnalyzerScreen(
-                          key: _analyzerKey,
-                          initialHand: hands[_currentIndex],
-                          actionSync: context.read<ActionSyncService>(),
-                          handContext: CurrentHandContextService(),
-                          playbackManager:
-                              context.read<PlaybackManagerService>(),
-                          stackService: context
-                              .read<PlaybackManagerService>()
-                              .stackService,
+                        builder: (context) => ChangeNotifierProvider(
+                          create: (_) => BoardManagerService(
+                            playerManager: context.read<PlayerManagerService>(),
+                            actionSync: context.read<ActionSyncService>(),
+                            playbackManager: context.read<PlaybackManagerService>(),
+                            lockService: TransitionLockService(),
+                          ),
+                          child: Builder(
+                            builder: (context) => PokerAnalyzerScreen(
+                              key: _analyzerKey,
+                              initialHand: hands[_currentIndex],
+                              actionSync: context.read<ActionSyncService>(),
+                              handContext: CurrentHandContextService(),
+                              playbackManager:
+                                  context.read<PlaybackManagerService>(),
+                              stackService: context
+                                  .read<PlaybackManagerService>()
+                                  .stackService,
+                              boardManager: context.read<BoardManagerService>(),
+                            ),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/action_entry.dart';
+import '../models/card_model.dart';
+import 'action_sync_service.dart';
+import 'playback_manager_service.dart';
+import 'player_manager_service.dart';
+import 'transition_lock_service.dart';
+
+class BoardManagerService extends ChangeNotifier {
+  BoardManagerService({
+    required PlayerManagerService playerManager,
+    required ActionSyncService actionSync,
+    required PlaybackManagerService playbackManager,
+    required this.lockService,
+  })  : _playerManager = playerManager,
+        _actionSync = actionSync,
+        _playbackManager = playbackManager {
+    _playerManager.addListener(_onPlayerManagerChanged);
+    updateRevealedBoardCards();
+  }
+
+  final PlayerManagerService _playerManager;
+  final ActionSyncService _actionSync;
+  final PlaybackManagerService _playbackManager;
+  final TransitionLockService lockService;
+
+  static const List<int> _stageCardCounts = [0, 3, 4, 5];
+  static const Duration _boardRevealDuration = Duration(milliseconds: 200);
+  static const Duration _boardRevealStagger = Duration(milliseconds: 50);
+
+  final List<CardModel> revealedBoardCards = [];
+  Timer? _boardTransitionTimer;
+
+  List<CardModel> get boardCards => _playerManager.boardCards;
+
+  int get currentStreet => _actionSync.currentStreet;
+  set currentStreet(int v) => _actionSync.changeStreet(v);
+
+  int get boardStreet => _actionSync.boardStreet;
+  set boardStreet(int v) => _actionSync.setBoardStreet(v);
+
+  List<ActionEntry> get actions => _actionSync.analyzerActions;
+
+  @override
+  void dispose() {
+    _playerManager.removeListener(_onPlayerManagerChanged);
+    _boardTransitionTimer?.cancel();
+    super.dispose();
+  }
+
+  int _inferBoardStreet() {
+    final count = boardCards.length;
+    if (count >= _stageCardCounts[3]) return 3;
+    if (count >= _stageCardCounts[2]) return 2;
+    if (count >= _stageCardCounts[1]) return 1;
+    return 0;
+  }
+
+  bool _isBoardStageComplete(int stage) {
+    return boardCards.length >= _stageCardCounts[stage];
+  }
+
+  void ensureBoardStreetConsistent() {
+    final inferred = _inferBoardStreet();
+    if (inferred != boardStreet) {
+      _actionSync.setBoardStreet(inferred);
+      _actionSync.changeStreet(inferred);
+      startBoardTransition();
+    }
+  }
+
+  void updateRevealedBoardCards() {
+    final visibleCount = _stageCardCounts[currentStreet];
+    revealedBoardCards
+      ..clear()
+      ..addAll(boardCards.take(visibleCount));
+  }
+
+  void _onPlayerManagerChanged() {
+    final prevStreet = boardStreet;
+    ensureBoardStreetConsistent();
+    if (boardStreet != prevStreet) {
+      _playbackManager.updatePlaybackState();
+    }
+    updateRevealedBoardCards();
+    notifyListeners();
+  }
+
+  void _jumpPlaybackToStreet(int street) {
+    final index =
+        actions.lastIndexWhere((a) => a.street <= street) + 1;
+    _playbackManager.seek(index);
+    _playbackManager.updatePlaybackState();
+  }
+
+  void changeStreet(int street) {
+    if (lockService.boardTransitioning) return;
+    cancelBoardReveal();
+    street = street.clamp(0, boardStreet);
+    if (street == currentStreet) return;
+    _actionSync.changeStreet(street);
+    startBoardTransition();
+    _playbackManager.animatedPlayersPerStreet
+        .putIfAbsent(street, () => <int>{});
+    updateRevealedBoardCards();
+    _jumpPlaybackToStreet(street);
+    notifyListeners();
+  }
+
+  bool canReverseStreet() {
+    if (currentStreet == 0) return false;
+    final prev = currentStreet - 1;
+    return !actions.any((a) => a.street > prev);
+  }
+
+  bool canAdvanceStreet() => currentStreet < boardStreet;
+
+  void advanceStreet() {
+    if (lockService.boardTransitioning || !canAdvanceStreet()) return;
+    changeStreet(currentStreet + 1);
+  }
+
+  void reverseStreet() {
+    if (lockService.boardTransitioning || !canReverseStreet()) return;
+    changeStreet(currentStreet - 1);
+  }
+
+  void startBoardTransition() {
+    _boardTransitionTimer?.cancel();
+    final targetVisible = _stageCardCounts[currentStreet];
+    final revealCount = max(0, targetVisible - revealedBoardCards.length);
+    final duration = Duration(
+      milliseconds: _boardRevealDuration.inMilliseconds +
+          _boardRevealStagger.inMilliseconds * (revealCount > 1 ? revealCount - 1 : 0),
+    );
+    lockService.boardTransitioning = true;
+    lockService.undoRedoTransitionLock = true;
+    _boardTransitionTimer = Timer(duration, () {
+      lockService.boardTransitioning = false;
+      lockService.undoRedoTransitionLock = false;
+      notifyListeners();
+    });
+  }
+
+  void cancelBoardReveal() {
+    if (lockService.boardTransitioning) {
+      _boardTransitionTimer?.cancel();
+      lockService.boardTransitioning = false;
+      lockService.undoRedoTransitionLock = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract board state handling into `BoardManagerService`
- inject board manager into `PokerAnalyzerScreen`
- provide board manager from `PlayerInputScreen` and `TrainingPackScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2eef2f58832aae71d032f7800a06