### PR TITLE
Add effective stack label

### DIFF
--- a/lib/widgets/player_effective_stack_label.dart
+++ b/lib/widgets/player_effective_stack_label.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Displays the current effective stack in BB for a player.
+class PlayerEffectiveStackLabel extends StatelessWidget {
+  /// Effective stack size to display.
+  final int? stack;
+
+  /// Scale factor for sizing.
+  final double scale;
+
+  const PlayerEffectiveStackLabel({
+    Key? key,
+    required this.stack,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (stack == null || stack == 0) return const SizedBox.shrink();
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      child: Text(
+        'Eff: $stack BB',
+        key: ValueKey(stack),
+        style: TextStyle(
+          color: Colors.grey,
+          fontSize: 10 * scale,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -25,6 +25,8 @@ import 'move_pot_animation.dart';
 import 'winner_zone_highlight.dart';
 import 'loss_amount_widget.dart';
 import 'gain_amount_widget.dart';
+import '../services/pot_sync_service.dart';
+import 'player_effective_stack_label.dart';
 
 final Map<String, _PlayerZoneWidgetState> playerZoneRegistry = {};
 
@@ -1047,6 +1049,11 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
               isBust: remaining != null && remaining <= 0,
             ),
           ),
+        PlayerEffectiveStackLabel(
+          stack: context.watch<PotSyncService>()
+                  .effectiveStacks[widget.street],
+          scale: widget.scale,
+        ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
           transitionBuilder: (child, animation) => FadeTransition(


### PR DESCRIPTION
## Summary
- show effective stack below each player's stack
- expose effective stack via new PlayerEffectiveStackLabel widget

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68577ffbaff0832ab68425c1fb5e24a8