### PR TITLE
Add date filter for mistakes

### DIFF
--- a/lib/screens/mistake_overview_screen.dart
+++ b/lib/screens/mistake_overview_screen.dart
@@ -17,6 +17,7 @@ class MistakeOverviewScreen extends StatefulWidget {
 class _MistakeOverviewScreenState extends State<MistakeOverviewScreen>
     with SingleTickerProviderStateMixin {
   late TabController _controller;
+  String _dateFilter = 'Все';
 
   @override
   void initState() {
@@ -71,12 +72,29 @@ class _MistakeOverviewScreenState extends State<MistakeOverviewScreen>
           ),
         ),
       ),
-      body: TabBarView(
-        controller: _controller,
-        children: const [
-          TagMistakeOverviewScreen(),
-          PositionMistakeOverviewScreen(),
-          StreetMistakeOverviewScreen(),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: DropdownButton<String>(
+              value: _dateFilter,
+              dropdownColor: const Color(0xFF2A2B2E),
+              onChanged: (v) => setState(() => _dateFilter = v ?? 'Все'),
+              items: const ['Сегодня', '7 дней', '30 дней', 'Все']
+                  .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+                  .toList(),
+            ),
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: _controller,
+              children: [
+                TagMistakeOverviewScreen(dateFilter: _dateFilter),
+                PositionMistakeOverviewScreen(dateFilter: _dateFilter),
+                StreetMistakeOverviewScreen(dateFilter: _dateFilter),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -23,7 +23,12 @@ import 'hand_history_review_screen.dart';
 /// hands for the chosen position. A share button exports the table to PDF
 /// for convenient review outside the app.
 class PositionMistakeOverviewScreen extends StatelessWidget {
-  const PositionMistakeOverviewScreen({super.key});
+  final String dateFilter;
+  const PositionMistakeOverviewScreen({super.key, required this.dateFilter});
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
 
   Future<void> _exportPdf(
       BuildContext context, SummaryResult summary, List<MapEntry<String, int>> entries) async {
@@ -73,7 +78,18 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hands = context.watch<SavedHandManagerService>().hands;
+    final allHands = context.watch<SavedHandManagerService>().hands;
+    final now = DateTime.now();
+    final hands = [
+      for (final h in allHands)
+        if (dateFilter == 'Все' ||
+            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (dateFilter == '7 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
+            (dateFilter == '30 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 30)))))
+          h
+    ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
     final entries = summary.positionMistakeFrequencies.entries.toList()
@@ -125,7 +141,10 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => _PositionMistakeHandsScreen(position: e.key),
+                          builder: (_) => _PositionMistakeHandsScreen(
+                            position: e.key,
+                            dateFilter: dateFilter,
+                          ),
                         ),
                       );
                     },
@@ -142,11 +161,27 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
 
 class _PositionMistakeHandsScreen extends StatelessWidget {
   final String position;
-  const _PositionMistakeHandsScreen({required this.position});
+  final String dateFilter;
+  const _PositionMistakeHandsScreen({required this.position, required this.dateFilter});
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final hands = context.watch<SavedHandManagerService>().hands;
+    final allHands = context.watch<SavedHandManagerService>().hands;
+    final now = DateTime.now();
+    final hands = [
+      for (final h in allHands)
+        if (dateFilter == 'Все' ||
+            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (dateFilter == '7 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
+            (dateFilter == '30 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 30)))))
+          h
+    ];
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -23,7 +23,12 @@ import 'hand_history_review_screen.dart';
 /// filtered [SavedHandListView] showing only the mistaken hands for the chosen
 /// tag.
 class TagMistakeOverviewScreen extends StatelessWidget {
-  const TagMistakeOverviewScreen({super.key});
+  final String dateFilter;
+  const TagMistakeOverviewScreen({super.key, required this.dateFilter});
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
 
   Future<void> _exportPdf(BuildContext context, SummaryResult summary,
       List<MapEntry<String, int>> entries) async {
@@ -73,7 +78,18 @@ class TagMistakeOverviewScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hands = context.watch<SavedHandManagerService>().hands;
+    final allHands = context.watch<SavedHandManagerService>().hands;
+    final now = DateTime.now();
+    final hands = [
+      for (final h in allHands)
+        if (dateFilter == 'Все' ||
+            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (dateFilter == '7 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
+            (dateFilter == '30 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 30)))))
+          h
+    ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
     final entries = summary.mistakeTagFrequencies.entries.toList()
@@ -125,7 +141,10 @@ class TagMistakeOverviewScreen extends StatelessWidget {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => _TagMistakeHandsScreen(tag: e.key),
+                          builder: (_) => _TagMistakeHandsScreen(
+                            tag: e.key,
+                            dateFilter: dateFilter,
+                          ),
                         ),
                       );
                     },
@@ -142,11 +161,27 @@ class TagMistakeOverviewScreen extends StatelessWidget {
 
 class _TagMistakeHandsScreen extends StatelessWidget {
   final String tag;
-  const _TagMistakeHandsScreen({required this.tag});
+  final String dateFilter;
+  const _TagMistakeHandsScreen({required this.tag, required this.dateFilter});
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final hands = context.watch<SavedHandManagerService>().hands;
+    final allHands = context.watch<SavedHandManagerService>().hands;
+    final now = DateTime.now();
+    final hands = [
+      for (final h in allHands)
+        if (dateFilter == 'Все' ||
+            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (dateFilter == '7 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
+            (dateFilter == '30 дней' &&
+                h.date.isAfter(now.subtract(const Duration(days: 30)))))
+          h
+    ];
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary
- add date filter state to MistakeOverviewScreen and dropdown selector
- filter hands by date in tag/position/street mistake overview tabs
- pass the chosen range to hand lists when drilling down

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b05e64ff8832ab84d764269e390ce