### PR TITLE
Add gradient coloring for hero range grid

### DIFF
--- a/lib/widgets/hero_range_grid_widget.dart
+++ b/lib/widgets/hero_range_grid_widget.dart
@@ -30,10 +30,20 @@ class HeroRangeGridWidget extends StatelessWidget {
     return '${r2}${r1}o';
   }
 
-  Color _cellColor(double freq) {
+  Color _rangeGradient(double freq) {
     final clamped = freq.clamp(0.0, 1.0) as double;
-    return Color.lerp(Colors.transparent, Colors.orangeAccent, clamped) ??
-        Colors.orangeAccent.withOpacity(clamped);
+    if (clamped <= 0.5) {
+      final t = clamped * 2;
+      return Color.lerp(Colors.transparent, Colors.red.shade900, t) ??
+          Colors.red.shade900.withOpacity(t);
+    }
+    final t = (clamped - 0.5) * 2;
+    return Color.lerp(Colors.red.shade900, Colors.orangeAccent, t) ??
+        Colors.orangeAccent.withOpacity(t);
+  }
+
+  Color _cellColor(double freq) {
+    return _rangeGradient(freq);
   }
 
   @override


### PR DESCRIPTION
## Summary
- use `_rangeGradient` to render GTO range cell colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685968e2d590832aa1fbeb24b371e231