### PR TITLE
Remove snapshot logic from BackupManagerService

### DIFF
--- a/lib/services/evaluation_processing_service.dart
+++ b/lib/services/evaluation_processing_service.dart
@@ -88,7 +88,6 @@ class EvaluationProcessingService {
           showNotification: false,
           snapshotRetentionEnabled: snapshotRetentionEnabled,
         );
-        backupManager?.scheduleSnapshotExport();
       }
       await queueService.persist();
       if (pauseRequested || cancelRequested) break;


### PR DESCRIPTION
## Summary
- clean up `BackupManagerService` to remove snapshot handling
- drop calls to removed snapshot export from evaluation processing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68502409edd4832aba4ce9f4f652c649