### PR TITLE
Add winner glow overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -72,6 +72,7 @@ import '../widgets/win_chips_animation.dart';
 import '../widgets/chip_reward_animation.dart';
 import '../widgets/win_amount_widget.dart';
 import '../widgets/win_text_widget.dart';
+import '../widgets/winner_glow_widget.dart';
 import '../widgets/pot_chip_animation.dart';
 import '../widgets/pot_collection_chips.dart';
 import '../widgets/trash_flying_chips.dart';
@@ -1306,6 +1307,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     Future.delayed(Duration(milliseconds: totalDelay), () {
       if (!mounted) return;
       _playPotCollectionAnimation(winners);
+      _showWinnerGlow(winners);
       if (_boardReveal.revealedBoardCards.length < 5) {
         _pendingPotAnimation = true;
       }
@@ -1394,6 +1396,38 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       if (!mounted) return;
       _autoResetAfterShowdown();
     });
+  }
+
+  void _showWinnerGlow(Set<int> winners) {
+    final overlay = Overlay.of(context);
+    if (overlay == null || winners.isEmpty) return;
+
+    final double scale = TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    for (final playerIndex in winners) {
+      final i = (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
+      final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+      final dx = radiusX * cos(angle);
+      final dy = radiusY * sin(angle);
+      final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+      final pos = Offset(
+        centerX + dx - 20 * scale,
+        centerY + dy + bias - 110 * scale,
+      );
+      Future.microtask(() {
+        if (!mounted) return;
+        showWinnerGlowOverlay(context: context, position: pos, scale: scale);
+      });
+    }
   }
 
   void _cleanupWinnerCards() {

--- a/lib/widgets/winner_glow_widget.dart
+++ b/lib/widgets/winner_glow_widget.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+/// Small fade-in/out badge displayed above the winning player's avatar.
+class WinnerGlowWidget extends StatefulWidget {
+  final Offset position;
+  final double scale;
+  final VoidCallback? onCompleted;
+
+  const WinnerGlowWidget({
+    Key? key,
+    required this.position,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<WinnerGlowWidget> createState() => _WinnerGlowWidgetState();
+}
+
+class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0).chain(
+          CurveTween(curve: Curves.easeIn),
+        ),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0).chain(
+          CurveTween(curve: Curves.easeOut),
+        ),
+        weight: 50,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: widget.position.dx,
+      top: widget.position.dy,
+      child: FadeTransition(
+        opacity: _opacity,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: 6 * widget.scale,
+            vertical: 2 * widget.scale,
+          ),
+          decoration: BoxDecoration(
+            color: Colors.amberAccent,
+            borderRadius: BorderRadius.circular(8 * widget.scale),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.amberAccent.withOpacity(0.7),
+                blurRadius: 8 * widget.scale,
+                spreadRadius: 1 * widget.scale,
+              ),
+            ],
+          ),
+          child: Text(
+            'Winner',
+            style: TextStyle(
+              color: Colors.black,
+              fontWeight: FontWeight.bold,
+              fontSize: 14 * widget.scale,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Display a [WinnerGlowWidget] above the current overlay.
+void showWinnerGlowOverlay({
+  required BuildContext context,
+  required Offset position,
+  double scale = 1.0,
+}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => WinnerGlowWidget(
+      position: position,
+      scale: scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- add WinnerGlowWidget and overlay helper
- show winner glow overlay when winner reveal animation finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f1f9ab9c832aac704ac87f862e86