### PR TITLE
Add MyTrainingHistoryScreen

### DIFF
--- a/lib/models/session_summary.dart
+++ b/lib/models/session_summary.dart
@@ -1,0 +1,23 @@
+class SessionSummary {
+  final DateTime date;
+  final int total;
+  final int correct;
+
+  SessionSummary({required this.date, required this.total, required this.correct});
+
+  double get accuracy => total == 0 ? 0 : correct * 100 / total;
+
+  factory SessionSummary.fromJson(Map<String, dynamic> json) {
+    return SessionSummary(
+      date: DateTime.parse(json['date'] as String),
+      total: json['total'] as int? ?? 0,
+      correct: json['correct'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'total': total,
+        'correct': correct,
+      };
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -5,6 +5,7 @@ import 'saved_hands_screen.dart';
 import 'training_packs_screen.dart';
 import 'all_sessions_screen.dart';
 import 'training_history_screen.dart';
+import 'my_training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
@@ -199,6 +200,17 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('📈 История тренировок'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const MyTrainingHistoryScreen()),
+                );
+              },
+              child: const Text('📒 Мои тренировки'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/screens/my_training_history_screen.dart
+++ b/lib/screens/my_training_history_screen.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/session_summary.dart';
+import '../models/training_pack.dart';
+import '../services/training_pack_storage_service.dart';
+import 'training_pack_screen.dart';
+
+class MyTrainingHistoryScreen extends StatefulWidget {
+  const MyTrainingHistoryScreen({super.key});
+
+  @override
+  State<MyTrainingHistoryScreen> createState() => _MyTrainingHistoryScreenState();
+}
+
+class _HistoryEntry {
+  final TrainingPack pack;
+  final SessionSummary summary;
+
+  _HistoryEntry(this.pack, this.summary);
+}
+
+class _MyTrainingHistoryScreenState extends State<MyTrainingHistoryScreen> {
+  final List<_HistoryEntry> _entries = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final packs = context.read<TrainingPackStorageService>().packs;
+    final List<_HistoryEntry> loaded = [];
+    for (final pack in packs) {
+      final key = 'results_${pack.name}';
+      final jsonStr = prefs.getString(key);
+      if (jsonStr == null) continue;
+      try {
+        final data = jsonDecode(jsonStr);
+        if (data is Map && data['history'] is List) {
+          final history = data['history'] as List;
+          for (final item in history.take(5)) {
+            if (item is Map) {
+              final summary =
+                  SessionSummary.fromJson(Map<String, dynamic>.from(item));
+              loaded.add(_HistoryEntry(pack, summary));
+            }
+          }
+        }
+      } catch (_) {}
+    }
+    loaded.sort((a, b) => b.summary.date.compareTo(a.summary.date));
+    setState(() {
+      _entries
+        ..clear()
+        ..addAll(loaded);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Мои тренировки'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: _entries.isEmpty
+          ? const Center(child: Text('История пуста'))
+          : ListView.separated(
+              itemCount: _entries.length,
+              separatorBuilder: (_, __) => const Divider(),
+              itemBuilder: (context, index) {
+                final entry = _entries[index];
+                final summary = entry.summary;
+                return ListTile(
+                  title: Text(
+                    entry.pack.name,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  subtitle: Text(
+                    '${formatDateTime(summary.date)} \u2022 ${summary.correct}/${summary.total} \u2022 ${summary.accuracy.toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                  trailing: ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => TrainingPackScreen(pack: entry.pack),
+                        ),
+                      );
+                    },
+                    child: const Text('Открыть'),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `SessionSummary` model for simple session stats
- add new screen `MyTrainingHistoryScreen` that shows recent sessions from SharedPreferences
- hook up new screen from main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859bdacfcbc832abdf94d1fa7269901