### PR TITLE
Add session swipe overlay

### DIFF
--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../widgets/session_label_overlay.dart';
+
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../widgets/saved_hand_tile.dart';
@@ -10,10 +12,26 @@ import '../theme/app_colors.dart';
 import '../theme/constants.dart';
 import 'hand_history_review_screen.dart';
 
-class SessionHandsScreen extends StatelessWidget {
+class SessionHandsScreen extends StatefulWidget {
   final int sessionId;
 
   const SessionHandsScreen({super.key, required this.sessionId});
+
+  @override
+  State<SessionHandsScreen> createState() => _SessionHandsScreenState();
+}
+
+class _SessionHandsScreenState extends State<SessionHandsScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        showSessionLabelOverlay(context, 'Сессия ${widget.sessionId}');
+      }
+    });
+  }
 
   String _actionType(SavedHand hand) {
     final expected = hand.expectedAction?.trim().toLowerCase();
@@ -110,24 +128,24 @@ class SessionHandsScreen extends StatelessWidget {
 
   Future<void> _exportMarkdown(BuildContext context) async {
     final manager = context.read<SavedHandManagerService>();
-    final path = await manager.exportSessionHandsMarkdown(sessionId);
+    final path = await manager.exportSessionHandsMarkdown(widget.sessionId);
     if (path == null) return;
-    await Share.shareXFiles([XFile(path)], text: 'session_${sessionId}.md');
+    await Share.shareXFiles([XFile(path)], text: 'session_${widget.sessionId}.md');
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: session_${sessionId}.md')),
+        SnackBar(content: Text('Файл сохранён: session_${widget.sessionId}.md')),
       );
     }
   }
 
   Future<void> _exportPdf(BuildContext context) async {
     final manager = context.read<SavedHandManagerService>();
-    final path = await manager.exportSessionHandsPdf(sessionId);
+    final path = await manager.exportSessionHandsPdf(widget.sessionId);
     if (path == null) return;
-    await Share.shareXFiles([XFile(path)], text: 'session_${sessionId}.pdf');
+    await Share.shareXFiles([XFile(path)], text: 'session_${widget.sessionId}.pdf');
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: session_${sessionId}.pdf')),
+        SnackBar(content: Text('Файл сохранён: session_${widget.sessionId}.pdf')),
       );
     }
   }
@@ -136,12 +154,12 @@ class SessionHandsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final manager = context.watch<SavedHandManagerService>();
     final hands = manager.hands
-        .where((h) => h.sessionId == sessionId)
+        .where((h) => h.sessionId == widget.sessionId)
         .toList()
       ..sort((a, b) => b.savedAt.compareTo(a.savedAt));
 
     final sessionIds = manager.handsBySession().keys.toList()..sort();
-    final currentIndex = sessionIds.indexOf(sessionId);
+    final currentIndex = sessionIds.indexOf(widget.sessionId);
     final previousId =
         currentIndex > 0 ? sessionIds[currentIndex - 1] : null;
     final nextId = currentIndex < sessionIds.length - 1
@@ -215,7 +233,7 @@ class SessionHandsScreen extends StatelessWidget {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: Text('Сессия $sessionId'),
+          title: Text('Сессия ${widget.sessionId}'),
           centerTitle: true,
         ),
         body: hands.isEmpty

--- a/lib/widgets/session_label_overlay.dart
+++ b/lib/widgets/session_label_overlay.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+/// Floating label shown when switching sessions.
+class SessionLabelOverlay extends StatefulWidget {
+  final String text;
+  final VoidCallback? onCompleted;
+
+  const SessionLabelOverlay({
+    Key? key,
+    required this.text,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<SessionLabelOverlay> createState() => _SessionLabelOverlayState();
+}
+
+class _SessionLabelOverlayState extends State<SessionLabelOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0).chain(
+          CurveTween(curve: Curves.easeInOut),
+        ),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0).chain(
+          CurveTween(curve: Curves.easeInOut),
+        ),
+        weight: 20,
+      ),
+    ]).animate(_controller);
+    _scale = Tween<double>(begin: 0.9, end: 1.0)
+        .chain(CurveTween(curve: Curves.easeInOut))
+        .animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: 80,
+      left: 0,
+      right: 0,
+      child: FadeTransition(
+        opacity: _opacity,
+        child: ScaleTransition(
+          scale: _scale,
+          child: Center(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                color: Colors.black.withOpacity(0.8),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                widget.text,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Display a [SessionLabelOverlay] above the current screen.
+void showSessionLabelOverlay(BuildContext context, String text) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => SessionLabelOverlay(
+      text: text,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- display transient label when switching sessions
- refactor `SessionHandsScreen` to `StatefulWidget`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a7100cdb4832ab40f9ff576ca6902