### PR TITLE
Add session export options

### DIFF
--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
@@ -10,6 +11,30 @@ class SessionHandsScreen extends StatelessWidget {
   final int sessionId;
 
   const SessionHandsScreen({super.key, required this.sessionId});
+
+  Future<void> _exportMarkdown(BuildContext context) async {
+    final manager = context.read<SavedHandManagerService>();
+    final path = await manager.exportSessionHandsMarkdown(sessionId);
+    if (path == null) return;
+    await Share.shareXFiles([XFile(path)], text: 'session_${sessionId}.md');
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Файл сохранён: session_${sessionId}.md')),
+      );
+    }
+  }
+
+  Future<void> _exportPdf(BuildContext context) async {
+    final manager = context.read<SavedHandManagerService>();
+    final path = await manager.exportSessionHandsPdf(sessionId);
+    if (path == null) return;
+    await Share.shareXFiles([XFile(path)], text: 'session_${sessionId}.pdf');
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Файл сохранён: session_${sessionId}.pdf')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,29 +56,55 @@ class SessionHandsScreen extends StatelessWidget {
                 style: TextStyle(color: Colors.white70),
               ),
             )
-          : ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: hands.length,
-              itemBuilder: (context, index) {
-                final hand = hands[index];
-                final originalIndex = manager.hands.indexOf(hand);
-                return SavedHandTile(
-                  hand: hand,
-                  onFavoriteToggle: () {
-                    final updated =
-                        hand.copyWith(isFavorite: !hand.isFavorite);
-                    manager.update(originalIndex, updated);
-                  },
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => HandHistoryReviewScreen(hand: hand),
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () => _exportMarkdown(context),
+                          child: const Text('Экспорт в Markdown'),
+                        ),
                       ),
-                    );
-                  },
-                );
-              },
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () => _exportPdf(context),
+                          child: const Text('Экспорт в PDF'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: hands.length,
+                    itemBuilder: (context, index) {
+                      final hand = hands[index];
+                      final originalIndex = manager.hands.indexOf(hand);
+                      return SavedHandTile(
+                        hand: hand,
+                        onFavoriteToggle: () {
+                          final updated =
+                              hand.copyWith(isFavorite: !hand.isFavorite);
+                          manager.update(originalIndex, updated);
+                        },
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => HandHistoryReviewScreen(hand: hand),
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
             ),
     );
   }


### PR DESCRIPTION
## Summary
- support exporting session hands to Markdown or PDF via SavedHandManagerService
- show export buttons on SessionHandsScreen

## Testing
- `flutter --version`

------
https://chatgpt.com/codex/tasks/task_e_685a6c29fc74832a8699b866ae5ca95e