### PR TITLE
Add fading losing hand animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1160,6 +1160,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
     final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
 
+    int delay = 0;
     for (final playerIndex in losers) {
       final i = (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
       final angle = 2 * pi * i / numberOfPlayers + pi / 2;
@@ -1172,21 +1173,25 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       for (int idx = 0; idx < cards.length; idx++) {
         final card = cards[idx];
         final pos = base + Offset((idx == 0 ? -18 : 18) * scale, 0);
-        late OverlayEntry e;
-        e = OverlayEntry(
-          builder: (_) => FoldRevealAnimation(
-            start: pos,
-            card: card,
-            scale: scale,
-            direction: dir,
-            onCompleted: () => e.remove(),
-          ),
-        );
-        overlay.insert(e);
+        Future.delayed(Duration(milliseconds: delay), () {
+          if (!mounted) return;
+          late OverlayEntry e;
+          e = OverlayEntry(
+            builder: (_) => FoldRevealAnimation(
+              start: pos,
+              card: card,
+              scale: scale,
+              direction: dir,
+              onCompleted: () => e.remove(),
+            ),
+          );
+          overlay.insert(e);
+        });
+        delay += 120;
       }
     }
 
-    Future.delayed(const Duration(milliseconds: 1000), () {
+    Future.delayed(Duration(milliseconds: delay + 700), () {
       if (!mounted) return;
       for (final p in losers) {
         _showdownPlayers.remove(p);
@@ -1467,7 +1472,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _potAnimationPlayed = true;
 
     // Fade out the central pot after the chips move away.
-    Future.delayed(const Duration(milliseconds: 600), () {
+    final winCount = wins?.length ?? 1;
+    final totalDelay = 300 * winCount + 500;
+    Future.delayed(Duration(milliseconds: totalDelay), () {
       if (!mounted) return;
       final prevPot = _displayedPots[currentStreet];
       if (prevPot > 0) {
@@ -1530,7 +1537,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
     _potAnimationPlayed = true;
 
-    Future.delayed(const Duration(milliseconds: 600), () {
+    final winCount = wins?.length ?? 1;
+    final totalDelay = 300 * winCount + 500;
+    Future.delayed(Duration(milliseconds: totalDelay), () {
       if (!mounted) return;
       final prevPot = _displayedPots[currentStreet];
       if (prevPot > 0) {
@@ -1565,7 +1574,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
     _potAnimationPlayed = true;
 
-    Future.delayed(const Duration(milliseconds: 600), () {
+    final winCount = wins?.length ?? 1;
+    final totalDelay = 300 * winCount + 500;
+    Future.delayed(Duration(milliseconds: totalDelay), () {
       if (!mounted) return;
       final prevPot = _displayedPots[currentStreet];
       if (prevPot > 0) {

--- a/lib/widgets/fold_reveal_animation.dart
+++ b/lib/widgets/fold_reveal_animation.dart
@@ -30,6 +30,7 @@ class _FoldRevealAnimationState extends State<FoldRevealAnimation>
   late final AnimationController _controller;
   late final Animation<double> _opacity;
   late final Animation<Offset> _offset;
+  late final Animation<double> _scaleAnim;
 
   @override
   void initState() {
@@ -42,6 +43,9 @@ class _FoldRevealAnimationState extends State<FoldRevealAnimation>
       begin: Offset.zero,
       end: Offset(widget.direction * 60 * widget.scale, 80 * widget.scale),
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeIn));
+    _scaleAnim = Tween<double>(begin: 1.0, end: 0.7).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         widget.onCompleted?.call();
@@ -70,7 +74,10 @@ class _FoldRevealAnimationState extends State<FoldRevealAnimation>
           top: pos.dy - height / 2,
           child: FadeTransition(
             opacity: _opacity,
-            child: child,
+            child: Transform.scale(
+              scale: _scaleAnim.value,
+              child: child,
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Summary
- animate folding players' hands out of view after the showdown
- scale cards while fading using updated `FoldRevealAnimation`
- wait for reward animations to finish before hiding hands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c54ecd3c832ab901c2587184494e