### PR TITLE
Implement auto-play mode

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1867,7 +1867,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   void _play() {
     if (lockService.isLocked) return;
-    _playbackManager.startPlayback();
+    _playbackManager.startPlayback(
+      stepDelay: const Duration(milliseconds: 1200),
+      canAdvance: () => !lockService.isLocked && _resetAnimationCount == 0,
+    );
   }
 
   void _pause() {

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -47,8 +47,12 @@ class PlaybackManagerService extends ChangeNotifier {
     return false;
   }
 
-  void startPlayback() =>
-      _playbackService.startPlayback(actionSync.analyzerActions.length);
+  void startPlayback({Duration? stepDelay, bool Function()? canAdvance}) =>
+      _playbackService.startPlayback(
+        actionSync.analyzerActions.length,
+        delay: stepDelay,
+        canAdvance: canAdvance,
+      );
 
   void pausePlayback() => _playbackService.pausePlayback();
 

--- a/lib/services/playback_service.dart
+++ b/lib/services/playback_service.dart
@@ -5,7 +5,7 @@ class PlaybackService extends ChangeNotifier {
   int _playbackIndex = 0;
   bool _isPlaying = false;
   Timer? _playbackTimer;
-  final Duration stepDuration;
+  Duration stepDuration;
 
   PlaybackService({this.stepDuration = const Duration(seconds: 1)});
 
@@ -25,15 +25,23 @@ class PlaybackService extends ChangeNotifier {
     }
   }
 
-  void startPlayback(int actionCount) {
+  void startPlayback(
+    int actionCount, {
+    Duration? delay,
+    bool Function()? canAdvance,
+  }) {
     pausePlayback();
     _isPlaying = true;
     if (_playbackIndex == actionCount) {
       _playbackIndex = 0;
     }
     updatePlaybackState();
-    _playbackTimer =
-        Timer.periodic(stepDuration, (_) => _playStepForward(actionCount));
+    final d = delay ?? stepDuration;
+    _playbackTimer = Timer.periodic(d, (_) {
+      if (canAdvance == null || canAdvance()) {
+        _playStepForward(actionCount);
+      }
+    });
   }
 
   void pausePlayback() {


### PR DESCRIPTION
## Summary
- extend playback services to support delayed auto-play
- adjust playback manager to pass delay and lock check
- update PokerAnalyzerScreen to start timed auto-play on Play

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d41dfb04832abed63d8cfc3a9e00