### PR TITLE
Add refund animation for uncalled bets

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1136,6 +1136,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       payouts[winner] = pot - returnTotal;
     }
     await triggerWinnerAnimation(winner, pot - returnTotal);
+    await triggerRefundAnimations(returns);
+    await Future.delayed(const Duration(milliseconds: 500));
     if (!mounted) return;
     final stacks = <int, int>{};
     _stackService.currentStacks.forEach((i, stack) {

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -1698,3 +1698,28 @@ Future<void> triggerWinnerAnimation(int winnerIndex, int potAmount) async {
   lock?.unlock();
 }
 
+/// Animates refunds flying from the center pot back to each player in [refunds].
+/// Uses the same chip trail as [triggerWinnerAnimation] without highlights.
+Future<void> triggerRefundAnimations(Map<int, int> refunds) async {
+  for (final entry in refunds.entries) {
+    final playerIndex = entry.key;
+    final amount = entry.value;
+    if (amount <= 0) continue;
+    _PlayerZoneWidgetState? state;
+    for (final s in _playerZoneRegistry.values) {
+      if (s.widget.playerIndex == playerIndex) {
+        state = s;
+        break;
+      }
+    }
+    if (state == null) continue;
+    final context = state.context;
+    final lock = Provider.of<TransitionLockService?>(context, listen: false);
+    lock?.lock(const Duration(milliseconds: 800));
+    state.playWinChipsAnimation(amount);
+    await state.animateStackIncrease(amount);
+    lock?.unlock();
+    await Future.delayed(const Duration(milliseconds: 150));
+  }
+}
+


### PR DESCRIPTION
## Summary
- animate returning uncalled bets back to players
- wait briefly after showing refund animation before displaying results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856b3a8e8bc832a9b6125b1235ce02a