### PR TITLE
Add doc for tag mistake overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ where the complete UI and logic are not required.
 
 - Save and load played hands
 - View training history and overall statistics
+- See mistake counts grouped by tag to identify weak spots
 - Share your results via exported files
 - Optional checkbox lets you export only sessions that contain at least three tags
 - Pending evaluations are stored in saved hand exports so queued

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -6,6 +6,12 @@ import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import 'hand_history_review_screen.dart';
 
+/// Screen showing mistakes grouped by tag.
+///
+/// The list is populated using [EvaluationExecutorService.summarizeHands]
+/// so that each tag displays how many errors were made. Tapping a tag
+/// navigates to a filtered [SavedHandListView] with only the mistakes for
+/// that tag.
 class TagMistakeOverviewScreen extends StatelessWidget {
   const TagMistakeOverviewScreen({super.key});
 


### PR DESCRIPTION
## Summary
- document TagMistakeOverviewScreen
- mention tag mistake overview in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ab04e087c832ab9f1896d9baa3e14