### PR TITLE
Fix stack deduction for calls

### DIFF
--- a/lib/helpers/stack_manager.dart
+++ b/lib/helpers/stack_manager.dart
@@ -24,7 +24,10 @@ class StackManager {
       sw.clear();
     }
     for (final ActionEntry a in actions) {
-      if (a.action == 'call' || a.action == 'bet' || a.action == 'raise') {
+      if (a.action == 'call' ||
+          a.action == 'bet' ||
+          a.action == 'raise' ||
+          a.action == 'all-in') {
         final int? amount = a.amount;
         if (amount != null) {
           _currentStacks[a.playerIndex]?.addInvestment(a.street, amount);

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -2147,7 +2147,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   void _deductStackAfterAction(ActionEntry entry) {
     if (entry.amount == null) return;
-    if (!['bet', 'raise', 'all-in'].contains(entry.action)) return;
+    if (!['bet', 'raise', 'call', 'all-in'].contains(entry.action)) return;
     final current = _displayedStacks[entry.playerIndex] ??
         _stackService.getStackForPlayer(entry.playerIndex);
     final newValue = (current - entry.amount!).clamp(0, current);


### PR DESCRIPTION
## Summary
- deduct stacks when actions include calls
- include all-ins in stack manager logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68570b26663c832aacc3b1262d0356f6