### PR TITLE
Extend PokerStars converter to parse preflop actions

### DIFF
--- a/plugins/converters/pokerstars_hand_history_converter.dart
+++ b/plugins/converters/pokerstars_hand_history_converter.dart
@@ -176,6 +176,73 @@ class PokerStarsHandHistoryConverter extends ConverterPlugin {
       }
     }
 
+    // Parse preflop actions between HOLE CARDS and FLOP.
+    final Map<String, int> nameToIndex = {
+      for (int i = 0; i < seatEntries.length; i++)
+        (seatEntries[i]['name'] as String).toLowerCase(): i
+    };
+    final actions = <ActionEntry>[];
+    final actionTags = <int, String?>{};
+    if (holeIndex != -1) {
+      final endIndex = lines.indexWhere(
+          (l) => l.startsWith('*** FLOP ***'), holeIndex + 1);
+      for (int i = holeIndex + 1;
+          i < lines.length && (endIndex == -1 || i < endIndex);
+          i++) {
+        final line = lines[i].trim();
+        if (line.isEmpty) continue;
+        Match? m;
+
+        m = RegExp(r'^(.+?): folds', caseSensitive: false).firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            actions.add(ActionEntry(0, idx, 'fold'));
+            actionTags[idx] = 'fold';
+          }
+          continue;
+        }
+
+        m = RegExp(r'^(.+?): calls [\$€£]?([\d,.]+)(.*)',
+                caseSensitive: false)
+            .firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            final amt = _parseAmount(m.group(2)!);
+            final amount =
+                bigBlind != null && bigBlind! > 0
+                    ? (amt / bigBlind!).round()
+                    : amt.round();
+            final isAllIn = m.group(3)!.toLowerCase().contains('all-in');
+            final action = isAllIn ? 'all-in' : 'call';
+            actions.add(ActionEntry(0, idx, action, amount: amount));
+            actionTags[idx] = '$action $amount';
+          }
+          continue;
+        }
+
+        m = RegExp(r'^(.+?): raises [\$€£]?([\d,.]+) to [\$€£]?([\d,.]+)(.*)',
+                caseSensitive: false)
+            .firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            final amt = _parseAmount(m.group(3)!);
+            final amount =
+                bigBlind != null && bigBlind! > 0
+                    ? (amt / bigBlind!).round()
+                    : amt.round();
+            final isAllIn = m.group(4)!.toLowerCase().contains('all-in');
+            final action = isAllIn ? 'all-in' : 'raise';
+            actions.add(ActionEntry(0, idx, action, amount: amount));
+            actionTags[idx] = '$action $amount';
+          }
+          continue;
+        }
+      }
+    }
+
     final stackSizes = <int, int>{};
     for (int i = 0; i < seatEntries.length; i++) {
       final stack = seatEntries[i]['stack'] as double? ?? 0;
@@ -221,11 +288,12 @@ class PokerStarsHandHistoryConverter extends ConverterPlugin {
       playerCards: playerCards,
       boardCards: boardCards,
       boardStreet: boardStreet,
-      actions: <ActionEntry>[],
+      actions: actions,
       stackSizes: stackSizes,
       playerPositions: playerPositions,
       playerTypes: {for (var i = 0; i < playerCount; i++) i: PlayerType.unknown},
       comment: tableName,
+      actionTags: actionTags.isEmpty ? null : actionTags,
     );
   }
 }


### PR DESCRIPTION
## Summary
- parse calls, raises, folds and all-ins from PokerStars histories
- store parsed actions and resulting action tags in `SavedHand`

## Testing
- `No tests run due to user request`

------
https://chatgpt.com/codex/tasks/task_e_6851825660e8832a8578e95867aae54c