### PR TITLE
Add fold refund chip animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -66,7 +66,6 @@ import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
 import '../widgets/bet_flying_chips.dart';
-import '../widgets/refund_chip_stack_moving_widget.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -562,17 +561,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final perp = Offset(-sin(angle), cos(angle));
     final control = Offset(
       midX + perp.dx * 20 * scale,
-      midY - (40 + RefundChipStackMovingWidget.activeCount * 8) * scale,
+      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
     );
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => RefundChipStackMovingWidget(
+      builder: (_) => BetFlyingChips(
         start: start,
         end: end,
         control: control,
         amount: amount,
-        color: Colors.grey.shade300,
+        color: Colors.green,
         scale: scale,
+        fadeStart: 0.8,
         onCompleted: () => overlayEntry.remove(),
       ),
     );

--- a/lib/widgets/bet_flying_chips.dart
+++ b/lib/widgets/bet_flying_chips.dart
@@ -10,6 +10,7 @@ class BetFlyingChips extends StatelessWidget {
   final double scale;
   final Offset? control;
   final VoidCallback? onCompleted;
+  final double fadeStart;
 
   const BetFlyingChips({
     Key? key,
@@ -20,6 +21,7 @@ class BetFlyingChips extends StatelessWidget {
     this.scale = 1.0,
     this.control,
     this.onCompleted,
+    this.fadeStart = 0.0,
   }) : super(key: key);
 
   @override
@@ -32,6 +34,7 @@ class BetFlyingChips extends StatelessWidget {
       color: color,
       scale: scale,
       onCompleted: onCompleted,
+      fadeStart: fadeStart,
     );
   }
 }

--- a/lib/widgets/chip_stack_moving_widget.dart
+++ b/lib/widgets/chip_stack_moving_widget.dart
@@ -30,6 +30,10 @@ class ChipStackMovingWidget extends StatefulWidget {
   /// Callback when the animation completes.
   final VoidCallback? onCompleted;
 
+  /// Fraction of the animation after which fading should begin.
+  /// Ranges from 0.0 (fade from start) to 1.0 (no fade).
+  final double fadeStart;
+
   const ChipStackMovingWidget({
     Key? key,
     required this.start,
@@ -39,6 +43,7 @@ class ChipStackMovingWidget extends StatefulWidget {
     this.scale = 1.0,
     this.control,
     this.onCompleted,
+    this.fadeStart = 0.0,
     this.duration = const Duration(milliseconds: 400),
   }) : super(key: key);
 
@@ -61,7 +66,10 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
       duration: widget.duration,
     );
     _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
+      CurvedAnimation(
+        parent: _controller,
+        curve: Interval(widget.fadeStart, 1.0, curve: Curves.easeOut),
+      ),
     );
     _scaleAnim = Tween<double>(begin: 1.0, end: 0.7).animate(
       CurvedAnimation(parent: _controller, curve: Curves.easeIn),


### PR DESCRIPTION
## Summary
- customize `ChipStackMovingWidget` to support delayed fade
- extend `BetFlyingChips` with fadeStart
- animate refund chips from pot back to player on fold

## Testing
- `flutter format lib/widgets/chip_stack_moving_widget.dart lib/widgets/bet_flying_chips.dart lib/screens/poker_analyzer_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf18b910832aa09da8e75a55dcb8