### PR TITLE
Add hand history import tools

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -10,6 +10,9 @@ import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
 import 'create_pack_screen.dart';
 import 'edit_pack_screen.dart';
+import 'package:provider/provider.dart';
+import '../services/hand_history_file_service.dart';
+import '../services/saved_hand_manager_service.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({super.key});
@@ -130,6 +133,21 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('⚙️ Settings'),
+            ),
+            const SizedBox(height: 32),
+            const Text(
+              '🛠️ Инструменты',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final manager =
+                    Provider.of<SavedHandManagerService>(context, listen: false);
+                final service = HandHistoryFileService(manager);
+                await service.importFromFiles(context);
+              },
+              child: const Text('Импортировать Hand History'),
             ),
           ],
         ),

--- a/lib/services/hand_history_file_service.dart
+++ b/lib/services/hand_history_file_service.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../import_export/converter_pipeline.dart';
+import '../plugins/plugin_loader.dart';
+import '../plugins/plugin_manager.dart';
+import '../plugins/converter_registry.dart';
+import '../services/service_registry.dart';
+import 'saved_hand_manager_service.dart';
+
+/// Handles importing external hand history files using available converters.
+class HandHistoryFileService {
+  HandHistoryFileService(this._handManager) {
+    final loader = PluginLoader();
+    final manager = PluginManager();
+    final registry = ServiceRegistry();
+    for (final plugin in loader.loadBuiltInPlugins()) {
+      manager.load(plugin);
+    }
+    manager.initializeAll(registry);
+    final converterRegistry = registry.get<ConverterRegistry>();
+    _pipeline = ConverterPipeline(converterRegistry);
+  }
+
+  final SavedHandManagerService _handManager;
+  late final ConverterPipeline _pipeline;
+
+  /// Prompts the user to select hand history files and imports them.
+  Future<int> importFromFiles(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(allowMultiple: true);
+    if (result == null || result.files.isEmpty) return 0;
+
+    final converters = _pipeline.availableConverters(supportsImport: true);
+    int imported = 0;
+
+    for (final file in result.files) {
+      final path = file.path;
+      if (path == null) continue;
+      try {
+        final content = await File(path).readAsString();
+        for (final info in converters) {
+          final hand = _pipeline.tryImport(info.formatId, content);
+          if (hand != null) {
+            await _handManager.add(hand);
+            imported++;
+            break;
+          }
+        }
+      } catch (_) {
+        // Ignore read/parse errors.
+      }
+    }
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        imported > 0
+            ? SnackBar(content: Text('Импортировано рук: $imported'))
+            : const SnackBar(content: Text('Не удалось импортировать файлы')),
+      );
+    }
+    return imported;
+  }
+}


### PR DESCRIPTION
## Summary
- add `HandHistoryFileService` to import hand histories via converter pipeline
- extend main menu with "🛠️ Инструменты" section and import button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853419861c8832a8703487d96fa1db9