### PR TITLE
Add CloudTrainingHistory deletion

### DIFF
--- a/lib/models/cloud_history_entry.dart
+++ b/lib/models/cloud_history_entry.dart
@@ -1,0 +1,8 @@
+import "session_summary.dart";
+
+class CloudHistoryEntry {
+  final String path;
+  final SessionSummary summary;
+
+  CloudHistoryEntry({required this.path, required this.summary});
+}


### PR DESCRIPTION
## Summary
- support deleting CloudTrainingHistory entries
- include file path with each loaded session
- allow long-pressing a session to delete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f4220eb8832ab8da395f864e5ce2