### PR TITLE
Add session delete from detail view

### DIFF
--- a/lib/models/cloud_training_session.dart
+++ b/lib/models/cloud_training_session.dart
@@ -1,17 +1,20 @@
 import "result_entry.dart";
 
 class CloudTrainingSession {
+  final String path;
   final DateTime date;
   final List<ResultEntry> results;
   final String? comment;
 
   CloudTrainingSession({
+    required this.path,
     required this.date,
     required this.results,
     this.comment,
   });
 
-  factory CloudTrainingSession.fromJson(Map<String, dynamic> json) {
+  factory CloudTrainingSession.fromJson(Map<String, dynamic> json,
+      {required String path}) {
     final results = <ResultEntry>[];
     final list = json['results'];
     if (list is List) {
@@ -22,6 +25,7 @@ class CloudTrainingSession {
       }
     }
     return CloudTrainingSession(
+      path: path,
       date: DateTime.parse(json['date'] as String),
       results: results,
       comment: json['comment'] as String?,

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -25,6 +25,38 @@ class _CloudTrainingSessionDetailsScreenState
     extends State<CloudTrainingSessionDetailsScreen> {
   bool _onlyErrors = false;
 
+  Future<void> _deleteSession(BuildContext context) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete Session?'),
+          content:
+              const Text('Are you sure you want to delete this session?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirm == true) {
+      final file = File(widget.session.path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      if (context.mounted) {
+        Navigator.pop(context);
+      }
+    }
+  }
+
   Future<void> _exportMarkdown(BuildContext context) async {
     if (widget.session.results.isEmpty) return;
     final buffer = StringBuffer();
@@ -89,6 +121,11 @@ class _CloudTrainingSessionDetailsScreenState
             tooltip: 'Экспорт',
             onPressed:
                 results.isEmpty ? null : () => _exportMarkdown(context),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: 'Delete',
+            onPressed: () => _deleteSession(context),
           ),
         ],
       ),

--- a/lib/services/cloud_sync_service.dart
+++ b/lib/services/cloud_sync_service.dart
@@ -164,7 +164,7 @@ class CloudSyncService {
             }
           }
           sessions.add(
-            CloudTrainingSession(date: date, results: results),
+            CloudTrainingSession(path: file.path, date: date, results: results),
           );
         } else if (data is Map<String, dynamic>) {
           final list = data['results'];
@@ -178,6 +178,7 @@ class CloudSyncService {
           }
           sessions.add(
             CloudTrainingSession(
+              path: file.path,
               date: date,
               results: results,
               comment: data['comment'] as String?,


### PR DESCRIPTION
## Summary
- store path in `CloudTrainingSession`
- expose session path when loading sessions
- allow deleting a cloud session from detail screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f6236a04832a9fec3cfe349c0aaa