### PR TITLE
Add clear filters button

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -804,6 +804,15 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                 onPressed: _saveCurrentOrder,
                 child: const Text('Сохранить порядок'),
               ),
+              const SizedBox(width: 8),
+              OutlinedButton(
+                onPressed: clearFilters,
+                style: OutlinedButton.styleFrom(
+                  side: const BorderSide(color: Colors.red),
+                  foregroundColor: Colors.red,
+                ),
+                child: const Text('Очистить фильтры'),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- add an outlined `Очистить фильтры` button in TrainingSpotList next to `Сохранить порядок`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852953badf8832aae68738924e1af83