### PR TITLE
Add filter activity indicator

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -167,6 +167,15 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     return summary;
   }
 
+  bool get _hasActiveFilters {
+    return _searchController.text.trim().isNotEmpty ||
+        _selectedTags.isNotEmpty ||
+        _difficultyFilter != null ||
+        _ratingFilter != null ||
+        _icmOnly ||
+        _ratedOnly;
+  }
+
   Future<void> _loadPresets() async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await _restoreOrderFromPrefs(prefs);
@@ -1185,8 +1194,18 @@ class TrainingSpotListState extends State<TrainingSpotList> {
           setState(() => _tagFiltersExpanded = !_tagFiltersExpanded);
           _savePresets();
         },
-        child: Text(
-          _tagFiltersExpanded ? 'Скрыть фильтры' : 'Показать фильтры',
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              _tagFiltersExpanded ? 'Скрыть фильтры' : 'Показать фильтры',
+            ),
+            if (_hasActiveFilters)
+              const Padding(
+                padding: EdgeInsets.only(left: 4.0),
+                child: Icon(Icons.circle, size: 8, color: Colors.red),
+              ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- show a red dot on the "Фильтры" toggle when any filter is active
- compute active filters via `_hasActiveFilters`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529a701570832aa2325fe880020e34