### PR TITLE
Align player positions with painted table

### DIFF
--- a/lib/helpers/table_geometry_helper.dart
+++ b/lib/helpers/table_geometry_helper.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 class TableGeometryHelper {
   static double tableScale(int numberOfPlayers) {
@@ -6,21 +7,32 @@ class TableGeometryHelper {
     return (1.0 - extraPlayers * 0.05).clamp(0.75, 1.0);
   }
 
+  /// Calculates the center offset for the table. The new painted table is
+  /// perfectly centered so no additional offset is required.
   static double centerYOffset(int numberOfPlayers, double scale) {
-    double base;
-    if (numberOfPlayers > 6) {
-      base = 200.0 + (numberOfPlayers - 6) * 10.0;
-    } else {
-      base = 140.0 - (6 - numberOfPlayers) * 10.0;
-    }
-    return base * scale;
+    return 0;
   }
 
+  /// Modifier for the distance of players from the center. With the new table
+  /// rendering we keep players on the ellipse edge so the modifier is 1.
   static double radiusModifier(int numberOfPlayers) {
-    return (1 + (6 - numberOfPlayers) * 0.05).clamp(0.8, 1.2);
+    return 1.0;
   }
 
+  /// Additional vertical bias for each player position. The old PNG based table
+  /// required a bias to visually align widgets. The painted table is symmetric
+  /// so no bias is needed.
   static double verticalBiasFromAngle(double angle) {
-    return 90 + 20 * sin(angle);
+    return 0;
+  }
+
+  /// Returns the position of the player relative to the table center using
+  /// simple elliptical geometry.
+  static Offset positionForPlayer(
+      int index, int numberOfPlayers, double tableWidth, double tableHeight) {
+    final angle = 2 * pi * index / numberOfPlayers + pi / 2;
+    final radiusX = tableWidth / 2;
+    final radiusY = tableHeight / 2;
+    return Offset(radiusX * cos(angle), radiusY * sin(angle));
   }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4905,15 +4905,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   List<Widget> _buildPlayerWidgets(int i, double scale) {
     final screenSize = MediaQuery.of(context).size;
     final double infoScale = numberOfPlayers > 8 ? 0.85 : 1.0;
-    final tableWidth = screenSize.width * 0.9;
+    final tableWidth = screenSize.width * 0.9 * scale;
     final tableHeight = tableWidth * 0.55;
-    final centerX = screenSize.width / 2 + 10;
-    final centerY = screenSize.height / 2 -
-        TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
-    final radiusMod =
-        TableGeometryHelper.radiusModifier(numberOfPlayers);
-    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
-    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+    final centerX = screenSize.width / 2;
+    final centerY = screenSize.height / 2;
 
     final visibleActions =
         actions.take(_playbackManager.playbackIndex).toList();
@@ -4928,9 +4923,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
     final index = (i + _viewIndex()) % numberOfPlayers;
     final angle = 2 * pi * i / numberOfPlayers + pi / 2;
-    final dx = radiusX * cos(angle);
-    final dy = radiusY * sin(angle);
-    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final offset = TableGeometryHelper.positionForPlayer(
+        i, numberOfPlayers, tableWidth, tableHeight);
+    final dx = offset.dx;
+    final dy = offset.dy;
+    final bias = 0.0;
 
     final String position = playerPositions[index] ?? '';
     final int stack = _displayedStacks[index] ??
@@ -5449,23 +5446,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   List<Widget> _buildChipTrail(int i, double scale) {
     final screenSize = MediaQuery.of(context).size;
-    final tableWidth = screenSize.width * 0.9;
+    final tableWidth = screenSize.width * 0.9 * scale;
     final tableHeight = tableWidth * 0.55;
-    final centerX = screenSize.width / 2 + 10;
-    final centerY = screenSize.height / 2 -
-        TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
-    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
-    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
-    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+    final centerX = screenSize.width / 2;
+    final centerY = screenSize.height / 2;
 
     final visibleActions =
         actions.take(_playbackManager.playbackIndex).toList();
 
     final index = (i + _viewIndex()) % numberOfPlayers;
     final angle = 2 * pi * i / numberOfPlayers + pi / 2;
-    final dx = radiusX * cos(angle);
-    final dy = radiusY * sin(angle);
-    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final offset = TableGeometryHelper.positionForPlayer(
+        i, numberOfPlayers, tableWidth, tableHeight);
+    final dx = offset.dx;
+    final dy = offset.dy;
+    final bias = 0.0;
 
     ActionEntry? lastAction;
     for (final a in visibleActions.reversed) {

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import '../helpers/table_geometry_helper.dart';
 import '../models/card_model.dart';
 import '../models/player_model.dart';
 import '../models/player_zone_action_entry.dart' as pz;
@@ -50,6 +51,15 @@ class PlayerZoneWidget extends StatefulWidget {
   final double scale;
   final Set<String> usedCards;
   // Stack editing is handled by PlayerInfoWidget
+
+  /// Returns the offset of a seat around an elliptical poker table. This is
+  /// based on the size of the table widget and indexes players so that index 0
+  /// (hero) sits at the bottom center.
+  static Offset seatPosition(
+      int index, int playerCount, Size tableSize) {
+    return TableGeometryHelper.positionForPlayer(
+        index, playerCount, tableSize.width, tableSize.height);
+  }
 
   const PlayerZoneWidget({
     Key? key,


### PR DESCRIPTION
## Summary
- add ellipse-based coordinate helper
- expose seatPosition for PlayerZoneWidget
- refactor player placement logic in the analyzer screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856412a568c832aa4a8cbaba909e439