### PR TITLE
Add TURN action parsing to PokerStars converter

### DIFF
--- a/plugins/converters/pokerstars_hand_history_converter.dart
+++ b/plugins/converters/pokerstars_hand_history_converter.dart
@@ -306,6 +306,69 @@ class PokerStarsHandHistoryConverter extends ConverterPlugin {
       }
     }
 
+    // Parse turn actions between TURN and RIVER.
+    final turnIndex =
+        lines.indexWhere((l) => l.startsWith('*** TURN'), flopIndex + 1);
+    if (turnIndex != -1) {
+      final endIndex =
+          lines.indexWhere((l) => l.startsWith('*** RIVER'), turnIndex + 1);
+      for (int i = turnIndex + 1;
+          i < lines.length && (endIndex == -1 || i < endIndex);
+          i++) {
+        final line = lines[i].trim();
+        if (line.isEmpty) continue;
+        Match? m;
+
+        m = RegExp(r'^(.+?): folds', caseSensitive: false).firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            actions.add(ActionEntry(2, idx, 'fold'));
+            actionTags[idx] = 'fold';
+          }
+          continue;
+        }
+
+        m = RegExp(r'^(.+?): calls [\$€£]?([\d,.]+)(.*)',
+                caseSensitive: false)
+            .firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            final amt = _parseAmount(m.group(2)!);
+            final amount =
+                bigBlind != null && bigBlind! > 0
+                    ? (amt / bigBlind!).round()
+                    : amt.round();
+            final isAllIn = m.group(3)!.toLowerCase().contains('all-in');
+            final action = isAllIn ? 'all-in' : 'call';
+            actions.add(ActionEntry(2, idx, action, amount: amount));
+            actionTags[idx] = '$action $amount';
+          }
+          continue;
+        }
+
+        m = RegExp(r'^(.+?): raises [\$€£]?([\d,.]+) to [\$€£]?([\d,.]+)(.*)',
+                caseSensitive: false)
+            .firstMatch(line);
+        if (m != null) {
+          final idx = nameToIndex[m.group(1)!.toLowerCase()];
+          if (idx != null) {
+            final amt = _parseAmount(m.group(3)!);
+            final amount =
+                bigBlind != null && bigBlind! > 0
+                    ? (amt / bigBlind!).round()
+                    : amt.round();
+            final isAllIn = m.group(4)!.toLowerCase().contains('all-in');
+            final action = isAllIn ? 'all-in' : 'raise';
+            actions.add(ActionEntry(2, idx, action, amount: amount));
+            actionTags[idx] = '$action $amount';
+          }
+          continue;
+        }
+      }
+    }
+
     final stackSizes = <int, int>{};
     for (int i = 0; i < seatEntries.length; i++) {
       final stack = seatEntries[i]['stack'] as double? ?? 0;


### PR DESCRIPTION
## Summary
- parse player actions that occur on the TURN in PokerStars hand histories

## Testing
- `dart` is not installed so formatting wasn't run

------
https://chatgpt.com/codex/tasks/task_e_6851854a7c6c832a897d77efff48b59c