### PR TITLE
Add stack bust indication

### DIFF
--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -50,6 +50,8 @@ class PlayerInfoWidget extends StatelessWidget {
   final int? remainingStack;
   /// Disables the active timer when true.
   final bool timersDisabled;
+  /// True when the player has no stack left after an all-in.
+  final bool isBust;
 
   const PlayerInfoWidget({
     super.key,
@@ -80,6 +82,7 @@ class PlayerInfoWidget extends StatelessWidget {
     this.showLastIndicator = false,
     this.remainingStack,
     this.timersDisabled = false,
+    this.isBust = false,
   });
 
   String _formatStack(int value) {
@@ -204,9 +207,15 @@ class PlayerInfoWidget extends StatelessWidget {
           if (remainingStack != null)
             Padding(
               padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                'Осталось: ${_formatStack(remainingStack!)} BB',
-                style: stackStyle,
+              child: AnimatedOpacity(
+                opacity: isBust ? 0.3 : 1.0,
+                duration: const Duration(milliseconds: 300),
+                child: Text(
+                  'Осталось: ${_formatStack(remainingStack!)} BB',
+                  style: stackStyle.copyWith(
+                    color: isBust ? Colors.grey : stackStyle.color,
+                  ),
+                ),
               ),
             ),
           if (positionLabel != null)
@@ -364,10 +373,16 @@ class PlayerInfoWidget extends StatelessWidget {
                 onStackTap!(result);
               }
             },
-          child: Text(
+          child: AnimatedOpacity(
+            opacity: isBust ? 0.3 : 1.0,
+            duration: const Duration(milliseconds: 300),
+            child: Text(
               'Стек: ${_formatStack(stack)}',
-              style: stackStyle,
+              style: stackStyle.copyWith(
+                color: isBust ? Colors.grey : stackStyle.color,
+              ),
             ),
+          ),
           ),
           if (tag.isNotEmpty) ...[
             const SizedBox(height: 4),

--- a/lib/widgets/player_stack_chips.dart
+++ b/lib/widgets/player_stack_chips.dart
@@ -8,10 +8,14 @@ class PlayerStackChips extends StatelessWidget {
   /// Scale factor depending on table size.
   final double scale;
 
+  /// Whether the player has no remaining chips after an all-in.
+  final bool isBust;
+
   const PlayerStackChips({
     Key? key,
     required this.stack,
     this.scale = 1.0,
+    this.isBust = false,
   }) : super(key: key);
 
   Color _colorForStack() {
@@ -22,41 +26,45 @@ class PlayerStackChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (stack <= 0) return const SizedBox.shrink();
-    final chipCount = (stack / 10).clamp(1, 10).round();
+    if (stack <= 0 && !isBust) return const SizedBox.shrink();
+    final chipCount = stack > 0 ? (stack / 10).clamp(1, 10).round() : 1;
     final double size = 10 * scale;
-    final color = _colorForStack();
+    final color = isBust ? Colors.grey : _colorForStack();
 
-    return SizedBox(
-      width: size * 2,
-      height: size + chipCount * size * 0.35,
-      child: Stack(
-        alignment: Alignment.bottomCenter,
-        children: [
-          for (int i = 0; i < chipCount; i++)
-            Positioned(
-              bottom: i * size * 0.35,
-              child: Container(
-                width: size * 2,
-                height: size,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: LinearGradient(
-                    colors: [color, Colors.black],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
+    return AnimatedOpacity(
+      opacity: isBust ? 0.0 : 1.0,
+      duration: const Duration(milliseconds: 300),
+      child: SizedBox(
+        width: size * 2,
+        height: size + chipCount * size * 0.35,
+        child: Stack(
+          alignment: Alignment.bottomCenter,
+          children: [
+            for (int i = 0; i < chipCount; i++)
+              Positioned(
+                bottom: i * size * 0.35,
+                child: Container(
+                  width: size * 2,
+                  height: size,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    gradient: LinearGradient(
+                      colors: [color, Colors.black],
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.6),
+                        blurRadius: 3,
+                        offset: const Offset(1, 2),
+                      )
+                    ],
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.6),
-                      blurRadius: 3,
-                      offset: const Offset(1, 2),
-                    )
-                  ],
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/player_stack_value.dart
+++ b/lib/widgets/player_stack_value.dart
@@ -8,10 +8,14 @@ class PlayerStackValue extends StatefulWidget {
   /// Scale factor controlling the size.
   final double scale;
 
+  /// True when the player has pushed all chips and has no stack left.
+  final bool isBust;
+
   const PlayerStackValue({
     Key? key,
     required this.stack,
     this.scale = 1.0,
+    this.isBust = false,
   }) : super(key: key);
 
   @override
@@ -47,7 +51,7 @@ class _PlayerStackValueState extends State<PlayerStackValue>
   @override
   void didUpdateWidget(covariant PlayerStackValue oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.stack != oldWidget.stack) {
+    if (widget.stack != oldWidget.stack || widget.isBust != oldWidget.isBust) {
       _controller.forward(from: 0);
     }
   }
@@ -60,33 +64,38 @@ class _PlayerStackValueState extends State<PlayerStackValue>
 
   @override
   Widget build(BuildContext context) {
-    if (widget.stack <= 0) return const SizedBox.shrink();
+    if (widget.stack <= 0 && !widget.isBust) return const SizedBox.shrink();
     final iconSize = 12.0 * widget.scale;
-    return ScaleTransition(
-      scale: _animation,
-      child: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: 6 * widget.scale,
-          vertical: 2 * widget.scale,
-        ),
-        decoration: BoxDecoration(
-          color: Colors.black54,
-          borderRadius: BorderRadius.circular(8 * widget.scale),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.casino, size: iconSize, color: Colors.orangeAccent),
-            SizedBox(width: 4 * widget.scale),
-            Text(
-              _formatStack(widget.stack),
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 12 * widget.scale,
-                fontWeight: FontWeight.bold,
+    final textColor = widget.isBust ? Colors.grey : Colors.white;
+    return AnimatedOpacity(
+      opacity: widget.isBust ? 0.0 : 1.0,
+      duration: const Duration(milliseconds: 300),
+      child: ScaleTransition(
+        scale: _animation,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: 6 * widget.scale,
+            vertical: 2 * widget.scale,
+          ),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(8 * widget.scale),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.casino, size: iconSize, color: Colors.orangeAccent),
+              SizedBox(width: 4 * widget.scale),
+              Text(
+                _formatStack(widget.stack),
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: 12 * widget.scale,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add `isBust` visual state to player stack widgets
- track busted players in `PokerAnalyzerScreen`
- fade player stack widgets when stack hits zero

## Testing
- `dart format lib/widgets/player_stack_value.dart lib/widgets/player_stack_chips.dart lib/widgets/player_info_widget.dart lib/screens/poker_analyzer_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685578fb7fa0832a8bfc9f5a3e6af964