### PR TITLE
Display evaluation hints

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -236,6 +236,13 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                 style: const TextStyle(color: Colors.white),
               ),
             ],
+            if (evaluation.hint != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                evaluation.hint!,
+                style: const TextStyle(color: Colors.white),
+              ),
+            ],
             const SizedBox(height: 16),
             StatefulBuilder(builder: (context, setStateDialog) {
               return Column(


### PR DESCRIPTION
## Summary
- show `EvaluationResult.hint` in the post-action feedback modal when available

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6859b934ec34832a81d525bb6f4ba407