### PR TITLE
Add ServiceRegistry architecture tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: ^1.24.0
 
   flutter_lints: ^2.0.0
   build_runner: ^2.4.6

--- a/tests/architecture/service_registry_test.dart
+++ b/tests/architecture/service_registry_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+
+class _DummyService {
+  const _DummyService();
+}
+
+void main() {
+  late ServiceRegistry registry;
+
+  setUp(() {
+    registry = ServiceRegistry();
+  });
+
+  test('register and retrieve service', () {
+    const service = _DummyService();
+    registry.register<_DummyService>(service);
+    final retrieved = registry.get<_DummyService>();
+    expect(retrieved, same(service));
+  });
+
+  test('missing service throws', () {
+    expect(() => registry.get<_DummyService>(), throwsStateError);
+  });
+
+  test('duplicate registration throws', () {
+    registry.register<_DummyService>(const _DummyService());
+    expect(
+      () => registry.register<_DummyService>(const _DummyService()),
+      throwsStateError,
+    );
+  });
+
+  test('child registry falls back to parent', () {
+    const service = _DummyService();
+    registry.register<_DummyService>(service);
+    final child = registry.createChild();
+    final retrieved = child.get<_DummyService>();
+    expect(retrieved, same(service));
+  });
+
+  test('dump and dumpAll diagnostics', () {
+    registry.register<_DummyService>(const _DummyService());
+    final child = registry.createChild();
+    child.register<Object>(Object());
+
+    expect(registry.dump(), contains(_DummyService));
+    expect(registry.dumpAll(), contains(_DummyService));
+
+    expect(child.dump(), contains(Object));
+    expect(child.dumpAll(), containsAll(<Type>[_DummyService, Object]));
+  });
+}


### PR DESCRIPTION
## Summary
- add first architecture validation tests for `ServiceRegistry`
- include `test` package in `pubspec.yaml`

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850be7d1884832abe972494aad832e6