### PR TITLE
Add quick color row

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -773,6 +773,51 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     );
   }
 
+  Widget _buildQuickColorRow() {
+    final tagService = context.read<TagService>();
+    final colors = <String>{};
+    for (final r in _history) {
+      for (final tag in r.tags) {
+        colors.add(tagService.colorOf(tag));
+      }
+    }
+    if (colors.isEmpty) return const SizedBox.shrink();
+    final Map<String, List<String>> colorMap = {};
+    for (final tag in tagService.tags) {
+      colorMap.putIfAbsent(tagService.colorOf(tag), () => []).add(tag);
+    }
+    return SizedBox(
+      height: 36,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        children: [
+          for (final color in colors)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: ChoiceChip(
+                label: Text(colorMap[color]?.join(', ') ?? color),
+                selected: _selectedTagColors.contains(color),
+                selectedColor: colorFromHex(color),
+                onSelected: (selected) async {
+                  final prefs = await SharedPreferences.getInstance();
+                  setState(() {
+                    if (selected) {
+                      _selectedTagColors.add(color);
+                    } else {
+                      _selectedTagColors.remove(color);
+                    }
+                  });
+                  await prefs.setStringList(
+                      _tagColorKey, _selectedTagColors.toList());
+                },
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
   bool _hasResultsForTag(String tag) {
     return _getFilteredHistory(tags: {tag}).isNotEmpty;
   }
@@ -1484,6 +1529,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 );
               }),
             _buildQuickTagRow(),
+            _buildQuickColorRow(),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Row(


### PR DESCRIPTION
## Summary
- add `_buildQuickColorRow` to show quick color buttons
- call new widget in `TrainingHistoryScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685405a9dd70832aa75e352dbd6860e8