### PR TITLE
Add session accuracy-volume chart

### DIFF
--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -13,6 +13,7 @@ import '../services/session_note_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/common/session_accuracy_distribution_chart.dart';
 import '../widgets/common/mistake_by_street_chart.dart';
+import '../widgets/common/session_volume_accuracy_chart.dart';
 import 'saved_hands_screen.dart';
 
 class SessionStatsScreen extends StatefulWidget {
@@ -229,6 +230,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     int sessionsAbove80 = 0;
     int sessionsAbove90 = 0;
     final sessionAccuracies = <double>[];
+    final sessionPoints = <SessionVolumeAccuracyPoint>[];
     final streetErrors = <int, int>{0: 0, 1: 0, 2: 0, 3: 0};
 
     for (final entry in grouped.entries) {
@@ -265,7 +267,9 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
         sessionsAbove90++;
       }
       if (total > 0) {
-        sessionAccuracies.add(correct / total * 100.0);
+        final acc = correct / total * 100.0;
+        sessionAccuracies.add(acc);
+        sessionPoints.add(SessionVolumeAccuracyPoint(end, acc, total));
       }
 
       final note = notes.noteFor(id);
@@ -360,6 +364,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
       sessionsAbove80: sessionsAbove80,
       sessionsAbove90: sessionsAbove90,
       sessionAccuracies: sessionAccuracies,
+      sessions: sessionPoints,
       weekly: weekly,
       tagEntries: tagEntries,
       errorTagEntries: errorTagEntries,
@@ -602,6 +607,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     final summary = _gatherStats(manager, notes);
 
     final weekly = summary.weekly;
+    final sessionSeries = summary.sessions;
     final spots = <FlSpot>[];
     for (var i = 0; i < weekly.length; i++) {
       spots.add(FlSpot(i.toDouble(), weekly[i].winrate));
@@ -672,6 +678,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
           _buildGoalProgress(context, summary.sessionsAbove90),
           MistakeByStreetChart(counts: summary.mistakesByStreet),
           SessionAccuracyDistributionChart(accuracies: summary.sessionAccuracies),
+          SessionVolumeAccuracyChart(sessions: sessionSeries),
           const SizedBox(height: 16),
           if (weekly.length > 1)
             Container(
@@ -873,6 +880,7 @@ class _StatsSummary {
   final int sessionsAbove80;
   final int sessionsAbove90;
   final List<double> sessionAccuracies;
+  final List<SessionVolumeAccuracyPoint> sessions;
   final List<_WeekData> weekly;
   final List<MapEntry<String, int>> tagEntries;
   final List<MapEntry<String, int>> errorTagEntries;
@@ -895,6 +903,7 @@ class _StatsSummary {
     required this.sessionsAbove80,
     required this.sessionsAbove90,
     required this.sessionAccuracies,
+    required this.sessions,
     required this.weekly,
     required this.tagEntries,
     required this.errorTagEntries,

--- a/lib/widgets/common/session_volume_accuracy_chart.dart
+++ b/lib/widgets/common/session_volume_accuracy_chart.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../theme/app_colors.dart';
+
+class SessionVolumeAccuracyPoint {
+  final DateTime date;
+  final double accuracy;
+  final int hands;
+
+  SessionVolumeAccuracyPoint(this.date, this.accuracy, this.hands);
+}
+
+class SessionVolumeAccuracyChart extends StatelessWidget {
+  final List<SessionVolumeAccuracyPoint> sessions;
+
+  const SessionVolumeAccuracyChart({super.key, required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    if (sessions.length < 2) {
+      return const SizedBox.shrink();
+    }
+
+    final sorted = [...sessions]..sort((a, b) => a.date.compareTo(b.date));
+    final accuracySpots = <FlSpot>[];
+    final volumeSpots = <FlSpot>[];
+    int maxVolume = 0;
+    for (var i = 0; i < sorted.length; i++) {
+      final s = sorted[i];
+      accuracySpots.add(FlSpot(i.toDouble(), s.accuracy));
+      volumeSpots.add(FlSpot(i.toDouble(), s.hands.toDouble()));
+      if (s.hands > maxVolume) maxVolume = s.hands;
+    }
+    final scaledVolumeSpots = [
+      for (final spot in volumeSpots)
+        FlSpot(
+          spot.x,
+          maxVolume > 0 ? spot.y / maxVolume * 100 : 0,
+        )
+    ];
+
+    final step = (sorted.length / 6).ceil();
+
+    double volumeInterval = 20;
+
+    final accuracyLine = LineChartBarData(
+      spots: accuracySpots,
+      isCurved: true,
+      color: Colors.orangeAccent,
+      barWidth: 2,
+      dotData: FlDotData(show: false),
+    );
+
+    final volumeLine = LineChartBarData(
+      spots: scaledVolumeSpots,
+      isCurved: true,
+      color: Colors.lightBlueAccent,
+      barWidth: 2,
+      dotData: FlDotData(show: false),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              rightTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: volumeInterval,
+                  reservedSize: 40,
+                  getTitlesWidget: (value, meta) {
+                    final v = (value / 100 * maxVolume).round();
+                    return Text(
+                      v.toString(),
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= sorted.length) {
+                      return const SizedBox.shrink();
+                    }
+                    if (index % step != 0 && index != sorted.length - 1) {
+                      return const SizedBox.shrink();
+                    }
+                    final d = sorted[index].date;
+                    final label =
+                        '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                    return Text(
+                      label,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            lineBarsData: [accuracyLine, volumeLine],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- visualize session accuracy and volume over time with a new line chart
- wire the chart into `SessionStatsScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a98445920832a97593b60dac539a1