### PR TITLE
Add simple GTO analysis explanation

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -49,6 +49,10 @@ class SavedHand {
   final bool isFavorite;
   final DateTime date;
   final String? expectedAction;
+  /// Recommended action from GTO solver.
+  final String? gtoAction;
+  /// Predefined group label for hero hand range.
+  final String? rangeGroup;
   final String? feedbackText;
   final Map<String, int>? effectiveStacksPerStreet;
   final Map<String, String>? validationNotes;
@@ -103,6 +107,8 @@ class SavedHand {
     this.isFavorite = false,
     DateTime? date,
     this.expectedAction,
+    this.gtoAction,
+    this.rangeGroup,
     this.feedbackText,
     this.effectiveStacksPerStreet,
     this.validationNotes,
@@ -156,6 +162,8 @@ class SavedHand {
     bool? isFavorite,
     DateTime? date,
     String? expectedAction,
+    String? gtoAction,
+    String? rangeGroup,
     String? feedbackText,
     Map<String, int>? effectiveStacksPerStreet,
     Map<String, String>? validationNotes,
@@ -211,6 +219,8 @@ class SavedHand {
       isFavorite: isFavorite ?? this.isFavorite,
       date: date ?? this.date,
       expectedAction: expectedAction ?? this.expectedAction,
+      gtoAction: gtoAction ?? this.gtoAction,
+      rangeGroup: rangeGroup ?? this.rangeGroup,
       feedbackText: feedbackText ?? this.feedbackText,
       effectiveStacksPerStreet:
           effectiveStacksPerStreet ?? this.effectiveStacksPerStreet,
@@ -319,6 +329,8 @@ class SavedHand {
         'isFavorite': isFavorite,
         'date': date.toIso8601String(),
         if (expectedAction != null) 'expectedAction': expectedAction,
+        if (gtoAction != null) 'gtoAction': gtoAction,
+        if (rangeGroup != null) 'rangeGroup': rangeGroup,
         if (feedbackText != null) 'feedbackText': feedbackText,
         if (effectiveStacksPerStreet != null)
           'effectiveStacksPerStreet': effectiveStacksPerStreet,
@@ -531,6 +543,8 @@ class SavedHand {
       isFavorite: isFavorite,
       date: date,
       expectedAction: json['expectedAction'] as String?,
+      gtoAction: json['gtoAction'] as String?,
+      rangeGroup: json['rangeGroup'] as String?,
       feedbackText: json['feedbackText'] as String?,
       effectiveStacksPerStreet: effStacks,
       validationNotes: notes,

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -282,6 +282,9 @@ class _CloudTrainingSessionDetailsScreenState
     final results = _onlyErrors
         ? widget.session.results.where((r) => !r.correct).toList()
         : widget.session.results;
+    final handMap = {
+      for (final h in context.watch<SavedHandManagerService>().hands) h.name: h
+    };
     return Scaffold(
       appBar: AppBar(
         title: Column(
@@ -397,11 +400,20 @@ class _CloudTrainingSessionDetailsScreenState
                             ],
                           ),
                           children: [
-                            const Padding(
-                              padding: EdgeInsets.all(12.0),
+                            Padding(
+                              padding: const EdgeInsets.all(12.0),
                               child: Text(
-                                'Тут будет анализ этой раздачи',
-                                style: TextStyle(color: Colors.white70),
+                                () {
+                                  final hand = handMap[r.name];
+                                  if (hand == null) {
+                                    return 'Раздача не найдена';
+                                  }
+                                  final gto = hand.gtoAction ?? r.expected;
+                                  final group = hand.rangeGroup ?? '-';
+                                  final verdict = r.correct ? 'верное' : 'ошибочное';
+                                  return 'GTO предлагает $gto, ваша рука из группы $group. Это действие $verdict.';
+                                }(),
+                                style: const TextStyle(color: Colors.white70),
                               ),
                             ),
                             Padding(


### PR DESCRIPTION
## Summary
- add `gtoAction` and `rangeGroup` fields to `SavedHand`
- compute explanation in CloudTrainingSessionDetailsScreen using saved hands

## Testing
- `flutter format lib/models/saved_hand.dart lib/screens/cloud_training_session_details_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a01815418832a901dc188726ec976