### PR TITLE
Add player profile import/export service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -8,6 +8,7 @@ import '../services/evaluation_queue_service.dart';
 import '../services/evaluation_queue_import_export_service.dart';
 import '../services/saved_hand_import_export_service.dart';
 import '../services/training_import_export_service.dart';
+import '../services/player_profile_import_export_service.dart';
 import '../services/evaluation_processing_service.dart';
 import '../services/debug_panel_preferences.dart';
 import 'package:uuid/uuid.dart';
@@ -83,6 +84,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final EvaluationQueueImportExportService? importExportService;
   final SavedHandImportExportService? handImportExportService;
   final TrainingImportExportService? trainingImportExportService;
+  final PlayerProfileImportExportService? playerProfileImportExportService;
   final EvaluationProcessingService? processingService;
   final DebugPanelPreferences? debugPrefsService;
   final ActionSyncService actionSync;
@@ -111,6 +113,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     this.importExportService,
     this.handImportExportService,
     this.trainingImportExportService,
+    this.playerProfileImportExportService,
     this.processingService,
     this.debugPrefsService,
     required this.actionSync,
@@ -142,6 +145,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late SavedHandManagerService _handManager;
   late SavedHandImportExportService _handImportExportService;
   late TrainingImportExportService _trainingImportExportService;
+  late PlayerProfileImportExportService _profileImportExportService;
   late PlayerManagerService _playerManager;
   late PlayerProfileService _profile;
   late BoardManagerService _boardManager;
@@ -573,6 +577,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _playerManager = widget.playerManager
       ..addListener(_onPlayerManagerChanged);
     _profile = widget.playerManager.profileService;
+    _profileImportExportService =
+        widget.playerProfileImportExportService ??
+            PlayerProfileImportExportService(_profile);
     _actionTagService = widget.actionTagService;
     _boardReveal = widget.boardReveal;
     _potSync = widget.potSyncService;
@@ -1700,6 +1707,31 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
     await _trainingImportExportService
         .exportArchive(context, [_currentTrainingSpot()]);
+  }
+
+  Future<void> exportPlayerProfileToClipboard() async {
+    if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
+    await _profileImportExportService.exportToClipboard(context);
+  }
+
+  Future<void> importPlayerProfileFromClipboard() async {
+    if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
+    await _profileImportExportService.importFromClipboard(context);
+  }
+
+  Future<void> exportPlayerProfileToFile() async {
+    if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
+    await _profileImportExportService.exportToFile(context);
+  }
+
+  Future<void> importPlayerProfileFromFile() async {
+    if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
+    await _profileImportExportService.importFromFile(context);
+  }
+
+  Future<void> exportPlayerProfileArchive() async {
+    if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
+    await _profileImportExportService.exportArchive(context);
   }
 
 
@@ -4916,6 +4948,18 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
         _dialogBtn('Import Spot From File', s.importTrainingSpotFromFile,
             disableDuringTransition: true),
         _dialogBtn('Export Spot Archive', s.exportTrainingArchive,
+            disableDuringTransition: true),
+        _dialogBtn('Export Profile To Clipboard',
+            s.exportPlayerProfileToClipboard,
+            disableDuringTransition: true),
+        _dialogBtn('Import Profile From Clipboard',
+            s.importPlayerProfileFromClipboard,
+            disableDuringTransition: true),
+        _dialogBtn('Export Profile To File', s.exportPlayerProfileToFile,
+            disableDuringTransition: true),
+        _dialogBtn('Import Profile From File', s.importPlayerProfileFromFile,
+            disableDuringTransition: true),
+        _dialogBtn('Export Profile Archive', s.exportPlayerProfileArchive,
             disableDuringTransition: true),
         _dialogBtn('Backup Evaluation Queue', s._backupEvaluationQueue,
             disableDuringTransition: true),

--- a/lib/services/player_profile_import_export_service.dart
+++ b/lib/services/player_profile_import_export_service.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:open_file/open_file.dart';
+
+import 'player_profile_service.dart';
+import '../models/player_model.dart';
+
+class PlayerProfileImportExportService {
+  PlayerProfileImportExportService(this.profile);
+
+  final PlayerProfileService profile;
+
+  Map<String, dynamic> _toMap() => {
+        'heroIndex': profile.heroIndex,
+        'heroPosition': profile.heroPosition,
+        'numberOfPlayers': profile.numberOfPlayers,
+        if (profile.opponentIndex != null)
+          'opponentIndex': profile.opponentIndex,
+        'playerPositions': [
+          for (int i = 0; i < profile.numberOfPlayers; i++)
+            profile.playerPositions[i]
+        ],
+        'playerTypes': [
+          for (int i = 0; i < profile.numberOfPlayers; i++)
+            profile.playerTypes[i]?.name ?? PlayerType.unknown.name
+        ],
+        'playerNames': [for (final p in profile.players) p.name],
+      };
+
+  void _loadFromMap(Map<String, dynamic> data) {
+    final heroIndex = data['heroIndex'] as int? ?? 0;
+    final heroPosition = data['heroPosition'] as String? ?? profile.heroPosition;
+    final count = data['numberOfPlayers'] as int? ?? profile.numberOfPlayers;
+    final opponent = data['opponentIndex'] as int?;
+    final posList = (data['playerPositions'] as List?)?.cast<String>() ?? [];
+    final typeList = (data['playerTypes'] as List?)?.cast<String>() ?? [];
+    final names = (data['playerNames'] as List?)?.cast<String>() ?? [];
+
+    profile.onPlayerCountChanged(count);
+    profile.setHeroIndex(heroIndex);
+    profile.heroPosition = heroPosition;
+    profile.opponentIndex =
+        opponent != null && opponent < profile.numberOfPlayers ? opponent : null;
+
+    profile.playerPositions.clear();
+    for (int i = 0; i < posList.length && i < profile.numberOfPlayers; i++) {
+      profile.playerPositions[i] = posList[i];
+    }
+
+    profile.playerTypes.clear();
+    for (int i = 0; i < typeList.length && i < profile.numberOfPlayers; i++) {
+      final type = PlayerType.values
+          .firstWhere((e) => e.name == typeList[i], orElse: () => PlayerType.unknown);
+      profile.playerTypes[i] = type;
+    }
+
+    for (int i = 0; i < names.length && i < profile.players.length; i++) {
+      final p = profile.players[i];
+      profile.players[i] = p.copyWith(name: names[i]);
+    }
+
+    profile.updatePositions();
+  }
+
+  String serialize() => jsonEncode(_toMap());
+
+  bool deserialize(String jsonStr) {
+    try {
+      final decoded = jsonDecode(jsonStr);
+      if (decoded is Map<String, dynamic>) {
+        _loadFromMap(Map<String, dynamic>.from(decoded));
+        return true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  Future<void> exportToClipboard(BuildContext context) async {
+    await Clipboard.setData(ClipboardData(text: serialize()));
+    if (context.mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Profile copied to clipboard')));
+    }
+  }
+
+  Future<void> importFromClipboard(BuildContext context) async {
+    try {
+      final data = await Clipboard.getData('text/plain');
+      if (data == null || data.text == null || !deserialize(data.text!)) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Invalid clipboard data')));
+        }
+        return;
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Profile loaded from clipboard')));
+      }
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to read clipboard')));
+      }
+    }
+  }
+
+  Future<void> exportToFile(BuildContext context) async {
+    final fileName =
+        'player_profile_${DateTime.now().millisecondsSinceEpoch}.json';
+    final savePath = await FilePicker.platform.saveFile(
+      dialogTitle: 'Save Profile',
+      fileName: fileName,
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (savePath == null) return;
+    final file = File(savePath);
+    try {
+      await file.writeAsString(serialize());
+      if (context.mounted) {
+        final displayName = savePath.split(Platform.pathSeparator).last;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('File saved: $displayName'),
+            action: SnackBarAction(
+              label: 'Open',
+              onPressed: () => OpenFile.open(file.path),
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to save file')));
+      }
+    }
+  }
+
+  Future<void> importFromFile(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return;
+    final path = result.files.single.path;
+    if (path == null) return;
+    final file = File(path);
+    try {
+      final content = await file.readAsString();
+      if (!deserialize(content)) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Invalid file format')));
+        }
+        return;
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('File loaded: ${file.path.split(Platform.pathSeparator).last}')));
+      }
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to read file')));
+      }
+    }
+  }
+
+  Future<void> exportArchive(BuildContext context) async {
+    final archive = Archive();
+    final data = utf8.encode(serialize());
+    final name = 'profile.json';
+    archive.addFile(ArchiveFile(name, data.length, data));
+    final bytes = ZipEncoder().encode(archive);
+    if (bytes == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to create archive')));
+      }
+      return;
+    }
+    final fileName =
+        'player_profile_${DateTime.now().millisecondsSinceEpoch}.zip';
+    final savePath = await FilePicker.platform.saveFile(
+      dialogTitle: 'Save Profile Archive',
+      fileName: fileName,
+      type: FileType.custom,
+      allowedExtensions: ['zip'],
+    );
+    if (savePath == null) return;
+    final file = File(savePath);
+    try {
+      await file.writeAsBytes(bytes, flush: true);
+      if (context.mounted) {
+        final displayName = savePath.split(Platform.pathSeparator).last;
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Archive saved: $displayName')));
+      }
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to save archive')));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `PlayerProfileImportExportService` for handling player profile IO
- inject the new service into `PokerAnalyzerScreen`
- add export/import helpers for player profiles
- expose profile import/export tools in the debug panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502fc970cc832aa067c55f28b5a2d8