### PR TITLE
Implement auto street advance

### DIFF
--- a/lib/services/action_editing_service.dart
+++ b/lib/services/action_editing_service.dart
@@ -218,8 +218,9 @@ class ActionEditingService {
   void _autoAdvanceStreetIfComplete(int street) {
     if (street != currentStreet || street >= 3) return;
     if (!_isStreetComplete(street)) return;
+    if (!boardManager.canAdvanceStreet()) return;
     undoRedo.recordSnapshot();
-    boardManager.changeStreet(street + 1);
+    boardManager.advanceStreet();
   }
 
   void _removeFutureActionsForPlayer(


### PR DESCRIPTION
## Summary
- auto advance to the next street once all active players have acted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68569d9c6520832aa2efbd07237cbfa9