### PR TITLE
Add transitionSafe helper

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4029,18 +4029,10 @@ class _DebugPanelDialogState extends State<_DebugPanelDialog> {
     super.dispose();
   }
 
-  VoidCallback? _transitionSafe(VoidCallback? cb) {
-    if (cb == null) return null;
-    return () {
-      if (s.lockService.isLocked) return;
-      cb();
-    };
-  }
-
   Widget _btn(String label, VoidCallback? onPressed,
       {bool disableDuringTransition = false}) {
     final cb =
-        disableDuringTransition ? _transitionSafe(onPressed) : onPressed;
+        disableDuringTransition ? s.lockService.transitionSafe(onPressed) : onPressed;
     final disabled = disableDuringTransition && s.lockService.isLocked;
     return ElevatedButton(onPressed: disabled ? null : cb, child: Text(label));
   }
@@ -4720,7 +4712,7 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
   TextButton _dialogBtn(String label, VoidCallback? onPressed,
       {bool disableDuringTransition = false}) {
     final cb =
-        disableDuringTransition ? _transitionSafe(onPressed) : onPressed;
+        disableDuringTransition ? s.lockService.transitionSafe(onPressed) : onPressed;
     final disabled = disableDuringTransition && s.lockService.isLocked;
     return TextButton(onPressed: disabled ? null : cb, child: Text(label));
   }

--- a/lib/services/transition_lock_service.dart
+++ b/lib/services/transition_lock_service.dart
@@ -23,6 +23,15 @@ class TransitionLockService {
     state.setState(fn);
   }
 
+  /// Wrap [callback] so it only executes when transitions are unlocked.
+  VoidCallback? transitionSafe(VoidCallback? callback) {
+    if (callback == null) return null;
+    return () {
+      if (isLocked) return;
+      callback();
+    };
+  }
+
   /// Start a board transition lock for [duration].
   void startBoardTransition(Duration duration, [VoidCallback? onComplete]) {
     _transitionTimer?.cancel();

--- a/test/services/transition_lock_service_test.dart
+++ b/test/services/transition_lock_service_test.dart
@@ -76,4 +76,26 @@ void main() {
       expect(service.isLocked, isFalse);
     });
   });
+
+  group('transitionSafe', () {
+    test('returns null when callback is null', () {
+      expect(service.transitionSafe(null), isNull);
+    });
+
+    test('executes callback when not locked', () {
+      var counter = 0;
+      final cb = service.transitionSafe(() => counter++);
+      cb!();
+      expect(counter, 1);
+    });
+
+    test('skips callback when locked', () {
+      var counter = 0;
+      final cb = service.transitionSafe(() => counter++);
+      service.lock();
+      cb!();
+      expect(counter, 0);
+      service.unlock();
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- extend `TransitionLockService` with `transitionSafe` wrapper
- refactor debug panel buttons to use `transitionSafe`
- test transitionSafe behavior

## Testing
- `git commit -m "Add transitionSafe to lock service and refactor screen"`


------
https://chatgpt.com/codex/tasks/task_e_68509a141ba4832a95ad16cffd9c6abb