### PR TITLE
Implement converter pipeline phase 1

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -1,0 +1,25 @@
+import 'package:poker_ai_analyzer/models/saved_hand.dart';
+import '../plugins/converter_registry.dart';
+
+/// High level pipeline for converting external hand formats.
+///
+/// This class is decoupled from the application core and relies only on the
+/// [ConverterRegistry] provided through the plugin discovery system.
+class ConverterPipeline {
+  ConverterPipeline(this._registry);
+
+  final ConverterRegistry _registry;
+
+  /// Attempts to import [data] using the converter identified by [formatId].
+  ///
+  /// Returns a [SavedHand] on success or `null` if the format is unsupported
+  /// or the converter failed to parse the data.
+  SavedHand? tryImport(String formatId, String data) {
+    return _registry.tryConvert(formatId, data);
+  }
+
+  /// Lists all format identifiers for which converters are registered.
+  List<String> supportedFormats() {
+    return _registry.dumpFormatIds();
+  }
+}

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -36,4 +36,8 @@ class ConverterRegistry {
     }
     return plugin.convertFrom(data);
   }
+
+  /// Returns the list of registered converter format identifiers.
+  List<String> dumpFormatIds() =>
+      List<String>.unmodifiable(<String>[for (final p in _plugins) p.formatId]);
 }


### PR DESCRIPTION
## Summary
- add ConverterPipeline to start import/export architecture
- expose a method on ConverterRegistry to list registered format IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851306a45fc832ab89b3d727412f605