### PR TITLE
Add losing hand reveal

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1197,7 +1197,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     overlay.insert(overlayEntry);
   }
 
-  void _playShowCardsAnimation(int playerIndex, {List<CardModel>? cards}) {
+  void _playShowCardsAnimation(int playerIndex,
+      {List<CardModel>? cards, bool grayscale = false}) {
     final overlay = Overlay.of(context);
     if (overlay == null) return;
     final double scale =
@@ -1230,6 +1231,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           card: card,
           scale: scale,
           fade: true,
+          grayscale: grayscale,
           onCompleted: () => entry.remove(),
         ),
       );
@@ -1304,7 +1306,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       delay++;
     }
 
-    final totalDelay = 300 * winners.length + 400;
+    final revealEnd = 300 * winners.length + 400;
+
+    final losers = [for (final p in _showdownPlayers) if (!winners.contains(p)) p];
+    for (int i = 0; i < losers.length; i++) {
+      final player = losers[i];
+      Future.delayed(Duration(milliseconds: revealEnd + 300 * i), () {
+        if (!mounted) return;
+        _playShowCardsAnimation(player, grayscale: true);
+      });
+    }
+
+    final totalDelay = revealEnd + 300 * losers.length + 400;
     Future.delayed(Duration(milliseconds: totalDelay), () {
       if (!mounted) return;
       _playPotCollectionAnimation(winners);

--- a/lib/widgets/reveal_card_animation.dart
+++ b/lib/widgets/reveal_card_animation.dart
@@ -22,6 +22,9 @@ class RevealCardAnimation extends StatefulWidget {
   /// Whether to cross-fade between the back and front during the flip.
   final bool fade;
 
+  /// Whether to desaturate the front of the card when revealed.
+  final bool grayscale;
+
   const RevealCardAnimation({
     Key? key,
     required this.position,
@@ -30,6 +33,7 @@ class RevealCardAnimation extends StatefulWidget {
     this.duration = const Duration(milliseconds: 400),
     this.onCompleted,
     this.fade = false,
+    this.grayscale = false,
   }) : super(key: key);
 
   @override
@@ -81,7 +85,7 @@ class _RevealCardAnimationState extends State<RevealCardAnimation>
               height: height,
             );
 
-            final front = Container(
+            Widget front = Container(
               alignment: Alignment.center,
               decoration: BoxDecoration(
                 color: Colors.white,
@@ -96,6 +100,14 @@ class _RevealCardAnimationState extends State<RevealCardAnimation>
                 ),
               ),
             );
+
+            if (widget.grayscale) {
+              front = ColorFiltered(
+                colorFilter:
+                    const ColorFilter.mode(Colors.grey, BlendMode.saturation),
+                child: front,
+              );
+            }
 
             if (widget.fade) {
               final backOpacity = value <= 0.5 ? 1 - value * 2 : 0.0;


### PR DESCRIPTION
## Summary
- show losing players' cards before pot collection
- add grayscale option to RevealCardAnimation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68563cf7b280832a92be62c8f5ac099d