### PR TITLE
Add git head ref check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,22 @@ codex/add-activeplayerindex-debug-panel
 ```
 
 Avoid Cyrillic, special characters or other Unicode symbols in branch names.
+
+## Troubleshooting
+
+If Git reports `The head ref may contain hidden characters`, the `.git/HEAD` or
+a ref file might contain invisible control characters. Run the helper script
+below to scan the repository:
+
+```bash
+tools/check_head_refs.sh
+```
+
+If the script finds issues, rewrite the affected file. For example, to reset the
+`HEAD` ref you can run:
+
+```bash
+echo 'ref: refs/heads/main' > .git/HEAD
+```
+
+This removes hidden characters and resolves the error.

--- a/tools/check_head_refs.sh
+++ b/tools/check_head_refs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Check for hidden characters in git HEAD and ref files.
+
+set -e
+
+echo "Checking git HEAD and ref files for hidden characters..."
+
+check_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    return
+  fi
+  if LC_ALL=C grep -nP '[\x00-\x08\x0b\x0c\x0e-\x1F\x7F-\x9F]' "$file" >/dev/null; then
+    echo "Hidden characters detected in $file:" >&2
+    LC_ALL=C grep -nP '[\x00-\x08\x0b\x0c\x0e-\x1F\x7F-\x9F]' -n "$file" >&2
+    return 1
+  fi
+}
+
+error=0
+check_file .git/HEAD || error=1
+for ref in .git/refs/heads/*; do
+  check_file "$ref" || error=1
+done
+
+if [ $error -eq 0 ]; then
+  echo "No hidden characters found."
+else
+  echo "Hidden characters were found. Consider rewriting the affected ref file(s)."
+fi
+


### PR DESCRIPTION
## Summary
- add a helper script to inspect `.git/HEAD` and branch refs for hidden characters
- document how to use it for fixing `The head ref may contain hidden characters` errors

## Testing
- `tools/check_head_refs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68545e7b42b8832a8b67f1ed2d5ca683