### PR TITLE
Add hero focus playback option

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -244,6 +244,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late final ScrollController _timelineController;
   bool _animateTimeline = false;
   bool isPerspectiveSwitched = false;
+  bool _focusOnHero = false;
 
   final Map<int, _BetDisplayInfo> _recentBets = {};
   final Map<int, _BetDisplayInfo> _betDisplays = {};
@@ -4292,6 +4293,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   });
                 },
                 playerPositions: playerPositions,
+                focusPlayerIndex: _focusOnHero ? heroIndex : null,
                 controller: _timelineController,
                 scale: scale,
               ),
@@ -4317,6 +4319,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 onImportAll: importAllHandsFromClipboard,
                 onReset: _resetHand,
                 onBack: _cancelHandAnalysis,
+                focusOnHero: _focusOnHero,
+                onFocusChanged: (v) => setState(() => _focusOnHero = v),
                 backDisabled: _showdownActive,
                 disabled: _transitionHistory.isLocked,
               ),
@@ -4550,7 +4554,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             scale: isFolded ? 0.9 : 1.0,
             duration: const Duration(milliseconds: 400),
             child: AnimatedOpacity(
-              opacity: isFolded ? 0.4 : 1.0,
+              opacity: isFolded
+                  ? 0.4
+                  : (_focusOnHero && index != _playerManager.heroIndex
+                      ? 0.3
+                      : 1.0),
               duration: const Duration(milliseconds: 400),
               child: AbsorbPointer(
                 absorbing: lockService.isLocked,
@@ -5830,6 +5838,8 @@ class _PlaybackControlsSection extends StatelessWidget {
   final ValueChanged<double> onSeek;
   final VoidCallback onReset;
   final VoidCallback onBack;
+  final bool focusOnHero;
+  final ValueChanged<bool> onFocusChanged;
   final bool backDisabled;
   final bool disabled;
 
@@ -5845,6 +5855,8 @@ class _PlaybackControlsSection extends StatelessWidget {
     required this.onSeek,
     required this.onReset,
     required this.onBack,
+    required this.focusOnHero,
+    required this.onFocusChanged,
     this.backDisabled = false,
     this.disabled = false,
   });
@@ -5912,6 +5924,12 @@ class _PlaybackControlsSection extends StatelessWidget {
         TextButton(
           onPressed: onReset,
           child: const Text('Сбросить раздачу'),
+        ),
+        SwitchListTile(
+          title: const Text('Focus on Hero', style: TextStyle(color: Colors.white)),
+          value: focusOnHero,
+          onChanged: disabled ? null : onFocusChanged,
+          activeColor: Colors.deepPurple,
         ),
       ],
     );
@@ -5996,6 +6014,8 @@ class _PlaybackAndHandControls extends StatelessWidget {
   final VoidCallback onImportAll;
   final VoidCallback onReset;
   final VoidCallback onBack;
+  final bool focusOnHero;
+  final ValueChanged<bool> onFocusChanged;
   final bool backDisabled;
   final bool disabled;
 
@@ -6018,6 +6038,8 @@ class _PlaybackAndHandControls extends StatelessWidget {
     required this.onImportAll,
     required this.onReset,
     required this.onBack,
+    required this.focusOnHero,
+    required this.onFocusChanged,
     this.backDisabled = false,
     this.disabled = false,
   });
@@ -6049,6 +6071,8 @@ class _PlaybackAndHandControls extends StatelessWidget {
           onSeek: onSeek,
           onReset: onReset,
           onBack: onBack,
+          focusOnHero: focusOnHero,
+          onFocusChanged: onFocusChanged,
           backDisabled: backDisabled,
           disabled: disabled,
         ),

--- a/lib/widgets/action_timeline_widget.dart
+++ b/lib/widgets/action_timeline_widget.dart
@@ -9,6 +9,7 @@ class ActionTimelineWidget extends StatelessWidget {
   final Map<int, String>? playerPositions;
   final double scale;
   final ScrollController? controller;
+  final int? focusPlayerIndex;
 
   const ActionTimelineWidget({
     Key? key,
@@ -18,6 +19,7 @@ class ActionTimelineWidget extends StatelessWidget {
     this.playerPositions,
     this.scale = 1.0,
     this.controller,
+    this.focusPlayerIndex,
   }) : super(key: key);
 
   @override
@@ -34,22 +36,27 @@ class ActionTimelineWidget extends StatelessWidget {
           final isSelected = index == playbackIndex;
           final pos = playerPositions?[action.playerIndex] ??
               'P${action.playerIndex + 1}';
+          final dim =
+              focusPlayerIndex != null && action.playerIndex != focusPlayerIndex;
 
           return GestureDetector(
             onTap: () => onTap(index),
-            child: Container(
-              margin: EdgeInsets.symmetric(horizontal: 4 * scale),
-              padding: EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 6 * scale),
-              decoration: BoxDecoration(
-                color: isSelected ? Colors.deepPurple : Colors.grey[800],
-                borderRadius: BorderRadius.circular(8 * scale),
-                border: Border.all(color: Colors.white24),
-              ),
-              child: Text(
-                '$pos ${action.action}${action.amount != null ? ' ${action.amount}' : ''}',
-                style: TextStyle(
-                  color: isSelected ? Colors.white : Colors.white70,
-                  fontSize: 12 * scale,
+            child: Opacity(
+              opacity: dim ? 0.3 : 1.0,
+              child: Container(
+                margin: EdgeInsets.symmetric(horizontal: 4 * scale),
+                padding: EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 6 * scale),
+                decoration: BoxDecoration(
+                  color: isSelected ? Colors.deepPurple : Colors.grey[800],
+                  borderRadius: BorderRadius.circular(8 * scale),
+                  border: Border.all(color: Colors.white24),
+                ),
+                child: Text(
+                  '$pos ${action.action}${action.amount != null ? ' ${action.amount}' : ''}',
+                  style: TextStyle(
+                    color: isSelected ? Colors.white : Colors.white70,
+                    fontSize: 12 * scale,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- add a Focus on Hero toggle in playback controls
- dim other players when focusing on Hero
- let timeline dim actions from other players

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d8ce9bc8832a90db76a3940602d4