### PR TITLE
Add animated pot display

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -80,6 +80,7 @@ import '../widgets/trash_flying_chips.dart';
 import '../widgets/burn_chips_animation.dart';
 import '../widgets/burn_card_animation.dart';
 import '../widgets/fold_flying_cards.dart';
+import '../widgets/central_pot_widget.dart';
 import '../widgets/fold_refund_animation.dart';
 import '../widgets/undo_refund_animation.dart';
 import '../widgets/refund_amount_widget.dart';
@@ -4782,7 +4783,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       editingDisabled: lockService.isLocked,
                       potSync: _potSync,
                       boardReveal: widget.boardReveal,
-                      showPot: !_showdownActive,
+                      showPot: false,
                     ),
                   ),
                   _PlayerZonesSection(
@@ -6116,8 +6117,8 @@ class _PotAndBetsOverlaySection extends StatelessWidget {
                   scale: potGrowth,
                   child: AnimatedBuilder(
                     animation: potCount,
-                    builder: (_, __) => BetStackChips(
-                      amount: potCount.value,
+                    builder: (_, __) => CentralPotWidget(
+                      text: ActionFormattingHelper.formatAmount(potCount.value),
                       scale: scale,
                     ),
                   ),

--- a/lib/widgets/pot_over_board_widget.dart
+++ b/lib/widgets/pot_over_board_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/pot_sync_service.dart';
-import '../widgets/bet_stack_chips.dart';
+import '../helpers/action_formatting_helper.dart';
+import 'central_pot_widget.dart';
 
 /// Displays current pot size above the board cards.
 class PotOverBoardWidget extends StatelessWidget {
@@ -39,8 +40,8 @@ class PotOverBoardWidget extends StatelessWidget {
           alignment: const Alignment(0, -0.05),
           child: Transform.translate(
             offset: Offset(0, -15 * scale),
-            child: BetStackChips(
-              amount: potAmount,
+            child: CentralPotWidget(
+              text: ActionFormattingHelper.formatAmount(potAmount),
               scale: scale,
             ),
           ),


### PR DESCRIPTION
## Summary
- display pot text with `CentralPotWidget` instead of chip stacks
- remove old pot-over-board chips

## Testing
- `dart format lib/widgets/pot_over_board_widget.dart lib/screens/poker_analyzer_screen.dart`

------
https://chatgpt.com/codex/tasks/task_e_685693da512c832a9e17242a5d3bab8a