### PR TITLE
Add usage docs for SavedHandListView

### DIFF
--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -1,4 +1,10 @@
-/// Reusable widget for displaying filtered saved hands with summary counts.
+/// Displays a scrollable list of [SavedHand] items with optional filtering and summary counts.
+///
+/// The widget filters [hands] by [tags], [positions] and [accuracy] before
+/// displaying them. [title] is shown above the list, and [onTap] is invoked
+/// when a hand is tapped. If [onFavoriteToggle] is provided, each tile will
+/// show a star button.
+
 import 'package:flutter/material.dart';
 
 import '../models/saved_hand.dart';


### PR DESCRIPTION
## Summary
- document SavedHandListView widget usage

## Testing
- `dart format lib/widgets/saved_hand_list_view.dart` *(fails: dart not installed)*
- `flutter format lib/widgets/saved_hand_list_view.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ab6bd8858832aaf13af592912430b