### PR TITLE
Add street indicator overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -83,6 +83,7 @@ import '../widgets/fold_reveal_animation.dart';
 import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
 import '../widgets/playback_progress_bar.dart';
+import '../widgets/street_indicator.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -4184,6 +4185,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                         () => isPerspectiveSwitched = !isPerspectiveSwitched),
                   ),
                   _PlaybackNarrationOverlay(text: _playbackNarration),
+                  StreetIndicator(street: currentStreet),
                   _HudOverlaySection(
                     streetName:
                         ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],

--- a/lib/widgets/street_indicator.dart
+++ b/lib/widgets/street_indicator.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Badge displaying the name of the current street.
+class StreetIndicator extends StatelessWidget {
+  final int street;
+  const StreetIndicator({Key? key, required this.street}) : super(key: key);
+
+  static const _names = ['Preflop', 'Flop', 'Turn', 'River'];
+
+  @override
+  Widget build(BuildContext context) {
+    final name = _names[street.clamp(0, _names.length - 1)];
+    return Align(
+      alignment: Alignment.topCenter,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        child: Container(
+          key: ValueKey(name),
+          margin: const EdgeInsets.only(top: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Text(
+            name,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a badge with the current street at the top center of the table
- implement `StreetIndicator` widget for the badge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855db9704bc832a92f01cede086cbb6