### PR TITLE
Add accuracy trend chart toggle

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -16,6 +16,7 @@ import '../helpers/color_utils.dart';
 import '../theme/app_colors.dart';
 import '../widgets/common/accuracy_chart.dart';
 import '../widgets/common/average_accuracy_chart.dart';
+import '../widgets/common/accuracy_trend_chart.dart';
 import '../widgets/common/history_list_item.dart';
 import '../widgets/common/session_accuracy_bar_chart.dart';
 import '../widgets/common/accuracy_distribution_chart.dart';
@@ -54,6 +55,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   static const _showChartsKey = 'training_history_show_charts';
   static const _showAvgChartKey = 'training_history_show_chart';
   static const _showDistributionKey = 'training_history_show_distribution';
+  static const _showTrendChartKey = 'training_history_show_trend_chart';
   static const _dateFromKey = 'training_history_date_from';
   static const _dateToKey = 'training_history_date_to';
   static const _chartModeKey = 'training_history_chart_mode';
@@ -74,6 +76,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   bool _showCharts = true;
   bool _showAvgChart = true;
   bool _showDistribution = true;
+  bool _showTrendChart = true;
   bool _hideEmptyTags = false;
   bool _sortByTag = false;
   _ChartMode _chartMode = _ChartMode.daily;
@@ -100,6 +103,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final showCharts = prefs.getBool(_showChartsKey);
     final showAvgChart = prefs.getBool(_showAvgChartKey);
     final showDistribution = prefs.getBool(_showDistributionKey);
+    final showTrendChart = prefs.getBool(_showTrendChartKey);
     final hideEmptyTags = prefs.getBool(_hideEmptyTagsKey) ?? false;
     final sortByTag = prefs.getBool(_sortByTagKey) ?? false;
     final chartModeIndex = prefs.getInt(_chartModeKey) ?? 0;
@@ -117,6 +121,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _showCharts = showCharts ?? true;
       _showAvgChart = showAvgChart ?? true;
       _showDistribution = showDistribution ?? true;
+      _showTrendChart = showTrendChart ?? true;
       _hideEmptyTags = hideEmptyTags;
       _sortByTag = sortByTag;
       _chartMode = _ChartMode.values[chartModeIndex];
@@ -993,6 +998,12 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     await prefs.setBool(_showDistributionKey, _showDistribution);
   }
 
+  Future<void> _setTrendChartVisible(bool value) async {
+    setState(() => _showTrendChart = value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showTrendChartKey, _showTrendChart);
+  }
+
   Future<void> _setHideEmptyTags(bool value) async {
     setState(() => _hideEmptyTags = value);
     final prefs = await SharedPreferences.getInstance();
@@ -1765,10 +1776,35 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         return AccuracyDistributionChart(sessions: grouped);
                       },
                     ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Row(
+                      children: [
+                        const Text('Показать тренд точности',
+                            style: TextStyle(color: Colors.white)),
+                        const Spacer(),
+                        Switch(
+                          value: _showTrendChart,
+                          onChanged: _setTrendChartVisible,
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (_showTrendChart)
+                    Builder(
+                      builder: (context) {
+                        final filtered = _getFilteredHistory();
+                        final grouped = _groupSessionsForChart(filtered);
+                        return AccuracyTrendChart(
+                          sessions: grouped,
+                          mode: ChartMode.values[_chartMode.index],
+                        );
+                      },
+                    ),
                 ],
-                ],
-                Expanded(
-                  child: Builder(builder: (context) {
+              ],
+              Expanded(
+                child: Builder(builder: (context) {
                     final filtered = _getFilteredHistory();
                     return ListView.separated(
                       padding: const EdgeInsets.all(16),

--- a/lib/widgets/common/accuracy_trend_chart.dart
+++ b/lib/widgets/common/accuracy_trend_chart.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../models/training_result.dart';
+import '../../theme/app_colors.dart';
+
+enum ChartMode { daily, weekly, monthly }
+
+class AccuracyTrendChart extends StatelessWidget {
+  final List<TrainingResult> sessions;
+  final ChartMode mode;
+
+  const AccuracyTrendChart({super.key, required this.sessions, required this.mode});
+
+  String _formatLabel(DateTime d) {
+    switch (mode) {
+      case ChartMode.monthly:
+        return '${d.month.toString().padLeft(2, '0')}.${d.year}';
+      case ChartMode.weekly:
+      case ChartMode.daily:
+      default:
+        return '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (sessions.length < 2) {
+      return const SizedBox.shrink();
+    }
+
+    final sorted = [...sessions]..sort((a, b) => a.date.compareTo(b.date));
+    final spots = <FlSpot>[];
+    for (var i = 0; i < sorted.length; i++) {
+      spots.add(FlSpot(i.toDouble(), sorted[i].accuracy));
+    }
+    final step = (sorted.length / 6).ceil();
+
+    final line = LineChartBarData(
+      spots: spots,
+      isCurved: true,
+      color: Colors.orangeAccent,
+      barWidth: 2,
+      dotData: FlDotData(show: false),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= sorted.length) {
+                      return const SizedBox.shrink();
+                    }
+                    if (index % step != 0 && index != sorted.length - 1) {
+                      return const SizedBox.shrink();
+                    }
+                    final d = sorted[index].date;
+                    final label = _formatLabel(d);
+                    return Text(
+                      label,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            lineBarsData: [line],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `AccuracyTrendChart` widget
- load/save preference for the new chart
- support toggle to display trend chart in TrainingHistoryScreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853e0d3b424832aaaa930e499ae2c97