### PR TITLE
Add badge for selected spots count

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -278,10 +278,34 @@ class TrainingSpotListState extends State<TrainingSpotList> {
         if (widget.onRemove != null) ...[
           Align(
             alignment: Alignment.centerLeft,
-            child: ElevatedButton(
-              onPressed:
-                  _selectedSpots.isEmpty ? null : _deleteSelected,
-              child: const Text('Удалить выбранные'),
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                ElevatedButton(
+                  onPressed:
+                      _selectedSpots.isEmpty ? null : _deleteSelected,
+                  child: const Text('Удалить выбранные'),
+                ),
+                if (_selectedSpots.isNotEmpty)
+                  Positioned(
+                    right: -6,
+                    top: -6,
+                    child: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: const BoxDecoration(
+                        color: Colors.red,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Text(
+                        '${_selectedSpots.length}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
             ),
           ),
           const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- show the number of currently selected training spots next to **Удалить выбранные** button
- badge is hidden when no spots are selected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851ecd4a9e4832ab4ac7a3360c91ee1