### PR TITLE
Add stack bar growth animation

### DIFF
--- a/lib/widgets/stack_bar_widget.dart
+++ b/lib/widgets/stack_bar_widget.dart
@@ -11,11 +11,20 @@ class StackBarWidget extends StatelessWidget {
   /// Scale factor for sizing.
   final double scale;
 
+  /// Animation controlling the progress value of the bar. When provided, the
+  /// [stack] value is used only for color determination.
+  final Animation<double>? progressAnimation;
+
+  /// Optional glow or pulse animation applied while the bar is animating.
+  final Animation<double>? glowAnimation;
+
   const StackBarWidget({
     Key? key,
     required this.stack,
     this.maxStack = 100,
     this.scale = 1.0,
+    this.progressAnimation,
+    this.glowAnimation,
   }) : super(key: key);
 
   Color _barColor(int stack) {
@@ -32,19 +41,36 @@ class StackBarWidget extends StatelessWidget {
     if (stack == null) return SizedBox(height: 4 * scale);
     final double progress = (stack! / maxStack).clamp(0.0, 1.0);
     final color = _barColor(stack!);
+
+    final progressAnim = progressAnimation ?? AlwaysStoppedAnimation<double>(progress);
+    final glowAnim = glowAnimation ?? const AlwaysStoppedAnimation<double>(0.0);
+
     return SizedBox(
       height: 4 * scale,
-      child: TweenAnimationBuilder<double>(
-        tween: Tween<double>(begin: 0, end: progress),
-        duration: const Duration(milliseconds: 300),
-        builder: (context, value, child) {
-          return ClipRRect(
-            borderRadius: BorderRadius.circular(2 * scale),
-            child: LinearProgressIndicator(
-              value: value,
-              backgroundColor: Colors.black26,
-              valueColor: AlwaysStoppedAnimation<Color>(color),
-              minHeight: 4 * scale,
+      child: AnimatedBuilder(
+        animation: Listenable.merge([progressAnim, glowAnim]),
+        builder: (context, child) {
+          final glow = glowAnim.value;
+          return Container(
+            decoration: glow > 0
+                ? BoxDecoration(
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.orangeAccent.withOpacity(glow),
+                        blurRadius: 8 * glow * scale,
+                        spreadRadius: 2 * glow * scale,
+                      ),
+                    ],
+                  )
+                : null,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2 * scale),
+              child: LinearProgressIndicator(
+                value: progressAnim.value,
+                backgroundColor: Colors.black26,
+                valueColor: AlwaysStoppedAnimation<Color>(color),
+                minHeight: 4 * scale,
+              ),
             ),
           );
         },


### PR DESCRIPTION
## Summary
- animate stack bar width with new AnimationController
- expose optional progress and glow animations for `StackBarWidget`
- trigger stack bar animation when increasing stack

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858901b7e64832aba714e15cee897e3