### PR TITLE
Add tag editing icon for training history

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -1354,6 +1354,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                             result: result,
                             onLongPress: () => _editSessionTags(context, result),
                             onTap: () => _editSessionNotes(context, result),
+                            onTagTap: () => _editSessionTags(context, result),
                           ),
                         );
                       },

--- a/lib/widgets/common/history_list_item.dart
+++ b/lib/widgets/common/history_list_item.dart
@@ -7,18 +7,21 @@ class HistoryListItem extends StatelessWidget {
   final TrainingResult result;
   final VoidCallback? onLongPress;
   final VoidCallback? onTap;
+  final VoidCallback? onTagTap;
 
   const HistoryListItem({
     super.key,
     required this.result,
     this.onLongPress,
     this.onTap,
+    this.onTagTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final accuracy = result.accuracy.toStringAsFixed(1);
     final notes = result.notes;
+    final tags = result.tags;
     return Container(
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -36,16 +39,38 @@ class HistoryListItem extends StatelessWidget {
               'Correct: ${result.correct} / ${result.total}',
               style: const TextStyle(color: Colors.white70),
             ),
+            if (tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Wrap(
+                  spacing: 4,
+                  children: [for (final t in tags) Chip(label: Text(t))],
+                ),
+              ),
             if (notes != null && notes.isNotEmpty)
-              Text(
-                notes,
-                style: const TextStyle(color: Colors.white54),
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  notes,
+                  style: const TextStyle(color: Colors.white54),
+                ),
               ),
           ],
         ),
-        trailing: Text(
-          '$accuracy%',
-          style: const TextStyle(color: Colors.greenAccent),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '$accuracy%',
+              style: const TextStyle(color: Colors.greenAccent),
+            ),
+            IconButton(
+              icon: const Icon(Icons.label_outline, color: Colors.white70),
+              tooltip: 'Edit Tags',
+              onPressed: onTagTap,
+            ),
+          ],
         ),
         onLongPress: onLongPress,
         onTap: onTap,


### PR DESCRIPTION
## Summary
- show tags and an edit icon in each history item
- open tag editor from the new icon

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853d13b2a58832ab9f95af64620d5bd