### PR TITLE
Display total invested under stacks

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -47,7 +47,7 @@ import '../widgets/card_selector.dart';
 import '../widgets/player_bet_indicator.dart';
 import '../widgets/player_stack_chips.dart';
 import '../widgets/player_spr_label.dart';
-import '../widgets/player_total_invested_label.dart';
+import '../widgets/total_invested_label.dart';
 import '../widgets/bet_stack_chips.dart';
 import '../widgets/chip_stack_widget.dart';
 import '../widgets/chip_amount_widget.dart';
@@ -3123,7 +3123,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         left: centerX + dx - 20 * scale,
         top: centerY + dy + bias + 108 * scale,
         child:
-            PlayerTotalInvestedLabel(total: totalInvested, scale: scale * 0.8),
+            TotalInvestedLabel(total: totalInvested, scale: scale * 0.8),
       ),
       Positioned(
         left: centerX + dx - 20 * scale,

--- a/lib/widgets/total_invested_label.dart
+++ b/lib/widgets/total_invested_label.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Small white label displaying total chips invested in the current hand.
+class TotalInvestedLabel extends StatelessWidget {
+  /// Total chips the player has invested so far.
+  final int? total;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const TotalInvestedLabel({
+    Key? key,
+    required this.total,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (total == null || total! <= 0) return const SizedBox.shrink();
+    return Text(
+      '$total',
+      style: TextStyle(
+        color: Colors.white,
+        fontSize: 12 * scale,
+        fontWeight: FontWeight.w600,
+        shadows: const [
+          Shadow(
+            offset: Offset(1, 1),
+            blurRadius: 2,
+            color: Colors.black54,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TotalInvestedLabel` widget for showing invested amount
- use new label in `PokerAnalyzerScreen` to show each player's total investment

## Testing
- `dart` and `flutter` binaries unavailable, so formatting and analysis were skipped

------
https://chatgpt.com/codex/tasks/task_e_6854b7b3f38c832a90e65029cb55b790