### PR TITLE
Show accuracy in cloud session details

### DIFF
--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -155,7 +155,19 @@ class _CloudTrainingSessionDetailsScreenState
         : widget.session.results;
     return Scaffold(
       appBar: AppBar(
-        title: Text(formatDateTime(widget.session.date)),
+        title: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '${formatDate(widget.session.date)} • ${widget.session.accuracy.toStringAsFixed(1)}%',
+              style: const TextStyle(color: Colors.white),
+            ),
+            Text(
+              'Ошибки: ${widget.session.mistakes} из ${widget.session.total}',
+              style: const TextStyle(color: Colors.white70, fontSize: 14),
+            ),
+          ],
+        ),
         centerTitle: true,
         actions: [
           IconButton(


### PR DESCRIPTION
## Summary
- enhance `CloudTrainingSessionDetailsScreen` app bar
  - show session date and accuracy
  - show mistakes count below

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859fbebc408832ab13700800af1f52f