### PR TITLE
Add bet size display overlay

### DIFF
--- a/lib/services/action_editing_service.dart
+++ b/lib/services/action_editing_service.dart
@@ -82,6 +82,7 @@ class ActionEditingService {
       players[entry.playerIndex].name,
       ActionFormattingHelper.formatLastAction(entry),
       ActionFormattingHelper.actionColor(entry.action),
+      entry.action,
       entry.amount,
     );
     if (recordHistory) {
@@ -122,6 +123,7 @@ class ActionEditingService {
       players[entry.playerIndex].name,
       ActionFormattingHelper.formatLastAction(entry),
       ActionFormattingHelper.actionColor(entry.action),
+      entry.action,
       entry.amount,
     );
     if (recordHistory) {

--- a/lib/widgets/bet_size_label.dart
+++ b/lib/widgets/bet_size_label.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Glowing chip-style label showing bet amount.
+class BetSizeLabel extends StatelessWidget {
+  final int amount;
+  final Color color;
+  final double scale;
+
+  const BetSizeLabel({
+    Key? key,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = color.withOpacity(0.9);
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 2 * scale),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(12 * scale),
+        boxShadow: [
+          BoxShadow(
+            color: color.withOpacity(0.8),
+            blurRadius: 8 * scale,
+            spreadRadius: 1 * scale,
+          ),
+        ],
+      ),
+      child: Text(
+        '+$amount',
+        style: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 12 * scale,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show bet amount in a glowing label below stack when a player bets or raises
- keep the label for 2 seconds then fade it out
- handle bet display updates through `setPlayerLastAction`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548fe52dac832aa5e041aaea184006