### PR TITLE
Add animated pot tracker below street actions

### DIFF
--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
 
 /// Displays pot size for a specific street in the history panel.
 class StreetPotWidget extends StatelessWidget {
@@ -24,9 +25,46 @@ class StreetPotWidget extends StatelessWidget {
     if (potSize <= 0) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.only(top: 4.0),
-      child: Text(
-        '$_streetName пот: $potSize',
-        style: const TextStyle(color: Colors.white70, fontSize: 12),
+      child: TweenAnimationBuilder<int>(
+        tween: IntTween(begin: 0, end: potSize),
+        duration: const Duration(milliseconds: 300),
+        builder: (context, value, child) {
+          final factor = potSize > 0
+              ? (value / potSize).clamp(0.0, 1.0) as double
+              : 0.0;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  ChipStackWidget(
+                    amount: value,
+                    scale: 0.6,
+                    color: Colors.orangeAccent,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '$_streetName пот: $value',
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(3),
+                child: LinearProgressIndicator(
+                  value: factor,
+                  backgroundColor: Colors.white10,
+                  color: Colors.orangeAccent,
+                  minHeight: 4,
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enhance StreetPotWidget to show animated chip count and progress bar

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_68547929b204832ab8934bb7c2fb84f4