### PR TITLE
Add weekday filter to history

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -42,6 +42,8 @@ enum _ChartMode { daily, weekly, monthly }
 
 enum _TagCountFilter { any, one, twoPlus, threePlus }
 
+enum _WeekdayFilter { all, mon, tue, wed, thu, fri, sat, sun }
+
 class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   static const _sortKey = 'training_history_sort';
   static const _ratingKey = 'training_history_rating';
@@ -57,6 +59,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   static const _sortByTagKey = 'training_history_sort_by_tag';
   static const _accuracyRangeKey = 'training_history_accuracy_range';
   static const _tagCountKey = 'training_history_tag_count';
+  static const _weekdayKey = 'training_history_weekday';
 
   final List<TrainingResult> _history = [];
   int _filterDays = 7;
@@ -72,6 +75,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   bool _sortByTag = false;
   _ChartMode _chartMode = _ChartMode.daily;
   _TagCountFilter _tagCountFilter = _TagCountFilter.any;
+  _WeekdayFilter _weekdayFilter = _WeekdayFilter.all;
 
   DateTime? _dateFrom;
   DateTime? _dateTo;
@@ -96,6 +100,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final sortByTag = prefs.getBool(_sortByTagKey) ?? false;
     final chartModeIndex = prefs.getInt(_chartModeKey) ?? 0;
     final tagCountIndex = prefs.getInt(_tagCountKey) ?? 0;
+    final weekdayIndex = prefs.getInt(_weekdayKey) ?? 0;
     final fromMillis = prefs.getInt(_dateFromKey);
     final toMillis = prefs.getInt(_dateToKey);
     setState(() {
@@ -111,6 +116,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _sortByTag = sortByTag;
       _chartMode = _ChartMode.values[chartModeIndex];
       _tagCountFilter = _TagCountFilter.values[tagCountIndex];
+      _weekdayFilter = _WeekdayFilter.values[weekdayIndex];
       _dateFrom =
           fromMillis != null ? DateTime.fromMillisecondsSinceEpoch(fromMillis) : null;
       _dateTo =
@@ -331,6 +337,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     await prefs.setInt(_ratingKey, _RatingFilter.all.index);
     await prefs.setInt(_accuracyRangeKey, _AccuracyRange.all.index);
     await prefs.setInt(_tagCountKey, _TagCountFilter.any.index);
+    await prefs.setInt(_weekdayKey, _WeekdayFilter.all.index);
     await prefs.setBool(_sortByTagKey, false);
     await prefs.remove(_tagKey);
     await prefs.remove(_tagColorKey);
@@ -341,6 +348,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _ratingFilter = _RatingFilter.all;
       _accuracyRange = _AccuracyRange.all;
       _tagCountFilter = _TagCountFilter.any;
+      _weekdayFilter = _WeekdayFilter.all;
       _selectedTags.clear();
       _selectedTagColors.clear();
       _sortByTag = false;
@@ -421,6 +429,26 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
               return r.tags.length >= 2;
             case _TagCountFilter.threePlus:
               return r.tags.length >= 3;
+          }
+        })
+        .where((r) {
+          switch (_weekdayFilter) {
+            case _WeekdayFilter.all:
+              return true;
+            case _WeekdayFilter.mon:
+              return r.date.weekday == DateTime.monday;
+            case _WeekdayFilter.tue:
+              return r.date.weekday == DateTime.tuesday;
+            case _WeekdayFilter.wed:
+              return r.date.weekday == DateTime.wednesday;
+            case _WeekdayFilter.thu:
+              return r.date.weekday == DateTime.thursday;
+            case _WeekdayFilter.fri:
+              return r.date.weekday == DateTime.friday;
+            case _WeekdayFilter.sat:
+              return r.date.weekday == DateTime.saturday;
+            case _WeekdayFilter.sun:
+              return r.date.weekday == DateTime.sunday;
           }
         })
         .where((r) {
@@ -1348,6 +1376,45 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                           final prefs = await SharedPreferences.getInstance();
                           await prefs.setInt(_tagCountKey, value.index);
                           setState(() => _tagCountFilter = value);
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      const Text('День недели',
+                          style: TextStyle(color: Colors.white)),
+                      const SizedBox(width: 8),
+                      DropdownButton<_WeekdayFilter>(
+                        value: _weekdayFilter,
+                        dropdownColor: AppColors.cardBackground,
+                        style: const TextStyle(color: Colors.white),
+                        items: const [
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.all, child: Text('Все')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.mon, child: Text('Пн')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.tue, child: Text('Вт')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.wed, child: Text('Ср')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.thu, child: Text('Чт')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.fri, child: Text('Пт')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.sat, child: Text('Сб')),
+                          DropdownMenuItem(
+                              value: _WeekdayFilter.sun, child: Text('Вс')),
+                        ],
+                        onChanged: (value) async {
+                          if (value == null) return;
+                          final prefs = await SharedPreferences.getInstance();
+                          await prefs.setInt(_weekdayKey, value.index);
+                          setState(() => _weekdayFilter = value);
                         },
                       ),
                     ],


### PR DESCRIPTION
## Summary
- add `_WeekdayFilter` enum and preference key
- apply day-of-week filtering in `_getFilteredHistory`
- store and reset the chosen weekday
- add dropdown on TrainingHistoryScreen to select weekday

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853dbd5e0e8832ab5a8f7f489ba172c