### PR TITLE
Add action duplication feature

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1191,6 +1191,23 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
   }
 
+  void _duplicateAction(int index) {
+    if (lockService.isLocked) return;
+    lockService.safeSetState(this, () {
+      final original = actions[index];
+      final copy = ActionEntry(
+        original.street,
+        original.playerIndex,
+        original.action,
+        amount: original.amount,
+        generated: original.generated,
+        manualEvaluation: original.manualEvaluation,
+        timestamp: original.timestamp,
+      );
+      _actionEditing.insertAction(index + 1, copy);
+    });
+  }
+
   Future<void> _removeLastPlayerAction(int playerIndex) async {
     final actionIndex = actions.lastIndexWhere(
         (a) => a.playerIndex == playerIndex && a.street == currentStreet);
@@ -1926,6 +1943,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               playerPositions: playerPositions,
               onEdit: _editAction,
               onDelete: _deleteAction,
+              onDuplicate: _duplicateAction,
               onReorder: _reorderAction,
               visibleCount: _playbackManager.playbackIndex,
               evaluateActionQuality: _evaluateActionQuality,
@@ -1943,6 +1961,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         stackSizes: _stackService.currentStacks,
         onEdit: _editAction,
       onDelete: _deleteAction,
+      onDuplicate: _duplicateAction,
       onReorder: _reorderAction,
       visibleCount: _playbackManager.playbackIndex,
       evaluateActionQuality: _evaluateActionQuality,
@@ -3586,6 +3605,7 @@ class _StreetActionsSection extends StatelessWidget {
   final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int) onDuplicate;
   final void Function(int, int) onReorder;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
@@ -3598,6 +3618,7 @@ class _StreetActionsSection extends StatelessWidget {
     required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
+    required this.onDuplicate,
     required this.onReorder,
     this.visibleCount,
     this.evaluateActionQuality,
@@ -3617,6 +3638,7 @@ class _StreetActionsSection extends StatelessWidget {
         numberOfPlayers: playerPositions.length,
         onEdit: onEdit,
         onDelete: onDelete,
+        onDuplicate: onDuplicate,
         onReorder: onReorder,
         visibleCount: visibleCount,
         evaluateActionQuality: evaluateActionQuality,
@@ -3996,6 +4018,7 @@ class _HandEditorSection extends StatelessWidget {
                   playerPositions: playerPositions,
                   onEdit: onEdit,
                   onDelete: onDelete,
+                  onDuplicate: _duplicateAction,
                   onReorder: _reorderAction,
                   visibleCount: visibleCount,
                   evaluateActionQuality: evaluateActionQuality,

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -101,6 +101,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
                 numberOfPlayers: positions.length,
                 onEdit: (_, __) {},
                 onDelete: (_) {},
+                onDuplicate: (_) {},
                 visibleCount: widget.spot.actions.length,
                 evaluateActionQuality:
                     prefs.coachMode ? _overrideQuality : null,

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -11,6 +11,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
   final Map<int, int> stackSizes;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int) onDuplicate;
   final void Function(int, int)? onReorder;
   final int visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
@@ -23,6 +24,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
     required this.stackSizes,
     required this.onEdit,
     required this.onDelete,
+    required this.onDuplicate,
     this.onReorder,
     required this.visibleCount,
     this.evaluateActionQuality,
@@ -143,6 +145,7 @@ class _ActionHistoryExpansionTileState
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
+                        onDuplicate: widget.onDuplicate,
                         onReorder: widget.onReorder,
                         visibleCount: widget.visibleCount,
                         evaluateActionQuality: widget.evaluateActionQuality,

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -11,6 +11,7 @@ class CollapsibleStreetSection extends StatefulWidget {
   final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int) onDuplicate;
   final void Function(int, int)? onReorder;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
@@ -24,6 +25,7 @@ class CollapsibleStreetSection extends StatefulWidget {
     required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
+    required this.onDuplicate,
     this.onReorder,
     this.visibleCount,
     this.evaluateActionQuality,
@@ -152,6 +154,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
                   numberOfPlayers: widget.playerPositions.length,
                   onEdit: widget.onEdit,
                   onDelete: widget.onDelete,
+                  onDuplicate: widget.onDuplicate,
                   onReorder: widget.onReorder,
                   visibleCount: widget.visibleCount,
                   evaluateActionQuality: widget.evaluateActionQuality,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -9,6 +9,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
   final Map<int, int> stackSizes;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int) onDuplicate;
   final void Function(int, int)? onReorder;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
@@ -21,6 +22,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
     required this.stackSizes,
     required this.onEdit,
     required this.onDelete,
+    required this.onDuplicate,
     this.onReorder,
     this.visibleCount,
     this.evaluateActionQuality,
@@ -123,6 +125,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
+                        onDuplicate: widget.onDuplicate,
                         onReorder: widget.onReorder,
                         visibleCount: widget.visibleCount,
                         evaluateActionQuality: widget.evaluateActionQuality,

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -17,6 +17,7 @@ class StreetActionsList extends StatelessWidget {
   final int numberOfPlayers;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int)? onDuplicate;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
   final void Function(ActionEntry, String?)? onManualEvaluationChanged;
@@ -32,6 +33,7 @@ class StreetActionsList extends StatelessWidget {
     required this.numberOfPlayers,
     required this.onEdit,
     required this.onDelete,
+    this.onDuplicate,
     this.visibleCount,
     this.evaluateActionQuality,
     this.onManualEvaluationChanged,
@@ -126,6 +128,25 @@ class StreetActionsList extends StatelessWidget {
           onEdit(globalIndex, edited);
         }
       },
+      onLongPress: onDuplicate == null
+          ? null
+          : () async {
+              final dup = await showDialog<bool>(
+                context: context,
+                builder: (ctx) => SimpleDialog(
+                  title: const Text('Выберите действие'),
+                  children: [
+                    SimpleDialogOption(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      child: const Text('Дублировать'),
+                    ),
+                  ],
+                ),
+              );
+              if (dup == true) {
+                onDuplicate!(globalIndex);
+              }
+            },
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
## Summary
- add ability to duplicate actions from the StreetActionsList
- expose duplicate callbacks through Collapsible and ActionHistory widgets
- handle duplication in PokerAnalyzerScreen

## Testing
- `dart`/`flutter` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_685473a0715c832a9b64df5878b6fa91