### PR TITLE
Implement manual reveal request

### DIFF
--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -58,6 +58,9 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
                     onStackChanged: (v) => setState(() => player.stack = v),
                     onBetChanged: (v) => setState(() => player.bet = v),
                     onCardsSelected: (i, c) {},
+                    onRevealRequest: (name) {
+                      debugPrint('Reveal requested for ' + name);
+                    },
                   ),
                 );
               },

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -66,6 +66,7 @@ class PlayerZoneWidget extends StatefulWidget {
   final PlayerModel player;
   final ValueChanged<int>? onStackChanged;
   final ValueChanged<int>? onBetChanged;
+  final ValueChanged<String>? onRevealRequest;
   // Stack editing is handled by PlayerInfoWidget
 
   /// Returns the offset of a seat around an elliptical poker table. This is
@@ -105,6 +106,7 @@ class PlayerZoneWidget extends StatefulWidget {
     this.editMode = false,
     this.onStackChanged,
     this.onBetChanged,
+    this.onRevealRequest,
   }) : super(key: key);
 
   @override
@@ -1335,6 +1337,31 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                   color: Colors.white,
                   fontSize: 10 * widget.scale,
                   fontWeight: FontWeight.bold,
+                ),
+              ),
+          ),
+        ),
+        if (!widget.isHero && !widget.isFolded && widget.onRevealRequest != null)
+          Positioned(
+            top: -8 * widget.scale,
+            left: 0,
+            right: 0,
+            child: AnimatedOpacity(
+              opacity: isMobile || _hoverAction ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.black54,
+                  borderRadius: BorderRadius.circular(8 * widget.scale),
+                ),
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  iconSize: 14 * widget.scale,
+                  splashRadius: 16 * widget.scale,
+                  icon: const Icon(Icons.remove_red_eye, color: Colors.white),
+                  onPressed: () =>
+                      widget.onRevealRequest?.call(widget.playerName),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- add `onRevealRequest` callback to PlayerZoneWidget
- show eye icon to trigger reveal for opponents
- log reveal request in demo screen

## Testing
- `git diff --color --unified=3 lib/widgets/player_zone_widget.dart`
- `git diff --color --unified=3 lib/screens/player_zone_demo_screen.dart`


------
https://chatgpt.com/codex/tasks/task_e_6858484f46b4832aa2b222252a9445a3