### PR TITLE
Extract SavedHandManagerService operations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1690,11 +1690,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   String saveHand() {
     _addQualityTags();
     final hand = _currentSavedHand();
-    return jsonEncode(hand.toJson());
+    return _handManager.serializeHand(hand);
   }
 
   void loadHand(String jsonStr) {
-    final hand = SavedHand.fromJson(jsonDecode(jsonStr));
+    final hand = _handManager.deserializeHand(jsonStr);
     _stackService = _handRestore.restoreHand(hand);
     _actionSync.attachStackManager(_stackService);
     _potSync.stackService = _stackService;

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -18,6 +18,13 @@ class SavedHandManagerService extends ChangeNotifier {
 
   Set<String> get allTags => hands.expand((h) => h.tags).toSet();
 
+  /// Convert a [SavedHand] object to a JSON string.
+  String serializeHand(SavedHand hand) => jsonEncode(hand.toJson());
+
+  /// Parse a [SavedHand] from a JSON string.
+  SavedHand deserializeHand(String jsonStr) =>
+      SavedHand.fromJson(jsonDecode(jsonStr) as Map<String, dynamic>);
+
   Future<void> add(SavedHand hand) async {
     await _storage.add(hand);
   }


### PR DESCRIPTION
## Summary
- centralize JSON serialization in SavedHandManagerService
- delegate PokerAnalyzerScreen save/load helpers to SavedHandManagerService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7371a384832aaf8a02bd65a6d27d