### PR TITLE
Add hand history import

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -8,6 +8,9 @@ import 'training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
+import '../services/hand_history_file_import_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import 'package:provider/provider.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -94,6 +97,17 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('🧪 Player Zone Demo'),
+            ),
+            const SizedBox(height: 32),
+            const Text('🛠️ Инструменты'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final manager = context.read<SavedHandManagerService>();
+                final service = HandHistoryFileImportService();
+                await service.importHandsFromFiles(context, manager);
+              },
+              child: const Text('Импортировать Hand History'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/services/hand_history_file_import_service.dart
+++ b/lib/services/hand_history_file_import_service.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:poker_ai_analyzer/import_export/converter_pipeline.dart';
+import 'package:poker_ai_analyzer/plugins/plugin_loader.dart';
+import 'package:poker_ai_analyzer/plugins/plugin_manager.dart';
+import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
+import 'package:poker_ai_analyzer/services/service_registry.dart';
+import 'saved_hand_manager_service.dart';
+import '../models/saved_hand.dart';
+
+/// Imports hand history files using available converters.
+class HandHistoryFileImportService {
+  HandHistoryFileImportService() {
+    final registry = ServiceRegistry();
+    final manager = PluginManager();
+    final loader = PluginLoader();
+    for (final plugin in loader.loadBuiltInPlugins()) {
+      manager.load(plugin);
+    }
+    manager.initializeAll(registry);
+    _pipeline = ConverterPipeline(registry.get<ConverterRegistry>());
+  }
+
+  late final ConverterPipeline _pipeline;
+
+  /// Opens a file picker, converts selected files and adds them to [handManager].
+  Future<int> importHandsFromFiles(
+      BuildContext context, SavedHandManagerService handManager) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['txt', 'json'],
+      allowMultiple: true,
+    );
+    if (result == null || result.files.isEmpty) return 0;
+    int count = 0;
+    for (final f in result.files) {
+      final path = f.path;
+      if (path == null) continue;
+      try {
+        final content = await File(path).readAsString();
+        SavedHand? hand;
+        for (final id in _pipeline.supportedFormats()) {
+          hand = _pipeline.tryImport(id, content);
+          if (hand != null) break;
+        }
+        if (hand != null) {
+          await handManager.add(hand);
+          count++;
+        }
+      } catch (_) {}
+    }
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Импортировано раздач: $count')),
+      );
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary
- add service to import hand histories using plugins
- wire new tool into main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853405f85b0832aaa89a1e09d5c7b48