### PR TITLE
Refactor action tags

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1651,7 +1651,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       foldedPlayers:
           _foldedPlayers.isEmpty ? null : List<int>.from(_foldedPlayers.players),
       actionTags:
-          _actionTagService.tags.isEmpty ? null : Map<int, String?>.from(_actionTagService.tags),
+          _actionTagService.toMap().isEmpty ? null : _actionTagService.toMap(),
       pendingEvaluations:
           _queueService.pending.isEmpty ? null : List<ActionEvaluationRequest>.from(_queueService.pending),
       playbackIndex: _playbackManager.playbackIndex,
@@ -4989,8 +4989,8 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
             debugDiag('Total Actions', s.actions.length),
             _vGap,
             const Text('Action Tags Diagnostics:'),
-            if (s._actionTagService.tags.isNotEmpty)
-              for (final entry in s._actionTagService.tags.entries) ...[
+            if (s._actionTagService.toMap().isNotEmpty)
+              for (final entry in s._actionTagService.toMap().entries) ...[
                 debugDiag('Player ${entry.key + 1} Action Tag', entry.value),
                 _vGap,
               ]

--- a/lib/services/action_tag_service.dart
+++ b/lib/services/action_tag_service.dart
@@ -47,4 +47,27 @@ class ActionTagService {
 
   /// Removes the tag for [playerIndex].
   void removeTag(int playerIndex) => _tags.remove(playerIndex);
+
+  /// Assigns [tag] to the player at [playerIndex].
+  void setTag(int playerIndex, String? tag) => _tags[playerIndex] = tag;
+
+  /// Serializes tags to a JSON-friendly map.
+  Map<String, String?> toJson() =>
+      {for (final e in _tags.entries) e.key.toString(): e.value};
+
+  /// Restores tags from a JSON map produced by [toJson].
+  void restoreFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      clear();
+      return;
+    }
+    _tags
+      ..clear()
+      ..addAll({
+        for (final e in json.entries) int.parse(e.key): e.value as String?
+      });
+  }
+
+  /// Returns a copy of the current tags map.
+  Map<int, String?> toMap() => Map<int, String?>.from(_tags);
 }


### PR DESCRIPTION
## Summary
- expand `ActionTagService` to handle serialization and manual tag updates
- use the service in `PokerAnalyzerScreen` when saving hands and showing debug info

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f7fb00a60832aacd1162a2d104648