### PR TITLE
Add current street bet indicators

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -5700,6 +5700,16 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               : SizedBox(key: const ValueKey('empty'), height: 16 * scale),
         ),
       ),
+      if (currentBet > 0 && !isFolded)
+        Positioned(
+          left: centerX + dx - 16 * scale,
+          top: centerY + dy + bias + 60 * scale,
+          child: PlayerBetIndicator(
+            action: lastAmountAction!.action,
+            amount: currentBet,
+            scale: scale * 0.8,
+          ),
+        ),
       Positioned(
         left: centerX + dx - 12 * scale,
         top: centerY + dy + bias + 70 * scale,


### PR DESCRIPTION
## Summary
- show PlayerBetIndicator under each avatar if a bet exists on the current street

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685723317dec832a9d2b3d57cd7cc80c