### PR TITLE
Highlight winner via animation service

### DIFF
--- a/lib/services/pot_animation_service.dart
+++ b/lib/services/pot_animation_service.dart
@@ -31,6 +31,18 @@ class ChipFlight {
 }
 
 class PotAnimationService {
+  String? _highlightedPlayer;
+
+  void showWinnerHighlight(BuildContext context, String playerName) {
+    final state = playerZoneRegistry[playerName];
+    if (state == null) return;
+    if (_highlightedPlayer != null && _highlightedPlayer != playerName) {
+      final prev = playerZoneRegistry[_highlightedPlayer!];
+      prev?.clearWinnerHighlight();
+    }
+    _highlightedPlayer = playerName;
+    state.highlightWinner();
+  }
   void startPotWinFlights({
     required BuildContext context,
     required Map<int, int> payouts,
@@ -85,7 +97,7 @@ class PotAnimationService {
     Future.delayed(const Duration(milliseconds: 500), () {
       if (!mounted) return;
       for (final p in payouts.keys) {
-        showWinnerHighlight(context, players[p].name);
+        this.showWinnerHighlight(context, players[p].name);
       }
       final prevPot = displayedPots[currentStreet];
       if (prevPot > 0) {
@@ -173,7 +185,7 @@ class PotAnimationService {
     Future.delayed(Duration(milliseconds: 500 + delay), () {
       if (!mounted) return;
       for (final p in payouts.keys) {
-        showWinnerHighlight(context, players[p].name);
+        this.showWinnerHighlight(context, players[p].name);
       }
       final prevPot = displayedPots[currentStreet];
       if (prevPot > 0) {

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -9,6 +9,7 @@ import '../models/player_model.dart';
 import '../models/player_zone_action_entry.dart' as pz;
 import '../services/action_sync_service.dart';
 import '../services/transition_lock_service.dart';
+import '../services/pot_animation_service.dart';
 import '../user_preferences.dart';
 import 'card_selector.dart';
 import 'chip_widget.dart';
@@ -250,6 +251,13 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     _highlightTimer = Timer(const Duration(seconds: 2), () {
       if (mounted) setState(() => _winnerHighlight = false);
     });
+  }
+
+  void clearWinnerHighlight() {
+    _highlightTimer?.cancel();
+    if (_winnerHighlight) {
+      setState(() => _winnerHighlight = false);
+    }
   }
 
   void showRefundGlow() {
@@ -1850,8 +1858,7 @@ class _CardRevealBackdropState extends State<_CardRevealBackdrop>
 /// This should be called before [showWinPotAnimation] to visually
 /// indicate the winner.
 void showWinnerHighlight(BuildContext context, String playerName) {
-  final state = playerZoneRegistry[playerName];
-  state?.highlightWinner();
+  PotAnimationService().showWinnerHighlight(context, playerName);
 }
 
 /// Displays an animated glow overlay around the winning player's zone.


### PR DESCRIPTION
## Summary
- centralize winner highlight logic in `PotAnimationService`
- expose `clearWinnerHighlight` in `PlayerZoneWidget`
- highlight the winning player using the service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68574a434948832abb4d25af436bedc2