### PR TITLE
Add session detail screen

### DIFF
--- a/lib/screens/training_detail_screen.dart
+++ b/lib/screens/training_detail_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/training_result.dart';
+import '../theme/app_colors.dart';
+
+class TrainingDetailScreen extends StatelessWidget {
+  final TrainingResult result;
+  final Future<void> Function() onDelete;
+  final Future<void> Function(BuildContext) onEditTags;
+
+  const TrainingDetailScreen({
+    super.key,
+    required this.result,
+    required this.onDelete,
+    required this.onEditTags,
+  });
+
+  Future<void> _confirmDelete(BuildContext context) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete Session?'),
+          content: const Text('Are you sure you want to delete this session?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirm ?? false) {
+      await onDelete();
+      // ignore: use_build_context_synchronously
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = result.accuracy.toStringAsFixed(1);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Session Details'),
+        centerTitle: true,
+      ),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Date: ${formatDateTime(result.date)}',
+              style: const TextStyle(color: Colors.white),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Total hands: ${result.total}',
+              style: const TextStyle(color: Colors.white),
+            ),
+            Text(
+              'Correct answers: ${result.correct}',
+              style: const TextStyle(color: Colors.white),
+            ),
+            Text(
+              'Accuracy: $accuracy%',
+              style: const TextStyle(color: Colors.greenAccent),
+            ),
+            const SizedBox(height: 16),
+            const Text('Tags:', style: TextStyle(color: Colors.white)),
+            const SizedBox(height: 8),
+            if (result.tags.isEmpty)
+              const Text('No tags', style: TextStyle(color: Colors.white70))
+            else
+              Wrap(
+                spacing: 4,
+                children: [
+                  for (final tag in result.tags)
+                    Chip(
+                      label: Text(tag),
+                    ),
+                ],
+              ),
+            const Spacer(),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      await onEditTags(context);
+                      // ignore: use_build_context_synchronously
+                      Navigator.pop(context);
+                    },
+                    child: const Text('Edit Tags'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                    onPressed: () => _confirmDelete(context),
+                    child: const Text('Delete'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -10,6 +10,7 @@ import 'package:file_picker/file_picker.dart';
 import '../theme/app_colors.dart';
 import '../widgets/common/accuracy_chart.dart';
 import '../widgets/common/history_list_item.dart';
+import 'training_detail_screen.dart';
 
 import '../models/training_result.dart';
 import '../helpers/date_utils.dart';
@@ -268,11 +269,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     }
   }
 
-  Future<void> _editSessionTags(TrainingResult session) async {
+  Future<void> _editSessionTags(BuildContext ctx, TrainingResult session) async {
     final tags = {for (final r in _history) ...r.tags};
     final local = Set<String>.from(session.tags);
     final updated = await showDialog<Set<String>>(
-      context: context,
+      context: ctx,
       builder: (context) {
         return AlertDialog(
           backgroundColor: AppColors.cardBackground,
@@ -342,6 +343,23 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _history.remove(session);
     });
     await _saveHistory();
+  }
+
+  void _openSessionDetail(TrainingResult session) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingDetailScreen(
+          result: session,
+          onDelete: () async {
+            await _deleteSession(session);
+          },
+          onEditTags: (ctx) async {
+            await _editSessionTags(ctx, session);
+          },
+        ),
+      ),
+    );
   }
 
 
@@ -570,7 +588,8 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                           onDismissed: (_) => _deleteSession(result),
                           child: HistoryListItem(
                             result: result,
-                            onLongPress: () => _editSessionTags(result),
+                            onLongPress: () => _editSessionTags(context, result),
+                            onTap: () => _openSessionDetail(result),
                           ),
                         );
                       },

--- a/lib/widgets/common/history_list_item.dart
+++ b/lib/widgets/common/history_list_item.dart
@@ -6,8 +6,14 @@ import '../../theme/app_colors.dart';
 class HistoryListItem extends StatelessWidget {
   final TrainingResult result;
   final VoidCallback? onLongPress;
+  final VoidCallback? onTap;
 
-  const HistoryListItem({super.key, required this.result, this.onLongPress});
+  const HistoryListItem({
+    super.key,
+    required this.result,
+    this.onLongPress,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +37,7 @@ class HistoryListItem extends StatelessWidget {
           style: const TextStyle(color: Colors.greenAccent),
         ),
         onLongPress: onLongPress,
+        onTap: onTap,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- create TrainingDetailScreen for viewing session info
- support tapping HistoryListItem to open detail view
- allow editing tags or deleting from detail screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68536648ba00832ab3e2ac521b8b85a3