### PR TITLE
Implement session result cloud upload

### DIFF
--- a/lib/models/result_entry.dart
+++ b/lib/models/result_entry.dart
@@ -1,0 +1,29 @@
+import "evaluation_result.dart";
+class ResultEntry {
+  final String name;
+  final String userAction;
+  final EvaluationResult evaluation;
+
+  ResultEntry({
+    required this.name,
+    required this.userAction,
+    required this.evaluation,
+  });
+
+  bool get correct => evaluation.correct;
+
+  String get expected => evaluation.expectedAction;
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'userAction': userAction,
+        'evaluation': evaluation.toJson(),
+      };
+
+  factory ResultEntry.fromJson(Map<String, dynamic> json) => ResultEntry(
+        name: json['name'] as String? ?? '',
+        userAction: json['userAction'] as String? ?? '-',
+        evaluation:
+            EvaluationResult.fromJson(Map<String, dynamic>.from(json['evaluation'] as Map)),
+      );
+}


### PR DESCRIPTION
## Summary
- add `ResultEntry` model
- extend `CloudSyncService` to save session results
- convert training screen to use `ResultEntry` and upload after export

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c8a50894832aadc8886fb5975e61