### PR TITLE
Implement Spot of the Day mode

### DIFF
--- a/assets/spots/spots.json
+++ b/assets/spots/spots.json
@@ -1,0 +1,94 @@
+[
+  {
+    "playerCards": [
+      [{"rank": "A", "suit": "♠"}, {"rank": "K", "suit": "♠"}],
+      [{"rank": "Q", "suit": "♦"}, {"rank": "Q", "suit": "♣"}]
+    ],
+    "boardCards": [
+      {"rank": "J", "suit": "♠"},
+      {"rank": "T", "suit": "♠"},
+      {"rank": "2", "suit": "♦"},
+      {"rank": "5", "suit": "♣"},
+      {"rank": "9", "suit": "♥"}
+    ],
+    "actions": [
+      {"street": 0, "playerIndex": 0, "action": "raise", "amount": 3},
+      {"street": 0, "playerIndex": 1, "action": "call", "amount": 3},
+      {"street": 1, "playerIndex": 0, "action": "bet", "amount": 5},
+      {"street": 1, "playerIndex": 1, "action": "call", "amount": 5},
+      {"street": 2, "playerIndex": 0, "action": "bet", "amount": 10},
+      {"street": 2, "playerIndex": 1, "action": "fold"}
+    ],
+    "heroIndex": 0,
+    "numberOfPlayers": 2,
+    "playerTypes": ["unknown", "unknown"],
+    "positions": ["BTN", "BB"],
+    "stacks": [100, 100],
+    "difficulty": 3,
+    "rating": 0,
+    "createdAt": "2023-01-01T00:00:00.000"
+  },
+  {
+    "playerCards": [
+      [{"rank": "T", "suit": "♥"}, {"rank": "T", "suit": "♦"}],
+      [{"rank": "A", "suit": "♣"}, {"rank": "K", "suit": "♣"}]
+    ],
+    "boardCards": [
+      {"rank": "T", "suit": "♠"},
+      {"rank": "5", "suit": "♥"},
+      {"rank": "8", "suit": "♣"},
+      {"rank": "K", "suit": "♦"},
+      {"rank": "3", "suit": "♠"}
+    ],
+    "actions": [
+      {"street": 0, "playerIndex": 1, "action": "raise", "amount": 4},
+      {"street": 0, "playerIndex": 0, "action": "call", "amount": 4},
+      {"street": 1, "playerIndex": 1, "action": "bet", "amount": 6},
+      {"street": 1, "playerIndex": 0, "action": "raise", "amount": 18},
+      {"street": 1, "playerIndex": 1, "action": "call", "amount": 12},
+      {"street": 2, "playerIndex": 0, "action": "bet", "amount": 25},
+      {"street": 2, "playerIndex": 1, "action": "fold"}
+    ],
+    "heroIndex": 0,
+    "numberOfPlayers": 2,
+    "playerTypes": ["unknown", "unknown"],
+    "positions": ["BB", "BTN"],
+    "stacks": [120, 120],
+    "difficulty": 4,
+    "rating": 0,
+    "createdAt": "2023-01-02T00:00:00.000"
+  },
+  {
+    "playerCards": [
+      [{"rank": "Q", "suit": "♠"}, {"rank": "J", "suit": "♠"}],
+      [{"rank": "9", "suit": "♣"}, {"rank": "9", "suit": "♦"}]
+    ],
+    "boardCards": [
+      {"rank": "Q", "suit": "♦"},
+      {"rank": "9", "suit": "♥"},
+      {"rank": "7", "suit": "♠"},
+      {"rank": "2", "suit": "♠"},
+      {"rank": "A", "suit": "♣"}
+    ],
+    "actions": [
+      {"street": 0, "playerIndex": 0, "action": "raise", "amount": 2},
+      {"street": 0, "playerIndex": 1, "action": "call", "amount": 2},
+      {"street": 1, "playerIndex": 0, "action": "check"},
+      {"street": 1, "playerIndex": 1, "action": "bet", "amount": 3},
+      {"street": 1, "playerIndex": 0, "action": "call", "amount": 3},
+      {"street": 2, "playerIndex": 0, "action": "check"},
+      {"street": 2, "playerIndex": 1, "action": "bet", "amount": 7},
+      {"street": 2, "playerIndex": 0, "action": "call", "amount": 7},
+      {"street": 3, "playerIndex": 0, "action": "check"},
+      {"street": 3, "playerIndex": 1, "action": "check"}
+    ],
+    "heroIndex": 0,
+    "numberOfPlayers": 2,
+    "playerTypes": ["unknown", "unknown"],
+    "positions": ["CO", "BB"],
+    "stacks": [80, 80],
+    "difficulty": 2,
+    "rating": 0,
+    "createdAt": "2023-01-03T00:00:00.000"
+  }
+]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/daily_hand_service.dart';
+import 'services/spot_of_the_day_service.dart';
 import 'services/action_sync_service.dart';
 import 'services/folded_players_service.dart';
 import 'services/all_in_players_service.dart';
@@ -25,6 +26,7 @@ void main() {
         ),
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
+        ChangeNotifierProvider(create: (_) => SpotOfTheDayService()..load()),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
         ChangeNotifierProvider(

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -8,6 +8,7 @@ import 'training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
+import 'spot_of_the_day_screen.dart';
 import 'create_pack_screen.dart';
 import 'edit_pack_screen.dart';
 import 'package:provider/provider.dart';
@@ -73,6 +74,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🃏 Ежедневная раздача'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SpotOfTheDayScreen()),
+                );
+              },
+              child: const Text('🎲 Спот дня'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/screens/spot_of_the_day_screen.dart
+++ b/lib/screens/spot_of_the_day_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/spot_of_the_day_service.dart';
+import '../widgets/board_cards_widget.dart';
+import '../widgets/poker_table_painter.dart';
+import '../widgets/player_info_widget.dart';
+import '../helpers/table_geometry_helper.dart';
+import '../models/card_model.dart';
+
+class SpotOfTheDayScreen extends StatefulWidget {
+  const SpotOfTheDayScreen({super.key});
+
+  @override
+  State<SpotOfTheDayScreen> createState() => _SpotOfTheDayScreenState();
+}
+
+class _SpotOfTheDayScreenState extends State<SpotOfTheDayScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final service = context.read<SpotOfTheDayService>();
+    service.ensureTodaySpot();
+  }
+
+  void _chooseAction(SpotOfTheDayService service) async {
+    const actions = ['fold', 'check', 'call', 'bet', 'raise'];
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: const Text('Ваше действие'),
+        children: [
+          for (final a in actions)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, a),
+              child: Text(a),
+            ),
+        ],
+      ),
+    );
+    if (result != null) {
+      await service.saveResult(result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<SpotOfTheDayService>();
+    final spot = service.spot;
+    if (spot == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Спот дня'), centerTitle: true),
+        body: const Center(child: Text('Нет данных')),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Спот дня'), centerTitle: true),
+      backgroundColor: const Color(0xFF121212),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final scale = TableGeometryHelper.tableScale(spot.numberOfPlayers);
+          final tableWidth = constraints.maxWidth * 0.9 * scale;
+          final tableHeight = tableWidth * 0.55;
+          final centerX = constraints.maxWidth / 2;
+          final centerY = constraints.maxHeight / 2 - 40;
+
+          List<Widget> children = [
+            Positioned(
+              left: centerX - tableWidth / 2,
+              top: centerY - tableHeight / 2,
+              width: tableWidth,
+              height: tableHeight,
+              child: CustomPaint(
+                painter: PokerTablePainter(),
+              ),
+            ),
+            Positioned.fill(
+              child: Align(
+                alignment: Alignment(0, -0.1),
+                child: BoardCardsWidget(
+                  currentStreet: 3,
+                  boardCards: spot.boardCards,
+                  onCardSelected: (_, __) {},
+                  onCardLongPress: null,
+                  usedCards: const {},
+                  editingDisabled: true,
+                ),
+              ),
+            ),
+          ];
+
+          for (int i = 0; i < spot.numberOfPlayers; i++) {
+            final pos = TableGeometryHelper.positionForPlayer(
+                i, spot.numberOfPlayers, tableWidth, tableHeight);
+            final offsetX = centerX + pos.dx - 55 * scale;
+            final offsetY = centerY + pos.dy - 55 * scale;
+            final cards = spot.playerCards.length > i ? spot.playerCards[i] : <CardModel>[];
+            children.add(Positioned(
+              left: offsetX,
+              top: offsetY,
+              child: PlayerInfoWidget(
+                position: spot.positions[i],
+                stack: spot.stacks[i],
+                tag: '',
+                cards: cards,
+                lastAction: null,
+                isActive: false,
+                isFolded: false,
+                isHero: i == spot.heroIndex,
+                isOpponent: false,
+                revealCards: true,
+                playerTypeIcon: '',
+                playerTypeLabel: null,
+                positionLabel: null,
+                blindLabel: null,
+                showLastIndicator: false,
+                onTap: null,
+                onDoubleTap: null,
+                onLongPress: null,
+                onEdit: null,
+                onStackTap: null,
+                onRemove: null,
+                onTimeExpired: null,
+                onCardTap: null,
+                streetInvestment: 0,
+                currentBet: 0,
+                remainingStack: spot.stacks[i],
+                timersDisabled: true,
+                isBust: false,
+              ),
+            ));
+          }
+
+          return Stack(children: children);
+        },
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: ElevatedButton(
+            onPressed: () => _chooseAction(service),
+            child: Text(service.result == null ? 'Ваше решение' : 'Изменить ответ'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/spot_of_the_day_service.dart
+++ b/lib/services/spot_of_the_day_service.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/training_spot.dart';
+
+class SpotOfTheDayService extends ChangeNotifier {
+  static const _dateKey = 'spot_of_day_date';
+  static const _indexKey = 'spot_of_day_index';
+  static const _resultKey = 'spot_of_day_result';
+
+  TrainingSpot? _spot;
+  DateTime? _date;
+  String? _result;
+
+  TrainingSpot? get spot => _spot;
+  String? get result => _result;
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<List<TrainingSpot>> _loadAllSpots() async {
+    final data = await rootBundle.loadString('assets/spots/spots.json');
+    final list = jsonDecode(data) as List;
+    return [
+      for (final e in list)
+        TrainingSpot.fromJson(Map<String, dynamic>.from(e as Map))
+    ];
+  }
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dateStr = prefs.getString(_dateKey);
+    final index = prefs.getInt(_indexKey);
+    _result = prefs.getString(_resultKey);
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    if (index != null && _date != null && _isSameDay(_date!, DateTime.now())) {
+      final spots = await _loadAllSpots();
+      if (index >= 0 && index < spots.length) {
+        _spot = spots[index];
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<void> ensureTodaySpot() async {
+    if (_spot != null && _date != null && _isSameDay(_date!, DateTime.now())) {
+      return;
+    }
+    final spots = await _loadAllSpots();
+    if (spots.isEmpty) return;
+    final rnd = Random().nextInt(spots.length);
+    _spot = spots[rnd];
+    _date = DateTime.now();
+    _result = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+    await prefs.setInt(_indexKey, rnd);
+    await prefs.remove(_resultKey);
+    notifyListeners();
+  }
+
+  Future<void> saveResult(String action) async {
+    _result = action;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_resultKey, action);
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ flutter:
 
   assets:
     - assets/cards/card_back.png
+    - assets/spots/spots.json
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo


### PR DESCRIPTION
## Summary
- add basic sample spot data
- add SpotOfTheDayService for daily random spot
- add SpotOfTheDayScreen with read-only table and action input
- wire up service in `main.dart` and add menu entry
- include spot assets in pubspec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685714b638d8832a9affc2d673629b39