### PR TITLE
Add debug callback support for evaluation queue

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4102,12 +4102,14 @@ class _DebugPanelDialogState extends State<_DebugPanelDialog> {
   void initState() {
     super.initState();
     s._debugPanelSetState = setState;
+    s._queueService.debugPanelCallback = setState;
     _searchController.text = s._debugPrefs.searchQuery;
   }
 
   @override
   void dispose() {
     s._debugPanelSetState = null;
+    s._queueService.debugPanelCallback = null;
     _searchController.dispose();
     super.dispose();
   }

--- a/lib/services/evaluation_queue_service.dart
+++ b/lib/services/evaluation_queue_service.dart
@@ -49,10 +49,14 @@ class EvaluationQueueService {
   late final RetryEvaluationService _retryService;
   BackupManagerService? _backupManager;
   late final Future<void> _initFuture;
+  /// Optional callback invoked whenever the queue state changes so the
+  /// debug panel can update immediately.
+  VoidCallback? debugPanelCallback;
 
   EvaluationQueueService({
     EvaluationExecutorService? executorService,
     RetryEvaluationService? retryService,
+    this.debugPanelCallback,
   }) {
     _executorService = executorService ?? EvaluationExecutorService();
     _retryService =
@@ -175,6 +179,7 @@ class EvaluationQueueService {
         debugPrint('Persist error: $e');
       }
     }
+    debugPanelCallback?.call();
   }
 
   /// Exposes persistence for external helpers.


### PR DESCRIPTION
## Summary
- notify debug panel when evaluation queue persists
- wire PokerAnalyzer debug panel to queue service

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684fb0a6ca14832aae29dcc95238d0a5