### PR TITLE
Refactor demo animation hooks

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -157,6 +157,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
   final PotSyncService potSyncService;
   final ActionHistoryService actionHistory;
   final TransitionLockService lockService;
+  final DemoAnimationManager? demoAnimationManager;
   final bool demoMode;
 
   const PokerAnalyzerScreen({
@@ -188,6 +189,7 @@ class PokerAnalyzerScreen extends StatefulWidget {
     required this.potSyncService,
     required this.actionHistory,
     required this.lockService,
+    this.demoAnimationManager,
     this.demoMode = false,
   });
 
@@ -1673,7 +1675,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     for (final p in winners) {
       showWinnerHighlight(context, players[p].name);
       if (widget.demoMode) {
-        showWinnerZoneOverlay(context, players[p].name);
+        _demoAnimations.showWinnerZoneOverlay(context, players[p].name);
         final amount = payouts[p] ?? _potSync.pots[currentStreet];
         Future.delayed(const Duration(milliseconds: 600), () {
           if (!mounted) return;
@@ -2909,7 +2911,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _processingService = _serviceRegistry.get<EvaluationProcessingService>();
     _serviceRegistry.register<TransitionLockService>(widget.lockService);
     lockService = _serviceRegistry.get<TransitionLockService>();
-    _demoAnimations = DemoAnimationManager();
+    _demoAnimations = widget.demoAnimationManager ?? DemoAnimationManager();
     _centerChipController = AnimationController(
       vsync: this,
       duration: _boardRevealDuration,

--- a/lib/services/demo_animation_manager.dart
+++ b/lib/services/demo_animation_manager.dart
@@ -4,7 +4,8 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import '../helpers/table_geometry_helper.dart';
-import '../widgets/pot_collection_chips.dart';
+import '../widgets/pot_collection_chips.dart' as chips;
+import '../widgets/player_zone_widget.dart' as pzw;
 import '../widgets/winner_glow_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
 
@@ -24,6 +25,35 @@ class DemoAnimationManager {
     _narrationTimer = Timer(const Duration(seconds: 2), () {
       narration.value = null;
     });
+  }
+
+  /// Wrapper around [showNarration] used during demo playback.
+  void playNarration(String text) => showNarration(text);
+
+  /// Display an overlay glow around the given winner's zone.
+  void showWinnerZoneOverlay(BuildContext context, String playerName) {
+    pzw.showWinnerZoneOverlay(context, playerName);
+  }
+
+  /// Show chips flying from the pot to the winner's stack.
+  void showPotCollectionChips({
+    required BuildContext context,
+    required Offset start,
+    required Offset end,
+    required int amount,
+    double scale = 1.0,
+    Offset? control,
+    double fadeStart = 0.7,
+  }) {
+    chips.showPotCollectionChips(
+      context: context,
+      start: start,
+      end: end,
+      amount: amount,
+      scale: scale,
+      control: control,
+      fadeStart: fadeStart,
+    );
   }
 
   /// Display a glow effect for each winner around their player zone.
@@ -119,7 +149,7 @@ class DemoAnimationManager {
       midY - (40 + ChipStackMovingWidget.activeCount * 8) * scale,
     );
 
-    showPotCollectionChips(
+    chips.showPotCollectionChips(
       context: context,
       start: start,
       end: end,


### PR DESCRIPTION
## Summary
- centralize demo animations in `DemoAnimationManager`
- allow injecting `DemoAnimationManager` via `PokerAnalyzerScreen`
- route winner zone overlay through manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857023e817c832a93a262640ca74872