### PR TITLE
Add difficulty rating to training spots

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -31,6 +31,7 @@ class TrainingGenerator {
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
       tags: List<String>.from(hand.tags),
+      difficulty: 3,
     );
   }
 }

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -18,6 +18,7 @@ class TrainingSpot {
   final int? numberOfEntrants;
   final String? gameType;
   final List<String> tags;
+  final int difficulty;
 
   TrainingSpot({
     required this.playerCards,
@@ -34,6 +35,7 @@ class TrainingSpot {
     this.numberOfEntrants,
     this.gameType,
     List<String>? tags,
+    this.difficulty = 3,
   }) : tags = tags ?? [];
 
   factory TrainingSpot.fromSavedHand(SavedHand hand) {
@@ -63,6 +65,7 @@ class TrainingSpot {
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
       tags: List<String>.from(hand.tags),
+      difficulty: 3,
     );
   }
 
@@ -94,6 +97,7 @@ class TrainingSpot {
         if (numberOfEntrants != null) 'numberOfEntrants': numberOfEntrants,
         if (gameType != null) 'gameType': gameType,
         if (tags.isNotEmpty) 'tags': tags,
+        'difficulty': difficulty,
       };
 
   factory TrainingSpot.fromJson(Map<String, dynamic> json) {
@@ -172,6 +176,27 @@ class TrainingSpot {
       numberOfEntrants: (json['numberOfEntrants'] as num?)?.toInt(),
       gameType: json['gameType'] as String?,
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
+      difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
+    );
+  }
+
+  TrainingSpot copyWith({int? difficulty, List<String>? tags}) {
+    return TrainingSpot(
+      playerCards: [for (final list in playerCards) List<CardModel>.from(list)],
+      boardCards: List<CardModel>.from(boardCards),
+      actions: List<ActionEntry>.from(actions),
+      heroIndex: heroIndex,
+      numberOfPlayers: numberOfPlayers,
+      playerTypes: List<PlayerType>.from(playerTypes),
+      positions: List<String>.from(positions),
+      stacks: List<int>.from(stacks),
+      tournamentId: tournamentId,
+      buyIn: buyIn,
+      totalPrizePool: totalPrizePool,
+      numberOfEntrants: numberOfEntrants,
+      gameType: gameType,
+      tags: tags ?? List<String>.from(this.tags),
+      difficulty: difficulty ?? this.difficulty,
     );
   }
 

--- a/lib/services/training_import_export_service.dart
+++ b/lib/services/training_import_export_service.dart
@@ -64,6 +64,7 @@ class TrainingImportExportService {
       numberOfEntrants: numberOfEntrants,
       gameType: gameType,
       tags: const [],
+      difficulty: 3,
     );
   }
 
@@ -286,6 +287,7 @@ class TrainingImportExportService {
             totalPrizePool: intOrNull(map['totalPrizePool']),
             numberOfEntrants: intOrNull(map['numberOfEntrants']),
             gameType: strOrNull(map['gameType']),
+            difficulty: 3,
           ),
         );
       } catch (_) {
@@ -332,6 +334,7 @@ class TrainingImportExportService {
         totalPrizePool: intOrNull(map['totalPrizePool']),
         numberOfEntrants: intOrNull(map['numberOfEntrants']),
         gameType: strOrNull(map['gameType']),
+        difficulty: 3,
       );
     } catch (_) {
       return null;

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -330,6 +330,7 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                         gameType: gameTypeController.text.trim().isEmpty
                             ? null
                             : gameTypeController.text.trim(),
+                        difficulty: spot.difficulty,
                         tags: localTags.toList(),
                       ),
                     );
@@ -429,6 +430,7 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                         totalPrizePool: spot.totalPrizePool,
                         numberOfEntrants: spot.numberOfEntrants,
                         gameType: spot.gameType,
+                        difficulty: spot.difficulty,
                         tags: localTags.toList(),
                       ),
                     );
@@ -489,6 +491,33 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     });
     widget.onChanged?.call();
     _saveOrderToPrefs();
+  }
+
+  void _updateDifficulty(TrainingSpot spot, int value) {
+    final index = widget.spots.indexOf(spot);
+    if (index == -1) return;
+    setState(() {
+      widget.spots[index] = spot.copyWith(difficulty: value);
+    });
+    widget.onChanged?.call();
+  }
+
+  Widget _buildRatingStars(TrainingSpot spot) {
+    return Row(
+      children: [
+        for (int i = 1; i <= 5; i++)
+          IconButton(
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            icon: Icon(
+              i <= spot.difficulty ? Icons.star : Icons.star_border,
+              color: Colors.amber,
+              size: 20,
+            ),
+            onPressed: () => _updateDifficulty(spot, i),
+          ),
+      ],
+    );
   }
 
   Future<void> _deleteSelected() async {
@@ -743,6 +772,7 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                                 ],
                               ),
                             ),
+                            _buildRatingStars(spot),
                           ],
                         ),
                       ),
@@ -832,6 +862,7 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                                       ],
                                     ),
                                   ),
+                                  _buildRatingStars(spot),
                                 ],
                               ),
                             ),


### PR DESCRIPTION
## Summary
- allow rating training spots by difficulty from 1–5
- persist difficulty in `TrainingSpot` model
- generate default difficulty for new spots

## Testing
- `dart` and `flutter` not installed, so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_68520a26e6d0832abce61d985931b43b