### PR TITLE
Add collapsible street action history

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -37,6 +37,7 @@ import '../widgets/chip_widget.dart';
 import '../widgets/player_info_widget.dart';
 import '../widgets/street_actions_list.dart';
 import '../widgets/collapsible_street_section.dart';
+import '../widgets/street_action_history_panel.dart';
 import '../widgets/hud_overlay.dart';
 import '../widgets/chip_trail.dart';
 import '../widgets/bet_chips_on_table.dart';
@@ -4998,26 +4999,18 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       padding: const EdgeInsets.symmetric(vertical: 4.0),
       child: AbsorbPointer(
         absorbing: lockService.isLocked,
-        child: Column(
-          children: [
-            ...List.generate(
-              4,
-              (i) => CollapsibleStreetSection(
-                street: i,
-                actions: savedActions,
-                pots: _potSync.pots,
-                stackSizes: _stackService.currentStacks,
-                playerPositions: playerPositions,
-                onEdit: _editAction,
-                onDelete: _deleteAction,
-                onInsert: _insertAction,
-                onDuplicate: _duplicateAction,
-                onReorder: _reorderAction,
-                visibleCount: _playbackManager.playbackIndex,
-                evaluateActionQuality: _evaluateActionQuality,
-              ),
-            ),
-          ],
+        child: StreetActionHistoryPanel(
+          actions: savedActions,
+          pots: _potSync.pots,
+          stackSizes: _stackService.currentStacks,
+          playerPositions: playerPositions,
+          onEdit: _editAction,
+          onDelete: _deleteAction,
+          onInsert: _insertAction,
+          onDuplicate: _duplicateAction,
+          onReorder: _reorderAction,
+          visibleCount: _playbackManager.playbackIndex,
+          evaluateActionQuality: _evaluateActionQuality,
         ),
       ),
     ),

--- a/lib/widgets/street_action_history_panel.dart
+++ b/lib/widgets/street_action_history_panel.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+import 'collapsible_street_section.dart';
+
+/// Panel showing action history with collapsible sections for each street.
+class StreetActionHistoryPanel extends StatelessWidget {
+  final List<ActionEntry> actions;
+  final List<int> pots;
+  final Map<int, int> stackSizes;
+  final Map<int, String> playerPositions;
+  final void Function(int, ActionEntry) onEdit;
+  final void Function(int) onDelete;
+  final void Function(int) onDuplicate;
+  final void Function(int, int)? onReorder;
+  final int? visibleCount;
+  final String Function(ActionEntry)? evaluateActionQuality;
+  final void Function(int index, ActionEntry entry)? onInsert;
+
+  const StreetActionHistoryPanel({
+    super.key,
+    required this.actions,
+    required this.pots,
+    required this.stackSizes,
+    required this.playerPositions,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onDuplicate,
+    this.onReorder,
+    this.onInsert,
+    this.visibleCount,
+    this.evaluateActionQuality,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: List.generate(
+        4,
+        (i) => CollapsibleStreetSection(
+          street: i,
+          actions: actions,
+          pots: pots,
+          stackSizes: stackSizes,
+          playerPositions: playerPositions,
+          onEdit: onEdit,
+          onDelete: onDelete,
+          onInsert: onInsert,
+          onDuplicate: onDuplicate,
+          onReorder: onReorder,
+          visibleCount: visibleCount,
+          evaluateActionQuality: evaluateActionQuality,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `StreetActionHistoryPanel` widget
- show collapsible street actions under the board in `PokerAnalyzerScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d4e47814832aa35641b2fb54e124