### PR TITLE
Update stack display with BB in review

### DIFF
--- a/lib/screens/training_review_screen.dart
+++ b/lib/screens/training_review_screen.dart
@@ -80,6 +80,22 @@ class TrainingReviewScreen extends StatelessWidget {
               ...tournamentRows,
               const SizedBox(height: 8),
             ],
+            if (spot.stacks.isNotEmpty) ...[
+              const Text(
+                'Stacks',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              for (final stack in spot.stacks)
+                Text(
+                  'Stack: $stack (${(stack / 12.5).round()} BB)',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              const SizedBox(height: 8),
+            ],
             TrainingSpotPreview(spot: spot),
           ],
         ),


### PR DESCRIPTION
## Summary
- add stacks section in TrainingReviewScreen that shows BB-equivalent values

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685928b25970832a9b460b5b28095ea9