### PR TITLE
Add converter capability filtering

### DIFF
--- a/import_export/converter_pipeline.dart
+++ b/import_export/converter_pipeline.dart
@@ -41,7 +41,16 @@ class ConverterPipeline {
   }
 
   /// Lists metadata for all registered converters.
-  List<ConverterInfo> availableConverters() {
-    return _registry.dumpConverters();
+  ///
+  /// Optional parameters can filter by import/export support. This is useful
+  /// for building UI selection lists.
+  List<ConverterInfo> availableConverters({
+    bool? supportsImport,
+    bool? supportsExport,
+  }) {
+    return _registry.dumpConverters(
+      supportsImport: supportsImport,
+      supportsExport: supportsExport,
+    );
   }
 }

--- a/plugins/converter_registry.dart
+++ b/plugins/converter_registry.dart
@@ -66,11 +66,36 @@ class ConverterRegistry {
       List<String>.unmodifiable(<String>[for (final p in _plugins) p.formatId]);
 
   /// Returns metadata about all registered converters.
-  List<ConverterInfo> dumpConverters() => List<ConverterInfo>.unmodifiable(
-      <ConverterInfo>[for (final p in _plugins)
+  ///
+  /// Optional parameters can filter converters by their capability flags.
+  /// If a parameter is `null`, it is ignored during filtering.
+  List<ConverterInfo> dumpConverters({
+    bool? supportsImport,
+    bool? supportsExport,
+    bool? requiresBoard,
+  }) {
+    final filtered = _plugins.where((ConverterPlugin p) {
+      if (supportsImport != null &&
+          p.capabilities.supportsImport != supportsImport) {
+        return false;
+      }
+      if (supportsExport != null &&
+          p.capabilities.supportsExport != supportsExport) {
+        return false;
+      }
+      if (requiresBoard != null &&
+          p.capabilities.requiresBoard != requiresBoard) {
+        return false;
+      }
+      return true;
+    });
+    return List<ConverterInfo>.unmodifiable(<ConverterInfo>[
+      for (final p in filtered)
         ConverterInfo(
           formatId: p.formatId,
           description: p.description,
           capabilities: p.capabilities,
-        )]);
+        )
+    ]);
+  }
 }

--- a/tests/architecture/converter_pipeline_test.dart
+++ b/tests/architecture/converter_pipeline_test.dart
@@ -99,5 +99,32 @@ void main() {
       expect(list.first.description, 'Desc');
       expect(list.first.capabilities.supportsImport, isTrue);
     });
+
+    test('availableConverters supports filtering', () {
+      final registry = ConverterRegistry();
+      registry.register(_MockConverter('i', 'Import', null, null, null,
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          )));
+      registry.register(_MockConverter('e', 'Export', null, null, null,
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: true,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          )));
+      final pipeline = ConverterPipeline(registry);
+
+      final onlyExports = pipeline.availableConverters(supportsExport: true);
+      expect(onlyExports, hasLength(1));
+      expect(onlyExports.first.formatId, 'e');
+
+      final onlyImports = pipeline.availableConverters(supportsExport: false);
+      expect(onlyImports, hasLength(1));
+      expect(onlyImports.first.formatId, 'i');
+    });
   });
 }

--- a/tests/architecture/converter_registry_test.dart
+++ b/tests/architecture/converter_registry_test.dart
@@ -149,5 +149,35 @@ void main() {
       expect(converters.first.description, 'Test fmt');
       expect(converters.first.capabilities.supportsExport, isTrue);
     });
+
+    test('dumpConverters can filter by capabilities', () {
+      final registry = ConverterRegistry();
+      registry.register(_MockConverter('imp', 'Import only', null, null, null,
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: true,
+          )));
+      registry.register(_MockConverter('exp', 'Export', null, null, null,
+          const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: true,
+            requiresBoard: true,
+            supportsMultiStreet: true,
+          )));
+
+      final imports = registry.dumpConverters(supportsExport: false);
+      expect(imports, hasLength(1));
+      expect(imports.first.formatId, 'imp');
+
+      final exports = registry.dumpConverters(supportsExport: true);
+      expect(exports, hasLength(1));
+      expect(exports.first.formatId, 'exp');
+
+      final requires = registry.dumpConverters(requiresBoard: true);
+      expect(requires, hasLength(1));
+      expect(requires.first.formatId, 'exp');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- support capability filtering in `ConverterRegistry.dumpConverters`
- expose filter options via `ConverterPipeline.availableConverters`
- test registry and pipeline filter logic

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68516a6cb928832ab0260f9a63d7bae7