### PR TITLE
Add cloud training history screen

### DIFF
--- a/lib/screens/cloud_training_history_service_screen.dart
+++ b/lib/screens/cloud_training_history_service_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/session_summary.dart';
+import '../services/cloud_training_history_service.dart';
+
+class CloudTrainingHistoryScreen extends StatefulWidget {
+  const CloudTrainingHistoryScreen({super.key});
+
+  @override
+  State<CloudTrainingHistoryScreen> createState() => _CloudTrainingHistoryScreenState();
+}
+
+class _CloudTrainingHistoryScreenState extends State<CloudTrainingHistoryScreen> {
+  List<SessionSummary> _sessions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final service = context.read<CloudTrainingHistoryService>();
+    final sessions = await service.loadSessions();
+    if (mounted) {
+      setState(() => _sessions = sessions);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cloud History'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: _sessions.isEmpty
+          ? const Center(child: Text('История пуста'))
+          : ListView.separated(
+              itemCount: _sessions.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final s = _sessions[index];
+                return ListTile(
+                  title: Text(
+                    formatDateTime(s.date),
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  subtitle: Text(
+                    '${s.correct}/${s.total} • ${s.accuracy.toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -6,6 +6,7 @@ import 'training_packs_screen.dart';
 import 'all_sessions_screen.dart';
 import 'cloud_training_history_screen.dart';
 import 'my_training_history_screen.dart';
+import 'cloud_training_history_service_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
@@ -288,6 +289,17 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🗓️ Training History'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const CloudTrainingHistoryScreen()),
+                );
+              },
+              child: const Text('☁️ Cloud History'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/services/cloud_training_history_service.dart
+++ b/lib/services/cloud_training_history_service.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/result_entry.dart';
+import '../models/session_summary.dart';
 
 /// Simple storage for cloud training history.
 /// Each session is stored as a JSON file per user.
@@ -41,5 +42,43 @@ class CloudTrainingHistoryService {
       ],
     };
     await file.writeAsString(jsonEncode(data), flush: true);
+  }
+
+  /// Load all stored training sessions for the current user.
+  Future<List<SessionSummary>> loadSessions() async {
+    final userId = await _getUserId();
+    final dir = await getApplicationDocumentsDirectory();
+    final subdir = Directory('${dir.path}/cloud_training_history/$userId');
+    if (!await subdir.exists()) return [];
+    final files = await subdir
+        .list()
+        .where((e) => e is File && e.path.endsWith('.json'))
+        .toList();
+    files.sort((a, b) => b.path.compareTo(a.path));
+    final List<SessionSummary> sessions = [];
+    for (final entity in files) {
+      final file = entity as File;
+      try {
+        final content = await file.readAsString();
+        final data = jsonDecode(content);
+        if (data is Map<String, dynamic>) {
+          final dateStr = data['date'] as String?;
+          final date = dateStr != null
+              ? DateTime.tryParse(dateStr) ?? DateTime.now()
+              : DateTime.now();
+          final entries = data['entries'];
+          if (entries is List) {
+            final total = entries.length;
+            final correct = entries
+                .whereType<Map>()
+                .where((e) => e['correct'] == true)
+                .length;
+            sessions.add(SessionSummary(
+                date: date, total: total, correct: correct));
+          }
+        }
+      } catch (_) {}
+    }
+    return sessions;
   }
 }


### PR DESCRIPTION
## Summary
- add history retrieval to `CloudTrainingHistoryService`
- implement `CloudTrainingHistoryScreen` to show past sessions
- link new screen from main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e9bf3a8c832aa47eac27fceab00f