### PR TITLE
Add win text overlay animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -70,6 +70,7 @@ import '../widgets/all_in_chips_animation.dart';
 import '../widgets/win_chips_animation.dart';
 import '../widgets/chip_reward_animation.dart';
 import '../widgets/win_amount_widget.dart';
+import '../widgets/win_text_widget.dart';
 import '../widgets/pot_chip_animation.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/fold_flying_cards.dart';
@@ -1432,6 +1433,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 context: context,
                 position: pos,
                 amount: amount,
+                scale: scale * tableScale,
+              );
+              final labelPos = Offset(
+                end.dx - 40 * tableScale,
+                end.dy - 90 * tableScale,
+              );
+              final playerName =
+                  playerIndex == _playerManager.heroIndex ? 'Hero' : name;
+              showWinTextOverlay(
+                context: context,
+                position: labelPos,
+                text: '$playerName wins the pot',
                 scale: scale * tableScale,
               );
               _onResetAnimationComplete();

--- a/lib/widgets/win_text_widget.dart
+++ b/lib/widgets/win_text_widget.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+/// Floating label indicating which player won the pot.
+class WinTextWidget extends StatefulWidget {
+  final Offset position;
+  final String text;
+  final double scale;
+  final VoidCallback? onCompleted;
+
+  const WinTextWidget({
+    Key? key,
+    required this.position,
+    required this.text,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<WinTextWidget> createState() => _WinTextWidgetState();
+}
+
+class _WinTextWidgetState extends State<WinTextWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0).chain(
+          CurveTween(curve: Curves.easeIn),
+        ),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0).chain(
+          CurveTween(curve: Curves.easeOut),
+        ),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: widget.position.dx,
+      top: widget.position.dy,
+      child: FadeTransition(
+        opacity: _opacity,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: 8 * widget.scale,
+            vertical: 4 * widget.scale,
+          ),
+          decoration: BoxDecoration(
+            color: Colors.black.withOpacity(0.8),
+            borderRadius: BorderRadius.circular(8 * widget.scale),
+          ),
+          child: Text(
+            widget.text,
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 14 * widget.scale,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Show a [WinTextWidget] above the current overlay.
+void showWinTextOverlay({
+  required BuildContext context,
+  required Offset position,
+  required String text,
+  double scale = 1.0,
+}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => WinTextWidget(
+      position: position,
+      text: text,
+      scale: scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- add WinTextWidget overlay to show a "wins the pot" label
- display chip win text when pot is distributed at showdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855da4f26b8832ab3a158a12a0a0534