### PR TITLE
Implement Ethereum private key validation

### DIFF
--- a/lib/screens/ethereum_tools_screen.dart
+++ b/lib/screens/ethereum_tools_screen.dart
@@ -16,6 +16,8 @@ class EthereumToolsScreen extends StatefulWidget {
 class _EthereumToolsScreenState extends State<EthereumToolsScreen> {
   String? _generated;
   String? _checksum;
+  final TextEditingController _keyController = TextEditingController();
+  bool? _keyValid;
 
   void _generate() {
     final addr = generateRandomAddress();
@@ -31,6 +33,19 @@ class _EthereumToolsScreenState extends State<EthereumToolsScreen> {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Copied to clipboard')));
     }
+  }
+
+  void _validateKey() {
+    final text = _keyController.text.trim();
+    setState(() {
+      _keyValid = isValidPrivateKey(text);
+    });
+  }
+
+  @override
+  void dispose() {
+    _keyController.dispose();
+    super.dispose();
   }
 
   @override
@@ -49,6 +64,28 @@ class _EthereumToolsScreenState extends State<EthereumToolsScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const EthereumAddressInput(),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _keyController,
+                decoration: const InputDecoration(
+                  labelText: 'Private Key',
+                ),
+                obscureText: true,
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _validateKey,
+                child: const Text('Проверить'),
+              ),
+              if (_keyValid != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    _keyValid! ? 'Valid private key' : 'Invalid private key',
+                    style:
+                        TextStyle(color: _keyValid! ? Colors.green : Colors.red),
+                  ),
+                ),
               const SizedBox(height: 24),
               ElevatedButton(
                 onPressed: _generate,

--- a/lib/utils/eth_utils.dart
+++ b/lib/utils/eth_utils.dart
@@ -11,6 +11,12 @@ bool isValidAddress(String address) {
   return regex.hasMatch(address);
 }
 
+/// Checks if [key] is a valid 64-character lowercase hexadecimal private key.
+bool isValidPrivateKey(String key) {
+  final regex = RegExp(r'^[0-9a-f]{64}\$');
+  return regex.hasMatch(key);
+}
+
 /// Converts [address] to its EIP-55 checksum representation.
 /// Throws an [ArgumentError] if [address] is not valid.
 String toChecksumAddress(String address) {


### PR DESCRIPTION
## Summary
- validate Ethereum private keys
- show validation UI on EthereumToolsScreen

## Testing
- `dart format lib/screens/ethereum_tools_screen.dart lib/utils/eth_utils.dart` *(fails: command not found)*
- `flutter format lib/screens/ethereum_tools_screen.dart lib/utils/eth_utils.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685331e235a0832a8a0f44566728600d