### PR TITLE
Add animated stack labels to player info

### DIFF
--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../models/card_model.dart';
 import 'action_timer_ring.dart';
 import 'flip_card.dart';
+import 'player_stack_value.dart';
 
 /// Compact display for a player's position, stack, tag and last action.
 /// Optionally shows a simplified position label as a badge.
@@ -373,15 +374,10 @@ class PlayerInfoWidget extends StatelessWidget {
                 onStackTap!(result);
               }
             },
-          child: AnimatedOpacity(
-            opacity: isBust ? 0.3 : 1.0,
-            duration: const Duration(milliseconds: 300),
-            child: Text(
-              'Стек: ${_formatStack(stack)}',
-              style: stackStyle.copyWith(
-                color: isBust ? Colors.grey : stackStyle.color,
-              ),
-            ),
+          child: PlayerStackValue(
+            stack: stack,
+            scale: 0.8,
+            isBust: isBust,
           ),
           ),
           if (tag.isNotEmpty) ...[

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -12,7 +12,7 @@ import 'card_selector.dart';
 import 'chip_widget.dart';
 import 'current_bet_label.dart';
 import 'bet_size_label.dart';
-import 'player_stack_label.dart';
+import 'player_stack_value.dart';
 import 'stack_bar_widget.dart';
 import 'chip_moving_widget.dart';
 import 'move_pot_animation.dart';
@@ -656,7 +656,11 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
       ),
         GestureDetector(
           onLongPress: _editStack,
-          child: PlayerStackLabel(stack: stack, scale: widget.scale),
+          child: PlayerStackValue(
+            stack: stack ?? 0,
+            scale: widget.scale,
+            isBust: remaining != null && remaining <= 0,
+          ),
         ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),


### PR DESCRIPTION
## Summary
- integrate `PlayerStackValue` into `PlayerInfoWidget`
- replace old stack label in `PlayerZoneWidget` with animated chip-based display

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac1312ac832aa20b94ca673adcc7