### PR TITLE
Add editable training spots

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -33,6 +33,132 @@ class _TrainingSpotListState extends State<TrainingSpotList> {
 
   final Set<String> _selectedTags = {};
 
+  Future<void> _editSpot(TrainingSpot spot) async {
+    final idController =
+        TextEditingController(text: spot.tournamentId ?? '');
+    final buyInController =
+        TextEditingController(text: spot.buyIn?.toString() ?? '');
+    final gameTypeController =
+        TextEditingController(text: spot.gameType ?? '');
+    final Set<String> localTags = Set<String>.from(spot.tags);
+
+    final updated = await showDialog<TrainingSpot>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              backgroundColor: AppColors.cardBackground,
+              title: const Text(
+                'Редактировать спот',
+                style: TextStyle(color: Colors.white),
+              ),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: idController,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: const InputDecoration(
+                        labelText: 'ID турнира',
+                        labelStyle: TextStyle(color: Colors.white),
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: buyInController,
+                      keyboardType: TextInputType.number,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: const InputDecoration(
+                        labelText: 'Buy-In',
+                        labelStyle: TextStyle(color: Colors.white),
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: gameTypeController,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: const InputDecoration(
+                        labelText: 'Тип игры',
+                        labelStyle: TextStyle(color: Colors.white),
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 4,
+                      children: [
+                        for (final tag in _availableTags)
+                          FilterChip(
+                            label: Text(tag),
+                            selected: localTags.contains(tag),
+                            onSelected: (selected) {
+                              setState(() {
+                                if (selected) {
+                                  localTags.add(tag);
+                                } else {
+                                  localTags.remove(tag);
+                                }
+                              });
+                            },
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Отмена'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(
+                      context,
+                      TrainingSpot(
+                        playerCards: spot.playerCards,
+                        boardCards: spot.boardCards,
+                        actions: spot.actions,
+                        heroIndex: spot.heroIndex,
+                        numberOfPlayers: spot.numberOfPlayers,
+                        playerTypes: spot.playerTypes,
+                        positions: spot.positions,
+                        stacks: spot.stacks,
+                        tournamentId: idController.text.trim().isEmpty
+                            ? null
+                            : idController.text.trim(),
+                        buyIn: int.tryParse(buyInController.text.trim()),
+                        totalPrizePool: spot.totalPrizePool,
+                        numberOfEntrants: spot.numberOfEntrants,
+                        gameType: gameTypeController.text.trim().isEmpty
+                            ? null
+                            : gameTypeController.text.trim(),
+                        tags: localTags.toList(),
+                      ),
+                    );
+                  },
+                  child: const Text('Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (updated != null) {
+      final index = widget.spots.indexOf(spot);
+      if (index != -1) {
+        setState(() => widget.spots[index] = updated);
+        widget.onChanged?.call();
+      }
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -135,6 +261,10 @@ class _TrainingSpotListState extends State<TrainingSpotList> {
                             ),
                           ],
                         ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.edit, color: Colors.white70),
+                        onPressed: () => _editSpot(spot),
                       ),
                       if (widget.onRemove != null)
                         IconButton(


### PR DESCRIPTION
## Summary
- add in-place editing for training spots
- show edit button next to each spot
- persist spot updates when changed

## Testing
- `dart` and `flutter` commands not available


------
https://chatgpt.com/codex/tasks/task_e_6851d863aa30832a89874cd27d9a5845