### PR TITLE
Display stack sizes in spot preview

### DIFF
--- a/lib/widgets/training_spot_preview.dart
+++ b/lib/widgets/training_spot_preview.dart
@@ -31,6 +31,12 @@ class TrainingSpotPreview extends StatelessWidget {
       label += ' ${entry.amount}';
     }
 
+    if (entry.playerIndex < spot.stacks.length) {
+      final stack = spot.stacks[entry.playerIndex];
+      final bb = (stack / 12.5).round();
+      label += ' $stack (${bb} BB)';
+    }
+
     String? advice;
     if (spot.strategyAdvice != null &&
         entry.playerIndex < spot.strategyAdvice!.length) {


### PR DESCRIPTION
## Summary
- show chip stack size for each action in TrainingSpotPreview

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68592389991c832ab734b57c3abf83a4