### PR TITLE
Add cumulative pot tracker

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1798,6 +1798,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final currentStreetEffectiveStack = _potSync
         .calculateEffectiveStackForStreet(currentStreet, visibleActions, numberOfPlayers);
     final pot = _potSync.pots[currentStreet];
+    final totalPot = _potSync.pots.reduce(max);
     final double? sprValue =
         pot > 0 ? effectiveStack / pot : null;
 
@@ -1932,6 +1933,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   },
                 )
               ],
+        ),
+      ),
+    ),
+    Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Text(
+        "Общий пот: $totalPot",
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 16,
         ),
       ),
     ),


### PR DESCRIPTION
## Summary
- track cumulative pot across all streets
- show total pot above action history in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68547d6c86f4832ab66a889ff009e9cf