### PR TITLE
Add savedAt timestamp to SavedHand

### DIFF
--- a/lib/helpers/date_utils.dart
+++ b/lib/helpers/date_utils.dart
@@ -7,3 +7,7 @@ String formatDateTime(DateTime date) {
 String formatDate(DateTime date) {
   return DateFormat('dd.MM.yyyy').format(date);
 }
+
+String formatLongDate(DateTime date) {
+  return DateFormat('d MMMM y', 'ru').format(date);
+}

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -47,6 +47,7 @@ class SavedHand {
   /// Cursor offset within the tags field when the hand was saved.
   final int? tagsCursor;
   final bool isFavorite;
+  final DateTime savedAt;
   final DateTime date;
   final String? expectedAction;
   /// Recommended action from GTO solver.
@@ -105,6 +106,7 @@ class SavedHand {
     this.commentCursor,
     this.tagsCursor,
     this.isFavorite = false,
+    DateTime? savedAt,
     DateTime? date,
     this.expectedAction,
     this.gtoAction,
@@ -126,6 +128,7 @@ class SavedHand {
   })  : tags = tags ?? [],
         revealedCards = revealedCards ??
             List.generate(numberOfPlayers, (_) => <CardModel>[]),
+        savedAt = savedAt ?? DateTime.now(),
         date = date ?? DateTime.now(),
         revealStreet = revealStreet ?? boardStreet;
 
@@ -160,6 +163,7 @@ class SavedHand {
     int? commentCursor,
     int? tagsCursor,
     bool? isFavorite,
+    DateTime? savedAt,
     DateTime? date,
     String? expectedAction,
     String? gtoAction,
@@ -217,6 +221,7 @@ class SavedHand {
       commentCursor: commentCursor ?? this.commentCursor,
       tagsCursor: tagsCursor ?? this.tagsCursor,
       isFavorite: isFavorite ?? this.isFavorite,
+      savedAt: savedAt ?? this.savedAt,
       date: date ?? this.date,
       expectedAction: expectedAction ?? this.expectedAction,
       gtoAction: gtoAction ?? this.gtoAction,
@@ -327,6 +332,7 @@ class SavedHand {
         if (commentCursor != null) 'commentCursor': commentCursor,
         if (tagsCursor != null) 'tagsCursor': tagsCursor,
         'isFavorite': isFavorite,
+        'savedAt': savedAt.toIso8601String(),
         'date': date.toIso8601String(),
         if (expectedAction != null) 'expectedAction': expectedAction,
         if (gtoAction != null) 'gtoAction': gtoAction,
@@ -431,6 +437,8 @@ class SavedHand {
     final tags = [for (final t in (json['tags'] as List? ?? [])) t as String];
     final rating = (json['rating'] as num?)?.toInt() ?? 0;
     final isFavorite = json['isFavorite'] as bool? ?? false;
+    final savedAt =
+        DateTime.tryParse(json['savedAt'] as String? ?? '') ?? DateTime.now();
     final date = DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now();
     Map<String, int>? effStacks;
     if (json['effectiveStacksPerStreet'] != null) {
@@ -541,6 +549,7 @@ class SavedHand {
       commentCursor: commentCursor,
       tagsCursor: tagsCursor,
       isFavorite: isFavorite,
+      savedAt: savedAt,
       date: date,
       expectedAction: json['expectedAction'] as String?,
       gtoAction: json['gtoAction'] as String?,

--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -9,6 +9,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:poker_ai_analyzer/models/saved_hand.dart';
 import 'package:poker_ai_analyzer/import_export/training_generator.dart';
 import 'package:poker_ai_analyzer/widgets/replay_spot_widget.dart';
+import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 
 /// Displays a saved hand with simple playback controls.
@@ -131,7 +132,9 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.hand.name),
+        title: Text(
+          '${widget.hand.name} \u2022 ${formatLongDate(widget.hand.savedAt)}',
+        ),
         centerTitle: true,
       ),
       backgroundColor: const Color(0xFF121212),

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -108,6 +108,7 @@ class SavedHandImportExportService {
       playerTypes: Map<int, PlayerType>.from(playerManager.playerTypes),
       isFavorite: false,
       rating: 0,
+      savedAt: DateTime.now(),
       date: DateTime.now(),
       effectiveStacksPerStreet: potSync.toNullableJson(),
       collapsedHistoryStreets: collapsed.isEmpty ? null : collapsed,

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
+import '../helpers/date_utils.dart';
 
 import '../models/saved_hand.dart';
 import 'saved_hand_storage_service.dart';
@@ -207,7 +208,7 @@ class SavedHandManagerService extends ChangeNotifier {
                         return ListTile(
                           dense: true,
                           title: Text(
-                            title,
+                            '$title \u2022 ${formatLongDate(hand.savedAt)}',
                             style: const TextStyle(fontWeight: FontWeight.bold),
                           ),
                           subtitle: () {


### PR DESCRIPTION
## Summary
- introduce `savedAt` field in `SavedHand` and persist to JSON
- show save date alongside hand name
- format long dates using new helper

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a635a9ea0832aa0108fc47bd8d147