### PR TITLE
Add repeat option for cloud session

### DIFF
--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -2,9 +2,14 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:provider/provider.dart';
 
 import '../helpers/date_utils.dart';
 import '../models/cloud_training_session.dart';
+import '../models/saved_hand.dart';
+import '../models/training_pack.dart';
+import '../services/saved_hand_manager_service.dart';
+import 'training_pack_screen.dart';
 
 class CloudTrainingSessionDetailsScreen extends StatelessWidget {
   final CloudTrainingSession session;
@@ -27,6 +32,37 @@ class CloudTrainingSessionDetailsScreen extends StatelessWidget {
         const SnackBar(content: Text('Файл сохранён: cloud_session.md')),
       );
     }
+  }
+
+  Future<void> _repeatSession(BuildContext context) async {
+    final manager = context.read<SavedHandManagerService>();
+    final Map<String, SavedHand> map = {
+      for (final h in manager.hands) h.name: h
+    };
+    final List<SavedHand> hands = [];
+    for (final r in session.results) {
+      final hand = map[r.name];
+      if (hand != null) hands.add(hand);
+    }
+    if (hands.isEmpty) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Раздачи не найдены')),
+        );
+      }
+      return;
+    }
+    final pack = TrainingPack(
+      name: 'Повторение',
+      description: '',
+      hands: hands,
+    );
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackScreen(pack: pack, hands: hands),
+      ),
+    );
   }
 
   @override
@@ -52,49 +88,66 @@ class CloudTrainingSessionDetailsScreen extends StatelessWidget {
                 style: TextStyle(color: Colors.white70),
               ),
             )
-          : ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: session.results.length,
-              itemBuilder: (context, index) {
-                final r = session.results[index];
-                return Container(
-                  margin: const EdgeInsets.symmetric(vertical: 4),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF2A2B2E),
-                    borderRadius: BorderRadius.circular(8),
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: ElevatedButton(
+                    onPressed: () => _repeatSession(context),
+                    child: const Text('Повторить'),
                   ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(
-                        r.correct ? Icons.check : Icons.close,
-                        color: r.correct ? Colors.green : Colors.red,
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
+                ),
+                const Divider(color: Colors.white12, height: 1),
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: session.results.length,
+                    itemBuilder: (context, index) {
+                      final r = session.results[index];
+                      return Container(
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF2A2B2E),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              r.name,
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
+                            Icon(
+                              r.correct ? Icons.check : Icons.close,
+                              color: r.correct ? Colors.green : Colors.red,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    r.name,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text('Вы: ${r.userAction}',
+                                      style:
+                                          const TextStyle(color: Colors.white70)),
+                                  Text('Ожидалось: ${r.expected}',
+                                      style:
+                                          const TextStyle(color: Colors.white70)),
+                                ],
                               ),
                             ),
-                            const SizedBox(height: 4),
-                            Text('Вы: ${r.userAction}',
-                                style: const TextStyle(color: Colors.white70)),
-                            Text('Ожидалось: ${r.expected}',
-                                style: const TextStyle(color: Colors.white70)),
                           ],
                         ),
-                      ),
-                    ],
+                      );
+                    },
                   ),
-                );
-              },
+                ),
+              ],
             ),
     );
   }


### PR DESCRIPTION
## Summary
- enable repeating a cloud training session using the same hands
- show a `Повторить` button in `CloudTrainingSessionDetailsScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f1395d88832a8d118a70f1f6eae6