### PR TITLE
Implement centralized transition lock

### DIFF
--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -79,7 +79,7 @@ class BoardManagerService extends ChangeNotifier {
   }
 
   void changeStreet(int street) {
-    if (lockService.boardTransitioning) return;
+    if (lockService.isLocked) return;
     cancelBoardReveal();
     street = street.clamp(0, boardStreet);
     if (street == currentStreet) return;
@@ -101,12 +101,12 @@ class BoardManagerService extends ChangeNotifier {
   bool canAdvanceStreet() => currentStreet < boardStreet;
 
   void advanceStreet() {
-    if (lockService.boardTransitioning || !canAdvanceStreet()) return;
+    if (lockService.isLocked || !canAdvanceStreet()) return;
     changeStreet(currentStreet + 1);
   }
 
   void reverseStreet() {
-    if (lockService.boardTransitioning || !canReverseStreet()) return;
+    if (lockService.isLocked || !canReverseStreet()) return;
     changeStreet(currentStreet - 1);
   }
 

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -66,11 +66,13 @@ class HandRestoreService {
 
 
   StackManagerService restoreHand(SavedHand hand) {
-    handContext.currentHandName = hand.name;
-    profile.heroIndex = hand.heroIndex;
-    profile.heroPosition = hand.heroPosition;
-    profile.numberOfPlayers = hand.numberOfPlayers;
-    playerManager.numberOfPlayers = hand.numberOfPlayers;
+    lockService.lock();
+    try {
+      handContext.currentHandName = hand.name;
+      profile.heroIndex = hand.heroIndex;
+      profile.heroPosition = hand.heroPosition;
+      profile.numberOfPlayers = hand.numberOfPlayers;
+      playerManager.numberOfPlayers = hand.numberOfPlayers;
     for (int i = 0; i < playerManager.playerCards.length; i++) {
       playerManager.playerCards[i]
         ..clear()
@@ -138,6 +140,9 @@ class HandRestoreService {
     queueService.startAutoBackupTimer();
     unawaited(debugPrefs.setEvaluationQueueResumed(false));
     return stackService;
+    } finally {
+      lockService.unlock();
+    }
   }
 
   void _autoCollapseStreets() {

--- a/test/services/transition_lock_service_test.dart
+++ b/test/services/transition_lock_service_test.dart
@@ -66,4 +66,14 @@ void main() {
       expect(state.setStateCalled, isTrue);
     });
   });
+
+  group('manual locking', () {
+    test('lock and unlock toggle isLocked', () {
+      expect(service.isLocked, isFalse);
+      service.lock();
+      expect(service.isLocked, isTrue);
+      service.unlock();
+      expect(service.isLocked, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- extend `TransitionLockService` with manual lock support
- use new lock logic in `BoardManagerService`
- lock UI while restoring hands
- add tests for manual lock behavior

## Testing
- `git commit -m "Introduce generic TransitionLockService"`


------
https://chatgpt.com/codex/tasks/task_e_684fd37fefec832ab4c275e306c7309c