### PR TITLE
Add showdown result badge

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1267,8 +1267,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         setPlayerLastActionOutcome(name, ActionOutcome.neutral);
       } else if (winnerSet.contains(i)) {
         setPlayerLastActionOutcome(name, ActionOutcome.win);
+        setPlayerShowdownStatus(name, 'W');
       } else {
         setPlayerLastActionOutcome(name, ActionOutcome.lose);
+        setPlayerShowdownStatus(name, 'L');
       }
     }
   }

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -158,6 +158,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
   bool _showCards = true;
   bool _hoverAction = false;
   String? _showdownLabel;
+  Timer? _showdownLabelTimer;
   late final AnimationController _showdownLabelController;
   late final Animation<double> _showdownLabelOpacity;
   late final AnimationController _revealController;
@@ -485,11 +486,21 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
 
   void showShowdownLabel(String text) {
     if (widget.isHero) return;
+    _showdownLabelTimer?.cancel();
     setState(() => _showdownLabel = text);
     _showdownLabelController.forward(from: 0.0);
+    _showdownLabelTimer = Timer(const Duration(seconds: 2), () {
+      if (!mounted) return;
+      _showdownLabelController.reverse().whenComplete(() {
+        if (mounted) {
+          setState(() => _showdownLabel = null);
+        }
+      });
+    });
   }
 
   void clearShowdownLabel() {
+    _showdownLabelTimer?.cancel();
     if (_showdownLabel != null) {
       setState(() => _showdownLabel = null);
       _showdownLabelController.reset();
@@ -902,6 +913,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     _lastActionTimer?.cancel();
     _actionGlowTimer?.cancel();
     _stackBetTimer?.cancel();
+    _showdownLabelTimer?.cancel();
     _betEntry?.remove();
     _betOverlayEntry?.remove();
     _actionLabelEntry?.remove();


### PR DESCRIPTION
## Summary
- show temporary showdown label in `PlayerZoneWidget`
- mark showdown winners or losers in `PokerAnalyzerScreen`

## Testing
- `dart` not installed so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_685859928e84832a96d299451c096f55