### PR TITLE
Add session notes feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'screens/main_navigation_screen.dart';
 import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
+import 'services/session_note_service.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/daily_hand_service.dart';
 import 'services/spot_of_the_day_service.dart';
@@ -30,6 +31,9 @@ void main() {
             storage: context.read<SavedHandStorageService>(),
             cloud: context.read<CloudSyncService>(),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => SessionNoteService()..load(),
         ),
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -130,11 +130,15 @@ class SavedHandManagerService extends ChangeNotifier {
   /// Export hands belonging to [sessionId] to a Markdown file. The file
   /// will be named `session_[id].md` and stored in the application documents
   /// directory. Returns the created path or `null` if the session is empty.
-  Future<String?> exportSessionHandsMarkdown(int sessionId) async {
+  Future<String?> exportSessionHandsMarkdown(int sessionId, {String? note}) async {
     final sessionHands =
         hands.where((h) => h.sessionId == sessionId).toList();
     if (sessionHands.isEmpty) return null;
     final buffer = StringBuffer();
+    if (note != null && note.trim().isNotEmpty) {
+      buffer.writeln(note.trim());
+      buffer.writeln();
+    }
     for (final hand in sessionHands) {
       final title = hand.name.isNotEmpty ? hand.name : 'Без названия';
       buffer.writeln('## $title');
@@ -162,7 +166,7 @@ class SavedHandManagerService extends ChangeNotifier {
   /// Export hands belonging to [sessionId] to a PDF file. The file will be
   /// named `session_[id].pdf` and stored in the application documents
   /// directory. Returns the created path or `null` if the session is empty.
-  Future<String?> exportSessionHandsPdf(int sessionId) async {
+  Future<String?> exportSessionHandsPdf(int sessionId, {String? note}) async {
     final sessionHands =
         hands.where((h) => h.sessionId == sessionId).toList();
     if (sessionHands.isEmpty) return null;
@@ -176,6 +180,10 @@ class SavedHandManagerService extends ChangeNotifier {
         pageFormat: PdfPageFormat.a4,
         build: (context) {
           return [
+            if (note != null && note.trim().isNotEmpty) ...[
+              pw.Text(note.trim(), style: pw.TextStyle(font: regularFont)),
+              pw.SizedBox(height: 12),
+            ],
             for (final hand in sessionHands) ...[
               pw.Text(
                 hand.name.isNotEmpty ? hand.name : 'Без названия',

--- a/lib/services/session_note_service.dart
+++ b/lib/services/session_note_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SessionNoteService extends ChangeNotifier {
+  static const _prefsKey = 'session_notes';
+
+  final Map<int, String> _notes = {};
+
+  String noteFor(int sessionId) => _notes[sessionId] ?? '';
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final Map<String, dynamic> data = jsonDecode(raw);
+        _notes
+          ..clear()
+          ..addEntries(data.entries.map((e) => MapEntry(int.parse(e.key), e.value as String)));
+      } catch (_) {
+        _notes.clear();
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<void> setNote(int sessionId, String note) async {
+    _notes[sessionId] = note;
+    final prefs = await SharedPreferences.getInstance();
+    final data = {for (final e in _notes.entries) e.key.toString(): e.value};
+    await prefs.setString(_prefsKey, jsonEncode(data));
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- allow notes for each session
- persist notes in `SessionNoteService`
- show editable note in session hand screen
- include notes in session export files
- register note service in `main.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a71f217c8832a9f5e5d82768fdb40