### PR TITLE
Refactor stack management logic

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -658,6 +658,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       });
     _boardSync = widget.boardSync;
     _stackService = widget.stackService;
+    _actionSync.attachStackManager(_stackService);
     _playbackManager = widget.playbackManager;
     _playbackManager
       ..stackService = _stackService
@@ -687,6 +688,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _boardSync.updateRevealedBoardCards();
     if (widget.initialHand != null) {
       _stackService = _handRestore.restoreHand(widget.initialHand!);
+      _actionSync.attachStackManager(_stackService);
+      _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
       _boardManager.startBoardTransition();
     }
     Future(() => _cleanupOldEvaluationBackups());
@@ -1811,6 +1814,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   void loadHand(String jsonStr) {
     final hand = SavedHand.fromJson(jsonDecode(jsonStr));
     _stackService = _handRestore.restoreHand(hand);
+    _actionSync.attachStackManager(_stackService);
+    _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
     _boardManager.startBoardTransition();
   }
 
@@ -1953,6 +1958,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final hand = _handManager.lastHand;
     if (hand == null) return;
     _stackService = _handRestore.restoreHand(hand);
+    _actionSync.attachStackManager(_stackService);
+    _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
     _boardManager.startBoardTransition();
   }
 
@@ -1961,6 +1968,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final selected = await _handManager.selectHand(context);
     if (selected != null) {
       _stackService = _handRestore.restoreHand(selected);
+      _actionSync.attachStackManager(_stackService);
+      _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
       _boardManager.startBoardTransition();
     }
   }
@@ -1981,6 +1990,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final hand = await _handManager.importHandFromClipboard(context);
     if (hand != null) {
       _stackService = _handRestore.restoreHand(hand);
+      _actionSync.attachStackManager(_stackService);
+      _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
       _boardManager.startBoardTransition();
     }
   }

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -100,6 +100,7 @@ class HandRestoreService {
       Map<int, int>.from(playerManager.initialStacks),
       remainingStacks: hand.remainingStacks,
     );
+    actionSync.attachStackManager(stackService);
     playbackManager.stackService = stackService;
     profile.playerPositions
       ..clear()

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -59,7 +59,7 @@ class PlaybackManagerService extends ChangeNotifier {
     if (_playbackService.playbackIndex == 0) {
       animatedPlayersPerStreet.clear();
     }
-    stackService.applyActions(subset);
+    // Stack sizes are synchronized via [ActionSyncService].
     _updatePots(fromActions: subset);
     lastActionPlayerIndex =
         subset.isNotEmpty ? subset.last.playerIndex : null;


### PR DESCRIPTION
## Summary
- manage stack tracking from ActionSyncService via new StackManagerService hooks
- wire StackManagerService injection through HandRestoreService and PokerAnalyzerScreen
- keep PlaybackManagerService focused on pots only

## Testing
- `dart format -o none lib/services/action_sync_service.dart lib/services/hand_restore_service.dart lib/services/playback_manager_service.dart lib/screens/poker_analyzer_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a477d34832abceab323d6076caf