### PR TITLE
Add bet display on player actions

### DIFF
--- a/lib/widgets/bet_display_widget.dart
+++ b/lib/widgets/bet_display_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
+
+/// Temporary chip stack with amount label used to visualize a bet.
+class BetDisplayWidget extends StatelessWidget {
+  /// Amount of chips in the stack.
+  final int amount;
+
+  /// Color of the chips.
+  final Color color;
+
+  /// Scale factor relative to table size.
+  final double scale;
+
+  const BetDisplayWidget({
+    Key? key,
+    required this.amount,
+    required this.color,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ChipStackWidget(
+          amount: amount,
+          color: color,
+          scale: scale,
+        ),
+        SizedBox(height: 2 * scale),
+        Text(
+          '+$amount',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 10 * scale,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `BetDisplayWidget` to show chip stacks during betting
- track and clear active bet displays in `PokerAnalyzerScreen`
- display bet stacks with new widget on actions

## Testing
- `No tests run (flutter unavailable)`

------
https://chatgpt.com/codex/tasks/task_e_68551ecd57ec832a8b3ed012adaee7c3