### PR TITLE
Add comment and history search

### DIFF
--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -21,6 +21,7 @@ class TrainingSpot {
   final int difficulty;
   final int rating;
   final String? userAction;
+  final String? userComment;
   final DateTime createdAt;
 
   TrainingSpot({
@@ -39,6 +40,7 @@ class TrainingSpot {
     this.gameType,
     List<String>? tags,
     this.userAction,
+    this.userComment,
     this.difficulty = 3,
     this.rating = 0,
     DateTime? createdAt,
@@ -73,6 +75,7 @@ class TrainingSpot {
       gameType: hand.gameType,
       tags: List<String>.from(hand.tags),
       userAction: null,
+      userComment: hand.comment,
       difficulty: 3,
       rating: 0,
       createdAt: hand.date,
@@ -110,6 +113,7 @@ class TrainingSpot {
         'difficulty': difficulty,
         'rating': rating,
         if (userAction != null) 'userAction': userAction,
+        if (userComment != null) 'userComment': userComment,
         'createdAt': createdAt.toIso8601String(),
       };
 
@@ -192,6 +196,7 @@ class TrainingSpot {
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
       rating: (json['rating'] as num?)?.toInt() ?? 0,
       userAction: json['userAction'] as String?,
+      userComment: json['userComment'] as String?,
       createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
           DateTime.now(),
     );
@@ -202,6 +207,7 @@ class TrainingSpot {
     int? rating,
     List<String>? tags,
     String? userAction,
+    String? userComment,
     DateTime? createdAt,
   }) {
     return TrainingSpot(
@@ -222,6 +228,7 @@ class TrainingSpot {
       difficulty: difficulty ?? this.difficulty,
       rating: rating ?? this.rating,
       userAction: userAction ?? this.userAction,
+      userComment: userComment ?? this.userComment,
       createdAt: createdAt ?? this.createdAt,
     );
   }

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -399,8 +399,20 @@ class TrainingSpotListState extends State<TrainingSpotList>
     final query = _searchController.text.toLowerCase();
     return widget.spots.where((spot) {
       final id = spot.tournamentId?.toLowerCase() ?? '';
-      final tagMatch = spot.tags.any((t) => t.toLowerCase().contains(query));
-      final matchesQuery = query.isEmpty || id.contains(query) || tagMatch;
+      bool matchesQuery = query.isEmpty;
+      if (!matchesQuery) {
+        final tagMatch = spot.tags.any((t) => t.toLowerCase().contains(query));
+        final comment = spot.userComment?.toLowerCase() ?? '';
+        final actions = spot.actions
+            .map((a) => '${a.action} ${a.amount ?? ''} ${a.street} ${a.playerIndex}')
+            .join(' ')
+            .toLowerCase();
+        matchesQuery =
+            id.contains(query) ||
+            tagMatch ||
+            comment.contains(query) ||
+            actions.contains(query);
+      }
       final matchesTags =
           _selectedTags.isEmpty || _selectedTags.every(spot.tags.contains);
       final matchesIcm = !_icmOnly || spot.tags.contains('ICM');
@@ -2182,9 +2194,9 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                               GestureDetector(
                                                 onTap: () =>
                                                     _editTitleAndTags(spot),
-                                                child: Wrap(
-                                                  spacing: 4,
-                                                  children: [
+                                            child: Wrap(
+                                                spacing: 4,
+                                                children: [
                                                     if (spot.tags.isEmpty)
                                                       const Text('Без тегов',
                                                           style: TextStyle(
@@ -2203,6 +2215,22 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                                   ],
                                                 ),
                                               ),
+                                              if (spot.userComment != null &&
+                                                  spot.userComment!.isNotEmpty)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(
+                                                      top: 4),
+                                                  child: Builder(builder: (context) {
+                                                    var _txt = spot.userComment!
+                                                        .replaceAll('\n', ' ');
+                                                    if (_txt.length > 80) {
+                                                      _txt = _txt.substring(0, 80) + '…';
+                                                    }
+                                                    return Text.rich(
+                                                      _highlightSpan(_txt),
+                                                    );
+                                                  }),
+                                                ),
                                               _buildRatingStars(spot),
                                               IconButton(
                                                 icon: const Icon(Icons.label_outline,
@@ -2335,8 +2363,24 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                                             AppColors.cardBackground,
                                                       ),
                                                 ],
-                                              ),
+                                                ),
                                             ),
+                                            if (spot.userComment != null &&
+                                                spot.userComment!.isNotEmpty)
+                                              Padding(
+                                                padding: const EdgeInsets.only(
+                                                    top: 4),
+                                                child: Builder(builder: (context) {
+                                                  var _txt = spot.userComment!
+                                                      .replaceAll('\n', ' ');
+                                                  if (_txt.length > 80) {
+                                                    _txt = _txt.substring(0, 80) + '…';
+                                                  }
+                                                  return Text.rich(
+                                                    _highlightSpan(_txt),
+                                                  );
+                                                }),
+                                              ),
                                             _buildRatingStars(spot),
                                             IconButton(
                                               icon: const Icon(Icons.label_outline,


### PR DESCRIPTION
## Summary
- support userComment in `TrainingSpot`
- include comment and action history text in spot filtering
- highlight user comments when searching

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852f0532cc8832a94a295bd9f827d84