### PR TITLE
Add player note tooltip

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -53,6 +53,7 @@ import '../widgets/bet_stack_chips.dart';
 import '../widgets/chip_stack_widget.dart';
 import '../widgets/chip_amount_widget.dart';
 import '../widgets/mini_stack_widget.dart';
+import '../widgets/player_note_button.dart';
 import '../widgets/bet_size_label.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
@@ -2607,18 +2608,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       Positioned(
         left: centerX + dx + 40 * scale,
         top: centerY + dy + bias - 40 * scale,
-        child: IconButton(
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(),
-          iconSize: 16 * scale,
+        child: PlayerNoteButton(
+          note: _playerNotes[index],
+          scale: scale,
           onPressed: () => _editPlayerNote(index),
-          icon: Icon(
-            Icons.sticky_note_2,
-            color: (_playerNotes[index]?.isNotEmpty ?? false)
-                ? Colors.amber
-                : Colors.white70,
-            size: 16 * scale,
-          ),
         ),
       ),
     ];

--- a/lib/widgets/player_note_button.dart
+++ b/lib/widgets/player_note_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// Icon button for editing a player's note with optional tooltip display.
+class PlayerNoteButton extends StatelessWidget {
+  final String? note;
+  final double scale;
+  final VoidCallback onPressed;
+
+  const PlayerNoteButton({
+    Key? key,
+    required this.note,
+    required this.onPressed,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final hasNote = note != null && note!.isNotEmpty;
+
+    Widget button = IconButton(
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      iconSize: 16 * scale,
+      onPressed: onPressed,
+      icon: Icon(
+        Icons.sticky_note_2,
+        color: hasNote ? Colors.amber : Colors.white70,
+        size: 16 * scale,
+      ),
+    );
+
+    if (!hasNote) return button;
+
+    return Tooltip(
+      message: note!,
+      triggerMode: TooltipTriggerMode.longPress,
+      decoration: BoxDecoration(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      textStyle: const TextStyle(color: Colors.white),
+      child: button,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `PlayerNoteButton` widget to show note tooltip
- display note button in `PokerAnalyzerScreen` with hover/long press tooltip

## Testing
- `dart` and `flutter` were unavailable so formatting was not run


------
https://chatgpt.com/codex/tasks/task_e_685492f23218832a9851f97875eb4515