### PR TITLE
Refactor queue clipboard operations

### DIFF
--- a/lib/services/backup_manager_service.dart
+++ b/lib/services/backup_manager_service.dart
@@ -137,24 +137,6 @@ class BackupManagerService {
     }
   }
 
-  Future<void> exportQueueToClipboard(BuildContext context) async {
-    await queueService.exportToClipboard();
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Queue copied to clipboard')),
-      );
-    }
-  }
-
-  Future<void> importQueueFromClipboard(BuildContext context) async {
-    await queueService.importFromClipboard();
-    if (context.mounted) {
-      debugPanelCallback?.call();
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Queue imported from clipboard')),
-      );
-    }
-  }
 
   Future<void> exportFullQueueState(BuildContext context) async {
     try {

--- a/lib/services/evaluation_queue_import_export_service.dart
+++ b/lib/services/evaluation_queue_import_export_service.dart
@@ -116,28 +116,20 @@ class EvaluationQueueImportExportService {
   }
 
   Future<void> exportQueueToClipboard(BuildContext context) async {
-    if (backupManager != null) {
-      await backupManager!.exportQueueToClipboard(context);
-    } else {
-      await _exportToClipboard();
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Queue copied to clipboard')),
-        );
-      }
+    await _exportToClipboard();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Queue copied to clipboard')),
+      );
     }
   }
 
   Future<void> importQueueFromClipboard(BuildContext context) async {
-    if (backupManager != null) {
-      await backupManager!.importQueueFromClipboard(context);
-    } else {
-      await _importFromClipboard();
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Queue imported from clipboard')),
-        );
-      }
+    await _importFromClipboard();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Queue imported from clipboard')),
+      );
     }
     debugPanelCallback?.call();
   }


### PR DESCRIPTION
## Summary
- centralize queue clipboard import/export in `EvaluationQueueImportExportService`
- drop clipboard helpers from `BackupManagerService`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68508fb8ea70832a857df1ac5be3f44f