### PR TITLE
Add session accuracy bar chart

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -10,6 +10,7 @@ import 'package:file_picker/file_picker.dart';
 import '../theme/app_colors.dart';
 import '../widgets/common/accuracy_chart.dart';
 import '../widgets/common/history_list_item.dart';
+import '../widgets/common/session_accuracy_bar_chart.dart';
 import 'training_detail_screen.dart';
 
 import '../models/training_result.dart';
@@ -517,7 +518,16 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 ),
                 Builder(builder: (context) {
                   final filtered = _getFilteredHistory();
-                  return AccuracyChart(sessions: filtered);
+                  final last7days = _history
+                      .where((r) =>
+                          r.date.isAfter(DateTime.now().subtract(const Duration(days: 7))))
+                      .toList();
+                  return Column(
+                    children: [
+                      AccuracyChart(sessions: filtered),
+                      SessionAccuracyBarChart(sessions: last7days),
+                    ],
+                  );
                 }),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/widgets/common/session_accuracy_bar_chart.dart
+++ b/lib/widgets/common/session_accuracy_bar_chart.dart
@@ -1,0 +1,116 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/training_result.dart';
+import '../../theme/app_colors.dart';
+
+class SessionAccuracyBarChart extends StatelessWidget {
+  final List<TrainingResult> sessions;
+
+  const SessionAccuracyBarChart({super.key, required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    final cutoff = DateTime.now().subtract(const Duration(days: 7));
+    final recent = sessions
+        .where((s) => s.date.isAfter(cutoff))
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    if (recent.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final groups = <BarChartGroupData>[];
+    for (var i = 0; i < recent.length; i++) {
+      final r = recent[i];
+      final color =
+          Color.lerp(Colors.red, Colors.green, r.accuracy.clamp(0, 100) / 100)!;
+      groups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: r.accuracy,
+              gradient: LinearGradient(
+                colors: [color.withOpacity(0.7), color],
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+              ),
+              width: 14,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: BarChart(
+          BarChartData(
+            maxY: 100,
+            minY: 0,
+            alignment: BarChartAlignment.spaceBetween,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= recent.length) {
+                      return const SizedBox.shrink();
+                    }
+                    final d = recent[index].date;
+                    final label =
+                        '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                    return Text(
+                      label,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            barGroups: groups,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- visualize accuracy of recent sessions using bars
- show bar chart together with the existing line chart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68536ac4c130832aa9a8837888267af9