### PR TITLE
Add hand completion progress indicator

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -97,6 +97,7 @@ import '../widgets/confetti_overlay.dart';
 import '../widgets/poker_table_painter.dart';
 import '../widgets/deal_card_animation.dart';
 import '../widgets/playback_progress_bar.dart';
+import '../widgets/hand_completion_indicator.dart';
 import '../widgets/street_indicator.dart';
 import '../widgets/street_transition_overlay.dart';
 import '../services/stack_manager_service.dart';
@@ -4541,6 +4542,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     return 'Раздача от $day.$month.$year';
   }
 
+  double _handFillProgress() {
+    final totalCards = numberOfPlayers * 2 + 5;
+    int filled = boardCards.length;
+    for (final cards in playerCards.take(numberOfPlayers)) {
+      filled += cards.length;
+    }
+    if (totalCards == 0) return 0;
+    return (filled / totalCards).clamp(0.0, 1.0);
+  }
+
 
   Future<void> _exportEvaluationQueue() async {
     await _importExportService.exportEvaluationQueue(context);
@@ -5024,6 +5035,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               playerCount: numberOfPlayers,
               streetName: ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
               onEdit: loadHandByName,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: HandCompletionIndicator(progress: _handFillProgress()),
             ),
             _PlayerCountSelector(
               numberOfPlayers: numberOfPlayers,

--- a/lib/widgets/hand_completion_indicator.dart
+++ b/lib/widgets/hand_completion_indicator.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Displays a progress bar indicating how much of the hand setup is complete.
+class HandCompletionIndicator extends StatelessWidget {
+  /// Progress value between 0 and 1.
+  final double progress;
+
+  const HandCompletionIndicator({super.key, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (progress.clamp(0.0, 1.0) * 100).round();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        LinearProgressIndicator(
+          value: progress.clamp(0.0, 1.0),
+          backgroundColor: Colors.white24,
+          valueColor: AlwaysStoppedAnimation<Color>(
+            Theme.of(context).colorScheme.secondary,
+          ),
+          minHeight: 6,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Заполнение: $percent%',
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: Colors.white70),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show progress of filling out a hand
- compute filled card ratio and display a progress bar

## Testing
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_68571f5a2b10832ab0cff6d002dba82a