### PR TITLE
Add live pot display in PokerAnalyzerScreen

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3545,6 +3545,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       editingDisabled: lockService.isLocked,
                       potSync: _potSync,
                       boardReveal: widget.boardReveal,
+                      showPot: !_showdownActive,
                     ),
                   ),
                   _PlayerZonesSection(
@@ -4937,6 +4938,7 @@ class _BoardCardsSection extends StatefulWidget {
   final Set<String> usedCards;
   final bool editingDisabled;
   final BoardRevealService boardReveal;
+  final bool showPot;
 
   const _BoardCardsSection({
     Key? key,
@@ -4951,6 +4953,7 @@ class _BoardCardsSection extends StatefulWidget {
     this.canEditBoard,
     this.usedCards = const {},
     this.editingDisabled = false,
+    this.showPot = true,
   }) : super(key: key);
 
   @override
@@ -5018,6 +5021,7 @@ class _BoardCardsSectionState extends State<_BoardCardsSection>
         usedCards: widget.usedCards,
         editingDisabled: widget.editingDisabled,
         potSync: widget.potSync,
+        showPot: widget.showPot,
       ),
     );
   }

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -17,6 +17,7 @@ class BoardDisplay extends StatelessWidget {
   final double scale;
   final List<Animation<double>>? revealAnimations;
   final bool editingDisabled;
+  final bool showPot;
 
   const BoardDisplay({
     Key? key,
@@ -31,6 +32,7 @@ class BoardDisplay extends StatelessWidget {
     this.scale = 1.0,
     this.revealAnimations,
     this.editingDisabled = false,
+    this.showPot = true,
   }) : super(key: key);
 
   @override
@@ -52,6 +54,7 @@ class BoardDisplay extends StatelessWidget {
           potSync: potSync,
           currentStreet: currentStreet,
           scale: scale,
+          show: showPot,
         ),
       ],
     );

--- a/lib/widgets/pot_over_board_widget.dart
+++ b/lib/widgets/pot_over_board_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/pot_sync_service.dart';
-import '../helpers/action_formatting_helper.dart';
+import '../widgets/pot_display_widget.dart';
 
 /// Displays current pot size above the board cards.
 class PotOverBoardWidget extends StatelessWidget {
@@ -13,34 +13,35 @@ class PotOverBoardWidget extends StatelessWidget {
   /// Scale factor to adapt to table size.
   final double scale;
 
+  /// Whether the pot should be displayed.
+  final bool show;
+
   const PotOverBoardWidget({
     Key? key,
     required this.potSync,
     required this.currentStreet,
     this.scale = 1.0,
+    this.show = true,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    if (currentStreet < 1) {
+    if (!show || currentStreet < 1) {
       return const SizedBox.shrink();
     }
     final potAmount = potSync.pots[currentStreet];
+    if (potAmount <= 0) {
+      return const SizedBox.shrink();
+    }
     return Positioned.fill(
       child: IgnorePointer(
         child: Align(
           alignment: const Alignment(0, -0.05),
           child: Transform.translate(
             offset: Offset(0, -15 * scale),
-            child: Opacity(
-              opacity: 0.7,
-              child: Text(
-                'Pot: ${ActionFormattingHelper.formatAmount(potAmount)}',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 14 * scale,
-                ),
-              ),
+            child: PotDisplayWidget(
+              amount: potAmount,
+              scale: scale,
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- show PotDisplayWidget above the board
- enable hiding it during showdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68557070ad8c832aaba0a4530649206f