### PR TITLE
Add cloud training history screen

### DIFF
--- a/lib/models/cloud_training_session.dart
+++ b/lib/models/cloud_training_session.dart
@@ -1,0 +1,13 @@
+import "result_entry.dart";
+
+class CloudTrainingSession {
+  final DateTime date;
+  final List<ResultEntry> results;
+
+  CloudTrainingSession({required this.date, required this.results});
+
+  int get total => results.length;
+  int get correct => results.where((r) => r.correct).length;
+  int get mistakes => total - correct;
+  double get accuracy => total == 0 ? 0 : correct * 100 / total;
+}

--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/cloud_training_session.dart';
+import '../services/cloud_sync_service.dart';
+import 'training_pack_screen.dart';
+
+class TrainingHistoryScreen extends StatefulWidget {
+  const TrainingHistoryScreen({super.key});
+
+  @override
+  State<TrainingHistoryScreen> createState() => _TrainingHistoryScreenState();
+}
+
+class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
+  List<CloudTrainingSession> _sessions = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final service = context.read<CloudSyncService>();
+    final sessions = await service.loadTrainingSessions();
+    setState(() {
+      _sessions = sessions;
+      _loading = false;
+    });
+  }
+
+  void _openSession(CloudTrainingSession session) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingAnalysisScreen(results: session.results),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История тренировок'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _sessions.isEmpty
+              ? const Center(
+                  child: Text('История пуста',
+                      style: TextStyle(color: Colors.white70)),
+                )
+              : ListView.separated(
+                  itemCount: _sessions.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final s = _sessions[index];
+                    return ListTile(
+                      title: Text(
+                        formatDateTime(s.date),
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                      subtitle: Text(
+                        '${s.accuracy.toStringAsFixed(1)}% • Ошибок: ${s.mistakes}',
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                      trailing: const Icon(Icons.chevron_right, color: Colors.white70),
+                      onTap: () => _openSession(s),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -4,7 +4,7 @@ import 'player_input_screen.dart';
 import 'saved_hands_screen.dart';
 import 'training_packs_screen.dart';
 import 'all_sessions_screen.dart';
-import 'training_history_screen.dart';
+import 'cloud_training_history_screen.dart';
 import 'my_training_history_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';


### PR DESCRIPTION
## Summary
- load cloud-based session history via `loadTrainingSessions`
- show the sessions in new `TrainingHistoryScreen`
- connect screen from main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ca7f35a8832aa52383977934eaaa