### PR TITLE
Add winning player zone highlight overlay

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1709,6 +1709,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _showWinnerGlow(winners);
     for (final p in winners) {
       showWinnerHighlight(context, players[p].name);
+      if (widget.demoMode) {
+        showWinnerZoneOverlay(context, players[p].name);
+      }
     }
     _showdownWinPlayed = true;
   }

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -18,6 +18,7 @@ import 'player_stack_value.dart';
 import 'stack_bar_widget.dart';
 import 'chip_moving_widget.dart';
 import 'move_pot_animation.dart';
+import 'winner_zone_highlight.dart';
 
 final Map<String, _PlayerZoneWidgetState> _playerZoneRegistry = {};
 
@@ -1624,6 +1625,21 @@ class _CardRevealBackdropState extends State<_CardRevealBackdrop>
 void showWinnerHighlight(BuildContext context, String playerName) {
   final state = _playerZoneRegistry[playerName];
   state?.highlightWinner();
+}
+
+/// Displays an animated glow overlay around the winning player's zone.
+void showWinnerZoneOverlay(BuildContext context, String playerName) {
+  final state = _playerZoneRegistry[playerName];
+  final overlay = Overlay.of(context);
+  if (overlay == null || state == null) return;
+  final box = state.context.findRenderObject() as RenderBox?;
+  if (box == null) return;
+  final rect = box.localToGlobal(Offset.zero) & box.size;
+  showWinnerZoneHighlightOverlay(
+    context: context,
+    rect: rect,
+    scale: state.widget.scale,
+  );
 }
 
 /// Updates and reveals cards for the [PlayerZoneWidget] with the given

--- a/lib/widgets/winner_zone_highlight.dart
+++ b/lib/widgets/winner_zone_highlight.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+/// Animated border highlight shown around the winning player's zone.
+class WinnerZoneHighlight extends StatefulWidget {
+  final Rect rect;
+  final double scale;
+  final VoidCallback? onCompleted;
+
+  const WinnerZoneHighlight({
+    Key? key,
+    required this.rect,
+    this.scale = 1.0,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<WinnerZoneHighlight> createState() => _WinnerZoneHighlightState();
+}
+
+class _WinnerZoneHighlightState extends State<WinnerZoneHighlight>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeInOut)),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeInOut)),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+    _scale = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.95, end: 1.05)
+            .chain(CurveTween(curve: Curves.easeInOut)),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.05, end: 0.95)
+            .chain(CurveTween(curve: Curves.easeInOut)),
+        weight: 50,
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: widget.rect.left,
+      top: widget.rect.top,
+      width: widget.rect.width,
+      height: widget.rect.height,
+      child: FadeTransition(
+        opacity: _opacity,
+        child: ScaleTransition(
+          scale: _scale,
+          child: IgnorePointer(
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12 * widget.scale),
+                border: Border.all(
+                  color: Colors.amberAccent,
+                  width: 2 * widget.scale,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.amberAccent.withOpacity(0.8),
+                    blurRadius: 20 * widget.scale,
+                    spreadRadius: 4 * widget.scale,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Inserts a [WinnerZoneHighlight] using an [OverlayEntry].
+void showWinnerZoneHighlightOverlay({
+  required BuildContext context,
+  required Rect rect,
+  double scale = 1.0,
+}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => WinnerZoneHighlight(
+      rect: rect,
+      scale: scale,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- implement `WinnerZoneHighlight` overlay widget
- expose `showWinnerZoneOverlay` helper in `player_zone_widget`
- trigger highlight overlay in demo showdown sequence

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f943b8d4832aaaf857e533fa4786