### PR TITLE
Refactor action tag logic into service

### DIFF
--- a/lib/services/action_tag_service.dart
+++ b/lib/services/action_tag_service.dart
@@ -20,6 +20,15 @@ class ActionTagService {
       ..addAll(saved ?? {});
   }
 
+  /// Recomputes all tags based on [actions].
+  void recompute(List<ActionEntry> actions) {
+    _tags.clear();
+    for (final a in actions) {
+      _tags[a.playerIndex] =
+          '${a.action}${a.amount != null ? ' ${a.amount}' : ''}';
+    }
+  }
+
   /// Updates the tag for a newly added or edited [entry].
   void updateForAction(ActionEntry entry) {
     _tags[entry.playerIndex] =

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -122,7 +122,11 @@ class HandRestoreService {
       tags: hand.tags,
       tagsCursor: hand.tagsCursor,
     );
-    actionTags.restore(hand.actionTags);
+    if (hand.actionTags != null) {
+      actionTags.restore(hand.actionTags);
+    } else {
+      actionTags.recompute(hand.actions);
+    }
     unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
     if (hand.foldedPlayers != null) {
       foldedPlayers.restoreFromJson(hand.foldedPlayers);


### PR DESCRIPTION
## Summary
- add `recompute` to `ActionTagService`
- restore action tags from saved hand or recompute if absent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685079e1f87c832a9b5fbf098d2dbaa8