### PR TITLE
Add batch rating update to TrainingSpotList

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -32,6 +32,7 @@ class TrainingGenerator {
       gameType: hand.gameType,
       tags: List<String>.from(hand.tags),
       difficulty: 3,
+      rating: 0,
     );
   }
 }

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -19,6 +19,7 @@ class TrainingSpot {
   final String? gameType;
   final List<String> tags;
   final int difficulty;
+  final int rating;
   final String? userAction;
 
   TrainingSpot({
@@ -38,6 +39,7 @@ class TrainingSpot {
     List<String>? tags,
     this.userAction,
     this.difficulty = 3,
+    this.rating = 0,
   }) : tags = tags ?? [];
 
   factory TrainingSpot.fromSavedHand(SavedHand hand) {
@@ -69,6 +71,7 @@ class TrainingSpot {
       tags: List<String>.from(hand.tags),
       userAction: null,
       difficulty: 3,
+      rating: 0,
     );
   }
 
@@ -101,6 +104,7 @@ class TrainingSpot {
         if (gameType != null) 'gameType': gameType,
         if (tags.isNotEmpty) 'tags': tags,
         'difficulty': difficulty,
+        'rating': rating,
         if (userAction != null) 'userAction': userAction,
       };
 
@@ -181,11 +185,12 @@ class TrainingSpot {
       gameType: json['gameType'] as String?,
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
+      rating: (json['rating'] as num?)?.toInt() ?? 0,
       userAction: json['userAction'] as String?,
     );
   }
 
-  TrainingSpot copyWith({int? difficulty, List<String>? tags, String? userAction}) {
+  TrainingSpot copyWith({int? difficulty, int? rating, List<String>? tags, String? userAction}) {
     return TrainingSpot(
       playerCards: [for (final list in playerCards) List<CardModel>.from(list)],
       boardCards: List<CardModel>.from(boardCards),
@@ -202,6 +207,7 @@ class TrainingSpot {
       gameType: gameType,
       tags: tags ?? List<String>.from(this.tags),
       difficulty: difficulty ?? this.difficulty,
+      rating: rating ?? this.rating,
       userAction: userAction ?? this.userAction,
     );
   }

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -539,6 +539,15 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     widget.onChanged?.call();
   }
 
+  void _updateRating(TrainingSpot spot, int value) {
+    final index = widget.spots.indexOf(spot);
+    if (index == -1) return;
+    setState(() {
+      widget.spots[index] = spot.copyWith(rating: value);
+    });
+    widget.onChanged?.call();
+  }
+
   void _applyDifficultyToFiltered(int value) {
     final filtered = _currentFilteredSpots();
     if (filtered.isEmpty) return;
@@ -553,6 +562,20 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     widget.onChanged?.call();
   }
 
+  void _applyRatingToFiltered(int value) {
+    final filtered = _currentFilteredSpots();
+    if (filtered.isEmpty) return;
+    setState(() {
+      for (final spot in filtered) {
+        final index = widget.spots.indexOf(spot);
+        if (index != -1) {
+          widget.spots[index] = spot.copyWith(rating: value);
+        }
+      }
+    });
+    widget.onChanged?.call();
+  }
+
   Widget _buildRatingStars(TrainingSpot spot) {
     return Row(
       children: [
@@ -561,11 +584,11 @@ class TrainingSpotListState extends State<TrainingSpotList> {
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
             icon: Icon(
-              i <= spot.difficulty ? Icons.star : Icons.star_border,
+              i <= spot.rating ? Icons.star : Icons.star_border,
               color: Colors.amber,
               size: 20,
             ),
-            onPressed: () => _updateDifficulty(spot, i),
+            onPressed: () => _updateRating(spot, i),
           ),
       ],
     );
@@ -777,6 +800,13 @@ class TrainingSpotListState extends State<TrainingSpotList> {
           onChanged: (value) {
             if (value == null) return;
             _applyDifficultyToFiltered(value);
+          },
+        ),
+        const SizedBox(height: 8),
+        _ApplyRatingDropdown(
+          onChanged: (value) {
+            if (value == null) return;
+            _applyRatingToFiltered(value);
           },
         ),
         const SizedBox(height: 8),
@@ -1756,6 +1786,33 @@ class _ApplyDifficultyDropdown extends StatelessWidget {
     return Row(
       children: [
         const Text('Применить сложность ко всем',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<int?>(
+          hint: const Text('Выбрать', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: [
+            for (int i = 1; i <= 5; i++)
+              DropdownMenuItem(value: i, child: Text('$i')),
+          ],
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _ApplyRatingDropdown extends StatelessWidget {
+  final ValueChanged<int?> onChanged;
+
+  const _ApplyRatingDropdown({required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Применить рейтинг ко всем',
             style: TextStyle(color: Colors.white)),
         const SizedBox(width: 8),
         DropdownButton<int?>(


### PR DESCRIPTION
## Summary
- introduce `rating` field in `TrainingSpot`
- default rating to `0` when generating from saved hands
- update training spot list to support rating updates
- add dropdown to batch-apply rating to visible spots

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68529156c9c8832a9a52d1dd27ca689e