### PR TITLE
Add ServiceExtension support

### DIFF
--- a/plugins/plugin.dart
+++ b/plugins/plugin.dart
@@ -1,9 +1,14 @@
 import 'package:poker_ai_analyzer/services/service_registry.dart';
 
+import 'service_extension.dart';
+
 /// Base interface for Poker Analyzer plug-ins.
 ///
 /// Plug-ins register their services through the provided [ServiceRegistry].
 abstract class Plugin {
   /// Registers services into the given [registry].
   void register(ServiceRegistry registry);
+
+  /// Additional service extensions provided by the plug-in.
+  List<ServiceExtension<dynamic>> get extensions => <ServiceExtension<dynamic>>[];
 }

--- a/plugins/plugin_manager.dart
+++ b/plugins/plugin_manager.dart
@@ -1,6 +1,7 @@
 import 'package:poker_ai_analyzer/services/service_registry.dart';
 
 import 'plugin.dart';
+import 'service_extension.dart';
 
 /// Manages plug-ins for the Poker Analyzer application.
 class PluginManager {
@@ -16,6 +17,9 @@ class PluginManager {
   void initializeAll(ServiceRegistry registry) {
     for (final Plugin plugin in _plugins) {
       plugin.register(registry);
+      for (final ServiceExtension<dynamic> extension in plugin.extensions) {
+        extension.register(registry);
+      }
     }
   }
 }

--- a/plugins/sample_logging_plugin.dart
+++ b/plugins/sample_logging_plugin.dart
@@ -3,6 +3,7 @@
 import 'package:poker_ai_analyzer/services/service_registry.dart';
 
 import 'plugin.dart';
+import 'service_extension.dart';
 
 /// Simple logger service for demonstration purposes.
 class LoggerService {
@@ -14,10 +15,17 @@ class LoggerService {
 }
 
 /// Example plug-in that registers a [LoggerService].
+class LoggerServiceExtension extends ServiceExtension<LoggerService> {
+  @override
+  LoggerService create(ServiceRegistry registry) => LoggerService();
+}
+
 class SampleLoggingPlugin implements Plugin {
   @override
-  void register(ServiceRegistry registry) {
-    registry.register<LoggerService>(LoggerService());
-  }
+  void register(ServiceRegistry registry) {}
+
+  @override
+  List<ServiceExtension<dynamic>> get extensions =>
+      <ServiceExtension<dynamic>>[LoggerServiceExtension()];
 }
 

--- a/plugins/service_extension.dart
+++ b/plugins/service_extension.dart
@@ -1,0 +1,16 @@
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+
+/// Base class for plugin-provided service extensions.
+///
+/// Extensions can override or provide additional service implementations.
+abstract class ServiceExtension<T> {
+  const ServiceExtension();
+
+  /// Creates an instance of [T] using the provided [registry].
+  T create(ServiceRegistry registry);
+
+  /// Registers the created service into the [registry].
+  void register(ServiceRegistry registry) {
+    registry.register<T>(create(registry));
+  }
+}


### PR DESCRIPTION
## Summary
- add abstract `ServiceExtension` class for plugin-provided services
- support plugin extensions in `Plugin` and `PluginManager`
- showcase usage in `SampleLoggingPlugin`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850bd665780832ab09eca293dcfc703