### PR TITLE
Extract BoardManagerService

### DIFF
--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -138,6 +138,21 @@ class BoardManagerService extends ChangeNotifier {
     _playerManager.removeBoardCard(index);
   }
 
+  /// Load board information from a training spot map and reset to preflop.
+  void loadFromMap(Map<String, dynamic> data) {
+    final boardData = data['boardCards'] as List? ?? [];
+    final cards = <CardModel>[];
+    for (final c in boardData) {
+      if (c is Map) {
+        cards.add(
+          CardModel(rank: c['rank'] as String, suit: c['suit'] as String),
+        );
+      }
+    }
+    setBoardCards(cards);
+    changeStreet(0);
+  }
+
   /// Whether [stage] has the required number of board cards.
   bool isBoardStageComplete(int stage) =>
       _boardSync.isBoardStageComplete(stage);


### PR DESCRIPTION
## Summary
- centralize board state management by adding `BoardManagerService.loadFromMap`
- delegate street navigation to `BoardManagerService` in `PokerAnalyzerScreen`
- load board state from training spots via `BoardManagerService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f920bfc54832a88f930d221c61d24