### PR TITLE
Centralize pot sync persistence

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -638,6 +638,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       actionHistory: _actionHistory,
       foldedPlayers: _foldedPlayers,
       boardReveal: _boardReveal,
+      potSync: _potSync,
       lockService: lockService,
     );
     _actionEditing = ActionEditingService(

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -85,6 +85,7 @@ class HandRestoreService {
     potSync.stackService = stackService;
     setActivePlayerIndex(hand.activePlayerIndex);
     actionSync.setAnalyzerActions(hand.actions);
+    potSync.restoreFromHand(hand);
     actionHistory.updateHistory(actionSync.analyzerActions,
         visibleCount: playbackManager.playbackIndex);
     actionTags.restoreFromHand(hand);

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -54,8 +54,7 @@ class SavedHandImportExportService {
     int? activePlayerIndex,
   }) {
     final actions = actionSync.analyzerActions;
-    final stacks =
-        potSync.calculateEffectiveStacksPerStreet(actions, playerManager.numberOfPlayers);
+    potSync.updateEffectiveStacks(actions, playerManager.numberOfPlayers);
     final collapsed = actionHistory.collapsedStreets();
     final reveal = boardReveal.toJson();
     final hand = SavedHand(
@@ -85,7 +84,7 @@ class SavedHandImportExportService {
       playerTypes: Map<int, PlayerType>.from(playerManager.playerTypes),
       isFavorite: false,
       date: DateTime.now(),
-      effectiveStacksPerStreet: stacks,
+      effectiveStacksPerStreet: potSync.toNullableJson(),
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,
       foldedPlayers: foldedPlayers.toNullableList(),
       actionTags: actionTags.toNullableMap(),


### PR DESCRIPTION
## Summary
- add effective stack state management to `PotSyncService`
- delegate saving/restoring of effective stacks to the service
- use new PotSyncService API from export, restore and undo/redo
- pass potSync through `UndoRedoService` constructor

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a5ae03ec832a895f0ec5e641f5ec