### PR TITLE
Add overlay-based showdown result animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1585,9 +1585,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
     if (payouts.isEmpty) return;
 
-    _startPotWinFlights(payouts);
+    final overlay = Overlay.of(context);
+    if (overlay != null) {
+      _showPotWinAnimations(
+        overlay,
+        payouts,
+        0,
+        Colors.orangeAccent,
+        highlight: true,
+        fadeStart: 0.5,
+      );
+    }
 
-    final cleanupDelay = 900 + 150 * (payouts.length - 1);
+    _potAnimationPlayed = true;
+
+    final cleanupDelay = 300 * payouts.length + 500;
     Future.delayed(Duration(milliseconds: cleanupDelay), () {
       if (!mounted) return;
       _autoResetAfterShowdown();


### PR DESCRIPTION
## Summary
- implement chip payout overlay via `_showPotWinAnimations`
- trigger pot collection animation with glow and floating win labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d71a22bc832aa33e00cd68287b2a