### PR TITLE
Enhance markdown export with hints

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -488,8 +488,15 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     if (mistakes.isNotEmpty) {
       buffer.writeln('## Mistakes');
       for (final m in mistakes) {
-        buffer.writeln(
-            '- ${m.name}: expected `${m.expected}`, got `${m.userAction}`');
+        final mark = m.correct ? '✔' : '✘';
+        final hint = m.evaluation.hint;
+        final line =
+            '- $mark ${m.name}: expected `${m.expected}`, got `${m.userAction}`';
+        if (hint != null && hint.isNotEmpty) {
+          buffer.writeln('$line. Hint: $hint');
+        } else {
+          buffer.writeln(line);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- show ✔/✘ marks and hints when exporting session mistakes to Markdown

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859bafe5180832aaf0f0d754ee17a79