### PR TITLE
Add side pot display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1140,6 +1140,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         _potCountController.forward(from: 0);
         _displayedPots[currentStreet] = 0;
       }
+      if (_sidePots.isNotEmpty) {
+        _sidePots.clear();
+        _potSync.sidePots.clear();
+        lockService.safeSetState(this, () {});
+      }
     });
   }
 
@@ -1196,6 +1201,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             IntTween(begin: prevPot, end: 0).animate(_potCountController);
         _potCountController.forward(from: 0);
         _displayedPots[currentStreet] = 0;
+      }
+      if (_sidePots.isNotEmpty) {
+        _sidePots.clear();
+        _potSync.sidePots.clear();
+        lockService.safeSetState(this, () {});
       }
     });
   }
@@ -1283,22 +1293,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   void _computeSidePots() {
-    final contributions = <int>[];
-    for (int i = 0; i < numberOfPlayers; i++) {
-      contributions.add(_stackService.getTotalInvested(i));
-    }
-    contributions.sort();
-    final pots = <int>[];
-    int prev = 0;
-    int remaining = contributions.length;
-    for (final c in contributions) {
-      if (c > prev) {
-        pots.add((c - prev) * remaining);
-        prev = c;
-      }
-      remaining--;
-    }
-    _sidePots = pots.length > 1 ? pots.sublist(1) : [];
+    _potSync.updateSidePots();
+    _sidePots = List<int>.from(_potSync.sidePots);
   }
 
 

--- a/lib/widgets/side_pot_widget.dart
+++ b/lib/widgets/side_pot_widget.dart
@@ -31,7 +31,7 @@ class SidePotWidget extends StatelessWidget {
         borderRadius: BorderRadius.circular(12 * scale),
       ),
       child: Text(
-        'Side ${index + 1}: $amount',
+        'Пот ${index + 1}: $amount',
         style: TextStyle(
           color: Colors.white,
           fontSize: 14 * scale,


### PR DESCRIPTION
## Summary
- compute side pots in `PotSyncService`
- use computed side pots in `PokerAnalyzerScreen`
- show side pots as labeled chips in Russian
- fade out side pots after pot win animation

## Testing
- `flutter format lib/screens/poker_analyzer_screen.dart lib/services/pot_sync_service.dart lib/widgets/side_pot_widget.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552ed97df0832aad8317b3c4ea5316