### PR TITLE
Extract folded players service

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -15,6 +15,7 @@ import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
+import '../services/folded_players_service.dart';
 
 class PlayerInputScreen extends StatefulWidget {
   const PlayerInputScreen({super.key});
@@ -172,6 +173,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                       key: key,
                                       actionSync:
                                           context.read<ActionSyncService>(),
+                                      foldedPlayersService:
+                                          context.read<FoldedPlayersService>(),
                                       handContext: CurrentHandContextService(),
                                       playbackManager:
                                           context.read<PlaybackManagerService>(),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -29,6 +29,7 @@ import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
+import '../services/folded_players_service.dart';
 
 class _ResultEntry {
   final String name;
@@ -662,11 +663,13 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   ),
                                 ],
                                 child: Builder(
-                                builder: (context) => PokerAnalyzerScreen(
-                                  key: _analyzerKey,
-                                  initialHand: hands[_currentIndex],
-                                  actionSync: context.read<ActionSyncService>(),
-                                  handContext: CurrentHandContextService(),
+                                  builder: (context) => PokerAnalyzerScreen(
+                                    key: _analyzerKey,
+                                    initialHand: hands[_currentIndex],
+                                    actionSync: context.read<ActionSyncService>(),
+                                    foldedPlayersService:
+                                        context.read<FoldedPlayersService>(),
+                                    handContext: CurrentHandContextService(),
                                   playbackManager:
                                       context.read<PlaybackManagerService>(),
                                   stackService: context


### PR DESCRIPTION
## Summary
- wire up FoldedPlayersService in PlayerInputScreen and TrainingPackScreen
- use the injected service when building PokerAnalyzerScreen

## Testing
- `dart format lib/screens/player_input_screen.dart lib/screens/training_pack_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684faa87af10832aa75daba7c7015126