### PR TITLE
Add action hint toggle

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -13,6 +13,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _showPotAnimation;
   late bool _showCardReveal;
   late bool _showWinnerCelebration;
+  late bool _showActionHints;
 
   @override
   void initState() {
@@ -21,6 +22,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _showPotAnimation = prefs.showPotAnimation;
     _showCardReveal = prefs.showCardReveal;
     _showWinnerCelebration = prefs.showWinnerCelebration;
+    _showActionHints = prefs.showActionHints;
   }
 
   Future<void> _togglePotAnimation(bool value) async {
@@ -38,6 +40,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     await UserPreferences.instance.setShowWinnerCelebration(value);
   }
 
+  Future<void> _toggleActionHints(bool value) async {
+    setState(() => _showActionHints = value);
+    await UserPreferences.instance.setShowActionHints(value);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -46,34 +53,42 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: const Text('Settings'),
         centerTitle: true,
       ),
-      body: ListView(
-        children: [
-          SwitchListTile(
-            value: _showPotAnimation,
-            title: const Text('Show Pot Animation'),
-            onChanged: _togglePotAnimation,
-            activeColor: Colors.orange,
-          ),
-          SwitchListTile(
-            value: _showCardReveal,
-            title: const Text('Show Card Reveal'),
-            onChanged: _toggleCardReveal,
-            activeColor: Colors.orange,
-          ),
-          SwitchListTile(
-            value: _showWinnerCelebration,
-            title: const Text('Show Winner Celebration'),
-            onChanged: _toggleWinnerCelebration,
-            activeColor: Colors.orange,
-          ),
-          const SizedBox(height: 20),
-          Center(
-            child: ElevatedButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Back to Main Menu'),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            SwitchListTile(
+              value: _showPotAnimation,
+              title: const Text('Show Pot Animation'),
+              onChanged: _togglePotAnimation,
+              activeColor: Colors.orange,
             ),
-          ),
-        ],
+            SwitchListTile(
+              value: _showCardReveal,
+              title: const Text('Show Card Reveal'),
+              onChanged: _toggleCardReveal,
+              activeColor: Colors.orange,
+            ),
+            SwitchListTile(
+              value: _showWinnerCelebration,
+              title: const Text('Show Winner Celebration'),
+              onChanged: _toggleWinnerCelebration,
+              activeColor: Colors.orange,
+            ),
+            SwitchListTile(
+              value: _showActionHints,
+              title: const Text('Показывать подсказки к действиям'),
+              onChanged: _toggleActionHints,
+              activeColor: Colors.orange,
+            ),
+            const SizedBox(height: 20),
+            Center(
+              child: ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Back to Main Menu'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/services/user_preferences_service.dart
+++ b/lib/services/user_preferences_service.dart
@@ -5,20 +5,24 @@ class UserPreferencesService extends ChangeNotifier {
   static const _potAnimationKey = 'show_pot_animation';
   static const _cardRevealKey = 'show_card_reveal';
   static const _winnerCelebrationKey = 'show_winner_celebration';
+  static const _actionHintsKey = 'show_action_hints';
 
   bool _showPotAnimation = true;
   bool _showCardReveal = true;
   bool _showWinnerCelebration = true;
+  bool _showActionHints = true;
 
   bool get showPotAnimation => _showPotAnimation;
   bool get showCardReveal => _showCardReveal;
   bool get showWinnerCelebration => _showWinnerCelebration;
+  bool get showActionHints => _showActionHints;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
     _showPotAnimation = prefs.getBool(_potAnimationKey) ?? true;
     _showCardReveal = prefs.getBool(_cardRevealKey) ?? true;
     _showWinnerCelebration = prefs.getBool(_winnerCelebrationKey) ?? true;
+    _showActionHints = prefs.getBool(_actionHintsKey) ?? true;
     notifyListeners();
   }
 
@@ -45,6 +49,13 @@ class UserPreferencesService extends ChangeNotifier {
     if (_showWinnerCelebration == value) return;
     _showWinnerCelebration = value;
     await _save(_winnerCelebrationKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setShowActionHints(bool value) async {
+    if (_showActionHints == value) return;
+    _showActionHints = value;
+    await _save(_actionHintsKey, value);
     notifyListeners();
   }
 }

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -14,8 +14,10 @@ class UserPreferences {
   bool get showPotAnimation => service.showPotAnimation;
   bool get showCardReveal => service.showCardReveal;
   bool get showWinnerCelebration => service.showWinnerCelebration;
+  bool get showActionHints => service.showActionHints;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
   Future<void> setShowCardReveal(bool value) => service.setShowCardReveal(value);
   Future<void> setShowWinnerCelebration(bool value) => service.setShowWinnerCelebration(value);
+  Future<void> setShowActionHints(bool value) => service.setShowActionHints(value);
 }

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -4,8 +4,9 @@ import 'detailed_action_bottom_sheet.dart';
 import 'package:intl/intl.dart';
 
 import 'street_pot_widget.dart';
-/// Whether action hints (tooltips) should be shown. TODO: load from preferences.
-const bool kShowActionHints = true;
+import '../user_preferences.dart';
+/// Whether action hints (tooltips) should be shown. Loaded from preferences.
+bool get kShowActionHints => UserPreferences.instance.showActionHints;
 
 /// Список действий на конкретной улице
 class StreetActionsList extends StatelessWidget {


### PR DESCRIPTION
## Summary
- make action hint visibility configurable in SharedPreferences
- expose `showActionHints` in `UserPreferences`
- show new toggle in `SettingsScreen`
- respect preference when displaying tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853404ebd34832aa17bac82dd121878