### PR TITLE
Add summary section to mistake overview tabs

### DIFF
--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -10,6 +10,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
+import '../widgets/mistake_summary_section.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays a list of hero positions sorted by mistake count.
@@ -80,6 +81,12 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
               onPressed: () => _exportPdf(context, entries),
             ),
           ],
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.all(16),
+          sliver: SliverToBoxAdapter(
+            child: MistakeSummarySection(summary: summary),
+          ),
         ),
         if (entries.isEmpty)
           const SliverFillRemaining(

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -11,6 +11,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
+import '../widgets/mistake_summary_section.dart';
 import '../helpers/poker_street_helper.dart';
 import 'hand_history_review_screen.dart';
 
@@ -81,6 +82,12 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
               onPressed: () => _exportPdf(context, entries),
             ),
           ],
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.all(16),
+          sliver: SliverToBoxAdapter(
+            child: MistakeSummarySection(summary: summary),
+          ),
         ),
         if (entries.isEmpty)
           const SliverFillRemaining(

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -11,6 +11,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
+import '../widgets/mistake_summary_section.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays a list of tags sorted by mistake count.
@@ -80,6 +81,12 @@ class TagMistakeOverviewScreen extends StatelessWidget {
               onPressed: () => _exportPdf(context, entries),
             ),
           ],
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.all(16),
+          sliver: SliverToBoxAdapter(
+            child: MistakeSummarySection(summary: summary),
+          ),
         ),
         if (entries.isEmpty)
           const SliverFillRemaining(

--- a/lib/widgets/mistake_summary_section.dart
+++ b/lib/widgets/mistake_summary_section.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/constants.dart';
+import '../models/summary_result.dart';
+
+class MistakeSummarySection extends StatelessWidget {
+  final SummaryResult summary;
+  const MistakeSummarySection({super.key, required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final mistakes = summary.incorrect;
+    final total = summary.totalHands;
+    final accuracy = summary.accuracy;
+    final mistakePercent = total > 0 ? mistakes / total * 100 : 0.0;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(AppConstants.radius8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Ошибки: $mistakes', style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          Text('Средняя точность: ${accuracy.toStringAsFixed(1)}%',
+              style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          Text('Доля рук с ошибками: ${mistakePercent.toStringAsFixed(1)}%',
+              style: const TextStyle(color: Colors.white)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable MistakeSummarySection widget
- show summary under the sticky header for tags, positions and streets

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b032f4a6c832a8e7542da1d13bfee