### PR TITLE
Add demo reset button

### DIFF
--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -191,5 +191,36 @@ class _DemoLauncherState extends State<DemoLauncher> {
   }
 
   @override
-  Widget build(BuildContext context) => widget.child;
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        widget.child,
+        Positioned(
+          top: MediaQuery.of(context).padding.top + 8,
+          right: 8,
+          child: IconButton(
+            icon: const Icon(Icons.refresh),
+            color: Colors.white70,
+            tooltip: 'Reset Demo',
+            onPressed: _resetDemo,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _resetDemo() {
+    final state = analyzerKey.currentState;
+    if (state == null) return;
+    final dynamic dyn = state;
+    Future<void> future = Future.value();
+    try {
+      future = dyn._autoResetAfterShowdown();
+    } catch (_) {}
+    future.whenComplete(() {
+      try {
+        dyn.resetAll();
+      } catch (_) {}
+    });
+  }
 }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1115,6 +1115,13 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     lockService.unlock();
   }
 
+  /// Clears the table and resets the hand to its initial empty state.
+  Future<void> resetAll() async {
+    await _clearTableState();
+    if (!mounted) return;
+    _resetHandState();
+  }
+
   void _resetHandState() {
     lockService.safeSetState(this, () {
       _clearShowdown();


### PR DESCRIPTION
## Summary
- add Reset Demo button overlay in demo launcher
- expose `resetAll` method on PokerAnalyzerScreen to fully clear the table

## Testing
- `dart` not installed so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_6856e035a86c832a863d4898b82d1697