### PR TITLE
Add PDF export for saved hands

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -361,6 +361,23 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
               },
               child: const Text('Экспорт всех раздач'),
             ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final manager =
+                    Provider.of<SavedHandManagerService>(context, listen: false);
+                final path = await manager.exportAllHandsPdf();
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(path != null
+                        ? 'Файл сохранён: all_saved_hands.pdf'
+                        : 'Нет сохранённых раздач'),
+                  ),
+                );
+              },
+              child: const Text('Экспорт PDF раздач'),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add PDF generation utilities to `SavedHandManagerService`
- add button in `MainMenuScreen` to export saved hands to PDF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a629a6d88832a855e8ca0190dbfc9