### PR TITLE
Refactor board reveal logic into service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -188,9 +188,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   static const double _timelineExtent = 80.0;
   /// Duration for individual board card animations.
-  static const Duration _boardRevealDuration = Duration(milliseconds: 200);
-  /// Delay between sequential board reveals.
-  static const Duration _boardRevealStagger = Duration(milliseconds: 50);
+  static const Duration _boardRevealDuration =
+      BoardRevealService.revealDuration;
 
 
   Widget _queueSection(String label, List<ActionEvaluationRequest> queue) {

--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 
 import '../models/action_entry.dart';
@@ -40,7 +38,6 @@ class BoardManagerService extends ChangeNotifier {
   final TransitionLockService lockService;
   final BoardSyncService _boardSync;
   final BoardRevealService boardReveal;
-  Timer? _boardTransitionTimer;
 
   List<CardModel> get boardCards => _playerManager.boardCards;
 
@@ -57,7 +54,6 @@ class BoardManagerService extends ChangeNotifier {
   @override
   void dispose() {
     _playerManager.removeListener(_onPlayerManagerChanged);
-    _boardTransitionTimer?.cancel();
     super.dispose();
   }
 
@@ -115,14 +111,11 @@ class BoardManagerService extends ChangeNotifier {
   }
 
   void startBoardTransition() {
-    _boardTransitionTimer?.cancel();
-    final duration = boardReveal.startBoardTransition();
-    _boardTransitionTimer = Timer(duration, notifyListeners);
+    boardReveal.startBoardTransition(notifyListeners);
   }
 
   void cancelBoardReveal() {
     if (lockService.boardTransitioning) {
-      _boardTransitionTimer?.cancel();
       boardReveal.cancelBoardReveal();
     }
   }

--- a/lib/services/board_reveal_service.dart
+++ b/lib/services/board_reveal_service.dart
@@ -68,7 +68,10 @@ class BoardRevealService {
   }
 
   /// Start a board transition and lock actions until animations finish.
-  Duration startBoardTransition() {
+  ///
+  /// [onComplete] is called when the transition finishes and the lock is
+  /// released.
+  void startBoardTransition([VoidCallback? onComplete]) {
     _transitionTimer?.cancel();
     final targetVisible = BoardSyncService.stageCardCounts[boardSync.currentStreet];
     final revealCount = max(0, targetVisible - boardSync.revealedBoardCards.length);
@@ -81,8 +84,8 @@ class BoardRevealService {
     _transitionTimer = Timer(duration, () {
       lockService.boardTransitioning = false;
       lockService.undoRedoTransitionLock = false;
+      onComplete?.call();
     });
-    return duration;
   }
 
   /// Update reveal animations based on the current board state.


### PR DESCRIPTION
## Summary
- centralize board reveal sequencing in `BoardRevealService`
- simplify `BoardManagerService` by delegating transition timer to `BoardRevealService`
- reference reveal constants from the service in `PokerAnalyzerScreen`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f6918bb94832aa63cf5cdf6dabb1e