### PR TITLE
Extend training spot metadata

### DIFF
--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -1,0 +1,172 @@
+import 'action_entry.dart';
+import 'card_model.dart';
+import 'player_model.dart';
+import 'saved_hand.dart';
+
+class TrainingSpot {
+  final List<List<CardModel>> playerCards;
+  final List<CardModel> boardCards;
+  final List<ActionEntry> actions;
+  final int heroIndex;
+  final int numberOfPlayers;
+  final List<PlayerType> playerTypes;
+  final List<String> positions;
+  final List<int> stacks;
+  final String? tournamentId;
+  final int? buyIn;
+  final int? totalPrizePool;
+  final int? numberOfEntrants;
+  final String? gameType;
+
+  TrainingSpot({
+    required this.playerCards,
+    required this.boardCards,
+    required this.actions,
+    required this.heroIndex,
+    required this.numberOfPlayers,
+    required this.playerTypes,
+    required this.positions,
+    required this.stacks,
+    this.tournamentId,
+    this.buyIn,
+    this.totalPrizePool,
+    this.numberOfEntrants,
+    this.gameType,
+  });
+
+  factory TrainingSpot.fromSavedHand(SavedHand hand) {
+    return TrainingSpot(
+      playerCards: [
+        for (final list in hand.playerCards) List<CardModel>.from(list)
+      ],
+      boardCards: List<CardModel>.from(hand.boardCards),
+      actions: List<ActionEntry>.from(hand.actions),
+      heroIndex: hand.heroIndex,
+      numberOfPlayers: hand.numberOfPlayers,
+      playerTypes: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.playerTypes?[i] ?? PlayerType.unknown
+      ],
+      positions: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.playerPositions[i] ?? ''
+      ],
+      stacks: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.stackSizes[i] ?? 0
+      ],
+      tournamentId: hand.tournamentId,
+      buyIn: hand.buyIn,
+      totalPrizePool: hand.totalPrizePool,
+      numberOfEntrants: hand.numberOfEntrants,
+      gameType: hand.gameType,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'playerCards': [
+          for (final list in playerCards)
+            [for (final c in list) {'rank': c.rank, 'suit': c.suit}]
+        ],
+        'boardCards': [
+          for (final c in boardCards) {'rank': c.rank, 'suit': c.suit}
+        ],
+        'actions': [
+          for (final a in actions)
+            {
+              'street': a.street,
+              'playerIndex': a.playerIndex,
+              'action': a.action,
+              if (a.amount != null) 'amount': a.amount,
+            }
+        ],
+        'heroIndex': heroIndex,
+        'numberOfPlayers': numberOfPlayers,
+        'playerTypes': [for (final t in playerTypes) t.name],
+        'positions': positions,
+        'stacks': stacks,
+        if (tournamentId != null) 'tournamentId': tournamentId,
+        if (buyIn != null) 'buyIn': buyIn,
+        if (totalPrizePool != null) 'totalPrizePool': totalPrizePool,
+        if (numberOfEntrants != null) 'numberOfEntrants': numberOfEntrants,
+        if (gameType != null) 'gameType': gameType,
+      };
+
+  factory TrainingSpot.fromJson(Map<String, dynamic> json) {
+    final pcData = json['playerCards'] as List? ?? [];
+    final pc = <List<CardModel>>[];
+    for (final list in pcData) {
+      if (list is List) {
+        pc.add([
+          for (final c in list)
+            CardModel(rank: c['rank'] as String, suit: c['suit'] as String)
+        ]);
+      } else {
+        pc.add([]);
+      }
+    }
+
+    final board = <CardModel>[];
+    for (final c in (json['boardCards'] as List? ?? [])) {
+      if (c is Map) {
+        board.add(CardModel(rank: c['rank'] as String, suit: c['suit'] as String));
+      }
+    }
+
+    final acts = <ActionEntry>[];
+    for (final a in (json['actions'] as List? ?? [])) {
+      if (a is Map) {
+        acts.add(ActionEntry(
+          a['street'] as int,
+          a['playerIndex'] as int,
+          a['action'] as String,
+          amount: (a['amount'] as num?)?.toInt(),
+        ));
+      }
+    }
+
+    final heroIndex = json['heroIndex'] as int? ?? 0;
+    final numberOfPlayers = json['numberOfPlayers'] as int? ?? pc.length;
+
+    final types = <PlayerType>[];
+    final typesData = (json['playerTypes'] as List?)?.cast<String>() ?? [];
+    for (int i = 0; i < numberOfPlayers; i++) {
+      if (i < typesData.length) {
+        types.add(PlayerType.values.firstWhere(
+          (e) => e.name == typesData[i],
+          orElse: () => PlayerType.unknown,
+        ));
+      } else {
+        types.add(PlayerType.unknown);
+      }
+    }
+
+    final posData = (json['positions'] as List?)?.cast<String>() ?? [];
+    final positions = <String>[];
+    for (int i = 0; i < numberOfPlayers; i++) {
+      positions.add(i < posData.length ? posData[i] : '');
+    }
+
+    final stackData = (json['stacks'] as List?)?.cast<num>() ?? [];
+    final stacks = <int>[];
+    for (int i = 0; i < numberOfPlayers; i++) {
+      stacks.add(i < stackData.length ? stackData[i].toInt() : 0);
+    }
+
+    return TrainingSpot(
+      playerCards: pc,
+      boardCards: board,
+      actions: acts,
+      heroIndex: heroIndex,
+      numberOfPlayers: numberOfPlayers,
+      playerTypes: types,
+      positions: positions,
+      stacks: stacks,
+      tournamentId: json['tournamentId'] as String?,
+      buyIn: (json['buyIn'] as num?)?.toInt(),
+      totalPrizePool: (json['totalPrizePool'] as num?)?.toInt(),
+      numberOfEntrants: (json['numberOfEntrants'] as num?)?.toInt(),
+      gameType: json['gameType'] as String?,
+    );
+  }
+}

--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'poker_analyzer_screen.dart';
 import 'settings_screen.dart';
 import 'training_packs_screen.dart';
+import '../models/training_spot.dart';
 import 'package:provider/provider.dart';
 import '../services/action_sync_service.dart';
 import '../services/current_hand_context_service.dart';
@@ -225,7 +226,8 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
                   );
                   WidgetsBinding.instance.addPostFrameCallback((_) {
                     final state = key.currentState as dynamic;
-                    state?.loadTrainingSpot(data);
+                    state?.loadTrainingSpot(
+                        TrainingSpot.fromJson(Map<String, dynamic>.from(data)));
                   });
                 }
               },

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -15,6 +15,7 @@ import 'package:uuid/uuid.dart';
 import 'package:intl/intl.dart';
 import '../models/card_model.dart';
 import '../models/action_entry.dart';
+import '../models/training_spot.dart';
 import '../services/playback_manager_service.dart';
 import '../services/board_manager_service.dart';
 import '../services/board_sync_service.dart';
@@ -1544,7 +1545,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _boardManager.startBoardTransition();
   }
 
-  Map<String, dynamic> _currentTrainingSpot() {
+  TrainingSpot _currentTrainingSpot() {
     return _trainingImportExportService.buildSpot(
       playerManager: _playerManager,
       boardManager: _boardManager,
@@ -1565,7 +1566,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   /// - `playerTypes`: optional list of player type names.
   /// - `positions`: list of position strings for each player.
   /// - `stacks`: optional list of stack sizes.
-  void loadTrainingSpot(Map<String, dynamic> data) {
+  void loadTrainingSpot(TrainingSpot data) {
     lockService.safeSetState(this, () {
       _trainingImportExportService.applySpot(
         data,
@@ -2059,7 +2060,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 'heroIndex': 0,
                 'numberOfPlayers': 3,
               };
-              loadTrainingSpot(data);
+              loadTrainingSpot(
+                  TrainingSpot.fromJson(Map<String, dynamic>.from(data)));
             },
             child: const Icon(Icons.play_arrow),
           ),


### PR DESCRIPTION
## Summary
- add new `TrainingSpot` model with optional tournament metadata
- update training import/export service for the new model
- adjust poker analyzer and player input screens to use `TrainingSpot`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851b712956c832a8bf1fc6e037d2793