### PR TITLE
Add pot win animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -236,6 +236,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   int _prevPlaybackIndex = 0;
   final Set<int> _showdownPlayers = {};
   bool _showdownActive = false;
+  int? _winnerIndex;
+  bool _potAnimationPlayed = false;
 
 
 
@@ -472,6 +474,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (_showdownPlayers.isEmpty) return;
     _showdownPlayers.clear();
     _showdownActive = false;
+    _potAnimationPlayed = false;
     lockService.safeSetState(this, () {});
   }
 
@@ -610,6 +613,52 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         amount: 20,
         color: Colors.grey,
         scale: scale,
+        onCompleted: () => overlayEntry.remove(),
+      ),
+    );
+    overlay.insert(overlayEntry);
+  }
+
+  void _playWinPotAnimation(int playerIndex, int amount) {
+    if (amount <= 0) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    final double scale =
+        TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+    final i =
+        (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+    final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+    final dx = radiusX * cos(angle);
+    final dy = radiusY * sin(angle);
+    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final start = Offset(centerX, centerY);
+    final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+    final midX = (start.dx + end.dx) / 2;
+    final midY = (start.dy + end.dy) / 2;
+    final perp = Offset(-sin(angle), cos(angle));
+    final control = Offset(
+      midX + perp.dx * 20 * scale,
+      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
+    );
+    late OverlayEntry overlayEntry;
+    overlayEntry = OverlayEntry(
+      builder: (_) => ChipStackMovingWidget(
+        start: start,
+        end: end,
+        control: control,
+        amount: amount,
+        color: Colors.amber,
+        scale: scale,
+        duration: const Duration(milliseconds: 500),
         onCompleted: () => overlayEntry.remove(),
       ),
     );
@@ -1114,6 +1163,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     Future(() => _initializeDebugPreferences());
     Future.microtask(_queueService.loadQueueSnapshot);
     _computeSidePots();
+    if (widget.initialHand?.winnings != null &&
+        widget.initialHand!.winnings!.isNotEmpty) {
+      _winnerIndex = widget.initialHand!.winnings!.entries
+          .reduce((a, b) => a.value >= b.value ? a : b)
+          .key;
+    }
     // BackupManagerService handles periodic backups and cleanup internally.
   }
 
@@ -1409,6 +1464,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _playShowdownAnimation();
       } else if (!shouldShowdown && _showdownActive) {
         _clearShowdown();
+      }
+      if (_showdownActive &&
+          !_potAnimationPlayed &&
+          _winnerIndex != null &&
+          _boardReveal.revealedBoardCards.length == 5 &&
+          _playbackManager.playbackIndex == actions.length) {
+        _playWinPotAnimation(_winnerIndex!, _potSync.pots[currentStreet]);
+        _potAnimationPlayed = true;
       }
       _prevPlaybackIndex = _playbackManager.playbackIndex;
     }

--- a/lib/widgets/chip_stack_moving_widget.dart
+++ b/lib/widgets/chip_stack_moving_widget.dart
@@ -21,6 +21,9 @@ class ChipStackMovingWidget extends StatefulWidget {
   /// Scale factor applied to the widget.
   final double scale;
 
+  /// Duration of the animation.
+  final Duration duration;
+
   /// Optional control point for a quadratic bezier path.
   final Offset? control;
 
@@ -36,6 +39,7 @@ class ChipStackMovingWidget extends StatefulWidget {
     this.scale = 1.0,
     this.control,
     this.onCompleted,
+    this.duration = const Duration(milliseconds: 400),
   }) : super(key: key);
 
   @override
@@ -54,7 +58,7 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
     ChipStackMovingWidget.activeCount++;
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 400),
+      duration: widget.duration,
     );
     _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
       CurvedAnimation(parent: _controller, curve: Curves.easeOut),


### PR DESCRIPTION
## Summary
- extend `ChipStackMovingWidget` with customizable duration
- animate chips flying to winner at showdown in `PokerAnalyzerScreen`
- track winner from loaded hand and reset animation state

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854afb37100832abe4be075d95bc7df