### PR TITLE
Add sticky headers to mistake overview tabs

### DIFF
--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -66,30 +66,39 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
     final entries = summary.positionMistakeFrequencies.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Ошибки по позициям'),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.share),
-            tooltip: 'PDF',
-            onPressed: () => _exportPdf(context, entries),
-          ),
-        ],
-      ),
-      body: entries.isEmpty
-          ? const Center(
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          pinned: true,
+          automaticallyImplyLeading: false,
+          title: const Text('Ошибки по позициям'),
+          centerTitle: true,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.share),
+              tooltip: 'PDF',
+              onPressed: () => _exportPdf(context, entries),
+            ),
+          ],
+        ),
+        if (entries.isEmpty)
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
               child: Text(
                 'Ошибок нет',
                 style: TextStyle(color: Colors.white70),
               ),
-            )
-          : ListView(
-              padding: const EdgeInsets.all(16),
-              children: [
-                for (final e in entries)
-                  ListTile(
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final e = entries[index];
+                  return ListTile(
                     title: Text(e.key, style: const TextStyle(color: Colors.white)),
                     trailing: Text(e.value.toString(),
                         style: const TextStyle(color: Colors.white)),
@@ -101,9 +110,13 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
                         ),
                       );
                     },
-                  ),
-              ],
+                  );
+                },
+                childCount: entries.length,
+              ),
             ),
+          ),
+      ],
     );
   }
 }

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -67,32 +67,40 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
     final entries = summary.streetBreakdown.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Ошибки по улицам'),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.share),
-            tooltip: 'PDF',
-            onPressed: () => _exportPdf(context, entries),
-          ),
-        ],
-      ),
-      body: entries.isEmpty
-          ? const Center(
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          pinned: true,
+          automaticallyImplyLeading: false,
+          title: const Text('Ошибки по улицам'),
+          centerTitle: true,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.share),
+              tooltip: 'PDF',
+              onPressed: () => _exportPdf(context, entries),
+            ),
+          ],
+        ),
+        if (entries.isEmpty)
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
               child: Text(
                 'Ошибок нет',
                 style: TextStyle(color: Colors.white70),
               ),
-            )
-          : ListView(
-              padding: const EdgeInsets.all(16),
-              children: [
-                for (final e in entries)
-                  ListTile(
-                    title:
-                        Text(e.key, style: const TextStyle(color: Colors.white)),
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final e = entries[index];
+                  return ListTile(
+                    title: Text(e.key, style: const TextStyle(color: Colors.white)),
                     trailing: Text(e.value.toString(),
                         style: const TextStyle(color: Colors.white)),
                     onTap: () {
@@ -103,9 +111,13 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
                         ),
                       );
                     },
-                  ),
-              ],
+                  );
+                },
+                childCount: entries.length,
+              ),
             ),
+          ),
+      ],
     );
   }
 }

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -66,30 +66,39 @@ class TagMistakeOverviewScreen extends StatelessWidget {
     final entries = summary.mistakeTagFrequencies.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Ошибки по тегам'),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.share),
-            tooltip: 'PDF',
-            onPressed: () => _exportPdf(context, entries),
-          ),
-        ],
-      ),
-      body: entries.isEmpty
-          ? const Center(
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          pinned: true,
+          automaticallyImplyLeading: false,
+          title: const Text('Ошибки по тегам'),
+          centerTitle: true,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.share),
+              tooltip: 'PDF',
+              onPressed: () => _exportPdf(context, entries),
+            ),
+          ],
+        ),
+        if (entries.isEmpty)
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
               child: Text(
                 'Ошибок нет',
                 style: TextStyle(color: Colors.white70),
               ),
-            )
-          : ListView(
-              padding: const EdgeInsets.all(16),
-              children: [
-                for (final e in entries)
-                  ListTile(
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final e = entries[index];
+                  return ListTile(
                     title: Text(e.key, style: const TextStyle(color: Colors.white)),
                     trailing:
                         Text(e.value.toString(), style: const TextStyle(color: Colors.white)),
@@ -101,9 +110,13 @@ class TagMistakeOverviewScreen extends StatelessWidget {
                         ),
                       );
                     },
-                  ),
-              ],
+                  );
+                },
+                childCount: entries.length,
+              ),
             ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- keep context visible while scrolling mistake overviews
- show pinned sliver app bar in tag, position and street screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b00860eac832a83852b5649b6482b