### PR TITLE
Add chip flight animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -65,6 +65,7 @@ import '../widgets/action_timeline_widget.dart';
 import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
+import '../widgets/bet_flying_chips.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -383,7 +384,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             : Colors.yellow;
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => ChipStackMovingWidget(
+      builder: (_) => BetFlyingChips(
         start: start,
         end: end,
         control: control,
@@ -1279,6 +1280,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             IntTween(begin: prevPot, end: newPot).animate(_potCountController);
         _potCountController.forward(from: 0);
         _displayedPots[currentStreet] = newPot;
+        _playBetFlyInAnimation(lastAction);
       } else {
         _displayedPots[currentStreet] = newPot;
         _potCountAnimation = IntTween(begin: newPot, end: newPot)

--- a/lib/widgets/bet_flying_chips.dart
+++ b/lib/widgets/bet_flying_chips.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_moving_widget.dart';
+
+/// Widget animating a player's bet flying from their position to the pot.
+class BetFlyingChips extends StatelessWidget {
+  final Offset start;
+  final Offset end;
+  final int amount;
+  final Color color;
+  final double scale;
+  final Offset? control;
+  final VoidCallback? onCompleted;
+
+  const BetFlyingChips({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+    this.control,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChipStackMovingWidget(
+      start: start,
+      end: end,
+      control: control,
+      amount: amount,
+      color: color,
+      scale: scale,
+      onCompleted: onCompleted,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `BetFlyingChips` widget that wraps `ChipStackMovingWidget`
- animate chip flight when playing back bet/raise/call actions
- use new widget in existing bet fly-in animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854abce6e64832a86c135fc563e7676