### PR TITLE
Implement PlayerEditingService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -13,6 +13,7 @@ import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
+import '../services/player_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
 import '../services/folded_players_service.dart';
@@ -167,6 +168,13 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                         profile: context.read<PlayerProfileService>(),
                                       ),
                                     ),
+                                    Provider(
+                                      create: (_) => PlayerEditingService(
+                                        playerManager: context.read<PlayerManagerService>(),
+                                        stackService: context.read<PlaybackManagerService>().stackService,
+                                        playbackManager: context.read<PlaybackManagerService>(),
+                                      ),
+                                    ),
                                   ],
                                   child: Builder(
                                     builder: (context) => PokerAnalyzerScreen(
@@ -190,6 +198,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerEditing:
+                                          context.read<PlayerEditingService>(),
                                       playerManager:
                                           context.read<PlayerManagerService>(),
                                       playerProfile:
@@ -307,6 +317,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerEditing:
+                                          context.read<PlayerEditingService>(),
                                       playerManager:
                                           context.read<PlayerManagerService>(),
                                       playerProfile:

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -22,6 +22,7 @@ import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
+import '../services/player_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
 import '../services/current_hand_context_service.dart';
@@ -661,6 +662,13 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                       profile: context.read<PlayerProfileService>(),
                                     ),
                                   ),
+                                  Provider(
+                                    create: (_) => PlayerEditingService(
+                                      playerManager: context.read<PlayerManagerService>(),
+                                      stackService: context.read<PlaybackManagerService>().stackService,
+                                      playbackManager: context.read<PlaybackManagerService>(),
+                                    ),
+                                  ),
                                 ],
                                 child: Builder(
                                   builder: (context) => PokerAnalyzerScreen(
@@ -682,6 +690,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   boardSync: context.read<BoardSyncService>(),
                                   boardEditing:
                                       context.read<BoardEditingService>(),
+                                  playerEditing:
+                                      context.read<PlayerEditingService>(),
                                   playerManager:
                                       context.read<PlayerManagerService>(),
                                   playerProfile:

--- a/lib/services/player_editing_service.dart
+++ b/lib/services/player_editing_service.dart
@@ -1,0 +1,88 @@
+import '../models/action_entry.dart';
+import '../models/card_model.dart';
+import '../models/player_model.dart';
+import 'player_manager_service.dart';
+import 'stack_manager_service.dart';
+import 'playback_manager_service.dart';
+
+/// Handles modifications to player info and keeps related services
+/// synchronized.
+class PlayerEditingService {
+  PlayerEditingService({
+    required PlayerManagerService playerManager,
+    required StackManagerService stackService,
+    required PlaybackManagerService playbackManager,
+  })  : _playerManager = playerManager,
+        _stackService = stackService,
+        _playbackManager = playbackManager;
+
+  final PlayerManagerService _playerManager;
+  final StackManagerService _stackService;
+  final PlaybackManagerService _playbackManager;
+
+  /// Update position for [playerIndex].
+  void setPosition(int playerIndex, String position) {
+    _playerManager.setPosition(playerIndex, position);
+  }
+
+  /// Change the hero seat to [index].
+  void setHeroIndex(int index) {
+    _playerManager.setHeroIndex(index);
+    _playbackManager.updatePlaybackState();
+  }
+
+  /// Update the player count and reset stacks accordingly.
+  void onPlayerCountChanged(int count) {
+    _playerManager.onPlayerCountChanged(count);
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+
+  /// Update the initial stack for [index].
+  void setInitialStack(int index, int stack) {
+    _playerManager.setInitialStack(index, stack);
+    _stackService.setInitialStack(index, stack);
+    _playbackManager.updatePlaybackState();
+  }
+
+  /// Apply [stack], [type], [isHero] and hole [cards] to a player.
+  void updatePlayer(
+    int index, {
+    required int stack,
+    required PlayerType type,
+    required bool isHero,
+    required List<CardModel> cards,
+    bool disableCards = false,
+  }) {
+    _playerManager.updatePlayer(
+      index,
+      stack: stack,
+      type: type,
+      isHero: isHero,
+      cards: cards,
+      disableCards: disableCards,
+    );
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+
+  /// Remove player at [index] and keep stacks/playback in sync.
+  void removePlayer(
+    int index, {
+    required int heroIndexOverride,
+    required List<ActionEntry> actions,
+    required List<bool> hintFlags,
+  }) {
+    _playerManager.removePlayer(
+      index,
+      heroIndexOverride: heroIndexOverride,
+      actions: actions,
+      hintFlags: hintFlags,
+    );
+    if (_playbackManager.playbackIndex > actions.length) {
+      _playbackManager.seek(actions.length);
+    }
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+}


### PR DESCRIPTION
## Summary
- add PlayerEditingService to centralize player updates
- inject PlayerEditingService into PokerAnalyzerScreen
- replace player modifications with service calls
- wire up PlayerEditingService in PlayerInput and TrainingPack screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe83cc954832aad476d57f889c862