### PR TITLE
Add average accuracy trend chart

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -10,6 +10,7 @@ import 'package:csv/csv.dart';
 
 import '../theme/app_colors.dart';
 import '../widgets/common/accuracy_chart.dart';
+import '../widgets/common/average_accuracy_chart.dart';
 import '../widgets/common/history_list_item.dart';
 import '../widgets/common/session_accuracy_bar_chart.dart';
 import 'training_detail_screen.dart';
@@ -804,6 +805,12 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                       );
                     },
                   ),
+                ),
+                Builder(
+                  builder: (context) {
+                    final filtered = _getFilteredHistory();
+                    return AverageAccuracyChart(sessions: filtered);
+                  },
                 ),
                 Expanded(
                   child: Builder(builder: (context) {

--- a/lib/widgets/common/average_accuracy_chart.dart
+++ b/lib/widgets/common/average_accuracy_chart.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../models/training_result.dart';
+import '../../theme/app_colors.dart';
+
+class AverageAccuracyChart extends StatelessWidget {
+  final List<TrainingResult> sessions;
+
+  const AverageAccuracyChart({super.key, required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    if (sessions.length < 2) {
+      return const SizedBox.shrink();
+    }
+
+    final sorted = [...sessions]..sort((a, b) => a.date.compareTo(b.date));
+    final spots = <FlSpot>[];
+    double sum = 0;
+    for (var i = 0; i < sorted.length; i++) {
+      sum += sorted[i].accuracy;
+      final avg = sum / (i + 1);
+      spots.add(FlSpot(i.toDouble(), avg));
+    }
+    final step = (sorted.length / 6).ceil();
+
+    final line = LineChartBarData(
+      spots: spots,
+      isCurved: true,
+      color: Colors.blueAccent,
+      barWidth: 2,
+      dotData: FlDotData(show: false),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= sorted.length) {
+                      return const SizedBox.shrink();
+                    }
+                    if (index % step != 0 && index != sorted.length - 1) {
+                      return const SizedBox.shrink();
+                    }
+                    final d = sorted[index].date;
+                    final label =
+                        '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                    return Text(
+                      label,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            lineBarsData: [line],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `AverageAccuracyChart` widget for displaying cumulative accuracy trend
- show the average accuracy chart below the summary panel on TrainingHistoryScreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68536ed768b0832abf2ec4395df40922