### PR TITLE
Add win chip animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -69,7 +69,7 @@ import '../widgets/chip_stack_moving_widget.dart';
 import '../widgets/bet_flying_chips.dart';
 import '../widgets/bet_to_center_animation.dart';
 import '../widgets/all_in_chips_animation.dart';
-import '../widgets/pot_win_animation.dart';
+import '../widgets/win_chips_animation.dart';
 import '../widgets/win_amount_widget.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
@@ -1136,7 +1136,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         if (!mounted) return;
         late OverlayEntry entry;
         entry = OverlayEntry(
-          builder: (_) => PotWinAnimation(
+          builder: (_) => WinChipsAnimation(
             start: start,
             end: end,
             control: control,

--- a/lib/widgets/win_chips_animation.dart
+++ b/lib/widgets/win_chips_animation.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_moving_widget.dart';
+
+/// Animation of chips flying from the pot to a player's stack.
+class WinChipsAnimation extends StatelessWidget {
+  /// Start position in global coordinates (center pot).
+  final Offset start;
+
+  /// End position at the winning player's stack.
+  final Offset end;
+
+  /// Chip amount to animate.
+  final int amount;
+
+  /// Scale factor applied to the animation.
+  final double scale;
+
+  /// Optional control point for the bezier path.
+  final Offset? control;
+
+  /// Callback when animation completes.
+  final VoidCallback? onCompleted;
+
+  /// Fraction of the animation after which fading should start.
+  final double fadeStart;
+
+  /// Color of the chip stack.
+  final Color color;
+
+  const WinChipsAnimation({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    this.scale = 1.0,
+    this.control,
+    this.onCompleted,
+    this.fadeStart = 0.7,
+    this.color = Colors.orangeAccent,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChipStackMovingWidget(
+      start: start,
+      end: end,
+      amount: amount,
+      color: color,
+      scale: scale,
+      control: control,
+      fadeStart: fadeStart,
+      labelStyle: TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.bold,
+        fontSize: 16 * scale,
+        shadows: const [Shadow(color: Colors.black54, blurRadius: 2)],
+      ),
+      showLabel: true,
+      onCompleted: onCompleted,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `WinChipsAnimation` for moving chips from pot to players
- show this animation in `_showPotWinAnimations`

## Testing
- `dart` not installed, skipped formatting

------
https://chatgpt.com/codex/tasks/task_e_6855b6310d40832ab946ce909eb12f82