### PR TITLE
Add pot growth animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -772,7 +772,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    _potGrowthAnimation = Tween<double>(begin: 1.0, end: 1.15).animate(
+    _potGrowthAnimation = Tween<double>(begin: 1.0, end: 1.2).animate(
       CurvedAnimation(parent: _potGrowthController, curve: Curves.easeOutCubic),
     )..addStatusListener((status) {
         if (status == AnimationStatus.completed) {


### PR DESCRIPTION
## Summary
- grow the pot widget to 1.2x when chips reach the center of the table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68549de30220832a9eab5760e711107b