### PR TITLE
Add PlaybackManagerService injection

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -478,10 +478,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     boardCards
       ..clear()
       ..addAll(snap.board);
-    _playbackManager.seek(snap.playbackIndex);
     _animateTimeline = true;
     _boardSync.updateRevealedBoardCards();
-    _playbackManager.updatePlaybackState();
     if (currentStreet != prevStreet) {
       _boardManager.startBoardTransition();
     }

--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -4,11 +4,17 @@ import '../models/action_entry.dart';
 import '../models/player_zone_action_entry.dart' as pz;
 import '../models/card_model.dart';
 import 'folded_players_service.dart';
+import 'playback_manager_service.dart';
 
 class ActionSyncService extends ChangeNotifier {
   ActionSyncService({this.foldedPlayers});
 
   final FoldedPlayersService? foldedPlayers;
+  PlaybackManagerService? playbackManager;
+
+  void attachPlaybackManager(PlaybackManagerService manager) {
+    playbackManager = manager;
+  }
 
   int currentStreet = 0;
   int boardStreet = 0;
@@ -106,7 +112,7 @@ class ActionSyncService extends ChangeNotifier {
   void restoreSnapshot(ActionSnapshot snap) {
     currentStreet = snap.street;
     boardStreet = snap.boardStreet;
-    playbackIndex = snap.playbackIndex;
+    playbackManager?.seek(snap.playbackIndex);
     expandedHistoryStreets
       ..clear()
       ..addAll(snap.expandedStreets);

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -32,6 +32,7 @@ class PlaybackManagerService extends ChangeNotifier {
   })  : _playbackService = playbackService ?? PlaybackService(),
         _potCalculator = potCalculator ?? PotCalculator() {
     _playbackService.addListener(_onPlaybackChanged);
+    actionSync.attachPlaybackManager(this);
   }
 
   int get playbackIndex => _playbackService.playbackIndex;


### PR DESCRIPTION
## Summary
- inject PlaybackManagerService into ActionSyncService
- centralize playback management
- streamline snapshot restoration

## Testing
- `dart format lib/screens/poker_analyzer_screen.dart lib/services/action_sync_service.dart lib/services/playback_manager_service.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f5828f71c832a8edb564e2738e383