### PR TITLE
Implement chip return animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -677,6 +677,57 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     overlay.insert(overlayEntry);
   }
 
+  /// Animate chips returning from the pot to players.
+  void _playChipReturnAnimation(Map<int, int> returns) {
+    if (returns.isEmpty) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    final double scale =
+        TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    returns.forEach((playerIndex, amount) {
+      if (amount <= 0) return;
+      final i =
+          (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+      final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+      final dx = radiusX * cos(angle);
+      final dy = radiusY * sin(angle);
+      final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+      final start = Offset(centerX, centerY);
+      final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+      final midX = (start.dx + end.dx) / 2;
+      final midY = (start.dy + end.dy) / 2;
+      final perp = Offset(-sin(angle), cos(angle));
+      final control = Offset(
+        midX + perp.dx * 20 * scale,
+        midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
+      );
+      late OverlayEntry overlayEntry;
+      overlayEntry = OverlayEntry(
+        builder: (_) => BetFlyingChips(
+          start: start,
+          end: end,
+          control: control,
+          amount: amount,
+          color: Colors.blueAccent,
+          scale: 0.9,
+          fadeStart: 0.2,
+          onCompleted: () => overlayEntry.remove(),
+        ),
+      );
+      overlay.insert(overlayEntry);
+    });
+  }
+
 
   void _playPotWinAnimation() {
     if (_potAnimationPlayed) return;


### PR DESCRIPTION
## Summary
- implement `_playChipReturnAnimation` in PokerAnalyzerScreen for returning chips to players

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854c4d0859c832aa795a5f5673d6a98