### PR TITLE
Enable modal edit dialog for actions

### DIFF
--- a/lib/widgets/edit_action_dialog.dart
+++ b/lib/widgets/edit_action_dialog.dart
@@ -15,6 +15,7 @@ Future<ActionEntry?> showEditActionDialog(
 
   return showDialog<ActionEntry>(
     context: context,
+    barrierDismissible: false,
     builder: (ctx) => StatefulBuilder(
       builder: (ctx, setState) {
         final needAmount =


### PR DESCRIPTION
## Summary
- make `EditActionDialog` modal so it locks interaction with the rest of the UI while open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68547759a4f8832aa1c4a6ce0e091e58