### PR TITLE
Add SPR display to history

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3627,6 +3627,8 @@ class _StreetActionsSection extends StatelessWidget {
   final List<int> pots;
   final Map<int, int> stackSizes;
   final Map<int, String> playerPositions;
+  final PotSyncService potSync;
+  final List<ActionEntry> allActions;
   final void Function(int, ActionEntry) onEdit;
   final void Function(int) onDelete;
   final void Function(int index, ActionEntry entry) onInsert;
@@ -3641,6 +3643,8 @@ class _StreetActionsSection extends StatelessWidget {
     required this.pots,
     required this.stackSizes,
     required this.playerPositions,
+    required this.potSync,
+    required this.allActions,
     required this.onEdit,
     required this.onDelete,
     required this.onInsert,
@@ -3652,6 +3656,10 @@ class _StreetActionsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final pot = pots[street];
+    final effStack = potSync.calculateEffectiveStackForStreet(
+        street, allActions, playerPositions.length);
+    final double? sprValue = pot > 0 ? effStack / pot : null;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: StreetActionsList(
@@ -3669,6 +3677,7 @@ class _StreetActionsSection extends StatelessWidget {
         onReorder: onReorder,
         visibleCount: visibleCount,
         evaluateActionQuality: evaluateActionQuality,
+        sprValue: sprValue,
       ),
     );
   }
@@ -4043,6 +4052,8 @@ class _HandEditorSection extends StatelessWidget {
                   pots: pots,
                   stackSizes: stackSizes,
                   playerPositions: playerPositions,
+                  potSync: _potSync,
+                  allActions: actions,
                   onEdit: onEdit,
                   onDelete: onDelete,
                   onInsert: _insertAction,

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -24,6 +24,7 @@ class StreetActionsList extends StatelessWidget {
   final void Function(ActionEntry, String?)? onManualEvaluationChanged;
   final void Function(int oldIndex, int newIndex)? onReorder;
   final void Function(int index, ActionEntry entry)? onInsert;
+  final double? sprValue;
 
   const StreetActionsList({
     super.key,
@@ -41,6 +42,7 @@ class StreetActionsList extends StatelessWidget {
     this.evaluateActionQuality,
     this.onManualEvaluationChanged,
     this.onReorder,
+    this.sprValue,
   });
 
   Widget _buildTile(
@@ -380,6 +382,7 @@ class StreetActionsList extends StatelessWidget {
         StreetPotWidget(
           streetIndex: street,
           potSize: pots[street],
+          sprValue: sprValue,
         ),
       ],
     );

--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -5,11 +5,13 @@ import 'chip_stack_widget.dart';
 class StreetPotWidget extends StatelessWidget {
   final int streetIndex;
   final int potSize;
+  final double? sprValue;
 
   const StreetPotWidget({
     super.key,
     required this.streetIndex,
     required this.potSize,
+    this.sprValue,
   });
 
   String get _streetName {
@@ -50,6 +52,16 @@ class StreetPotWidget extends StatelessWidget {
                       fontSize: 12,
                     ),
                   ),
+                  if (sprValue != null) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      'SPR: ${sprValue!.toStringAsFixed(1)}',
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
                 ],
               ),
               const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- show SPR next to pot size tracker for each street
- calculate effective stack per street with PotSyncService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685482307bb0832a81a95906209c72b0