### PR TITLE
Add export validation convenience

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -22,7 +22,7 @@ class ConverterPipeline {
   ///
   /// Returns a string on success or `null` if the format is unsupported or the
   /// converter failed to produce a representation.
-  String? tryExport(SavedHand hand, String formatId) {
+  String? tryExport(String formatId, SavedHand hand) {
     return _registry.tryExport(formatId, hand);
   }
 
@@ -30,7 +30,7 @@ class ConverterPipeline {
   ///
   /// Returns an error message if the converter rejects the hand, or `null` if
   /// the hand is valid for export or the converter is not found.
-  String? validateForExport(SavedHand hand, String formatId) {
+  String? validateForExport(String formatId, SavedHand hand) {
     return _registry.validateForExport(formatId, hand);
   }
 

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -63,7 +63,7 @@ void main() {
       registry.register(converter);
 
       final pipeline = ConverterPipeline(registry);
-      expect(pipeline.tryExport(_dummyHand(), 'fmt'), 'out');
+      expect(pipeline.tryExport('fmt', _dummyHand()), 'out');
     });
 
     test('delegates validation to registry', () {
@@ -72,7 +72,7 @@ void main() {
       registry.register(converter);
 
       final pipeline = ConverterPipeline(registry);
-      expect(pipeline.validateForExport(_dummyHand(), 'fmt'), 'err');
+      expect(pipeline.validateForExport('fmt', _dummyHand()), 'err');
     });
   });
 }


### PR DESCRIPTION
## Summary
- reorder params for `tryExport` and `validateForExport`
- update pipeline tests for new API

## Testing
- `no tests run`

------
https://chatgpt.com/codex/tasks/task_e_6851438cd6b8832a9eecc9b7ee3c3149