### PR TITLE
Refactor player management

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -187,6 +187,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerManager:
+                                          context.read<PlayerManagerService>(),
                                       playerProfile:
                                           context.read<PlayerProfileService>(),
                                   actionTagService: context
@@ -302,6 +304,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerManager:
+                                          context.read<PlayerManagerService>(),
                                       playerProfile:
                                           context.read<PlayerProfileService>(),
                                       actionTagService: context

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -679,6 +679,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   boardSync: context.read<BoardSyncService>(),
                                   boardEditing:
                                       context.read<BoardEditingService>(),
+                                  playerManager:
+                                      context.read<PlayerManagerService>(),
                                   playerProfile:
                                       context.read<PlayerProfileService>(),
                                   actionTagService: context


### PR DESCRIPTION
## Summary
- expose `heroIndex` getter in `PlayerManagerService`
- centralize player-loading logic with `loadFromMap`
- pass `PlayerManagerService` into `PokerAnalyzerScreen`
- use `PlayerManagerService` for hero, cards, and player position data
- wire up player manager when building analyzer screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f8efd2978832abf19a46110f5a66f