### PR TITLE
Refactor board editing to service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -642,11 +642,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void selectCard(int index, CardModel card) {
-    if (_boardEditing.isDuplicateSelection(card, null)) {
-      _boardEditing.showDuplicateCardMessage(context);
-      return;
+    if (_boardEditing.selectCard(context, index, card)) {
+      lockService.safeSetState(this, () {});
     }
-    lockService.safeSetState(this, () => _playerManager.selectCard(index, card));
   }
 
   Future<void> _onPlayerCardTap(int index, int cardIndex) async {
@@ -658,12 +656,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       disabledCards: _boardEditing.usedCardKeys(except: current),
     );
     if (selectedCard == null) return;
-    if (_boardEditing.isDuplicateSelection(selectedCard, current)) {
-      _boardEditing.showDuplicateCardMessage(context);
-      return;
+    if (_boardEditing.setPlayerCard(
+        context, index, cardIndex, selectedCard, current)) {
+      lockService.safeSetState(this, () {});
     }
-    lockService.safeSetState(this, () =>
-        _playerManager.setPlayerCard(index, cardIndex, selectedCard));
   }
 
   void _onPlayerTimeExpired(int index) {
@@ -688,36 +684,30 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       disabledCards: _boardEditing.usedCardKeys(except: current),
     );
     if (selected == null) return;
-    if (_boardEditing.isDuplicateSelection(selected, current)) {
-      _boardEditing.showDuplicateCardMessage(context);
-      return;
+    if (_boardEditing.setRevealedCard(
+        context, playerIndex, cardIndex, selected, current)) {
+      lockService.safeSetState(this, () {});
     }
-    lockService.safeSetState(this, () =>
-        _playerManager.setRevealedCard(playerIndex, cardIndex, selected));
   }
 
 
 
   void selectBoardCard(int index, CardModel card) {
     if (lockService.boardTransitioning) return;
-    if (!_boardEditing.canEditBoard(context, index)) return;
     final current = index < boardCards.length ? boardCards[index] : null;
-    if (_boardEditing.isDuplicateSelection(card, current)) {
-      _boardEditing.showDuplicateCardMessage(context);
-      return;
+    if (_boardEditing.selectBoardCard(context, index, card, current: current)) {
+      lockService.safeSetState(this, () {
+        _recordSnapshot();
+      });
     }
-    lockService.safeSetState(this, () {
-      _recordSnapshot();
-      _boardManager.selectBoardCard(index, card);
-    });
   }
 
   void _removeBoardCard(int index) {
     if (lockService.boardTransitioning) return;
     if (index >= boardCards.length) return;
+    _boardEditing.removeBoardCard(index);
     lockService.safeSetState(this, () {
       _recordSnapshot();
-      _boardManager.removeBoardCard(index);
     });
   }
 

--- a/lib/services/board_editing_service.dart
+++ b/lib/services/board_editing_service.dart
@@ -129,3 +129,58 @@ class BoardEditingService {
   bool canEditBoard(BuildContext context, int index) =>
       isBoardEditAllowed(context, index);
 }
+
+  /// Select a new card for a player by index. Returns true if the card was
+  /// applied, otherwise shows a duplicate warning and returns false.
+  bool selectCard(BuildContext context, int playerIndex, CardModel card) {
+    if (isDuplicateSelection(card, null)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.selectCard(playerIndex, card);
+    return true;
+  }
+
+  /// Replace the card at [cardIndex] for the player at [playerIndex].
+  /// [current] should be the existing card at that position if any.
+  /// Returns true if the replacement succeeded.
+  bool setPlayerCard(BuildContext context, int playerIndex, int cardIndex,
+      CardModel card, CardModel? current) {
+    if (isDuplicateSelection(card, current)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.setPlayerCard(playerIndex, cardIndex, card);
+    return true;
+  }
+
+  /// Replace a revealed card for [playerIndex]. Similar duplicate protection
+  /// as [setPlayerCard].
+  bool setRevealedCard(BuildContext context, int playerIndex, int cardIndex,
+      CardModel card, CardModel? current) {
+    if (isDuplicateSelection(card, current)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.setRevealedCard(playerIndex, cardIndex, card);
+    return true;
+  }
+
+  /// Select or add a board card at [index]. Duplicate and stage order checks
+  /// are enforced. Returns true if the card was applied.
+  bool selectBoardCard(BuildContext context, int index, CardModel card,
+      {CardModel? current}) {
+    if (!isBoardEditAllowed(context, index)) return false;
+    if (isDuplicateSelection(card, current)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _boardManager.selectBoardCard(index, card);
+    return true;
+  }
+
+  /// Remove the board card at [index] if it exists.
+  void removeBoardCard(int index) {
+    _boardManager.removeBoardCard(index);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize board editing logic into `BoardEditingService`
- delegate card selection and board updates from `PokerAnalyzerScreen` to the service

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f7c9faad4832aae322c0a9d28f4be