### PR TITLE
Implement PlayerEditingService for card edits

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -175,6 +175,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                         playerManager: context.read<PlayerManagerService>(),
                                         stackService: context.read<PlaybackManagerService>().stackService,
                                         playbackManager: context.read<PlaybackManagerService>(),
+                                        profile: context.read<PlayerProfileService>(),
                                       ),
                                     ),
                                   ],

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -662,7 +662,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void selectCard(int index, CardModel card) {
-    if (_boardEditing.selectCard(context, index, card)) {
+    if (_playerEditing.selectCard(context, index, card)) {
       lockService.safeSetState(this, () {});
     }
   }
@@ -673,10 +673,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         cardIndex < playerCards[index].length ? playerCards[index][cardIndex] : null;
     final selectedCard = await showCardSelector(
       context,
-      disabledCards: _boardEditing.usedCardKeys(except: current),
+      disabledCards: _playerEditing.usedCardKeys(except: current),
     );
     if (selectedCard == null) return;
-    if (_boardEditing.setPlayerCard(
+    if (_playerEditing.setPlayerCard(
         context, index, cardIndex, selectedCard, current)) {
       lockService.safeSetState(this, () {});
     }
@@ -701,10 +701,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final current = players[playerIndex].revealedCards[cardIndex];
     final selected = await showCardSelector(
       context,
-      disabledCards: _boardEditing.usedCardKeys(except: current),
+      disabledCards: _playerEditing.usedCardKeys(except: current),
     );
     if (selected == null) return;
-    if (_boardEditing.setRevealedCard(
+    if (_playerEditing.setRevealedCard(
         context, playerIndex, cardIndex, selected, current)) {
       lockService.safeSetState(this, () {});
     }

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -669,6 +669,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                       playerManager: context.read<PlayerManagerService>(),
                                       stackService: context.read<PlaybackManagerService>().stackService,
                                       playbackManager: context.read<PlaybackManagerService>(),
+                                      profile: context.read<PlayerProfileService>(),
                                     ),
                                   ),
                                 ],

--- a/lib/services/board_editing_service.dart
+++ b/lib/services/board_editing_service.dart
@@ -129,41 +129,6 @@ class BoardEditingService {
   bool canEditBoard(BuildContext context, int index) =>
       isBoardEditAllowed(context, index);
 
-  /// Select a new card for a player by index. Returns true if the card was
-  /// applied, otherwise shows a duplicate warning and returns false.
-  bool selectCard(BuildContext context, int playerIndex, CardModel card) {
-    if (isDuplicateSelection(card, null)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.selectCard(playerIndex, card);
-    return true;
-  }
-
-  /// Replace the card at [cardIndex] for the player at [playerIndex].
-  /// [current] should be the existing card at that position if any.
-  /// Returns true if the replacement succeeded.
-  bool setPlayerCard(BuildContext context, int playerIndex, int cardIndex,
-      CardModel card, CardModel? current) {
-    if (isDuplicateSelection(card, current)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.setPlayerCard(playerIndex, cardIndex, card);
-    return true;
-  }
-
-  /// Replace a revealed card for [playerIndex]. Similar duplicate protection
-  /// as [setPlayerCard].
-  bool setRevealedCard(BuildContext context, int playerIndex, int cardIndex,
-      CardModel card, CardModel? current) {
-    if (isDuplicateSelection(card, current)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.setRevealedCard(playerIndex, cardIndex, card);
-    return true;
-  }
 
   /// Select or add a board card at [index]. Duplicate and stage order checks
   /// are enforced. Returns true if the card was applied.

--- a/lib/services/player_editing_service.dart
+++ b/lib/services/player_editing_service.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/material.dart';
+
 import '../models/action_entry.dart';
 import '../models/card_model.dart';
 import '../models/player_model.dart';
 import 'player_manager_service.dart';
 import 'stack_manager_service.dart';
 import 'playback_manager_service.dart';
+import 'player_profile_service.dart';
 
 /// Handles modifications to player info and keeps related services
 /// synchronized.
@@ -12,13 +15,76 @@ class PlayerEditingService {
     required PlayerManagerService playerManager,
     required StackManagerService stackService,
     required PlaybackManagerService playbackManager,
+    required PlayerProfileService profile,
   })  : _playerManager = playerManager,
         _stackService = stackService,
-        _playbackManager = playbackManager;
+        _playbackManager = playbackManager,
+        _profile = profile;
 
   final PlayerManagerService _playerManager;
   final StackManagerService _stackService;
   final PlaybackManagerService _playbackManager;
+  final PlayerProfileService _profile;
+
+  List<CardModel> get _boardCards => _playerManager.boardCards;
+  List<List<CardModel>> get _playerCards => _playerManager.playerCards;
+  List<PlayerModel> get _players => _profile.players;
+
+  bool _cardsEqual(CardModel? a, CardModel b) =>
+      a != null && a.rank == b.rank && a.suit == b.suit;
+
+  bool _isCardInUse(CardModel card) {
+    for (final c in _boardCards) {
+      if (_cardsEqual(c, card)) return true;
+    }
+    for (final list in _playerCards) {
+      for (final c in list) {
+        if (_cardsEqual(c, card)) return true;
+      }
+    }
+    for (final p in _players) {
+      for (final c in p.revealedCards) {
+        if (_cardsEqual(c, card)) return true;
+      }
+    }
+    return false;
+  }
+
+  /// Returns true if [card] is already used elsewhere in the hand.
+  bool isDuplicateSelection(CardModel card, CardModel? current) {
+    if (_cardsEqual(current, card)) return false;
+    return _isCardInUse(card);
+  }
+
+  /// Computes a set of card keys currently used across the table.
+  Set<String> usedCardKeys({CardModel? except}) {
+    String key(CardModel c) => '${c.rank}${c.suit}';
+    final keys = <String>{};
+    for (final c in _boardCards) {
+      keys.add(key(c));
+    }
+    for (final list in _playerCards) {
+      for (final c in list) {
+        keys.add(key(c));
+      }
+    }
+    for (final p in _players) {
+      for (final c in p.revealedCards) {
+        keys.add(key(c));
+      }
+    }
+    if (except != null) keys.remove(key(except));
+    return keys;
+  }
+
+  /// Display a snackbar warning that the selected card is already in use.
+  void showDuplicateCardMessage(BuildContext context) {
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(
+        const SnackBar(content: Text('This card is already in use')),
+      );
+  }
 
   /// Update position for [playerIndex].
   void setPosition(int playerIndex, String position) {
@@ -84,5 +150,41 @@ class PlayerEditingService {
     }
     _stackService.reset(Map<int, int>.from(_playerManager.initialStacks));
     _playbackManager.updatePlaybackState();
+  }
+
+  /// Select a new card for a player by index. Returns true if the card was
+  /// applied, otherwise shows a duplicate warning and returns false.
+  bool selectCard(BuildContext context, int playerIndex, CardModel card) {
+    if (isDuplicateSelection(card, null)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.selectCard(playerIndex, card);
+    return true;
+  }
+
+  /// Replace the card at [cardIndex] for the player at [playerIndex].
+  /// [current] should be the existing card at that position if any.
+  /// Returns true if the replacement succeeded.
+  bool setPlayerCard(BuildContext context, int playerIndex, int cardIndex,
+      CardModel card, CardModel? current) {
+    if (isDuplicateSelection(card, current)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.setPlayerCard(playerIndex, cardIndex, card);
+    return true;
+  }
+
+  /// Replace a revealed card for [playerIndex]. Similar duplicate protection
+  /// as [setPlayerCard].
+  bool setRevealedCard(BuildContext context, int playerIndex, int cardIndex,
+      CardModel card, CardModel? current) {
+    if (isDuplicateSelection(card, current)) {
+      showDuplicateCardMessage(context);
+      return false;
+    }
+    _playerManager.setRevealedCard(playerIndex, cardIndex, card);
+    return true;
   }
 }


### PR DESCRIPTION
## Summary
- expand `PlayerEditingService` with card editing and duplicate checks
- drop player card methods from `BoardEditingService`
- use `PlayerEditingService` in `PokerAnalyzerScreen`
- provide `PlayerEditingService` with `PlayerProfileService` in screens

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_685083f239c4832a9412b47680982a21