### PR TITLE
Implement converter metadata

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -1,5 +1,6 @@
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import '../plugins/converter_registry.dart';
+import '../plugins/converter_info.dart';
 
 /// High level pipeline for converting external hand formats.
 ///
@@ -26,8 +27,13 @@ class ConverterPipeline {
     return _registry.tryExport(formatId, hand);
   }
 
+  /// Lists metadata for all available converters.
+  List<ConverterInfo> availableConverters() {
+    return _registry.dumpConverters();
+  }
+
   /// Lists all format identifiers for which converters are registered.
   List<String> supportedFormats() {
-    return _registry.dumpFormatIds();
+    return <String>[for (final c in availableConverters()) c.formatId];
   }
 }

--- a/plugins/converter_info.dart
+++ b/plugins/converter_info.dart
@@ -1,0 +1,6 @@
+class ConverterInfo {
+  final String formatId;
+  final String description;
+
+  ConverterInfo({required this.formatId, required this.description});
+}

--- a/plugins/converter_plugin.dart
+++ b/plugins/converter_plugin.dart
@@ -5,6 +5,9 @@ abstract class ConverterPlugin {
   /// Unique identifier of the supported external format.
   String get formatId;
 
+  /// Human readable description of the supported format.
+  String get description;
+
   /// Converts [externalData] to a [SavedHand].
   ///
   /// Returns `null` if [externalData] cannot be parsed.

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -3,6 +3,7 @@
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 
 import 'converter_plugin.dart';
+import 'converter_info.dart';
 
 /// Manages [ConverterPlugin] instances used for converting external data.
 class ConverterRegistry {
@@ -47,6 +48,11 @@ class ConverterRegistry {
     }
     return plugin.convertTo(hand);
   }
+
+  /// Returns metadata for all registered converters.
+  List<ConverterInfo> dumpConverters() => List<ConverterInfo>.unmodifiable(
+      <ConverterInfo>[for (final p in _plugins)
+        ConverterInfo(formatId: p.formatId, description: p.description)]);
 
   /// Returns the list of registered converter format identifiers.
   List<String> dumpFormatIds() =>

--- a/tests/architecture/converter_discovery_plugin_test.dart
+++ b/tests/architecture/converter_discovery_plugin_test.dart
@@ -15,6 +15,9 @@ class _DummyConverter implements ConverterPlugin {
   String get formatId => id;
 
   @override
+  String get description => 'dummy';
+
+  @override
   SavedHand? convertFrom(String externalData) => null;
 }
 

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -8,10 +8,12 @@ import 'package:poker_ai_analyzer/models/action_entry.dart';
 import 'package:poker_ai_analyzer/models/player_model.dart';
 
 class _MockConverter implements ConverterPlugin {
-  _MockConverter(this.formatId);
+  _MockConverter(this.formatId, [this.description = 'mock']);
 
   @override
   final String formatId;
+  @override
+  final String description;
 
   SavedHand? importResult;
   String? exportResult;
@@ -60,6 +62,17 @@ void main() {
 
       final pipeline = ConverterPipeline(registry);
       expect(pipeline.tryExport(_dummyHand(), 'fmt'), 'out');
+    });
+
+    test('availableConverters returns registry info', () {
+      final registry = ConverterRegistry();
+      registry.register(_MockConverter('fmt', 'Format')); 
+
+      final pipeline = ConverterPipeline(registry);
+      final infos = pipeline.availableConverters();
+      expect(infos, hasLength(1));
+      expect(infos.first.formatId, 'fmt');
+      expect(infos.first.description, 'Format');
     });
   });
 }

--- a/tests/architecture/converter_registry_test.dart
+++ b/tests/architecture/converter_registry_test.dart
@@ -7,10 +7,13 @@ import 'package:poker_ai_analyzer/models/action_entry.dart';
 import 'package:poker_ai_analyzer/models/player_model.dart';
 
 class _MockConverter implements ConverterPlugin {
-  _MockConverter(this.formatId, [this.onConvertFrom, this.onConvertTo]);
+  _MockConverter(this.formatId,
+      [this.onConvertFrom, this.onConvertTo, this.description = 'mock']);
 
   @override
   final String formatId;
+  @override
+  final String description;
 
   final SavedHand? Function(String data)? onConvertFrom;
   final String? Function(SavedHand hand)? onConvertTo;
@@ -103,6 +106,17 @@ void main() {
 
       expect(registry.tryExport('fail', _dummyHand()), isNull);
       expect(registry.tryExport('missing', _dummyHand()), isNull);
+    });
+
+    test('dumpConverters exposes converter info', () {
+      final registry = ConverterRegistry();
+      registry.register(_MockConverter('a', null, null, 'Format A'));
+      registry.register(_MockConverter('b', null, null, 'Format B'));
+
+      final infos = registry.dumpConverters();
+      expect(infos, hasLength(2));
+      expect(infos.firstWhere((i) => i.formatId == 'a').description, 'Format A');
+      expect(infos.firstWhere((i) => i.formatId == 'b').description, 'Format B');
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `description` property on `ConverterPlugin`
- introduce `ConverterInfo` to expose converter metadata
- let `ConverterRegistry` and `ConverterPipeline` provide converter info
- update discovery and registry pipeline tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685133854d7c832aa53d5d5093b1eefc