### PR TITLE
Add tagging for training spots

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -30,6 +30,7 @@ class TrainingGenerator {
       totalPrizePool: hand.totalPrizePool,
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
+      tags: List<String>.from(hand.tags),
     );
   }
 }

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -17,6 +17,7 @@ class TrainingSpot {
   final int? totalPrizePool;
   final int? numberOfEntrants;
   final String? gameType;
+  final List<String> tags;
 
   TrainingSpot({
     required this.playerCards,
@@ -32,7 +33,8 @@ class TrainingSpot {
     this.totalPrizePool,
     this.numberOfEntrants,
     this.gameType,
-  });
+    List<String>? tags,
+  }) : tags = tags ?? [];
 
   factory TrainingSpot.fromSavedHand(SavedHand hand) {
     return TrainingSpot(
@@ -60,6 +62,7 @@ class TrainingSpot {
       totalPrizePool: hand.totalPrizePool,
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
+      tags: List<String>.from(hand.tags),
     );
   }
 
@@ -90,6 +93,7 @@ class TrainingSpot {
         if (totalPrizePool != null) 'totalPrizePool': totalPrizePool,
         if (numberOfEntrants != null) 'numberOfEntrants': numberOfEntrants,
         if (gameType != null) 'gameType': gameType,
+        if (tags.isNotEmpty) 'tags': tags,
       };
 
   factory TrainingSpot.fromJson(Map<String, dynamic> json) {
@@ -167,6 +171,7 @@ class TrainingSpot {
       totalPrizePool: (json['totalPrizePool'] as num?)?.toInt(),
       numberOfEntrants: (json['numberOfEntrants'] as num?)?.toInt(),
       gameType: json['gameType'] as String?,
+      tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
     );
   }
 }

--- a/lib/services/training_import_export_service.dart
+++ b/lib/services/training_import_export_service.dart
@@ -63,6 +63,7 @@ class TrainingImportExportService {
       totalPrizePool: totalPrizePool,
       numberOfEntrants: numberOfEntrants,
       gameType: gameType,
+      tags: const [],
     );
   }
 

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -15,6 +15,13 @@ class TrainingSpotList extends StatefulWidget {
 
 class _TrainingSpotListState extends State<TrainingSpotList> {
   final TextEditingController _searchController = TextEditingController();
+  static const List<String> _availableTags = [
+    '3бет пот',
+    'Фиш',
+    'Рег',
+    'ICM',
+    'vs агро',
+  ];
 
   @override
   void initState() {
@@ -79,6 +86,28 @@ class _TrainingSpotListState extends State<TrainingSpotList> {
                             if (spot.gameType != null && spot.gameType!.isNotEmpty)
                               Text('Game: ${spot.gameType}',
                                   style: const TextStyle(color: Colors.white)),
+                            const SizedBox(height: 8),
+                            Wrap(
+                              spacing: 4,
+                              children: [
+                                for (final tag in _availableTags)
+                                  FilterChip(
+                                    label: Text(tag),
+                                    selected: spot.tags.contains(tag),
+                                    onSelected: (selected) {
+                                      setState(() {
+                                        if (selected) {
+                                          if (!spot.tags.contains(tag)) {
+                                            spot.tags.add(tag);
+                                          }
+                                        } else {
+                                          spot.tags.remove(tag);
+                                        }
+                                      });
+                                    },
+                                  ),
+                              ],
+                            ),
                           ],
                         ),
                       ),


### PR DESCRIPTION
## Summary
- allow TrainingSpot to store a list of tags
- carry tags over when generating spots from saved hands
- keep tags when building spots via import/export service
- show FilterChips in TrainingSpotList so each spot can be tagged

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_6851d3dc11b8832a832a044df4eca87f