### PR TITLE
Refactor folded players state handling

### DIFF
--- a/lib/services/folded_players_service.dart
+++ b/lib/services/folded_players_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../models/action_entry.dart';
+import '../models/saved_hand.dart';
 import 'action_sync_service.dart';
 
 /// Manages the set of folded players and provides helpers to update it.
@@ -76,9 +77,14 @@ class FoldedPlayersService extends ChangeNotifier {
     addFromAction(newEntry);
   }
 
+  /// Returns the list of folded player indexes.
+  List<int> toList() => List<int>.from(_foldedPlayers);
+
+  /// Returns `null` when no players have folded, otherwise a copy of the list.
+  List<int>? toNullableList() => _foldedPlayers.isEmpty ? null : toList();
+
   /// Returns a JSON-compatible list of folded player indexes, or `null` if none.
-  List<int>? toJson() =>
-      _foldedPlayers.isEmpty ? null : List<int>.from(_foldedPlayers);
+  List<int>? toJson() => toNullableList();
 
   /// Restores folded players from a list produced by [toJson].
   void restoreFromJson(List<dynamic>? json) {
@@ -86,6 +92,16 @@ class FoldedPlayersService extends ChangeNotifier {
       reset();
     } else {
       restore(json.cast<int>());
+    }
+  }
+
+  /// Restores folded players from [hand], recomputing from actions when
+  /// no folded player list is present.
+  void restoreFromHand(SavedHand hand) {
+    if (hand.foldedPlayers != null) {
+      restoreFromJson(hand.foldedPlayers);
+    } else {
+      recompute(hand.actions);
     }
   }
 

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -89,11 +89,7 @@ class HandRestoreService {
         visibleCount: playbackManager.playbackIndex);
     actionTags.restoreFromHand(hand);
     unawaited(queueService.setPending(hand.pendingEvaluations ?? []));
-    if (hand.foldedPlayers != null) {
-      foldedPlayers.restoreFromJson(hand.foldedPlayers);
-    } else {
-      foldedPlayers.recompute(hand.actions);
-    }
+    foldedPlayers.restoreFromHand(hand);
     actionHistory.restoreFromCollapsed(hand.collapsedHistoryStreets);
     _autoCollapseStreets();
     actionHistory.updateHistory(actionSync.analyzerActions,

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -86,7 +86,7 @@ class SavedHandImportExportService {
       date: DateTime.now(),
       effectiveStacksPerStreet: stacks,
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
-      foldedPlayers: foldedPlayers.toJson(),
+      foldedPlayers: foldedPlayers.toNullableList(),
       actionTags: actionTags.toNullableMap(),
       pendingEvaluations:
           queueService.pending.isEmpty ? null : List<ActionEvaluationRequest>.from(queueService.pending),

--- a/lib/services/undo_redo_service.dart
+++ b/lib/services/undo_redo_service.dart
@@ -73,7 +73,7 @@ class UndoRedoService {
       commentCursor: handContext.commentCursor,
       tagsCursor: handContext.tagsCursor,
       collapsedHistoryStreets: actionHistory.collapsedStreets(),
-      foldedPlayers: foldedPlayers.toJson(),
+      foldedPlayers: foldedPlayers.toNullableList(),
       actionTags: actionTagService.toNullableMap(),
       playbackIndex: playbackManager.playbackIndex,
       showFullBoard: boardReveal.showFullBoard,
@@ -109,11 +109,7 @@ class UndoRedoService {
       );
       actionSync.setAnalyzerActions(List<ActionEntry>.from(snap.actions));
       actionTagService.restoreFromHand(snap);
-      if (snap.foldedPlayers != null) {
-        foldedPlayers.restoreFromJson(snap.foldedPlayers);
-      } else {
-        foldedPlayers.recompute(snap.actions);
-      }
+      foldedPlayers.restoreFromHand(snap);
       actionHistory.restoreFromCollapsed(snap.collapsedHistoryStreets);
       actionHistory.updateHistory(actionSync.analyzerActions,
           visibleCount: playbackManager.playbackIndex);


### PR DESCRIPTION
## Summary
- centralize folded player serialization in `FoldedPlayersService`
- expose new helpers for saving and restoring folded state
- delegate restoration logic in `HandRestoreService` and `UndoRedoService`
- use new methods when exporting a saved hand

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6850a3961020832ab25fb7090c8f60fb