### PR TITLE
Add flying bet chips animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2172,7 +2172,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         );
         late OverlayEntry overlayEntry;
         overlayEntry = OverlayEntry(
-          builder: (_) => BetToCenterAnimation(
+          builder: (_) => BetFlyingChips(
             start: start,
             end: end,
             control: control,


### PR DESCRIPTION
## Summary
- show bet chips flying to the pot for bet/raise/call actions

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68569b6d6d84832abc808aec4b9bb876