### PR TITLE
Add option to skip sessions without notes during export

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -75,6 +75,8 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       'training_history_pdf_include_chart';
   static const _exportTags3OnlyKey =
       'training_history_export_tags_3plus';
+  static const _ignoreEmptyNotesKey =
+      'training_history_export_ignore_empty_notes';
 
   final List<TrainingResult> _history = [];
   int _filterDays = 7;
@@ -95,6 +97,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   _WeekdayFilter _weekdayFilter = _WeekdayFilter.all;
   _SessionLengthFilter _lengthFilter = _SessionLengthFilter.any;
   bool _exportTags3Only = false;
+  bool _ignoreEmptyNotes = false;
 
   String? _lastCsvPath;
   String? _lastPdfPath;
@@ -127,6 +130,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final lengthIndex = prefs.getInt(_lengthKey) ?? 0;
     final includeChart = prefs.getBool(_pdfIncludeChartKey) ?? true;
     final tags3Only = prefs.getBool(_exportTags3OnlyKey) ?? false;
+    final ignoreNotes = prefs.getBool(_ignoreEmptyNotesKey) ?? false;
     final fromMillis = prefs.getInt(_dateFromKey);
     final toMillis = prefs.getInt(_dateToKey);
     setState(() {
@@ -148,6 +152,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _lengthFilter = _SessionLengthFilter.values[lengthIndex];
       _includeChartInPdf = includeChart;
       _exportTags3Only = tags3Only;
+      _ignoreEmptyNotes = ignoreNotes;
       _dateFrom =
           fromMillis != null ? DateTime.fromMillisecondsSinceEpoch(fromMillis) : null;
       _dateTo =
@@ -201,8 +206,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _exportCsv() async {
-    final sessions =
-        _getFilteredHistory().where((r) => !_exportTags3Only || r.tags.length >= 3).toList();
+    final sessions = _getFilteredHistory()
+        .where((r) => !_exportTags3Only || r.tags.length >= 3)
+        .where((r) => !_ignoreEmptyNotes || (r.notes?.isNotEmpty ?? false))
+        .toList();
     if (sessions.isEmpty) return;
     final rows = <List<dynamic>>[];
     final filters = _buildExportFilterLines();
@@ -233,8 +240,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _exportMarkdown() async {
-    final sessions =
-        _getFilteredHistory().where((r) => !_exportTags3Only || r.tags.length >= 3).toList();
+    final sessions = _getFilteredHistory()
+        .where((r) => !_exportTags3Only || r.tags.length >= 3)
+        .where((r) => !_ignoreEmptyNotes || (r.notes?.isNotEmpty ?? false))
+        .toList();
     if (sessions.isEmpty) return;
     final buffer = StringBuffer();
     final filters = _buildExportFilterLines();
@@ -279,8 +288,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _exportHtml() async {
-    final sessions =
-        _getFilteredHistory().where((r) => !_exportTags3Only || r.tags.length >= 3).toList();
+    final sessions = _getFilteredHistory()
+        .where((r) => !_exportTags3Only || r.tags.length >= 3)
+        .where((r) => !_ignoreEmptyNotes || (r.notes?.isNotEmpty ?? false))
+        .toList();
     if (sessions.isEmpty) return;
     const htmlEscape = HtmlEscape();
     final buffer = StringBuffer();
@@ -443,8 +454,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _exportVisibleCsv() async {
-    final sessions =
-        _getFilteredHistory().where((r) => !_exportTags3Only || r.tags.length >= 3).toList();
+    final sessions = _getFilteredHistory()
+        .where((r) => !_exportTags3Only || r.tags.length >= 3)
+        .where((r) => !_ignoreEmptyNotes || (r.notes?.isNotEmpty ?? false))
+        .toList();
     if (sessions.isEmpty) return;
     final rows = <List<dynamic>>[];
     rows.add(['Date', 'Accuracy', 'Total', 'Correct', 'Tags', 'Notes']);
@@ -476,8 +489,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _exportVisiblePdf() async {
-    final sessions =
-        _getFilteredHistory().where((r) => !_exportTags3Only || r.tags.length >= 3).toList();
+    final sessions = _getFilteredHistory()
+        .where((r) => !_exportTags3Only || r.tags.length >= 3)
+        .where((r) => !_ignoreEmptyNotes || (r.notes?.isNotEmpty ?? false))
+        .toList();
     if (sessions.isEmpty) return;
 
     final chartData = _groupSessionsForChart(sessions);
@@ -1815,6 +1830,12 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     await prefs.setBool(_exportTags3OnlyKey, _exportTags3Only);
   }
 
+  Future<void> _setIgnoreEmptyNotes(bool value) async {
+    setState(() => _ignoreEmptyNotes = value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_ignoreEmptyNotesKey, _ignoreEmptyNotes);
+  }
+
   Future<void> _setHideEmptyTags(bool value) async {
     setState(() => _hideEmptyTags = value);
     final prefs = await SharedPreferences.getInstance();
@@ -2052,6 +2073,23 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                           ),
                         );
                 }),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Игнорировать сессии без заметок',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ),
+                      Checkbox(
+                        value: _ignoreEmptyNotes,
+                        onChanged: (v) => _setIgnoreEmptyNotes(v ?? false),
+                      ),
+                    ],
+                  ),
+                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: Row(


### PR DESCRIPTION
## Summary
- add SharedPreferences key to store ignore-empty-notes setting
- add checkbox under tag filter to ignore sessions without notes
- filter sessions lacking notes when exporting CSV, Markdown, HTML and PDF

## Testing
- `dart` was unavailable so formatting could not be run


------
https://chatgpt.com/codex/tasks/task_e_685469d2963c832abb2cbd3548d2f484