### PR TITLE
Add tag backup & restore

### DIFF
--- a/lib/screens/tag_management_screen.dart
+++ b/lib/screens/tag_management_screen.dart
@@ -68,6 +68,20 @@ class TagManagementScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Теги'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.download),
+            tooltip: 'Экспорт',
+            onPressed: () =>
+                context.read<TagService>().exportToFile(context),
+          ),
+          IconButton(
+            icon: const Icon(Icons.upload),
+            tooltip: 'Импорт',
+            onPressed: () =>
+                context.read<TagService>().importFromFile(context),
+          ),
+        ],
       ),
       body: ReorderableListView(
         onReorder: (oldIndex, newIndex) =>


### PR DESCRIPTION
## Summary
- add export/import methods to `TagService`
- add buttons to manage global tags in `TagManagementScreen`

## Testing
- `flutter pub get`
- (tests omitted per instructions)


------
https://chatgpt.com/codex/tasks/task_e_6853d3ca0128832a9040cb0072cca2a8