### PR TITLE
Add centralized street name helper

### DIFF
--- a/lib/helpers/street_name_helper.dart
+++ b/lib/helpers/street_name_helper.dart
@@ -1,0 +1,5 @@
+const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
+
+String streetName(int index) {
+  return streetNames[index.clamp(0, streetNames.length - 1)];
+}

--- a/lib/screens/accuracy_mistake_overview_screen.dart
+++ b/lib/screens/accuracy_mistake_overview_screen.dart
@@ -3,15 +3,10 @@ import 'package:provider/provider.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../helpers/street_name_helper.dart';
 
 class AccuracyMistakeOverviewScreen extends StatelessWidget {
   const AccuracyMistakeOverviewScreen({super.key});
-
-  static const _streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
-
-  String _streetName(int index) {
-    return _streetNames[index.clamp(0, _streetNames.length - 1)];
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +16,7 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
 
     final Map<String, int> tagTotals = {};
     final Map<String, int> streetTotals = {
-      for (final s in _streetNames) s: 0
+      for (final s in streetNames) s: 0
     };
     final Map<String, int> positionTotals = {};
 
@@ -29,7 +24,7 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
       for (final t in h.tags) {
         tagTotals[t] = (tagTotals[t] ?? 0) + 1;
       }
-      final street = _streetName(h.boardStreet);
+      final street = streetName(h.boardStreet);
       streetTotals[street] = (streetTotals[street] ?? 0) + 1;
       positionTotals[h.heroPosition] =
           (positionTotals[h.heroPosition] ?? 0) + 1;

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -7,6 +7,7 @@ import 'package:pdf/pdf.dart';
 import 'dart:io';
 
 import '../helpers/date_utils.dart';
+import '../helpers/street_name_helper.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
@@ -118,7 +119,7 @@ class _StreetMistakeHandsScreen extends StatelessWidget {
     final allHands = context.watch<SavedHandManagerService>().hands;
     final filtered = [
       for (final h in allHands)
-        if (_streetName(h.boardStreet) == street) h
+        if (streetName(h.boardStreet) == street) h
     ];
 
     return Scaffold(
@@ -143,7 +144,3 @@ class _StreetMistakeHandsScreen extends StatelessWidget {
   }
 }
 
-String _streetName(int index) {
-  const names = ['Preflop', 'Flop', 'Turn', 'River'];
-  return names[index.clamp(0, names.length - 1)];
-}

--- a/lib/widgets/street_indicator.dart
+++ b/lib/widgets/street_indicator.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
+import '../helpers/street_name_helper.dart';
+
 /// Badge displaying the name of the current street.
 class StreetIndicator extends StatelessWidget {
   final int street;
   const StreetIndicator({Key? key, required this.street}) : super(key: key);
 
-  static const _names = ['Preflop', 'Flop', 'Turn', 'River'];
 
   @override
   Widget build(BuildContext context) {
-    final name = _names[street.clamp(0, _names.length - 1)];
+    final name = streetName(street);
     return Align(
       alignment: Alignment.topCenter,
       child: AnimatedSwitcher(


### PR DESCRIPTION
## Summary
- extract street names into shared helper
- use helper inside accuracy/street mistake screens
- update street indicator to use helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685af5dd94c8832a8456b157ee6447a6