### PR TITLE
Add bet chip flight animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -77,6 +77,7 @@ import '../widgets/win_text_widget.dart';
 import '../widgets/winner_glow_widget.dart';
 import '../widgets/loss_fade_widget.dart';
 import '../widgets/pot_chip_animation.dart';
+import '../widgets/bet_chip_animation.dart';
 import '../widgets/trash_flying_chips.dart';
 import '../widgets/burn_chips_animation.dart';
 import '../widgets/burn_card_animation.dart';
@@ -848,25 +849,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final start = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
     final potOffsetY = -12 * scale + 36 * scale * potIndex;
     final end = Offset(centerX, centerY + potOffsetY);
-    final midX = (start.dx + end.dx) / 2;
-    final midY = (start.dy + end.dy) / 2;
-    final perp = Offset(-sin(angle), cos(angle));
-    final control = Offset(
-      midX + perp.dx * 20 * scale,
-      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
-    );
     late OverlayEntry overlayEntry;
     overlayEntry = OverlayEntry(
-      builder: (_) => PotChipAnimation(
-        start: start,
-        end: end,
-        control: control,
-        amount: entry.amount!,
-        scale: scale,
-        onCompleted: () {
-          overlayEntry.remove();
-          _animatePotGrowth();
-        },
+      builder: (_) => Stack(
+        children: [
+          BetChipAnimation(
+            start: start,
+            end: end,
+            amount: entry.amount!,
+            scale: scale,
+            onCompleted: () {
+              overlayEntry.remove();
+              _animatePotGrowth();
+            },
+          ),
+        ],
       ),
     );
     overlay.insert(overlayEntry);

--- a/lib/widgets/bet_chip_animation.dart
+++ b/lib/widgets/bet_chip_animation.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'chip_stack_widget.dart';
+
+/// Animation of a small chip stack flying from a player to the pot.
+class BetChipAnimation extends StatelessWidget {
+  /// Starting position in global coordinates.
+  final Offset start;
+
+  /// Ending position at the pot center.
+  final Offset end;
+
+  /// Amount of chips represented by the stack.
+  final int amount;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  /// Duration of the flight.
+  final Duration duration;
+
+  /// Called when the animation completes.
+  final VoidCallback? onCompleted;
+
+  const BetChipAnimation({
+    Key? key,
+    required this.start,
+    required this.end,
+    required this.amount,
+    this.scale = 1.0,
+    this.duration = const Duration(milliseconds: 500),
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0.0, end: 1.0),
+      duration: duration,
+      onEnd: onCompleted,
+      builder: (context, value, child) {
+        final pos = Offset.lerp(start, end, value)!;
+        return Positioned(
+          left: pos.dx - 12 * scale,
+          top: pos.dy - 12 * scale,
+          child: child!,
+        );
+      },
+      child: ChipStackWidget(
+        amount: amount,
+        scale: 0.8 * scale,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- animate chips from player to pot when betting using `BetChipAnimation`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d5e4e1b0832a8d83514ca4e37145