### PR TITLE
Add playback center chip animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2692,6 +2692,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             IntTween(begin: prevPot, end: newPot).animate(_potCountController);
         _potCountController.forward(from: 0);
         _displayedPots[currentStreet] = newPot;
+        _triggerCenterChip(lastAction);
         _handleBetAction(lastAction, potIndex: potIndex);
       } else if (undone != null) {
         _potCountAnimation =


### PR DESCRIPTION
## Summary
- trigger center chip display in playback when bets occur

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d06a38dc832a9bff7c069c4da8ed