### PR TITLE
Add fold trash chip animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -66,6 +66,7 @@ import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
 import '../widgets/bet_flying_chips.dart';
+import '../widgets/trash_flying_chips.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -607,7 +608,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final dy = radiusY * sin(angle);
     final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
     final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
-    final end = Offset(screen.width + 30 * scale, screen.height + 30 * scale);
+    final end = Offset(-30 * scale, screen.height + 30 * scale);
     final midX = (start.dx + end.dx) / 2;
     final midY = (start.dy + end.dy) / 2;
     final perp = Offset(-sin(angle), cos(angle));
@@ -617,13 +618,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     );
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => ChipStackMovingWidget(
+      builder: (_) => TrashFlyingChips(
         start: start,
         end: end,
         control: control,
         amount: 20,
-        color: Colors.grey,
-        scale: scale,
+        scale: 0.8 * scale,
+        fadeStart: 0.2,
         onCompleted: () => overlayEntry.remove(),
       ),
     );

--- a/lib/widgets/chip_stack_moving_widget.dart
+++ b/lib/widgets/chip_stack_moving_widget.dart
@@ -34,6 +34,9 @@ class ChipStackMovingWidget extends StatefulWidget {
   /// Ranges from 0.0 (fade from start) to 1.0 (no fade).
   final double fadeStart;
 
+  /// Final rotation applied to the chip stack when the animation completes.
+  final double endRotation;
+
   const ChipStackMovingWidget({
     Key? key,
     required this.start,
@@ -44,6 +47,7 @@ class ChipStackMovingWidget extends StatefulWidget {
     this.control,
     this.onCompleted,
     this.fadeStart = 0.0,
+    this.endRotation = 0.0,
     this.duration = const Duration(milliseconds: 400),
   }) : super(key: key);
 
@@ -56,6 +60,7 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
   late final AnimationController _controller;
   late final Animation<double> _opacity;
   late final Animation<double> _scaleAnim;
+  late final Animation<double> _rotation;
 
   @override
   void initState() {
@@ -73,6 +78,9 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
     );
     _scaleAnim = Tween<double>(begin: 1.0, end: 0.7).animate(
       CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
+    _rotation = Tween<double>(begin: 0.0, end: widget.endRotation).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
     );
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -114,7 +122,10 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
           top: pos.dy - 12 * sizeFactor,
           child: FadeTransition(
             opacity: _opacity,
-            child: Transform.scale(scale: sizeFactor, child: child),
+            child: Transform.rotate(
+              angle: _rotation.value,
+              child: Transform.scale(scale: sizeFactor, child: child),
+            ),
           ),
         );
       },

--- a/lib/widgets/trash_flying_chips.dart
+++ b/lib/widgets/trash_flying_chips.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_moving_widget.dart';
+
+/// Widget animating chips flying toward the trash with rotation.
+class TrashFlyingChips extends StatelessWidget {
+  final Offset start;
+  final Offset end;
+  final int amount;
+  final double scale;
+  final Offset? control;
+  final VoidCallback? onCompleted;
+  final double fadeStart;
+  final double endRotation;
+
+  const TrashFlyingChips({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    this.scale = 1.0,
+    this.control,
+    this.onCompleted,
+    this.fadeStart = 0.0,
+    this.endRotation = -1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChipStackMovingWidget(
+      start: start,
+      end: end,
+      control: control,
+      amount: amount,
+      color: Colors.grey,
+      scale: scale,
+      fadeStart: fadeStart,
+      endRotation: endRotation,
+      onCompleted: onCompleted,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce rotation support in `ChipStackMovingWidget`
- add new `TrashFlyingChips` widget
- animate chips flying to trash in `PokerAnalyzerScreen`

## Testing
- `dart` or `flutter` commands not available in container

------
https://chatgpt.com/codex/tasks/task_e_6854c33e79d4832a8a0a41cde8255962