### PR TITLE
Add validation support to converter pipeline

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -26,6 +26,14 @@ class ConverterPipeline {
     return _registry.tryExport(formatId, hand);
   }
 
+  /// Validates [hand] for export using the converter identified by [formatId].
+  ///
+  /// Returns an error message if the converter rejects the hand, or `null` if
+  /// the hand is valid for export or the converter is not found.
+  String? validateForExport(SavedHand hand, String formatId) {
+    return _registry.validateForExport(formatId, hand);
+  }
+
   /// Lists all format identifiers for which converters are registered.
   List<String> supportedFormats() {
     return _registry.dumpFormatIds();

--- a/plugins/converter_plugin.dart
+++ b/plugins/converter_plugin.dart
@@ -14,4 +14,10 @@ abstract class ConverterPlugin {
   ///
   /// Implementations may return `null` if export is unsupported or fails.
   String? convertTo(SavedHand hand) => null;
+
+  /// Validates whether [hand] can be exported by this converter.
+  ///
+  /// Returns an error message if the hand is incompatible with the format,
+  /// or `null` if the hand is valid for export.
+  String? validate(SavedHand hand) => null;
 }

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -48,6 +48,18 @@ class ConverterRegistry {
     return plugin.convertTo(hand);
   }
 
+  /// Validates [hand] before exporting with the converter associated with [id].
+  ///
+  /// Returns an error message if the converter rejects the hand, or `null` if
+  /// the hand is valid for export or the converter is not found.
+  String? validateForExport(String id, SavedHand hand) {
+    final ConverterPlugin? plugin = findByFormatId(id);
+    if (plugin == null) {
+      return null;
+    }
+    return plugin.validate(hand);
+  }
+
   /// Returns the list of registered converter format identifiers.
   List<String> dumpFormatIds() =>
       List<String>.unmodifiable(<String>[for (final p in _plugins) p.formatId]);

--- a/tests/architecture/converter_discovery_plugin_test.dart
+++ b/tests/architecture/converter_discovery_plugin_test.dart
@@ -16,6 +16,9 @@ class _DummyConverter implements ConverterPlugin {
 
   @override
   SavedHand? convertFrom(String externalData) => null;
+
+  @override
+  String? validate(SavedHand hand) => null;
 }
 
 void main() {

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -15,12 +15,16 @@ class _MockConverter implements ConverterPlugin {
 
   SavedHand? importResult;
   String? exportResult;
+  String? validationResult;
 
   @override
   SavedHand? convertFrom(String externalData) => importResult;
 
   @override
   String? convertTo(SavedHand hand) => exportResult;
+
+  @override
+  String? validate(SavedHand hand) => validationResult;
 }
 
 SavedHand _dummyHand() {
@@ -60,6 +64,15 @@ void main() {
 
       final pipeline = ConverterPipeline(registry);
       expect(pipeline.tryExport(_dummyHand(), 'fmt'), 'out');
+    });
+
+    test('delegates validation to registry', () {
+      final registry = ConverterRegistry();
+      final converter = _MockConverter('fmt')..validationResult = 'err';
+      registry.register(converter);
+
+      final pipeline = ConverterPipeline(registry);
+      expect(pipeline.validateForExport(_dummyHand(), 'fmt'), 'err');
     });
   });
 }


### PR DESCRIPTION
## Summary
- extend `ConverterPlugin` with an optional `validate` method
- expose `validateForExport` on `ConverterRegistry` and `ConverterPipeline`
- update unit tests for registry, pipeline, and discovery plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68513bc602d0832a8ca70b134cb97da2