### PR TITLE
Add long-press reorder for training spots

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -740,21 +740,20 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                     itemCount: filtered.length,
                     itemBuilder: (context, index) {
                       final spot = filtered[index];
-                      return Container(
+                      return ReorderableDelayedDragStartListener(
                         key: ValueKey(spot),
-                        margin: const EdgeInsets.symmetric(vertical: 4),
-                        padding: const EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: AppColors.cardBackground,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            ReorderableDragStartListener(
-                              index: index,
-                              child: const Icon(Icons.drag_handle, color: Colors.white70),
-                            ),
+                        index: index,
+                        child: Container(
+                          margin: const EdgeInsets.symmetric(vertical: 4),
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: AppColors.cardBackground,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Icon(Icons.drag_handle, color: Colors.white70),
                               const SizedBox(width: 8),
                               Checkbox(
                                 value: _selectedSpots.contains(spot),


### PR DESCRIPTION
## Summary
- enable long-press reorder on TrainingSpotList using `ReorderableDelayedDragStartListener`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68528664491c832a80b6d99e8278078e