### PR TITLE
Refactor board sync into BoardSyncService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -10,6 +10,7 @@ import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
 import '../services/board_manager_service.dart';
+import '../services/board_sync_service.dart';
 import '../services/transition_lock_service.dart';
 
 class PlayerInputScreen extends StatefulWidget {
@@ -119,17 +120,23 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                               actionSync: context.read<ActionSyncService>(),
                             ),
                             child: Builder(
-                          builder: (context) => ChangeNotifierProvider(
-                            create: (_) => BoardManagerService(
-                              playerManager:
-                                  context.read<PlayerManagerService>(),
+                          builder: (context) => Provider(
+                            create: (_) => BoardSyncService(
+                              playerManager: context.read<PlayerManagerService>(),
                               actionSync: context.read<ActionSyncService>(),
-                              playbackManager:
-                                  context.read<PlaybackManagerService>(),
-                              lockService: TransitionLockService(),
                             ),
-                            child: Builder(
-                              builder: (context) => PokerAnalyzerScreen(
+                            child: ChangeNotifierProvider(
+                              create: (_) => BoardManagerService(
+                                playerManager:
+                                    context.read<PlayerManagerService>(),
+                                actionSync: context.read<ActionSyncService>(),
+                                playbackManager:
+                                    context.read<PlaybackManagerService>(),
+                                lockService: TransitionLockService(),
+                                boardSync: context.read<BoardSyncService>(),
+                              ),
+                              child: Builder(
+                                builder: (context) => PokerAnalyzerScreen(
                                 key: key,
                                 actionSync: context.read<ActionSyncService>(),
                                 handContext: CurrentHandContextService(),
@@ -140,6 +147,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                     .stackService,
                                 boardManager:
                                     context.read<BoardManagerService>(),
+                                boardSync:
+                                    context.read<BoardSyncService>(),
                                 playerProfile:
                                     context.read<PlayerProfileService>(),
                               ),
@@ -184,17 +193,23 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                               actionSync: context.read<ActionSyncService>(),
                             ),
                             child: Builder(
-                          builder: (context) => ChangeNotifierProvider(
-                            create: (_) => BoardManagerService(
-                              playerManager:
-                                  context.read<PlayerManagerService>(),
+                          builder: (context) => Provider(
+                            create: (_) => BoardSyncService(
+                              playerManager: context.read<PlayerManagerService>(),
                               actionSync: context.read<ActionSyncService>(),
-                              playbackManager:
-                                  context.read<PlaybackManagerService>(),
-                              lockService: TransitionLockService(),
                             ),
-                            child: Builder(
-                              builder: (context) => PokerAnalyzerScreen(
+                            child: ChangeNotifierProvider(
+                              create: (_) => BoardManagerService(
+                                playerManager:
+                                    context.read<PlayerManagerService>(),
+                                actionSync: context.read<ActionSyncService>(),
+                                playbackManager:
+                                    context.read<PlaybackManagerService>(),
+                                lockService: TransitionLockService(),
+                                boardSync: context.read<BoardSyncService>(),
+                              ),
+                              child: Builder(
+                                builder: (context) => PokerAnalyzerScreen(
                                 actionSync: context.read<ActionSyncService>(),
                                 handContext: CurrentHandContextService(),
                                 playbackManager:
@@ -204,6 +219,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                     .stackService,
                                 boardManager:
                                     context.read<BoardManagerService>(),
+                                boardSync:
+                                    context.read<BoardSyncService>(),
                                 playerProfile:
                                     context.read<PlayerProfileService>(),
                               ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -19,6 +19,7 @@ import 'create_pack_screen.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/action_sync_service.dart';
 import '../services/board_manager_service.dart';
+import '../services/board_sync_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/current_hand_context_service.dart';
 import '../services/player_manager_service.dart';
@@ -616,14 +617,20 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                         actionSync: context.read<ActionSyncService>(),
                       ),
                       child: Builder(
-                        builder: (context) => ChangeNotifierProvider(
-                          create: (_) => BoardManagerService(
+                        builder: (context) => Provider(
+                          create: (_) => BoardSyncService(
                             playerManager: context.read<PlayerManagerService>(),
                             actionSync: context.read<ActionSyncService>(),
-                            playbackManager: context.read<PlaybackManagerService>(),
-                            lockService: TransitionLockService(),
                           ),
-                          child: Builder(
+                          child: ChangeNotifierProvider(
+                            create: (_) => BoardManagerService(
+                              playerManager: context.read<PlayerManagerService>(),
+                              actionSync: context.read<ActionSyncService>(),
+                              playbackManager: context.read<PlaybackManagerService>(),
+                              lockService: TransitionLockService(),
+                              boardSync: context.read<BoardSyncService>(),
+                            ),
+                            child: Builder(
                             builder: (context) => PokerAnalyzerScreen(
                               key: _analyzerKey,
                               initialHand: hands[_currentIndex],
@@ -635,6 +642,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   .read<PlaybackManagerService>()
                                   .stackService,
                               boardManager: context.read<BoardManagerService>(),
+                              boardSync: context.read<BoardSyncService>(),
                               playerProfile:
                                   context.read<PlayerProfileService>(),
                             ),

--- a/lib/services/board_sync_service.dart
+++ b/lib/services/board_sync_service.dart
@@ -1,0 +1,55 @@
+import '../models/card_model.dart';
+import 'action_sync_service.dart';
+import 'player_manager_service.dart';
+
+/// Handles board consistency and revealed card state.
+class BoardSyncService {
+  BoardSyncService({
+    required PlayerManagerService playerManager,
+    required ActionSyncService actionSync,
+  })  : _playerManager = playerManager,
+        _actionSync = actionSync;
+
+  final PlayerManagerService _playerManager;
+  final ActionSyncService _actionSync;
+
+  static const List<int> stageCardCounts = [0, 3, 4, 5];
+
+  final List<CardModel> revealedBoardCards = [];
+
+  List<CardModel> get boardCards => _playerManager.boardCards;
+
+  int get currentStreet => _actionSync.currentStreet;
+  int get boardStreet => _actionSync.boardStreet;
+
+  /// Update [_actionSync.boardStreet] based on the number of [boardCards].
+  /// Returns true if the street changed.
+  bool ensureBoardStreetConsistent() {
+    final inferred = _inferBoardStreet();
+    if (inferred != boardStreet) {
+      _actionSync.setBoardStreet(inferred);
+      _actionSync.changeStreet(inferred);
+      return true;
+    }
+    return false;
+  }
+
+  void updateRevealedBoardCards() {
+    final visibleCount = stageCardCounts[currentStreet];
+    revealedBoardCards
+      ..clear()
+      ..addAll(boardCards.take(visibleCount));
+  }
+
+  int _inferBoardStreet() {
+    final count = boardCards.length;
+    if (count >= stageCardCounts[3]) return 3;
+    if (count >= stageCardCounts[2]) return 2;
+    if (count >= stageCardCounts[1]) return 1;
+    return 0;
+  }
+
+  bool isBoardStageComplete(int stage) {
+    return boardCards.length >= stageCardCounts[stage];
+  }
+}

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -17,6 +17,7 @@ import 'current_hand_context_service.dart';
 
 import 'folded_players_service.dart';
 import 'board_manager_service.dart';
+import 'board_sync_service.dart';
 
 /// Restores a [SavedHand] object by updating all runtime services.
 ///
@@ -31,6 +32,7 @@ class HandRestoreService {
     required this.actionSync,
     required this.playbackManager,
     required this.boardManager,
+    required this.boardSync,
     required this.queueService,
     required this.backupManager,
     required this.debugPrefs,
@@ -49,6 +51,7 @@ class HandRestoreService {
   final ActionSyncService actionSync;
   final PlaybackManagerService playbackManager;
   final BoardManagerService boardManager;
+  final BoardSyncService boardSync;
   final EvaluationQueueService queueService;
   final BackupManagerService backupManager;
   final DebugPreferencesService debugPrefs;
@@ -136,8 +139,8 @@ class HandRestoreService {
     _autoCollapseStreets();
     actionSync.setBoardStreet(hand.boardStreet);
     actionSync.changeStreet(hand.boardStreet);
-    boardManager.ensureBoardStreetConsistent();
-    boardManager.updateRevealedBoardCards();
+    boardSync.ensureBoardStreetConsistent();
+    boardSync.updateRevealedBoardCards();
     final seekIndex =
         hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
     playbackManager.seek(seekIndex);


### PR DESCRIPTION
## Summary
- add `BoardSyncService` to own board state logic
- use the new service inside `BoardManagerService`
- inject `BoardSyncService` into `PokerAnalyzerScreen`
- update hand restoration and initialization flows
- wire up new provider creation in player and training screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f4dd53654832abd7f107e5e51030c