### PR TITLE
Introduce BoardManagerService for board state

### DIFF
--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -140,4 +140,26 @@ class BoardManagerService extends ChangeNotifier {
       lockService.undoRedoTransitionLock = false;
     }
   }
+
+  /// Replace the current board with [cards] and notify listeners.
+  void setBoardCards(List<CardModel> cards) {
+    _playerManager.boardCards
+      ..clear()
+      ..addAll(cards);
+    _playerManager.notifyListeners();
+  }
+
+  /// Select a community card at [index].
+  void selectBoardCard(int index, CardModel card) {
+    _playerManager.selectBoardCard(index, card);
+  }
+
+  /// Remove the board card at [index] if it exists.
+  void removeBoardCard(int index) {
+    _playerManager.removeBoardCard(index);
+  }
+
+  /// Whether [stage] has the required number of board cards.
+  bool isBoardStageComplete(int stage) =>
+      _boardSync.isBoardStageComplete(stage);
 }

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -77,9 +77,7 @@ class HandRestoreService {
         ..clear()
         ..addAll(i < hand.playerCards.length ? hand.playerCards[i] : []);
     }
-    playerManager.boardCards
-      ..clear()
-      ..addAll(hand.boardCards);
+    boardManager.setBoardCards(hand.boardCards);
     for (int i = 0; i < profile.players.length; i++) {
       final list = profile.players[i].revealedCards;
       list.fillRange(0, list.length, null);
@@ -136,10 +134,8 @@ class HandRestoreService {
           i
     ]);
     _autoCollapseStreets();
-    actionSync.setBoardStreet(hand.boardStreet);
-    actionSync.changeStreet(hand.boardStreet);
-    boardSync.ensureBoardStreetConsistent();
-    boardSync.updateRevealedBoardCards();
+    boardManager.boardStreet = hand.boardStreet;
+    boardManager.currentStreet = hand.boardStreet;
     final seekIndex =
         hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
     playbackManager.seek(seekIndex);


### PR DESCRIPTION
## Summary
- centralize board card logic in `BoardManagerService`
- update `HandRestoreService` to use board manager
- refactor `PokerAnalyzerScreen` to delegate board operations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f5cdf5a34832abfb66005cd47b3d2