### PR TITLE
Add HandRestoreService integration

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -728,6 +728,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       playerManager: _playerManager,
       actionSync: _actionSync,
       playbackManager: _playbackManager,
+      boardManager: _boardManager,
       queueService: _queueService,
       backupManager: _backupManager,
       debugPrefs: _debugPrefs,
@@ -735,7 +736,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       handContext: _handContext,
       pendingEvaluations: _pendingEvaluations,
       foldedPlayers: _foldedPlayers,
-      revealedBoardCards: _boardManager.revealedBoardCards,
       setCurrentHandName: (name) => _handContext.currentHandName = name,
       setActivePlayerIndex: (i) => activePlayerIndex = i,
     );


### PR DESCRIPTION
## Summary
- centralize hand state restoration in `HandRestoreService`
- wire `PokerAnalyzerScreen` to use updated service

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f3aa3c47c832a90659b4c4aa1eb74