### PR TITLE
Add ICM tag filter toggle

### DIFF
--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -22,6 +22,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
   List<TrainingSpot> _spots = [];
   final GlobalKey<TrainingSpotListState> _spotListKey =
       GlobalKey<TrainingSpotListState>();
+  bool _icmOnly = false;
 
   @override
   void initState() {
@@ -119,10 +120,18 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
                 child: const Text('Очистить фильтры'),
               ),
             ),
+            SwitchListTile(
+              value: _icmOnly,
+              onChanged: (v) => setState(() => _icmOnly = v),
+              title: const Text('Только ICM',
+                  style: TextStyle(color: Colors.white)),
+              activeColor: Colors.orange,
+            ),
             const SizedBox(height: 12),
             TrainingSpotList(
               key: _spotListKey,
               spots: _spots,
+              icmOnly: _icmOnly,
               onRemove: (index) {
                 setState(() {
                   _spots.removeAt(index);

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -72,6 +72,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
   final GlobalKey _analyzerKey = GlobalKey();
   final GlobalKey<TrainingSpotListState> _spotListKey =
       GlobalKey<TrainingSpotListState>();
+  bool _icmOnly = false;
   int _currentIndex = 0;
 
   late TrainingPack _pack;
@@ -568,10 +569,18 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
             child: const Text('Очистить фильтры'),
           ),
         ),
+        SwitchListTile(
+          value: _icmOnly,
+          onChanged: (v) => setState(() => _icmOnly = v),
+          title:
+              const Text('Только ICM', style: TextStyle(color: Colors.white)),
+          activeColor: Colors.orange,
+        ),
         const SizedBox(height: 12),
         TrainingSpotList(
           key: _spotListKey,
           spots: _spots,
+          icmOnly: _icmOnly,
           onRemove: (index) {
             setState(() {
               _spots.removeAt(index);

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -8,6 +8,7 @@ class TrainingSpotList extends StatefulWidget {
   final ValueChanged<int>? onRemove;
   final VoidCallback? onChanged;
   final ReorderCallback? onReorder;
+  final bool icmOnly;
 
   const TrainingSpotList({
     super.key,
@@ -15,6 +16,7 @@ class TrainingSpotList extends StatefulWidget {
     this.onRemove,
     this.onChanged,
     this.onReorder,
+    this.icmOnly = false,
   });
 
   @override
@@ -258,7 +260,8 @@ class TrainingSpotListState extends State<TrainingSpotList> {
           buyIn.contains(query);
       final matchesTags =
           _selectedTags.isEmpty || _selectedTags.every(spot.tags.contains);
-      return matchesQuery && matchesTags;
+      final matchesIcm = !widget.icmOnly || spot.tags.contains('ICM');
+      return matchesQuery && matchesTags && matchesIcm;
     }).toList();
 
     return Column(


### PR DESCRIPTION
## Summary
- add `icmOnly` option to TrainingSpotList
- enable toggling "Только ICM" filter in create and training pack screens
- filter displayed spots by ICM tag when enabled

## Testing
- `dart format lib/screens/create_pack_screen.dart lib/screens/training_pack_screen.dart lib/widgets/common/training_spot_list.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851e6a9e09c832a8fa25636071df7e1