### PR TITLE
Add quick action buttons in hand review

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -5,20 +5,27 @@ import 'package:poker_ai_analyzer/widgets/replay_spot_widget.dart';
 
 /// Displays a saved hand with simple playback controls.
 /// Shows GTO recommendation and range group when available.
-class HandHistoryReviewScreen extends StatelessWidget {
+class HandHistoryReviewScreen extends StatefulWidget {
   final SavedHand hand;
 
   const HandHistoryReviewScreen({super.key, required this.hand});
 
   @override
+  State<HandHistoryReviewScreen> createState() => _HandHistoryReviewScreenState();
+}
+
+class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
+  String? _selectedAction;
+
+  @override
   Widget build(BuildContext context) {
-    final spot = TrainingGenerator().generateFromSavedHand(hand);
-    final gto = hand.gtoAction;
-    final group = hand.rangeGroup;
+    final spot = TrainingGenerator().generateFromSavedHand(widget.hand);
+    final gto = widget.hand.gtoAction;
+    final group = widget.hand.rangeGroup;
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(hand.name),
+        title: Text(widget.hand.name),
         centerTitle: true,
       ),
       backgroundColor: const Color(0xFF121212),
@@ -42,9 +49,36 @@ class HandHistoryReviewScreen extends StatelessWidget {
                         style: const TextStyle(color: Colors.white)),
                 ],
               ),
-          ],
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _actionButton('Push'),
+                _actionButton('Fold'),
+                _actionButton('Call'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (_selectedAction != null)
+              Text(
+                'Вы выбрали: $_selectedAction. GTO рекомендует: ${gto ?? '-'}',
+                style: const TextStyle(color: Colors.white),
+              ),
+            ],
+          ),
         ),
+      );
+  }
+
+  Widget _actionButton(String label) {
+    final bool isSelected = _selectedAction == label;
+    return ElevatedButton(
+      onPressed: () => setState(() => _selectedAction = label),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: isSelected ? Colors.blueGrey : Colors.black87,
+        foregroundColor: Colors.white,
       ),
+      child: Text(label),
     );
   }
 }


### PR DESCRIPTION
## Summary
- convert `HandHistoryReviewScreen` to a stateful widget
- add Push/Fold/Call buttons
- highlight the chosen action and display comparison with GTO

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a572cad50832aab252c165215c4c2