### PR TITLE
Add stack animation after pot collection

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1794,7 +1794,24 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             shadows: const [Shadow(color: Colors.black54, blurRadius: 2)],
           ),
           fadeStart: fadeStart,
-          onCompleted: () => overlayEntry.remove(),
+          onCompleted: () {
+            overlayEntry.remove();
+            final startStack =
+                _displayedStacks[playerIndex] ??
+                    _stackService.getStackForPlayer(playerIndex);
+            final endStack = startStack + amount;
+            _animateStackIncrease(playerIndex, startStack, endStack);
+            final pos = Offset(
+              end.dx - 20 * tableScale,
+              end.dy - 60 * tableScale,
+            );
+            showWinAmountOverlay(
+              context: context,
+              position: pos,
+              amount: amount,
+              scale: scale * tableScale,
+            );
+          },
         ),
       );
       overlay.insert(overlayEntry);


### PR DESCRIPTION
## Summary
- animate stack increase when distributing chips to showdown winners

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68569fb09460832aac9debebc06ad614