### PR TITLE
Add fold discard animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -491,6 +491,50 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     overlay.insert(overlayEntry);
   }
 
+  void _playFoldTrashAnimation(int playerIndex) {
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    final double scale =
+        TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+    final i =
+        (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+    final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+    final dx = radiusX * cos(angle);
+    final dy = radiusY * sin(angle);
+    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+    final end = Offset(screen.width + 30 * scale, screen.height + 30 * scale);
+    final midX = (start.dx + end.dx) / 2;
+    final midY = (start.dy + end.dy) / 2;
+    final perp = Offset(-sin(angle), cos(angle));
+    final control = Offset(
+      midX + perp.dx * 20 * scale,
+      midY + 40 * scale,
+    );
+    late OverlayEntry overlayEntry;
+    overlayEntry = OverlayEntry(
+      builder: (_) => ChipStackMovingWidget(
+        start: start,
+        end: end,
+        control: control,
+        amount: 20,
+        color: Colors.grey,
+        scale: scale,
+        onCompleted: () => overlayEntry.remove(),
+      ),
+    );
+    overlay.insert(overlayEntry);
+  }
+
   void _triggerBetDisplay(ActionEntry entry) {
     if ((entry.action == 'bet' || entry.action == 'raise') && entry.amount != null) {
       final color = ActionFormattingHelper.actionColor(entry.action);
@@ -1405,6 +1449,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     lockService.safeSetState(this, () {
       _addAutoFolds(entry);
       if (entry.action == 'fold') {
+        _playFoldTrashAnimation(entry.playerIndex);
         final invested = _stackService.getTotalInvested(entry.playerIndex);
         if (invested > 0) {
           final refund = (invested * 0.1).round().clamp(1, invested);


### PR DESCRIPTION
## Summary
- animate chip stack flying to trash when player folds
- trigger new animation in `onActionSelected`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6854a70b31c8832a96aed20e42a494ee