### PR TITLE
Refactor board pot display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1831,7 +1831,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       canEditBoard: (i) => _boardEditing.canEditBoard(context, i),
                       usedCards: _boardEditing.usedCardKeys(),
                       editingDisabled: lockService.isLocked,
-                      visibleActions: visibleActions,
+                      potSync: _potSync,
                       boardReveal: widget.boardReveal,
                     ),
                   ),
@@ -2965,7 +2965,7 @@ class _BoardCardsSection extends StatefulWidget {
   final int currentStreet;
   final List<CardModel> boardCards;
   final List<CardModel> revealedBoardCards;
-  final List<ActionEntry> visibleActions;
+  final PotSyncService potSync;
   final void Function(int, CardModel) onCardSelected;
   final void Function(int) onCardLongPress;
   final bool Function(int index)? canEditBoard;
@@ -2981,7 +2981,7 @@ class _BoardCardsSection extends StatefulWidget {
     required this.revealedBoardCards,
     required this.onCardSelected,
     required this.onCardLongPress,
-    required this.visibleActions,
+    required this.potSync,
     required this.boardReveal,
     this.canEditBoard,
     this.usedCards = const {},
@@ -3052,7 +3052,7 @@ class _BoardCardsSectionState extends State<_BoardCardsSection>
         canEditBoard: widget.canEditBoard,
         usedCards: widget.usedCards,
         editingDisabled: widget.editingDisabled,
-        visibleActions: widget.visibleActions,
+        potSync: widget.potSync,
       ),
     );
   }

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/card_model.dart';
-import '../models/action_entry.dart';
+import '../services/pot_sync_service.dart';
 import 'board_cards_widget.dart';
 import 'pot_over_board_widget.dart';
 
@@ -9,7 +9,7 @@ class BoardDisplay extends StatelessWidget {
   final int currentStreet;
   final List<CardModel> boardCards;
   final List<CardModel> revealedBoardCards;
-  final List<ActionEntry> visibleActions;
+  final PotSyncService potSync;
   final void Function(int, CardModel) onCardSelected;
   final void Function(int index)? onCardLongPress;
   final bool Function(int index)? canEditBoard;
@@ -23,7 +23,7 @@ class BoardDisplay extends StatelessWidget {
     required this.currentStreet,
     required this.boardCards,
     required this.revealedBoardCards,
-    required this.visibleActions,
+    required this.potSync,
     required this.onCardSelected,
     this.onCardLongPress,
     this.canEditBoard,
@@ -49,7 +49,7 @@ class BoardDisplay extends StatelessWidget {
           editingDisabled: editingDisabled,
         ),
         PotOverBoardWidget(
-          visibleActions: visibleActions,
+          potSync: potSync,
           currentStreet: currentStreet,
           scale: scale,
         ),

--- a/lib/widgets/pot_over_board_widget.dart
+++ b/lib/widgets/pot_over_board_widget.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import '../models/action_entry.dart';
+import '../services/pot_sync_service.dart';
+import '../helpers/action_formatting_helper.dart';
 
 /// Displays current pot size above the board cards.
 class PotOverBoardWidget extends StatelessWidget {
-  /// Visible actions up to the current playback index.
-  final List<ActionEntry> visibleActions;
+  /// Provides synchronized pot information.
+  final PotSyncService potSync;
 
   /// Current street index. 0 = preflop, 1 = flop, ...
   final int currentStreet;
@@ -14,25 +15,17 @@ class PotOverBoardWidget extends StatelessWidget {
 
   const PotOverBoardWidget({
     Key? key,
-    required this.visibleActions,
+    required this.potSync,
     required this.currentStreet,
     this.scale = 1.0,
   }) : super(key: key);
-
-  double _calculatePot() {
-    return visibleActions
-        .where((a) =>
-            a.street <= currentStreet &&
-            (a.action == 'call' || a.action == 'bet' || a.action == 'raise'))
-        .fold<double>(0, (sum, a) => sum + (a.amount ?? 0).toDouble());
-  }
 
   @override
   Widget build(BuildContext context) {
     if (currentStreet < 1) {
       return const SizedBox.shrink();
     }
-    final potAmount = _calculatePot();
+    final potAmount = potSync.pots[currentStreet];
     return Positioned.fill(
       child: IgnorePointer(
         child: Align(
@@ -42,7 +35,7 @@ class PotOverBoardWidget extends StatelessWidget {
             child: Opacity(
               opacity: 0.7,
               child: Text(
-                'Pot: ${potAmount.toStringAsFixed(1)} BB',
+                'Pot: ${ActionFormattingHelper.formatAmount(potAmount)}',
                 style: TextStyle(
                   color: Colors.white,
                   fontSize: 14 * scale,


### PR DESCRIPTION
## Summary
- route pot display through `PotSyncService`
- stop computing pot from visible actions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68503b4fd2d4832a9befde0001e6e8c4