### PR TITLE
Add flying chip stack animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -64,6 +64,7 @@ import '../models/action_evaluation_request.dart';
 import '../widgets/action_timeline_widget.dart';
 import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
+import '../widgets/chip_stack_moving_widget.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -339,7 +340,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void _playBetFlyInAnimation(ActionEntry entry) {
-    if (!['bet', 'raise'].contains(entry.action) ||
+    if (!['bet', 'raise', 'call'].contains(entry.action) ||
         entry.amount == null ||
         entry.generated) return;
     final overlay = Overlay.of(context);
@@ -368,12 +369,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final perp = Offset(-sin(angle), cos(angle));
     final control = Offset(
       midX + perp.dx * 20 * scale,
-      midY - (40 + ChipMovingWidget.activeCount * 8) * scale,
+      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
     );
-    final color = entry.action == 'raise' ? Colors.green : Colors.amber;
+    final color = entry.action == 'raise'
+        ? Colors.green
+        : entry.action == 'call'
+            ? Colors.blue
+            : Colors.yellow;
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => ChipMovingWidget(
+      builder: (_) => ChipStackMovingWidget(
         start: start,
         end: end,
         control: control,
@@ -425,7 +430,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         ? Colors.green
         : entry.action == 'call'
             ? Colors.blue
-            : Colors.amber;
+            : Colors.yellow;
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
       builder: (_) => ChipMovingWidget(

--- a/lib/widgets/chip_stack_moving_widget.dart
+++ b/lib/widgets/chip_stack_moving_widget.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
+
+/// Animates a stack of chips flying along a curved path.
+class ChipStackMovingWidget extends StatefulWidget {
+  /// Number of instances animating concurrently.
+  static int activeCount = 0;
+
+  /// Global start position of the animation.
+  final Offset start;
+
+  /// Global end position of the animation.
+  final Offset end;
+
+  /// Amount represented by the chip stack.
+  final int amount;
+
+  /// Color of the chips.
+  final Color color;
+
+  /// Scale factor applied to the widget.
+  final double scale;
+
+  /// Optional control point for a quadratic bezier path.
+  final Offset? control;
+
+  /// Callback when the animation completes.
+  final VoidCallback? onCompleted;
+
+  const ChipStackMovingWidget({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+    this.control,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<ChipStackMovingWidget> createState() => _ChipStackMovingWidgetState();
+}
+
+class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _scaleAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    ChipStackMovingWidget.activeCount++;
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    );
+    _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
+    );
+    _scaleAnim = Tween<double>(begin: 1.0, end: 0.7).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    ChipStackMovingWidget.activeCount--;
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Offset _bezier(Offset p0, Offset p1, Offset p2, double t) {
+    final u = 1 - t;
+    return Offset(
+      u * u * p0.dx + 2 * u * t * p1.dx + t * t * p2.dx,
+      u * u * p0.dy + 2 * u * t * p1.dy + t * t * p2.dy,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final control = widget.control ?? Offset(
+          (widget.start.dx + widget.end.dx) / 2,
+          (widget.start.dy + widget.end.dy) / 2 -
+              (40 + ChipStackMovingWidget.activeCount * 8) * widget.scale,
+        );
+        final pos = _bezier(widget.start, control, widget.end, _controller.value);
+        final sizeFactor = _scaleAnim.value * widget.scale;
+        return Positioned(
+          left: pos.dx - 12 * sizeFactor,
+          top: pos.dy - 12 * sizeFactor,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: Transform.scale(scale: sizeFactor, child: child),
+          ),
+        );
+      },
+      child: ChipStackWidget(
+        amount: widget.amount,
+        scale: 0.8 * widget.scale,
+        color: widget.color,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- animate colored chip stacks flying to the center pot
- color chips by action type and include calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a60aa3f4832ab96f202eab871a33