### PR TITLE
Add playback step controls

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -5788,6 +5788,21 @@ class _PlaybackControlsSection extends StatelessWidget {
             ),
           ],
         ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: disabled ? null : onStepBackward,
+              child: const Text('Step Back'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: disabled ? null : onStepForward,
+              child: const Text('Step Forward'),
+            ),
+          ],
+        ),
         const SizedBox(height: 10),
         TextButton(
           onPressed: backDisabled ? null : onBack,


### PR DESCRIPTION
## Summary
- show new step forward/back buttons in playback controls for Poker Analyzer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855cc3febf4832a8cac60700e5bc70c