### PR TITLE
Add winner highlight for simple win

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3589,6 +3589,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     }
 
     _winnerIndex = activePlayers.first;
+    final winnerName = players[_winnerIndex!].name;
+    showWinnerHighlight(context, winnerName);
+    showWinnerZoneOverlay(context, winnerName);
     _returns = _calculateUncalledReturns();
     _playPotWinAnimation();
     Future.delayed(const Duration(milliseconds: 1600), () {


### PR DESCRIPTION
## Summary
- highlight winner in `_maybeTriggerSimpleWin` using same overlay/glow as showdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857302ca728832a87f73e35734f3551