### PR TITLE
Add table clearing animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -69,6 +69,7 @@ import '../widgets/bet_flying_chips.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
 import '../widgets/show_card_flip.dart';
+import "../widgets/clear_table_cards.dart";
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -494,6 +495,75 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _potAnimationPlayed = false;
     lockService.safeSetState(this, () {});
   }
+
+  Future<void> _clearTableState() async {
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    final entries = <OverlayEntry>[];
+    final double scale = TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 -
+            TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    // Board cards
+    final visible = boardCards.length;
+    final baseY = centerY - 52 * scale;
+    for (int i = 0; i < visible; i++) {
+      final card = boardCards[i];
+      final x = centerX + (i - (visible - 1) / 2) * 44 * scale;
+      late OverlayEntry e;
+      e = OverlayEntry(
+        builder: (_) => ClearTableCards(
+          start: Offset(x, baseY),
+          card: card,
+          scale: scale,
+          onCompleted: () => e.remove(),
+        ),
+      );
+      overlay.insert(e);
+      entries.add(e);
+    }
+
+    // Player cards
+    for (int p = 0; p < numberOfPlayers; p++) {
+      final cards = playerCards[p];
+      if (cards.isEmpty) continue;
+      final i = (p - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+      final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+      final dx = radiusX * cos(angle);
+      final dy = radiusY * sin(angle);
+      final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+      final base = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+      for (int idx = 0; idx < cards.length; idx++) {
+        final card = cards[idx];
+        final pos = base + Offset((idx == 0 ? -18 : 18) * scale, 0);
+        late OverlayEntry e;
+        e = OverlayEntry(
+          builder: (_) => ClearTableCards(
+            start: pos,
+            card: card,
+            scale: scale,
+            onCompleted: () => e.remove(),
+          ),
+        );
+        overlay.insert(e);
+        entries.add(e);
+      }
+    }
+
+    await Future.delayed(const Duration(milliseconds: 600));
+    for (final e in entries) {
+      e.remove();
+    }
+  }
+
 
   void _playReturnChipAnimation(ActionEntry entry) {
     if (!['bet', 'raise', 'call'].contains(entry.action) ||
@@ -2024,6 +2094,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       ),
     );
     if (confirm == true) {
+      await _clearTableState();
       lockService.safeSetState(this, () {
         _deleteAction(actionIndex, withSetState: false);
       });
@@ -2171,6 +2242,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       ),
     );
     if (confirm == true) {
+      await _clearTableState();
       lockService.safeSetState(this, () {
         _playerManager.reset();
         _undoRedoService.resetHistory();

--- a/lib/widgets/clear_table_cards.dart
+++ b/lib/widgets/clear_table_cards.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+
+/// Animation for clearing table cards.
+/// Slides the card down off-screen while fading out.
+class ClearTableCards extends StatefulWidget {
+  final Offset start;
+  final CardModel card;
+  final double scale;
+  final Duration duration;
+  final VoidCallback? onCompleted;
+
+  const ClearTableCards({
+    Key? key,
+    required this.start,
+    required this.card,
+    this.scale = 1.0,
+    this.duration = const Duration(milliseconds: 600),
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<ClearTableCards> createState() => _ClearTableCardsState();
+}
+
+class _ClearTableCardsState extends State<ClearTableCards>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _offsetY;
+  late final Animation<double> _rotation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.4, 1.0)),
+    );
+    _offsetY = Tween<double>(begin: 0.0, end: 100.0 * widget.scale).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
+    _rotation = Tween<double>(begin: 0.0, end: 0.2).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
+    );
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = 36 * widget.scale;
+    final height = 52 * widget.scale;
+    final isRed = widget.card.suit == '♥' || widget.card.suit == '♦';
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pos = Offset(
+          widget.start.dx,
+          widget.start.dy + _offsetY.value,
+        );
+        return Positioned(
+          left: pos.dx - width / 2,
+          top: pos.dy - height / 2,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: Transform.rotate(angle: _rotation.value, child: child),
+          ),
+        );
+      },
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          '${widget.card.rank}${widget.card.suit}',
+          style: TextStyle(
+            color: isRed ? Colors.red : Colors.black,
+            fontWeight: FontWeight.bold,
+            fontSize: 18 * widget.scale,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `ClearTableCards` widget to animate cards sliding off screen
- add `_clearTableState` animation routine in analyzer
- trigger table clear animation before resetting a hand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854ca537dcc832a8ba477e062037278