### PR TITLE
Serialize board reveal state

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -41,6 +41,10 @@ class SavedHand {
   final List<ActionEvaluationRequest>? pendingEvaluations;
   /// Index in the action list used when the hand was last viewed.
   final int playbackIndex;
+  /// Whether all board cards were revealed when the hand was saved.
+  final bool showFullBoard;
+  /// Street that was visible when the hand was saved.
+  final int revealStreet;
 
   SavedHand({
     required this.name,
@@ -74,10 +78,13 @@ class SavedHand {
     this.actionTags,
     this.pendingEvaluations,
     this.playbackIndex = 0,
+    this.showFullBoard = false,
+    int? revealStreet,
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
-        date = date ?? DateTime.now();
+        date = date ?? DateTime.now(),
+        revealStreet = revealStreet ?? boardStreet;
 
   SavedHand copyWith({
     String? name,
@@ -111,6 +118,8 @@ class SavedHand {
     Map<int, String?>? actionTags,
     List<ActionEvaluationRequest>? pendingEvaluations,
     int? playbackIndex,
+    bool? showFullBoard,
+    int? revealStreet,
   }) {
     return SavedHand(
       name: name ?? this.name,
@@ -174,6 +183,8 @@ class SavedHand {
                         )
                     ]),
       playbackIndex: playbackIndex ?? this.playbackIndex,
+      showFullBoard: showFullBoard ?? this.showFullBoard,
+      revealStreet: revealStreet ?? this.revealStreet,
     );
   }
 
@@ -235,6 +246,8 @@ class SavedHand {
         if (pendingEvaluations != null)
           'pendingEvaluations': [for (final e in pendingEvaluations!) e.toJson()],
         'playbackIndex': playbackIndex,
+        'showFullBoard': showFullBoard,
+        'revealStreet': revealStreet,
       };
 
   factory SavedHand.fromJson(Map<String, dynamic> json) {
@@ -331,6 +344,8 @@ class SavedHand {
       ];
     }
     final playbackIndex = json['playbackIndex'] as int? ?? 0;
+    final showFullBoard = json['showFullBoard'] as bool? ?? false;
+    final revealStreet = json['revealStreet'] as int? ?? boardStreet;
     final commentCursor = json['commentCursor'] as int?;
     final tagsCursor = json['tagsCursor'] as int?;
     Map<int, PlayerType> types = {};
@@ -379,6 +394,8 @@ class SavedHand {
       actionTags: aTags,
       pendingEvaluations: pending,
       playbackIndex: playbackIndex,
+      showFullBoard: showFullBoard,
+      revealStreet: revealStreet,
     );
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -614,6 +614,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       setActivePlayerIndex: (i) => activePlayerIndex = i,
       potSync: _potSync,
       actionHistory: _actionHistory,
+      boardReveal: _boardReveal,
     );
     _playerManager.updatePositions();
     _playbackManager.updatePlaybackState();
@@ -1506,6 +1507,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       pendingEvaluations:
           _queueService.pending.isEmpty ? null : List<ActionEvaluationRequest>.from(_queueService.pending),
       playbackIndex: _playbackManager.playbackIndex,
+      showFullBoard: _boardReveal.showFullBoard,
+      revealStreet: _boardReveal.revealStreet,
     );
   }
 

--- a/lib/services/board_reveal_service.dart
+++ b/lib/services/board_reveal_service.dart
@@ -149,5 +149,16 @@ class BoardRevealService {
 
   /// Returns true if [stage] is currently revealed.
   bool isStageRevealed(int stage) => revealStreet >= stage;
+
+  /// Serializes the current reveal state to a JSON-compatible map.
+  Map<String, dynamic> toJson() =>
+      {'showFullBoard': _showFullBoard, 'revealStreet': revealStreet};
+
+  /// Restores reveal state from [json] produced by [toJson].
+  void restoreFromJson(Map<String, dynamic>? json) {
+    _showFullBoard = json?['showFullBoard'] as bool? ?? false;
+    _revealStreet = (json?['revealStreet'] as int?) ?? boardSync.currentStreet;
+    updateRevealState();
+  }
 }
 

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -20,6 +20,7 @@ import 'folded_players_service.dart';
 import 'board_manager_service.dart';
 import 'board_sync_service.dart';
 import 'action_tag_service.dart';
+import 'board_reveal_service.dart';
 
 /// Restores a [SavedHand] object by updating all runtime services.
 ///
@@ -44,6 +45,7 @@ class HandRestoreService {
     required this.setActivePlayerIndex,
     required this.potSync,
     required this.actionHistory,
+    required this.boardReveal,
   }) {
     foldedPlayers.attach(actionSync);
   }
@@ -63,6 +65,7 @@ class HandRestoreService {
   final void Function(int?) setActivePlayerIndex;
   final PotSyncService potSync;
   final ActionHistoryService actionHistory;
+  final BoardRevealService boardReveal;
 
 
   StackManagerService restoreHand(SavedHand hand) {
@@ -133,6 +136,10 @@ class HandRestoreService {
     boardManager.boardStreet = hand.boardStreet;
     boardManager.currentStreet = hand.boardStreet;
     boardSync.updateRevealedBoardCards();
+    boardReveal.restoreFromJson({
+      'showFullBoard': hand.showFullBoard,
+      'revealStreet': hand.revealStreet,
+    });
     final seekIndex =
         hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
     playbackManager.seek(seekIndex);


### PR DESCRIPTION
## Summary
- add serialization helpers for BoardRevealService
- persist board reveal state in SavedHand
- restore board reveal state when loading a hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685073a05c90832a88b9107a410e7543