### PR TITLE
Enable analysis from TrainingSpot card

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -14,6 +14,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../models/training_spot.dart';
 import '../../theme/app_colors.dart';
+import '../../screens/training_spot_analysis_screen.dart';
 
 enum SortOption {
   buyInAsc,
@@ -2809,6 +2810,21 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                               color: Colors.white70),
                                           onPressed: () => _duplicateSpot(spot),
                                         ),
+                                        IconButton(
+                                          icon: const Text('⚔️',
+                                              style: TextStyle(fontSize: 18)),
+                                          tooltip: 'Анализ',
+                                          onPressed: () {
+                                            Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (_) =>
+                                                    TrainingSpotAnalysisScreen(
+                                                        spot: spot),
+                                              ),
+                                            );
+                                          },
+                                        ),
                                         if (widget.onRemove != null)
                                           IconButton(
                                             icon: const Icon(Icons.delete,
@@ -3013,6 +3029,21 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                         icon: const Icon(Icons.copy,
                                             color: Colors.white70),
                                         onPressed: () => _duplicateSpot(spot),
+                                      ),
+                                      IconButton(
+                                        icon: const Text('⚔️',
+                                            style: TextStyle(fontSize: 18)),
+                                        tooltip: 'Анализ',
+                                        onPressed: () {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (_) =>
+                                                  TrainingSpotAnalysisScreen(
+                                                      spot: spot),
+                                            ),
+                                          );
+                                        },
                                       ),
                                       if (widget.onRemove != null)
                                         IconButton(


### PR DESCRIPTION
## Summary
- allow a TrainingSpot card to open analysis view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685350d4e7d8832abab2093062ab30b3