### PR TITLE
Refactor demo animations into manager

### DIFF
--- a/lib/services/demo_animation_manager.dart
+++ b/lib/services/demo_animation_manager.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../helpers/table_geometry_helper.dart';
+import '../widgets/pot_collection_chips.dart';
+import '../widgets/winner_glow_widget.dart';
+import '../widgets/chip_stack_moving_widget.dart';
+
+/// Manages demo mode animations such as narration text and
+/// winner/pot overlays.
+class DemoAnimationManager {
+  /// Current narration text for the playback overlay.
+  final ValueNotifier<String?> narration = ValueNotifier<String?>(null);
+
+  Timer? _narrationTimer;
+  final List<OverlayEntry> _overlayEntries = [];
+
+  /// Show a short narration message at the top of the screen.
+  void showNarration(String text) {
+    _narrationTimer?.cancel();
+    narration.value = text;
+    _narrationTimer = Timer(const Duration(seconds: 2), () {
+      narration.value = null;
+    });
+  }
+
+  /// Display a glow effect for each winner around their player zone.
+  void showWinnerGlow({
+    required BuildContext context,
+    required Set<int> winners,
+    required int numberOfPlayers,
+    required int Function() viewIndex,
+  }) {
+    final overlay = Overlay.of(context);
+    if (overlay == null || winners.isEmpty) return;
+
+    final double scale = TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    final ordered = winners.toList();
+    for (int n = 0; n < ordered.length; n++) {
+      final playerIndex = ordered[n];
+      final i = (playerIndex - viewIndex() + numberOfPlayers) % numberOfPlayers;
+      final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+      final dx = radiusX * cos(angle);
+      final dy = radiusY * sin(angle);
+      final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+      final pos = Offset(
+        centerX + dx - 20 * scale,
+        centerY + dy + bias - 110 * scale,
+      );
+      Future.delayed(Duration(milliseconds: 300 * n), () {
+        late OverlayEntry entry;
+        entry = OverlayEntry(
+          builder: (_) => WinnerGlowWidget(
+            position: pos,
+            scale: scale,
+            onCompleted: () {
+              entry.remove();
+              _overlayEntries.remove(entry);
+            },
+          ),
+        );
+        overlay.insert(entry);
+        _overlayEntries.add(entry);
+        Future.delayed(const Duration(milliseconds: 1800), () {
+          entry.remove();
+          _overlayEntries.remove(entry);
+        });
+      });
+    }
+  }
+
+  /// Animate chips from the central pot to the winning player's stack.
+  void playPotCollection({
+    required BuildContext context,
+    required int playerIndex,
+    required int amount,
+    required int numberOfPlayers,
+    required int Function() viewIndex,
+  }) {
+    if (amount <= 0) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+
+    final double scale = TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    final i = (playerIndex - viewIndex() + numberOfPlayers) % numberOfPlayers;
+    final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+    final dx = radiusX * cos(angle);
+    final dy = radiusY * sin(angle);
+    final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+    final start = Offset(centerX, centerY);
+    final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+    final midX = (start.dx + end.dx) / 2;
+    final midY = (start.dy + end.dy) / 2;
+    final perp = Offset(-sin(angle), cos(angle));
+    final control = Offset(
+      midX + perp.dx * 20 * scale,
+      midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
+    );
+
+    showPotCollectionChips(
+      context: context,
+      start: start,
+      end: end,
+      amount: amount,
+      scale: scale,
+      control: control,
+      fadeStart: 0.6,
+    );
+  }
+
+  /// Remove any active overlays and timers.
+  void dispose() {
+    _narrationTimer?.cancel();
+    for (final e in _overlayEntries) {
+      e.remove();
+    }
+    _overlayEntries.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- add `DemoAnimationManager` to encapsulate narration, winner glow and pot collection
- inject the manager in `PokerAnalyzerScreen`
- use new manager for demo mode narration and pot animations
- update narration overlay to listen to manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856fc40fb54832a9c17b5506c647a2b