### PR TITLE
Add pot growth animation for chip arrival

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -351,6 +351,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     });
   }
 
+  void _animatePotGrowth() {
+    if (_potGrowthController.isAnimating) {
+      _potGrowthController.stop();
+    }
+    _potGrowthController.forward(from: 0);
+  }
+
   void _playBetFlyInAnimation(ActionEntry entry) {
     if (!['bet', 'raise', 'call'].contains(entry.action) ||
         entry.amount == null ||
@@ -400,7 +407,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         scale: scale,
         onCompleted: () {
           overlayEntry.remove();
-          _potGrowthController.forward(from: 0);
+          _animatePotGrowth();
         },
       ),
     );


### PR DESCRIPTION
## Summary
- trigger pot scaling after chips land in the center
- add helper `_animatePotGrowth` to avoid overlapping animations

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854bfe26b28832a933f1bc4d769bea0