### PR TITLE
Add Demo Mode toggle

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -13,9 +13,35 @@ import 'edit_pack_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/hand_history_file_service.dart';
 import '../services/saved_hand_manager_service.dart';
+import '../user_preferences.dart';
+import '../main_demo.dart';
 
-class MainMenuScreen extends StatelessWidget {
+class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
+
+  @override
+  State<MainMenuScreen> createState() => _MainMenuScreenState();
+}
+
+class _MainMenuScreenState extends State<MainMenuScreen> {
+  bool _demoMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _demoMode = UserPreferences.instance.demoMode;
+  }
+
+  Future<void> _toggleDemoMode(bool value) async {
+    setState(() => _demoMode = value);
+    await UserPreferences.instance.setDemoMode(value);
+    if (value) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const PokerAnalyzerDemoApp()),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -133,6 +159,13 @@ class MainMenuScreen extends StatelessWidget {
                 );
               },
               child: const Text('⚙️ Settings'),
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              value: _demoMode,
+              title: const Text('Demo Mode'),
+              onChanged: _toggleDemoMode,
+              activeColor: Colors.orange,
             ),
             const SizedBox(height: 32),
             const Text(

--- a/lib/services/user_preferences_service.dart
+++ b/lib/services/user_preferences_service.dart
@@ -7,18 +7,21 @@ class UserPreferencesService extends ChangeNotifier {
   static const _winnerCelebrationKey = 'show_winner_celebration';
   static const _actionHintsKey = 'show_action_hints';
   static const _coachModeKey = 'coach_mode';
+  static const _demoModeKey = 'demo_mode';
 
   bool _showPotAnimation = true;
   bool _showCardReveal = true;
   bool _showWinnerCelebration = true;
   bool _showActionHints = true;
   bool _coachMode = false;
+  bool _demoMode = false;
 
   bool get showPotAnimation => _showPotAnimation;
   bool get showCardReveal => _showCardReveal;
   bool get showWinnerCelebration => _showWinnerCelebration;
   bool get showActionHints => _showActionHints;
   bool get coachMode => _coachMode;
+  bool get demoMode => _demoMode;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -27,6 +30,7 @@ class UserPreferencesService extends ChangeNotifier {
     _showWinnerCelebration = prefs.getBool(_winnerCelebrationKey) ?? true;
     _showActionHints = prefs.getBool(_actionHintsKey) ?? true;
     _coachMode = prefs.getBool(_coachModeKey) ?? false;
+    _demoMode = prefs.getBool(_demoModeKey) ?? false;
     notifyListeners();
   }
 
@@ -67,6 +71,13 @@ class UserPreferencesService extends ChangeNotifier {
     if (_coachMode == value) return;
     _coachMode = value;
     await _save(_coachModeKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setDemoMode(bool value) async {
+    if (_demoMode == value) return;
+    _demoMode = value;
+    await _save(_demoModeKey, value);
     notifyListeners();
   }
 }

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -16,10 +16,12 @@ class UserPreferences {
   bool get showWinnerCelebration => service.showWinnerCelebration;
   bool get showActionHints => service.showActionHints;
   bool get coachMode => service.coachMode;
+  bool get demoMode => service.demoMode;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
   Future<void> setShowCardReveal(bool value) => service.setShowCardReveal(value);
   Future<void> setShowWinnerCelebration(bool value) => service.setShowWinnerCelebration(value);
   Future<void> setShowActionHints(bool value) => service.setShowActionHints(value);
   Future<void> setCoachMode(bool value) => service.setCoachMode(value);
+  Future<void> setDemoMode(bool value) => service.setDemoMode(value);
 }


### PR DESCRIPTION
## Summary
- persist a new `demoMode` flag in `UserPreferences`
- expose demo mode setting through the preferences service
- convert main menu to `StatefulWidget`
- add Demo Mode switch that opens the analyzer demo

## Testing
- `dart format lib/services/user_preferences_service.dart lib/user_preferences.dart lib/screens/main_menu_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856df4be10c832aa2d129aa5716a32e