### PR TITLE
Add training generator with metadata forwarding

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -1,0 +1,36 @@
+import 'package:poker_ai_analyzer/models/saved_hand.dart';
+import 'package:poker_ai_analyzer/models/training_spot.dart';
+
+/// Generates [TrainingSpot]s from [SavedHand] instances.
+class TrainingGenerator {
+  /// Converts [hand] into a [TrainingSpot] preserving tournament metadata.
+  TrainingSpot generateFromSavedHand(SavedHand hand) {
+    return TrainingSpot(
+      playerCards: [
+        for (final list in hand.playerCards) List.of(list),
+      ],
+      boardCards: List.of(hand.boardCards),
+      actions: List.of(hand.actions),
+      heroIndex: hand.heroIndex,
+      numberOfPlayers: hand.numberOfPlayers,
+      playerTypes: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.playerTypes?[i] ?? PlayerType.unknown,
+      ],
+      positions: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.playerPositions[i] ?? '',
+      ],
+      stacks: [
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          hand.stackSizes[i] ?? 0,
+      ],
+      tournamentId: hand.tournamentId,
+      buyIn: hand.buyIn,
+      totalPrizePool: hand.totalPrizePool,
+      numberOfEntrants: hand.numberOfEntrants,
+      gameType: hand.gameType,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce a TrainingGenerator to produce TrainingSpot objects from SavedHand data
- pass through tournament metadata so auto generated spots keep these fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851bc0d33b8832ab532c77adf335340