### PR TITLE
Introduce PlayerProfileService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../services/action_sync_service.dart';
 import '../services/current_hand_context_service.dart';
 import '../services/player_manager_service.dart';
+import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
 import '../services/board_manager_service.dart';
@@ -100,8 +101,11 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) => ChangeNotifierProvider(
-                        create: (_) => PlayerManagerService(),
+                      builder: (_) => MultiProvider(
+                        providers: [
+                          ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+                          ChangeNotifierProvider(create: (_) => PlayerManagerService(context.read<PlayerProfileService>())),
+                        ],
                         child: Builder(
                           builder: (context) => ChangeNotifierProvider(
                             create: (_) => PlaybackManagerService(
@@ -136,6 +140,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                     .stackService,
                                 boardManager:
                                     context.read<BoardManagerService>(),
+                                playerProfile:
+                                    context.read<PlayerProfileService>(),
                               ),
                             ),
                           ),
@@ -160,8 +166,11 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                 if (text.isNotEmpty) {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (context) => ChangeNotifierProvider(
-                        create: (_) => PlayerManagerService(),
+                      builder: (context) => MultiProvider(
+                        providers: [
+                          ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+                          ChangeNotifierProvider(create: (_) => PlayerManagerService(context.read<PlayerProfileService>())),
+                        ],
                         child: Builder(
                           builder: (context) => ChangeNotifierProvider(
                             create: (_) => PlaybackManagerService(
@@ -195,6 +204,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                     .stackService,
                                 boardManager:
                                     context.read<BoardManagerService>(),
+                                playerProfile:
+                                    context.read<PlayerProfileService>(),
                               ),
                             ),
                           ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -22,6 +22,7 @@ import '../services/board_manager_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/current_hand_context_service.dart';
 import '../services/player_manager_service.dart';
+import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
 
@@ -599,8 +600,11 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
               ),
               child: KeyedSubtree(
                 key: ValueKey(_currentIndex),
-                child: ChangeNotifierProvider(
-                  create: (_) => PlayerManagerService(),
+                child: MultiProvider(
+                  providers: [
+                    ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+                    ChangeNotifierProvider(create: (_) => PlayerManagerService(context.read<PlayerProfileService>())),
+                  ],
                   child: Builder(
                     builder: (context) => ChangeNotifierProvider(
                       create: (_) => PlaybackManagerService(
@@ -631,6 +635,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   .read<PlaybackManagerService>()
                                   .stackService,
                               boardManager: context.read<BoardManagerService>(),
+                              playerProfile:
+                                  context.read<PlayerProfileService>(),
                             ),
                           ),
                         ),

--- a/lib/services/current_hand_context_service.dart
+++ b/lib/services/current_hand_context_service.dart
@@ -7,13 +7,11 @@ class CurrentHandContextService {
 
   final TextEditingController commentController = TextEditingController();
   final TextEditingController tagsController = TextEditingController();
-  final Map<int, String?> actionTags = {};
 
   void clear() {
     _currentHandName = null;
     commentController.clear();
     tagsController.clear();
-    actionTags.clear();
   }
 
   void dispose() {

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -27,6 +27,7 @@ import 'board_manager_service.dart';
 class HandRestoreService {
   HandRestoreService({
     required this.playerManager,
+    required this.profile,
     required this.actionSync,
     required this.playbackManager,
     required this.boardManager,
@@ -44,6 +45,7 @@ class HandRestoreService {
   }
 
   final PlayerManagerService playerManager;
+  final PlayerProfileService profile;
   final ActionSyncService actionSync;
   final PlaybackManagerService playbackManager;
   final BoardManagerService boardManager;
@@ -60,8 +62,9 @@ class HandRestoreService {
 
   StackManagerService restoreHand(SavedHand hand) {
     setCurrentHandName(hand.name);
-    playerManager.heroIndex = hand.heroIndex;
-    playerManager.heroPosition = hand.heroPosition;
+    profile.heroIndex = hand.heroIndex;
+    profile.heroPosition = hand.heroPosition;
+    profile.numberOfPlayers = hand.numberOfPlayers;
     playerManager.numberOfPlayers = hand.numberOfPlayers;
     for (int i = 0; i < playerManager.playerCards.length; i++) {
       playerManager.playerCards[i]
@@ -71,8 +74,8 @@ class HandRestoreService {
     playerManager.boardCards
       ..clear()
       ..addAll(hand.boardCards);
-    for (int i = 0; i < playerManager.players.length; i++) {
-      final list = playerManager.players[i].revealedCards;
+    for (int i = 0; i < profile.players.length; i++) {
+      final list = profile.players[i].revealedCards;
       list.fillRange(0, list.length, null);
       if (i < hand.revealedCards.length) {
         final from = hand.revealedCards[i];
@@ -81,7 +84,7 @@ class HandRestoreService {
         }
       }
     }
-    playerManager.opponentIndex = hand.opponentIndex;
+    profile.opponentIndex = hand.opponentIndex;
     setActivePlayerIndex(hand.activePlayerIndex);
     actionSync.setAnalyzerActions(hand.actions);
     playerManager.initialStacks
@@ -92,10 +95,10 @@ class HandRestoreService {
       remainingStacks: hand.remainingStacks,
     );
     playbackManager.stackService = stackService;
-    playerManager.playerPositions
+    profile.playerPositions
       ..clear()
       ..addAll(hand.playerPositions);
-    playerManager.playerTypes
+    profile.playerTypes
       ..clear()
       ..addAll(hand.playerTypes ??
           {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
@@ -110,7 +113,7 @@ class HandRestoreService {
         offset: hand.tagsCursor != null && hand.tagsCursor! <= handContext.tagsController.text.length
             ? hand.tagsCursor!
             : handContext.tagsController.text.length);
-    handContext.actionTags
+    profile.actionTags
       ..clear()
       ..addAll(hand.actionTags ?? {});
     pendingEvaluations
@@ -140,7 +143,7 @@ class HandRestoreService {
     playbackManager.seek(seekIndex);
     playbackManager.animatedPlayersPerStreet.clear();
     playbackManager.updatePlaybackState();
-    playerManager.updatePositions();
+    profile.updatePositions();
     // foldedPlayers recomputes automatically when actions change
     queueService.persist();
     backupManager.startAutoBackupTimer();

--- a/lib/services/player_profile_service.dart
+++ b/lib/services/player_profile_service.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/foundation.dart';
+
+import '../helpers/poker_position_helper.dart';
+import '../models/card_model.dart';
+import '../models/player_model.dart';
+import '../models/action_entry.dart';
+
+/// Manages player-specific profiles such as positions, types and revealed cards.
+class PlayerProfileService extends ChangeNotifier {
+  int heroIndex = 0;
+  String heroPosition = 'BTN';
+  int numberOfPlayers = 6;
+  int? opponentIndex;
+
+  Map<int, String> playerPositions = {};
+  Map<int, PlayerType> playerTypes = {};
+  final List<PlayerModel> players =
+      List.generate(10, (i) => PlayerModel(name: 'Player ${i + 1}'));
+  final Map<int, String?> actionTags = {};
+
+  PlayerProfileService() {
+    playerPositions = Map.fromIterables(
+      List.generate(numberOfPlayers, (i) => i),
+      getPositionList(numberOfPlayers),
+    );
+    playerTypes = Map.fromIterables(
+      List.generate(numberOfPlayers, (i) => i),
+      List.filled(numberOfPlayers, PlayerType.unknown),
+    );
+  }
+
+  List<String> positionsForPlayers(int count) => getPositionList(count);
+
+  void setPosition(int playerIndex, String position) {
+    playerPositions[playerIndex] = position;
+    notifyListeners();
+  }
+
+  void updatePositions() {
+    final order = positionsForPlayers(numberOfPlayers);
+    final heroPosIndex = order.indexOf(heroPosition);
+    final buttonIndex = (heroIndex - heroPosIndex + numberOfPlayers) % numberOfPlayers;
+    playerPositions = {};
+    for (int i = 0; i < numberOfPlayers; i++) {
+      final posIndex = (i - buttonIndex + numberOfPlayers) % numberOfPlayers;
+      if (posIndex < order.length) {
+        playerPositions[i] = order[posIndex];
+      }
+    }
+    notifyListeners();
+  }
+
+  void onPlayerCountChanged(int value) {
+    numberOfPlayers = value;
+    playerPositions = Map.fromIterables(
+      List.generate(numberOfPlayers, (i) => i),
+      getPositionList(numberOfPlayers),
+    );
+    for (int i = 0; i < numberOfPlayers; i++) {
+      playerTypes.putIfAbsent(i, () => PlayerType.unknown);
+    }
+    playerTypes.removeWhere((key, _) => key >= numberOfPlayers);
+    updatePositions();
+  }
+
+  void setHeroIndex(int index) {
+    heroIndex = index;
+    updatePositions();
+  }
+
+  void setRevealedCard(int playerIndex, int cardIndex, CardModel card) {
+    final list = players[playerIndex].revealedCards;
+    list[cardIndex] = card;
+    notifyListeners();
+  }
+
+  void removePlayer(
+    int index, {
+    required int heroIndexOverride,
+    required List<ActionEntry> actions,
+    required List<bool> hintFlags,
+  }) {
+    if (numberOfPlayers <= 2) return;
+
+    heroIndex = heroIndexOverride;
+
+    actions.removeWhere((a) => a.playerIndex == index);
+    for (int i = 0; i < actions.length; i++) {
+      final a = actions[i];
+      if (a.playerIndex > index) {
+        actions[i] = ActionEntry(
+          a.street,
+          a.playerIndex - 1,
+          a.action,
+          amount: a.amount,
+          generated: a.generated,
+        );
+      }
+    }
+
+    for (int i = index; i < numberOfPlayers - 1; i++) {
+      players[i] = players[i + 1];
+      actionTags[i] = actionTags[i + 1];
+      playerPositions[i] = playerPositions[i + 1] ?? '';
+      playerTypes[i] = playerTypes[i + 1] ?? PlayerType.unknown;
+      hintFlags[i] = hintFlags[i + 1];
+    }
+    players[numberOfPlayers - 1] = PlayerModel(name: 'Player $numberOfPlayers');
+    actionTags.remove(numberOfPlayers - 1);
+    playerPositions.remove(numberOfPlayers - 1);
+    playerTypes.remove(numberOfPlayers - 1);
+    hintFlags[numberOfPlayers - 1] = true;
+
+    if (heroIndex == index) {
+      heroIndex = 0;
+    } else if (heroIndex > index) {
+      heroIndex--;
+    }
+    if (opponentIndex != null) {
+      if (opponentIndex == index) {
+        opponentIndex = null;
+      } else if (opponentIndex! > index) {
+        opponentIndex = opponentIndex! - 1;
+      }
+    }
+
+    numberOfPlayers--;
+    updatePositions();
+  }
+
+  /// Reset all player-related state to defaults while preserving names.
+  void reset() {
+    for (final p in players) {
+      p.revealedCards.fillRange(0, p.revealedCards.length, null);
+    }
+    opponentIndex = null;
+    playerTypes.clear();
+    for (int i = 0; i < playerPositions.length; i++) {
+      actionTags.remove(i);
+    }
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- manage player positions, types, revealed cards and indexes in new PlayerProfileService
- inject PlayerProfileService into PokerAnalyzerScreen and supporting screens
- adapt PlayerManagerService and HandRestoreService to use PlayerProfileService
- move player action tags from hand context to profile service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f458ea3c0832aad18e25c160c7fca