### PR TITLE
Extract ActionTagService

### DIFF
--- a/lib/services/action_tag_service.dart
+++ b/lib/services/action_tag_service.dart
@@ -1,4 +1,5 @@
 import '../models/action_entry.dart';
+import '../models/saved_hand.dart';
 
 /// Manages action tags for each player, such as the last action and amount.
 class ActionTagService {
@@ -79,4 +80,17 @@ class ActionTagService {
 
   /// Returns a copy of the current tags map.
   Map<int, String?> toMap() => Map<int, String?>.from(_tags);
+
+  /// Returns `null` when no tags are present, otherwise a copy of the map.
+  Map<int, String?>? toNullableMap() => _tags.isEmpty ? null : toMap();
+
+  /// Restores tags from [hand], falling back to recomputing from actions
+  /// when the saved map is absent.
+  void restoreFromHand(SavedHand hand) {
+    if (hand.actionTags != null) {
+      restore(hand.actionTags);
+    } else {
+      recompute(hand.actions);
+    }
+  }
 }

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -87,11 +87,7 @@ class HandRestoreService {
     actionSync.setAnalyzerActions(hand.actions);
     actionHistory.updateHistory(actionSync.analyzerActions,
         visibleCount: playbackManager.playbackIndex);
-    if (hand.actionTags != null) {
-      actionTags.restore(hand.actionTags);
-    } else {
-      actionTags.recompute(hand.actions);
-    }
+    actionTags.restoreFromHand(hand);
     unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
     if (hand.foldedPlayers != null) {
       foldedPlayers.restoreFromJson(hand.foldedPlayers);

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -87,7 +87,7 @@ class SavedHandImportExportService {
       effectiveStacksPerStreet: stacks,
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
       foldedPlayers: foldedPlayers.toJson(),
-      actionTags: actionTags.toMap().isEmpty ? null : actionTags.toMap(),
+      actionTags: actionTags.toNullableMap(),
       pendingEvaluations:
           queueService.pending.isEmpty ? null : List<ActionEvaluationRequest>.from(queueService.pending),
       playbackIndex: playbackManager.playbackIndex,

--- a/lib/services/undo_redo_service.dart
+++ b/lib/services/undo_redo_service.dart
@@ -74,8 +74,7 @@ class UndoRedoService {
       tagsCursor: handContext.tagsCursor,
       collapsedHistoryStreets: actionHistory.collapsedStreets(),
       foldedPlayers: foldedPlayers.toJson(),
-      actionTags:
-          actionTagService.toMap().isEmpty ? null : actionTagService.toMap(),
+      actionTags: actionTagService.toNullableMap(),
       playbackIndex: playbackManager.playbackIndex,
       showFullBoard: boardReveal.showFullBoard,
       revealStreet: boardReveal.revealStreet,
@@ -109,11 +108,7 @@ class UndoRedoService {
         remainingStacks: snap.remainingStacks,
       );
       actionSync.setAnalyzerActions(List<ActionEntry>.from(snap.actions));
-      if (snap.actionTags != null) {
-        actionTagService.restore(snap.actionTags);
-      } else {
-        actionTagService.recompute(snap.actions);
-      }
+      actionTagService.restoreFromHand(snap);
       if (snap.foldedPlayers != null) {
         foldedPlayers.restoreFromJson(snap.foldedPlayers);
       } else {


### PR DESCRIPTION
## Summary
- consolidate action tag logic into `ActionTagService`
- expose helper to return nullable map and restore from a saved hand
- use new helpers in undo/redo, saved-hand import/export and restore

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850a1fafdac832a8f3e9924925518d6