### PR TITLE
Extract PlayerPositionLabel widget

### DIFF
--- a/lib/widgets/player_position_label.dart
+++ b/lib/widgets/player_position_label.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Returns a color associated with a poker table position.
+Color getPositionColor(String? position) {
+  switch (position) {
+    case 'BTN':
+      return Colors.amber;
+    case 'SB':
+    case 'BB':
+      return Colors.blueAccent;
+    default:
+      return Colors.white70;
+  }
+}
+
+/// Displays the player's table position like BTN or UTG.
+class PlayerPositionLabel extends StatelessWidget {
+  final String? position;
+  final double scale;
+  final bool isDark;
+
+  const PlayerPositionLabel({
+    Key? key,
+    required this.position,
+    this.scale = 1.0,
+    this.isDark = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (position == null) return const SizedBox.shrink();
+    return Text(
+      position!,
+      style: TextStyle(
+        color: getPositionColor(position),
+        fontSize: 12 * scale,
+        fontWeight: FontWeight.bold,
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -30,6 +30,7 @@ import 'gain_amount_widget.dart';
 import 'stack_delta_label.dart';
 import '../services/pot_sync_service.dart';
 import 'player_effective_stack_label.dart';
+import 'player_position_label.dart';
 
 final Map<String, _PlayerZoneWidgetState> playerZoneRegistry = {};
 
@@ -1023,11 +1024,6 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
       fontWeight: FontWeight.bold,
       fontSize: 14 * widget.scale,
     );
-    final captionStyle = TextStyle(
-      color: _getPositionColor(widget.position),
-      fontSize: 12 * widget.scale,
-      fontWeight: FontWeight.bold,
-    );
     final stackStyle = TextStyle(
       color: Colors.white70,
       fontSize: 10 * widget.scale,
@@ -1120,10 +1116,10 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
             if (widget.position != null)
               Padding(
                 padding: EdgeInsets.only(top: 2.0 * widget.scale),
-                child: Text(
-                  widget.position!,
-                  style: captionStyle,
-                  textAlign: TextAlign.center,
+                child: PlayerPositionLabel(
+                  position: widget.position,
+                  scale: widget.scale,
+                  isDark: isDark,
                 ),
               ),
             if (stack != null)
@@ -1776,18 +1772,6 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
         child: result,
       ),
     );
-  }
-
-  Color _getPositionColor(String? position) {
-    switch (position) {
-      case 'BTN':
-        return Colors.amber;
-      case 'SB':
-      case 'BB':
-        return Colors.blueAccent;
-      default:
-        return Colors.white70;
-    }
   }
 
   bool _isLeftSide(String? position) {


### PR DESCRIPTION
## Summary
- create `PlayerPositionLabel` widget
- display PlayerPositionLabel in PlayerZoneWidget
- remove old color helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685877f941f8832aabb9f88844683d7c