### PR TITLE
Implement basic TutorialFlow

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -21,6 +21,8 @@ import '../models/training_spot.dart';
 import '../user_preferences.dart';
 import '../main_demo.dart';
 import '../widgets/training_spot_preview.dart';
+import '../tutorial/tutorial_flow.dart';
+import 'training_history_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -32,6 +34,9 @@ class MainMenuScreen extends StatefulWidget {
 class _MainMenuScreenState extends State<MainMenuScreen> {
   bool _demoMode = false;
   TrainingSpot? _spotOfDay;
+  final GlobalKey _trainingButtonKey = GlobalKey();
+  final GlobalKey _newHandButtonKey = GlobalKey();
+  final GlobalKey _historyButtonKey = GlobalKey();
 
   @override
   void initState() {
@@ -105,6 +110,40 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     }
   }
 
+  void _startTutorial() {
+    final flow = TutorialFlow([
+      TutorialStep(
+        targetKey: _trainingButtonKey,
+        description: 'Выберите тренировочный пак',
+        onNext: (_, __) {},
+      ),
+      TutorialStep(
+        targetKey: _newHandButtonKey,
+        description: 'Затем решите раздачу',
+        onNext: (_, __) {},
+      ),
+      TutorialStep(
+        targetKey: _historyButtonKey,
+        description: 'Просмотрите статистику ваших сессий',
+        onNext: (ctx, flow) {
+          Navigator.push(
+            ctx,
+            MaterialPageRoute(
+              builder: (_) => TrainingHistoryScreen(tutorial: flow),
+            ),
+          );
+        },
+      ),
+      TutorialStep(
+        targetKey: TrainingHistoryScreen.exportCsvKey,
+        description: 'Экспортируйте результаты для дальнейшего изучения',
+        onNext: (_, __) {},
+      ),
+    ]);
+
+    flow.start(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -112,6 +151,12 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: _startTutorial,
+          ),
+        ],
       ),
       body: Center(
         child: Column(
@@ -119,6 +164,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           children: [
             _buildSpotOfDaySection(context),
             ElevatedButton(
+              key: _newHandButtonKey,
               onPressed: () {
                 Navigator.push(
                   context,
@@ -159,6 +205,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             ),
             const SizedBox(height: 16),
             ElevatedButton(
+              key: _trainingButtonKey,
               onPressed: () {
                 Navigator.push(
                   context,
@@ -193,6 +240,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             ),
             const SizedBox(height: 16),
             ElevatedButton(
+              key: _historyButtonKey,
               onPressed: () {
                 Navigator.push(
                   context,

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -31,9 +31,13 @@ import '../models/training_result.dart';
 import '../models/training_session.dart';
 import '../helpers/date_utils.dart';
 import '../helpers/accuracy_utils.dart';
+import '../tutorial/tutorial_flow.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
-  const TrainingHistoryScreen({super.key});
+  final TutorialFlow? tutorial;
+  static final GlobalKey exportCsvKey = GlobalKey();
+
+  const TrainingHistoryScreen({super.key, this.tutorial});
 
   @override
   State<TrainingHistoryScreen> createState() => _TrainingHistoryScreenState();
@@ -109,6 +113,9 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   void initState() {
     super.initState();
     _loadPrefs();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.tutorial?.showCurrentStep(context);
+    });
   }
 
   Future<void> _loadPrefs() async {
@@ -2649,6 +2656,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       ElevatedButton(
+                        key: TrainingHistoryScreen.exportCsvKey,
                         onPressed:
                             _getFilteredHistory().isEmpty ? null : _exportCsv,
                         child: const Text('Экспорт в CSV'),

--- a/lib/tutorial/tutorial_flow.dart
+++ b/lib/tutorial/tutorial_flow.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+class TutorialStep {
+  final GlobalKey targetKey;
+  final String description;
+  final void Function(BuildContext context, TutorialFlow flow)? onNext;
+
+  TutorialStep({
+    required this.targetKey,
+    required this.description,
+    this.onNext,
+  });
+}
+
+class TutorialFlow {
+  final List<TutorialStep> steps;
+  int _index = 0;
+  OverlayEntry? _entry;
+
+  TutorialFlow(this.steps);
+
+  void start(BuildContext context) {
+    _index = 0;
+    _show(context);
+  }
+
+  void next(BuildContext context) {
+    _entry?.remove();
+    if (_index >= steps.length) return;
+    final action = steps[_index].onNext;
+    _index++;
+    if (action != null) {
+      action(context, this);
+    }
+  }
+
+  void showCurrentStep(BuildContext context) {
+    if (_index < steps.length) _show(context);
+  }
+
+  void _show(BuildContext context) {
+    final step = steps[_index];
+    final overlay = Overlay.of(context);
+    final renderBox = step.targetKey.currentContext?.findRenderObject() as RenderBox?;
+    if (overlay == null || renderBox == null) return;
+    final offset = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+    _entry = OverlayEntry(
+      builder: (_) => Stack(
+        children: [
+          ModalBarrier(color: Colors.black54, dismissible: false),
+          Positioned(
+            left: offset.dx - 4,
+            top: offset.dy - 4,
+            width: size.width + 8,
+            height: size.height + 8,
+            child: IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.orange, width: 3),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: offset.dx,
+            top: offset.dy + size.height + 8,
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                width: 250,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.black87,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      step.description,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        onPressed: () => next(context),
+                        child: const Text('Далее'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    overlay.insert(_entry!);
+  }
+}


### PR DESCRIPTION
## Summary
- add new TutorialFlow class for interactive tooltips
- integrate TutorialFlow with main menu and training history screen
- add help button to trigger onboarding

## Testing
- `dart` command was unavailable, so formatting was skipped

------
https://chatgpt.com/codex/tasks/task_e_6859deb8e328832a9306c148dd58086b