### PR TITLE
Enable action editing

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3603,6 +3603,7 @@ class _StreetActionsSection extends StatelessWidget {
         pots: pots,
         stackSizes: stackSizes,
         playerPositions: playerPositions,
+        numberOfPlayers: playerPositions.length,
         onEdit: onEdit,
         onDelete: onDelete,
         visibleCount: visibleCount,

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -98,6 +98,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
                 pots: pots,
                 stackSizes: stacks,
                 playerPositions: positions,
+                numberOfPlayers: positions.length,
                 onEdit: (_, __) {},
                 onDelete: (_) {},
                 visibleCount: widget.spot.actions.length,

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -138,6 +138,7 @@ class _ActionHistoryExpansionTileState
                         pots: widget.pots,
                         stackSizes: widget.stackSizes,
                         playerPositions: widget.playerPositions,
+                        numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -147,6 +147,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
                   pots: widget.pots,
                   stackSizes: widget.stackSizes,
                   playerPositions: widget.playerPositions,
+                  numberOfPlayers: widget.playerPositions.length,
                   onEdit: widget.onEdit,
                   onDelete: widget.onDelete,
                   visibleCount: widget.visibleCount,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -118,6 +118,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                         pots: widget.pots,
                         stackSizes: widget.stackSizes,
                         playerPositions: widget.playerPositions,
+                        numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/edit_action_dialog.dart
+++ b/lib/widgets/edit_action_dialog.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+
+Future<ActionEntry?> showEditActionDialog(
+  BuildContext context, {
+  required ActionEntry entry,
+  required int numberOfPlayers,
+  required Map<int, String> playerPositions,
+}) {
+  int player = entry.playerIndex;
+  String action = entry.action;
+  final controller = TextEditingController(
+    text: entry.amount != null ? entry.amount.toString() : '',
+  );
+
+  return showDialog<ActionEntry>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setState) {
+        final needAmount =
+            action == 'bet' || action == 'raise' || action == 'call';
+        return AlertDialog(
+          title: const Text('Редактировать действие'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DropdownButton<int>(
+                value: player,
+                items: [
+                  for (int i = 0; i < numberOfPlayers; i++)
+                    DropdownMenuItem(
+                      value: i,
+                      child: Text(playerPositions[i] ?? 'Player ${i + 1}'),
+                    ),
+                ],
+                onChanged: (v) => setState(() => player = v ?? player),
+              ),
+              const SizedBox(height: 8),
+              DropdownButton<String>(
+                value: action,
+                items: const [
+                  DropdownMenuItem(value: 'fold', child: Text('fold')),
+                  DropdownMenuItem(value: 'check', child: Text('check')),
+                  DropdownMenuItem(value: 'call', child: Text('call')),
+                  DropdownMenuItem(value: 'bet', child: Text('bet')),
+                  DropdownMenuItem(value: 'raise', child: Text('raise')),
+                ],
+                onChanged: (v) => setState(() => action = v ?? action),
+              ),
+              if (needAmount)
+                TextField(
+                  controller: controller,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Amount'),
+                ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Отмена'),
+            ),
+            TextButton(
+              onPressed: () {
+                final amount = (action == 'bet' ||
+                        action == 'raise' ||
+                        action == 'call')
+                    ? int.tryParse(controller.text)
+                    : null;
+                Navigator.pop(
+                  ctx,
+                  ActionEntry(entry.street, player, action, amount: amount),
+                );
+              },
+              child: const Text('Сохранить'),
+            ),
+          ],
+        );
+      },
+    ),
+  );
+}

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
-import 'detailed_action_bottom_sheet.dart';
+import 'edit_action_dialog.dart';
 import 'package:intl/intl.dart';
 
 import 'street_pot_widget.dart';
@@ -14,6 +14,7 @@ class StreetActionsList extends StatelessWidget {
   final List<int> pots;
   final Map<int, int> stackSizes;
   final Map<int, String> playerPositions;
+  final int numberOfPlayers;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final int? visibleCount;
@@ -27,6 +28,7 @@ class StreetActionsList extends StatelessWidget {
     required this.pots,
     required this.stackSizes,
     required this.playerPositions,
+    required this.numberOfPlayers,
     required this.onEdit,
     required this.onDelete,
     this.visibleCount,
@@ -111,22 +113,14 @@ class StreetActionsList extends StatelessWidget {
         ],
       ),
       onTap: () async {
-        final result = await showDetailedActionBottomSheet(
+        final edited = await showEditActionDialog(
           context,
-          potSizeBB: pots[a.street],
-          stackSizeBB: stackSizes[a.playerIndex] ?? 0,
-          currentStreet: a.street,
-          initialAction: a.action,
-          initialAmount: a.amount,
+          entry: a,
+          numberOfPlayers: numberOfPlayers,
+          playerPositions: playerPositions,
         );
-        if (result != null) {
-          final entry = ActionEntry(
-            result['street'] as int,
-            a.playerIndex,
-            result['action'] as String,
-            amount: result['amount'] as int?,
-          );
-          onEdit(globalIndex, entry);
+        if (edited != null) {
+          onEdit(globalIndex, edited);
         }
       },
       trailing: Row(


### PR DESCRIPTION
## Summary
- add `showEditActionDialog` helper for updating actions
- open edit dialog when tapping an action in history
- pass player count to StreetActionsList

## Testing
- `dart` and `flutter` commands are unavailable in this environment so formatting was skipped

------
https://chatgpt.com/codex/tasks/task_e_68546cb17a44832ab01d06f745b98366