### PR TITLE
Enable swipe deletion of actions

### DIFF
--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -306,14 +306,25 @@ class StreetActionsList extends StatelessWidget {
                 final entry = streetActions[index];
                 final showDivider = index > 0 &&
                     (entry.action == 'bet' || entry.action == 'raise');
-                return Column(
+                return Dismissible(
                   key: ValueKey(entry),
-                  children: [
-                    if (showDivider)
-                      const Divider(height: 4, color: Colors.white24),
-                    _buildTile(
-                        context, entry, actions.indexOf(entry), index),
-                  ],
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    color: Colors.red,
+                    child: const Icon(Icons.delete, color: Colors.white),
+                  ),
+                  onDismissed: (_) =>
+                      onDelete(actions.indexOf(entry)),
+                  child: Column(
+                    children: [
+                      if (showDivider)
+                        const Divider(height: 4, color: Colors.white24),
+                      _buildTile(
+                          context, entry, actions.indexOf(entry), index),
+                    ],
+                  ),
                 );
               },
             ),


### PR DESCRIPTION
## Summary
- enable swipe-to-delete in `StreetActionsList`

## Testing
- `dart format lib/widgets/street_actions_list.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854752c1ff8832a84fb9d0b66ff4d7c