### PR TITLE
Centralize board clearing logic

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1266,8 +1266,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _playerManager.reset();
         _undoRedoService.resetHistory();
         _foldedPlayers.reset();
-        _boardManager.changeStreet(0);
-        _boardManager.startBoardTransition();
+        _boardManager.clearBoard();
         _actionTagService.clear();
         _stackService.reset(
             Map<int, int>.from(_playerManager.initialStacks));

--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -138,6 +138,21 @@ class BoardManagerService extends ChangeNotifier {
     _playerManager.removeBoardCard(index);
   }
 
+  /// Clear all community cards and reset board streets.
+  void clearBoard() {
+    final prevStreet = boardStreet;
+    _playerManager.boardCards.clear();
+    _playerManager.notifyListeners();
+    boardStreet = 0;
+    currentStreet = 0;
+    boardReveal.setRevealStreet(0);
+    startBoardTransition();
+    if (prevStreet != 0) {
+      _playbackManager.updatePlaybackState();
+    }
+    notifyListeners();
+  }
+
   /// Load board information from a training spot map and reset to preflop.
   void loadFromMap(Map<String, dynamic> data) {
     final boardData = data['boardCards'] as List? ?? [];

--- a/lib/services/player_manager_service.dart
+++ b/lib/services/player_manager_service.dart
@@ -268,7 +268,6 @@ class PlayerManagerService extends ChangeNotifier {
     for (final list in playerCards) {
       list.clear();
     }
-    boardCards.clear();
     for (final p in players) {
       p.revealedCards.fillRange(0, p.revealedCards.length, null);
     }


### PR DESCRIPTION
## Summary
- manage clearing board within `BoardManagerService`
- keep `PlayerManagerService.reset` focused on player state
- use `BoardManagerService.clearBoard` when resetting a hand

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68507efbe830832ab1acbcab387f6c64