### PR TITLE
Fix duplicate method in FoldedPlayersService

### DIFF
--- a/lib/services/folded_players_service.dart
+++ b/lib/services/folded_players_service.dart
@@ -19,10 +19,7 @@ class FoldedPlayersService extends ChangeNotifier {
   Set<int> get players => _foldedPlayers;
   bool get isEmpty => _foldedPlayers.isEmpty;
 
-  /// Returns `true` if [index] is currently marked as folded.
-  bool isPlayerFolded(int index) => _foldedPlayers.contains(index);
-
-  /// Returns true if the player at [index] has folded.
+  /// Returns `true` if the player at [index] has folded.
   bool isPlayerFolded(int index) => _foldedPlayers.contains(index);
 
   /// Reset all folded players.


### PR DESCRIPTION
## Summary
- remove duplicate `isPlayerFolded` method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68508a90276c832aaf5b96d3939604c8