### PR TITLE
Add turn countdown overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -56,6 +56,7 @@ import '../widgets/mini_stack_widget.dart';
 import '../widgets/player_stack_value.dart';
 import '../widgets/player_note_button.dart';
 import '../widgets/bet_size_label.dart';
+import '../widgets/turn_countdown_overlay.dart';
 import '../helpers/poker_position_helper.dart';
 import '../models/saved_hand.dart';
 import '../models/player_model.dart';
@@ -2503,6 +2504,15 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           position: Offset(centerX + dx, centerY + dy),
           scale: scale * infoScale,
           bias: bias,
+        ),
+      if (isActive)
+        Positioned(
+          left: centerX + dx - 12 * scale,
+          top: centerY + dy + bias - 90 * scale,
+          child: TurnCountdownOverlay(
+            scale: scale,
+            onComplete: () => _onPlayerTimeExpired(index),
+          ),
         ),
       // action arrow behind player widgets
       Positioned(

--- a/lib/widgets/turn_countdown_overlay.dart
+++ b/lib/widgets/turn_countdown_overlay.dart
@@ -1,0 +1,95 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+/// Small shrinking countdown ring used to indicate the active player's turn.
+class TurnCountdownOverlay extends StatefulWidget {
+  final Duration duration;
+  final VoidCallback? onComplete;
+  final double scale;
+
+  const TurnCountdownOverlay({
+    Key? key,
+    this.duration = const Duration(seconds: 3),
+    this.onComplete,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  State<TurnCountdownOverlay> createState() => _TurnCountdownOverlayState();
+}
+
+class _TurnCountdownOverlayState extends State<TurnCountdownOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration)
+      ..forward();
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onComplete?.call();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final progress = 1.0 - _controller.value;
+        return Transform.scale(
+          scale: progress,
+          child: CustomPaint(
+            size: Size(24 * widget.scale, 24 * widget.scale),
+            painter: _RingPainter(
+              progress: progress,
+              color: color,
+              thickness: 3 * widget.scale,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  final double progress;
+  final Color color;
+  final double thickness;
+
+  _RingPainter({
+    required this.progress,
+    required this.color,
+    required this.thickness,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = math.min(size.width, size.height) / 2 - thickness / 2;
+    final rect = Rect.fromCircle(center: size.center(Offset.zero), radius: radius);
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = thickness
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(rect, -math.pi / 2, 2 * math.pi * progress, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.color != color ||
+        oldDelegate.thickness != thickness;
+  }
+}


### PR DESCRIPTION
## Summary
- create `TurnCountdownOverlay` widget with shrinking progress ring
- show countdown overlay above active player in `PokerAnalyzerScreen`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854a4996c44832a8de132cb675c9162