### PR TITLE
Add busted player zone animation timing

### DIFF
--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -384,7 +384,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
 
     _bustedController = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 300),
+      duration: const Duration(milliseconds: 800),
     );
     _bustedOpacity =
         CurvedAnimation(parent: _bustedController, curve: Curves.easeIn);


### PR DESCRIPTION
## Summary
- tweak bust animation controller to use 800ms duration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68588c112fec832a9d530deed5ac985d