### PR TITLE
Add Fold All FAB in training mode

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -254,6 +254,8 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   late TransitionHistoryService _transitionHistory;
   late ActionEditingService _actionEditing;
 
+  bool get _trainingMode => UserPreferences.instance.coachMode;
+
   Set<int> get _expandedHistoryStreets => _actionHistory.expandedStreets;
 
   ActionEntry? _centerChipAction;
@@ -4947,6 +4949,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _debugPanelSetState?.call(() {});
   }
 
+  void _foldAllOpponents() {
+    const color = Colors.red;
+    for (int i = 0; i < numberOfPlayers; i++) {
+      if (i == heroIndex) continue;
+      setPlayerLastAction(players[i].name, 'Fold', color, 'fold');
+    }
+  }
+
 
   SavedHand _currentSavedHand({
     String? name,
@@ -5443,7 +5453,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                 if (_showNextHandButton)
                   _NextHandButtonOverlay(
                     onPressed: _onNextHandPressed,
-                  )
+                  ),
+                if (_trainingMode)
+                  _FoldAllButtonOverlay(
+                    onPressed: _foldAllOpponents,
+                  ),
               ],
         ),
       ),
@@ -8401,6 +8415,26 @@ class _ReplayDemoButtonOverlay extends StatelessWidget {
             child: const Text('Replay Demo'),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _FoldAllButtonOverlay extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _FoldAllButtonOverlay({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      bottom: 16,
+      right: 16,
+      child: FloatingActionButton.extended(
+        heroTag: 'foldAllFab',
+        backgroundColor: Colors.red,
+        onPressed: onPressed,
+        label: const Text('Fold All'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add `_trainingMode` helper
- implement `_foldAllOpponents` to mark opponents as folded
- show `Fold All` floating button in training mode
- overlay widget for the new button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68583e6e17cc832a87e17583d7654218