### PR TITLE
Add PlayerEditingService

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -13,6 +13,7 @@ import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
+import '../services/player_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
 import '../services/folded_players_service.dart';
@@ -167,6 +168,13 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                         profile: context.read<PlayerProfileService>(),
                                       ),
                                     ),
+                                    Provider(
+                                      create: (_) => PlayerEditingService(
+                                        playerManager: context.read<PlayerManagerService>(),
+                                        stackService: context.read<PlaybackManagerService>().stackService,
+                                        playbackManager: context.read<PlaybackManagerService>(),
+                                      ),
+                                    ),
                                   ],
                                   child: Builder(
                                     builder: (context) => PokerAnalyzerScreen(
@@ -190,6 +198,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerEditing:
+                                          context.read<PlayerEditingService>(),
                                       playerManager:
                                           context.read<PlayerManagerService>(),
                                       playerProfile:
@@ -287,6 +297,13 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                         profile: context.read<PlayerProfileService>(),
                                       ),
                                     ),
+                                    Provider(
+                                      create: (_) => PlayerEditingService(
+                                        playerManager: context.read<PlayerManagerService>(),
+                                        stackService: context.read<PlaybackManagerService>().stackService,
+                                        playbackManager: context.read<PlaybackManagerService>(),
+                                      ),
+                                    ),
                                   ],
                                   child: Builder(
                                     builder: (context) => PokerAnalyzerScreen(
@@ -307,6 +324,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                           context.read<BoardSyncService>(),
                                       boardEditing:
                                           context.read<BoardEditingService>(),
+                                      playerEditing:
+                                          context.read<PlayerEditingService>(),
                                       playerManager:
                                           context.read<PlayerManagerService>(),
                                       playerProfile:

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -14,6 +14,7 @@ import '../services/playback_manager_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
+import '../services/player_editing_service.dart';
 import '../services/board_reveal_service.dart';
 import '../widgets/player_zone_widget.dart';
 import '../widgets/street_actions_widget.dart';
@@ -86,6 +87,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final BoardManagerService boardManager;
   final BoardSyncService boardSync;
   final BoardEditingService boardEditing;
+  final PlayerEditingService playerEditing;
   final PlayerManagerService playerManager;
   final PlayerProfileService playerProfile;
   final ActionTagService actionTagService;
@@ -109,6 +111,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     required this.boardManager,
     required this.boardSync,
     required this.boardEditing,
+    required this.playerEditing,
     required this.playerManager,
     required this.playerProfile,
     required this.actionTagService,
@@ -130,14 +133,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late BoardManagerService _boardManager;
   late BoardSyncService _boardSync;
   late BoardEditingService _boardEditing;
+  late PlayerEditingService _playerEditing;
   late BoardRevealService _boardReveal;
   late ActionTagService _actionTagService;
   int get heroIndex => _playerManager.heroIndex;
-  set heroIndex(int v) => _playerManager.setHeroIndex(v);
+  set heroIndex(int v) => _playerEditing.setHeroIndex(v);
   String get _heroPosition => _profile.heroPosition;
   set _heroPosition(String v) => _profile.heroPosition = v;
   int get numberOfPlayers => _playerManager.numberOfPlayers;
-  set numberOfPlayers(int v) => _playerManager.numberOfPlayers = v;
+  set numberOfPlayers(int v) => _playerEditing.onPlayerCountChanged(v);
   List<List<CardModel>> get playerCards => _playerManager.playerCards;
   List<CardModel> get boardCards => _boardManager.boardCards;
   List<PlayerModel> get players => _playerManager.players;
@@ -223,21 +227,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   void setPosition(int playerIndex, String position) {
     if (lockService.isLocked) return;
     lockService.safeSetState(this, () {
-      _playerManager.setPosition(playerIndex, position);
+      _playerEditing.setPosition(playerIndex, position);
     });
   }
 
   void _setHeroIndex(int index) {
     if (lockService.isLocked) return;
     lockService.safeSetState(this, () {
-      _playerManager.setHeroIndex(index);
+      _playerEditing.setHeroIndex(index);
     });
   }
 
   void _onPlayerCountChanged(int value) {
     if (lockService.isLocked) return;
     lockService.safeSetState(this, () {
-      _playerManager.onPlayerCountChanged(value);
+      _playerEditing.onPlayerCountChanged(value);
     });
   }
 
@@ -509,7 +513,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             final cards = <CardModel>[];
             if (c1 != null) cards.add(c1);
             if (c2 != null) cards.add(c2);
-            _playerManager.updatePlayer(
+            _playerEditing.updatePlayer(
               index,
               stack: stack,
               type: type,
@@ -517,9 +521,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               cards: cards,
               disableCards: disableCards,
             );
-            _stackService
-                .reset(Map<int, int>.from(_playerManager.initialStacks));
-            _playbackManager.updatePlaybackState();
           });
         },
       ),
@@ -560,6 +561,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       });
     _boardSync = widget.boardSync;
     _boardEditing = widget.boardEditing;
+    _playerEditing = widget.playerEditing;
     _stackService = widget.stackService;
     _actionSync.attachStackManager(_stackService);
     _potSync.stackService = _stackService;
@@ -1196,18 +1198,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
 
     lockService.safeSetState(this, () {
-      _playerManager.removePlayer(
+      _playerEditing.removePlayer(
         index,
         heroIndexOverride: updatedHeroIndex,
         actions: actions,
         hintFlags: _playerManager.showActionHints,
       );
-      if (_playbackManager.playbackIndex > actions.length) {
-        _playbackManager.seek(actions.length);
-      }
-      _stackService.reset(
-          Map<int, int>.from(_playerManager.initialStacks));
-      _playbackManager.updatePlaybackState();
     });
   }
 
@@ -1231,15 +1227,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     );
     if (confirm == true) {
       lockService.safeSetState(this, () {
-        _playerManager.reset();
+        _playerEditing.reset();
         _undoRedoService.resetHistory();
         _foldedPlayers.reset();
         _boardManager.changeStreet(0);
         _boardManager.startBoardTransition();
         _actionTagService.clear();
-        _stackService.reset(
-            Map<int, int>.from(_playerManager.initialStacks));
-        _playbackManager.resetHand();
         _handContext.clear();
       });
     }
@@ -2146,12 +2139,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             onEdit: lockService.isLocked ? null : () => _editPlayerInfo(index),
             onStackTap: lockService.isLocked
                 ? null
-                : (value) => lockService.safeSetState(this, () {
-                      _playerManager.setInitialStack(index, value);
-                      _stackService
-                          .reset(Map<int, int>.from(_playerManager.initialStacks));
-                      _playbackManager.updatePlaybackState();
-                    }),
+                : (value) => lockService.safeSetState(this,
+                    () => _playerEditing.setInitialStack(index, value)),
             onRemove: _playerManager.numberOfPlayers > 2 && !lockService.isLocked
                 ? () {
                     _removePlayer(index);

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -22,6 +22,7 @@ import '../services/pot_sync_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
 import '../services/board_editing_service.dart';
+import '../services/player_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
 import '../services/current_hand_context_service.dart';
@@ -661,6 +662,13 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                       profile: context.read<PlayerProfileService>(),
                                     ),
                                   ),
+                                  Provider(
+                                    create: (_) => PlayerEditingService(
+                                      playerManager: context.read<PlayerManagerService>(),
+                                      stackService: context.read<PlaybackManagerService>().stackService,
+                                      playbackManager: context.read<PlaybackManagerService>(),
+                                    ),
+                                  ),
                                 ],
                                 child: Builder(
                                   builder: (context) => PokerAnalyzerScreen(
@@ -682,6 +690,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                   boardSync: context.read<BoardSyncService>(),
                                   boardEditing:
                                       context.read<BoardEditingService>(),
+                                  playerEditing:
+                                      context.read<PlayerEditingService>(),
                                   playerManager:
                                       context.read<PlayerManagerService>(),
                                   playerProfile:

--- a/lib/services/player_editing_service.dart
+++ b/lib/services/player_editing_service.dart
@@ -1,0 +1,92 @@
+import '../models/action_entry.dart';
+import '../models/card_model.dart';
+import '../models/player_model.dart';
+import 'player_manager_service.dart';
+import 'stack_manager_service.dart';
+import 'playback_manager_service.dart';
+
+/// Service that centralizes player info editing and keeps related
+/// services in sync.
+class PlayerEditingService {
+  PlayerEditingService({
+    required PlayerManagerService playerManager,
+    required StackManagerService stackService,
+    required PlaybackManagerService playbackManager,
+  })  : _playerManager = playerManager,
+        _stackService = stackService,
+        _playbackManager = playbackManager;
+
+  final PlayerManagerService _playerManager;
+  final StackManagerService _stackService;
+  final PlaybackManagerService _playbackManager;
+
+  Map<int, String> get playerPositions => _playerManager.playerPositions;
+  Map<int, PlayerType> get playerTypes => _playerManager.playerTypes;
+  List<List<CardModel>> get playerCards => _playerManager.playerCards;
+  int get heroIndex => _playerManager.heroIndex;
+  int get numberOfPlayers => _playerManager.numberOfPlayers;
+  List<PlayerModel> get players => _playerManager.players;
+
+  void setPosition(int playerIndex, String position) {
+    _playerManager.setPosition(playerIndex, position);
+  }
+
+  void setHeroIndex(int index) {
+    _playerManager.setHeroIndex(index);
+  }
+
+  void onPlayerCountChanged(int value) {
+    _playerManager.onPlayerCountChanged(value);
+  }
+
+  void updatePlayer(
+    int index, {
+    required int stack,
+    required PlayerType type,
+    required bool isHero,
+    required List<CardModel> cards,
+    bool disableCards = false,
+  }) {
+    _playerManager.updatePlayer(
+      index,
+      stack: stack,
+      type: type,
+      isHero: isHero,
+      cards: cards,
+      disableCards: disableCards,
+    );
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+
+  void setInitialStack(int index, int stack) {
+    _playerManager.setInitialStack(index, stack);
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+
+  void removePlayer(
+    int index, {
+    required int heroIndexOverride,
+    required List<ActionEntry> actions,
+    required List<bool> hintFlags,
+  }) {
+    _playerManager.removePlayer(
+      index,
+      heroIndexOverride: heroIndexOverride,
+      actions: actions,
+      hintFlags: hintFlags,
+    );
+    if (_playbackManager.playbackIndex > actions.length) {
+      _playbackManager.seek(actions.length);
+    }
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.updatePlaybackState();
+  }
+
+  void reset() {
+    _playerManager.reset();
+    _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
+    _playbackManager.resetHand();
+  }
+}


### PR DESCRIPTION
## Summary
- create PlayerEditingService for stack, hero, and player updates
- inject PlayerEditingService into analyzer screen and provider trees
- delegate player editing actions through the new service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fead362e8832aa149258d5524d39b