### PR TITLE
Add undo snackbar on swipe delete

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1152,6 +1152,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         recordHistory: recordHistory);
   }
 
+  void _insertAction(int index, ActionEntry entry) {
+    if (lockService.isLocked) return;
+    lockService.safeSetState(this, () {
+      _addAction(entry, index: index);
+    });
+  }
+
   void onActionSelected(ActionEntry entry) {
     lockService.safeSetState(this, () {
       _addAutoFolds(entry);
@@ -1943,6 +1950,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               playerPositions: playerPositions,
               onEdit: _editAction,
               onDelete: _deleteAction,
+              onInsert: _insertAction,
               onDuplicate: _duplicateAction,
               onReorder: _reorderAction,
               visibleCount: _playbackManager.playbackIndex,
@@ -1960,12 +1968,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         pots: _potSync.pots,
         stackSizes: _stackService.currentStacks,
         onEdit: _editAction,
-      onDelete: _deleteAction,
-      onDuplicate: _duplicateAction,
-      onReorder: _reorderAction,
-      visibleCount: _playbackManager.playbackIndex,
-      evaluateActionQuality: _evaluateActionQuality,
-    ),
+        onDelete: _deleteAction,
+        onInsert: _insertAction,
+        onDuplicate: _duplicateAction,
+        onReorder: _reorderAction,
+        visibleCount: _playbackManager.playbackIndex,
+        evaluateActionQuality: _evaluateActionQuality,
+      ),
     StreetActionsWidget(
       currentStreet: currentStreet,
       canGoPrev: _boardManager.canReverseStreet(),
@@ -3605,6 +3614,7 @@ class _StreetActionsSection extends StatelessWidget {
   final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
+  final void Function(int index, ActionEntry entry) onInsert;
   final void Function(int) onDuplicate;
   final void Function(int, int) onReorder;
   final int? visibleCount;
@@ -3618,6 +3628,7 @@ class _StreetActionsSection extends StatelessWidget {
     required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
+    required this.onInsert,
     required this.onDuplicate,
     required this.onReorder,
     this.visibleCount,
@@ -3638,6 +3649,7 @@ class _StreetActionsSection extends StatelessWidget {
         numberOfPlayers: playerPositions.length,
         onEdit: onEdit,
         onDelete: onDelete,
+        onInsert: onInsert,
         onDuplicate: onDuplicate,
         onReorder: onReorder,
         visibleCount: visibleCount,
@@ -4018,6 +4030,7 @@ class _HandEditorSection extends StatelessWidget {
                   playerPositions: playerPositions,
                   onEdit: onEdit,
                   onDelete: onDelete,
+                  onInsert: _insertAction,
                   onDuplicate: _duplicateAction,
                   onReorder: _reorderAction,
                   visibleCount: visibleCount,

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -101,6 +101,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
                 numberOfPlayers: positions.length,
                 onEdit: (_, __) {},
                 onDelete: (_) {},
+                onInsert: (_, __) {},
                 onDuplicate: (_) {},
                 visibleCount: widget.spot.actions.length,
                 evaluateActionQuality:

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -15,6 +15,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
   final void Function(int, int)? onReorder;
   final int visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
+  final void Function(int index, ActionEntry entry)? onInsert;
 
   const ActionHistoryExpansionTile({
     super.key,
@@ -26,6 +27,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
     required this.onDelete,
     required this.onDuplicate,
     this.onReorder,
+    this.onInsert,
     required this.visibleCount,
     this.evaluateActionQuality,
   });
@@ -145,6 +147,7 @@ class _ActionHistoryExpansionTileState
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
+                        onInsert: widget.onInsert,
                         onDuplicate: widget.onDuplicate,
                         onReorder: widget.onReorder,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -15,6 +15,7 @@ class CollapsibleStreetSection extends StatefulWidget {
   final void Function(int, int)? onReorder;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
+  final void Function(int index, ActionEntry entry)? onInsert;
 
   const CollapsibleStreetSection({
     super.key,
@@ -27,6 +28,7 @@ class CollapsibleStreetSection extends StatefulWidget {
     required this.onDelete,
     required this.onDuplicate,
     this.onReorder,
+    this.onInsert,
     this.visibleCount,
     this.evaluateActionQuality,
   });
@@ -154,6 +156,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
                   numberOfPlayers: widget.playerPositions.length,
                   onEdit: widget.onEdit,
                   onDelete: widget.onDelete,
+                  onInsert: widget.onInsert,
                   onDuplicate: widget.onDuplicate,
                   onReorder: widget.onReorder,
                   visibleCount: widget.visibleCount,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -13,6 +13,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
   final void Function(int, int)? onReorder;
   final int? visibleCount;
   final String Function(ActionEntry)? evaluateActionQuality;
+  final void Function(int index, ActionEntry entry)? onInsert;
 
   const CollapsibleStreetSummary({
     super.key,
@@ -24,6 +25,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
     required this.onDelete,
     required this.onDuplicate,
     this.onReorder,
+    this.onInsert,
     this.visibleCount,
     this.evaluateActionQuality,
   });
@@ -125,6 +127,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,
                         onDelete: widget.onDelete,
+                        onInsert: widget.onInsert,
                         onDuplicate: widget.onDuplicate,
                         onReorder: widget.onReorder,
                         visibleCount: widget.visibleCount,

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -22,6 +22,7 @@ class StreetActionsList extends StatelessWidget {
   final String Function(ActionEntry)? evaluateActionQuality;
   final void Function(ActionEntry, String?)? onManualEvaluationChanged;
   final void Function(int oldIndex, int newIndex)? onReorder;
+  final void Function(int index, ActionEntry entry)? onInsert;
 
   const StreetActionsList({
     super.key,
@@ -33,6 +34,7 @@ class StreetActionsList extends StatelessWidget {
     required this.numberOfPlayers,
     required this.onEdit,
     required this.onDelete,
+    this.onInsert,
     this.onDuplicate,
     this.visibleCount,
     this.evaluateActionQuality,
@@ -328,7 +330,7 @@ class StreetActionsList extends StatelessWidget {
                 final showDivider = index > 0 &&
                     (entry.action == 'bet' || entry.action == 'raise');
                 return Dismissible(
-                  key: ValueKey(entry),
+                  key: ValueKey(entry.timestamp.microsecondsSinceEpoch),
                   direction: DismissDirection.endToStart,
                   background: Container(
                     alignment: Alignment.centerRight,
@@ -336,8 +338,24 @@ class StreetActionsList extends StatelessWidget {
                     color: Colors.red,
                     child: const Icon(Icons.delete, color: Colors.white),
                   ),
-                  onDismissed: (_) =>
-                      onDelete(actions.indexOf(entry)),
+                  onDismissed: (_) {
+                    final index = actions.indexOf(entry);
+                    onDelete(index);
+                    ScaffoldMessenger.of(context).clearSnackBars();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('Действие удалено'),
+                        action: SnackBarAction(
+                          label: 'Отмена',
+                          onPressed: () {
+                            if (onInsert != null) {
+                              onInsert!(index, entry);
+                            }
+                          },
+                        ),
+                      ),
+                    );
+                  },
                   child: Column(
                     children: [
                       if (showDivider)


### PR DESCRIPTION
## Summary
- show snackbar after swipe delete in `StreetActionsList`
- allow undo insertion with new callback
- propagate new `onInsert` handler to street action widgets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685475d57ff0832abc9ee32e49bdc3bb