### PR TITLE
Add ConverterDiscovery plugin and registry utility

### DIFF
--- a/lib/services/service_registry.dart
+++ b/lib/services/service_registry.dart
@@ -24,6 +24,16 @@ class ServiceRegistry {
     _services[type] = service as Object;
   }
 
+  /// Registers [service] for type [T] only if absent.
+  ///
+  /// This allows plugins to provide default implementations without
+  /// overriding services that may have been registered earlier.
+  void registerIfAbsent<T>(T service) {
+    if (!contains<T>()) {
+      register<T>(service);
+    }
+  }
+
   /// Returns the registered service for type [T].
   /// Throws a [StateError] if no service is registered for this type.
   T get<T>() {

--- a/plugins/converter_discovery_plugin.dart
+++ b/plugins/converter_discovery_plugin.dart
@@ -1,0 +1,25 @@
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+
+import 'converter_plugin.dart';
+import 'converter_registry.dart';
+import 'plugin.dart';
+
+/// Discovery plugin that registers provided [ConverterPlugin]s into a common
+/// [ConverterRegistry].
+class ConverterDiscoveryPlugin implements Plugin {
+  /// Creates the plugin with a list of converter [plugins].
+  ConverterDiscoveryPlugin(this.plugins);
+
+  /// Converters to register.
+  final List<ConverterPlugin> plugins;
+
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
+    final ConverterRegistry converterRegistry =
+        registry.get<ConverterRegistry>();
+    for (final ConverterPlugin plugin in plugins) {
+      converterRegistry.register(plugin);
+    }
+  }
+}

--- a/tests/architecture/converter_discovery_plugin_test.dart
+++ b/tests/architecture/converter_discovery_plugin_test.dart
@@ -1,0 +1,40 @@
+import 'package:test/test.dart';
+import 'package:poker_ai_analyzer/plugins/converter_discovery_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
+import 'package:poker_ai_analyzer/plugins/plugin_manager.dart';
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+import 'package:poker_ai_analyzer/models/saved_hand.dart';
+
+class _DummyConverter implements ConverterPlugin {
+  _DummyConverter(this.id);
+
+  final String id;
+
+  @override
+  String get formatId => id;
+
+  @override
+  SavedHand? convertFrom(String externalData) => null;
+}
+
+void main() {
+  group('ConverterDiscoveryPlugin', () {
+    test('aggregates converters from multiple plugins', () {
+      final registry = ServiceRegistry();
+      final manager = PluginManager();
+      manager.load(ConverterDiscoveryPlugin(<ConverterPlugin>[
+        _DummyConverter('a'),
+      ]));
+      manager.load(ConverterDiscoveryPlugin(<ConverterPlugin>[
+        _DummyConverter('b'),
+      ]));
+
+      manager.initializeAll(registry);
+
+      final converterRegistry = registry.get<ConverterRegistry>();
+      expect(converterRegistry.findByFormatId('a'), isNotNull);
+      expect(converterRegistry.findByFormatId('b'), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend ServiceRegistry with `registerIfAbsent` helper
- add new `ConverterDiscoveryPlugin` to aggregate converter plugins
- test that discovery plugins share a single `ConverterRegistry`

## Testing
- `No tests run due to instruction`

------
https://chatgpt.com/codex/tasks/task_e_6850c8dc3154832a86dc34f2aa72483c