### PR TITLE
Add live pot display above board

### DIFF
--- a/lib/services/pot_sync_service.dart
+++ b/lib/services/pot_sync_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../helpers/pot_calculator.dart';
 import '../models/action_entry.dart';
 import '../models/street_investments.dart';
@@ -6,7 +8,7 @@ import 'stack_manager_service.dart';
 import 'pot_history_service.dart';
 
 /// Synchronizes pot sizes and provides effective stack calculations.
-class PotSyncService {
+class PotSyncService extends ChangeNotifier {
   PotSyncService({
     PotCalculator? potCalculator,
     StackManagerService? stackService,
@@ -72,6 +74,7 @@ class PotSyncService {
     sidePots
       ..clear()
       ..addAll(computeSidePots());
+    notifyListeners();
   }
 
   /// Recompute [pots] based on visible [actions] and record history.
@@ -82,6 +85,7 @@ class PotSyncService {
     }
     updateSidePots();
     _history.record(actions.length, pots);
+    notifyListeners();
   }
 
   /// Updates [pots] using only actions up to [playbackIndex].
@@ -93,6 +97,7 @@ class PotSyncService {
     }
     updateSidePots();
     _history.record(playbackIndex, pots);
+    notifyListeners();
   }
 
   /// Returns the recorded pot sizes for [index].
@@ -162,6 +167,7 @@ class PotSyncService {
       List<ActionEntry> actions, int numberOfPlayers) {
     _effectiveStacks =
         calculateEffectiveStacksPerStreet(actions, numberOfPlayers);
+    notifyListeners();
     return effectiveStacks;
   }
 
@@ -176,11 +182,13 @@ class PotSyncService {
   void restoreFromJson(Map<String, dynamic>? json) {
     if (json == null) {
       _effectiveStacks.clear();
+      notifyListeners();
       return;
     }
     _effectiveStacks = {
       for (final entry in json.entries) entry.key: entry.value as int
     };
+    notifyListeners();
   }
 
   /// Restores effective stacks from [hand], computing them when missing.
@@ -200,5 +208,6 @@ class PotSyncService {
     sidePots.clear();
     _effectiveStacks.clear();
     _history.clear();
+    notifyListeners();
   }
 }

--- a/lib/widgets/board_display.dart
+++ b/lib/widgets/board_display.dart
@@ -4,6 +4,7 @@ import '../models/card_model.dart';
 import '../services/pot_sync_service.dart';
 import 'board_cards_widget.dart';
 import 'pot_over_board_widget.dart';
+import 'package:provider/provider.dart';
 
 class BoardDisplay extends StatelessWidget {
   final int currentStreet;
@@ -37,26 +38,31 @@ class BoardDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        BoardCardsWidget(
-          scale: scale,
-          currentStreet: currentStreet,
-          boardCards: revealedBoardCards,
-          revealAnimations: revealAnimations,
-          onCardSelected: onCardSelected,
-          onCardLongPress: onCardLongPress,
-          canEditBoard: canEditBoard,
-          usedCards: usedCards,
-          editingDisabled: editingDisabled,
-        ),
-        PotOverBoardWidget(
-          potSync: potSync,
-          currentStreet: currentStreet,
-          scale: scale,
-          show: showPot,
-        ),
-      ],
+    return ChangeNotifierProvider.value(
+      value: potSync,
+      child: Stack(
+        children: [
+          BoardCardsWidget(
+            scale: scale,
+            currentStreet: currentStreet,
+            boardCards: revealedBoardCards,
+            revealAnimations: revealAnimations,
+            onCardSelected: onCardSelected,
+            onCardLongPress: onCardLongPress,
+            canEditBoard: canEditBoard,
+            usedCards: usedCards,
+            editingDisabled: editingDisabled,
+          ),
+          Consumer<PotSyncService>(
+            builder: (_, sync, __) => PotOverBoardWidget(
+              potSync: sync,
+              currentStreet: currentStreet,
+              scale: scale,
+              show: showPot,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- make `PotSyncService` a `ChangeNotifier` so widgets can listen for updates
- wrap `BoardDisplay` with a provider and rebuild pot widget when pot changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68577e99efb8832aae8a64afdebc55a4