### PR TITLE
Add StreetMistakeOverviewScreen

### DIFF
--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
 import 'saved_hands_screen.dart';
 import 'tag_mistake_overview_screen.dart';
+import 'street_mistake_overview_screen.dart';
 
 class SessionStatsScreen extends StatefulWidget {
   const SessionStatsScreen({super.key});
@@ -778,6 +779,20 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
                 );
               },
               child: const Text('Ошибки по тегам'),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const StreetMistakeOverviewScreen(),
+                  ),
+                );
+              },
+              child: const Text('Ошибки по улицам'),
             ),
           ),
           _buildStreetFilters(),

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/evaluation_executor_service.dart';
+import '../widgets/saved_hand_list_view.dart';
+import 'hand_history_review_screen.dart';
+
+/// Displays a list of streets sorted by mistake count.
+///
+/// Information is pulled from [EvaluationExecutorService.summarizeHands]. Each
+/// tile shows how many errors were made on that street. Selecting a street opens
+/// a filtered [SavedHandListView] showing only the mistaken hands for the chosen
+/// street.
+class StreetMistakeOverviewScreen extends StatelessWidget {
+  const StreetMistakeOverviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final summary = EvaluationExecutorService().summarizeHands(hands);
+    final entries = summary.streetBreakdown.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ошибки по улицам'),
+        centerTitle: true,
+      ),
+      body: entries.isEmpty
+          ? const Center(
+              child: Text(
+                'Ошибок нет',
+                style: TextStyle(color: Colors.white70),
+              ),
+            )
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                for (final e in entries)
+                  ListTile(
+                    title:
+                        Text(e.key, style: const TextStyle(color: Colors.white)),
+                    trailing: Text(e.value.toString(),
+                        style: const TextStyle(color: Colors.white)),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => _StreetMistakeHandsScreen(street: e.key),
+                        ),
+                      );
+                    },
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+class _StreetMistakeHandsScreen extends StatelessWidget {
+  final String street;
+  const _StreetMistakeHandsScreen({required this.street});
+
+  @override
+  Widget build(BuildContext context) {
+    final allHands = context.watch<SavedHandManagerService>().hands;
+    final filtered = [
+      for (final h in allHands)
+        if (_streetName(h.boardStreet) == street) h
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(street),
+        centerTitle: true,
+      ),
+      body: SavedHandListView(
+        hands: filtered,
+        accuracy: 'errors',
+        title: 'Ошибки: $street',
+        onTap: (hand) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => HandHistoryReviewScreen(hand: hand),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _streetName(int index) {
+  const names = ['Preflop', 'Flop', 'Turn', 'River'];
+  return names[index.clamp(0, names.length - 1)];
+}


### PR DESCRIPTION
## Summary
- create `StreetMistakeOverviewScreen` for viewing mistakes per street
- link the new screen from the session statistics page

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab873f88c832aa607d2312260e30e