### PR TITLE
Add expanded street action summary

### DIFF
--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -60,10 +60,10 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
 
   String _buildSummary(List<ActionEntry> actions) {
     if (actions.isEmpty) return 'Нет действий';
-    final last = actions.last;
-    final pos = widget.playerPositions[last.playerIndex] ?? 'P${last.playerIndex + 1}';
-    final actionText = '${_capitalize(last.action)}${last.amount != null ? ' ${last.amount}' : ''}';
-    return '$pos $actionText';
+    return actions
+        .map((a) =>
+            '${_capitalize(a.action)}${a.amount != null ? ' ${a.amount}' : ''}')
+        .join(' – ');
   }
 
   @override


### PR DESCRIPTION
## Summary
- summarize all street actions instead of last one in CollapsibleStreetSection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856cf85e380832ab6745126c1a972e6