### PR TITLE
Implement Coach Mode preference

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -14,6 +14,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _showCardReveal;
   late bool _showWinnerCelebration;
   late bool _showActionHints;
+  late bool _coachMode;
 
   @override
   void initState() {
@@ -23,6 +24,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _showCardReveal = prefs.showCardReveal;
     _showWinnerCelebration = prefs.showWinnerCelebration;
     _showActionHints = prefs.showActionHints;
+    _coachMode = prefs.coachMode;
   }
 
   Future<void> _togglePotAnimation(bool value) async {
@@ -43,6 +45,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _toggleActionHints(bool value) async {
     setState(() => _showActionHints = value);
     await UserPreferences.instance.setShowActionHints(value);
+  }
+
+  Future<void> _toggleCoachMode(bool value) async {
+    setState(() => _coachMode = value);
+    await UserPreferences.instance.setCoachMode(value);
   }
 
   @override
@@ -78,6 +85,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               value: _showActionHints,
               title: const Text('Показывать подсказки к действиям'),
               onChanged: _toggleActionHints,
+              activeColor: Colors.orange,
+            ),
+            SwitchListTile(
+              value: _coachMode,
+              title: const Text('Режим тренера (Coach Mode)'),
+              onChanged: _toggleCoachMode,
               activeColor: Colors.orange,
             ),
             const SizedBox(height: 20),

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -5,12 +5,30 @@ import '../helpers/pot_calculator.dart';
 import '../models/street_investments.dart';
 import '../helpers/stack_manager.dart';
 import '../widgets/street_actions_list.dart';
+import '../models/action_entry.dart';
+import '../services/user_preferences_service.dart';
+import 'package:provider/provider.dart';
 
 /// Displays actions for a [TrainingSpot] grouped by street in collapsible sections.
 class TrainingSpotAnalysisScreen extends StatelessWidget {
   final TrainingSpot spot;
 
   const TrainingSpotAnalysisScreen({super.key, required this.spot});
+
+  String _evaluateActionQuality(ActionEntry entry) {
+    switch (entry.action) {
+      case 'raise':
+      case 'bet':
+        return 'Лучшая линия';
+      case 'call':
+      case 'check':
+        return 'Нормальная линия';
+      case 'fold':
+        return 'Ошибка';
+      default:
+        return 'Нормальная линия';
+    }
+  }
 
   List<int> _computePots() {
     final investments = StreetInvestments();
@@ -38,6 +56,7 @@ class TrainingSpotAnalysisScreen extends StatelessWidget {
     final pots = _computePots();
     final stacks = _computeStacks();
     final positions = _posMap();
+    final prefs = context.watch<UserPreferencesService>();
     const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
 
     final tiles = <Widget>[];
@@ -65,6 +84,8 @@ class TrainingSpotAnalysisScreen extends StatelessWidget {
                 onEdit: (_, __) {},
                 onDelete: (_) {},
                 visibleCount: spot.actions.length,
+                evaluateActionQuality:
+                    prefs.coachMode ? _evaluateActionQuality : null,
               ),
             ),
           ],

--- a/lib/services/user_preferences_service.dart
+++ b/lib/services/user_preferences_service.dart
@@ -6,16 +6,19 @@ class UserPreferencesService extends ChangeNotifier {
   static const _cardRevealKey = 'show_card_reveal';
   static const _winnerCelebrationKey = 'show_winner_celebration';
   static const _actionHintsKey = 'show_action_hints';
+  static const _coachModeKey = 'coach_mode';
 
   bool _showPotAnimation = true;
   bool _showCardReveal = true;
   bool _showWinnerCelebration = true;
   bool _showActionHints = true;
+  bool _coachMode = false;
 
   bool get showPotAnimation => _showPotAnimation;
   bool get showCardReveal => _showCardReveal;
   bool get showWinnerCelebration => _showWinnerCelebration;
   bool get showActionHints => _showActionHints;
+  bool get coachMode => _coachMode;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -23,6 +26,7 @@ class UserPreferencesService extends ChangeNotifier {
     _showCardReveal = prefs.getBool(_cardRevealKey) ?? true;
     _showWinnerCelebration = prefs.getBool(_winnerCelebrationKey) ?? true;
     _showActionHints = prefs.getBool(_actionHintsKey) ?? true;
+    _coachMode = prefs.getBool(_coachModeKey) ?? false;
     notifyListeners();
   }
 
@@ -56,6 +60,13 @@ class UserPreferencesService extends ChangeNotifier {
     if (_showActionHints == value) return;
     _showActionHints = value;
     await _save(_actionHintsKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setCoachMode(bool value) async {
+    if (_coachMode == value) return;
+    _coachMode = value;
+    await _save(_coachModeKey, value);
     notifyListeners();
   }
 }

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -15,9 +15,11 @@ class UserPreferences {
   bool get showCardReveal => service.showCardReveal;
   bool get showWinnerCelebration => service.showWinnerCelebration;
   bool get showActionHints => service.showActionHints;
+  bool get coachMode => service.coachMode;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
   Future<void> setShowCardReveal(bool value) => service.setShowCardReveal(value);
   Future<void> setShowWinnerCelebration(bool value) => service.setShowWinnerCelebration(value);
   Future<void> setShowActionHints(bool value) => service.setShowActionHints(value);
+  Future<void> setCoachMode(bool value) => service.setCoachMode(value);
 }


### PR DESCRIPTION
## Summary
- add `coachMode` preference to track trainer mode
- expose Coach Mode toggle in settings
- show evaluation badges in TrainingSpotAnalysisScreen when Coach Mode is on

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685352313d74832ab8bd75f9e87a0ede