### PR TITLE
Add burn card animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -78,6 +78,7 @@ import '../widgets/pot_chip_animation.dart';
 import '../widgets/pot_collection_chips.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/burn_chips_animation.dart';
+import '../widgets/burn_card_animation.dart';
 import '../widgets/fold_flying_cards.dart';
 import '../widgets/fold_refund_animation.dart';
 import '../widgets/undo_refund_animation.dart';
@@ -316,6 +317,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   /// Duration for individual board card animations.
   static const Duration _boardRevealDuration =
       BoardRevealService.revealDuration;
+  static const Duration _burnDuration = Duration(milliseconds: 300);
 
 
   Widget _queueSection(String label, List<ActionEvaluationRequest> queue) {
@@ -3411,6 +3413,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
   }
 
+  void _playBurnCardAnimation(OverlayState overlay, Offset center, double scale) {
+    late OverlayEntry entry;
+    final end = center + Offset(-40 * scale, -80 * scale);
+    entry = OverlayEntry(
+      builder: (_) => BurnCardAnimation(
+        start: center,
+        end: end,
+        scale: scale,
+        duration: _burnDuration,
+        onCompleted: () => entry.remove(),
+      ),
+    );
+    overlay.insert(entry);
+  }
+
   void _playFlopRevealAnimation() {
     final overlay = Overlay.of(context);
     if (overlay == null) return;
@@ -3424,7 +3441,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final center = Offset(centerX, centerY);
     final baseY = centerY - 52 * scale;
 
-    int delay = 0;
+    _playBurnCardAnimation(overlay, center, scale);
+
+    int delay = _burnDuration.inMilliseconds;
     for (int i = 0; i < 3; i++) {
       final card = boardCards[i];
       final x = centerX + (i - 1) * 44 * scale;
@@ -3459,6 +3478,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final center = Offset(centerX, centerY);
     final baseY = centerY - 52 * scale;
 
+    _playBurnCardAnimation(overlay, center, scale);
+
+    int delay = _burnDuration.inMilliseconds;
+
     final visible = BoardSyncService.stageCardCounts[2];
     final x = centerX + (3 - (visible - 1) / 2) * 44 * scale;
     late OverlayEntry e;
@@ -3471,7 +3494,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         onCompleted: () => e.remove(),
       ),
     );
-    overlay.insert(e);
+    Future.delayed(Duration(milliseconds: delay), () {
+      if (!mounted) return;
+      overlay.insert(e);
+    });
   }
 
   void _playRiverRevealAnimation() {
@@ -3487,6 +3513,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final center = Offset(centerX, centerY);
     final baseY = centerY - 52 * scale;
 
+    _playBurnCardAnimation(overlay, center, scale);
+
+    int delay = _burnDuration.inMilliseconds;
+
     final visible = BoardSyncService.stageCardCounts[3];
     final x = centerX + (4 - (visible - 1) / 2) * 44 * scale;
     late OverlayEntry e;
@@ -3499,7 +3529,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         onCompleted: () => e.remove(),
       ),
     );
-    overlay.insert(e);
+    Future.delayed(Duration(milliseconds: delay), () {
+      if (!mounted) return;
+      overlay.insert(e);
+    });
   }
 
   /// Plays the full dealing sequence for a newly reset hand.
@@ -3512,13 +3545,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       Future.delayed(Duration(milliseconds: delay), () {
         if (mounted) _playFlopRevealAnimation();
       });
-      delay += 400;
+      delay += _burnDuration.inMilliseconds + 360;
     }
     if (boardCards.length >= 4) {
       Future.delayed(Duration(milliseconds: delay), () {
         if (mounted) _playTurnRevealAnimation();
       });
-      delay += 400;
+      delay += _burnDuration.inMilliseconds + 200;
     }
     if (boardCards.length >= 5) {
       Future.delayed(Duration(milliseconds: delay), () {

--- a/lib/widgets/burn_card_animation.dart
+++ b/lib/widgets/burn_card_animation.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+/// Animation of a burn card flying to the discard pile and fading out.
+class BurnCardAnimation extends StatefulWidget {
+  /// Start position of the card (typically deck center).
+  final Offset start;
+
+  /// End position where the card fades out.
+  final Offset end;
+
+  /// Scale factor for card size.
+  final double scale;
+
+  /// Duration of the animation.
+  final Duration duration;
+
+  /// Callback when animation completes.
+  final VoidCallback? onCompleted;
+
+  const BurnCardAnimation({
+    Key? key,
+    required this.start,
+    required this.end,
+    this.scale = 1.0,
+    this.duration = const Duration(milliseconds: 300),
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<BurnCardAnimation> createState() => _BurnCardAnimationState();
+}
+
+class _BurnCardAnimationState extends State<BurnCardAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _progress;
+  late final Animation<double> _opacity;
+  late final Animation<double> _rotation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration)
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          widget.onCompleted?.call();
+        }
+      });
+    _progress = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+    _opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.6, 1.0)),
+    );
+    _rotation = Tween<double>(begin: 0.0, end: 0.5).animate(_progress);
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Offset _bezier(Offset p0, Offset p1, Offset p2, double t) {
+    final u = 1 - t;
+    return Offset(
+      u * u * p0.dx + 2 * u * t * p1.dx + t * t * p2.dx,
+      u * u * p0.dy + 2 * u * t * p1.dy + t * t * p2.dy,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = 36 * widget.scale;
+    final height = 52 * widget.scale;
+    final control = Offset.lerp(widget.start, widget.end, 0.3)! -
+        Offset(0, 40 * widget.scale);
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pos = _bezier(widget.start, control, widget.end, _progress.value);
+        return Positioned(
+          left: pos.dx - width / 2,
+          top: pos.dy - height / 2,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: Transform.rotate(angle: _rotation.value, child: child),
+          ),
+        );
+      },
+      child: Image.asset(
+        'assets/cards/card_back.png',
+        width: width,
+        height: height,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement BurnCardAnimation widget
- hook burning card before flop, turn, and river reveals
- include burn card delay in dealing sequence

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685646566e48832aa55013901cfa2fad