### PR TITLE
Add SPR display next to pot per street

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1780,6 +1780,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final visibleActions =
         actions.take(_playbackManager.playbackIndex).toList();
     final savedActions = _currentSavedHand().actions;
+    final effectiveStacks = List.generate(
+        4,
+        (i) => _potSync.calculateEffectiveStackForStreet(
+            i, visibleActions, numberOfPlayers));
     final double scale =
         TableGeometryHelper.tableScale(numberOfPlayers);
     final viewIndex = _viewIndex();
@@ -1959,6 +1963,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               actions: savedActions,
               pots: _potSync.pots,
               stackSizes: _stackService.currentStacks,
+              effectiveStack: effectiveStacks[i],
               playerPositions: playerPositions,
               onEdit: _editAction,
               onDelete: _deleteAction,
@@ -1979,6 +1984,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         playerPositions: playerPositions,
         pots: _potSync.pots,
         stackSizes: _stackService.currentStacks,
+        effectiveStacks: effectiveStacks,
         onEdit: _editAction,
         onDelete: _deleteAction,
         onInsert: _insertAction,
@@ -2067,6 +2073,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   currentStreet: currentStreet,
                   pots: _potSync.pots,
                   stackSizes: _stackService.currentStacks,
+                  effectiveStacks: effectiveStacks,
                   onEdit: _editAction,
                   onDelete: _deleteAction,
                   visibleCount: _playbackManager.playbackIndex,
@@ -3623,6 +3630,7 @@ class _StreetActionsSection extends StatelessWidget {
   final ActionHistoryService actionHistory;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final int effectiveStack;
   final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
@@ -3637,6 +3645,7 @@ class _StreetActionsSection extends StatelessWidget {
     required this.actionHistory,
     required this.pots,
     required this.stackSizes,
+    required this.effectiveStack,
     required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
@@ -3657,6 +3666,7 @@ class _StreetActionsSection extends StatelessWidget {
             collapsed: false),
         pots: pots,
         stackSizes: stackSizes,
+        effectiveStack: effectiveStack,
         playerPositions: playerPositions,
         numberOfPlayers: playerPositions.length,
         onEdit: onEdit,
@@ -3984,6 +3994,7 @@ class _HandEditorSection extends StatelessWidget {
   final int currentStreet;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final List<int> effectiveStacks;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final int? visibleCount;
@@ -4004,6 +4015,7 @@ class _HandEditorSection extends StatelessWidget {
     required this.currentStreet,
     required this.pots,
     required this.stackSizes,
+    required this.effectiveStacks,
     required this.onEdit,
     required this.onDelete,
     required this.visibleCount,
@@ -4039,6 +4051,7 @@ class _HandEditorSection extends StatelessWidget {
                   actionHistory: _actionHistory,
                   pots: pots,
                   stackSizes: stackSizes,
+                  effectiveStack: effectiveStacks[currentStreet],
                   playerPositions: playerPositions,
                   onEdit: onEdit,
                   onDelete: onDelete,

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -54,6 +54,29 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
     return manager.currentStacks;
   }
 
+  int _effectiveStackForStreet(int street) {
+    int? minStack;
+    for (int index = 0; index < widget.spot.numberOfPlayers; index++) {
+      final folded = widget.spot.actions.any((a) =>
+          a.playerIndex == index && a.action == 'fold' && a.street <= street);
+      if (folded) continue;
+
+      int invested = 0;
+      for (final a in widget.spot.actions) {
+        if (a.playerIndex == index && a.street <= street) {
+          if (a.action == 'bet' || a.action == 'raise' || a.action == 'call') {
+            invested += a.amount ?? 0;
+          }
+        }
+      }
+      final remaining = widget.spot.stacks[index] - invested;
+      if (minStack == null || remaining < minStack) {
+        minStack = remaining;
+      }
+    }
+    return minStack ?? 0;
+  }
+
   Map<int, String> _posMap() => {
         for (int i = 0; i < widget.spot.numberOfPlayers; i++) i: widget.spot.positions[i]
       };
@@ -97,6 +120,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
                 actions: widget.spot.actions,
                 pots: pots,
                 stackSizes: stacks,
+                effectiveStack: _effectiveStackForStreet(street),
                 playerPositions: positions,
                 numberOfPlayers: positions.length,
                 onEdit: (_, __) {},

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -9,6 +9,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
   final Map<int, String> playerPositions;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final List<int> effectiveStacks;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final void Function(int) onDuplicate;
@@ -23,6 +24,7 @@ class ActionHistoryExpansionTile extends StatefulWidget {
     required this.playerPositions,
     required this.pots,
     required this.stackSizes,
+    required this.effectiveStacks,
     required this.onEdit,
     required this.onDelete,
     required this.onDuplicate,
@@ -143,6 +145,7 @@ class _ActionHistoryExpansionTileState
                         actions: widget.actions,
                         pots: widget.pots,
                         stackSizes: widget.stackSizes,
+                        effectiveStack: widget.effectiveStacks[i],
                         playerPositions: widget.playerPositions,
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -8,6 +8,7 @@ class CollapsibleStreetSection extends StatefulWidget {
   final List<ActionEntry> actions;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final int effectiveStack;
   final Map<int, String> playerPositions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
@@ -23,6 +24,7 @@ class CollapsibleStreetSection extends StatefulWidget {
     required this.actions,
     required this.pots,
     required this.stackSizes,
+    required this.effectiveStack,
     required this.playerPositions,
     required this.onEdit,
     required this.onDelete,
@@ -152,6 +154,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
                   actions: widget.actions,
                   pots: widget.pots,
                   stackSizes: widget.stackSizes,
+                  effectiveStack: widget.effectiveStack,
                   playerPositions: widget.playerPositions,
                   numberOfPlayers: widget.playerPositions.length,
                   onEdit: widget.onEdit,

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -7,6 +7,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
   final Map<int, String> playerPositions;
   final List<int> pots;
   final Map<int, int> stackSizes;
+  final List<int> effectiveStacks;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final void Function(int) onDuplicate;
@@ -21,6 +22,7 @@ class CollapsibleStreetSummary extends StatefulWidget {
     required this.playerPositions,
     required this.pots,
     required this.stackSizes,
+    required this.effectiveStacks,
     required this.onEdit,
     required this.onDelete,
     required this.onDuplicate,
@@ -123,6 +125,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                         actions: widget.actions,
                         pots: widget.pots,
                         stackSizes: widget.stackSizes,
+                        effectiveStack: widget.effectiveStacks[i],
                         playerPositions: widget.playerPositions,
                         numberOfPlayers: widget.playerPositions.length,
                         onEdit: widget.onEdit,

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -16,6 +16,7 @@ class StreetActionsList extends StatelessWidget {
   final Map<int, int> stackSizes;
   final Map<int, String> playerPositions;
   final int numberOfPlayers;
+  final int effectiveStack;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final void Function(int)? onDuplicate;
@@ -33,6 +34,7 @@ class StreetActionsList extends StatelessWidget {
     required this.stackSizes,
     required this.playerPositions,
     required this.numberOfPlayers,
+    required this.effectiveStack,
     required this.onEdit,
     required this.onDelete,
     this.onInsert,
@@ -380,6 +382,7 @@ class StreetActionsList extends StatelessWidget {
         StreetPotWidget(
           streetIndex: street,
           potSize: pots[street],
+          effectiveStack: effectiveStack,
         ),
       ],
     );

--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -5,11 +5,13 @@ import 'chip_stack_widget.dart';
 class StreetPotWidget extends StatelessWidget {
   final int streetIndex;
   final int potSize;
+  final int effectiveStack;
 
   const StreetPotWidget({
     super.key,
     required this.streetIndex,
     required this.potSize,
+    required this.effectiveStack,
   });
 
   String get _streetName {
@@ -50,6 +52,16 @@ class StreetPotWidget extends StatelessWidget {
                       fontSize: 12,
                     ),
                   ),
+                  if (value > 0) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      'SPR: ${(effectiveStack / value).toStringAsFixed(1)}',
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
                 ],
               ),
               const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- show SPR for each street in PokerAnalyzerScreen
- compute effective stack per street
- display SPR values in StreetPotWidget
- pass effective stack through StreetActionsList and related widgets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68547fef1a50832ab3747502281f5398