### PR TITLE
Add central pot chip stack

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -40,8 +40,7 @@ import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
 import '../widgets/bet_chips_on_table.dart';
 import '../widgets/invested_chip_tokens.dart';
-import '../widgets/central_pot_widget.dart';
-import '../widgets/central_pot_chips.dart';
+import '../widgets/central_pot_stack.dart';
 import '../widgets/pot_display_widget.dart';
 import '../widgets/side_pot_widget.dart';
 import '../widgets/card_selector.dart';
@@ -3563,9 +3562,12 @@ class _PotAndBetsOverlaySection extends StatelessWidget {
                 offset: Offset(0, -12 * scale),
                 child: ScaleTransition(
                   scale: potGrowth,
-                  child: CentralPotChips(
-                    amount: pot,
-                    scale: scale,
+                  child: AnimatedBuilder(
+                    animation: potCount,
+                    builder: (_, __) => CentralPotStack(
+                      amount: potCount.value,
+                      scale: scale,
+                    ),
                   ),
                 ),
               ),

--- a/lib/widgets/central_pot_stack.dart
+++ b/lib/widgets/central_pot_stack.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
+
+/// Animated chip stack visualization of the central pot.
+class CentralPotStack extends StatelessWidget {
+  /// Amount of chips currently in the pot.
+  final int amount;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const CentralPotStack({
+    Key? key,
+    required this.amount,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (amount <= 0) return const SizedBox.shrink();
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: ChipStackWidget(
+        key: ValueKey(amount),
+        amount: amount,
+        scale: scale,
+        color: Colors.orangeAccent,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `CentralPotStack` widget for pot chip visualization
- show animated chip stack in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854b50fbfd8832a8dd241d8f5e3f90d