### PR TITLE
Add delayed hand completion indicator

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -823,6 +823,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         amount: flight!.amount,
         scale: flight!.scale,
       );
+      _onResetAnimationComplete();
     }
   }
 
@@ -859,6 +860,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           color: Colors.orangeAccent,
           scale: scale,
         ));
+        _registerResetAnimation();
       });
     });
 
@@ -928,6 +930,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             color: Colors.orangeAccent,
             scale: scale,
           ));
+          _registerResetAnimation();
         });
       });
     }
@@ -3683,19 +3686,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     showWinnerZoneOverlay(context, winnerName);
     _returns = _calculateUncalledReturns();
     _playPotWinAnimation();
-    Future.delayed(const Duration(milliseconds: 1600), () {
-      if (!mounted) return;
-      lockService.safeSetState(this, () {
-        _showHandCompleteIndicator = true;
-      });
-      Future.delayed(const Duration(milliseconds: 800), () {
-        if (!mounted) return;
-        lockService.safeSetState(this, () {
-          _showHandCompleteIndicator = false;
-          _showNextHandButton = true;
-        });
-      });
-    });
+    _scheduleAutoReset();
   }
 
   void _onPlaybackManagerChanged() {


### PR DESCRIPTION
## Summary
- animate chip flights tracked as reset animations
- show `Hand Complete` overlay only after all animations via `_scheduleAutoReset`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68573d368e94832abb23bcefd159998d