### PR TITLE
Refactor debug snapshots service

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -68,6 +68,7 @@ import '../helpers/debug_helpers.dart';
 import '../helpers/table_geometry_helper.dart';
 import '../helpers/action_formatting_helper.dart';
 import '../services/backup_manager_service.dart';
+import '../services/debug_snapshot_service.dart';
 import '../services/action_sync_service.dart';
 import '../services/undo_redo_service.dart';
 import '../services/action_editing_service.dart';
@@ -209,6 +210,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late final EvaluationQueueService _queueService;
   late final EvaluationQueueImportExportService _importExportService;
   late final EvaluationProcessingService _processingService;
+  late final DebugSnapshotService _debugSnapshotService;
 
 
 
@@ -558,16 +560,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _importExportService =
         widget.importExportService ??
             EvaluationQueueImportExportService(queueService: _queueService);
+    _debugSnapshotService = DebugSnapshotService();
     _trainingImportExportService =
         widget.trainingImportExportService ?? const TrainingImportExportService();
     final backupManager = widget.backupManagerService ??
         BackupManagerService(queueService: _queueService, debugPrefs: _debugPrefs);
     _importExportService.attachBackupManager(backupManager);
-    _queueService.attachBackupManager(backupManager);
+    _queueService
+      ..attachBackupManager(backupManager)
+      ..attachDebugSnapshotService(_debugSnapshotService);
+    _importExportService.attachDebugSnapshotService(_debugSnapshotService);
     _processingService = widget.processingService ?? EvaluationProcessingService(
       queueService: _queueService,
       debugPrefs: _debugPrefs,
-      backupManager: backupManager,
+      debugSnapshotService: _debugSnapshotService,
     );
     lockService = widget.lockService;
     _centerChipController = AnimationController(

--- a/lib/services/evaluation_processing_service.dart
+++ b/lib/services/evaluation_processing_service.dart
@@ -6,6 +6,7 @@ import 'evaluation_queue_service.dart';
 import 'retry_evaluation_service.dart';
 import 'evaluation_executor_service.dart';
 import 'backup_manager_service.dart';
+import 'debug_snapshot_service.dart';
 import 'debug_panel_preferences.dart';
 
 /// Manages processing of the evaluation queue.
@@ -14,6 +15,7 @@ class EvaluationProcessingService {
     required this.queueService,
     required this.debugPrefs,
     this.backupManager,
+    this.debugSnapshotService,
     this.debugPanelCallback,
     EvaluationExecutorService? executorService,
     RetryEvaluationService? retryService,
@@ -29,6 +31,7 @@ class EvaluationProcessingService {
   final EvaluationQueueService queueService;
   final DebugPanelPreferences debugPrefs;
   BackupManagerService? backupManager;
+  DebugSnapshotService? debugSnapshotService;
 
   late final EvaluationExecutorService _executorService;
   late final RetryEvaluationService _retryService;
@@ -79,7 +82,7 @@ class EvaluationProcessingService {
       });
       (success ? queueService.completed : queueService.failed).add(req);
       if (success) {
-        await backupManager?.saveQueueSnapshot(
+        await debugSnapshotService?.saveQueueSnapshot(
           await queueService.state(),
           showNotification: false,
           snapshotRetentionEnabled: snapshotRetentionEnabled,

--- a/lib/services/evaluation_queue_service.dart
+++ b/lib/services/evaluation_queue_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import '../models/action_evaluation_request.dart';
 import 'backup_manager_service.dart';
+import 'debug_snapshot_service.dart';
 import 'retry_evaluation_service.dart';
 
 class EvaluationQueueService {
@@ -41,15 +42,21 @@ class EvaluationQueueService {
   /// debug panel can update immediately.
   VoidCallback? debugPanelCallback;
   BackupManagerService? backupManager;
+  DebugSnapshotService? debugSnapshotService;
 
   void attachBackupManager(BackupManagerService manager) {
     backupManager = manager;
+  }
+
+  void attachDebugSnapshotService(DebugSnapshotService service) {
+    debugSnapshotService = service;
   }
 
   EvaluationQueueService({
     RetryEvaluationService? retryService,
     this.debugPanelCallback,
     this.backupManager,
+    this.debugSnapshotService,
   }) {
     _retryService = retryService ?? RetryEvaluationService();
     _initFuture = _initialize();
@@ -177,7 +184,7 @@ class EvaluationQueueService {
 
   Future<void> saveQueueSnapshot({bool showNotification = true}) async {
     await _initFuture;
-    await backupManager?.saveQueueSnapshot(
+    await debugSnapshotService?.saveQueueSnapshot(
       await state(),
       showNotification: showNotification,
       snapshotRetentionEnabled: snapshotRetentionEnabled,
@@ -186,7 +193,7 @@ class EvaluationQueueService {
 
   Future<void> loadQueueSnapshot() async {
     await _initFuture;
-    final decoded = await backupManager?.loadLatestQueueSnapshot();
+    final decoded = await debugSnapshotService?.loadQueueSnapshot();
     if (decoded == null) return;
     final queues = _decodeQueues(decoded);
     await _queueLock.synchronized(() {


### PR DESCRIPTION
## Summary
- create DebugSnapshotService for isolated debug queue snapshots
- wire EvaluationQueueService with DebugSnapshotService
- use DebugSnapshotService in EvaluationQueueImportExportService
- update EvaluationProcessingService to save snapshots via DebugSnapshotService
- initialize DebugSnapshotService in PokerAnalyzerScreen

## Testing
- `git diff --staged --stat`

------
https://chatgpt.com/codex/tasks/task_e_68509535a9d0832a87a58c7bda43cbbd