### PR TITLE
Refactor player card editing

### DIFF
--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -175,6 +175,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                                         playerManager: context.read<PlayerManagerService>(),
                                         stackService: context.read<PlaybackManagerService>().stackService,
                                         playbackManager: context.read<PlaybackManagerService>(),
+                                        profile: context.read<PlayerProfileService>(),
                                       ),
                                     ),
                                   ],

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -662,7 +662,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void selectCard(int index, CardModel card) {
-    if (_boardEditing.selectCard(context, index, card)) {
+    if (_playerEditing.selectCard(context, index, card)) {
       lockService.safeSetState(this, () {});
     }
   }
@@ -673,10 +673,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         cardIndex < playerCards[index].length ? playerCards[index][cardIndex] : null;
     final selectedCard = await showCardSelector(
       context,
-      disabledCards: _boardEditing.usedCardKeys(except: current),
+      disabledCards: _playerEditing.usedCardKeys(except: current),
     );
     if (selectedCard == null) return;
-    if (_boardEditing.setPlayerCard(
+    if (_playerEditing.setPlayerCard(
         context, index, cardIndex, selectedCard, current)) {
       lockService.safeSetState(this, () {});
     }
@@ -701,10 +701,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final current = players[playerIndex].revealedCards[cardIndex];
     final selected = await showCardSelector(
       context,
-      disabledCards: _boardEditing.usedCardKeys(except: current),
+      disabledCards: _playerEditing.usedCardKeys(except: current),
     );
     if (selected == null) return;
-    if (_boardEditing.setRevealedCard(
+    if (_playerEditing.setRevealedCard(
         context, playerIndex, cardIndex, selected, current)) {
       lockService.safeSetState(this, () {});
     }

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -669,6 +669,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                                       playerManager: context.read<PlayerManagerService>(),
                                       stackService: context.read<PlaybackManagerService>().stackService,
                                       playbackManager: context.read<PlaybackManagerService>(),
+                                      profile: context.read<PlayerProfileService>(),
                                     ),
                                   ),
                                 ],

--- a/lib/services/board_editing_service.dart
+++ b/lib/services/board_editing_service.dart
@@ -129,42 +129,6 @@ class BoardEditingService {
   bool canEditBoard(BuildContext context, int index) =>
       isBoardEditAllowed(context, index);
 
-  /// Select a new card for a player by index. Returns true if the card was
-  /// applied, otherwise shows a duplicate warning and returns false.
-  bool selectCard(BuildContext context, int playerIndex, CardModel card) {
-    if (isDuplicateSelection(card, null)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.selectCard(playerIndex, card);
-    return true;
-  }
-
-  /// Replace the card at [cardIndex] for the player at [playerIndex].
-  /// [current] should be the existing card at that position if any.
-  /// Returns true if the replacement succeeded.
-  bool setPlayerCard(BuildContext context, int playerIndex, int cardIndex,
-      CardModel card, CardModel? current) {
-    if (isDuplicateSelection(card, current)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.setPlayerCard(playerIndex, cardIndex, card);
-    return true;
-  }
-
-  /// Replace a revealed card for [playerIndex]. Similar duplicate protection
-  /// as [setPlayerCard].
-  bool setRevealedCard(BuildContext context, int playerIndex, int cardIndex,
-      CardModel card, CardModel? current) {
-    if (isDuplicateSelection(card, current)) {
-      showDuplicateCardMessage(context);
-      return false;
-    }
-    _playerManager.setRevealedCard(playerIndex, cardIndex, card);
-    return true;
-  }
-
   /// Select or add a board card at [index]. Duplicate and stage order checks
   /// are enforced. Returns true if the card was applied.
   bool selectBoardCard(BuildContext context, int index, CardModel card,


### PR DESCRIPTION
## Summary
- extend `PlayerEditingService` with card editing and duplicate validation
- route player card selections through `PlayerEditingService`
- strip player editing from `BoardEditingService`
- wire up `PlayerEditingService` with `PlayerProfileService`

## Testing
- `dart format lib/services/player_editing_service.dart lib/services/board_editing_service.dart lib/screens/poker_analyzer_screen.dart lib/screens/player_input_screen.dart lib/screens/training_pack_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508599d4e0832aa698bf282eb6dbd6