### PR TITLE
Add answer evaluation to Spot of the Day

### DIFF
--- a/lib/models/spot_of_day_history_entry.dart
+++ b/lib/models/spot_of_day_history_entry.dart
@@ -3,12 +3,14 @@ class SpotOfDayHistoryEntry {
   final int spotIndex;
   final String? userAction;
   final String? recommendedAction;
+  final bool? correct;
 
   SpotOfDayHistoryEntry({
     required this.date,
     required this.spotIndex,
     this.userAction,
     this.recommendedAction,
+    this.correct,
   });
 
   Map<String, dynamic> toJson() => {
@@ -16,6 +18,7 @@ class SpotOfDayHistoryEntry {
         'spotIndex': spotIndex,
         if (userAction != null) 'userAction': userAction,
         if (recommendedAction != null) 'recommendedAction': recommendedAction,
+        if (correct != null) 'correct': correct,
       };
 
   factory SpotOfDayHistoryEntry.fromJson(Map<String, dynamic> json) =>
@@ -24,13 +27,15 @@ class SpotOfDayHistoryEntry {
         spotIndex: json['spotIndex'] as int? ?? 0,
         userAction: json['userAction'] as String?,
         recommendedAction: json['recommendedAction'] as String?,
+        correct: json['correct'] as bool?,
       );
 
-  SpotOfDayHistoryEntry copyWith({String? userAction, String? recommendedAction}) =>
+  SpotOfDayHistoryEntry copyWith({String? userAction, String? recommendedAction, bool? correct}) =>
       SpotOfDayHistoryEntry(
         date: date,
         spotIndex: spotIndex,
         userAction: userAction ?? this.userAction,
         recommendedAction: recommendedAction ?? this.recommendedAction,
+        correct: correct ?? this.correct,
       );
 }

--- a/lib/screens/spot_of_the_day_history_screen.dart
+++ b/lib/screens/spot_of_the_day_history_screen.dart
@@ -78,6 +78,21 @@ class _SpotOfTheDayHistoryScreenState extends State<SpotOfTheDayHistoryScreen> {
                     Text(
                         'Ваш ответ: ${entry.userAction ?? '-'} \u2022 Реком.: ${entry.recommendedAction ?? '-'}',
                         style: const TextStyle(color: Colors.white)),
+                    if ((entry.userAction != null && entry.recommendedAction != null) ||
+                        entry.correct != null)
+                      Text(
+                        (entry.correct ??
+                                (entry.userAction == entry.recommendedAction))
+                            ? 'Верно'
+                            : 'Ошибка',
+                        style: TextStyle(
+                          color: (entry.correct ??
+                                  (entry.userAction == entry.recommendedAction))
+                              ? Colors.green
+                              : Colors.red,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
                   ],
                 ),
               );

--- a/lib/screens/spot_of_the_day_screen.dart
+++ b/lib/screens/spot_of_the_day_screen.dart
@@ -179,6 +179,17 @@ class _SpotOfTheDayScreenState extends State<SpotOfTheDayScreen> {
                     style: const TextStyle(color: Colors.white),
                   ),
                 ),
+              if (service.correct != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(
+                    service.correct! ? 'Верно' : 'Ошибка',
+                    style: TextStyle(
+                      color: service.correct! ? Colors.green : Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
               ElevatedButton(
                 onPressed: () => _chooseAction(service),
                 child: Text(service.result == null ? 'Ваше решение' : 'Изменить ответ'),

--- a/lib/services/spot_of_the_day_service.dart
+++ b/lib/services/spot_of_the_day_service.dart
@@ -19,6 +19,13 @@ class SpotOfTheDayService extends ChangeNotifier {
   String? _result;
   List<SpotOfDayHistoryEntry> _history = [];
 
+  bool? get correct {
+    if (_spot == null || _result == null || _spot!.recommendedAction == null) {
+      return null;
+    }
+    return _result == _spot!.recommendedAction;
+  }
+
   TrainingSpot? get spot => _spot;
   String? get result => _result;
   List<SpotOfDayHistoryEntry> get history => List.unmodifiable(_history);
@@ -79,8 +86,21 @@ class SpotOfTheDayService extends ChangeNotifier {
         await _saveHistory();
       } else if (_history[idx].recommendedAction == null &&
           _spot?.recommendedAction != null) {
-        _history[idx] = _history[idx]
-            .copyWith(recommendedAction: _spot!.recommendedAction);
+        final entry = _history[idx];
+        _history[idx] = entry.copyWith(
+          recommendedAction: _spot!.recommendedAction,
+          correct: entry.userAction != null
+              ? entry.userAction == _spot!.recommendedAction
+              : null,
+        );
+        await _saveHistory();
+      } else if (_history[idx].correct == null &&
+          _history[idx].userAction != null &&
+          _history[idx].recommendedAction != null) {
+        final entry = _history[idx];
+        _history[idx] = entry.copyWith(
+            correct:
+                entry.userAction == entry.recommendedAction);
         await _saveHistory();
       }
     }
@@ -117,7 +137,10 @@ class SpotOfTheDayService extends ChangeNotifier {
         final entry = _history[idx];
         _history[idx] = entry.copyWith(
             userAction: action,
-            recommendedAction: entry.recommendedAction ?? _spot?.recommendedAction);
+            recommendedAction: entry.recommendedAction ?? _spot?.recommendedAction,
+            correct: _spot?.recommendedAction != null
+                ? action == _spot!.recommendedAction
+                : null);
         await _saveHistory();
       }
     }


### PR DESCRIPTION
## Summary
- support answer evaluation in SpotOfDay history entries
- compute correctness in SpotOfTheDayService
- show correctness label for today's spot
- show correctness in Spot of the Day history

## Testing
- `dart format lib/models/spot_of_day_history_entry.dart lib/services/spot_of_the_day_service.dart lib/screens/spot_of_the_day_screen.dart lib/screens/spot_of_the_day_history_screen.dart` *(fails: `dart` not found)*
- `flutter format lib/models/spot_of_day_history_entry.dart lib/services/spot_of_the_day_service.dart lib/screens/spot_of_the_day_screen.dart lib/screens/spot_of_the_day_history_screen.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685719eda594832a85f877c360f18996