### PR TITLE
Extract debug prefs to service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -134,14 +134,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late FoldedPlayersService _foldedPlayers;
   late ActionSyncService _actionSync;
 
-  bool debugLayout = false;
   Set<int> get _expandedHistoryStreets => _actionSync.expandedHistoryStreets;
 
   ActionEntry? _centerChipAction;
   bool _showCenterChip = false;
   Timer? _centerChipTimer;
   late AnimationController _centerChipController;
-  bool _showAllRevealedCards = false;
   final TransitionLockService lockService = TransitionLockService();
   final GlobalKey<_BoardCardsSectionState> _boardKey =
       GlobalKey<_BoardCardsSectionState>();
@@ -1953,12 +1951,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
 
   Future<void> _showDebugPanel() async {
-    lockService.safeSetState(this, () => _debugPrefs.isDebugPanelOpen = true);
+    await _debugPrefs.setIsDebugPanelOpen(true);
     await showDialog<void>(
       context: context,
       builder: (context) => _DebugPanelDialog(parent: this),
     );
-    lockService.safeSetState(this, () => _debugPrefs.isDebugPanelOpen = false);
+    await _debugPrefs.setIsDebugPanelOpen(false);
     _debugPanelSetState = null;
   }
 
@@ -2405,9 +2403,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   if (lockService.boardTransitioning)
                     const _BoardTransitionBusyIndicator(),
                 _RevealAllCardsButton(
-                  showAllRevealedCards: _showAllRevealedCards,
-                  onToggle: () => lockService.safeSetState(this, 
-                      () => _showAllRevealedCards = !_showAllRevealedCards),
+                  showAllRevealedCards: _debugPrefs.showAllRevealedCards,
+                  onToggle: () async {
+                    await _debugPrefs.setShowAllRevealedCards(
+                        !_debugPrefs.showAllRevealedCards);
+                    lockService.safeSetState(this, () {});
+                  },
                 )
               ],
         ),
@@ -2721,7 +2722,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             position: position,
             stack: stack,
             tag: tag,
-            cards: _showAllRevealedCards &&
+            cards: _debugPrefs.showAllRevealedCards &&
                     players[index]
                         .revealedCards
                         .whereType<CardModel>()
@@ -2919,7 +2920,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       ));
     }
 
-    if (debugLayout) {
+    if (_debugPrefs.debugLayout) {
       widgets.add(Positioned(
         left: centerX + dx - 40 * scale,
         top: centerY + dy + bias - 70 * scale,
@@ -5193,11 +5194,11 @@ class _InternalStateFlagsSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text('Internal State Flags:'),
-        debugDiag('Debug Layout', s.debugLayout),
+        debugDiag('Debug Layout', s._debugPrefs.debugLayout),
         _DebugPanelDialogState._vGap,
         debugDiag('Perspective Switched', s.isPerspectiveSwitched),
         _DebugPanelDialogState._vGap,
-        debugDiag('Show All Revealed Cards', s._showAllRevealedCards),
+        debugDiag('Show All Revealed Cards', s._debugPrefs.showAllRevealedCards),
       ],
     );
   }

--- a/lib/services/debug_preferences_service.dart
+++ b/lib/services/debug_preferences_service.dart
@@ -5,6 +5,9 @@ import '../models/action_evaluation_request.dart';
 
 class DebugPreferencesService extends ChangeNotifier {
   static const _queueResumedKey = 'evaluation_queue_resumed';
+  static const _debugPanelOpenKey = 'debug_panel_open';
+  static const _debugLayoutKey = 'debug_layout_enabled';
+  static const _showAllCardsKey = 'show_all_revealed_cards';
 
   final DebugPanelPreferences _prefs = DebugPanelPreferences();
 
@@ -14,6 +17,8 @@ class DebugPreferencesService extends ChangeNotifier {
   String _searchQuery = '';
   bool _queueResumed = false;
   bool _isDebugPanelOpen = false;
+  bool _debugLayout = false;
+  bool _showAllRevealedCards = false;
   Set<String> _queueFilters = {'pending'};
   Set<String> _advancedFilters = {};
 
@@ -23,12 +28,44 @@ class DebugPreferencesService extends ChangeNotifier {
   String get searchQuery => _searchQuery;
   bool get queueResumed => _queueResumed;
   bool get isDebugPanelOpen => _isDebugPanelOpen;
+  bool get debugLayout => _debugLayout;
+  bool get showAllRevealedCards => _showAllRevealedCards;
   Set<String> get queueFilters => _queueFilters;
   Set<String> get advancedFilters => _advancedFilters;
 
-  set isDebugPanelOpen(bool value) {
+  Future<void> setIsDebugPanelOpen(bool value) async {
     if (_isDebugPanelOpen == value) return;
     _isDebugPanelOpen = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_debugPanelOpenKey, value);
+    notifyListeners();
+  }
+
+  Future<void> loadDebugLayoutPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    _debugLayout = prefs.getBool(_debugLayoutKey) ?? false;
+    notifyListeners();
+  }
+
+  Future<void> setDebugLayout(bool value) async {
+    if (_debugLayout == value) return;
+    _debugLayout = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_debugLayoutKey, value);
+    notifyListeners();
+  }
+
+  Future<void> loadShowAllRevealedCardsPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    _showAllRevealedCards = prefs.getBool(_showAllCardsKey) ?? false;
+    notifyListeners();
+  }
+
+  Future<void> setShowAllRevealedCards(bool value) async {
+    if (_showAllRevealedCards == value) return;
+    _showAllRevealedCards = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showAllCardsKey, value);
     notifyListeners();
   }
 
@@ -199,6 +236,12 @@ class DebugPreferencesService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> loadDebugPanelOpenPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isDebugPanelOpen = prefs.getBool(_debugPanelOpenKey) ?? false;
+    notifyListeners();
+  }
+
   /// Loads all stored debug preferences.
   Future<void> loadAllPreferences() async {
     await loadSnapshotRetentionPreference();
@@ -208,6 +251,9 @@ class DebugPreferencesService extends ChangeNotifier {
     await loadSearchQueryPreference();
     await loadSortBySprPreference();
     await loadQueueResumedPreference();
+    await loadDebugPanelOpenPreference();
+    await loadDebugLayoutPreference();
+    await loadShowAllRevealedCardsPreference();
   }
 
   Future<void> setEvaluationQueueResumed(bool value) async {
@@ -226,7 +272,13 @@ class DebugPreferencesService extends ChangeNotifier {
     _queueFilters = await _prefs.getQueueFilters();
     _advancedFilters = await _prefs.getAdvancedFilters();
     final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_debugPanelOpenKey);
+    await prefs.remove(_debugLayoutKey);
+    await prefs.remove(_showAllCardsKey);
     _queueResumed = prefs.getBool(_queueResumedKey) ?? false;
+    _isDebugPanelOpen = prefs.getBool(_debugPanelOpenKey) ?? false;
+    _debugLayout = prefs.getBool(_debugLayoutKey) ?? false;
+    _showAllRevealedCards = prefs.getBool(_showAllCardsKey) ?? false;
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- store debug preferences in DebugPreferencesService
- persist debug panel open and UI debug flags with SharedPreferences
- control debug panel from service in PokerAnalyzerScreen
- expose debug toggles through the service

## Testing
- `dart format lib/services/debug_preferences_service.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*
- `flutter format lib/services/debug_preferences_service.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f36f4d404832a9049a6ec3ecebaa1