### PR TITLE
Implement CurrentHandContextService

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1468,7 +1468,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final stacks =
         _potSync.calculateEffectiveStacksPerStreet(actions, numberOfPlayers);
     final collapsed = _actionHistory.collapsedStreets();
-    return SavedHand(
+    final hand = SavedHand(
       name: name ?? _defaultHandName(),
       heroIndex: _playerManager.heroIndex,
       heroPosition: _profile.heroPosition,
@@ -1493,10 +1493,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       },
       playerPositions: Map<int, String>.from(_playerManager.playerPositions),
       playerTypes: Map<int, PlayerType>.from(_playerManager.playerTypes),
-      comment: _handContext.comment,
-      tags: _handContext.tags,
-      commentCursor: _handContext.commentCursor,
-      tagsCursor: _handContext.tagsCursor,
       isFavorite: false,
       date: DateTime.now(),
       effectiveStacksPerStreet: stacks,
@@ -1510,6 +1506,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       showFullBoard: _boardReveal.showFullBoard,
       revealStreet: _boardReveal.revealStreet,
     );
+    return _handContext.applyTo(hand);
   }
 
   String saveHand() {
@@ -1597,7 +1594,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _actionSync.setAnalyzerActions(newActions);
 
       _playbackManager.resetHand();
-      _handContext.currentHandName = null;
+      _handContext.clearName();
     });
     _boardManager.startBoardTransition();
   }

--- a/lib/services/current_hand_context_service.dart
+++ b/lib/services/current_hand_context_service.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../models/saved_hand.dart';
+
 class CurrentHandContextService {
   String? _currentHandName;
 
@@ -71,6 +73,33 @@ class CurrentHandContextService {
     this.tags = tags ?? <String>[];
     this.commentCursor = commentCursor;
     this.tagsCursor = tagsCursor;
+  }
+
+  /// Restore context directly from a [SavedHand].
+  void restoreFromHand(SavedHand hand) {
+    restore(
+      name: hand.name,
+      comment: hand.comment,
+      commentCursor: hand.commentCursor,
+      tags: hand.tags,
+      tagsCursor: hand.tagsCursor,
+    );
+  }
+
+  /// Apply the current context values to an existing [SavedHand].
+  SavedHand applyTo(SavedHand hand) {
+    return hand.copyWith(
+      name: _currentHandName ?? hand.name,
+      comment: comment,
+      tags: tags,
+      commentCursor: commentCursor,
+      tagsCursor: tagsCursor,
+    );
+  }
+
+  /// Clear only the name of the current hand.
+  void clearName() {
+    _currentHandName = null;
   }
 
   void dispose() {

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -71,11 +71,11 @@ class HandRestoreService {
   StackManagerService restoreHand(SavedHand hand) {
     lockService.lock();
     try {
-      handContext.currentHandName = hand.name;
-      profile.heroIndex = hand.heroIndex;
-      profile.heroPosition = hand.heroPosition;
-      profile.numberOfPlayers = hand.numberOfPlayers;
-      playerManager.numberOfPlayers = hand.numberOfPlayers;
+    handContext.restoreFromHand(hand);
+    profile.heroIndex = hand.heroIndex;
+    profile.heroPosition = hand.heroPosition;
+    profile.numberOfPlayers = hand.numberOfPlayers;
+    playerManager.numberOfPlayers = hand.numberOfPlayers;
     for (int i = 0; i < playerManager.playerCards.length; i++) {
       playerManager.playerCards[i]
         ..clear()
@@ -115,13 +115,6 @@ class HandRestoreService {
       ..clear()
       ..addAll(hand.playerTypes ??
           {for (final k in hand.playerPositions.keys) k: PlayerType.unknown});
-    handContext.restore(
-      name: hand.name,
-      comment: hand.comment,
-      commentCursor: hand.commentCursor,
-      tags: hand.tags,
-      tagsCursor: hand.tagsCursor,
-    );
     if (hand.actionTags != null) {
       actionTags.restore(hand.actionTags);
     } else {


### PR DESCRIPTION
## Summary
- extend `CurrentHandContextService` with helpers for restoring from and applying to `SavedHand`
- delegate state management to the new service in `HandRestoreService`
- delegate saving of hand notes to the service in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507b91daec832a8e2a569740ec01ca