### PR TITLE
Add daily hand screen

### DIFF
--- a/lib/screens/daily_hand_screen.dart
+++ b/lib/screens/daily_hand_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/daily_hand_service.dart';
+import '../widgets/saved_hand_tile.dart';
+import '../widgets/saved_hand_detail_sheet.dart';
+import '../helpers/date_utils.dart';
+
+class DailyHandScreen extends StatelessWidget {
+  const DailyHandScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DailyHandService>();
+    final hand = service.hand;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ежедневная раздача'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const PastDailyHandsScreen()),
+              );
+            },
+          ),
+        ],
+      ),
+      backgroundColor: const Color(0xFF121212),
+      body: Center(
+        child: hand == null
+            ? const Text(
+                'Нет активной раздачи на сегодня',
+                style: TextStyle(color: Colors.white70),
+              )
+            : SavedHandTile(
+                hand: hand,
+                onTap: () {
+                  showModalBottomSheet(
+                    context: context,
+                    isScrollControlled: true,
+                    backgroundColor: Colors.grey[900],
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                    ),
+                    builder: (_) => SavedHandDetailSheet(
+                      hand: hand,
+                      onDelete: () {},
+                      onExportJson: () async {},
+                      onExportCsv: () async {},
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}
+
+class PastDailyHandsScreen extends StatelessWidget {
+  const PastDailyHandsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DailyHandService>();
+    final history = service.history.reversed.toList();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История ежедневных раздач'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF121212),
+      body: history.isEmpty
+          ? const Center(
+              child: Text(
+                'История пуста',
+                style: TextStyle(color: Colors.white54),
+              ),
+            )
+          : ListView.builder(
+              itemCount: history.length,
+              itemBuilder: (context, index) {
+                final entry = history[index];
+                return ListTile(
+                  title: Text(
+                    formatDate(entry.date),
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  trailing: Icon(
+                    entry.correct ? Icons.check_circle : Icons.cancel,
+                    color: entry.correct ? Colors.green : Colors.red,
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -7,6 +7,7 @@ import 'all_sessions_screen.dart';
 import 'training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
+import 'daily_hand_screen.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -31,6 +32,16 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('➕ Новая раздача'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const DailyHandScreen()),
+                );
+              },
+              child: const Text('🃏 Ежедневная раздача'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- add DailyHandScreen with a history view
- open daily hands from main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68533c1e8eec832aaebd9c9d02a54d0b