### PR TITLE
Add BottomNavigationBar for main screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'screens/main_menu_screen.dart';
+import 'screens/main_navigation_screen.dart';
 import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
 import 'services/training_pack_storage_service.dart';
@@ -68,7 +68,7 @@ class PokerAIAnalyzerApp extends StatelessWidget {
               displayColor: Colors.white,
             ),
       ),
-      home: const MainMenuScreen(),
+      home: const MainNavigationScreen(),
     );
   }
 }

--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'poker_analyzer_screen.dart';
+import '../services/action_sync_service.dart';
+import '../services/all_in_players_service.dart';
+import '../services/board_editing_service.dart';
+import '../services/board_manager_service.dart';
+import '../services/board_reveal_service.dart';
+import '../services/board_sync_service.dart';
+import '../services/current_hand_context_service.dart';
+import '../services/folded_players_service.dart';
+import '../services/player_editing_service.dart';
+import '../services/player_manager_service.dart';
+import '../services/player_profile_service.dart';
+import '../services/playback_manager_service.dart';
+import '../services/pot_history_service.dart';
+import '../services/pot_sync_service.dart';
+import '../services/stack_manager_service.dart';
+import '../services/transition_lock_service.dart';
+import '../services/action_history_service.dart';
+import '../services/training_import_export_service.dart';
+
+class AnalyzerTab extends StatelessWidget {
+  const AnalyzerTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+        ChangeNotifierProvider(create: (context) =>
+            PlayerManagerService(context.read<PlayerProfileService>())),
+        ChangeNotifierProvider(create: (_) => AllInPlayersService()),
+        ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
+        ChangeNotifierProvider(
+          create: (context) => ActionSyncService(
+            foldedPlayers: context.read<FoldedPlayersService>(),
+            allInPlayers: context.read<AllInPlayersService>(),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) {
+            final history = PotHistoryService();
+            final potSync = PotSyncService(historyService: history);
+            final stackService = StackManagerService(
+              Map<int, int>.from(context.read<PlayerManagerService>().initialStacks),
+              potSync: potSync,
+            );
+            return PlaybackManagerService(
+              stackService: stackService,
+              potSync: potSync,
+              actionSync: context.read<ActionSyncService>(),
+            );
+          },
+        ),
+        Provider(
+          create: (context) => BoardSyncService(
+            playerManager: context.read<PlayerManagerService>(),
+            actionSync: context.read<ActionSyncService>(),
+          ),
+        ),
+        Provider(create: (_) => ActionHistoryService()),
+        Provider(create: (_) => const TrainingImportExportService()),
+      ],
+      child: Builder(
+        builder: (context) {
+          final lockService = TransitionLockService();
+          final boardReveal = BoardRevealService(
+            lockService: lockService,
+            boardSync: context.read<BoardSyncService>(),
+          );
+          return MultiProvider(
+            providers: [
+              Provider<TransitionLockService>.value(value: lockService),
+              Provider<BoardRevealService>.value(value: boardReveal),
+              ChangeNotifierProvider(
+                create: (_) => BoardManagerService(
+                  playerManager: context.read<PlayerManagerService>(),
+                  actionSync: context.read<ActionSyncService>(),
+                  playbackManager: context.read<PlaybackManagerService>(),
+                  lockService: lockService,
+                  boardSync: context.read<BoardSyncService>(),
+                  boardReveal: boardReveal,
+                ),
+              ),
+              Provider(
+                create: (_) => BoardEditingService(
+                  boardManager: context.read<BoardManagerService>(),
+                  boardSync: context.read<BoardSyncService>(),
+                  playerManager: context.read<PlayerManagerService>(),
+                  profile: context.read<PlayerProfileService>(),
+                ),
+              ),
+              Provider(
+                create: (_) => PlayerEditingService(
+                  playerManager: context.read<PlayerManagerService>(),
+                  stackService: context.read<PlaybackManagerService>().stackService,
+                  playbackManager: context.read<PlaybackManagerService>(),
+                  profile: context.read<PlayerProfileService>(),
+                ),
+              ),
+            ],
+            child: PokerAnalyzerScreen(
+              actionSync: context.read<ActionSyncService>(),
+              foldedPlayersService: context.read<FoldedPlayersService>(),
+              allInPlayersService: context.read<AllInPlayersService>(),
+              handContext: CurrentHandContextService(),
+              playbackManager: context.read<PlaybackManagerService>(),
+              stackService: context.read<PlaybackManagerService>().stackService,
+              potSyncService: context.read<PlaybackManagerService>().potSync,
+              boardManager: context.read<BoardManagerService>(),
+              boardSync: context.read<BoardSyncService>(),
+              boardEditing: context.read<BoardEditingService>(),
+              playerEditing: context.read<PlayerEditingService>(),
+              playerManager: context.read<PlayerManagerService>(),
+              playerProfile: context.read<PlayerProfileService>(),
+              actionTagService: context.read<PlayerProfileService>().actionTagService,
+              boardReveal: boardReveal,
+              lockService: lockService,
+              actionHistory: context.read<ActionHistoryService>(),
+              demoMode: false,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'analyzer_tab.dart';
+import 'spot_of_the_day_screen.dart';
+import 'spot_of_the_day_history_screen.dart';
+import 'settings_placeholder_screen.dart';
+
+class MainNavigationScreen extends StatefulWidget {
+  const MainNavigationScreen({super.key});
+
+  @override
+  State<MainNavigationScreen> createState() => _MainNavigationScreenState();
+}
+
+class _MainNavigationScreenState extends State<MainNavigationScreen> {
+  int _currentIndex = 0;
+
+  final List<Widget> _pages = const [
+    AnalyzerTab(),
+    SpotOfTheDayScreen(),
+    SpotOfTheDayHistoryScreen(),
+    SettingsPlaceholderScreen(),
+  ];
+
+  void _onTap(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(index: _currentIndex, children: _pages),
+      bottomNavigationBar: BottomNavigationBar(
+        backgroundColor: Colors.black,
+        selectedItemColor: Colors.greenAccent,
+        unselectedItemColor: Colors.white70,
+        currentIndex: _currentIndex,
+        onTap: _onTap,
+        type: BottomNavigationBarType.fixed,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.assessment),
+            label: 'Раздачи',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.today),
+            label: 'Спот дня',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.history),
+            label: 'История',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.more_horiz),
+            label: 'Ещё',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class SettingsPlaceholderScreen extends StatelessWidget {
+  const SettingsPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Color(0xFF121212),
+      body: Center(
+        child: Text(
+          'Настройки будут доступны позже',
+          style: TextStyle(color: Colors.white70),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AnalyzerTab` with all required providers for `PokerAnalyzerScreen`
- add placeholder screen for future settings
- implement `MainNavigationScreen` with bottom navigation bar
- use `MainNavigationScreen` as the app home

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68571c7c68ac832ab851b89ccaaa9a73