### PR TITLE
Implement optional hand restoration injection

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -78,6 +78,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final PlaybackManagerService playbackManager;
   final StackManagerService stackService;
   final BoardManagerService boardManager;
+  final HandRestoreService? handRestoreService;
 
   const PokerAnalyzerScreen({
     super.key,
@@ -90,6 +91,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     required this.playbackManager,
     required this.stackService,
     required this.boardManager,
+    this.handRestoreService,
   });
 
   @override
@@ -724,21 +726,22 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _playbackManager
       ..stackService = _stackService
       ..addListener(_onPlaybackManagerChanged);
-    _handRestore = HandRestoreService(
-      playerManager: _playerManager,
-      actionSync: _actionSync,
-      playbackManager: _playbackManager,
-      queueService: _queueService,
-      backupManager: _backupManager,
-      debugPrefs: _debugPrefs,
-      lockService: lockService,
-      handContext: _handContext,
-      pendingEvaluations: _pendingEvaluations,
-      foldedPlayers: _foldedPlayers,
-      revealedBoardCards: _boardManager.revealedBoardCards,
-      setCurrentHandName: (name) => _handContext.currentHandName = name,
-      setActivePlayerIndex: (i) => activePlayerIndex = i,
-    );
+    _handRestore = widget.handRestoreService ??
+        HandRestoreService(
+          playerManager: _playerManager,
+          actionSync: _actionSync,
+          playbackManager: _playbackManager,
+          queueService: _queueService,
+          backupManager: _backupManager,
+          debugPrefs: _debugPrefs,
+          lockService: lockService,
+          handContext: _handContext,
+          pendingEvaluations: _pendingEvaluations,
+          foldedPlayers: _foldedPlayers,
+          revealedBoardCards: _boardManager.revealedBoardCards,
+          setCurrentHandName: (name) => _handContext.currentHandName = name,
+          setActivePlayerIndex: (i) => activePlayerIndex = i,
+        );
     _playerManager.updatePositions();
     _boardManager.ensureBoardStreetConsistent();
     _boardManager.updateRevealedBoardCards();


### PR DESCRIPTION
## Summary
- allow `PokerAnalyzerScreen` to accept an optional `HandRestoreService`
- default to creating a `HandRestoreService` in `initState` if none provided

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f398c49a8832a90e6ecba15a286d0