### PR TITLE
Enable rating/tag edit in pack review

### DIFF
--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import '../models/training_spot.dart';
 import '../widgets/replay_spot_widget.dart';
 import '../theme/app_colors.dart';
+import '../services/tag_service.dart';
+import '../services/training_pack_storage_service.dart';
 
 /// Displays all spots from [pack] with option to show only mistaken ones.
 class TrainingPackReviewScreen extends StatefulWidget {
@@ -30,6 +33,88 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
       for (final h in widget.pack.hands)
         if (widget.mistakenNames.contains(h.name)) h
     ];
+  }
+
+  Future<void> _savePack() async {
+    final service = context.read<TrainingPackStorageService>();
+    await service.removePack(widget.pack);
+    await service.addPack(widget.pack);
+  }
+
+  Future<void> _editHand(SavedHand hand) async {
+    int rating = hand.rating;
+    final Set<String> tags = {...hand.tags};
+    final allTags = context.read<TagService>().tags;
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setStateDialog) {
+          return AlertDialog(
+            title: Text(hand.name),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      for (int i = 1; i <= 5; i++)
+                        IconButton(
+                          icon: Icon(
+                            i <= rating ? Icons.star : Icons.star_border,
+                            color: Colors.amber,
+                          ),
+                          onPressed: () => setStateDialog(() => rating = i),
+                        ),
+                    ],
+                  ),
+                  Wrap(
+                    spacing: 4,
+                    children: [
+                      for (final tag in allTags)
+                        FilterChip(
+                          label: Text(tag),
+                          selected: tags.contains(tag),
+                          onSelected: (selected) => setStateDialog(() {
+                            if (selected) {
+                              tags.add(tag);
+                            } else {
+                              tags.remove(tag);
+                            }
+                          }),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () {
+                  final updated = hand.copyWith(
+                    rating: rating,
+                    tags: tags.toList(),
+                  );
+                  final index = widget.pack.hands.indexOf(hand);
+                  if (index != -1) {
+                    widget.pack.hands[index] = updated;
+                  }
+                  _savePack();
+                  Navigator.pop(context);
+                  setState(() {});
+                },
+                child: const Text('OK'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
   }
 
   Widget _buildHandTile(SavedHand hand) {
@@ -65,6 +150,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
                 ReplaySpotWidget(spot: TrainingSpot.fromSavedHand(hand)),
           );
         },
+        onLongPress: () => _editHand(hand),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow adjusting rating and tags directly from `TrainingPackReviewScreen`
- open dialog on hand long‑press with star picker and tag chips
- persist modifications via `TrainingPackStorageService`

## Testing
- `dart format lib/screens/training_pack_review_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597d3c5574832ab392d771a1c7409c