### PR TITLE
Add session accuracy histogram

### DIFF
--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -6,6 +6,7 @@ import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/session_note_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/common/session_accuracy_distribution_chart.dart';
 
 class SessionStatsScreen extends StatelessWidget {
   const SessionStatsScreen({super.key});
@@ -148,6 +149,7 @@ class SessionStatsScreen extends StatelessWidget {
     int sessionsWithNotes = 0;
     int sessionsAbove80 = 0;
     int sessionsAbove90 = 0;
+    final sessionAccuracies = <double>[];
 
     for (final entry in grouped.entries) {
       final id = entry.key;
@@ -180,6 +182,9 @@ class SessionStatsScreen extends StatelessWidget {
       }
       if (total > 0 && (correct / total * 100) >= 90) {
         sessionsAbove90++;
+      }
+      if (total > 0) {
+        sessionAccuracies.add(correct / total * 100.0);
       }
 
       final note = notes.noteFor(id);
@@ -244,6 +249,7 @@ class SessionStatsScreen extends StatelessWidget {
           _buildStat('Сессий с заметками', sessionsWithNotes.toString()),
           _buildAccuracyProgress(context, sessionsAbove80, sessionsCount),
           _buildGoalProgress(context, sessionsAbove90),
+          SessionAccuracyDistributionChart(accuracies: sessionAccuracies),
           const SizedBox(height: 16),
           if (weekly.length > 1)
             Container(

--- a/lib/widgets/common/session_accuracy_distribution_chart.dart
+++ b/lib/widgets/common/session_accuracy_distribution_chart.dart
@@ -1,0 +1,129 @@
+import 'dart:math';
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+
+class SessionAccuracyDistributionChart extends StatelessWidget {
+  final List<double> accuracies;
+
+  const SessionAccuracyDistributionChart({super.key, required this.accuracies});
+
+  @override
+  Widget build(BuildContext context) {
+    if (accuracies.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final labels = ['50–60%', '60–70%', '70–80%', '80–90%', '90–100%'];
+    final counts = List<int>.filled(labels.length, 0);
+    for (final a in accuracies) {
+      if (a >= 50 && a < 60) {
+        counts[0]++;
+      } else if (a < 70) {
+        counts[1]++;
+      } else if (a < 80) {
+        counts[2]++;
+      } else if (a < 90) {
+        counts[3]++;
+      } else {
+        counts[4]++;
+      }
+    }
+
+    final maxCount = counts.reduce(max);
+    final groups = <BarChartGroupData>[];
+    for (var i = 0; i < counts.length; i++) {
+      final color = Colors.blueGrey;
+      groups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: counts[i].toDouble(),
+              width: 14,
+              borderRadius: BorderRadius.circular(4),
+              gradient: LinearGradient(
+                colors: [color.withOpacity(0.7), color],
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    double interval = 1;
+    if (maxCount > 5) {
+      interval = (maxCount / 5).ceilToDouble();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: BarChart(
+          BarChartData(
+            maxY: maxCount.toDouble(),
+            minY: 0,
+            alignment: BarChartAlignment.spaceAround,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: interval,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: interval,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= labels.length) {
+                      return const SizedBox.shrink();
+                    }
+                    final text = labels[index];
+                    return Text(
+                      text,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            barGroups: groups,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- visualize distribution of session accuracy
- compute per-session accuracy and render in `SessionStatsScreen`

## Testing
- `git commit -m "feat(stats): add accuracy histogram"`

------
https://chatgpt.com/codex/tasks/task_e_685a83641cf8832ab55e3ad1a121cff4