### PR TITLE
Add CSV export for training spots

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   share_plus: ^7.0.0
   uuid: ^3.0.0
   synchronized: ^3.0.0
+  csv: ^6.0.0
+  file_saver: ^0.2.14
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `csv` and `file_saver` dependencies
- expose new `Скачать CSV` button next to export pack controls
- implement CSV export with `ListToCsvConverter`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c9218bdc832aad923960266a9bf6