### PR TITLE
Add pot chip stack display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -40,7 +40,7 @@ import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
 import '../widgets/bet_chips_on_table.dart';
 import '../widgets/invested_chip_tokens.dart';
-import '../widgets/central_pot_stack.dart';
+import '../widgets/pot_chips_widget.dart';
 import '../widgets/pot_display_widget.dart';
 import '../widgets/side_pot_widget.dart';
 import '../widgets/card_selector.dart';
@@ -4637,31 +4637,25 @@ class _PotAndBetsOverlaySection extends StatelessWidget {
                 offset: Offset(0, -12 * scale),
                 child: ScaleTransition(
                   scale: potGrowth,
-                  child: AnimatedBuilder(
-                    animation: potCount,
-                    builder: (_, __) => CentralPotStack(
-                      amount: potCount.value,
-                      scale: scale,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-      items.add(
-        Positioned.fill(
-          child: IgnorePointer(
-            child: Align(
-              alignment: Alignment.center,
-              child: ScaleTransition(
-                scale: potGrowth,
-                child: AnimatedBuilder(
-                  animation: potCount,
-                  builder: (_, __) => PotDisplayWidget(
-                    amount: potCount.value,
-                    scale: scale,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      AnimatedBuilder(
+                        animation: potCount,
+                        builder: (_, __) => PotDisplayWidget(
+                          amount: potCount.value,
+                          scale: scale,
+                        ),
+                      ),
+                      SizedBox(height: 4 * scale),
+                      AnimatedBuilder(
+                        animation: potCount,
+                        builder: (_, __) => PotChipsWidget(
+                          amount: potCount.value,
+                          scale: scale,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/widgets/pot_chips_widget.dart
+++ b/lib/widgets/pot_chips_widget.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
+
+/// Displays a stack of chips that scales with the pot size.
+///
+/// Used in the center of the table below the pot amount text.
+class PotChipsWidget extends StatefulWidget {
+  /// Current pot value.
+  final int amount;
+
+  /// Base scale for sizing.
+  final double scale;
+
+  const PotChipsWidget({
+    Key? key,
+    required this.amount,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  State<PotChipsWidget> createState() => _PotChipsWidgetState();
+}
+
+class _PotChipsWidgetState extends State<PotChipsWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant PotChipsWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.amount > oldWidget.amount) {
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  double _scaled() {
+    // Grow chip stack slightly with pot size.
+    final extra = (widget.amount / 2000).clamp(0.0, 0.5);
+    return (1.0 + extra) * widget.scale;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.amount <= 0) return const SizedBox.shrink();
+    return ScaleTransition(
+      scale: Tween<double>(begin: 0.8, end: 1.0).animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeOutBack),
+      ),
+      child: ChipStackWidget(
+        amount: widget.amount,
+        scale: _scaled(),
+        color: Colors.orangeAccent,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show pot amount with animated chip stack
- implement `PotChipsWidget`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685579e9b19c832aba23eeaadec3b1e2