### PR TITLE
Refactor evaluation queue handling

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -204,11 +204,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             _debugPrefs.searchQuery.isEmpty
             ? (oldIndex, newIndex) {
                 if (newIndex > oldIndex) newIndex -= 1;
-                lockService.safeSetState(this, () {
-                  final item = queue.removeAt(oldIndex);
-                  queue.insert(newIndex, item);
-                });
-                _queueService.persist();
+                lockService.safeSetState(this, () {});
+                unawaited(
+                    _queueService.reorderQueue(queue, oldIndex, newIndex));
                 _debugPanelSetState?.call(() {});
               }
             : (_, __) {});
@@ -617,7 +615,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       debugPrefs: _debugPrefs,
       lockService: lockService,
       handContext: _handContext,
-      pendingEvaluations: _queueService.pending,
       foldedPlayers: _foldedPlayers,
       actionTags: _actionTagService,
       setCurrentHandName: (name) => _handContext.currentHandName = name,

--- a/lib/services/evaluation_queue_service.dart
+++ b/lib/services/evaluation_queue_service.dart
@@ -367,6 +367,26 @@ class EvaluationQueueService {
     await _persist();
   }
 
+  /// Replace the entire pending queue with [items].
+  Future<void> setPending(List<ActionEvaluationRequest> items) async {
+    await _queueLock.synchronized(() {
+      pending
+        ..clear()
+        ..addAll(items);
+    });
+    await _persist();
+  }
+
+  /// Reorder [queue] moving the item at [oldIndex] to [newIndex].
+  Future<void> reorderQueue(
+      List<ActionEvaluationRequest> queue, int oldIndex, int newIndex) async {
+    await _queueLock.synchronized(() {
+      final item = queue.removeAt(oldIndex);
+      queue.insert(newIndex, item);
+    });
+    await _persist();
+  }
+
   int _deduplicateList(List<ActionEvaluationRequest> list, Set<String> seenIds) {
     final originalLength = list.length;
     final unique = <ActionEvaluationRequest>[];

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -40,7 +40,6 @@ class HandRestoreService {
     required this.debugPrefs,
     required this.lockService,
     required this.handContext,
-    required this.pendingEvaluations,
     required this.foldedPlayers,
     required this.actionTags,
     required this.setCurrentHandName,
@@ -61,7 +60,6 @@ class HandRestoreService {
   final DebugPreferencesService debugPrefs;
   final TransitionLockService lockService;
   final CurrentHandContextService handContext;
-  final List<ActionEvaluationRequest> pendingEvaluations;
   final FoldedPlayersService foldedPlayers;
   final ActionTagService actionTags;
   final void Function(String) setCurrentHandName;
@@ -124,9 +122,7 @@ class HandRestoreService {
             ? hand.tagsCursor!
             : handContext.tagsController.text.length);
     actionTags.restore(hand.actionTags);
-    pendingEvaluations
-      ..clear()
-      ..addAll(hand.pendingEvaluations ?? []);
+    unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
     if (hand.foldedPlayers != null) {
       foldedPlayers.restore(hand.foldedPlayers!);
     } else {


### PR DESCRIPTION
## Summary
- add `setPending` and `reorderQueue` helpers to `EvaluationQueueService`
- use `EvaluationQueueService` inside `HandRestoreService`
- delegate queue reordering in `PokerAnalyzerScreen` to the service

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_684f70628320832a9de01a2154f5d95b