### PR TITLE
Extract BoardEditingService

### DIFF
--- a/lib/services/board_editing_service.dart
+++ b/lib/services/board_editing_service.dart
@@ -174,12 +174,12 @@ class BoardEditingService {
       showDuplicateCardMessage(context);
       return false;
     }
-    _boardManager.selectBoardCard(index, card);
+    _playerManager.selectBoardCard(index, card);
     return true;
   }
 
   /// Remove the board card at [index] if it exists.
   void removeBoardCard(int index) {
-    _boardManager.removeBoardCard(index);
+    _playerManager.removeBoardCard(index);
   }
 }

--- a/lib/services/board_manager_service.dart
+++ b/lib/services/board_manager_service.dart
@@ -130,15 +130,6 @@ class BoardManagerService extends ChangeNotifier {
     _playerManager.notifyListeners();
   }
 
-  /// Select a community card at [index].
-  void selectBoardCard(int index, CardModel card) {
-    _playerManager.selectBoardCard(index, card);
-  }
-
-  /// Remove the board card at [index] if it exists.
-  void removeBoardCard(int index) {
-    _playerManager.removeBoardCard(index);
-  }
 
   /// Clear all community cards and reset board streets.
   void clearBoard() {


### PR DESCRIPTION
## Summary
- centralize board editing logic in `BoardEditingService`
- remove board editing helpers from `BoardManagerService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850824ac610832ab637770c765380d6