### PR TITLE
Add tag mistake overview screen

### DIFF
--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -16,6 +16,7 @@ import '../widgets/common/session_accuracy_distribution_chart.dart';
 import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
 import 'saved_hands_screen.dart';
+import 'tag_mistake_overview_screen.dart';
 
 class SessionStatsScreen extends StatefulWidget {
   const SessionStatsScreen({super.key});
@@ -765,6 +766,20 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
           _buildStat('Сессий с заметками', summary.sessionsWithNotes.toString()),
           _buildAccuracyProgress(context, summary.sessionsAbove80, summary.sessionsCount),
           _buildGoalProgress(context, summary.sessionsAbove90),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TagMistakeOverviewScreen(),
+                  ),
+                );
+              },
+              child: const Text('Ошибки по тегам'),
+            ),
+          ),
           _buildStreetFilters(),
           MistakeByStreetChart(counts: summary.mistakesByStreet),
           SessionAccuracyDistributionChart(accuracies: summary.sessionAccuracies),

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/evaluation_executor_service.dart';
+import '../widgets/saved_hand_list_view.dart';
+import 'hand_history_review_screen.dart';
+
+class TagMistakeOverviewScreen extends StatelessWidget {
+  const TagMistakeOverviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final summary = EvaluationExecutorService().summarizeHands(hands);
+    final entries = summary.mistakeTagFrequencies.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ошибки по тегам'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          for (final e in entries)
+            ListTile(
+              title: Text(e.key, style: const TextStyle(color: Colors.white)),
+              trailing:
+                  Text(e.value.toString(), style: const TextStyle(color: Colors.white)),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => _TagMistakeHandsScreen(tag: e.key),
+                  ),
+                );
+              },
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TagMistakeHandsScreen extends StatelessWidget {
+  final String tag;
+  const _TagMistakeHandsScreen({required this.tag});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final filtered = hands.where((h) {
+      final expected = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      final isError = expected != null && gto != null && expected != gto;
+      return isError && h.tags.contains(tag);
+    }).toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(tag),
+        centerTitle: true,
+      ),
+      body: SavedHandListView(
+        hands: filtered,
+        title: 'Ошибки: $tag',
+        onTap: (hand) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => HandHistoryReviewScreen(hand: hand),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- list mistake counts for each tag via new `TagMistakeOverviewScreen`
- navigate to a filtered `SavedHandListView` when a tag is tapped
- link the overview from `SessionStatsScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aaef7e8b0832aa5a8a9f0056bbb4f