### PR TITLE
Add serialization helpers for folded players

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1648,8 +1648,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       date: DateTime.now(),
       effectiveStacksPerStreet: stacks,
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
-      foldedPlayers:
-          _foldedPlayers.isEmpty ? null : List<int>.from(_foldedPlayers.players),
+      foldedPlayers: _foldedPlayers.toJson(),
       actionTags:
           _actionTagService.toMap().isEmpty ? null : _actionTagService.toMap(),
       pendingEvaluations:

--- a/lib/services/folded_players_service.dart
+++ b/lib/services/folded_players_service.dart
@@ -75,6 +75,19 @@ class FoldedPlayersService extends ChangeNotifier {
     addFromAction(newEntry);
   }
 
+  /// Returns a JSON-compatible list of folded player indexes, or `null` if none.
+  List<int>? toJson() =>
+      _foldedPlayers.isEmpty ? null : List<int>.from(_foldedPlayers);
+
+  /// Restores folded players from a list produced by [toJson].
+  void restoreFromJson(List<dynamic>? json) {
+    if (json == null) {
+      reset();
+    } else {
+      restore(json.cast<int>());
+    }
+  }
+
   void attach(ActionSyncService actionSync) {
     _actionSync?.removeListener(_listener ?? () {});
     _actionSync = actionSync;

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -124,7 +124,7 @@ class HandRestoreService {
     actionTags.restore(hand.actionTags);
     unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
     if (hand.foldedPlayers != null) {
-      foldedPlayers.restore(hand.foldedPlayers!);
+      foldedPlayers.restoreFromJson(hand.foldedPlayers);
     } else {
       foldedPlayers.recompute(hand.actions);
     }


### PR DESCRIPTION
## Summary
- allow FoldedPlayersService to export/import folded state via JSON-compatible lists
- simplify saving folded players in PokerAnalyzerScreen
- restore folded players from JSON list in HandRestoreService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f82bf312c832aba61a2aa2da1c3d9