### PR TITLE
Enable hand replay from review screen

### DIFF
--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
+import '../models/training_spot.dart';
+import '../widgets/replay_spot_widget.dart';
 import '../theme/app_colors.dart';
 
 /// Displays all spots from [pack] with option to show only mistaken ones.
@@ -51,6 +53,18 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
               ),
           ],
         ),
+        onTap: () {
+          showModalBottomSheet(
+            context: context,
+            backgroundColor: Colors.grey[900],
+            isScrollControlled: true,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+            ),
+            builder: (_) =>
+                ReplaySpotWidget(spot: TrainingSpot.fromSavedHand(hand)),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- show `ReplaySpotWidget` from `TrainingPackReviewScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68597ca22f3c832aaf7e8b08b30a857b