### PR TITLE
Add recommended spot actions

### DIFF
--- a/assets/spots/spots.json
+++ b/assets/spots/spots.json
@@ -26,6 +26,7 @@
     "stacks": [100, 100],
     "difficulty": 3,
     "rating": 0,
+    "recommendedAction": "fold",
     "createdAt": "2023-01-01T00:00:00.000"
   },
   {
@@ -56,6 +57,7 @@
     "stacks": [120, 120],
     "difficulty": 4,
     "rating": 0,
+    "recommendedAction": "call",
     "createdAt": "2023-01-02T00:00:00.000"
   },
   {
@@ -89,6 +91,7 @@
     "stacks": [80, 80],
     "difficulty": 2,
     "rating": 0,
+    "recommendedAction": "check",
     "createdAt": "2023-01-03T00:00:00.000"
   }
 ]

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -23,6 +23,7 @@ class TrainingSpot {
   final String? userAction;
   final String? userComment;
   final String? actionHistory;
+  final String? recommendedAction;
   final DateTime createdAt;
 
   TrainingSpot({
@@ -43,6 +44,7 @@ class TrainingSpot {
     this.userAction,
     this.userComment,
     this.actionHistory,
+    this.recommendedAction,
     this.difficulty = 3,
     this.rating = 0,
     DateTime? createdAt,
@@ -120,6 +122,7 @@ class TrainingSpot {
         if (userAction != null) 'userAction': userAction,
         if (userComment != null) 'userComment': userComment,
         if (actionHistory != null) 'actionHistory': actionHistory,
+        if (recommendedAction != null) 'recommendedAction': recommendedAction,
         'createdAt': createdAt.toIso8601String(),
       };
 
@@ -205,6 +208,7 @@ class TrainingSpot {
       userAction: json['userAction'] as String?,
       userComment: json['userComment'] as String?,
       actionHistory: json['actionHistory'] as String?,
+      recommendedAction: json['recommendedAction'] as String?,
       createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
           DateTime.now(),
     );
@@ -217,6 +221,7 @@ class TrainingSpot {
     String? userAction,
     String? userComment,
     String? actionHistory,
+    String? recommendedAction,
     DateTime? createdAt,
   }) {
     return TrainingSpot(
@@ -239,6 +244,7 @@ class TrainingSpot {
       userAction: userAction ?? this.userAction,
       userComment: userComment ?? this.userComment,
       actionHistory: actionHistory ?? this.actionHistory,
+      recommendedAction: recommendedAction ?? this.recommendedAction,
       createdAt: createdAt ?? this.createdAt,
     );
   }

--- a/lib/screens/spot_of_the_day_screen.dart
+++ b/lib/screens/spot_of_the_day_screen.dart
@@ -168,10 +168,23 @@ class _SpotOfTheDayScreenState extends State<SpotOfTheDayScreen> {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: ElevatedButton(
-            onPressed: () => _chooseAction(service),
-            child: Text(service.result == null ? 'Ваше решение' : 'Изменить ответ'),
-          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (service.result != null || spot.recommendedAction != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(
+                    'Ваш ответ: ${service.result ?? '-'} • Реком.: ${spot.recommendedAction ?? '-'}',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+              ElevatedButton(
+                onPressed: () => _chooseAction(service),
+                child: Text(service.result == null ? 'Ваше решение' : 'Изменить ответ'),
+              ),
+            ],
+          )
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- include placeholder `recommendedAction` in spots data
- parse `recommendedAction` for `TrainingSpot`
- store and display recommendations in Spot of the Day service
- show the recommendation in Spot of the Day screens

## Testing
- `base64 -d /tmp/patch_b64_short.txt | apply_patch`

------
https://chatgpt.com/codex/tasks/task_e_685717994be4832ab559dd0f8777798f