### PR TITLE
Refactor automatic backup handling

### DIFF
--- a/lib/services/backup_manager_service.dart
+++ b/lib/services/backup_manager_service.dart
@@ -23,7 +23,16 @@ class BackupManagerService {
     required this.queueService,
     required this.debugPrefs,
     BackupService? backupService,
-  }) : backupService = backupService ?? BackupService();
+  }) : backupService = backupService ?? BackupService() {
+    // Start periodic automatic backups when the service is created and
+    // clean up any stale files in the background.
+    startAutoBackupTimer();
+    unawaited(cleanupOldAutoBackups());
+    unawaited(cleanupOldEvaluationBackups());
+    if (debugPrefs.snapshotRetentionEnabled) {
+      unawaited(cleanupOldEvaluationSnapshots());
+    }
+  }
 
   final EvaluationQueueService queueService;
   final DebugPreferencesService debugPrefs;


### PR DESCRIPTION
## Summary
- start backup timers and cleanup from `BackupManagerService`
- rely on `BackupManagerService` for snapshot cleanup and remove old wrapper methods
- simplify initialization of `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7680ea54832a92e2fd7fdf86aef4