### PR TITLE
Add fold refund animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -712,6 +712,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         control: control,
         amount: amount,
         scale: scale,
+        color: Colors.blueAccent,
         onCompleted: () => overlayEntry.remove(),
       ),
     );
@@ -1101,8 +1102,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         delay += 150;
       }
       if (returns != null && returns.isNotEmpty) {
-        _showPotWinAnimations(overlay, returns, delay, Colors.blueAccent,
-            scale: 0.9);
+        returns.forEach((player, amount) {
+          Future.delayed(Duration(milliseconds: delay), () {
+            if (!mounted) return;
+            _playFoldRefundAnimation(player, amount);
+          });
+          delay += 150;
+        });
       }
     }
     _potAnimationPlayed = true;
@@ -1147,8 +1153,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         Colors.orangeAccent,
         highlight: true,
       );
+      delay += 150;
     } else {
       return;
+    }
+
+    final returns = _returns;
+    if (returns != null && returns.isNotEmpty) {
+      returns.forEach((player, amount) {
+        Future.delayed(Duration(milliseconds: delay), () {
+          if (!mounted) return;
+          _playFoldRefundAnimation(player, amount);
+        });
+        delay += 150;
+      });
     }
 
     _potAnimationPlayed = true;

--- a/lib/widgets/fold_refund_animation.dart
+++ b/lib/widgets/fold_refund_animation.dart
@@ -23,6 +23,9 @@ class FoldRefundAnimation extends StatefulWidget {
   /// Called when the animation completes.
   final VoidCallback? onCompleted;
 
+  /// Color of the refunded chips.
+  final Color color;
+
   const FoldRefundAnimation({
     Key? key,
     required this.start,
@@ -31,6 +34,7 @@ class FoldRefundAnimation extends StatefulWidget {
     this.scale = 1.0,
     this.control,
     this.onCompleted,
+    this.color = Colors.grey,
   }) : super(key: key);
 
   @override
@@ -107,7 +111,7 @@ class _FoldRefundAnimationState extends State<FoldRefundAnimation>
       child: ChipStackWidget(
         amount: widget.amount,
         scale: 0.8 * widget.scale,
-        color: Colors.grey,
+        color: widget.color,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow FoldRefundAnimation to set chip color
- show blue refund chips when pots are returned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68551cc11aec832a9283d4d0b114a989