### PR TITLE
Implement action reordering in overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -4828,6 +4828,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                       });
                     },
                     onEdit: _editAction,
+                    onDelete: _deleteAction,
+                    onReorder: _reorderAction,
                     isLocked: lockService.isLocked,
                   ),
                   _PerspectiveSwitchButton(
@@ -6432,6 +6434,8 @@ class _ActionHistorySection extends StatelessWidget {
   final Set<int> expandedStreets;
   final ValueChanged<int> onToggleStreet;
   final void Function(int index, ActionEntry entry) onEdit;
+  final void Function(int index) onDelete;
+  final void Function(int oldIndex, int newIndex) onReorder;
   final bool isLocked;
 
   const _ActionHistorySection({
@@ -6440,6 +6444,8 @@ class _ActionHistorySection extends StatelessWidget {
     required this.expandedStreets,
     required this.onToggleStreet,
     required this.onEdit,
+    required this.onDelete,
+    required this.onReorder,
     required this.isLocked,
   });
 
@@ -6451,6 +6457,8 @@ class _ActionHistorySection extends StatelessWidget {
       expandedStreets: expandedStreets,
       onToggleStreet: onToggleStreet,
       onEdit: onEdit,
+      onDelete: onDelete,
+      onReorder: onReorder,
       isLocked: isLocked,
     );
   }


### PR DESCRIPTION
## Summary
- extend `ActionHistoryOverlay` to allow deleting and reordering actions
- add drag targets and reorder buttons for each action chip
- pass delete/reorder callbacks from `_ActionHistorySection`

## Testing
- `dart` unavailable so formatting skipped


------
https://chatgpt.com/codex/tasks/task_e_6856a7e58644832a9e9a744e48c27fa0