### PR TITLE
Fix reveal icon overlay logic

### DIFF
--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -1341,7 +1341,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
               ),
           ),
         ),
-        if (!widget.isHero && !widget.isFolded && widget.onRevealRequest != null)
+        if (!widget.isHero && !widget.isFolded && widget.onRevealRequest != null && widget.cards.length == 2)
           Positioned(
             top: -8 * widget.scale,
             left: 0,


### PR DESCRIPTION
## Summary
- show the opponent eye overlay only when they have two cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68584a7c6afc832a8af8ae282f4f4bc5