### PR TITLE
Add TrainingSpotAnalysisScreen

### DIFF
--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_spot.dart';
+import '../helpers/pot_calculator.dart';
+import '../models/street_investments.dart';
+import '../helpers/stack_manager.dart';
+import '../widgets/street_actions_list.dart';
+
+/// Displays actions for a [TrainingSpot] grouped by street in collapsible sections.
+class TrainingSpotAnalysisScreen extends StatelessWidget {
+  final TrainingSpot spot;
+
+  const TrainingSpotAnalysisScreen({super.key, required this.spot});
+
+  List<int> _computePots() {
+    final investments = StreetInvestments();
+    for (final a in spot.actions) {
+      investments.addAction(a);
+    }
+    return PotCalculator().calculatePots(spot.actions, investments);
+  }
+
+  Map<int, int> _computeStacks() {
+    final initial = {
+      for (int i = 0; i < spot.numberOfPlayers; i++) i: spot.stacks[i]
+    };
+    final manager = StackManager(initial);
+    manager.applyActions(spot.actions);
+    return manager.currentStacks;
+  }
+
+  Map<int, String> _posMap() => {
+        for (int i = 0; i < spot.numberOfPlayers; i++) i: spot.positions[i]
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final pots = _computePots();
+    final stacks = _computeStacks();
+    final positions = _posMap();
+    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+
+    final tiles = <Widget>[];
+    for (int street = 0; street < 4; street++) {
+      if (!spot.actions.any((a) => a.street == street)) continue;
+      tiles.add(
+        ExpansionTile(
+          title: Text(
+            streetNames[street],
+            style: const TextStyle(color: Colors.white),
+          ),
+          collapsedIconColor: Colors.white,
+          iconColor: Colors.white,
+          textColor: Colors.white,
+          childrenPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          children: [
+            SizedBox(
+              height: 180,
+              child: StreetActionsList(
+                street: street,
+                actions: spot.actions,
+                pots: pots,
+                stackSizes: stacks,
+                playerPositions: positions,
+                onEdit: (_, __) {},
+                onDelete: (_) {},
+                visibleCount: spot.actions.length,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Spot Analysis'),
+        centerTitle: true,
+      ),
+      backgroundColor: Colors.black,
+      body: ListView(
+        padding: const EdgeInsets.all(8),
+        children: tiles,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new TrainingSpotAnalysisScreen showing actions per street in collapsible ExpansionTiles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68534ec41908832a9d63b484f06ba1bf