### PR TITLE
Phase 9 converter filtering

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -40,8 +40,15 @@ class ConverterPipeline {
     return _registry.dumpFormatIds();
   }
 
-  /// Lists metadata for all registered converters.
-  List<ConverterInfo> availableConverters() {
-    return _registry.dumpConverters();
+  /// Lists metadata for registered converters, optionally filtered by
+  /// [supportsImport] or [supportsExport].
+  List<ConverterInfo> availableConverters({
+    bool? supportsImport,
+    bool? supportsExport,
+  }) {
+    return _registry.queryConverters(
+      supportsImport: supportsImport,
+      supportsExport: supportsExport,
+    );
   }
 }

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -73,4 +73,28 @@ class ConverterRegistry {
           description: p.description,
           capabilities: p.capabilities,
         )]);
+
+  /// Returns converter metadata filtered by capability flags.
+  ///
+  /// When a flag is `null` it will not be used for filtering.
+  List<ConverterInfo> queryConverters({
+    bool? supportsImport,
+    bool? supportsExport,
+    bool? requiresBoard,
+  }) {
+    return List<ConverterInfo>.unmodifiable(<ConverterInfo>[
+      for (final p in _plugins)
+        if ((supportsImport == null ||
+                p.capabilities.supportsImport == supportsImport) &&
+            (supportsExport == null ||
+                p.capabilities.supportsExport == supportsExport) &&
+            (requiresBoard == null ||
+                p.capabilities.requiresBoard == requiresBoard))
+          ConverterInfo(
+            formatId: p.formatId,
+            description: p.description,
+            capabilities: p.capabilities,
+          )
+    ]);
+  }
 }

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -99,5 +99,45 @@ void main() {
       expect(list.first.description, 'Desc');
       expect(list.first.capabilities.supportsImport, isTrue);
     });
+
+    test('availableConverters supports capability filters', () {
+      final registry = ConverterRegistry();
+      registry.register(
+        _MockConverter(
+          'exp',
+          'Export',
+          const ConverterFormatCapabilities(
+            supportsImport: false,
+            supportsExport: true,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          ),
+        ),
+      );
+      registry.register(
+        _MockConverter(
+          'imp',
+          'Import',
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          ),
+        ),
+      );
+
+      final pipeline = ConverterPipeline(registry);
+
+      final exportList =
+          pipeline.availableConverters(supportsExport: true, supportsImport: false);
+      expect(exportList.map((c) => c.formatId), contains('exp'));
+      expect(exportList.map((c) => c.formatId), isNot(contains('imp')));
+
+      final importList =
+          pipeline.availableConverters(supportsImport: true, supportsExport: false);
+      expect(importList.map((c) => c.formatId), contains('imp'));
+      expect(importList.map((c) => c.formatId), isNot(contains('exp')));
+    });
   });
 }

--- a/tests/architecture/converter_registry_test.dart
+++ b/tests/architecture/converter_registry_test.dart
@@ -149,5 +149,49 @@ void main() {
       expect(converters.first.description, 'Test fmt');
       expect(converters.first.capabilities.supportsExport, isTrue);
     });
+
+    test('queryConverters filters by capability flags', () {
+      final registry = ConverterRegistry();
+      registry.register(
+        _MockConverter(
+          'import_only',
+          'Import Only',
+          null,
+          null,
+          null,
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          ),
+        ),
+      );
+      registry.register(
+        _MockConverter(
+          'export_only',
+          'Export Only',
+          null,
+          null,
+          null,
+          const ConverterFormatCapabilities(
+            supportsImport: false,
+            supportsExport: true,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          ),
+        ),
+      );
+
+      final importConverters =
+          registry.queryConverters(supportsImport: true, supportsExport: false);
+      expect(importConverters, hasLength(1));
+      expect(importConverters.first.formatId, 'import_only');
+
+      final exportConverters =
+          registry.queryConverters(supportsExport: true, supportsImport: false);
+      expect(exportConverters, hasLength(1));
+      expect(exportConverters.first.formatId, 'export_only');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add capability-based filtering in `ConverterRegistry`
- expose filter params via `ConverterPipeline.availableConverters`
- cover registry and pipeline filters with unit tests

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685168824fc0832aace290193de263da