### PR TITLE
Add playback progress bar

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -81,6 +81,7 @@ import '../widgets/clear_table_cards.dart';
 import '../widgets/fold_reveal_animation.dart';
 import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
+import '../widgets/playback_progress_bar.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -4190,6 +4191,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       potSync: _potSync,
       currentStreet: currentStreet,
       sidePots: _sidePots,
+    ),
+    AbsorbPointer(
+      absorbing: lockService.isLocked,
+      child: PlaybackProgressBar(
+        playbackIndex: _playbackManager.playbackIndex,
+        actionCount: actions.length,
+        onSeek: (index) {
+          lockService.safeSetState(this, () {
+            _playbackManager.seek(index);
+            _playbackManager.updatePlaybackState();
+          });
+        },
+      ),
     ),
     Padding(
       padding: const EdgeInsets.symmetric(vertical: 4.0),

--- a/lib/widgets/playback_progress_bar.dart
+++ b/lib/widgets/playback_progress_bar.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// Interactive progress bar for seeking within hand playback.
+class PlaybackProgressBar extends StatelessWidget {
+  final int playbackIndex;
+  final int actionCount;
+  final ValueChanged<int> onSeek;
+
+  const PlaybackProgressBar({
+    super.key,
+    required this.playbackIndex,
+    required this.actionCount,
+    required this.onSeek,
+  });
+
+  void _handleSeek(BuildContext context, Offset globalPosition) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null) return;
+    final local = box.globalToLocal(globalPosition);
+    final fraction = (local.dx / box.size.width).clamp(0.0, 1.0);
+    onSeek((fraction * actionCount).round());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress =
+        actionCount > 0 ? playbackIndex / actionCount : 0.0;
+    final accent = Theme.of(context).colorScheme.secondary;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapDown: (details) => _handleSeek(context, details.globalPosition),
+      onHorizontalDragUpdate: (details) =>
+          _handleSeek(context, details.globalPosition),
+      child: Container(
+        height: 8,
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: progress,
+            backgroundColor: Colors.white24,
+            valueColor: AlwaysStoppedAnimation<Color>(accent),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `PlaybackProgressBar` widget
- show progress bar below the table to indicate playback progress
- allow tapping or dragging progress bar to seek actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d64f7fbc832abe96f45030b0438b