### PR TITLE
Refactor stack management service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -531,7 +531,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     await showDialog(
       context: context,
       builder: (context) => _PlayerEditorSection(
-        initialStack: _stackService.initialStacks[index] ?? 0,
+        initialStack: _stackService.getInitialStack(index),
         initialType: _playerManager.playerTypes[index] ?? PlayerType.unknown,
         isHeroSelected: index == _playerManager.heroIndex,
         card1: _playerManager.playerCards[index].isNotEmpty
@@ -1961,7 +1961,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               street: i,
               actions: savedActions,
               pots: _playbackManager.pots,
-              stackSizes: _stackService.stackSizes,
+              stackSizes: _stackService.currentStacks,
               playerPositions: playerPositions,
               onEdit: _editAction,
               onDelete: _deleteAction,
@@ -1978,7 +1978,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         actions: visibleActions,
         playerPositions: playerPositions,
         pots: _playbackManager.pots,
-        stackSizes: _stackService.stackSizes,
+        stackSizes: _stackService.currentStacks,
         onEdit: _editAction,
       onDelete: _deleteAction,
       visibleCount: _playbackManager.playbackIndex,
@@ -2060,7 +2060,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   currentStreet: currentStreet,
                   actions: actions,
                   pots: _playbackManager.pots,
-                  stackSizes: _stackService.stackSizes,
+                  stackSizes: _stackService.currentStacks,
                   onEdit: _editAction,
                   onDelete: _deleteAction,
                   visibleCount: _playbackManager.playbackIndex,
@@ -2159,7 +2159,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
 
     final String position = playerPositions[index] ?? '';
-    final int stack = _stackService.stackSizes[index] ?? 0;
+    final int stack = _stackService.getStackForPlayer(index);
     final String tag = _actionTagService.getTag(index) ?? '';
     final bool isActive = activePlayerIndex == index;
     final bool isFolded = _foldedPlayers.contains(index);
@@ -4794,7 +4794,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
             for (int i = 0; i < s.numberOfPlayers; i++)
               debugDiag(
                 'Player ${i + 1}',
-                'Initial ${s._stackService.initialStacks[i] ?? 0}, '
+                'Initial ${s._stackService.getInitialStack(i)}, '
                 'Invested ${s._stackService.getTotalInvested(i)}, '
                 'Remaining ${s._stackService.getStackForPlayer(i)}',
               ),

--- a/lib/services/stack_manager_service.dart
+++ b/lib/services/stack_manager_service.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/foundation.dart';
+
 import '../helpers/stack_manager.dart';
 import '../models/action_entry.dart';
 import 'pot_sync_service.dart';
 
 /// Service that manages stack sizes and investments based on actions.
-class StackManagerService {
+class StackManagerService extends ChangeNotifier {
   final Map<int, int> _initialStacks;
   late StackManager _manager;
   final Map<int, int> stackSizes = {};
@@ -20,6 +22,12 @@ class StackManagerService {
   /// Current initial stack sizes.
   Map<int, int> get initialStacks => Map<int, int>.from(_initialStacks);
 
+  /// Current stacks after applying actions.
+  Map<int, int> get currentStacks => Map<int, int>.from(stackSizes);
+
+  /// Initial stack for a specific player.
+  int getInitialStack(int playerIndex) => _initialStacks[playerIndex] ?? 0;
+
   /// Re-initialize with a new set of initial stacks.
   void reset(Map<int, int> stacks, {Map<int, int>? remainingStacks}) {
     _initialStacks
@@ -31,6 +39,7 @@ class StackManagerService {
       ..clear()
       ..addAll(_manager.currentStacks);
     potSync.stackService = this;
+    notifyListeners();
   }
 
   /// Apply [actions] and update current stack sizes.
@@ -40,6 +49,37 @@ class StackManagerService {
       ..clear()
       ..addAll(_manager.currentStacks);
     potSync.updatePots(actions);
+    notifyListeners();
+  }
+
+  /// Update the initial stack for [playerIndex].
+  void setInitialStack(int playerIndex, int stack) {
+    _initialStacks[playerIndex] = stack;
+    _manager = StackManager(Map<int, int>.from(_initialStacks));
+    stackSizes
+      ..clear()
+      ..addAll(_manager.currentStacks);
+    notifyListeners();
+  }
+
+  /// Remove a player and shift subsequent stack entries.
+  void removePlayer(int index) {
+    final updated = <int, int>{};
+    for (final entry in _initialStacks.entries) {
+      if (entry.key < index) {
+        updated[entry.key] = entry.value;
+      } else if (entry.key > index) {
+        updated[entry.key - 1] = entry.value;
+      }
+    }
+    _initialStacks
+      ..clear()
+      ..addAll(updated);
+    _manager = StackManager(Map<int, int>.from(_initialStacks));
+    stackSizes
+      ..clear()
+      ..addAll(_manager.currentStacks);
+    notifyListeners();
   }
 
   int getStackForPlayer(int playerIndex) =>


### PR DESCRIPTION
## Summary
- refactor stack management into StackManagerService as a `ChangeNotifier`
- expose helpers for current stacks and per player initial stack
- update PokerAnalyzerScreen to use new StackManagerService API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f9e49ea88832a9378d4215456a752