### PR TITLE
Add consolidated mistake overview

### DIFF
--- a/lib/screens/mistake_overview_screen.dart
+++ b/lib/screens/mistake_overview_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'tag_mistake_overview_screen.dart';
+import 'position_mistake_overview_screen.dart';
+import 'street_mistake_overview_screen.dart';
+
+class MistakeOverviewScreen extends StatefulWidget {
+  const MistakeOverviewScreen({super.key});
+
+  @override
+  State<MistakeOverviewScreen> createState() => _MistakeOverviewScreenState();
+}
+
+class _MistakeOverviewScreenState extends State<MistakeOverviewScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ошибки'),
+        centerTitle: true,
+        bottom: TabBar(
+          controller: _controller,
+          tabs: const [
+            Tab(text: 'По тегам'),
+            Tab(text: 'По позициям'),
+            Tab(text: 'По улицам'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _controller,
+        children: const [
+          TagMistakeOverviewScreen(),
+          PositionMistakeOverviewScreen(),
+          StreetMistakeOverviewScreen(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -17,9 +17,7 @@ import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
 import '../helpers/poker_street_helper.dart';
 import 'saved_hands_screen.dart';
-import 'tag_mistake_overview_screen.dart';
-import 'street_mistake_overview_screen.dart';
-import 'position_mistake_overview_screen.dart';
+import 'mistake_overview_screen.dart';
 import 'accuracy_mistake_overview_screen.dart';
 
 class SessionStatsScreen extends StatefulWidget {
@@ -775,39 +773,11 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => const TagMistakeOverviewScreen(),
+                    builder: (_) => const MistakeOverviewScreen(),
                   ),
                 );
               },
-              child: const Text('Ошибки по тегам'),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const StreetMistakeOverviewScreen(),
-                  ),
-                );
-              },
-              child: const Text('Ошибки по улицам'),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const PositionMistakeOverviewScreen(),
-                  ),
-                );
-              },
-              child: const Text('Ошибки по позициям'),
+              child: const Text('Ошибки'),
             ),
           ),
           Padding(


### PR DESCRIPTION
## Summary
- create `MistakeOverviewScreen` with tabbed view for tag, position and street stats
- add a single "Ошибки" button in session stats that opens the new screen

## Testing
- `git status --short`
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685afed7c0a8832a8861d9a696ec3d7f