### PR TITLE
Add chip stack visuals to StreetActionsList

### DIFF
--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -4,6 +4,7 @@ import 'edit_action_dialog.dart';
 import 'package:intl/intl.dart';
 
 import 'street_pot_widget.dart';
+import 'chip_stack_widget.dart';
 import 'package:provider/provider.dart';
 import '../services/user_preferences_service.dart';
 
@@ -89,6 +90,14 @@ class StreetActionsList extends StatelessWidget {
       title: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
+          if (a.amount != null) ...[
+            ChipStackWidget(
+              amount: a.amount!,
+              scale: 0.7,
+              color: color,
+            ),
+            const SizedBox(width: 6),
+          ],
           if (a.amount != null)
             Container(
               padding:


### PR DESCRIPTION
## Summary
- show chip stack indicators in action list
- color chips by action type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685478634c14832abcba7e67b4b61a1c