### PR TITLE
Add JSON export option

### DIFF
--- a/lib/models/training_session.dart
+++ b/lib/models/training_session.dart
@@ -34,4 +34,13 @@ class TrainingSession {
         tags: tags,
         notes: notes,
       );
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'total': total,
+        'correct': correct,
+        'accuracy': accuracy,
+        if (tags.isNotEmpty) 'tags': tags,
+        if (notes != null && notes!.isNotEmpty) 'notes': notes,
+      };
 }


### PR DESCRIPTION
## Summary
- implement `toJson` for `TrainingSession`
- allow exporting training history to raw JSON using FileSaver
- add "Экспорт JSON" button to TrainingHistoryScreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853fece005c832a8abdf79f62060de2