### PR TITLE
Add CloudSyncService stub

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'services/folded_players_service.dart';
 import 'services/all_in_players_service.dart';
 import 'services/user_preferences_service.dart';
 import 'services/tag_service.dart';
+import 'services/cloud_sync_service.dart';
 import 'user_preferences.dart';
 
 void main() {
@@ -45,6 +46,7 @@ void main() {
         ChangeNotifierProvider(
           create: (_) => TagService()..load(),
         ),
+        Provider(create: (_) => CloudSyncService()),
       ],
       child: const PokerAIAnalyzerApp(),
     ),

--- a/lib/services/cloud_sync_service.dart
+++ b/lib/services/cloud_sync_service.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import '../models/training_spot.dart';
+import '../models/saved_hand.dart';
+
+/// Temporary stub for syncing data with the cloud.
+///
+/// In the future this will use Firebase for storage. Currently it writes
+/// and reads JSON files in the application documents directory to emulate
+/// remote uploads and downloads.
+class CloudSyncService {
+  static const String _spotsFile = 'cloud_spots.json';
+  static const String _handsFile = 'cloud_hands.json';
+
+  Future<File> _file(String name) async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$name');
+  }
+
+  /// Upload a single [TrainingSpot].
+  Future<void> uploadSpot(TrainingSpot spot) async {
+    final file = await _file(_spotsFile);
+    List<dynamic> data = [];
+    if (await file.exists()) {
+      try {
+        final content = await file.readAsString();
+        final decoded = jsonDecode(content);
+        if (decoded is List) data = decoded;
+      } catch (_) {}
+    }
+    data.add(spot.toJson());
+    await file.writeAsString(jsonEncode(data), flush: true);
+  }
+
+  /// Download all uploaded [TrainingSpot]s.
+  Future<List<TrainingSpot>> downloadSpots() async {
+    final file = await _file(_spotsFile);
+    if (!await file.exists()) return [];
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is List) {
+        return [
+          for (final item in data)
+            if (item is Map)
+              TrainingSpot.fromJson(Map<String, dynamic>.from(item))
+        ];
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Upload a single [SavedHand].
+  Future<void> uploadHand(SavedHand hand) async {
+    final file = await _file(_handsFile);
+    List<dynamic> data = [];
+    if (await file.exists()) {
+      try {
+        final content = await file.readAsString();
+        final decoded = jsonDecode(content);
+        if (decoded is List) data = decoded;
+      } catch (_) {}
+    }
+    data.add(hand.toJson());
+    await file.writeAsString(jsonEncode(data), flush: true);
+  }
+
+  /// Download all uploaded [SavedHand]s.
+  Future<List<SavedHand>> downloadHands() async {
+    final file = await _file(_handsFile);
+    if (!await file.exists()) return [];
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is List) {
+        return [
+          for (final item in data)
+            if (item is Map)
+              SavedHand.fromJson(Map<String, dynamic>.from(item))
+        ];
+      }
+    } catch (_) {}
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add `CloudSyncService` for uploading/downloading TrainingSpot and SavedHand data
- register CloudSyncService in `main.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685995f64458832a8383b105e88da8a2