### PR TITLE
Add friendly empty state for mistakes

### DIFF
--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -13,6 +13,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
+import '../widgets/mistake_empty_state.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays a list of hero positions sorted by mistake count.
@@ -119,12 +120,7 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
         if (entries.isEmpty)
           const SliverFillRemaining(
             hasScrollBody: false,
-            child: Center(
-              child: Text(
-                'Ошибок нет',
-                style: TextStyle(color: Colors.white70),
-              ),
-            ),
+            child: MistakeEmptyState(),
           )
         else
           SliverPadding(

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -14,6 +14,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
+import '../widgets/mistake_empty_state.dart';
 import '../helpers/poker_street_helper.dart';
 import 'hand_history_review_screen.dart';
 
@@ -120,12 +121,7 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
         if (entries.isEmpty)
           const SliverFillRemaining(
             hasScrollBody: false,
-            child: Center(
-              child: Text(
-                'Ошибок нет',
-                style: TextStyle(color: Colors.white70),
-              ),
-            ),
+            child: MistakeEmptyState(),
           )
         else
           SliverPadding(

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -14,6 +14,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
+import '../widgets/mistake_empty_state.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays a list of tags sorted by mistake count.
@@ -119,12 +120,7 @@ class TagMistakeOverviewScreen extends StatelessWidget {
         if (entries.isEmpty)
           const SliverFillRemaining(
             hasScrollBody: false,
-            child: Center(
-              child: Text(
-                'Ошибок нет',
-                style: TextStyle(color: Colors.white70),
-              ),
-            ),
+            child: MistakeEmptyState(),
           )
         else
           SliverPadding(

--- a/lib/widgets/mistake_empty_state.dart
+++ b/lib/widgets/mistake_empty_state.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class MistakeEmptyState extends StatelessWidget {
+  const MistakeEmptyState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Icon(Icons.emoji_events, color: Colors.amberAccent, size: 64),
+          SizedBox(height: 12),
+          Text(
+            'Ошибок нет!',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'Ты отлично сыграл! Ни одной ошибки за выбранный период.',
+            style: TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `MistakeEmptyState` widget showing a trophy icon and friendly text
- show the new empty state in tag, position, and street mistake overviews

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b093dba84832aa94018071a859342