### PR TITLE
Add toggle to pin hero seat

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -299,7 +299,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (isPerspectiveSwitched && opponentIndex != null) {
       return opponentIndex!;
     }
-    return _playerManager.heroIndex;
+    return _debugPrefs.pinHeroPosition ? _playerManager.heroIndex : 0;
   }
 
   int _inferBoardStreet() => _boardSync.inferBoardStreet();
@@ -4711,6 +4711,23 @@ class _SnapshotControls extends StatelessWidget {
     );
   }
 
+  Widget _pinHeroSwitch() {
+    return Row(
+      children: [
+        const Expanded(child: Text('Pin Hero Position')),
+        Switch(
+          value: s._debugPrefs.pinHeroPosition,
+          onChanged: (v) async {
+            await s._debugPrefs.setPinHeroPosition(v);
+            s.lockService.safeSetState(this, () {});
+            s._debugPanelSetState?.call(() {});
+          },
+          activeColor: Colors.orange,
+        ),
+      ],
+    );
+  }
+
 
 class _ProcessingControls extends StatelessWidget {
   const _ProcessingControls({required this.state});
@@ -4842,6 +4859,8 @@ class _QueueDisplaySection extends StatelessWidget {
         ),
         _DebugPanelDialogState._vGap,
         state._sortBySprSwitch(),
+        _DebugPanelDialogState._vGap,
+        state._pinHeroSwitch(),
         _DebugPanelDialogState._vGap,
         TextField(
           controller: state._searchController,
@@ -5143,6 +5162,8 @@ class _InternalStateFlagsSection extends StatelessWidget {
         debugDiag('Perspective Switched', s.isPerspectiveSwitched),
         _DebugPanelDialogState._vGap,
         debugDiag('Show All Revealed Cards', s._debugPrefs.showAllRevealedCards),
+        _DebugPanelDialogState._vGap,
+        debugDiag('Pin Hero Position', s._debugPrefs.pinHeroPosition),
       ],
     );
   }

--- a/lib/services/debug_panel_preferences.dart
+++ b/lib/services/debug_panel_preferences.dart
@@ -14,6 +14,7 @@ class DebugPanelPreferences extends ChangeNotifier {
   static const _debugPanelOpenKey = 'debug_panel_open';
   static const _debugLayoutKey = 'debug_layout_enabled';
   static const _showAllCardsKey = 'show_all_revealed_cards';
+  static const _pinHeroKey = 'pin_hero_position';
 
   bool _snapshotRetentionEnabled = true;
   int _processingDelay = 500;
@@ -25,6 +26,7 @@ class DebugPanelPreferences extends ChangeNotifier {
   bool _isDebugPanelOpen = false;
   bool _debugLayout = false;
   bool _showAllRevealedCards = false;
+  bool _pinHeroPosition = false;
 
   bool get snapshotRetentionEnabled => _snapshotRetentionEnabled;
   int get processingDelay => _processingDelay;
@@ -36,6 +38,7 @@ class DebugPanelPreferences extends ChangeNotifier {
   bool get isDebugPanelOpen => _isDebugPanelOpen;
   bool get debugLayout => _debugLayout;
   bool get showAllRevealedCards => _showAllRevealedCards;
+  bool get pinHeroPosition => _pinHeroPosition;
 
   Future<void> loadSnapshotRetention() async {
     final prefs = await SharedPreferences.getInstance();
@@ -174,6 +177,19 @@ class DebugPanelPreferences extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> loadPinHeroPosition() async {
+    final prefs = await SharedPreferences.getInstance();
+    _pinHeroPosition = prefs.getBool(_pinHeroKey) ?? false;
+  }
+
+  Future<void> setPinHeroPosition(bool value) async {
+    if (_pinHeroPosition == value) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pinHeroKey, value);
+    _pinHeroPosition = value;
+    notifyListeners();
+  }
+
   List<T> applyAdvancedFilters<T extends ActionEvaluationRequest>(List<T> list) {
     final filters = _advancedFilters;
     final sort = _sortBySpr;
@@ -260,6 +276,7 @@ class DebugPanelPreferences extends ChangeNotifier {
     await loadDebugPanelOpen();
     await loadDebugLayout();
     await loadShowAllRevealedCards();
+    await loadPinHeroPosition();
     notifyListeners();
   }
 
@@ -274,6 +291,7 @@ class DebugPanelPreferences extends ChangeNotifier {
     await prefs.remove(_debugPanelOpenKey);
     await prefs.remove(_debugLayoutKey);
     await prefs.remove(_showAllCardsKey);
+    await prefs.remove(_pinHeroKey);
     _queueResumed = prefs.getBool(_queueResumedKey) ?? false;
     await loadAllPreferences();
   }


### PR DESCRIPTION
## Summary
- allow storing a `pinHeroPosition` preference
- expose switch in debug panel to pin hero under the table
- respect pinned setting when determining player rotation

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_685493bf0c80832aacbe772dc8fe76a8