### PR TITLE
Extract PotSyncService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -9,6 +9,7 @@ import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
+import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
@@ -111,16 +112,20 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                         ],
                         child: Builder(
                           builder: (context) => ChangeNotifierProvider(
-                            create: (_) => PlaybackManagerService(
-                              actions: context
-                                  .read<ActionSyncService>()
-                                  .analyzerActions,
-                              stackService: StackManagerService(
+                            create: (_) {
+                              final potSync = PotSyncService();
+                              final stackService = StackManagerService(
                                 Map<int, int>.from(
                                     context.read<PlayerManagerService>().initialStacks),
-                              ),
-                              actionSync: context.read<ActionSyncService>(),
-                            ),
+                                potSync: potSync,
+                              );
+                              return PlaybackManagerService(
+                                actions: context.read<ActionSyncService>().analyzerActions,
+                                stackService: stackService,
+                                potSync: potSync,
+                                actionSync: context.read<ActionSyncService>(),
+                              );
+                            },
                             child: Builder(
                           builder: (context) => Provider(
                             create: (_) => BoardSyncService(
@@ -173,6 +178,9 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                       stackService: context
                                           .read<PlaybackManagerService>()
                                           .stackService,
+                                      potSyncService: context
+                                          .read<PlaybackManagerService>()
+                                          .potSync,
                                       boardManager:
                                           context.read<BoardManagerService>(),
                                       boardSync:
@@ -219,16 +227,20 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                         ],
                         child: Builder(
                           builder: (context) => ChangeNotifierProvider(
-                            create: (_) => PlaybackManagerService(
-                              actions: context
-                                  .read<ActionSyncService>()
-                                  .analyzerActions,
-                              stackService: StackManagerService(
+                            create: (_) {
+                              final potSync = PotSyncService();
+                              final stackService = StackManagerService(
                                 Map<int, int>.from(
                                     context.read<PlayerManagerService>().initialStacks),
-                              ),
-                              actionSync: context.read<ActionSyncService>(),
-                            ),
+                                potSync: potSync,
+                              );
+                              return PlaybackManagerService(
+                                actions: context.read<ActionSyncService>().analyzerActions,
+                                stackService: stackService,
+                                potSync: potSync,
+                                actionSync: context.read<ActionSyncService>(),
+                              );
+                            },
                             child: Builder(
                           builder: (context) => Provider(
                             create: (_) => BoardSyncService(
@@ -280,6 +292,9 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                       stackService: context
                                           .read<PlaybackManagerService>()
                                           .stackService,
+                                      potSyncService: context
+                                          .read<PlaybackManagerService>()
+                                          .potSync,
                                       boardManager:
                                           context.read<BoardManagerService>(),
                                       boardSync:

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -49,8 +49,7 @@ import '../models/saved_hand.dart';
 import '../models/player_model.dart';
 import '../models/action_evaluation_request.dart';
 import '../widgets/action_timeline_widget.dart';
-import '../models/street_investments.dart';
-import '../helpers/pot_calculator.dart';
+import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
@@ -87,6 +86,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final PlayerProfileService playerProfile;
   final ActionTagService actionTagService;
   final BoardRevealService boardReveal;
+  final PotSyncService potSyncService;
 
   const PokerAnalyzerScreen({
     super.key,
@@ -106,6 +106,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     required this.playerProfile,
     required this.actionTagService,
     required this.boardReveal,
+    required this.potSyncService,
   });
 
   @override
@@ -143,7 +144,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   set boardStreet(int v) => _boardManager.boardStreet = v;
   List<ActionEntry> get actions => _actionSync.analyzerActions;
   late PlaybackManagerService _playbackManager;
-  final PotCalculator _potCalculator = PotCalculator();
+  late PotSyncService _potSync;
   late StackManagerService _stackService;
   late HandRestoreService _handRestore;
   late CurrentHandContextService _handContext;
@@ -590,6 +591,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _profile = widget.playerProfile;
     _actionTagService = widget.actionTagService;
     _boardReveal = widget.boardReveal;
+    _potSync = widget.potSyncService;
     _boardManager = widget.boardManager
       ..addListener(() {
         if (mounted) lockService.safeSetState(this, () {});
@@ -598,6 +600,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _boardEditing = widget.boardEditing;
     _stackService = widget.stackService;
     _actionSync.attachStackManager(_stackService);
+    _potSync.stackService = _stackService;
     _playbackManager = widget.playbackManager;
     _playbackManager
       ..stackService = _stackService
@@ -619,12 +622,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       actionTags: _actionTagService,
       setCurrentHandName: (name) => _handContext.currentHandName = name,
       setActivePlayerIndex: (i) => activePlayerIndex = i,
+      potSync: _potSync,
     );
     _profile.updatePositions();
     _playbackManager.updatePlaybackState();
     if (widget.initialHand != null) {
       _stackService = _handRestore.restoreHand(widget.initialHand!);
       _actionSync.attachStackManager(_stackService);
+      _potSync.stackService = _stackService;
       _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
       _boardManager.startBoardTransition();
     }
@@ -1630,7 +1635,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   SavedHand _currentSavedHand({String? name}) {
     final stacks =
-        _stackService.calculateEffectiveStacksPerStreet(actions, numberOfPlayers);
+        _potSync.calculateEffectiveStacksPerStreet(actions, numberOfPlayers);
     final collapsed = [
       for (int i = 0; i < 4; i++)
         if (!_expandedHistoryStreets.contains(i)) i
@@ -1698,6 +1703,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final hand = SavedHand.fromJson(jsonDecode(jsonStr));
     _stackService = _handRestore.restoreHand(hand);
     _actionSync.attachStackManager(_stackService);
+    _potSync.stackService = _stackService;
     _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
     _boardManager.startBoardTransition();
   }
@@ -1839,6 +1845,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (hand == null) return;
     _stackService = _handRestore.restoreHand(hand);
     _actionSync.attachStackManager(_stackService);
+    _potSync.stackService = _stackService;
     _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
     _boardManager.startBoardTransition();
   }
@@ -1846,12 +1853,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   Future<void> loadHandByName() async {
     if (lockService.undoRedoTransitionLock || lockService.boardTransitioning) return;
     final selected = await _handManager.selectHand(context);
-    if (selected != null) {
-      _stackService = _handRestore.restoreHand(selected);
-      _actionSync.attachStackManager(_stackService);
-      _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
-      _boardManager.startBoardTransition();
-    }
+      if (selected != null) {
+        _stackService = _handRestore.restoreHand(selected);
+        _actionSync.attachStackManager(_stackService);
+        _potSync.stackService = _stackService;
+        _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
+        _boardManager.startBoardTransition();
+      }
   }
 
 
@@ -1871,6 +1879,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (hand != null) {
       _stackService = _handRestore.restoreHand(hand);
       _actionSync.attachStackManager(_stackService);
+      _potSync.stackService = _stackService;
       _actionSync.updatePlaybackIndex(_playbackManager.playbackIndex);
       _boardManager.startBoardTransition();
     }
@@ -1921,8 +1930,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
 
     final effectiveStack =
-        _stackService.calculateEffectiveStack(currentStreet, visibleActions);
-    final currentStreetEffectiveStack = _stackService
+        _potSync.calculateEffectiveStack(currentStreet, visibleActions);
+    final currentStreetEffectiveStack = _potSync
         .calculateEffectiveStackForStreet(currentStreet, visibleActions, numberOfPlayers);
     final pot = _playbackManager.pots[currentStreet];
     final double? sprValue =
@@ -4626,7 +4635,7 @@ class _HudOverlayDiagnosticsSection extends StatelessWidget {
     final hudStreetName = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][s.currentStreet];
     final hudPotText =
         ActionFormattingHelper.formatAmount(s._playbackManager.pots[s.currentStreet]);
-    final int hudEffStack = s._stackService.calculateEffectiveStackForStreet(
+    final int hudEffStack = s._potSync.calculateEffectiveStackForStreet(
         s.currentStreet, s.actions, s.numberOfPlayers);
     final double? hudSprValue = s._playbackManager.pots[s.currentStreet] > 0
         ? hudEffStack / s._playbackManager.pots[s.currentStreet]
@@ -5000,7 +5009,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
                   'Turn',
                   'River',
                 ][street],
-                s._stackService.calculateEffectiveStackForStreet(
+                s._potSync.calculateEffectiveStackForStreet(
                     street, s.actions, s.numberOfPlayers),
               ),
             _vGap,

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -18,6 +18,7 @@ import 'poker_analyzer_screen.dart';
 import 'create_pack_screen.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/action_sync_service.dart';
+import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
@@ -610,14 +611,21 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                   ],
                   child: Builder(
                     builder: (context) => ChangeNotifierProvider(
-                      create: (_) => PlaybackManagerService(
-                        actions: context.read<ActionSyncService>().analyzerActions,
-                        stackService: StackManagerService(
+                      create: (_) {
+                        final potSync = PotSyncService();
+                        final stackService = StackManagerService(
                           Map<int, int>.from(
                               context.read<PlayerManagerService>().initialStacks),
-                        ),
-                        actionSync: context.read<ActionSyncService>(),
-                      ),
+                          potSync: potSync,
+                        );
+                        return PlaybackManagerService(
+                          actions:
+                              context.read<ActionSyncService>().analyzerActions,
+                          stackService: stackService,
+                          potSync: potSync,
+                          actionSync: context.read<ActionSyncService>(),
+                        );
+                      },
                       child: Builder(
                         builder: (context) => Provider(
                           create: (_) => BoardSyncService(
@@ -664,6 +672,9 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   stackService: context
                                       .read<PlaybackManagerService>()
                                       .stackService,
+                                  potSyncService: context
+                                      .read<PlaybackManagerService>()
+                                      .potSync,
                                   boardManager: context.read<BoardManagerService>(),
                                   boardSync: context.read<BoardSyncService>(),
                                   boardEditing:
@@ -673,7 +684,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   actionTagService: context
                                       .read<PlayerProfileService>()
                                       .actionTagService,
-                                   boardReveal: context.read<BoardRevealService>(),
+                                  boardReveal: context.read<BoardRevealService>(),
                                 ),
                               ),
                               );

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -14,6 +14,7 @@ import 'backup_manager_service.dart';
 import 'debug_preferences_service.dart';
 import 'transition_lock_service.dart';
 import 'current_hand_context_service.dart';
+import 'pot_sync_service.dart';
 
 import 'folded_players_service.dart';
 import 'board_manager_service.dart';
@@ -44,6 +45,7 @@ class HandRestoreService {
     required this.actionTags,
     required this.setCurrentHandName,
     required this.setActivePlayerIndex,
+    required this.potSync,
   }) {
     foldedPlayers.attach(actionSync);
   }
@@ -64,6 +66,7 @@ class HandRestoreService {
   final ActionTagService actionTags;
   final void Function(String) setCurrentHandName;
   final void Function(int?) setActivePlayerIndex;
+  final PotSyncService potSync;
 
 
   StackManagerService restoreHand(SavedHand hand) {
@@ -96,10 +99,12 @@ class HandRestoreService {
       ..addAll(hand.stackSizes);
     final stackService = StackManagerService(
       Map<int, int>.from(playerManager.initialStacks),
+      potSync: potSync,
       remainingStacks: hand.remainingStacks,
     );
     actionSync.attachStackManager(stackService);
     playbackManager.stackService = stackService;
+    potSync.stackService = stackService;
     profile.playerPositions
       ..clear()
       ..addAll(hand.playerPositions);

--- a/lib/services/pot_sync_service.dart
+++ b/lib/services/pot_sync_service.dart
@@ -1,0 +1,86 @@
+import '../helpers/pot_calculator.dart';
+import '../models/action_entry.dart';
+import '../models/street_investments.dart';
+import 'stack_manager_service.dart';
+
+/// Synchronizes pot sizes and provides effective stack calculations.
+class PotSyncService {
+  PotSyncService({
+    PotCalculator? potCalculator,
+    StackManagerService? stackService,
+  })  : _potCalculator = potCalculator ?? PotCalculator(),
+        _stackService = stackService;
+
+  final PotCalculator _potCalculator;
+  StackManagerService? _stackService;
+
+  /// Current pot size for each street.
+  final List<int> pots = List.filled(4, 0);
+
+  set stackService(StackManagerService v) => _stackService = v;
+  StackManagerService get stackService => _stackService!;
+
+  /// Recompute [pots] based on visible [actions].
+  void updatePots(List<ActionEntry> actions) {
+    final investments = StreetInvestments();
+    for (final a in actions) {
+      investments.addAction(a);
+    }
+    final p = _potCalculator.calculatePots(actions, investments);
+    for (int i = 0; i < pots.length; i++) {
+      pots[i] = p[i];
+    }
+  }
+
+  /// Calculates the effective stack size using [actions] visible up to the
+  /// current point in the hand.
+  int calculateEffectiveStack(int currentStreet, List<ActionEntry> actions) {
+    int? minStack;
+    for (final entry in stackService.stackSizes.entries) {
+      final index = entry.key;
+      final folded = actions.any((a) =>
+          a.playerIndex == index && a.action == 'fold' && a.street <= currentStreet);
+      if (folded) continue;
+      final stack = entry.value;
+      if (minStack == null || stack < minStack) {
+        minStack = stack;
+      }
+    }
+    return minStack ?? 0;
+  }
+
+  /// Calculates the effective stack size at the end of [street].
+  int calculateEffectiveStackForStreet(
+      int street, List<ActionEntry> visibleActions, int numberOfPlayers) {
+    int? minStack;
+    for (int index = 0; index < numberOfPlayers; index++) {
+      final folded = visibleActions.any((a) =>
+          a.playerIndex == index && a.action == 'fold' && a.street <= street);
+      if (folded) continue;
+
+      final initial = stackService.initialStacks[index] ?? 0;
+      int invested = 0;
+      for (int s = 0; s <= street; s++) {
+        invested += stackService.getInvestmentForStreet(index, s);
+      }
+      final remaining = initial - invested;
+
+      if (minStack == null || remaining < minStack) {
+        minStack = remaining;
+      }
+    }
+    return minStack ?? 0;
+  }
+
+  /// Calculates effective stack sizes for every street.
+  Map<String, int> calculateEffectiveStacksPerStreet(
+      List<ActionEntry> actions, int numberOfPlayers) {
+    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+    final Map<String, int> stacks = {};
+    for (int street = 0; street < streetNames.length; street++) {
+      stacks[streetNames[street]] =
+          calculateEffectiveStackForStreet(street, actions, numberOfPlayers);
+    }
+    return stacks;
+  }
+}


### PR DESCRIPTION
## Summary
- add `PotSyncService` to centralize pot updates and effective stack logic
- update `PlaybackManagerService` and `StackManagerService` to use `PotSyncService`
- wire `PotSyncService` through `HandRestoreService`, `PokerAnalyzerScreen`, and supporting screens
- adjust providers to construct the new service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f69d76b84832ab701cfb756302a72