### PR TITLE
Add clear filters for TrainingSpotList

### DIFF
--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -20,6 +20,8 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
   final TextEditingController _categoryController = TextEditingController();
   final TrainingSpotFileService _spotFileService = const TrainingSpotFileService();
   List<TrainingSpot> _spots = [];
+  final GlobalKey<TrainingSpotListState> _spotListKey =
+      GlobalKey<TrainingSpotListState>();
 
   @override
   void initState() {
@@ -109,7 +111,17 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
               child: const Text('Импорт спотов из CSV'),
             ),
             const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: ElevatedButton(
+                onPressed: () =>
+                    _spotListKey.currentState?.clearFilters(),
+                child: const Text('Очистить фильтры'),
+              ),
+            ),
+            const SizedBox(height: 12),
             TrainingSpotList(
+              key: _spotListKey,
               spots: _spots,
               onRemove: (index) {
                 setState(() {

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -70,6 +70,8 @@ class TrainingPackScreen extends StatefulWidget {
 
 class _TrainingPackScreenState extends State<TrainingPackScreen> {
   final GlobalKey _analyzerKey = GlobalKey();
+  final GlobalKey<TrainingSpotListState> _spotListKey =
+      GlobalKey<TrainingSpotListState>();
   int _currentIndex = 0;
 
   late TrainingPack _pack;
@@ -555,22 +557,37 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
   }
 
   Widget _buildImportedSpotsList() {
-    return TrainingSpotList(
-      spots: _spots,
-      onRemove: (index) {
-        setState(() {
-          _spots.removeAt(index);
-        });
-        _saveSpots();
-      },
-      onChanged: _saveSpots,
-      onReorder: (oldIndex, newIndex) {
-        setState(() {
-          final item = _spots.removeAt(oldIndex);
-          _spots.insert(newIndex, item);
-        });
-        _saveSpots();
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ElevatedButton(
+            onPressed: () =>
+                _spotListKey.currentState?.clearFilters(),
+            child: const Text('Очистить фильтры'),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TrainingSpotList(
+          key: _spotListKey,
+          spots: _spots,
+          onRemove: (index) {
+            setState(() {
+              _spots.removeAt(index);
+            });
+            _saveSpots();
+          },
+          onChanged: _saveSpots,
+          onReorder: (oldIndex, newIndex) {
+            setState(() {
+              final item = _spots.removeAt(oldIndex);
+              _spots.insert(newIndex, item);
+            });
+            _saveSpots();
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -18,10 +18,10 @@ class TrainingSpotList extends StatefulWidget {
   });
 
   @override
-  State<TrainingSpotList> createState() => _TrainingSpotListState();
+  TrainingSpotListState createState() => TrainingSpotListState();
 }
 
-class _TrainingSpotListState extends State<TrainingSpotList> {
+class TrainingSpotListState extends State<TrainingSpotList> {
   final TextEditingController _searchController = TextEditingController();
   static const List<String> _availableTags = [
     '3бет пот',
@@ -408,5 +408,13 @@ class _TrainingSpotListState extends State<TrainingSpotList> {
         ),
       ],
     );
+  }
+
+  void clearFilters() {
+    setState(() {
+      _searchController.clear();
+      _selectedTags.clear();
+      _selectedPreset = null;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- expose `TrainingSpotListState` for external access
- implement `clearFilters` method to reset search and tags
- add clear filters buttons on training pack and create pack screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851e480f63c832ab5ff51fec3a5d601