### PR TITLE
Refactor profile import/export

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -146,9 +146,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late SavedHandManagerService _handManager;
   late SavedHandImportExportService _handImportExportService;
   late TrainingImportExportService _trainingImportExportService;
-  late PlayerProfileImportExportService _profileImportExportService;
   late PlayerManagerService _playerManager;
-  late PlayerProfileService _profile;
   late BoardManagerService _boardManager;
   late BoardSyncService _boardSync;
   late BoardEditingService _boardEditing;
@@ -583,10 +581,6 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _timelineController = ScrollController();
     _playerManager = widget.playerManager
       ..addListener(_onPlayerManagerChanged);
-    _profile = widget.playerManager.profileService;
-    _profileImportExportService =
-        widget.playerProfileImportExportService ??
-            PlayerProfileImportExportService(_profile);
     _actionTagService = widget.actionTagService;
     _boardReveal = widget.boardReveal;
     _potSync = widget.potSyncService;
@@ -1674,27 +1668,27 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   Future<void> exportPlayerProfileToClipboard() async {
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
-    await _profileImportExportService.exportToClipboard(context);
+    await _playerManager.exportProfileToClipboard(context);
   }
 
   Future<void> importPlayerProfileFromClipboard() async {
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
-    await _profileImportExportService.importFromClipboard(context);
+    await _playerManager.importProfileFromClipboard(context);
   }
 
   Future<void> exportPlayerProfileToFile() async {
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
-    await _profileImportExportService.exportToFile(context);
+    await _playerManager.exportProfileToFile(context);
   }
 
   Future<void> importPlayerProfileFromFile() async {
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
-    await _profileImportExportService.importFromFile(context);
+    await _playerManager.importProfileFromFile(context);
   }
 
   Future<void> exportPlayerProfileArchive() async {
     if (lockService.undoRedoTransitionLock || lockService.isLocked) return;
-    await _profileImportExportService.exportArchive(context);
+    await _playerManager.exportProfileArchive(context);
   }
 
 

--- a/lib/services/player_manager_service.dart
+++ b/lib/services/player_manager_service.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import '../models/action_entry.dart';
 import '../models/card_model.dart';
 import '../models/player_model.dart';
 import '../models/saved_hand.dart';
 import 'player_profile_service.dart';
+import 'player_profile_import_export_service.dart';
 
 class PlayerManagerService extends ChangeNotifier {
-  PlayerManagerService(this.profileService);
+  PlayerManagerService(this.profileService)
+      : profileImportExportService =
+            PlayerProfileImportExportService(profileService);
 
   final PlayerProfileService profileService;
+  final PlayerProfileImportExportService profileImportExportService;
 
   int get heroIndex => profileService.heroIndex;
   String get heroPosition => profileService.heroPosition;
@@ -62,6 +67,48 @@ class PlayerManagerService extends ChangeNotifier {
 
   void setHeroIndex(int index) {
     profileService.setHeroIndex(index);
+  }
+
+  /// Convert the player profile to a map via [PlayerProfileImportExportService].
+  Map<String, dynamic> profileToMap() =>
+      profileImportExportService.toMap();
+
+  /// Load player profile information from a serialized map.
+  void loadProfileFromMap(Map<String, dynamic> data) {
+    profileImportExportService.loadFromMap(data);
+    notifyListeners();
+  }
+
+  /// Serialize the current player profile to a json string.
+  String serializeProfile() => profileImportExportService.serialize();
+
+  /// Deserialize the given json string into the player profile.
+  bool deserializeProfile(String jsonStr) {
+    final result = profileImportExportService.deserialize(jsonStr);
+    if (result) notifyListeners();
+    return result;
+  }
+
+  Future<void> exportProfileToClipboard(BuildContext context) async {
+    await profileImportExportService.exportToClipboard(context);
+  }
+
+  Future<void> importProfileFromClipboard(BuildContext context) async {
+    await profileImportExportService.importFromClipboard(context);
+    notifyListeners();
+  }
+
+  Future<void> exportProfileToFile(BuildContext context) async {
+    await profileImportExportService.exportToFile(context);
+  }
+
+  Future<void> importProfileFromFile(BuildContext context) async {
+    await profileImportExportService.importFromFile(context);
+    notifyListeners();
+  }
+
+  Future<void> exportProfileArchive(BuildContext context) async {
+    await profileImportExportService.exportArchive(context);
   }
 
   void setInitialStack(int index, int stack) {

--- a/lib/services/player_profile_import_export_service.dart
+++ b/lib/services/player_profile_import_export_service.dart
@@ -15,7 +15,8 @@ class PlayerProfileImportExportService {
 
   final PlayerProfileService profile;
 
-  Map<String, dynamic> _toMap() => {
+  /// Convert the current player profile to a serializable map.
+  Map<String, dynamic> toMap() => {
         'heroIndex': profile.heroIndex,
         'heroPosition': profile.heroPosition,
         'numberOfPlayers': profile.numberOfPlayers,
@@ -32,7 +33,8 @@ class PlayerProfileImportExportService {
         'playerNames': [for (final p in profile.players) p.name],
       };
 
-  void _loadFromMap(Map<String, dynamic> data) {
+  /// Load player profile information from a previously serialized map.
+  void loadFromMap(Map<String, dynamic> data) {
     final heroIndex = data['heroIndex'] as int? ?? 0;
     final heroPosition = data['heroPosition'] as String? ?? profile.heroPosition;
     final count = data['numberOfPlayers'] as int? ?? profile.numberOfPlayers;
@@ -67,13 +69,13 @@ class PlayerProfileImportExportService {
     profile.updatePositions();
   }
 
-  String serialize() => jsonEncode(_toMap());
+  String serialize() => jsonEncode(toMap());
 
   bool deserialize(String jsonStr) {
     try {
       final decoded = jsonDecode(jsonStr);
       if (decoded is Map<String, dynamic>) {
-        _loadFromMap(Map<String, dynamic>.from(decoded));
+        loadFromMap(Map<String, dynamic>.from(decoded));
         return true;
       }
     } catch (_) {}


### PR DESCRIPTION
## Summary
- expose profile (de)serialization helpers in `PlayerProfileImportExportService`
- embed `PlayerProfileImportExportService` into `PlayerManagerService`
- delegate profile IO from `PokerAnalyzerScreen` to `PlayerManagerService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68509b1c130c832ab3a513dfb7650bb0