### PR TITLE
Add refund chips animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -66,6 +66,7 @@ import '../widgets/action_timeline_widget.dart';
 import '../services/pot_sync_service.dart';
 import '../widgets/chip_moving_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
+import '../widgets/refund_chip_stack_moving_widget.dart';
 import '../widgets/bet_flying_chips.dart';
 import '../widgets/bet_to_center_animation.dart';
 import '../widgets/all_in_chips_animation.dart';
@@ -74,6 +75,7 @@ import '../widgets/win_amount_widget.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
 import '../widgets/fold_refund_animation.dart';
+import '../widgets/refund_amount_widget.dart';
 import '../widgets/reveal_card_animation.dart';
 import '../widgets/clear_table_cards.dart';
 import '../widgets/fold_reveal_animation.dart';
@@ -436,7 +438,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final perp = Offset(-sin(angle), cos(angle));
     final control = Offset(
       midX + perp.dx * 20 * scale,
-      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
+      midY - (40 + RefundChipStackMovingWidget.activeCount * 8) * scale,
     );
     final isAllIn = entry.action == 'all-in';
     final color = entry.action == 'raise'
@@ -740,7 +742,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final perp = Offset(-sin(angle), cos(angle));
     final control = Offset(
       midX + perp.dx * 20 * scale,
-      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
+      midY - (40 + RefundChipStackMovingWidget.activeCount * 8) * scale,
     );
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
@@ -750,8 +752,25 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         control: control,
         amount: amount,
         scale: scale,
-        color: Colors.blueAccent,
-        onCompleted: () => overlayEntry.remove(),
+        color: Colors.lightGreenAccent,
+        onCompleted: () {
+          overlayEntry.remove();
+          final startStack =
+              _displayedStacks[playerIndex] ??
+                  _stackService.getStackForPlayer(playerIndex);
+          final endStack = startStack + amount;
+          _animateStackIncrease(playerIndex, startStack, endStack);
+          final pos = Offset(
+            end.dx - 20 * scale,
+            end.dy - 60 * scale,
+          );
+          showRefundAmountOverlay(
+            context: context,
+            position: pos,
+            amount: amount,
+            scale: scale,
+          );
+        },
       ),
     );
     overlay.insert(overlayEntry);

--- a/lib/widgets/refund_amount_widget.dart
+++ b/lib/widgets/refund_amount_widget.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+/// Fading label displaying the amount refunded to a player.
+class RefundAmountWidget extends StatefulWidget {
+  final Offset position;
+  final int amount;
+  final double scale;
+  final VoidCallback? onCompleted;
+
+  const RefundAmountWidget({
+    Key? key,
+    required this.position,
+    required this.amount,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<RefundAmountWidget> createState() => _RefundAmountWidgetState();
+}
+
+class _RefundAmountWidgetState extends State<RefundAmountWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0).chain(
+          CurveTween(curve: Curves.easeIn),
+        ),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0).chain(
+          CurveTween(curve: Curves.easeOut),
+        ),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: widget.position.dx,
+      top: widget.position.dy,
+      child: FadeTransition(
+        opacity: _opacity,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: 8 * widget.scale,
+            vertical: 4 * widget.scale,
+          ),
+          decoration: BoxDecoration(
+            color: Colors.lightGreenAccent.withOpacity(0.9),
+            borderRadius: BorderRadius.circular(8 * widget.scale),
+            boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
+          ),
+          child: Text(
+            'Возврат: ${widget.amount}',
+            style: TextStyle(
+              color: Colors.black,
+              fontWeight: FontWeight.bold,
+              fontSize: 14 * widget.scale,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays a [RefundAmountWidget] above the current overlay.
+void showRefundAmountOverlay({
+  required BuildContext context,
+  required Offset position,
+  required int amount,
+  double scale = 1.0,
+}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => RefundAmountWidget(
+      position: position,
+      amount: amount,
+      scale: scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}
+


### PR DESCRIPTION
## Summary
- animate chips returned to players after showdown
- new `RefundAmountWidget` shows green refund labels
- show refund overlay and increase stack when refund animation completes

## Testing
- `dart` and `flutter` commands not available; formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_6855b74dec54832ab9b5be5c1105540d