### PR TITLE
Add tag reset in filter section

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -451,6 +451,14 @@ class TrainingSpotListState extends State<TrainingSpotList> {
         _buildTagFilters(),
         const SizedBox(height: 8),
         _buildPresetDropdown(filtered),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ElevatedButton(
+            onPressed: _clearTagFilters,
+            child: const Text('Сбросить теги'),
+          ),
+        ),
       ],
     );
   }
@@ -496,6 +504,13 @@ class TrainingSpotListState extends State<TrainingSpotList> {
   void clearFilters() {
     setState(() {
       _searchController.clear();
+      _selectedTags.clear();
+      _selectedPreset = null;
+    });
+  }
+
+  void _clearTagFilters() {
+    setState(() {
       _selectedTags.clear();
       _selectedPreset = null;
     });


### PR DESCRIPTION
## Summary
- add a "Сбросить теги" button inside the tag filters section
- clear selected tags and preset when reset button pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851e8b81d3c832aa6336af11d429fc2