### PR TITLE
Add fold animation for losing hands

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -74,7 +74,8 @@ import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
 import '../widgets/fold_refund_animation.dart';
 import '../widgets/reveal_card_animation.dart';
-import "../widgets/clear_table_cards.dart";
+import '../widgets/clear_table_cards.dart';
+import '../widgets/fold_reveal_animation.dart';
 import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
 import '../services/stack_manager_service.dart';
@@ -940,16 +941,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
       final base = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
       final cards = playerCards[playerIndex];
+      final dir = dx >= 0 ? 1.0 : -1.0;
       for (int idx = 0; idx < cards.length; idx++) {
         final card = cards[idx];
         final pos = base + Offset((idx == 0 ? -18 : 18) * scale, 0);
         late OverlayEntry e;
         e = OverlayEntry(
-          builder: (_) => ClearTableCards(
+          builder: (_) => FoldRevealAnimation(
             start: pos,
             card: card,
             scale: scale,
-            duration: const Duration(milliseconds: 1000),
+            direction: dir,
             onCompleted: () => e.remove(),
           ),
         );

--- a/lib/widgets/fold_reveal_animation.dart
+++ b/lib/widgets/fold_reveal_animation.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+
+/// Animation used to fade and slide a revealed card off the table when
+/// a player loses at showdown.
+class FoldRevealAnimation extends StatefulWidget {
+  final Offset start;
+  final CardModel card;
+  final double scale;
+  final Duration duration;
+  final double direction; // 1 for right, -1 for left
+  final VoidCallback? onCompleted;
+
+  const FoldRevealAnimation({
+    Key? key,
+    required this.start,
+    required this.card,
+    this.scale = 1.0,
+    this.duration = const Duration(milliseconds: 700),
+    this.direction = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<FoldRevealAnimation> createState() => _FoldRevealAnimationState();
+}
+
+class _FoldRevealAnimationState extends State<FoldRevealAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<Offset> _offset;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.4, 1.0)),
+    );
+    _offset = Tween<Offset>(
+      begin: Offset.zero,
+      end: Offset(widget.direction * 60 * widget.scale, 80 * widget.scale),
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeIn));
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = 36 * widget.scale;
+    final height = 52 * widget.scale;
+    final isRed = widget.card.suit == '♥' || widget.card.suit == '♦';
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pos = widget.start + _offset.value;
+        return Positioned(
+          left: pos.dx - width / 2,
+          top: pos.dy - height / 2,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: child,
+          ),
+        );
+      },
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          '${widget.card.rank}${widget.card.suit}',
+          style: TextStyle(
+            color: isRed ? Colors.red : Colors.black,
+            fontWeight: FontWeight.bold,
+            fontSize: 18 * widget.scale,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `FoldRevealAnimation` widget for fading and sliding losing cards away
- use `FoldRevealAnimation` when hiding losing hands

## Testing
- `bash -lc 'flutter --version'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855656bda78832a9873b9c9fa5c40d0