### PR TITLE
Add converter discovery plugin

### DIFF
--- a/plugins/converter_discovery_plugin.dart
+++ b/plugins/converter_discovery_plugin.dart
@@ -1,0 +1,30 @@
+import 'package:poker_ai_analyzer/plugins/converter_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
+import 'package:poker_ai_analyzer/plugins/plugin.dart';
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+
+/// Plugin that registers provided [ConverterPlugin]s into a shared
+/// [ConverterRegistry] stored in the [ServiceRegistry].
+class ConverterDiscoveryPlugin implements Plugin {
+  /// Creates a plugin that will register the given [converters].
+  ConverterDiscoveryPlugin(this._converters);
+
+  final List<ConverterPlugin> _converters;
+
+  @override
+  void register(ServiceRegistry registry) {
+    // Obtain existing ConverterRegistry or create a new one.
+    ConverterRegistry converterRegistry;
+    if (registry.contains<ConverterRegistry>()) {
+      converterRegistry = registry.get<ConverterRegistry>();
+    } else {
+      converterRegistry = ConverterRegistry();
+      registry.register<ConverterRegistry>(converterRegistry);
+    }
+
+    // Register all provided converter plugins.
+    for (final ConverterPlugin converter in _converters) {
+      converterRegistry.register(converter);
+    }
+  }
+}

--- a/tests/architecture/converter_discovery_plugin_test.dart
+++ b/tests/architecture/converter_discovery_plugin_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+import 'package:poker_ai_analyzer/plugins/converter_discovery_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+import 'package:poker_ai_analyzer/models/saved_hand.dart';
+
+class DummyConverter implements ConverterPlugin {
+  DummyConverter(this.formatId);
+
+  @override
+  final String formatId;
+
+  @override
+  SavedHand? convertFrom(String externalData) => null;
+}
+
+void main() {
+  group('ConverterDiscoveryPlugin', () {
+    test('registers converters into shared registry', () {
+      final registry = ServiceRegistry();
+      final converterA = DummyConverter('A');
+      final converterB = DummyConverter('B');
+      final pluginA = ConverterDiscoveryPlugin(<ConverterPlugin>[converterA]);
+      final pluginB = ConverterDiscoveryPlugin(<ConverterPlugin>[converterB]);
+
+      pluginA.register(registry);
+      pluginB.register(registry);
+
+      final ConverterRegistry convRegistry = registry.get<ConverterRegistry>();
+      expect(convRegistry.findByFormatId('A'), same(converterA));
+      expect(convRegistry.findByFormatId('B'), same(converterB));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `ConverterDiscoveryPlugin` for centralizing converter registration
- add unit test for the discovery plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850c7c668a4832ab47eb1118d15d9d7