### PR TITLE
Add street mistake overview improvements

### DIFF
--- a/lib/helpers/poker_street_helper.dart
+++ b/lib/helpers/poker_street_helper.dart
@@ -1,0 +1,15 @@
+/// Utilities for working with poker streets.
+///
+/// Provides a constant list of street names and a helper to map
+/// numeric indices to those names.
+library poker_street_helper;
+
+/// Street name list ordered from preflop to river.
+const kStreetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+
+/// Returns the street name for [index].
+///
+/// Values outside the valid range are clamped.
+String streetName(int index) {
+  return kStreetNames[index.clamp(0, kStreetNames.length - 1)];
+}

--- a/lib/screens/accuracy_mistake_overview_screen.dart
+++ b/lib/screens/accuracy_mistake_overview_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../helpers/poker_street_helper.dart';
 
 /// Shows accuracy percentages grouped by tag, street and hero position.
 ///
@@ -12,11 +13,6 @@ import '../services/evaluation_executor_service.dart';
 class AccuracyMistakeOverviewScreen extends StatelessWidget {
   const AccuracyMistakeOverviewScreen({super.key});
 
-  static const _streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
-
-  String _streetName(int index) {
-    return _streetNames[index.clamp(0, _streetNames.length - 1)];
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +22,7 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
 
     final Map<String, int> tagTotals = {};
     final Map<String, int> streetTotals = {
-      for (final s in _streetNames) s: 0
+      for (final s in kStreetNames) s: 0
     };
     final Map<String, int> positionTotals = {};
 
@@ -34,7 +30,7 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
       for (final t in h.tags) {
         tagTotals[t] = (tagTotals[t] ?? 0) + 1;
       }
-      final street = _streetName(h.boardStreet);
+      final street = streetName(h.boardStreet);
       streetTotals[street] = (streetTotals[street] ?? 0) + 1;
       positionTotals[h.heroPosition] =
           (positionTotals[h.heroPosition] ?? 0) + 1;

--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/street_action_list_simple.dart';
 import '../models/card_model.dart';
 import '../services/action_sync_service.dart';
 import '../models/player_model.dart';
+import '../helpers/poker_street_helper.dart';
 
 class PlayerZoneDemoScreen extends StatefulWidget {
   const PlayerZoneDemoScreen({super.key});
@@ -17,7 +18,6 @@ class PlayerZoneDemoScreen extends StatefulWidget {
 
 class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
   int _street = 0;
-  final List<String> _streetNames = const ['Preflop', 'Flop', 'Turn', 'River'];
   final List<PlayerModel> _players = [
     PlayerModel(name: 'Alice', stack: 100, bet: 0),
     PlayerModel(name: 'Bob', stack: 75, bet: 0),
@@ -45,7 +45,7 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
                   child: PlayerZoneWidget(
                     player: player,
                     playerName: player.name,
-                    street: _streetNames[_street],
+                    street: kStreetNames[_street],
                     position: null,
                     cards: _cards[index],
                     currentBet: player.bet,
@@ -72,7 +72,7 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  for (final s in _streetNames)
+                  for (final s in kStreetNames)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 12.0),
                       child: StreetActionListSimple(street: s),

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -15,6 +15,7 @@ import '../theme/app_colors.dart';
 import '../widgets/common/session_accuracy_distribution_chart.dart';
 import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
+import '../helpers/poker_street_helper.dart';
 import 'saved_hands_screen.dart';
 import 'tag_mistake_overview_screen.dart';
 import 'street_mistake_overview_screen.dart';
@@ -270,7 +271,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
   }
 
   Widget _buildStreetFilters() {
-    const labels = ['Preflop', 'Flop', 'Turn', 'River'];
+    const labels = kStreetNames;
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Wrap(
@@ -465,10 +466,8 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
       mistakeErrors: mistakeErrors,
       mistakeRate: highestRate,
       mistakesByStreet: {
-        'Preflop': streetErrors[0] ?? 0,
-        'Flop': streetErrors[1] ?? 0,
-        'Turn': streetErrors[2] ?? 0,
-        'River': streetErrors[3] ?? 0,
+        for (int i = 0; i < kStreetNames.length; i++)
+          kStreetNames[i]: streetErrors[i] ?? 0,
       },
       accuracyDiff: accuracyDiff,
       mistakeDiff: mistakeDiff,

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -11,6 +11,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
+import '../helpers/poker_street_helper.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays a list of streets sorted by mistake count.
@@ -109,6 +110,7 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
   }
 }
 
+/// Shows all hands with mistakes on the selected [street].
 class _StreetMistakeHandsScreen extends StatelessWidget {
   final String street;
   const _StreetMistakeHandsScreen({required this.street});
@@ -118,7 +120,7 @@ class _StreetMistakeHandsScreen extends StatelessWidget {
     final allHands = context.watch<SavedHandManagerService>().hands;
     final filtered = [
       for (final h in allHands)
-        if (_streetName(h.boardStreet) == street) h
+        if (streetName(h.boardStreet) == street) h
     ];
 
     return Scaffold(
@@ -143,7 +145,3 @@ class _StreetMistakeHandsScreen extends StatelessWidget {
   }
 }
 
-String _streetName(int index) {
-  const names = ['Preflop', 'Flop', 'Turn', 'River'];
-  return names[index.clamp(0, names.length - 1)];
-}

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -8,6 +8,7 @@ import '../widgets/street_actions_list.dart';
 import '../models/action_entry.dart';
 import '../services/user_preferences_service.dart';
 import 'package:provider/provider.dart';
+import '../helpers/poker_street_helper.dart';
 
 /// Displays actions for a [TrainingSpot] grouped by street in collapsible sections.
 class TrainingSpotAnalysisScreen extends StatefulWidget {
@@ -74,7 +75,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
     final stacks = _computeStacks();
     final positions = _posMap();
     final prefs = context.watch<UserPreferencesService>();
-    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+    const streetNames = kStreetNames;
 
     final tiles = <Widget>[];
     for (int street = 0; street < 4; street++) {

--- a/lib/widgets/detailed_action_bottom_sheet.dart
+++ b/lib/widgets/detailed_action_bottom_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../helpers/poker_street_helper.dart';
 
 Future<Map<String, dynamic>?> showDetailedActionBottomSheet(
   BuildContext context, {
@@ -145,7 +146,7 @@ class _DetailedActionSheetState extends State<_DetailedActionSheet> {
       {'label': 'Bet', 'value': 'bet', 'icon': '💰'},
       {'label': 'Raise', 'value': 'raise', 'icon': '📈'},
     ];
-    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+    const streetNames = kStreetNames;
 
     return Padding(
       padding: MediaQuery.of(context).viewInsets + const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- centralize street name helpers
- hook existing screens to `poker_street_helper`
- use `streetName` for filtering mistake hands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685afbe60ee0832abd1a21037bcc2075