### PR TITLE
Add street transition overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -84,6 +84,7 @@ import '../widgets/table_fade_overlay.dart';
 import '../widgets/deal_card_animation.dart';
 import '../widgets/playback_progress_bar.dart';
 import '../widgets/street_indicator.dart';
+import '../widgets/street_transition_overlay.dart';
 import '../services/stack_manager_service.dart';
 import '../services/player_manager_service.dart';
 import '../services/player_profile_service.dart';
@@ -2795,6 +2796,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (_boardManager.currentStreet != _prevStreet) {
       _clearBetDisplays();
       _revealBoard();
+      _playStreetTransition(_boardManager.currentStreet);
       _prevStreet = _boardManager.currentStreet;
     }
     if (_pendingPotAnimation &&
@@ -3047,6 +3049,20 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             'River revealed: ${_cardToDebugString(boardCards[4])}';
       }
     }
+  }
+
+  void _playStreetTransition(int street) {
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+    const names = ['Preflop', 'Flop', 'Turn', 'River'];
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (_) => StreetTransitionOverlay(
+        streetName: names[street.clamp(0, names.length - 1)],
+        onComplete: () => entry.remove(),
+      ),
+    );
+    overlay.insert(entry);
   }
 
   void _onStackServiceChanged() {

--- a/lib/widgets/street_transition_overlay.dart
+++ b/lib/widgets/street_transition_overlay.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+/// Overlay that fades street name in and out when the street changes.
+class StreetTransitionOverlay extends StatefulWidget {
+  final String streetName;
+  final VoidCallback onComplete;
+  const StreetTransitionOverlay({
+    Key? key,
+    required this.streetName,
+    required this.onComplete,
+  }) : super(key: key);
+
+  @override
+  State<StreetTransitionOverlay> createState() => _StreetTransitionOverlayState();
+}
+
+class _StreetTransitionOverlayState extends State<StreetTransitionOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 20,
+      ),
+      TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onComplete();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: FadeTransition(
+        opacity: _opacity,
+        child: Container(
+          color: Colors.black54,
+          alignment: Alignment.center,
+          child: Text(
+            widget.streetName,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 48,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a fade-in/out overlay naming the street when it changes
- display overlay in PokerAnalyzerScreen using new StreetTransitionOverlay widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855dc61fce0832aa07049eed2d3aec0