### PR TITLE
Add automatic cloud synchronization

### DIFF
--- a/lib/screens/cloud_sync_screen.dart
+++ b/lib/screens/cloud_sync_screen.dart
@@ -15,14 +15,16 @@ class CloudSyncScreen extends StatefulWidget {
 }
 
 class _CloudSyncScreenState extends State<CloudSyncScreen> {
-  final TrainingSpotStorageService _spotStorage =
-      const TrainingSpotStorageService();
+  late TrainingSpotStorageService _spotStorage;
   int _cloudSpotCount = 0;
   int _cloudHandCount = 0;
 
   @override
   void initState() {
     super.initState();
+    _spotStorage = TrainingSpotStorageService(
+      cloud: context.read<CloudSyncService>(),
+    );
     _loadCounts();
   }
 

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -37,6 +37,7 @@ import '../services/saved_hand_import_export_service.dart';
 import '../services/training_import_export_service.dart';
 import '../services/training_spot_file_service.dart';
 import '../services/training_spot_storage_service.dart';
+import '../services/cloud_sync_service.dart';
 import '../models/training_spot.dart';
 import '../widgets/replay_spot_widget.dart';
 import '../widgets/common/training_spot_list.dart';
@@ -94,13 +95,15 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
       const TrainingImportExportService();
   final TrainingSpotFileService _spotFileService =
       const TrainingSpotFileService();
-  final TrainingSpotStorageService _spotStorageService =
-      const TrainingSpotStorageService();
+  late TrainingSpotStorageService _spotStorageService;
   List<TrainingSpot> _spots = [];
 
   @override
   void initState() {
     super.initState();
+    _spotStorageService = TrainingSpotStorageService(
+      cloud: context.read<CloudSyncService>(),
+    );
     _pack = widget.pack;
     _sessionHands = widget.hands ?? _pack.hands;
     _isMistakeReviewMode = widget.mistakeReviewMode;

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -3,12 +3,17 @@ import 'package:flutter/material.dart';
 
 import '../models/saved_hand.dart';
 import 'saved_hand_storage_service.dart';
+import 'cloud_sync_service.dart';
 
 class SavedHandManagerService extends ChangeNotifier {
-  SavedHandManagerService({required SavedHandStorageService storage})
-      : _storage = storage;
+  SavedHandManagerService({
+    required SavedHandStorageService storage,
+    CloudSyncService? cloud,
+  })  : _storage = storage,
+        _cloud = cloud;
 
   final SavedHandStorageService _storage;
+  final CloudSyncService? _cloud;
 
   List<SavedHand> get hands => _storage.hands;
 
@@ -18,6 +23,7 @@ class SavedHandManagerService extends ChangeNotifier {
 
   Future<void> add(SavedHand hand) async {
     await _storage.add(hand);
+    await _cloud?.uploadHand(hand);
   }
 
   Future<void> update(int index, SavedHand hand) async {

--- a/lib/services/training_spot_storage_service.dart
+++ b/lib/services/training_spot_storage_service.dart
@@ -4,11 +4,14 @@ import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 
 import '../models/training_spot.dart';
+import 'cloud_sync_service.dart';
 
 class TrainingSpotStorageService {
   static const String _fileName = 'training_spots.json';
 
-  const TrainingSpotStorageService();
+  const TrainingSpotStorageService({this.cloud});
+
+  final CloudSyncService? cloud;
 
   Future<File> _getFile() async {
     final dir = await getApplicationDocumentsDirectory();
@@ -38,5 +41,10 @@ class TrainingSpotStorageService {
       jsonEncode([for (final s in spots) s.toJson()]),
       flush: true,
     );
+    if (cloud != null) {
+      for (final spot in spots) {
+        await cloud!.uploadSpot(spot);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add CloudSyncService to SavedHandManagerService and TrainingSpotStorageService
- automatically upload on save or add
- sync local data on startup via PokerAIAnalyzerApp
- make TrainingSpotStorageService and CloudSyncScreen cloud-aware

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68599a503394832a8f64970f6afa8576