### PR TITLE
Add pack creation/edit options in menu

### DIFF
--- a/lib/screens/edit_pack_screen.dart
+++ b/lib/screens/edit_pack_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_pack.dart';
+import '../services/training_pack_storage_service.dart';
+import 'create_pack_screen.dart';
+
+class EditPackScreen extends StatelessWidget {
+  const EditPackScreen({super.key});
+
+  Future<void> _openEditor(BuildContext context, TrainingPack pack) async {
+    final service = context.read<TrainingPackStorageService>();
+    final updated = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CreatePackScreen(initialPack: pack),
+      ),
+    );
+    if (updated is TrainingPack) {
+      await service.removePack(pack);
+      await service.addPack(updated);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final packs = context.watch<TrainingPackStorageService>().packs;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Редактировать тренировку'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: packs.isEmpty
+          ? const Center(child: Text('Нет доступных пакетов'))
+          : ListView.builder(
+              itemCount: packs.length,
+              itemBuilder: (context, index) {
+                final pack = packs[index];
+                return ListTile(
+                  title: Text(pack.name),
+                  subtitle: Text(pack.description),
+                  trailing: const Icon(Icons.edit),
+                  onTap: () => _openEditor(context, pack),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -8,6 +8,8 @@ import 'training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
+import 'create_pack_screen.dart';
+import 'edit_pack_screen.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -62,6 +64,30 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('🎯 Тренировка'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const CreatePackScreen(),
+                  ),
+                );
+              },
+              child: const Text('📦 Создать тренировку'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EditPackScreen(),
+                  ),
+                );
+              },
+              child: const Text('✏️ Редактировать тренировку'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- expose create and edit pack flow from main menu
- implement new `EditPackScreen` for editing stored packs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68534059b6f8832abbafcc9b24f24b19