### PR TITLE
Implement busted player fade animation

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1187,6 +1187,12 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _tableCleanupPlayed = true;
     await _clearTableState();
     if (!mounted) return;
+    Future.delayed(const Duration(milliseconds: 1500), () {
+      if (!mounted) return;
+      for (final i in _bustedPlayers) {
+        fadeOutBustedPlayerZone(players[i].name);
+      }
+    });
     if (widget.demoMode) {
       showConfettiOverlay(context);
     }


### PR DESCRIPTION
## Summary
- fade the entire player zone when stack drops to zero
- expose utility `fadeOutBustedPlayerZone`
- trigger busted fade after hand reset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685889bc6dcc832a9cc8b2764c7b46a3