### PR TITLE
Add doc comment for AccuracyMistakeOverviewScreen

### DIFF
--- a/lib/screens/accuracy_mistake_overview_screen.dart
+++ b/lib/screens/accuracy_mistake_overview_screen.dart
@@ -4,6 +4,11 @@ import 'package:provider/provider.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 
+/// Shows accuracy percentages grouped by tag, street and hero position.
+///
+/// Information is pulled from [EvaluationExecutorService.summarizeHands]. Lists
+/// are sorted by ascending accuracy so the weakest groups appear first.
+
 class AccuracyMistakeOverviewScreen extends StatelessWidget {
   const AccuracyMistakeOverviewScreen({super.key});
 


### PR DESCRIPTION
## Summary
- document accuracy overview screen

## Testing
- `dart format lib/screens/accuracy_mistake_overview_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af3260ffc832a953d29bb575a915b