### PR TITLE
Add delete button in history list items

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -1138,6 +1138,31 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     await _saveHistory();
   }
 
+  Future<void> _confirmDelete(TrainingResult session) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete Session?'),
+          content: const Text('Are you sure you want to delete this session?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirm ?? false) {
+      await _deleteSession(session);
+    }
+  }
+
   Future<void> _setChartsVisible(bool value) async {
     setState(() => _showCharts = value);
     final prefs = await SharedPreferences.getInstance();
@@ -2017,6 +2042,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                             onLongPress: () => _editSessionTags(context, result),
                             onTap: () => _editSessionNotes(context, result),
                             onTagTap: () => _editSessionTags(context, result),
+                            onDelete: () => _confirmDelete(result),
                           ),
                         );
                       },

--- a/lib/widgets/common/history_list_item.dart
+++ b/lib/widgets/common/history_list_item.dart
@@ -11,6 +11,7 @@ class HistoryListItem extends StatelessWidget {
   final VoidCallback? onLongPress;
   final VoidCallback? onTap;
   final VoidCallback? onTagTap;
+  final VoidCallback? onDelete;
 
   const HistoryListItem({
     super.key,
@@ -18,6 +19,7 @@ class HistoryListItem extends StatelessWidget {
     this.onLongPress,
     this.onTap,
     this.onTagTap,
+    this.onDelete,
   });
 
   @override
@@ -81,6 +83,11 @@ class HistoryListItem extends StatelessWidget {
               icon: const Icon(Icons.label_outline, color: Colors.white70),
               tooltip: 'Edit Tags',
               onPressed: onTagTap,
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline, color: Colors.white70),
+              tooltip: 'Delete Session',
+              onPressed: onDelete,
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add optional `onDelete` callback to `HistoryListItem`
- show delete icon button that calls new callback
- handle button tap in `TrainingHistoryScreen` with confirmation dialog and delete logic

## Testing
- `flutter format lib/screens/training_history_screen.dart lib/widgets/common/history_list_item.dart` *(fails: `flutter` not found)*
- `dart format lib/screens/training_history_screen.dart lib/widgets/common/history_list_item.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540009ae88832aa4c8aec6fee62c55