### PR TITLE
Refactor queue import/export

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import '../services/evaluation_queue_service.dart';
+import '../services/evaluation_queue_import_export_service.dart';
 import '../services/evaluation_processing_service.dart';
 import '../services/debug_panel_preferences.dart';
 import 'package:uuid/uuid.dart';
@@ -77,6 +78,7 @@ import '../services/action_history_service.dart';
 class PokerAnalyzerScreen extends StatefulWidget {
   final SavedHand? initialHand;
   final EvaluationQueueService? queueService;
+  final EvaluationQueueImportExportService? importExportService;
   final EvaluationProcessingService? processingService;
   final DebugPanelPreferences? debugPrefsService;
   final ActionSyncService actionSync;
@@ -102,6 +104,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     super.key,
     this.initialHand,
     this.queueService,
+    this.importExportService,
     this.processingService,
     this.debugPrefsService,
     required this.actionSync,
@@ -192,6 +195,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   /// Handles evaluation queue state and processing.
   late final EvaluationQueueService _queueService;
+  late final EvaluationQueueImportExportService _importExportService;
   late final EvaluationProcessingService _processingService;
 
 
@@ -539,9 +543,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _foldedPlayers = widget.foldedPlayersService ?? FoldedPlayersService();
     _debugPrefs = widget.debugPrefsService ?? DebugPanelPreferences();
     _queueService = widget.queueService ?? EvaluationQueueService();
+    _importExportService =
+        widget.importExportService ??
+            EvaluationQueueImportExportService(queueService: _queueService);
     final backupManager = widget.backupManagerService ??
         BackupManagerService(queueService: _queueService, debugPrefs: _debugPrefs);
-    _queueService.attachBackupManager(backupManager);
+    _importExportService.attachBackupManager(backupManager);
     _processingService = widget.processingService ?? EvaluationProcessingService(
       queueService: _queueService,
       debugPrefs: _debugPrefs,
@@ -1255,46 +1262,46 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   Future<void> _exportEvaluationQueue() async {
-    await _queueService.exportEvaluationQueue(context);
+    await _importExportService.exportEvaluationQueue(context);
   }
 
   Future<void> _exportQueueToClipboard() async {
-    await _queueService.exportQueueToClipboard(context);
+    await _importExportService.exportQueueToClipboard(context);
   }
 
   Future<void> _importQueueFromClipboard() async {
-    await _queueService.importQueueFromClipboard(context);
+    await _importExportService.importQueueFromClipboard(context);
     lockService.safeSetState(this, () {});
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _exportFullEvaluationQueueState() async {
-    await _queueService.exportFullQueueState(context);
+    await _importExportService.exportFullQueueState(context);
   }
 
   Future<void> _importFullEvaluationQueueState() async {
-    await _queueService.importFullQueueState(context);
+    await _importExportService.importFullQueueState(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _restoreFullEvaluationQueueState() async {
-    await _queueService.restoreFullQueueState(context);
+    await _importExportService.restoreFullQueueState(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _backupEvaluationQueue() async {
-    await _queueService.backupEvaluationQueue(context);
+    await _importExportService.backupEvaluationQueue(context);
   }
 
   Future<void> _quickBackupEvaluationQueue() async {
-    await _queueService.quickBackupEvaluationQueue(context);
+    await _importExportService.quickBackupEvaluationQueue(context);
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _exportEvaluationQueueSnapshot({bool showNotification = true}) async {
-    await _queueService.exportEvaluationQueueSnapshot(
+    await _importExportService.exportEvaluationQueueSnapshot(
       context,
       showNotification: showNotification,
     );
@@ -1340,63 +1347,63 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   Future<void> _initializeDebugPreferences() async {
     await _debugPrefs.loadAllPreferences();
     if (_debugPrefs.snapshotRetentionEnabled) {
-      await _queueService.cleanupOldEvaluationSnapshots();
+      await _importExportService.cleanupOldEvaluationSnapshots();
     }
     if (mounted) lockService.safeSetState(this, () {});
   }
 
   Future<void> _exportArchive(String subfolder, String archivePrefix) async {
-    await _queueService.exportArchive(context, subfolder, archivePrefix);
+    await _importExportService.exportArchive(context, subfolder, archivePrefix);
     if (mounted) setState(() {});
   }
 
   Future<void> _exportAllEvaluationBackups() async {
-    await _queueService.exportAllEvaluationBackups(context);
+    await _importExportService.exportAllEvaluationBackups(context);
   }
 
   Future<void> _exportAutoBackups() async {
-    await _queueService.exportAutoBackups(context);
+    await _importExportService.exportAutoBackups(context);
   }
 
   Future<void> _exportSnapshots() async {
-    await _queueService.exportSnapshots(context);
+    await _importExportService.exportSnapshots(context);
   }
 
   Future<void> _restoreFromAutoBackup() async {
-    await _queueService.restoreFromAutoBackup(context);
+    await _importExportService.restoreFromAutoBackup(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _exportAllEvaluationSnapshots() async {
-    await _queueService.exportAllEvaluationSnapshots(context);
+    await _importExportService.exportAllEvaluationSnapshots(context);
   }
 
   Future<void> _importEvaluationQueue() async {
-    await _queueService.importEvaluationQueue(context);
+    await _importExportService.importEvaluationQueue(context);
     _debugPanelSetState?.call(() {});
     unawaited(_debugPrefs.setEvaluationQueueResumed(false));
   }
 
   Future<void> _restoreEvaluationQueue() async {
-    await _queueService.restoreEvaluationQueue(context);
+    await _importExportService.restoreEvaluationQueue(context);
   }
 
   Future<void> _bulkImportEvaluationQueue() async {
-    await _queueService.bulkImportEvaluationQueue(context);
+    await _importExportService.bulkImportEvaluationQueue(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
 
 
   Future<void> _importEvaluationQueueSnapshot() async {
-    await _queueService.importEvaluationQueueSnapshot(context);
+    await _importExportService.importEvaluationQueueSnapshot(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
 
   Future<void> _bulkImportEvaluationSnapshots() async {
-    await _queueService.bulkImportEvaluationSnapshots(context);
+    await _importExportService.bulkImportEvaluationSnapshots(context);
     if (mounted) setState(() {});
     _debugPanelSetState?.call(() {});
   }
@@ -1415,7 +1422,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   Future<void> _resetDebugPanelPreferences() async {
     await _debugPrefs.clearAll();
     if (_debugPrefs.snapshotRetentionEnabled) {
-      await _queueService.cleanupOldEvaluationSnapshots();
+      await _importExportService.cleanupOldEvaluationSnapshots();
     }
     lockService.safeSetState(this, () {});
     _debugPanelSetState?.call(() {});
@@ -4002,12 +4009,12 @@ class _QueueTools extends StatelessWidget {
       'Restore From Auto-Backup': s._restoreFromAutoBackup,
       'Bulk Import Evaluation Queue': s._bulkImportEvaluationQueue,
       'Bulk Import Backups': () async {
-        await s._queueService.bulkImportEvaluationBackups(s.context);
+        await s._importExportService.bulkImportEvaluationBackups(s.context);
         if (s.mounted) s.setState(() {});
         s._debugPanelSetState?.call(() {});
       },
       'Bulk Import Auto-Backups': () async {
-        await s._queueService.bulkImportAutoBackups(s.context);
+        await s._importExportService.bulkImportAutoBackups(s.context);
         if (s.mounted) s.setState(() {});
         s._debugPanelSetState?.call(() {});
       },
@@ -4022,7 +4029,7 @@ class _QueueTools extends StatelessWidget {
       'Export Current Queue Snapshot': s._exportEvaluationQueueSnapshot,
       'Quick Backup': s._quickBackupEvaluationQueue,
       'Import Quick Backups': () async {
-        await s._queueService.importQuickBackups(s.context);
+        await s._importExportService.importQuickBackups(s.context);
         s._debugPanelSetState?.call(() {});
       },
       'Export All Backups': s._exportAllEvaluationBackups,
@@ -4093,7 +4100,7 @@ class _SnapshotControls extends StatelessWidget {
           value: s._debugPrefs.snapshotRetentionEnabled,
           onChanged: (v) async {
             await s._debugPrefs.setSnapshotRetentionEnabled(v);
-            if (v) await s._queueService.cleanupOldEvaluationSnapshots();
+            if (v) await s._importExportService.cleanupOldEvaluationSnapshots();
             s.lockService.safeSetState(this, () {});
             s._debugPanelSetState?.call(() {});
           },

--- a/lib/services/evaluation_queue_import_export_service.dart
+++ b/lib/services/evaluation_queue_import_export_service.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/action_evaluation_request.dart';
+import 'evaluation_queue_service.dart';
+import 'backup_manager_service.dart';
+
+class EvaluationQueueImportExportService {
+  EvaluationQueueImportExportService({
+    required this.queueService,
+    this.backupManager,
+    this.debugPanelCallback,
+  });
+
+  final EvaluationQueueService queueService;
+  BackupManagerService? backupManager;
+  VoidCallback? debugPanelCallback;
+
+  void attachBackupManager(BackupManagerService manager) {
+    backupManager = manager;
+  }
+
+  Future<void> startAutoBackupTimer() async {
+    await backupManager?.startAutoBackupTimer();
+  }
+
+  ActionEvaluationRequest _decodeRequest(Map<String, dynamic> json) {
+    final map = Map<String, dynamic>.from(json);
+    if (map['id'] == null || map['id'] is! String || (map['id'] as String).isEmpty) {
+      map['id'] = const Uuid().v4();
+    }
+    return ActionEvaluationRequest.fromJson(map);
+  }
+
+  List<ActionEvaluationRequest> _decodeList(dynamic list) {
+    final items = <ActionEvaluationRequest>[];
+    if (list is List) {
+      for (final item in list) {
+        if (item is Map) {
+          try {
+            items.add(_decodeRequest(Map<String, dynamic>.from(item)));
+          } catch (_) {}
+        }
+      }
+    }
+    return items;
+  }
+
+  Map<String, List<ActionEvaluationRequest>> _decodeQueues(dynamic json) {
+    if (json is List) {
+      return {
+        'pending': _decodeList(json),
+        'failed': <ActionEvaluationRequest>[],
+        'completed': <ActionEvaluationRequest>[],
+      };
+    } else if (json is Map) {
+      return {
+        'pending': _decodeList(json['pending']),
+        'failed': _decodeList(json['failed']),
+        'completed': _decodeList(json['completed']),
+      };
+    }
+    throw const FormatException();
+  }
+
+  Future<void> _persist() async {
+    await queueService.persist();
+    debugPanelCallback?.call();
+  }
+
+  Future<void> _importFromClipboard() async {
+    try {
+      final data = await Clipboard.getData('text/plain');
+      if (data == null || data.text == null) return;
+      final decoded = jsonDecode(data.text!);
+      if (decoded is Map &&
+          decoded.containsKey('pending') && decoded['pending'] is List &&
+          decoded.containsKey('failed') && decoded['failed'] is List &&
+          decoded.containsKey('completed') && decoded['completed'] is List) {
+        final queues = _decodeQueues(decoded);
+        await queueService.queueLock.synchronized(() {
+          queueService.pending
+            ..clear()
+            ..addAll(queues['pending']!);
+        });
+        queueService.failed
+          ..clear()
+          ..addAll(queues['failed']!);
+        queueService.completed
+          ..clear()
+          ..addAll(queues['completed']!);
+        await _persist();
+      } else if (kDebugMode) {
+        debugPrint('Invalid clipboard data format');
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Failed to import from clipboard: $e');
+      }
+    }
+  }
+
+  Future<void> _exportToClipboard() async {
+    final jsonStr = jsonEncode(await queueService.state());
+    await Clipboard.setData(ClipboardData(text: jsonStr));
+  }
+
+  Future<void> exportEvaluationQueue(BuildContext context) async {
+    await backupManager?.exportEvaluationQueue(context);
+  }
+
+  Future<void> exportQueueToClipboard(BuildContext context) async {
+    if (backupManager != null) {
+      await backupManager!.exportQueueToClipboard(context);
+    } else {
+      await _exportToClipboard();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Queue copied to clipboard')),
+        );
+      }
+    }
+  }
+
+  Future<void> importQueueFromClipboard(BuildContext context) async {
+    if (backupManager != null) {
+      await backupManager!.importQueueFromClipboard(context);
+    } else {
+      await _importFromClipboard();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Queue imported from clipboard')),
+        );
+      }
+    }
+    debugPanelCallback?.call();
+  }
+
+  Future<void> exportFullQueueState(BuildContext context) async {
+    await backupManager?.exportFullQueueState(context);
+  }
+
+  Future<void> importFullQueueState(BuildContext context) async {
+    await backupManager?.importFullQueueState(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> restoreFullQueueState(BuildContext context) async {
+    await backupManager?.restoreFullQueueState(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> backupEvaluationQueue(BuildContext context) async {
+    await backupManager?.backupEvaluationQueue(context);
+  }
+
+  Future<void> quickBackupEvaluationQueue(BuildContext context) async {
+    await backupManager?.quickBackupEvaluationQueue(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> importQuickBackups(BuildContext context) async {
+    await backupManager?.importQuickBackups(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> cleanupOldEvaluationSnapshots() async {
+    await backupManager?.cleanupOldEvaluationSnapshots();
+  }
+
+  Future<void> exportEvaluationQueueSnapshot(BuildContext context,
+      {bool showNotification = true}) async {
+    await backupManager?.exportEvaluationQueueSnapshot(context,
+        showNotification: showNotification);
+  }
+
+  Future<void> exportArchive(
+      BuildContext context, String subfolder, String archivePrefix) async {
+    await backupManager?.exportArchive(context, subfolder, archivePrefix);
+  }
+
+  Future<void> exportAllEvaluationBackups(BuildContext context) async {
+    await backupManager?.exportAllEvaluationBackups(context);
+  }
+
+  Future<void> exportAutoBackups(BuildContext context) async {
+    await backupManager?.exportAutoBackups(context);
+  }
+
+  Future<void> exportSnapshots(BuildContext context) async {
+    await backupManager?.exportSnapshots(context);
+  }
+
+  Future<void> restoreFromAutoBackup(BuildContext context) async {
+    await backupManager?.restoreFromAutoBackup(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> exportAllEvaluationSnapshots(BuildContext context) async {
+    await backupManager?.exportAllEvaluationSnapshots(context);
+  }
+
+  Future<void> importEvaluationQueue(BuildContext context) async {
+    await backupManager?.importEvaluationQueue(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> restoreEvaluationQueue(BuildContext context) async {
+    await backupManager?.restoreEvaluationQueue(context);
+  }
+
+  Future<void> bulkImportEvaluationQueue(BuildContext context) async {
+    await backupManager?.bulkImportEvaluationQueue(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> bulkImportEvaluationBackups(BuildContext context) async {
+    await backupManager?.bulkImportEvaluationBackups(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> bulkImportAutoBackups(BuildContext context) async {
+    await backupManager?.bulkImportAutoBackups(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> importEvaluationQueueSnapshot(BuildContext context) async {
+    await backupManager?.importEvaluationQueueSnapshot(context);
+    debugPanelCallback?.call();
+  }
+
+  Future<void> bulkImportEvaluationSnapshots(BuildContext context) async {
+    await backupManager?.bulkImportEvaluationSnapshots(context);
+    debugPanelCallback?.call();
+  }
+
+  void disposeBackupManager() {
+    backupManager?.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- add `EvaluationQueueImportExportService` for handling export/import
- update `EvaluationQueueService` to expose `state()` and drop backup logic
- inject import/export service into `PokerAnalyzerScreen`
- route clipboard/file operations through the new service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850030950c8832a8ae3e90a1e14d3a6