### PR TITLE
Show side pot breakdown in results

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1320,6 +1320,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     } else {
       payouts[winner] = pot - returnTotal;
     }
+    final resultSidePots = List<int>.from(_sidePots);
     await triggerWinnerAnimation(winner, pot - returnTotal);
     await triggerRefundAnimations(returns);
     await Future.delayed(const Duration(milliseconds: 500));
@@ -1339,6 +1340,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           finalStacks: stacks,
           potSize: pot - returnTotal,
           actions: visibleActions,
+          sidePots: resultSidePots,
         ),
       ),
     );

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -7,6 +7,7 @@ class ResultScreen extends StatelessWidget {
   final Map<int, int> winnings;
   final Map<int, int> finalStacks;
   final int potSize;
+  final List<int> sidePots;
   final List<ActionEntry> actions;
 
   const ResultScreen({
@@ -15,6 +16,7 @@ class ResultScreen extends StatelessWidget {
     required this.winnings,
     required this.finalStacks,
     required this.potSize,
+    required this.sidePots,
     required this.actions,
   });
 
@@ -37,6 +39,12 @@ class ResultScreen extends StatelessWidget {
                           .join(', ')
                   : 'Победитель: Игрок ${winnerIndex + 1}',
               style: const TextStyle(fontSize: 18, color: Colors.white),
+            ),
+            const SizedBox(height: 8),
+            _PotBreakdown(
+              potSize: potSize,
+              sidePots: sidePots,
+              winnings: winnings,
             ),
             const SizedBox(height: 8),
             Text('Пот: $potSize',
@@ -68,6 +76,57 @@ class ResultScreen extends StatelessWidget {
         ),
       ),
       backgroundColor: const Color(0xFF1B1C1E),
+    );
+  }
+}
+
+class _PotBreakdown extends StatelessWidget {
+  final int potSize;
+  final List<int> sidePots;
+  final Map<int, int> winnings;
+
+  const _PotBreakdown({
+    required this.potSize,
+    required this.sidePots,
+    required this.winnings,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final mainPot = potSize - sidePots.fold<int>(0, (p, e) => p + e);
+    final pots = <int>[mainPot, ...sidePots];
+    final names = <String>['Main Pot'];
+    names.addAll(List.generate(sidePots.length, (i) => 'Side Pot ${i + 1}'));
+    final totalWin = winnings.values.fold<int>(0, (p, e) => p + e);
+
+    final lines = <Widget>[];
+    for (int i = 0; i < pots.length; i++) {
+      final potAmount = pots[i];
+      if (potAmount <= 0) continue;
+      final shares = <int, int>{};
+      winnings.forEach((player, amount) {
+        final share =
+            (potAmount * (amount / (totalWin == 0 ? 1 : totalWin))).round();
+        if (share > 0) shares[player] = share;
+      });
+      final winnersText = shares.entries
+          .map((e) => 'P${e.key + 1} wins ${e.value}')
+          .join(', ');
+      lines.add(Text(
+        '${names[i]} → $winnersText',
+        style: const TextStyle(fontSize: 16, color: Colors.white70),
+      ));
+    }
+
+    if (lines.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Pot Breakdown:',
+            style: TextStyle(fontSize: 16, color: Colors.white)),
+        const SizedBox(height: 4),
+        ...lines,
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- show main & side pots and winners on ResultScreen
- pass side pot data when navigating to ResultScreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685733f6e588832a8e53bb36377b3d2e