### PR TITLE
Add pot win animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -239,6 +239,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   final Set<int> _showdownPlayers = {};
   bool _showdownActive = false;
   int? _winnerIndex;
+  Map<int, int>? _winnings;
   bool _potAnimationPlayed = false;
 
 
@@ -665,6 +666,67 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       ),
     );
     overlay.insert(overlayEntry);
+  }
+
+  void _animatePotToPlayer(int playerIndex, int amount) {
+    if (amount <= 0) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    final double scale =
+        TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+    final i =
+        (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+    final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+    final dx = radiusX * cos(angle);
+    final dy = radiusY * sin(angle);
+    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final start = Offset(centerX, centerY - 12 * scale);
+    final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+    final midX = (start.dx + end.dx) / 2;
+    final midY = (start.dy + end.dy) / 2;
+    final perp = Offset(-sin(angle), cos(angle));
+    final control = Offset(
+      midX + perp.dx * 20 * scale,
+      midY - (40 + RefundChipStackMovingWidget.activeCount * 8) * scale,
+    );
+    late OverlayEntry overlayEntry;
+    overlayEntry = OverlayEntry(
+      builder: (_) => RefundChipStackMovingWidget(
+        start: start,
+        end: end,
+        control: control,
+        amount: amount,
+        color: Colors.amber,
+        scale: scale,
+        onCompleted: () => overlayEntry.remove(),
+      ),
+    );
+    overlay.insert(overlayEntry);
+  }
+
+  void _playPotWinAnimation() {
+    if (_potAnimationPlayed) return;
+    final wins = _winnings;
+    if (wins == null || wins.isEmpty) {
+      if (_winnerIndex != null) {
+        _animatePotToPlayer(_winnerIndex!, _potSync.pots[currentStreet]);
+        _potAnimationPlayed = true;
+      }
+      return;
+    }
+    wins.forEach((index, amount) {
+      _animatePotToPlayer(index, amount);
+    });
+    _potAnimationPlayed = true;
   }
 
   void _triggerBetDisplay(ActionEntry entry) {
@@ -1175,6 +1237,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       _winnerIndex = widget.initialHand!.winnings!.entries
           .reduce((a, b) => a.value >= b.value ? a : b)
           .key;
+      _winnings = Map<int, int>.from(widget.initialHand!.winnings!);
     }
     // BackupManagerService handles periodic backups and cleanup internally.
   }
@@ -1474,11 +1537,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       }
       if (_showdownActive &&
           !_potAnimationPlayed &&
-          _winnerIndex != null &&
           _boardReveal.revealedBoardCards.length == 5 &&
           _playbackManager.playbackIndex == actions.length) {
-        _playWinPotAnimation(_winnerIndex!, _potSync.pots[currentStreet]);
-        _potAnimationPlayed = true;
+        _playPotWinAnimation();
       }
       _prevPlaybackIndex = _playbackManager.playbackIndex;
     }


### PR DESCRIPTION
## Summary
- animate pot chips moving to winner when a showdown concludes
- store `winnings` from the initial hand
- drive animation from new `_playPotWinAnimation`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854b606ee60832ab9ae77d5af13b78d