### PR TITLE
Add single hand export options

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -1,5 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:pdf/pdf.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import 'package:poker_ai_analyzer/import_export/training_generator.dart';
 import 'package:poker_ai_analyzer/widgets/replay_spot_widget.dart';
@@ -40,6 +46,80 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
         comment: text.trim().isNotEmpty ? text.trim() : null,
       );
       await manager.update(index, updated);
+    }
+  }
+
+  Future<void> _exportMarkdown() async {
+    final buffer = StringBuffer();
+    buffer.writeln('## ${widget.hand.name}');
+    if (_selectedAction != null) {
+      buffer.writeln('- Выбор пользователя: $_selectedAction');
+    }
+    if (widget.hand.gtoAction != null && widget.hand.gtoAction!.isNotEmpty) {
+      buffer.writeln('- GTO: ${widget.hand.gtoAction}');
+    }
+    if (widget.hand.rangeGroup != null && widget.hand.rangeGroup!.isNotEmpty) {
+      buffer.writeln('- Группа: ${widget.hand.rangeGroup}');
+    }
+    final comment = _commentController.text.trim();
+    if (comment.isNotEmpty) {
+      buffer.writeln('- Комментарий: $comment');
+    }
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/hand_export.md');
+    await file.writeAsString(buffer.toString());
+    await Share.shareXFiles([XFile(file.path)], text: 'hand_export.md');
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Файл сохранён: hand_export.md')),
+      );
+    }
+  }
+
+  Future<void> _exportPdf() async {
+    final regularFont = await pw.PdfGoogleFonts.robotoRegular();
+    final boldFont = await pw.PdfGoogleFonts.robotoBold();
+
+    final pdf = pw.Document();
+    pdf.addPage(
+      pw.Page(
+        pageFormat: PdfPageFormat.a4,
+        build: (context) {
+          return pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(widget.hand.name,
+                  style: pw.TextStyle(font: boldFont, fontSize: 24)),
+              pw.SizedBox(height: 16),
+              if (_selectedAction != null)
+                pw.Text('Выбор пользователя: $_selectedAction',
+                    style: pw.TextStyle(font: regularFont)),
+              if (widget.hand.gtoAction != null &&
+                  widget.hand.gtoAction!.isNotEmpty)
+                pw.Text('GTO: ${widget.hand.gtoAction}',
+                    style: pw.TextStyle(font: regularFont)),
+              if (widget.hand.rangeGroup != null &&
+                  widget.hand.rangeGroup!.isNotEmpty)
+                pw.Text('Группа: ${widget.hand.rangeGroup}',
+                    style: pw.TextStyle(font: regularFont)),
+              if (_commentController.text.trim().isNotEmpty)
+                pw.Text('Комментарий: ${_commentController.text.trim()}',
+                    style: pw.TextStyle(font: regularFont)),
+            ],
+          );
+        },
+      ),
+    );
+
+    final bytes = await pdf.save();
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/hand_export.pdf');
+    await file.writeAsBytes(bytes);
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Файл сохранён: hand_export.pdf')),
+      );
     }
   }
 
@@ -87,6 +167,20 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
                 labelText: 'Комментарий',
                 labelStyle: TextStyle(color: Colors.white),
               ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed: _exportMarkdown,
+                  child: const Text('Экспорт Markdown'),
+                ),
+                ElevatedButton(
+                  onPressed: _exportPdf,
+                  child: const Text('Экспорт PDF'),
+                ),
+              ],
             ),
             const SizedBox(height: 24),
             Row(


### PR DESCRIPTION
## Summary
- add markdown/pdf export functions in `HandHistoryReviewScreen`
- show export buttons under the comment field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a5bace92c832a80363b3c5d446ac4