### PR TITLE
Refactor EvaluationExecutorService as singleton

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'services/tag_service.dart';
 import 'services/cloud_sync_service.dart';
 import 'services/cloud_training_history_service.dart';
 import 'services/training_spot_storage_service.dart';
+import 'services/evaluation_executor_service.dart';
 import 'user_preferences.dart';
 
 void main() {
@@ -60,6 +61,7 @@ void main() {
         ChangeNotifierProvider(
           create: (_) => TagService()..load(),
         ),
+        Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),
       ],
       child: const PokerAIAnalyzerApp(),

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -60,7 +60,8 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hands = context.watch<SavedHandManagerService>().hands;
-    final summary = EvaluationExecutorService().summarizeHands(hands);
+    final summary =
+        context.read<EvaluationExecutorService>().summarizeHands(hands);
     final entries = summary.positionMistakeFrequencies.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -61,7 +61,8 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hands = context.watch<SavedHandManagerService>().hands;
-    final summary = EvaluationExecutorService().summarizeHands(hands);
+    final summary =
+        context.read<EvaluationExecutorService>().summarizeHands(hands);
     final entries = summary.streetBreakdown.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -61,7 +61,8 @@ class TagMistakeOverviewScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hands = context.watch<SavedHandManagerService>().hands;
-    final summary = EvaluationExecutorService().summarizeHands(hands);
+    final summary =
+        context.read<EvaluationExecutorService>().summarizeHands(hands);
     final entries = summary.mistakeTagFrequencies.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -1393,7 +1393,7 @@ body { font-family: sans-serif; padding: 16px; }
                   providers: [
                     ChangeNotifierProvider(create: (_) => PlayerProfileService()),
                     ChangeNotifierProvider(create: (_) => PlayerManagerService(context.read<PlayerProfileService>())),
-                    Provider(create: (_) => EvaluationExecutorService()),
+                    Provider.value(value: EvaluationExecutorService()),
                   ],
                   child: Builder(
                     builder: (context) => ChangeNotifierProvider(

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -7,12 +7,26 @@ import '../models/training_spot.dart';
 import '../models/saved_hand.dart';
 import '../models/summary_result.dart';
 
+/// Interface for evaluation execution logic.
+abstract class EvaluationExecutor {
+  Future<void> execute(ActionEvaluationRequest req);
+  EvaluationResult evaluate(TrainingSpot spot, String userAction);
+  SummaryResult summarizeHands(List<SavedHand> hands);
+}
+
 /// Handles execution of a single evaluation request.
-class EvaluationExecutorService {
+class EvaluationExecutorService implements EvaluationExecutor {
+  EvaluationExecutorService._internal();
+  static final EvaluationExecutorService _instance =
+      EvaluationExecutorService._internal();
+
+  factory EvaluationExecutorService() => _instance;
+
   /// Executes the evaluation for [req].
   ///
   /// This stub simulates a delay and introduces a random failure
   /// for debugging purposes.
+  @override
   Future<void> execute(ActionEvaluationRequest req) async {
     await Future.delayed(const Duration(milliseconds: 300));
     if (Random().nextDouble() < 0.2) {
@@ -24,6 +38,7 @@ class EvaluationExecutorService {
   ///
   /// The initial implementation simply checks if the action matches the
   /// expected action for the hero at the given training spot.
+  @override
   EvaluationResult evaluate(TrainingSpot spot, String userAction) {
     final expectedAction = spot.actions[spot.heroIndex].action;
     final correct = userAction == expectedAction;
@@ -44,6 +59,7 @@ class EvaluationExecutorService {
   }
 
   /// Generates a summary for a list of saved hands.
+  @override
   SummaryResult summarizeHands(List<SavedHand> hands) {
     final Map<int, List<SavedHand>> sessions = {};
     for (final hand in hands) {


### PR DESCRIPTION
## Summary
- make EvaluationExecutorService a singleton and expose an interface
- register EvaluationExecutorService via Provider
- use context.read<EvaluationExecutorService>() in mistake overview screens
- share singleton instance in TrainingPackScreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ae0663e04832a98d5c1b61502a541