### PR TITLE
Display bet amounts on flying chip animations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -448,6 +448,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         amount: entry.amount!,
         color: color,
         scale: scale,
+        fadeStart: 0.8,
+        labelStyle: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 14 * scale,
+          shadows: const [Shadow(color: Colors.black54, blurRadius: 2)],
+        ),
         onCompleted: () {
           overlayEntry.remove();
           _animatePotGrowth();
@@ -1016,6 +1023,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           amount: amount,
           color: color,
           scale: scale,
+          labelStyle: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 14 * scale,
+            shadows: const [Shadow(color: Colors.black54, blurRadius: 2)],
+          ),
           fadeStart: fadeStart,
           onCompleted: () => overlayEntry.remove(),
         ),
@@ -1346,6 +1359,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             amount: entry.amount!,
             color: color,
             scale: tableScale,
+            fadeStart: 0.8,
+            labelStyle: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 14 * tableScale,
+              shadows: const [Shadow(color: Colors.black54, blurRadius: 2)],
+            ),
             onCompleted: () => overlayEntry.remove(),
           ),
         );

--- a/lib/widgets/bet_flying_chips.dart
+++ b/lib/widgets/bet_flying_chips.dart
@@ -11,6 +11,7 @@ class BetFlyingChips extends StatelessWidget {
   final Offset? control;
   final VoidCallback? onCompleted;
   final double fadeStart;
+  final TextStyle? labelStyle;
 
   const BetFlyingChips({
     Key? key,
@@ -22,6 +23,7 @@ class BetFlyingChips extends StatelessWidget {
     this.control,
     this.onCompleted,
     this.fadeStart = 0.0,
+    this.labelStyle,
   }) : super(key: key);
 
   @override
@@ -35,6 +37,7 @@ class BetFlyingChips extends StatelessWidget {
       scale: scale,
       onCompleted: onCompleted,
       fadeStart: fadeStart,
+      labelStyle: labelStyle,
       showLabel: true,
     );
   }

--- a/lib/widgets/bet_to_center_animation.dart
+++ b/lib/widgets/bet_to_center_animation.dart
@@ -24,6 +24,12 @@ class BetToCenterAnimation extends StatelessWidget {
   /// Callback when animation completes.
   final VoidCallback? onCompleted;
 
+  /// Fraction of the animation after which fading should begin.
+  final double fadeStart;
+
+  /// Optional style for the amount label.
+  final TextStyle? labelStyle;
+
   const BetToCenterAnimation({
     Key? key,
     required this.start,
@@ -33,6 +39,8 @@ class BetToCenterAnimation extends StatelessWidget {
     this.scale = 1.0,
     this.control,
     this.onCompleted,
+    this.fadeStart = 0.8,
+    this.labelStyle,
   }) : super(key: key);
 
   @override
@@ -44,6 +52,8 @@ class BetToCenterAnimation extends StatelessWidget {
       color: color,
       scale: scale,
       control: control,
+      fadeStart: fadeStart,
+      labelStyle: labelStyle,
       showLabel: true,
       onCompleted: onCompleted,
     );


### PR DESCRIPTION
## Summary
- show amount label on bet animations
- fade chip text near end of flight
- expose label styling options for animations

## Testing
- `bash -lc "which flutter"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685589b049d0832ab976f73152f72007