### PR TITLE
Add editable stack and bet fields

### DIFF
--- a/lib/models/player_model.dart
+++ b/lib/models/player_model.dart
@@ -29,10 +29,14 @@ class PlayerModel {
   final List<CardModel?> revealedCards;
   final Map<String, List<PlayerActionModel>> actions;
   PlayerType type;
+  int stack;
+  int bet;
 
   PlayerModel({
     required this.name,
     this.type = PlayerType.unknown,
+    this.stack = 0,
+    this.bet = 0,
     List<CardModel?>? revealedCards,
   })  : cards = [],
         revealedCards =
@@ -48,10 +52,14 @@ class PlayerModel {
     String? name,
     PlayerType? type,
     List<CardModel?>? revealedCards,
+    int? stack,
+    int? bet,
   }) {
     return PlayerModel(
       name: name ?? this.name,
       type: type ?? this.type,
+      stack: stack ?? this.stack,
+      bet: bet ?? this.bet,
       revealedCards: revealedCards ??
           List<CardModel?>.from(this.revealedCards),
     )
@@ -77,6 +85,8 @@ class PlayerModel {
                 }
             ])),
         'type': type.name,
+        'stack': stack,
+        'bet': bet,
       };
 
   factory PlayerModel.fromJson(Map<String, dynamic> json) {
@@ -86,6 +96,8 @@ class PlayerModel {
         (e) => e.name == json['type'],
         orElse: () => PlayerType.unknown,
       ),
+      stack: json['stack'] as int? ?? 0,
+      bet: json['bet'] as int? ?? 0,
       revealedCards: [
         for (final item in (json['revealedCards'] as List? ?? [null, null]))
           item == null

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -28,6 +28,7 @@ class SavedHand {
   /// Game type description such as "Hold'em No Limit".
   final String? gameType;
   final Map<int, int> stackSizes;
+  final Map<int, int>? currentBets;
   final Map<int, int>? remainingStacks;
   /// Winnings collected by each player in chips or big blinds.
   final Map<int, int>? winnings;
@@ -80,6 +81,7 @@ class SavedHand {
     this.activePlayerIndex,
     required this.actions,
     required this.stackSizes,
+    this.currentBets,
     this.remainingStacks,
     this.winnings,
     this.totalPot,
@@ -131,6 +133,7 @@ class SavedHand {
     int? activePlayerIndex,
     List<ActionEntry>? actions,
     Map<int, int>? stackSizes,
+    Map<int, int>? currentBets,
     Map<int, int>? remainingStacks,
     Map<int, int>? winnings,
     int? totalPot,
@@ -179,6 +182,8 @@ class SavedHand {
       activePlayerIndex: activePlayerIndex ?? this.activePlayerIndex,
       actions: actions ?? List<ActionEntry>.from(this.actions),
       stackSizes: stackSizes ?? Map<int, int>.from(this.stackSizes),
+      currentBets: currentBets ??
+          (this.currentBets == null ? null : Map<int, int>.from(this.currentBets!)),
       remainingStacks: remainingStacks ??
           (this.remainingStacks == null
               ? null
@@ -283,6 +288,8 @@ class SavedHand {
             }
         ],
         'stackSizes': stackSizes.map((k, v) => MapEntry(k.toString(), v)),
+        if (currentBets != null)
+          'currentBets': currentBets!.map((k, v) => MapEntry(k.toString(), v)),
         if (remainingStacks != null)
           'remainingStacks':
               remainingStacks!.map((k, v) => MapEntry(k.toString(), v)),
@@ -371,6 +378,13 @@ class SavedHand {
     (json['stackSizes'] as Map? ?? {}).forEach((key, value) {
       stack[int.parse(key as String)] = value as int;
     });
+    Map<int, int>? bets;
+    if (json['currentBets'] != null) {
+      bets = <int, int>{};
+      (json['currentBets'] as Map).forEach((key, value) {
+        bets![int.parse(key as String)] = value as int;
+      });
+    }
     Map<int, int>? remaining;
     if (json['remainingStacks'] != null) {
       remaining = <int, int>{};
@@ -490,6 +504,7 @@ class SavedHand {
       activePlayerIndex: activeIndex,
       actions: acts,
       stackSizes: stack,
+      currentBets: bets,
       remainingStacks: remaining,
       winnings: wins,
       totalPot: totalPot,

--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/street_tabs.dart';
 import '../widgets/street_action_list_simple.dart';
 import '../models/card_model.dart';
 import '../services/action_sync_service.dart';
+import '../models/player_model.dart';
 
 class PlayerZoneDemoScreen extends StatefulWidget {
   const PlayerZoneDemoScreen({super.key});
@@ -17,9 +18,12 @@ class PlayerZoneDemoScreen extends StatefulWidget {
 class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
   int _street = 0;
   final List<String> _streetNames = const ['Preflop', 'Flop', 'Turn', 'River'];
-  final List<String> _players = const ['Alice', 'Bob', 'Carol'];
+  final List<PlayerModel> _players = [
+    PlayerModel(name: 'Alice', stack: 100, bet: 0),
+    PlayerModel(name: 'Bob', stack: 75, bet: 0),
+    PlayerModel(name: 'Carol', stack: 200, bet: 0),
+  ];
   final List<List<CardModel>> _cards = [[], [], []];
-  final Map<int, int> _stackSizes = const {0: 100, 1: 75, 2: 200};
 
   @override
   Widget build(BuildContext context) {
@@ -35,18 +39,24 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
             child: ListView.builder(
               itemCount: _players.length,
               itemBuilder: (context, index) {
+                final player = _players[index];
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16),
                   child: PlayerZoneWidget(
-                    playerName: _players[index],
+                    player: player,
+                    playerName: player.name,
                     street: _streetNames[_street],
                     position: null,
                     cards: _cards[index],
-                    stackSizes: _stackSizes,
+                    currentBet: player.bet,
+                    stackSize: player.stack,
                     playerIndex: index,
-                    remainingStack: _stackSizes[index],
+                    remainingStack: player.stack,
                     isHero: index == 0,
                     isFolded: false,
+                    editMode: true,
+                    onStackChanged: (v) => setState(() => player.stack = v),
+                    onBetChanged: (v) => setState(() => player.bet = v),
                     onCardsSelected: (i, c) {},
                   ),
                 );

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -91,6 +91,10 @@ class SavedHandImportExportService {
       activePlayerIndex: activePlayerIndex,
       actions: List<ActionEntry>.from(actions),
       stackSizes: Map<int, int>.from(stackService.initialStacks),
+      currentBets: {
+        for (int i = 0; i < playerManager.numberOfPlayers; i++)
+          i: playerManager.players[i].bet
+      },
       remainingStacks: {
         for (int i = 0; i < playerManager.numberOfPlayers; i++)
           i: stackService.getStackForPlayer(i)


### PR DESCRIPTION
## Summary
- expand `PlayerModel` with `stack` and `bet`
- allow editing stack and bet in `PlayerZoneWidget`
- demo editing in `PlayerZoneDemoScreen`
- store current bets in `SavedHand` JSON
- export bet data via `SavedHandImportExportService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685708621814832a8874b91ef627d21a