### PR TITLE
Add bet size presets in action dialog

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3195,24 +3195,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   ),
                   child: const Text('Fold'),
                 ),
-                const SizedBox(height: 8),
-                ElevatedButton(
-                  onPressed: () => Navigator.pop(ctx, {'action': 'all-in'}),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.black87,
-                    foregroundColor: Colors.white,
-                  ),
-                  child: const Text('All-In'),
-                ),
                 if (needAmount) ...[
                   const SizedBox(height: 12),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      _sizeButton('1/3', (pot / 3).round(), ctx, selected!),
-                      _sizeButton('1/2', (pot / 2).round(), ctx, selected!),
+                      _sizeButton('50%', (pot / 2).round(), ctx, selected!),
+                      _sizeButton('66%', (pot * 2 / 3).round(), ctx, selected!),
                       _sizeButton('Pot', pot, ctx, selected!),
-                      _sizeButton('All-In', stack, ctx, selected!),
                     ],
                   ),
                   Slider(


### PR DESCRIPTION
## Summary
- update the action picker in `PokerAnalyzerScreen`
- provide bet/raise sizing buttons for 50%, 66% and Pot
- remove outdated All-In option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856c892c228832a81a00ed906b1505b