### PR TITLE
Add tournament info section to saved hand details

### DIFF
--- a/lib/widgets/saved_hand_detail_sheet.dart
+++ b/lib/widgets/saved_hand_detail_sheet.dart
@@ -16,6 +16,13 @@ class SavedHandDetailSheet extends StatelessWidget {
     required this.onExportCsv,
   });
 
+  String _formatDate(DateTime date) {
+    final d = date.day.toString().padLeft(2, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    final y = date.year.toString();
+    return '$d.$m.$y';
+  }
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -39,7 +46,42 @@ class SavedHandDetailSheet extends StatelessWidget {
                 ),
               ],
             ),
+            const SizedBox(height: 4),
+            Text(
+              _formatDate(hand.date),
+              style: const TextStyle(color: Colors.white60),
+            ),
             const SizedBox(height: 8),
+            if ([
+                  hand.tournamentId,
+                  hand.buyIn,
+                  hand.totalPrizePool,
+                  hand.numberOfEntrants,
+                  hand.gameType
+                ].any((e) => e != null && e.toString().isNotEmpty)) ...[
+              const Text('Tournament Info',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  )),
+              const SizedBox(height: 4),
+              if (hand.tournamentId != null && hand.tournamentId!.isNotEmpty)
+                Text('ID: ${hand.tournamentId}',
+                    style: const TextStyle(color: Colors.white70)),
+              if (hand.buyIn != null)
+                Text('Buy-In: ${hand.buyIn}',
+                    style: const TextStyle(color: Colors.white70)),
+              if (hand.totalPrizePool != null)
+                Text('Prize Pool: ${hand.totalPrizePool}',
+                    style: const TextStyle(color: Colors.white70)),
+              if (hand.numberOfEntrants != null)
+                Text('Entrants: ${hand.numberOfEntrants}',
+                    style: const TextStyle(color: Colors.white70)),
+              if (hand.gameType != null && hand.gameType!.isNotEmpty)
+                Text('Game: ${hand.gameType}',
+                    style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+            ],
             Text('Позиция: ${hand.heroPosition}',
                 style: const TextStyle(color: Colors.white70)),
             const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- show the date below the saved hand name
- add new "Tournament Info" section in SavedHandDetailSheet

## Testing
- `dart format lib/widgets/saved_hand_detail_sheet.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6593db4832ab75171a7755bb009