### PR TITLE
Add reset filters button

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -73,6 +73,16 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     });
   }
 
+  Future<void> _resetFilters() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_sortKey, _SortOption.newest.index);
+    await prefs.setInt(_ratingKey, _RatingFilter.all.index);
+    setState(() {
+      _sort = _SortOption.newest;
+      _ratingFilter = _RatingFilter.all;
+    });
+  }
+
   List<TrainingResult> _getFilteredHistory() {
     final cutoff = DateTime.now().subtract(Duration(days: _filterDays));
     final list = _history
@@ -199,13 +209,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                           setState(() => _ratingFilter = value);
                         },
                       ),
-                    ],
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
+                      const SizedBox(width: 16),
                       const Text('Сортировка',
                           style: TextStyle(color: Colors.white)),
                       const SizedBox(width: 8),
@@ -231,6 +235,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                           await prefs.setInt(_sortKey, value.index);
                           setState(() => _sort = value);
                         },
+                      ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: _resetFilters,
+                        child: const Text('Сбросить фильтры'),
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- add `_resetFilters` to reset sort and rating filters
- integrate `Сбросить фильтры` button next to dropdowns in `TrainingHistoryScreen`

## Testing
- `dart format lib/screens/training_history_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535fd8ee18832a9d2c826078bb7eb0