### PR TITLE
Add comment support in hand review

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import 'package:poker_ai_analyzer/import_export/training_generator.dart';
 import 'package:poker_ai_analyzer/widgets/replay_spot_widget.dart';
+import '../services/saved_hand_manager_service.dart';
 
 /// Displays a saved hand with simple playback controls.
 /// Shows GTO recommendation and range group when available.
@@ -16,6 +18,30 @@ class HandHistoryReviewScreen extends StatefulWidget {
 
 class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
   String? _selectedAction;
+  late TextEditingController _commentController;
+
+  @override
+  void initState() {
+    super.initState();
+    _commentController = TextEditingController(text: widget.hand.comment ?? '');
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveComment(String text) async {
+    final manager = context.read<SavedHandManagerService>();
+    final index = manager.hands.indexOf(widget.hand);
+    if (index >= 0) {
+      final updated = widget.hand.copyWith(
+        comment: text.trim().isNotEmpty ? text.trim() : null,
+      );
+      await manager.update(index, updated);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +75,19 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
                         style: const TextStyle(color: Colors.white)),
                 ],
               ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _commentController,
+              onChanged: _saveComment,
+              maxLines: null,
+              minLines: 3,
+              style: const TextStyle(color: Colors.white),
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Комментарий',
+                labelStyle: TextStyle(color: Colors.white),
+              ),
+            ),
             const SizedBox(height: 24),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,


### PR DESCRIPTION
## Summary
- add TextField for leaving a hand comment in `HandHistoryReviewScreen`
- save edits using `SavedHandManagerService`

## Testing
- `flutter format lib/screens/hand_history_review_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a591cfe04832a9798ec7ed2fe22a1