### PR TITLE
Enable tutorial completion and repeat option

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -22,6 +22,7 @@ import '../user_preferences.dart';
 import '../main_demo.dart';
 import '../widgets/training_spot_preview.dart';
 import '../tutorial/tutorial_flow.dart';
+import '../tutorial/tutorial_completion_screen.dart';
 import 'training_history_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
@@ -37,11 +38,13 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
   final GlobalKey _trainingButtonKey = GlobalKey();
   final GlobalKey _newHandButtonKey = GlobalKey();
   final GlobalKey _historyButtonKey = GlobalKey();
+  bool _tutorialCompleted = false;
 
   @override
   void initState() {
     super.initState();
     _demoMode = UserPreferences.instance.demoMode;
+    _tutorialCompleted = UserPreferences.instance.tutorialCompleted;
     _loadSpot();
   }
 
@@ -139,7 +142,21 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         description: 'Экспортируйте результаты для дальнейшего изучения',
         onNext: (_, __) {},
       ),
-    ]);
+    ], onComplete: () {
+      setState(() => _tutorialCompleted = true);
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TutorialCompletionScreen(
+            onRepeat: () {
+              final nav = Navigator.of(context);
+              nav.popUntil((route) => route.isFirst);
+              flow.start(nav.context);
+            },
+          ),
+        ),
+      );
+    });
 
     flow.start(context);
   }
@@ -152,10 +169,11 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         title: const Text('Poker AI Analyzer'),
         centerTitle: true,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.help_outline),
-            onPressed: _startTutorial,
-          ),
+          if (!_tutorialCompleted)
+            IconButton(
+              icon: const Icon(Icons.help_outline),
+              onPressed: _startTutorial,
+            ),
         ],
       ),
       body: Center(

--- a/lib/services/user_preferences_service.dart
+++ b/lib/services/user_preferences_service.dart
@@ -8,6 +8,7 @@ class UserPreferencesService extends ChangeNotifier {
   static const _actionHintsKey = 'show_action_hints';
   static const _coachModeKey = 'coach_mode';
   static const _demoModeKey = 'demo_mode';
+  static const _tutorialCompletedKey = 'tutorial_completed';
 
   bool _showPotAnimation = true;
   bool _showCardReveal = true;
@@ -15,6 +16,7 @@ class UserPreferencesService extends ChangeNotifier {
   bool _showActionHints = true;
   bool _coachMode = false;
   bool _demoMode = false;
+  bool _tutorialCompleted = false;
 
   bool get showPotAnimation => _showPotAnimation;
   bool get showCardReveal => _showCardReveal;
@@ -22,6 +24,7 @@ class UserPreferencesService extends ChangeNotifier {
   bool get showActionHints => _showActionHints;
   bool get coachMode => _coachMode;
   bool get demoMode => _demoMode;
+  bool get tutorialCompleted => _tutorialCompleted;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -31,6 +34,7 @@ class UserPreferencesService extends ChangeNotifier {
     _showActionHints = prefs.getBool(_actionHintsKey) ?? true;
     _coachMode = prefs.getBool(_coachModeKey) ?? false;
     _demoMode = prefs.getBool(_demoModeKey) ?? false;
+    _tutorialCompleted = prefs.getBool(_tutorialCompletedKey) ?? false;
     notifyListeners();
   }
 
@@ -78,6 +82,13 @@ class UserPreferencesService extends ChangeNotifier {
     if (_demoMode == value) return;
     _demoMode = value;
     await _save(_demoModeKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setTutorialCompleted(bool value) async {
+    if (_tutorialCompleted == value) return;
+    _tutorialCompleted = value;
+    await _save(_tutorialCompletedKey, value);
     notifyListeners();
   }
 }

--- a/lib/tutorial/tutorial_completion_screen.dart
+++ b/lib/tutorial/tutorial_completion_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../user_preferences.dart';
+
+class TutorialCompletionScreen extends StatefulWidget {
+  final void Function() onRepeat;
+
+  const TutorialCompletionScreen({super.key, required this.onRepeat});
+
+  @override
+  State<TutorialCompletionScreen> createState() => _TutorialCompletionScreenState();
+}
+
+class _TutorialCompletionScreenState extends State<TutorialCompletionScreen> {
+  @override
+  void initState() {
+    super.initState();
+    UserPreferences.instance.setTutorialCompleted(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Обучение завершено',
+              style: TextStyle(fontSize: 24),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: widget.onRepeat,
+              child: const Text('Повторить'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/tutorial/tutorial_flow.dart
+++ b/lib/tutorial/tutorial_flow.dart
@@ -14,10 +14,11 @@ class TutorialStep {
 
 class TutorialFlow {
   final List<TutorialStep> steps;
+  final VoidCallback? onComplete;
   int _index = 0;
   OverlayEntry? _entry;
 
-  TutorialFlow(this.steps);
+  TutorialFlow(this.steps, {this.onComplete});
 
   void start(BuildContext context) {
     _index = 0;
@@ -31,6 +32,9 @@ class TutorialFlow {
     _index++;
     if (action != null) {
       action(context, this);
+    }
+    if (_index >= steps.length) {
+      onComplete?.call();
     }
   }
 

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -17,6 +17,7 @@ class UserPreferences {
   bool get showActionHints => service.showActionHints;
   bool get coachMode => service.coachMode;
   bool get demoMode => service.demoMode;
+  bool get tutorialCompleted => service.tutorialCompleted;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
   Future<void> setShowCardReveal(bool value) => service.setShowCardReveal(value);
@@ -24,4 +25,5 @@ class UserPreferences {
   Future<void> setShowActionHints(bool value) => service.setShowActionHints(value);
   Future<void> setCoachMode(bool value) => service.setCoachMode(value);
   Future<void> setDemoMode(bool value) => service.setDemoMode(value);
+  Future<void> setTutorialCompleted(bool value) => service.setTutorialCompleted(value);
 }


### PR DESCRIPTION
## Summary
- track tutorial completion in SharedPreferences
- add tutorial completion screen with Repeat option
- update TutorialFlow to trigger completion callback
- hide tutorial button when tutorial finished

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e165142c832aa97a72dfbca12f1b