### PR TITLE
Implement converter plugin validation and metadata

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -1,5 +1,6 @@
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import '../plugins/converter_registry.dart';
+import '../plugins/converter_info.dart';
 
 /// High level pipeline for converting external hand formats.
 ///
@@ -37,5 +38,10 @@ class ConverterPipeline {
   /// Lists all format identifiers for which converters are registered.
   List<String> supportedFormats() {
     return _registry.dumpFormatIds();
+  }
+
+  /// Lists metadata for all registered converters.
+  List<ConverterInfo> availableConverters() {
+    return _registry.dumpConverters();
   }
 }

--- a/plugins/converter_info.dart
+++ b/plugins/converter_info.dart
@@ -1,0 +1,10 @@
+/// Metadata for a registered converter.
+class ConverterInfo {
+  ConverterInfo({required this.formatId, required this.description});
+
+  /// Identifier of the converter's format.
+  final String formatId;
+
+  /// Human readable description of the converter's format.
+  final String description;
+}

--- a/plugins/converter_plugin.dart
+++ b/plugins/converter_plugin.dart
@@ -5,6 +5,9 @@ abstract class ConverterPlugin {
   /// Unique identifier of the supported external format.
   String get formatId;
 
+  /// Human readable description of the supported format.
+  String get description;
+
   /// Converts [externalData] to a [SavedHand].
   ///
   /// Returns `null` if [externalData] cannot be parsed.

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -3,6 +3,7 @@
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 
 import 'converter_plugin.dart';
+import 'converter_info.dart';
 
 /// Manages [ConverterPlugin] instances used for converting external data.
 class ConverterRegistry {
@@ -63,4 +64,9 @@ class ConverterRegistry {
   /// Returns the list of registered converter format identifiers.
   List<String> dumpFormatIds() =>
       List<String>.unmodifiable(<String>[for (final p in _plugins) p.formatId]);
+
+  /// Returns metadata about all registered converters.
+  List<ConverterInfo> dumpConverters() => List<ConverterInfo>.unmodifiable(
+      <ConverterInfo>[for (final p in _plugins)
+        ConverterInfo(formatId: p.formatId, description: p.description)]);
 }

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -2,16 +2,19 @@ import 'package:test/test.dart';
 import 'package:poker_ai_analyzer/import_export/converter_pipeline.dart';
 import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
 import 'package:poker_ai_analyzer/plugins/converter_plugin.dart';
+import 'package:poker_ai_analyzer/plugins/converter_info.dart';
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import 'package:poker_ai_analyzer/models/card_model.dart';
 import 'package:poker_ai_analyzer/models/action_entry.dart';
 import 'package:poker_ai_analyzer/models/player_model.dart';
 
 class _MockConverter implements ConverterPlugin {
-  _MockConverter(this.formatId);
+  _MockConverter(this.formatId, this.description);
 
   @override
   final String formatId;
+  @override
+  final String description;
 
   SavedHand? importResult;
   String? exportResult;
@@ -50,7 +53,7 @@ void main() {
   group('ConverterPipeline', () {
     test('delegates import to registry', () {
       final registry = ConverterRegistry();
-      final converter = _MockConverter('fmt')..importResult = _dummyHand();
+      final converter = _MockConverter('fmt', 'Format')..importResult = _dummyHand();
       registry.register(converter);
 
       final pipeline = ConverterPipeline(registry);
@@ -59,7 +62,7 @@ void main() {
 
     test('delegates export to registry', () {
       final registry = ConverterRegistry();
-      final converter = _MockConverter('fmt')..exportResult = 'out';
+      final converter = _MockConverter('fmt', 'Format')..exportResult = 'out';
       registry.register(converter);
 
       final pipeline = ConverterPipeline(registry);
@@ -68,11 +71,22 @@ void main() {
 
     test('delegates validation to registry', () {
       final registry = ConverterRegistry();
-      final converter = _MockConverter('fmt')..validationResult = 'err';
+      final converter = _MockConverter('fmt', 'Format')..validationResult = 'err';
       registry.register(converter);
 
       final pipeline = ConverterPipeline(registry);
       expect(pipeline.validateForExport(_dummyHand(), 'fmt'), 'err');
+    });
+
+    test('provides converter metadata via availableConverters', () {
+      final registry = ConverterRegistry();
+      registry.register(_MockConverter('fmt', 'Desc'));
+
+      final pipeline = ConverterPipeline(registry);
+      final list = pipeline.availableConverters();
+      expect(list, hasLength(1));
+      expect(list.first.formatId, 'fmt');
+      expect(list.first.description, 'Desc');
     });
   });
 }


### PR DESCRIPTION
## Summary
- extend ConverterPlugin with `description`
- introduce `ConverterInfo` for converter metadata
- add `dumpConverters` in ConverterRegistry and `availableConverters` in ConverterPipeline
- add validation and metadata tests

## Testing
- `dart` not available: skipped formatting

------
https://chatgpt.com/codex/tasks/task_e_685146244b60832aae6ba427f0ea8e56