### PR TITLE
Add confetti overlay after demo completion

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -89,6 +89,7 @@ import '../widgets/clear_table_cards.dart';
 import '../widgets/fold_reveal_animation.dart';
 import '../widgets/table_cleanup_overlay.dart';
 import '../widgets/table_fade_overlay.dart';
+import '../widgets/confetti_overlay.dart';
 import '../widgets/poker_table_painter.dart';
 import '../widgets/deal_card_animation.dart';
 import '../widgets/playback_progress_bar.dart';
@@ -1092,6 +1093,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _tableCleanupPlayed = true;
     await _clearTableState();
     if (!mounted) return;
+    if (widget.demoMode) {
+      showConfettiOverlay(context);
+    }
     lockService.safeSetState(this, () {
       if (widget.demoMode) {
         _showReplayDemoButton = true;

--- a/lib/widgets/confetti_overlay.dart
+++ b/lib/widgets/confetti_overlay.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:confetti/confetti.dart';
+
+/// Simple confetti animation overlay that auto-removes after the given [duration].
+class ConfettiOverlay extends StatefulWidget {
+  final Duration duration;
+  final VoidCallback onCompleted;
+
+  const ConfettiOverlay({
+    Key? key,
+    this.duration = const Duration(seconds: 3),
+    required this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<ConfettiOverlay> createState() => _ConfettiOverlayState();
+}
+
+class _ConfettiOverlayState extends State<ConfettiOverlay>
+    with SingleTickerProviderStateMixin {
+  late final ConfettiController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ConfettiController(duration: widget.duration);
+    _controller.play();
+    Future.delayed(widget.duration, widget.onCompleted);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: SizedBox.expand(
+        child: ConfettiWidget(
+          confettiController: _controller,
+          blastDirectionality: BlastDirectionality.explosive,
+          shouldLoop: false,
+        ),
+      ),
+    );
+  }
+}
+
+/// Helper to display [ConfettiOverlay] above the current screen.
+void showConfettiOverlay(BuildContext context) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => ConfettiOverlay(onCompleted: () => entry.remove()),
+  );
+  overlay.insert(entry);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   synchronized: ^3.0.0
   csv: ^6.0.0
   file_saver: ^0.2.14
+  confetti: ^0.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a ConfettiOverlay widget that removes itself after 3 seconds
- depend on the `confetti` package
- show confetti when the demo ends via `_autoResetAfterShowdown`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c2c9b884832a93324c5a48c6e74d