### PR TITLE
Improve win animations

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1632,7 +1632,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
     final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
 
-    for (final playerIndex in winners) {
+    final orderedWinners = winners.toList();
+    for (int n = 0; n < orderedWinners.length; n++) {
+      final playerIndex = orderedWinners[n];
       final i = (playerIndex - _viewIndex() + numberOfPlayers) % numberOfPlayers;
       final angle = 2 * pi * i / numberOfPlayers + pi / 2;
       final dx = radiusX * cos(angle);
@@ -1642,7 +1644,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         centerX + dx - 20 * scale,
         centerY + dy + bias - 110 * scale,
       );
-      Future.microtask(() {
+      Future.delayed(Duration(milliseconds: 300 * n), () {
         if (!mounted) return;
         late OverlayEntry entry;
         entry = OverlayEntry(

--- a/lib/widgets/win_text_widget.dart
+++ b/lib/widgets/win_text_widget.dart
@@ -23,6 +23,7 @@ class _WinTextWidgetState extends State<WinTextWidget>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
+  late final Animation<double> _scale;
 
   @override
   void initState() {
@@ -34,18 +35,21 @@ class _WinTextWidgetState extends State<WinTextWidget>
     _opacity = TweenSequence<double>([
       TweenSequenceItem(
         tween: Tween(begin: 0.0, end: 1.0).chain(
-          CurveTween(curve: Curves.easeIn),
+          CurveTween(curve: Curves.easeInOut),
         ),
         weight: 20,
       ),
       const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
       TweenSequenceItem(
         tween: Tween(begin: 1.0, end: 0.0).chain(
-          CurveTween(curve: Curves.easeOut),
+          CurveTween(curve: Curves.easeInOut),
         ),
         weight: 20,
       ),
     ]).animate(_controller);
+    _scale = Tween<double>(begin: 0.9, end: 1.0)
+        .chain(CurveTween(curve: Curves.easeInOut))
+        .animate(_controller);
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         widget.onCompleted?.call();
@@ -67,11 +71,13 @@ class _WinTextWidgetState extends State<WinTextWidget>
       top: widget.position.dy,
       child: FadeTransition(
         opacity: _opacity,
-        child: Container(
-          padding: EdgeInsets.symmetric(
-            horizontal: 8 * widget.scale,
-            vertical: 4 * widget.scale,
-          ),
+        child: ScaleTransition(
+          scale: _scale,
+          child: Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: 8 * widget.scale,
+              vertical: 4 * widget.scale,
+            ),
           decoration: BoxDecoration(
             color: Colors.black.withOpacity(0.8),
             borderRadius: BorderRadius.circular(8 * widget.scale),
@@ -84,6 +90,7 @@ class _WinTextWidgetState extends State<WinTextWidget>
               fontSize: 14 * widget.scale,
             ),
           ),
+        ),
         ),
       ),
     );

--- a/lib/widgets/winner_glow_widget.dart
+++ b/lib/widgets/winner_glow_widget.dart
@@ -21,6 +21,7 @@ class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
+  late final Animation<double> _scale;
 
   @override
   void initState() {
@@ -32,17 +33,20 @@ class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
     _opacity = TweenSequence<double>([
       TweenSequenceItem(
         tween: Tween(begin: 0.0, end: 1.0).chain(
-          CurveTween(curve: Curves.easeIn),
+          CurveTween(curve: Curves.easeInOut),
         ),
         weight: 50,
       ),
       TweenSequenceItem(
         tween: Tween(begin: 1.0, end: 0.0).chain(
-          CurveTween(curve: Curves.easeOut),
+          CurveTween(curve: Curves.easeInOut),
         ),
         weight: 50,
       ),
     ]).animate(_controller);
+    _scale = Tween<double>(begin: 0.9, end: 1.0)
+        .chain(CurveTween(curve: Curves.easeInOut))
+        .animate(_controller);
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         widget.onCompleted?.call();
@@ -64,11 +68,13 @@ class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
       top: widget.position.dy,
       child: FadeTransition(
         opacity: _opacity,
-        child: Container(
-          padding: EdgeInsets.symmetric(
-            horizontal: 6 * widget.scale,
-            vertical: 2 * widget.scale,
-          ),
+        child: ScaleTransition(
+          scale: _scale,
+          child: Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: 6 * widget.scale,
+              vertical: 2 * widget.scale,
+            ),
           decoration: BoxDecoration(
             color: Colors.amberAccent,
             borderRadius: BorderRadius.circular(8 * widget.scale),
@@ -88,6 +94,7 @@ class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
               fontSize: 14 * widget.scale,
             ),
           ),
+        ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add scale transitions and easeInOut curves to winner glow overlay
- add scale transitions and easeInOut curves to win text overlay
- stagger multiple winner glow overlays by 300ms

## Testing
- `dart format`: command not found


------
https://chatgpt.com/codex/tasks/task_e_6856de7d6338832a9481fc30d9b8ed58