### PR TITLE
Replace FAB with sliding filter reset panel

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -1533,24 +1533,39 @@ class TrainingSpotListState extends State<TrainingSpotList> {
             child: const Text('Импортировать пакет'),
           ),
         ),
-      ],
-          ),
-          if (_hasActiveFilters)
-            Positioned(
-              right: 16,
-              bottom: 16,
-              child: FloatingActionButton(
-                heroTag: 'clearFiltersFab',
-                onPressed: clearFilters,
-                backgroundColor: Colors.red,
-                foregroundColor: Colors.white,
-                elevation: 2,
-                tooltip: 'Сбросить фильтры',
-                child: const Icon(Icons.filter_alt_off),
-              ),
+        ],
             ),
+          SliverToBoxAdapter(
+            child: SizedBox(height: _hasActiveFilters ? 72 : 0),
+          ),
         ],
       ),
+      Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: AnimatedSlide(
+            offset: _hasActiveFilters ? Offset.zero : const Offset(0, 1),
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+            child: SafeArea(
+              top: false,
+              child: Container(
+                width: double.infinity,
+                color: AppColors.cardBackground,
+                padding: const EdgeInsets.all(16),
+                child: ElevatedButton(
+                  onPressed: clearFilters,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('Сбросить фильтры'),
+                ),
+              ),
+            ),
+          ),
+        ),
     );
   }
 


### PR DESCRIPTION
## Summary
- use a bottom sliding panel for clearing filters in TrainingSpotList

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852b1c06a08832abcc5c1e0118d4eae