### PR TITLE
Add batch rating dropdown

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -32,6 +32,7 @@ class TrainingGenerator {
       gameType: hand.gameType,
       tags: List<String>.from(hand.tags),
       difficulty: 3,
+      rating: 0,
     );
   }
 }

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -19,6 +19,7 @@ class TrainingSpot {
   final String? gameType;
   final List<String> tags;
   final int difficulty;
+  final int rating;
   final String? userAction;
 
   TrainingSpot({
@@ -38,6 +39,7 @@ class TrainingSpot {
     List<String>? tags,
     this.userAction,
     this.difficulty = 3,
+    this.rating = 0,
   }) : tags = tags ?? [];
 
   factory TrainingSpot.fromSavedHand(SavedHand hand) {
@@ -69,6 +71,7 @@ class TrainingSpot {
       tags: List<String>.from(hand.tags),
       userAction: null,
       difficulty: 3,
+      rating: 0,
     );
   }
 
@@ -101,6 +104,7 @@ class TrainingSpot {
         if (gameType != null) 'gameType': gameType,
         if (tags.isNotEmpty) 'tags': tags,
         'difficulty': difficulty,
+        'rating': rating,
         if (userAction != null) 'userAction': userAction,
       };
 
@@ -181,11 +185,12 @@ class TrainingSpot {
       gameType: json['gameType'] as String?,
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
+      rating: (json['rating'] as num?)?.toInt() ?? 0,
       userAction: json['userAction'] as String?,
     );
   }
 
-  TrainingSpot copyWith({int? difficulty, List<String>? tags, String? userAction}) {
+  TrainingSpot copyWith({int? difficulty, int? rating, List<String>? tags, String? userAction}) {
     return TrainingSpot(
       playerCards: [for (final list in playerCards) List<CardModel>.from(list)],
       boardCards: List<CardModel>.from(boardCards),
@@ -202,6 +207,7 @@ class TrainingSpot {
       gameType: gameType,
       tags: tags ?? List<String>.from(this.tags),
       difficulty: difficulty ?? this.difficulty,
+      rating: rating ?? this.rating,
       userAction: userAction ?? this.userAction,
     );
   }

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -553,6 +553,20 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     widget.onChanged?.call();
   }
 
+  void _applyRatingToFiltered(int value) {
+    final filtered = _currentFilteredSpots();
+    if (filtered.isEmpty) return;
+    setState(() {
+      for (final spot in filtered) {
+        final index = widget.spots.indexOf(spot);
+        if (index != -1) {
+          widget.spots[index] = spot.copyWith(rating: value);
+        }
+      }
+    });
+    widget.onChanged?.call();
+  }
+
   Widget _buildRatingStars(TrainingSpot spot) {
     return Row(
       children: [
@@ -777,6 +791,13 @@ class TrainingSpotListState extends State<TrainingSpotList> {
           onChanged: (value) {
             if (value == null) return;
             _applyDifficultyToFiltered(value);
+          },
+        ),
+        const SizedBox(height: 8),
+        _ApplyRatingDropdown(
+          onChanged: (value) {
+            if (value == null) return;
+            _applyRatingToFiltered(value);
           },
         ),
         const SizedBox(height: 8),
@@ -1756,6 +1777,33 @@ class _ApplyDifficultyDropdown extends StatelessWidget {
     return Row(
       children: [
         const Text('Применить сложность ко всем',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<int?>(
+          hint: const Text('Выбрать', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: [
+            for (int i = 1; i <= 5; i++)
+              DropdownMenuItem(value: i, child: Text('$i')),
+          ],
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _ApplyRatingDropdown extends StatelessWidget {
+  final ValueChanged<int?> onChanged;
+
+  const _ApplyRatingDropdown({required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Применить рейтинг ко всем',
             style: TextStyle(color: Colors.white)),
         const SizedBox(width: 8),
         DropdownButton<int?>(


### PR DESCRIPTION
## Summary
- extend `TrainingSpot` with a new `rating` field
- support `rating` when generating and copying spots
- add `_ApplyRatingDropdown` to mass-assign rating in `TrainingSpotList`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685291528e48832a9d7f19a61341bb5d