### PR TITLE
Centralize playback persistence

### DIFF
--- a/lib/services/action_sync_service.dart
+++ b/lib/services/action_sync_service.dart
@@ -125,7 +125,7 @@ class ActionSyncService extends ChangeNotifier {
   void restoreSnapshot(ActionSnapshot snap) {
     currentStreet = snap.street;
     boardStreet = snap.boardStreet;
-    playbackManager?.seek(snap.playbackIndex);
+    playbackManager?.restoreFromJson({'playbackIndex': snap.playbackIndex});
     _syncStacks();
     notifyListeners();
   }

--- a/lib/services/hand_restore_service.dart
+++ b/lib/services/hand_restore_service.dart
@@ -98,11 +98,7 @@ class HandRestoreService {
     boardManager.boardStreet = hand.boardStreet;
     boardManager.currentStreet = hand.boardStreet;
     boardReveal.restoreFromHand(hand);
-    final seekIndex =
-        hand.playbackIndex > hand.actions.length ? hand.actions.length : hand.playbackIndex;
-    playbackManager.seek(seekIndex);
-    playbackManager.animatedPlayersPerStreet.clear();
-    playbackManager.updatePlaybackState();
+    playbackManager.restoreFromHand(hand);
     // foldedPlayers recomputes automatically when actions change
     queueService.persist();
     backupManager.startAutoBackupTimer();

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -4,6 +4,7 @@ import 'action_sync_service.dart';
 import 'playback_service.dart';
 import 'stack_manager_service.dart';
 import 'pot_sync_service.dart';
+import '../models/saved_hand.dart';
 
 /// Manages playback state updates and delegates to [PlaybackService].
 class PlaybackManagerService extends ChangeNotifier {
@@ -120,4 +121,28 @@ class PlaybackManagerService extends ChangeNotifier {
       ..dispose();
     super.dispose();
   }
+
+  /// Serializes the current playback state.
+  Map<String, dynamic> toJson() => {'playbackIndex': playbackIndex};
+
+  /// Returns `null` when [playbackIndex] is zero, otherwise [toJson()].
+  Map<String, dynamic>? toNullableJson() =>
+      playbackIndex == 0 ? null : toJson();
+
+  /// Applies the current playback state to [hand].
+  SavedHand applyTo(SavedHand hand) =>
+      hand.copyWith(playbackIndex: playbackIndex);
+
+  /// Restores playback state from [json].
+  void restoreFromJson(Map<String, dynamic>? json) {
+    final idx = (json?['playbackIndex'] as int?) ?? 0;
+    final clamped = idx.clamp(0, actionSync.analyzerActions.length);
+    seek(clamped);
+    animatedPlayersPerStreet.clear();
+    updatePlaybackState();
+  }
+
+  /// Restores playback state from [hand].
+  void restoreFromHand(SavedHand hand) =>
+      restoreFromJson({'playbackIndex': hand.playbackIndex});
 }

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -98,11 +98,11 @@ class SavedHandImportExportService {
       actionTags: actionTags.toNullableMap(),
       pendingEvaluations:
           queueService.pending.isEmpty ? null : List<ActionEvaluationRequest>.from(queueService.pending),
-      playbackIndex: playbackManager.playbackIndex,
       showFullBoard: reveal['showFullBoard'] as bool,
       revealStreet: reveal['revealStreet'] as int,
     );
-    return handContext.applyTo(hand);
+    final withPlayback = playbackManager.applyTo(hand);
+    return handContext.applyTo(withPlayback);
   }
 
   Future<void> exportLastHand(BuildContext context) async {

--- a/lib/services/undo_redo_service.dart
+++ b/lib/services/undo_redo_service.dart
@@ -50,7 +50,7 @@ class UndoRedoService {
     final reveal = boardReveal.toJson();
     potSync.updateEffectiveStacks(
         actionSync.analyzerActions, playerManager.numberOfPlayers);
-    return SavedHand(
+    final hand = SavedHand(
       name: handContext.currentHandName ?? '',
       heroIndex: playerManager.heroIndex,
       heroPosition: playerManager.heroPosition,
@@ -82,10 +82,10 @@ class UndoRedoService {
       foldedPlayers: foldedPlayers.toNullableList(),
       actionTags: actionTagService.toNullableMap(),
       effectiveStacksPerStreet: potSync.toNullableJson(),
-      playbackIndex: playbackManager.playbackIndex,
       showFullBoard: reveal['showFullBoard'] as bool,
       revealStreet: reveal['revealStreet'] as int,
     );
+    return playbackManager.applyTo(hand);
   }
 
   void recordSnapshot() {
@@ -124,12 +124,7 @@ class UndoRedoService {
       boardManager.boardStreet = snap.boardStreet;
       boardManager.currentStreet = snap.boardStreet;
       boardReveal.restoreFromHand(snap);
-      final idx = snap.playbackIndex > snap.actions.length
-          ? snap.actions.length
-          : snap.playbackIndex;
-      playbackManager.seek(idx);
-      playbackManager.animatedPlayersPerStreet.clear();
-      playbackManager.updatePlaybackState();
+      playbackManager.restoreFromHand(snap);
       boardManager.startBoardTransition();
     } finally {
       lockService.unlock();


### PR DESCRIPTION
## Summary
- add serialization utilities to `PlaybackManagerService`
- delegate building playback info in `SavedHandImportExportService`
- snapshot playback state via `PlaybackManagerService` in `UndoRedoService`
- restore playback via manager for hands and action snapshots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850a8999760832ab2b0f7b4e38744a6