### PR TITLE
Add playback progress bar and elapsed time

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3827,6 +3827,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     return 'Раздача от $day.$month.$year';
   }
 
+
   Future<void> _exportEvaluationQueue() async {
     await _importExportService.exportEvaluationQueue(context);
   }
@@ -4544,6 +4545,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 isPlaying: _playbackManager.isPlaying,
                 playbackIndex: _playbackManager.playbackIndex,
                 actionCount: actions.length,
+                elapsedTime: _playbackManager.elapsedTime,
                 onPlay: _play,
                 onPause: _pause,
                 onPlayAll: _playAll,
@@ -6071,6 +6073,7 @@ class _PlaybackControlsSection extends StatelessWidget {
   final bool isPlaying;
   final int playbackIndex;
   final int actionCount;
+  final Duration elapsedTime;
   final VoidCallback onPlay;
   final VoidCallback onPause;
   final VoidCallback onPlayAll;
@@ -6089,6 +6092,7 @@ class _PlaybackControlsSection extends StatelessWidget {
     required this.isPlaying,
     required this.playbackIndex,
     required this.actionCount,
+    required this.elapsedTime,
     required this.onPlay,
     required this.onPause,
     required this.onPlayAll,
@@ -6144,12 +6148,32 @@ class _PlaybackControlsSection extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Column(
+            children: [
+              LinearProgressIndicator(
+                value: actionCount > 0 ? playbackIndex / actionCount : 0.0,
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                    Theme.of(context).colorScheme.secondary),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                "Step \$playbackIndex / \$actionCount" +
+                    (isPlaying ? " - " + _formatDuration(elapsedTime) : ""),
+                style: const TextStyle(color: Colors.white),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             ElevatedButton(
               onPressed: disabled ? null : (isPlaying ? onPause : onPlayAll),
-              child: Text(isPlaying ? 'Pause' : 'Play All'),
+              child: Text(isPlaying ? "Pause" : "Play All"),
             ),
           ],
         ),
@@ -6252,6 +6276,7 @@ class _PlaybackAndHandControls extends StatelessWidget {
   final bool isPlaying;
   final int playbackIndex;
   final int actionCount;
+  final Duration elapsedTime;
   final VoidCallback onPlay;
   final VoidCallback onPause;
   final VoidCallback onPlayAll;
@@ -6277,6 +6302,7 @@ class _PlaybackAndHandControls extends StatelessWidget {
     required this.isPlaying,
     required this.playbackIndex,
     required this.actionCount,
+    required this.elapsedTime,
     required this.onPlay,
     required this.onPause,
     required this.onPlayAll,
@@ -6318,6 +6344,7 @@ class _PlaybackAndHandControls extends StatelessWidget {
           isPlaying: isPlaying,
           playbackIndex: playbackIndex,
           actionCount: actionCount,
+          elapsedTime: elapsedTime,
           onPlay: onPlay,
           onPause: onPause,
           onPlayAll: onPlayAll,
@@ -8302,4 +8329,11 @@ class _CenterChipDiagnosticsSection extends StatelessWidget {
       ],
     );
   }
+
+ 
+String _formatDuration(Duration d) {
+  final minutes = d.inMinutes.remainder(60).toString().padLeft(2, "0");
+  final seconds = d.inSeconds.remainder(60).toString().padLeft(2, "0");
+  return "$minutes:$seconds";
+}
 

--- a/lib/services/playback_manager_service.dart
+++ b/lib/services/playback_manager_service.dart
@@ -36,6 +36,7 @@ class PlaybackManagerService extends ChangeNotifier {
 
   int get playbackIndex => _playbackService.playbackIndex;
   bool get isPlaying => _playbackService.isPlaying;
+  Duration get elapsedTime => _playbackService.elapsedTime;
 
   /// Returns `true` if the [playerIndex] should animate for [street].
   bool shouldAnimatePlayer(int street, int playerIndex) {

--- a/lib/services/playback_service.dart
+++ b/lib/services/playback_service.dart
@@ -6,11 +6,18 @@ class PlaybackService extends ChangeNotifier {
   bool _isPlaying = false;
   Timer? _playbackTimer;
   Duration stepDuration;
+  DateTime? _startTime;
+  Duration _elapsed = Duration.zero;
 
   PlaybackService({this.stepDuration = const Duration(seconds: 1)});
 
   int get playbackIndex => _playbackIndex;
   bool get isPlaying => _isPlaying;
+  Duration get elapsedTime =>
+      _elapsed +
+      ((_isPlaying && _startTime != null)
+          ? DateTime.now().difference(_startTime!)
+          : Duration.zero);
 
   void updatePlaybackState() {
     notifyListeners();
@@ -34,7 +41,9 @@ class PlaybackService extends ChangeNotifier {
     _isPlaying = true;
     if (_playbackIndex == actionCount) {
       _playbackIndex = 0;
+      _elapsed = Duration.zero;
     }
+    _startTime = DateTime.now();
     updatePlaybackState();
     final d = delay ?? stepDuration;
     _playbackTimer = Timer.periodic(d, (_) {
@@ -46,6 +55,10 @@ class PlaybackService extends ChangeNotifier {
 
   void pausePlayback() {
     _playbackTimer?.cancel();
+    if (_isPlaying && _startTime != null) {
+      _elapsed += DateTime.now().difference(_startTime!);
+    }
+    _startTime = null;
     _isPlaying = false;
     notifyListeners();
   }
@@ -72,6 +85,8 @@ class PlaybackService extends ChangeNotifier {
   void resetHand() {
     pausePlayback();
     _playbackIndex = 0;
+    _elapsed = Duration.zero;
+    _startTime = null;
     updatePlaybackState();
   }
 


### PR DESCRIPTION
## Summary
- add elapsed time tracking in PlaybackService
- expose elapsedTime via PlaybackManagerService
- add progress bar with timestamp in `_PlaybackControlsSection`
- show step count and elapsed time in playback controls

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ecb176f0832ab74ad3053082514b