### PR TITLE
Add details screen for CloudTrainingHistory sessions

### DIFF
--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -10,7 +10,7 @@ import '../models/cloud_training_session.dart';
 import '../models/training_result.dart';
 import '../services/cloud_sync_service.dart';
 import '../widgets/common/accuracy_trend_chart.dart';
-import 'training_pack_screen.dart';
+import 'cloud_training_session_details_screen.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   const TrainingHistoryScreen({super.key});
@@ -48,7 +48,8 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => TrainingAnalysisScreen(results: session.results),
+        builder: (_) =>
+            CloudTrainingSessionDetailsScreen(session: session),
       ),
     );
   }

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/cloud_training_session.dart';
+
+class CloudTrainingSessionDetailsScreen extends StatelessWidget {
+  final CloudTrainingSession session;
+
+  const CloudTrainingSessionDetailsScreen({super.key, required this.session});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(formatDateTime(session.date)),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: session.results.isEmpty
+          ? const Center(
+              child: Text(
+                'Нет данных',
+                style: TextStyle(color: Colors.white70),
+              ),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: session.results.length,
+              itemBuilder: (context, index) {
+                final r = session.results[index];
+                return Container(
+                  margin: const EdgeInsets.symmetric(vertical: 4),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF2A2B2E),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        r.correct ? Icons.check : Icons.close,
+                        color: r.correct ? Colors.green : Colors.red,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              r.name,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text('Вы: ${r.userAction}',
+                                style: const TextStyle(color: Colors.white70)),
+                            Text('Ожидалось: ${r.expected}',
+                                style: const TextStyle(color: Colors.white70)),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- new `CloudTrainingSessionDetailsScreen` lists all hands with user/expected actions and result
- open this details screen from `CloudTrainingHistoryScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ea98ed64832aa471f58830bd3e0f