### PR TITLE
Add save order button

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -332,6 +332,11 @@ class TrainingSpotListState extends State<TrainingSpotList> {
               ),
               const SizedBox(width: 8),
               _buildSortDropdown(filtered),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _saveCurrentOrder,
+                child: const Text('Сохранить порядок'),
+              ),
             ],
           ),
         ),
@@ -683,6 +688,17 @@ class TrainingSpotListState extends State<TrainingSpotList> {
       _sortOption = option;
     });
     widget.onChanged?.call();
+  }
+
+  void _saveCurrentOrder() {
+    setState(() {
+      _originalOrder = List<TrainingSpot>.from(widget.spots);
+      _sortOption = null;
+    });
+    widget.onChanged?.call();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Порядок сохранён')),
+    );
   }
 
   void _resetSort() {


### PR DESCRIPTION
## Summary
- add **Save Order** button next to shuffle and sort
- implement `_saveCurrentOrder` to keep current spot order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851eff3723c832a875286d6995cbd80