### PR TITLE
Add comments to cloud training sessions

### DIFF
--- a/lib/models/cloud_training_session.dart
+++ b/lib/models/cloud_training_session.dart
@@ -3,8 +3,36 @@ import "result_entry.dart";
 class CloudTrainingSession {
   final DateTime date;
   final List<ResultEntry> results;
+  final String? comment;
 
-  CloudTrainingSession({required this.date, required this.results});
+  CloudTrainingSession({
+    required this.date,
+    required this.results,
+    this.comment,
+  });
+
+  factory CloudTrainingSession.fromJson(Map<String, dynamic> json) {
+    final results = <ResultEntry>[];
+    final list = json['results'];
+    if (list is List) {
+      for (final item in list) {
+        if (item is Map<String, dynamic>) {
+          results.add(ResultEntry.fromJson(item));
+        }
+      }
+    }
+    return CloudTrainingSession(
+      date: DateTime.parse(json['date'] as String),
+      results: results,
+      comment: json['comment'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'results': [for (final r in results) r.toJson()],
+        if (comment != null && comment!.isNotEmpty) 'comment': comment,
+      };
 
   int get total => results.length;
   int get correct => results.where((r) => r.correct).length;

--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -106,9 +106,19 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         formatDateTime(s.date),
                         style: const TextStyle(color: Colors.white),
                       ),
-                      subtitle: Text(
-                        '${s.accuracy.toStringAsFixed(1)}% • Ошибок: ${s.mistakes}',
-                        style: const TextStyle(color: Colors.white70),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${s.accuracy.toStringAsFixed(1)}% • Ошибок: ${s.mistakes}',
+                            style: const TextStyle(color: Colors.white70),
+                          ),
+                          if (s.comment != null && s.comment!.isNotEmpty)
+                            Text(
+                              s.comment!,
+                              style: const TextStyle(color: Colors.white60),
+                            ),
+                        ],
                       ),
                       trailing: const Icon(Icons.chevron_right, color: Colors.white70),
                       onTap: () => _openSession(s),


### PR DESCRIPTION
## Summary
- extend CloudTrainingSession model with optional `comment`
- support comment in CloudSyncService for upload/load
- prompt for comment after completing a session and store it
- show existing comment in session summary
- display comments in Cloud training history list

## Testing
- `dart` not available so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_6859cd4ec0e0832a8645c0ba538ed256