### PR TITLE
Implement table cleanup fade animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -73,6 +73,7 @@ import '../widgets/fold_flying_cards.dart';
 import '../widgets/fold_refund_animation.dart';
 import '../widgets/show_card_flip.dart';
 import "../widgets/clear_table_cards.dart";
+import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
@@ -600,6 +601,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     for (final e in entries) {
       e.remove();
     }
+
+    // Fade out remaining table elements before state reset.
+    late OverlayEntry fadeEntry;
+    final completer = Completer<void>();
+    fadeEntry = OverlayEntry(
+      builder: (_) => TableFadeOverlay(
+        onCompleted: () {
+          fadeEntry.remove();
+          completer.complete();
+        },
+      ),
+    );
+    overlay.insert(fadeEntry);
+    await completer.future;
   }
 
 

--- a/lib/widgets/table_fade_overlay.dart
+++ b/lib/widgets/table_fade_overlay.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+/// Overlay that briefly fades the table to black and back.
+class TableFadeOverlay extends StatefulWidget {
+  final Duration duration;
+  final VoidCallback onCompleted;
+
+  const TableFadeOverlay({
+    Key? key,
+    this.duration = const Duration(milliseconds: 400),
+    required this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<TableFadeOverlay> createState() => _TableFadeOverlayState();
+}
+
+class _TableFadeOverlayState extends State<TableFadeOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        _controller.reverse().whenComplete(widget.onCompleted);
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(color: Colors.black87),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TableFadeOverlay widget for fade-out effect
- invoke new fade animation in `_clearTableState`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685511152dc8832a830d2b3ce4eb4c1d