### PR TITLE
Add manual evaluation reset option

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -271,6 +271,8 @@ class SavedHand {
               'amount': a.amount,
               'generated': a.generated,
               'timestamp': a.timestamp.toIso8601String(),
+              if (a.manualEvaluation != null)
+                'manualEvaluation': a.manualEvaluation,
             }
         ],
         'stackSizes': stackSizes.map((k, v) => MapEntry(k.toString(), v)),
@@ -354,6 +356,7 @@ class SavedHand {
           generated: a['generated'] as bool? ?? false,
           timestamp:
               DateTime.tryParse(a['timestamp'] as String? ?? '') ?? DateTime.now(),
+          manualEvaluation: a['manualEvaluation'] as String?,
         )
     ];
     final stack = <int, int>{};

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -62,7 +62,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
     return entry.manualEvaluation ?? _evaluateActionQuality(entry);
   }
 
-  void _setManualEvaluation(ActionEntry entry, String value) {
+  void _setManualEvaluation(ActionEntry entry, String? value) {
     setState(() {
       entry.manualEvaluation = value;
     });

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -18,7 +18,7 @@ class StreetActionsList extends StatelessWidget {
   final void Function(int) onDelete;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
-  final void Function(ActionEntry, String)? onManualEvaluationChanged;
+  final void Function(ActionEntry, String?)? onManualEvaluationChanged;
 
   const StreetActionsList({
     super.key,
@@ -174,20 +174,39 @@ class StreetActionsList extends StatelessWidget {
                           onManualEvaluationChanged!(a, result);
                         }
                       },
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                  decoration: BoxDecoration(
-                    color: qualityColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    qualityLabel!,
-                    style: const TextStyle(
-                      color: Colors.black,
-                      fontSize: 12,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: qualityColor,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        qualityLabel!,
+                        style: const TextStyle(
+                          color: Colors.black,
+                          fontSize: 12,
+                        ),
+                      ),
                     ),
-                  ),
+                    if (a.manualEvaluation != null &&
+                        onManualEvaluationChanged != null)
+                      GestureDetector(
+                        onTap: () =>
+                            onManualEvaluationChanged!(a, null),
+                        child: const Padding(
+                          padding: EdgeInsets.only(left: 4.0),
+                          child: Icon(
+                            Icons.close,
+                            size: 12,
+                            color: Colors.black,
+                          ),
+                        ),
+                      ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- add serialization of `manualEvaluation` in saved hands
- allow clearing manual evaluations from analysis screen
- show a reset ❌ button beside manual evaluation labels

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_685355109454832a845dc2bca5696d7b