### PR TITLE
Refactor evaluation workflow

### DIFF
--- a/lib/services/evaluation_processing_service.dart
+++ b/lib/services/evaluation_processing_service.dart
@@ -104,6 +104,7 @@ class EvaluationProcessingService {
     if (!pauseRequested && !processing && queueService.pending.isNotEmpty) {
       await processQueue();
     }
+    debugPanelCallback?.call();
   }
 
   Future<void> cancelProcessing() async {
@@ -128,6 +129,21 @@ class EvaluationProcessingService {
     if (queueService.pending.isNotEmpty) {
       await processQueue();
     }
+    debugPanelCallback?.call();
+  }
+
+  Future<void> addEvaluationRequest(ActionEvaluationRequest req) async {
+    await queueService.addToQueue(req);
+    if (!processing && !pauseRequested) {
+      await processQueue();
+    } else {
+      debugPanelCallback?.call();
+    }
+  }
+
+  Future<void> retryFailedEvaluations() async {
+    await _retryService.retryFailedEvaluations(queueService);
+    debugPanelCallback?.call();
   }
 
   void cleanup() {

--- a/lib/services/evaluation_queue_service.dart
+++ b/lib/services/evaluation_queue_service.dart
@@ -200,10 +200,6 @@ class EvaluationQueueService {
     await _persist();
   }
 
-  /// Moves failed requests back into the pending queue.
-  Future<void> retryFailedEvaluations() async {
-    await _retryService.retryFailedEvaluations(this);
-  }
 
   void applySavedOrder(List<ActionEvaluationRequest> list, List<String>? order) {
     if (order == null || order.isEmpty) return;


### PR DESCRIPTION
## Summary
- centralize queue processing in `EvaluationProcessingService`
- remove evaluation processing helpers from `PokerAnalyzerScreen`
- update processing controls to call service directly
- drop retry helper from `EvaluationQueueService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68508ddf3478832abb94821c537f32fe