### PR TITLE
Refactor hand context management

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -504,11 +504,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void _addQualityTags() {
-    final tags = _handContext.tagsController.text
-        .split(',')
-        .map((t) => t.trim())
-        .where((t) => t.isNotEmpty)
-        .toSet();
+    final tags = _handContext.tags.toSet();
     bool misplay = false;
     bool aggressive = false;
     for (final a in actions) {
@@ -522,7 +518,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
     if (misplay) tags.add('🚫 Мисс-плей');
     if (aggressive) tags.add('🤯 Слишком агрессивно');
-    _handContext.tagsController.text = tags.join(', ');
+    _handContext.tags = tags.toList();
   }
 
 
@@ -617,7 +613,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       handContext: _handContext,
       foldedPlayers: _foldedPlayers,
       actionTags: _actionTagService,
-      setCurrentHandName: (name) => _handContext.currentHandName = name,
       setActivePlayerIndex: (i) => activePlayerIndex = i,
       potSync: _potSync,
     );
@@ -1408,9 +1403,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _stackService.reset(
             Map<int, int>.from(_playerManager.initialStacks));
         _playbackManager.resetHand();
-        _handContext.commentController.clear();
-        _handContext.tagsController.clear();
-        _handContext.currentHandName = null;
+        _handContext.clear();
       });
     }
   }
@@ -1630,20 +1623,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       },
       playerPositions: Map<int, String>.from(_profile.playerPositions),
       playerTypes: Map<int, PlayerType>.from(_profile.playerTypes),
-      comment: _handContext.commentController.text.isNotEmpty
-          ? _handContext.commentController.text
-          : null,
-      tags: _handContext.tagsController.text
-          .split(',')
-          .map((t) => t.trim())
-          .where((t) => t.isNotEmpty)
-          .toList(),
-      commentCursor: _handContext.commentController.selection.baseOffset >= 0
-          ? _handContext.commentController.selection.baseOffset
-          : null,
-      tagsCursor: _handContext.tagsController.selection.baseOffset >= 0
-          ? _handContext.tagsController.selection.baseOffset
-          : null,
+      comment: _handContext.comment,
+      tags: _handContext.tags,
+      commentCursor: _handContext.commentCursor,
+      tagsCursor: _handContext.tagsCursor,
       isFavorite: false,
       date: DateTime.now(),
       effectiveStacksPerStreet: stacks,

--- a/lib/services/current_hand_context_service.dart
+++ b/lib/services/current_hand_context_service.dart
@@ -2,16 +2,75 @@ import 'package:flutter/material.dart';
 
 class CurrentHandContextService {
   String? _currentHandName;
+
+  /// Name of the currently loaded hand. `null` when no hand is loaded.
   String? get currentHandName => _currentHandName;
   set currentHandName(String? value) => _currentHandName = value;
 
+  /// Text field controllers shared with the UI.
   final TextEditingController commentController = TextEditingController();
   final TextEditingController tagsController = TextEditingController();
 
+  /// Current comment text or `null` if empty.
+  String? get comment =>
+      commentController.text.isNotEmpty ? commentController.text : null;
+
+  set comment(String? value) => commentController.text = value ?? '';
+
+  /// Cursor position inside the comment field.
+  int? get commentCursor => commentController.selection.baseOffset >= 0
+      ? commentController.selection.baseOffset
+      : null;
+
+  set commentCursor(int? offset) {
+    commentController.selection = TextSelection.collapsed(
+      offset: offset != null && offset <= commentController.text.length
+          ? offset
+          : commentController.text.length,
+    );
+  }
+
+  /// Tags entered by the user.
+  List<String> get tags => tagsController.text
+      .split(',')
+      .map((t) => t.trim())
+      .where((t) => t.isNotEmpty)
+      .toList();
+
+  set tags(List<String> value) => tagsController.text = value.join(', ');
+
+  /// Cursor offset inside the tag field.
+  int? get tagsCursor => tagsController.selection.baseOffset >= 0
+      ? tagsController.selection.baseOffset
+      : null;
+
+  set tagsCursor(int? offset) {
+    tagsController.selection = TextSelection.collapsed(
+      offset:
+          offset != null && offset <= tagsController.text.length ? offset : tagsController.text.length,
+    );
+  }
+
+  /// Reset all fields to their initial state.
   void clear() {
     _currentHandName = null;
     commentController.clear();
     tagsController.clear();
+  }
+
+  /// Restore context from persisted data.
+  void restore({
+    String? name,
+    String? comment,
+    int? commentCursor,
+    List<String>? tags,
+    int? tagsCursor,
+  }) {
+    _currentHandName = name;
+    this.comment = comment;
+    this.tags = tags ?? <String>[];
+    this.commentCursor = commentCursor;
+    this.tagsCursor = tagsCursor;
   }
 
   void dispose() {

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -42,7 +42,6 @@ class HandRestoreService {
     required this.handContext,
     required this.foldedPlayers,
     required this.actionTags,
-    required this.setCurrentHandName,
     required this.setActivePlayerIndex,
     required this.potSync,
   }) {
@@ -62,13 +61,12 @@ class HandRestoreService {
   final CurrentHandContextService handContext;
   final FoldedPlayersService foldedPlayers;
   final ActionTagService actionTags;
-  final void Function(String) setCurrentHandName;
   final void Function(int?) setActivePlayerIndex;
   final PotSyncService potSync;
 
 
   StackManagerService restoreHand(SavedHand hand) {
-    setCurrentHandName(hand.name);
+    handContext.currentHandName = hand.name;
     profile.heroIndex = hand.heroIndex;
     profile.heroPosition = hand.heroPosition;
     profile.numberOfPlayers = hand.numberOfPlayers;
@@ -110,17 +108,13 @@ class HandRestoreService {
       ..clear()
       ..addAll(hand.playerTypes ??
           {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
-    handContext.commentController.text = hand.comment ?? '';
-    handContext.tagsController.text = hand.tags.join(', ');
-    handContext.commentController.selection = TextSelection.collapsed(
-        offset: hand.commentCursor != null &&
-                hand.commentCursor! <= handContext.commentController.text.length
-            ? hand.commentCursor!
-            : handContext.commentController.text.length);
-    handContext.tagsController.selection = TextSelection.collapsed(
-        offset: hand.tagsCursor != null && hand.tagsCursor! <= handContext.tagsController.text.length
-            ? hand.tagsCursor!
-            : handContext.tagsController.text.length);
+    handContext.restore(
+      name: hand.name,
+      comment: hand.comment,
+      commentCursor: hand.commentCursor,
+      tags: hand.tags,
+      tagsCursor: hand.tagsCursor,
+    );
     actionTags.restore(hand.actionTags);
     unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
     if (hand.foldedPlayers != null) {


### PR DESCRIPTION
## Summary
- extend `CurrentHandContextService` with comment, tags and cursor handling
- migrate `HandRestoreService` to use `CurrentHandContextService` for restoring
- update `PokerAnalyzerScreen` to rely on the new service API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f88dde480832a9406eb44dea443fa