### PR TITLE
Add curved chip movement animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -358,6 +358,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
     final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
     final end = Offset(centerX, centerY);
+    final control = Offset(
+      (start.dx + end.dx) / 2,
+      (start.dy + end.dy) / 2 - (40 + ChipMovingWidget.activeCount * 8) * scale,
+    );
     final color = entry.action == 'raise'
         ? Colors.green
         : entry.action == 'call'
@@ -368,6 +372,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       builder: (_) => ChipMovingWidget(
         start: start,
         end: end,
+        control: control,
         amount: entry.amount!,
         color: color,
         scale: scale,

--- a/lib/widgets/chip_moving_widget.dart
+++ b/lib/widgets/chip_moving_widget.dart
@@ -19,6 +19,9 @@ class ChipMovingWidget extends StatefulWidget {
   /// Scale factor for sizing.
   final double scale;
 
+  /// Optional control point for a curved flight path.
+  final Offset? control;
+
   /// Callback fired when the animation completes.
   final VoidCallback? onCompleted;
 
@@ -29,6 +32,7 @@ class ChipMovingWidget extends StatefulWidget {
     required this.amount,
     required this.color,
     this.scale = 1.0,
+    this.control,
     this.onCompleted,
   }) : super(key: key);
 
@@ -76,7 +80,21 @@ class _ChipMovingWidgetState extends State<ChipMovingWidget>
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        final pos = Offset.lerp(widget.start, widget.end, _controller.value)!;
+        Offset bezier(Offset p0, Offset p1, Offset p2, double t) {
+          final u = 1 - t;
+          return Offset(
+            u * u * p0.dx + 2 * u * t * p1.dx + t * t * p2.dx,
+            u * u * p0.dy + 2 * u * t * p1.dy + t * t * p2.dy,
+          );
+        }
+        final control = widget.control ??
+            Offset(
+              (widget.start.dx + widget.end.dx) / 2,
+              (widget.start.dy + widget.end.dy) / 2 -
+                  (40 + ChipMovingWidget.activeCount * 8) * widget.scale,
+            );
+        final pos = bezier(
+            widget.start, control, widget.end, _controller.value);
         final sizeFactor = _scaleAnim.value * widget.scale;
         return Positioned(
           left: pos.dx - 12 * sizeFactor,

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -233,11 +233,16 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     final start = box.localToGlobal(box.size.center(Offset.zero));
     final media = MediaQuery.of(context).size;
     final end = Offset(media.width / 2, media.height / 2 - 60 * widget.scale);
+    final control = Offset(
+      (start.dx + end.dx) / 2,
+      (start.dy + end.dy) / 2 - (40 + ChipMovingWidget.activeCount * 8) * widget.scale,
+    );
     late OverlayEntry entry;
     entry = OverlayEntry(
       builder: (_) => ChipMovingWidget(
         start: start,
         end: end,
+        control: control,
         amount: amount,
         color: Colors.amber,
         scale: widget.scale,


### PR DESCRIPTION
## Summary
- update `ChipMovingWidget` to support curved paths using a control point
- animate chips along a curve in `PokerAnalyzerScreen`
- apply same curve when playing bet animation in `PlayerZoneWidget`

## Testing
- `git diff --color --stat`


------
https://chatgpt.com/codex/tasks/task_e_685499a72168832ab7f27f814fd85e38