### PR TITLE
Add showdown reveal animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -71,7 +71,7 @@ import '../widgets/pot_win_animation.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
 import '../widgets/fold_refund_animation.dart';
-import '../widgets/show_card_flip.dart';
+import '../widgets/reveal_card_animation.dart';
 import "../widgets/clear_table_cards.dart";
 import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
@@ -830,7 +830,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       final pos = base + Offset((idx == 0 ? -18 : 18) * scale, 0);
       late OverlayEntry entry;
       entry = OverlayEntry(
-        builder: (_) => ShowCardFlip(
+        builder: (_) => RevealCardAnimation(
           position: pos,
           card: card,
           scale: scale,

--- a/lib/widgets/reveal_card_animation.dart
+++ b/lib/widgets/reveal_card_animation.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+
+/// Animation that flips a facedown card at [position] to reveal its face.
+class RevealCardAnimation extends StatefulWidget {
+  /// Center position of the card in global coordinates.
+  final Offset position;
+
+  /// Card to reveal.
+  final CardModel card;
+
+  /// Scale factor applied to card size.
+  final double scale;
+
+  /// Duration of the flip animation.
+  final Duration duration;
+
+  /// Callback invoked when the animation finishes.
+  final VoidCallback? onCompleted;
+
+  const RevealCardAnimation({
+    Key? key,
+    required this.position,
+    required this.card,
+    this.scale = 1.0,
+    this.duration = const Duration(milliseconds: 400),
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<RevealCardAnimation> createState() => _RevealCardAnimationState();
+}
+
+class _RevealCardAnimationState extends State<RevealCardAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration)
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          widget.onCompleted?.call();
+        }
+      })
+      ..forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = 36 * widget.scale;
+    final height = 52 * widget.scale;
+    final isRed = widget.card.suit == '♥' || widget.card.suit == '♦';
+    return Positioned(
+      left: widget.position.dx - width / 2,
+      top: widget.position.dy - height / 2,
+      child: SizedBox(
+        width: width,
+        height: height,
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            double value = _controller.value;
+            double angle = value * pi;
+            Widget display;
+            if (value <= 0.5) {
+              display = Image.asset(
+                'assets/cards/card_back.png',
+                width: width,
+                height: height,
+              );
+            } else {
+              angle -= pi;
+              display = Container(
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '${widget.card.rank}${widget.card.suit}',
+                  style: TextStyle(
+                    color: isRed ? Colors.red : Colors.black,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18 * widget.scale,
+                  ),
+                ),
+              );
+            }
+            return Transform(
+              transform: Matrix4.identity()
+                ..setEntry(3, 2, 0.001)
+                ..rotateY(angle),
+              alignment: Alignment.center,
+              child: display,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- import RevealCardAnimation for card flipping effect
- show players' cards with RevealCardAnimation when revealing hole cards
- implement `RevealCardAnimation` widget for flip animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855190bd470832a96ce0d9ab87ed0c1