### PR TITLE
Add filters visibility toggle

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -342,9 +342,13 @@ class TrainingSpotListState extends State<TrainingSpotList> {
         _buildSearchField(),
         _buildFilterSummary(),
         const SizedBox(height: 8),
-        _buildTagFilterSection(filtered),
-        const SizedBox(height: 8),
-        _buildTagFilterRow(),
+        _buildFilterToggleButton(),
+        if (_tagFiltersExpanded) ...[
+          const SizedBox(height: 8),
+          _buildTagFilterSection(filtered),
+          const SizedBox(height: 8),
+          _buildTagFilterRow(),
+        ],
         const SizedBox(height: 8),
         if (widget.onRemove != null) ...[
           Align(
@@ -558,6 +562,21 @@ class TrainingSpotListState extends State<TrainingSpotList> {
       child: Text(
         summary,
         style: const TextStyle(color: Colors.white60),
+      ),
+    );
+  }
+
+  Widget _buildFilterToggleButton() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton(
+        onPressed: () {
+          setState(() => _tagFiltersExpanded = !_tagFiltersExpanded);
+          _savePresets();
+        },
+        child: Text(
+          _tagFiltersExpanded ? 'Скрыть фильтры' : 'Показать фильтры',
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow users to show/hide tag filters in `TrainingSpotList`
- persist toggle state using `SharedPreferences`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f7696680832a8cc4c643524156ba