### PR TITLE
Show opponent equity

### DIFF
--- a/lib/widgets/training_spot_diagram.dart
+++ b/lib/widgets/training_spot_diagram.dart
@@ -153,6 +153,12 @@ class TrainingSpotDiagram extends StatelessWidget {
                             '$stack',
                             style: const TextStyle(color: Colors.white70, fontSize: 11),
                           ),
+                          if (!isHero && spot.equities != null &&
+                              i < spot.equities!.length)
+                            Text(
+                              'EQ: ${spot.equities![i].round()}%',
+                              style: const TextStyle(color: Colors.grey, fontSize: 10),
+                            ),
                           if (action.isNotEmpty)
                             Text(
                               action,


### PR DESCRIPTION
## Summary
- show player equities in TrainingSpotDiagram when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685969513520832aa6f55a33d1a96509