### PR TITLE
Add pot win animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -663,14 +663,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     );
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => ChipStackMovingWidget(
+      builder: (_) => BetFlyingChips(
         start: start,
         end: end,
         control: control,
         amount: amount,
-        color: Colors.amber,
-        scale: scale,
-        duration: const Duration(milliseconds: 500),
+        color: Colors.orangeAccent,
+        scale: 1.0,
+        fadeStart: 0.3,
         onCompleted: () => overlayEntry.remove(),
       ),
     );


### PR DESCRIPTION
## Summary
- make `_playWinPotAnimation` use `BetFlyingChips` for a golden chip stack
- chips now fly along a curved path and fade when the pot is won

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854c4206b10832aa1238ce4f3fb1b69