### PR TITLE
Add equity display to TrainingSpotPreview

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -25,6 +25,7 @@ class TrainingGenerator {
         for (int i = 0; i < hand.numberOfPlayers; i++)
           hand.stackSizes[i] ?? 0,
       ],
+      equities: null,
       tournamentId: hand.tournamentId,
       buyIn: hand.buyIn,
       totalPrizePool: hand.totalPrizePool,

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -14,6 +14,8 @@ class TrainingSpot {
   final List<int> stacks;
   /// Optional strategy advice for each player indexed by player position.
   final List<String>? strategyAdvice;
+  /// Optional equity values for each player as percentages.
+  final List<double>? equities;
   final String? tournamentId;
   final int? buyIn;
   final int? totalPrizePool;
@@ -38,6 +40,7 @@ class TrainingSpot {
     required this.positions,
     required this.stacks,
     this.strategyAdvice,
+    this.equities,
     this.tournamentId,
     this.buyIn,
     this.totalPrizePool,
@@ -75,6 +78,7 @@ class TrainingSpot {
         for (int i = 0; i < hand.numberOfPlayers; i++)
           hand.stackSizes[i] ?? 0
       ],
+      equities: null,
       tournamentId: hand.tournamentId,
       buyIn: hand.buyIn,
       totalPrizePool: hand.totalPrizePool,
@@ -114,6 +118,7 @@ class TrainingSpot {
         'playerTypes': [for (final t in playerTypes) t.name],
         'positions': positions,
         'stacks': stacks,
+        if (equities != null) 'equities': equities,
         if (tournamentId != null) 'tournamentId': tournamentId,
         if (buyIn != null) 'buyIn': buyIn,
         if (totalPrizePool != null) 'totalPrizePool': totalPrizePool,
@@ -193,6 +198,11 @@ class TrainingSpot {
     }
 
     final adviceData = (json['strategyAdvice'] as List?)?.cast<String>();
+    final equityData = (json['equities'] as List?)?.cast<num>();
+    List<double>? equities;
+    if (equityData != null) {
+      equities = [for (final e in equityData) e.toDouble()];
+    }
 
     return TrainingSpot(
       playerCards: pc,
@@ -204,6 +214,7 @@ class TrainingSpot {
       positions: positions,
       stacks: stacks,
       strategyAdvice: adviceData,
+      equities: equities,
       tournamentId: json['tournamentId'] as String?,
       buyIn: (json['buyIn'] as num?)?.toInt(),
       totalPrizePool: (json['totalPrizePool'] as num?)?.toInt(),
@@ -230,6 +241,7 @@ class TrainingSpot {
     String? actionHistory,
     String? recommendedAction,
     List<String>? strategyAdvice,
+    List<double>? equities,
     DateTime? createdAt,
   }) {
     return TrainingSpot(
@@ -242,6 +254,7 @@ class TrainingSpot {
       positions: List<String>.from(positions),
       stacks: List<int>.from(stacks),
       strategyAdvice: strategyAdvice ?? this.strategyAdvice,
+      equities: equities ?? this.equities,
       tournamentId: tournamentId,
       buyIn: buyIn,
       totalPrizePool: totalPrizePool,

--- a/lib/services/training_import_export_service.dart
+++ b/lib/services/training_import_export_service.dart
@@ -58,6 +58,7 @@ class TrainingImportExportService {
         for (int i = 0; i < playerManager.numberOfPlayers; i++)
           stackManager.getStackForPlayer(i)
       ],
+      equities: null,
       tournamentId: tournamentId,
       buyIn: buyIn,
       totalPrizePool: totalPrizePool,
@@ -283,6 +284,7 @@ class TrainingImportExportService {
             playerTypes: const [],
             positions: const [],
             stacks: const [],
+            equities: null,
             tournamentId: strOrNull(map['tournamentId']),
             buyIn: intOrNull(map['buyIn']),
             totalPrizePool: intOrNull(map['totalPrizePool']),
@@ -330,6 +332,7 @@ class TrainingImportExportService {
         playerTypes: const [],
         positions: const [],
         stacks: const [],
+        equities: null,
         tournamentId: strOrNull(map['tournamentId']),
         buyIn: intOrNull(map['buyIn']),
         totalPrizePool: intOrNull(map['totalPrizePool']),

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -892,6 +892,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                         playerTypes: spot.playerTypes,
                         positions: spot.positions,
                         stacks: spot.stacks,
+                        equities: spot.equities,
                         tournamentId: idController.text.trim().isEmpty
                             ? null
                             : idController.text.trim(),
@@ -988,6 +989,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                     playerTypes: spot.playerTypes,
                     positions: spot.positions,
                     stacks: spot.stacks,
+                    equities: spot.equities,
                     tournamentId: titleController.text.trim().isEmpty
                         ? null
                         : titleController.text.trim(),

--- a/lib/widgets/training_spot_preview.dart
+++ b/lib/widgets/training_spot_preview.dart
@@ -45,10 +45,24 @@ class TrainingSpotPreview extends StatelessWidget {
 
     final adviceColor = advice != null ? _colorForAdvice(advice) : null;
 
+    double? equity;
+    if (spot.equities != null && entry.playerIndex < spot.equities!.length) {
+      equity = spot.equities![entry.playerIndex].toDouble();
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('P${entry.playerIndex + 1}: $label'),
+        Row(
+          children: [
+            Text('P${entry.playerIndex + 1}: $label'),
+            if (equity != null)
+              Text(
+                ' – ${equity.round()}%',
+                style: const TextStyle(color: Colors.grey, fontSize: 12),
+              ),
+          ],
+        ),
         if (advice != null && adviceColor != null)
           Padding(
             padding: const EdgeInsets.only(top: 2),


### PR DESCRIPTION
## Summary
- extend `TrainingSpot` with optional `equities` list
- support `equities` in generator and import/export utilities
- propagate `equities` through UI constructors
- show player equity percentages in `TrainingSpotPreview`

## Testing
- `No tests run due to developer instructions`

------
https://chatgpt.com/codex/tasks/task_e_685926d3f70c832aafa7dc22d28a8d69