### PR TITLE
Add hero range grid overlay

### DIFF
--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -16,6 +16,8 @@ class TrainingSpot {
   final List<String>? strategyAdvice;
   /// Optional equity values for each player as percentages.
   final List<double>? equities;
+  /// Optional hero range matrix [13x13] with frequencies 0.0-1.0.
+  final List<List<double>>? rangeMatrix;
   final String? tournamentId;
   final int? buyIn;
   final int? totalPrizePool;
@@ -41,6 +43,7 @@ class TrainingSpot {
     required this.stacks,
     this.strategyAdvice,
     this.equities,
+    this.rangeMatrix,
     this.tournamentId,
     this.buyIn,
     this.totalPrizePool,
@@ -78,6 +81,7 @@ class TrainingSpot {
         for (int i = 0; i < hand.numberOfPlayers; i++)
           hand.stackSizes[i] ?? 0
       ],
+      rangeMatrix: null,
       equities: null,
       tournamentId: hand.tournamentId,
       buyIn: hand.buyIn,
@@ -119,6 +123,7 @@ class TrainingSpot {
         'positions': positions,
         'stacks': stacks,
         if (equities != null) 'equities': equities,
+        if (rangeMatrix != null) 'rangeMatrix': rangeMatrix,
         if (tournamentId != null) 'tournamentId': tournamentId,
         if (buyIn != null) 'buyIn': buyIn,
         if (totalPrizePool != null) 'totalPrizePool': totalPrizePool,
@@ -199,9 +204,22 @@ class TrainingSpot {
 
     final adviceData = (json['strategyAdvice'] as List?)?.cast<String>();
     final equityData = (json['equities'] as List?)?.cast<num>();
+    final rangeData = json['rangeMatrix'] as List?;
     List<double>? equities;
     if (equityData != null) {
       equities = [for (final e in equityData) e.toDouble()];
+    }
+    List<List<double>>? rangeMatrix;
+    if (rangeData != null) {
+      rangeMatrix = [];
+      for (final row in rangeData) {
+        if (row is List) {
+          rangeMatrix.add([
+            for (final v in row)
+              (v as num?)?.toDouble() ?? 0.0
+          ]);
+        }
+      }
     }
 
     return TrainingSpot(
@@ -215,6 +233,7 @@ class TrainingSpot {
       stacks: stacks,
       strategyAdvice: adviceData,
       equities: equities,
+      rangeMatrix: rangeMatrix,
       tournamentId: json['tournamentId'] as String?,
       buyIn: (json['buyIn'] as num?)?.toInt(),
       totalPrizePool: (json['totalPrizePool'] as num?)?.toInt(),
@@ -242,6 +261,7 @@ class TrainingSpot {
     String? recommendedAction,
     List<String>? strategyAdvice,
     List<double>? equities,
+    List<List<double>>? rangeMatrix,
     DateTime? createdAt,
   }) {
     return TrainingSpot(
@@ -255,6 +275,7 @@ class TrainingSpot {
       stacks: List<int>.from(stacks),
       strategyAdvice: strategyAdvice ?? this.strategyAdvice,
       equities: equities ?? this.equities,
+      rangeMatrix: rangeMatrix ?? this.rangeMatrix,
       tournamentId: tournamentId,
       buyIn: buyIn,
       totalPrizePool: totalPrizePool,

--- a/lib/widgets/hero_range_grid_widget.dart
+++ b/lib/widgets/hero_range_grid_widget.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+/// Displays the hero's strategy range in a 13x13 hand grid.
+class HeroRangeGridWidget extends StatelessWidget {
+  final List<List<double>> rangeMatrix;
+
+  const HeroRangeGridWidget({super.key, required this.rangeMatrix});
+
+  static const _ranks = [
+    'A',
+    'K',
+    'Q',
+    'J',
+    'T',
+    '9',
+    '8',
+    '7',
+    '6',
+    '5',
+    '4',
+    '3',
+    '2'
+  ];
+
+  String _label(int row, int col) {
+    final r1 = _ranks[row];
+    final r2 = _ranks[col];
+    if (row == col) return '$r1$r2';
+    if (row < col) return '${r1}${r2}s';
+    return '${r2}${r1}o';
+  }
+
+  Color _cellColor(double freq) {
+    final clamped = freq.clamp(0.0, 1.0) as double;
+    return Color.lerp(Colors.transparent, Colors.orangeAccent, clamped) ??
+        Colors.orangeAccent.withOpacity(clamped);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int row = 0; row < 13; row++)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (int col = 0; col < 13; col++)
+                Container(
+                  width: 24,
+                  height: 24,
+                  margin: const EdgeInsets.all(1),
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: _cellColor(rangeMatrix[row][col]),
+                    border: Border.all(color: Colors.white24, width: 0.5),
+                  ),
+                  child: Text(
+                    _label(row, col),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 9,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/training_spot_diagram.dart
+++ b/lib/widgets/training_spot_diagram.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../helpers/table_geometry_helper.dart';
 import '../models/training_spot.dart';
 import 'player_info_overlay.dart';
+import 'hero_range_grid_widget.dart';
 
 /// Displays players around a circular table with a highlight for the hero.
 ///
@@ -79,22 +80,39 @@ class TrainingSpotDiagram extends StatelessWidget {
                 left: offset.dx - seatSize / 2,
                 top: offset.dy - seatSize / 2,
                 child: GestureDetector(
-                  onTapDown: isHero
-                      ? null
-                      : (details) {
-                          final pos =
-                              details.globalPosition + const Offset(0, -30);
-                          final positionName = i < spot.positions.length
-                              ? spot.positions[i]
-                              : '';
-                          showPlayerInfoOverlay(
-                            context: context,
-                            position: pos,
-                            stack: stack,
-                            positionName: positionName,
-                            advice: advice,
-                          );
-                        },
+                  onTapDown: (details) {
+                    if (isHero) {
+                      if (spot.rangeMatrix != null) {
+                        showModalBottomSheet(
+                          context: context,
+                          backgroundColor: Colors.grey[900],
+                          shape: const RoundedRectangleBorder(
+                            borderRadius: BorderRadius.vertical(
+                                top: Radius.circular(16)),
+                          ),
+                          builder: (_) => Padding(
+                            padding: const EdgeInsets.all(16.0),
+                            child: HeroRangeGridWidget(
+                              rangeMatrix: spot.rangeMatrix!,
+                            ),
+                          ),
+                        );
+                      }
+                    } else {
+                      final pos =
+                          details.globalPosition + const Offset(0, -30);
+                      final positionName = i < spot.positions.length
+                          ? spot.positions[i]
+                          : '';
+                      showPlayerInfoOverlay(
+                        context: context,
+                        position: pos,
+                        stack: stack,
+                        positionName: positionName,
+                        advice: advice,
+                      );
+                    }
+                  },
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
## Summary
- show hero range matrix if seat tapped
- display strategy range with new `HeroRangeGridWidget`
- support optional `rangeMatrix` on `TrainingSpot`

## Testing
- `dart` not installed; formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_685967b78d0c832a8b37a808186af13e