### PR TITLE
Finalize service isolation

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -32,6 +32,7 @@ import '../services/player_profile_service.dart';
 import '../services/playback_manager_service.dart';
 import '../services/stack_manager_service.dart';
 import '../services/folded_players_service.dart';
+import '../services/saved_hand_import_export_service.dart';
 
 class _ResultEntry {
   final String name;
@@ -111,7 +112,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     if (state != null) {
       try {
         final jsonStr = state.saveHand() as String;
-        played = SavedHand.fromJson(jsonDecode(jsonStr));
+        played =
+            SavedHandImportExportService.decode(jsonStr);
       } catch (_) {}
     }
     final original = _sessionHands[_currentIndex];

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -32,10 +32,18 @@ class SavedHandImportExportService {
 
   final SavedHandManagerService manager;
 
-  String serializeHand(SavedHand hand) => jsonEncode(hand.toJson());
+  /// Serialize [hand] to a JSON string.
+  static String encode(SavedHand hand) => jsonEncode(hand.toJson());
 
-  SavedHand deserializeHand(String jsonStr) =>
+  /// Deserialize a [SavedHand] from the given JSON string.
+  static SavedHand decode(String jsonStr) =>
       SavedHand.fromJson(jsonDecode(jsonStr) as Map<String, dynamic>);
+
+  /// Instance convenience wrapper around [encode].
+  String serializeHand(SavedHand hand) => encode(hand);
+
+  /// Instance convenience wrapper around [decode].
+  SavedHand deserializeHand(String jsonStr) => decode(jsonStr);
 
   SavedHand buildHand({
     String? name,


### PR DESCRIPTION
## Summary
- expose static encode/decode utilities in `SavedHandImportExportService`
- import export utilities in training pack screen
- use new decode method when showing training results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850a783c674832a920ddd7a70db874f