### PR TITLE
Add ServiceRegistry diagnostics

### DIFF
--- a/lib/services/service_registry.dart
+++ b/lib/services/service_registry.dart
@@ -47,4 +47,17 @@ class ServiceRegistry {
 
   /// Unregisters and returns the service of type [T] if it exists.
   T? unregister<T>() => _services.remove(T) as T?;
+
+  /// Returns the list of types registered in this registry only.
+  List<Type> dump() => List<Type>.unmodifiable(_services.keys);
+
+  /// Returns all registered types visible from this registry,
+  /// including those from parent registries.
+  List<Type> dumpAll() {
+    final Set<Type> types = <Type>{..._services.keys};
+    if (_parent != null) {
+      types.addAll(_parent!.dumpAll());
+    }
+    return List<Type>.unmodifiable(types);
+  }
 }


### PR DESCRIPTION
## Summary
- expose service types in ServiceRegistry
- add `dump()` for local registrations
- add `dumpAll()` for aggregated view of the hierarchy

## Testing
- `dart` or `flutter` not installed; skipped analysis and tests

------
https://chatgpt.com/codex/tasks/task_e_6850b59ef198832a9b4b5a4db891c1f4