### PR TITLE
Implement simple hint for EvaluationExecutorService

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -28,7 +28,7 @@ class EvaluationExecutorService {
     return EvaluationResult(
       correct: correct,
       expectedAction: expectedAction,
-      hint: correct ? null : null,
+      hint: correct ? null : 'Подумай о диапазоне оппонента',
     );
   }
 }


### PR DESCRIPTION
## Summary
- provide a basic hint in `evaluate` when the user action is incorrect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b8cb7080832a8b85a3a2a224008e