### PR TITLE
Add reusable SavedHandListView widget

### DIFF
--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../models/saved_hand.dart';
+import '../theme/constants.dart';
+import 'saved_hand_tile.dart';
+
+class SavedHandListView extends StatelessWidget {
+  final List<SavedHand> hands;
+  final Iterable<String>? tags;
+  final Iterable<String>? positions;
+  final String? accuracy; // 'correct' or 'errors'
+  final String title;
+  final ValueChanged<SavedHand> onTap;
+  final ValueChanged<SavedHand>? onFavoriteToggle;
+
+  const SavedHandListView({
+    super.key,
+    required this.hands,
+    required this.title,
+    required this.onTap,
+    this.tags,
+    this.positions,
+    this.accuracy,
+    this.onFavoriteToggle,
+  });
+
+  bool _matchesAccuracy(SavedHand h) {
+    if (accuracy == null) return true;
+    final expected = h.expectedAction?.trim().toLowerCase();
+    final gto = h.gtoAction?.trim().toLowerCase();
+    if (expected == null || gto == null) return false;
+    final equal = expected == gto;
+    if (accuracy == 'correct') return equal;
+    if (accuracy == 'errors') return !equal;
+    return true;
+  }
+
+  List<SavedHand> _filtered() {
+    return [
+      for (final h in hands)
+        if ((tags == null || tags!.any(h.tags.contains)) &&
+            (positions == null || positions!.contains(h.heroPosition)) &&
+            _matchesAccuracy(h))
+          h
+    ]..sort((a, b) => b.date.compareTo(a.date));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = _filtered();
+    int correct = 0;
+    int mistakes = 0;
+    for (final h in filtered) {
+      final expected = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (expected != null && gto != null) {
+        if (expected == gto) {
+          correct++;
+        } else {
+          mistakes++;
+        }
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(AppConstants.padding16),
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: AppConstants.fontSize20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppConstants.padding16,
+          ),
+          child: Text(
+            'Раздач: ${filtered.length} • Верно: $correct • Ошибки: $mistakes',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: filtered.isEmpty
+              ? const Center(
+                  child: Text(
+                    'Нет раздач',
+                    style: TextStyle(color: Colors.white54),
+                  ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(AppConstants.padding16),
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final hand = filtered[index];
+                    return SavedHandTile(
+                      hand: hand,
+                      onTap: () => onTap(hand),
+                      onFavoriteToggle: onFavoriteToggle == null
+                          ? null
+                          : () => onFavoriteToggle!(hand),
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `SavedHandListView` for displaying filtered hands with counts
- use the widget in `SavedHandsScreen`

## Testing
- `dart` or `flutter` not available, formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_685aaa5b38d4832aa423d0ec9f7e4c4a