### PR TITLE
Fix test imports for converter validation

### DIFF
--- a/tests/converter_validation_test.dart
+++ b/tests/converter_validation_test.dart
@@ -1,9 +1,9 @@
 import 'package:test/test.dart';
-import 'package:poker_ai_analyzer/plugins/plugin_loader.dart';
-import 'package:poker_ai_analyzer/plugins/plugin_manager.dart';
+import '../plugins/plugin_loader.dart';
+import '../plugins/plugin_manager.dart';
 import 'package:poker_ai_analyzer/services/service_registry.dart';
-import 'package:poker_ai_analyzer/plugins/converter_registry.dart';
-import 'package:poker_ai_analyzer/plugins/converter_plugin.dart';
+import '../plugins/converter_registry.dart';
+import '../plugins/converter_plugin.dart';
 
 void main() {
   group('Converter validation', () {


### PR DESCRIPTION
## Summary
- use relative imports for plugin classes in `converter_validation_test.dart`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_685655f48e34832abe2ce789e64b824a