### PR TITLE
Add stack value below avatar

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -47,13 +47,13 @@ import '../widgets/side_pot_widget.dart';
 import '../widgets/card_selector.dart';
 import '../widgets/player_bet_indicator.dart';
 import '../widgets/player_stack_chips.dart';
-import '../widgets/player_stack_label.dart';
 import '../widgets/player_spr_label.dart';
 import '../widgets/player_total_invested_label.dart';
 import '../widgets/bet_stack_chips.dart';
 import '../widgets/chip_stack_widget.dart';
 import '../widgets/chip_amount_widget.dart';
 import '../widgets/mini_stack_widget.dart';
+import '../widgets/player_stack_value.dart';
 import '../widgets/player_note_button.dart';
 import '../widgets/bet_size_label.dart';
 import '../helpers/poker_position_helper.dart';
@@ -2590,7 +2590,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       Positioned(
         left: centerX + dx - 20 * scale,
         top: centerY + dy + bias + 84 * scale,
-        child: PlayerStackLabel(stack: stack, scale: scale * 0.9),
+        child: PlayerStackValue(stack: stack, scale: scale * 0.9),
       ),
       Positioned(
         left: centerX + dx - 20 * scale,

--- a/lib/widgets/player_stack_value.dart
+++ b/lib/widgets/player_stack_value.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+/// Displays the current remaining stack with a chip icon.
+class PlayerStackValue extends StatelessWidget {
+  /// Amount of chips remaining for the player.
+  final int stack;
+
+  /// Scale factor controlling the size.
+  final double scale;
+
+  const PlayerStackValue({
+    Key? key,
+    required this.stack,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (stack <= 0) return const SizedBox.shrink();
+    final iconSize = 12.0 * scale;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: 6 * scale,
+        vertical: 2 * scale,
+      ),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(8 * scale),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.casino, size: iconSize, color: Colors.orangeAccent),
+          SizedBox(width: 4 * scale),
+          Text(
+            '$stack',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 12 * scale,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `PlayerStackValue` widget to show remaining stack with a chip icon
- show `PlayerStackValue` under each avatar in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a213ccbc832aabc3f30df5df695d