### PR TITLE
Implement refunds return animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -821,12 +821,21 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         flight!.end.dx - 20 * flight!.scale,
         flight!.end.dy - 60 * flight!.scale,
       );
-      showWinAmountOverlay(
-        context: context,
-        position: pos,
-        amount: flight!.amount,
-        scale: flight!.scale,
-      );
+      if (flight!.color == Colors.lightBlueAccent) {
+        showRefundAmountOverlay(
+          context: context,
+          position: pos,
+          amount: flight!.amount,
+          scale: flight!.scale,
+        );
+      } else {
+        showWinAmountOverlay(
+          context: context,
+          position: pos,
+          amount: flight!.amount,
+          scale: flight!.scale,
+        );
+      }
       _onResetAnimationComplete();
     }
   }
@@ -2344,13 +2353,19 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (_returnsAnimated) return;
     final returns = _returns;
     if (returns == null || returns.isEmpty) return;
-    int d = delay;
-    returns.forEach((player, amount) {
-      Future.delayed(Duration(milliseconds: d), () {
-        if (!mounted) return;
-        _applyRefund(player, amount);
+    Future.delayed(Duration(milliseconds: delay), () {
+      if (!mounted) return;
+      _potAnimations.startRefundFlights(
+        context: context,
+        refunds: returns,
+        numberOfPlayers: numberOfPlayers,
+        viewIndex: _viewIndex,
+        flights: _chipFlights,
+        registerResetAnimation: _registerResetAnimation,
+      );
+      returns.forEach((player, amount) {
+        _applyRefund(player, amount, animate: false);
       });
-      d += 150;
     });
     _returnsAnimated = true;
   }

--- a/lib/services/pot_animation_service.dart
+++ b/lib/services/pot_animation_service.dart
@@ -191,6 +191,48 @@ class PotAnimationService {
     });
   }
 
+  void startRefundFlights({
+    required BuildContext context,
+    required Map<int, int> refunds,
+    required int numberOfPlayers,
+    required int Function() viewIndex,
+    required List<ChipFlight> flights,
+    required VoidCallback registerResetAnimation,
+  }) {
+    if (refunds.isEmpty) return;
+    final scale = TableGeometryHelper.tableScale(numberOfPlayers);
+    final screen = MediaQuery.of(context).size;
+    final tableWidth = screen.width * 0.9;
+    final tableHeight = tableWidth * 0.55;
+    final centerX = screen.width / 2 + 10;
+    final centerY =
+        screen.height / 2 - TableGeometryHelper.centerYOffset(numberOfPlayers, scale);
+    final radiusMod = TableGeometryHelper.radiusModifier(numberOfPlayers);
+    final radiusX = (tableWidth / 2 - 60) * scale * radiusMod;
+    final radiusY = (tableHeight / 2 + 90) * scale * radiusMod;
+
+    refunds.forEach((player, amount) {
+      if (amount <= 0) return;
+      final i = (player - viewIndex() + numberOfPlayers) % numberOfPlayers;
+      final angle = 2 * pi * i / numberOfPlayers + pi / 2;
+      final dx = radiusX * cos(angle);
+      final dy = radiusY * sin(angle);
+      final bias = TableGeometryHelper.verticalBiasFromAngle(angle) * scale;
+      final start = Offset(centerX, centerY);
+      final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
+      flights.add(ChipFlight(
+        key: UniqueKey(),
+        start: start,
+        end: end,
+        amount: amount,
+        playerIndex: player,
+        color: Colors.lightBlueAccent,
+        scale: scale,
+      ));
+      registerResetAnimation();
+    });
+  }
+
   Future<void> triggerRefundAnimations(Map<int, int> refunds) async {
     for (final entry in refunds.entries) {
       final playerIndex = entry.key;


### PR DESCRIPTION
## Summary
- add `startRefundFlights` in `PotAnimationService`
- animate uncalled return chips on pot win
- display refund amounts in chip flight overlay

## Testing
- `dart format lib/services/pot_animation_service.dart lib/screens/poker_analyzer_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_685748934d48832a86697a8522fe3d21