### PR TITLE
Add folded player indicator

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2369,6 +2369,27 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         top: centerY + dy + bias + 96 * scale,
         child: PlayerSprLabel(spr: playerSpr, scale: scale * 0.8),
       ),
+      if (isFolded)
+        Positioned(
+          left: centerX + dx - 24 * scale,
+          top: centerY + dy + bias - 40 * scale,
+          child: Container(
+            padding:
+                EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 2 * scale),
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.6),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              'FOLDED',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 10 * scale,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
       Positioned(
         left: centerX + dx + (cos(angle) < 0 ? -45 * scale : 30 * scale),
         top: centerY + dy + bias + 50 * scale,


### PR DESCRIPTION
## Summary
- show a `FOLDED` label near a player's seat after they fold

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685487f25720832a989b3ff62110c8d8