### PR TITLE
Extract BoardSyncService

### DIFF
--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -61,6 +61,7 @@ class BoardManagerService extends ChangeNotifier {
   void _onPlayerManagerChanged() {
     final prevStreet = boardStreet;
     final changed = _boardSync.ensureBoardStreetConsistent();
+    _boardSync.updateRevealedBoardCards();
     if (changed) {
       startBoardTransition();
     }
@@ -84,6 +85,7 @@ class BoardManagerService extends ChangeNotifier {
     street = street.clamp(0, boardStreet);
     if (street == currentStreet) return;
     _actionSync.changeStreet(street);
+    _boardSync.updateRevealedBoardCards();
     startBoardTransition();
     _playbackManager.animatedPlayersPerStreet
         .putIfAbsent(street, () => <int>{});
@@ -145,6 +147,7 @@ class BoardManagerService extends ChangeNotifier {
     _playerManager.notifyListeners();
     boardStreet = 0;
     currentStreet = 0;
+    _boardSync.updateRevealedBoardCards();
     boardReveal.setRevealStreet(0);
     startBoardTransition();
     if (prevStreet != 0) {

--- a/lib/services/board_reveal_service.dart
+++ b/lib/services/board_reveal_service.dart
@@ -128,11 +128,10 @@ class BoardRevealService {
 
   /// Synchronize [boardSync.revealedBoardCards] with the current reveal state.
   void updateRevealState() {
-    final street = revealStreet.clamp(0, boardSync.boardStreet);
-    final count = BoardSyncService.stageCardCounts[street];
-    boardSync.revealedBoardCards
-      ..clear()
-      ..addAll(boardSync.boardCards.take(count));
+    boardSync.syncRevealState(
+      revealStreet: _revealStreet,
+      showFullBoard: _showFullBoard,
+    );
   }
 
   /// Toggle showing the full board regardless of the current street.

--- a/lib/services/board_sync_service.dart
+++ b/lib/services/board_sync_service.dart
@@ -41,7 +41,17 @@ class BoardSyncService {
   int inferBoardStreet() => _inferBoardStreet();
 
   void updateRevealedBoardCards() {
-    final visibleCount = stageCardCounts[currentStreet];
+    syncRevealState(revealStreet: currentStreet);
+  }
+
+  /// Synchronize [revealedBoardCards] for the given [revealStreet].
+  ///
+  /// When [showFullBoard] is true the board is shown up to [boardStreet]
+  /// regardless of the current street.
+  void syncRevealState({required int revealStreet, bool showFullBoard = false}) {
+    final street =
+        (showFullBoard ? boardStreet : revealStreet).clamp(0, boardStreet);
+    final visibleCount = stageCardCounts[street];
     revealedBoardCards
       ..clear()
       ..addAll(boardCards.take(visibleCount));

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -101,7 +101,6 @@ class HandRestoreService {
         visibleCount: playbackManager.playbackIndex);
     boardManager.boardStreet = hand.boardStreet;
     boardManager.currentStreet = hand.boardStreet;
-    boardSync.updateRevealedBoardCards();
     boardReveal.restoreFromJson({
       'showFullBoard': hand.showFullBoard,
       'revealStreet': hand.revealStreet,


### PR DESCRIPTION
## Summary
- centralize board reveal logic in BoardSyncService
- synchronize board state via BoardSyncService
- simplify hand restore and board reveal

## Testing
- `dart format lib/services/board_manager_service.dart lib/services/board_reveal_service.dart lib/services/board_sync_service.dart lib/services/hand_restore_service.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685080a45118832a8d1e1bb2f4429204