### PR TITLE
Add demo mode entry point

### DIFF
--- a/.github/workflows/demo_build.yml
+++ b/.github/workflows/demo_build.yml
@@ -20,7 +20,7 @@ jobs:
         run: flutter pub get
 
       - name: Build demo APK
-        run: flutter build apk --target=lib/main_demo.dart
+        run: flutter build apk --target=main_demo.dart
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The project includes a lightweight demo entry point for showcasing the
 analyzer without the full feature set. Run the demo in debug mode with:
 
 ```bash
-flutter run -t lib/main_demo.dart
+flutter run -t main_demo.dart
 ```
 
 To generate a production APK for the demo use:
 
 ```bash
-flutter build apk --target=lib/main_demo.dart
+flutter build apk --target=main_demo.dart
 ```
 
 This build is useful for previews, demonstrations and other scenarios

--- a/build.yaml
+++ b/build.yaml
@@ -2,5 +2,5 @@ targets:
   demo:
     sources:
       include:
-        - lib/main_demo.dart
+        - main_demo.dart
         - lib/**

--- a/lib/services/demo_playback_controller.dart
+++ b/lib/services/demo_playback_controller.dart
@@ -28,9 +28,8 @@ class DemoPlaybackController {
   }) {
     final spot =
         TrainingSpot.fromJson(Map<String, dynamic>.from(_demoData));
-    Future.delayed(const Duration(seconds: 2), () {
-      loadSpot(spot);
-      Future.delayed(const Duration(seconds: 1), () {
+    loadSpot(spot);
+    Future.delayed(const Duration(seconds: 1), () {
         playAll();
         void listener() {
           if (playbackManager.playbackIndex == spot.actions.length) {
@@ -40,7 +39,6 @@ class DemoPlaybackController {
           }
         }
         playbackManager.addListener(listener);
-      });
     });
   }
 

--- a/main_demo.dart
+++ b/main_demo.dart
@@ -1,0 +1,5 @@
+import 'package:poker_ai_analyzer/main_demo.dart' as demo;
+
+void main() {
+  demo.main();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,8 +53,8 @@ flutter:
     - assets/cards/card_back.png
 
 # Release build configuration for the demo entry point. Run
-# `flutter build apk --target=lib/main_demo.dart` to compile the demo
+# `flutter build apk --target=main_demo.dart` to compile the demo
 # application with these settings.
 flutter_build:
   targets:
-    demo: lib/main_demo.dart
+    demo: main_demo.dart


### PR DESCRIPTION
## Summary
- add top-level `main_demo.dart` wrapper for demo entry
- preload training spot instantly in demo controller
- update build config and workflow to target new file
- document new entry point in README

## Testing
- `flutter format main_demo.dart lib/services/demo_playback_controller.dart README.md pubspec.yaml build.yaml .github/workflows/demo_build.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c3b3ab30832a80e86b27ba5e25e8