### PR TITLE
Add mistake severity badges

### DIFF
--- a/lib/models/mistake_severity.dart
+++ b/lib/models/mistake_severity.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+enum MistakeSeverity { high, medium, low }
+
+extension MistakeSeverityColor on MistakeSeverity {
+  Color get color {
+    switch (this) {
+      case MistakeSeverity.high:
+        return Colors.redAccent;
+      case MistakeSeverity.medium:
+        return Colors.orangeAccent;
+      case MistakeSeverity.low:
+      default:
+        return Colors.greenAccent;
+    }
+  }
+}

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -11,6 +11,7 @@ import 'dart:io';
 import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../models/mistake_severity.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -149,10 +150,28 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
               delegate: SliverChildBuilderDelegate(
                 (context, index) {
                   final e = entries[index];
+                  final severity = context
+                      .read<EvaluationExecutorService>()
+                      .classifySeverity(e.value);
                   return ListTile(
-                    title: Text(e.key, style: const TextStyle(color: Colors.white)),
-                    trailing: Text(e.value.toString(),
+                    title: Text(e.key,
                         style: const TextStyle(color: Colors.white)),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 10,
+                          height: 10,
+                          decoration: BoxDecoration(
+                            color: severity.color,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(e.value.toString(),
+                            style: const TextStyle(color: Colors.white)),
+                      ],
+                    ),
                     onTap: () {
                       Navigator.push(
                         context,

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -12,6 +12,7 @@ import '../helpers/date_utils.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../models/mistake_severity.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -150,10 +151,28 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
               delegate: SliverChildBuilderDelegate(
                 (context, index) {
                   final e = entries[index];
+                  final severity = context
+                      .read<EvaluationExecutorService>()
+                      .classifySeverity(e.value);
                   return ListTile(
-                    title: Text(e.key, style: const TextStyle(color: Colors.white)),
-                    trailing: Text(e.value.toString(),
+                    title: Text(e.key,
                         style: const TextStyle(color: Colors.white)),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 10,
+                          height: 10,
+                          decoration: BoxDecoration(
+                            color: severity.color,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(e.value.toString(),
+                            style: const TextStyle(color: Colors.white)),
+                      ],
+                    ),
                     onTap: () {
                       Navigator.push(
                         context,

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -12,6 +12,7 @@ import '../helpers/date_utils.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../models/mistake_severity.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -148,10 +149,28 @@ class TagMistakeOverviewScreen extends StatelessWidget {
               delegate: SliverChildBuilderDelegate(
                 (context, index) {
                   final e = entries[index];
+                  final severity = context
+                      .read<EvaluationExecutorService>()
+                      .classifySeverity(e.value);
                   return ListTile(
-                    title: Text(e.key, style: const TextStyle(color: Colors.white)),
-                    trailing:
-                        Text(e.value.toString(), style: const TextStyle(color: Colors.white)),
+                    title: Text(e.key,
+                        style: const TextStyle(color: Colors.white)),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 10,
+                          height: 10,
+                          decoration: BoxDecoration(
+                            color: severity.color,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(e.value.toString(),
+                            style: const TextStyle(color: Colors.white)),
+                      ],
+                    ),
                     onTap: () {
                       Navigator.push(
                         context,

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -6,6 +6,7 @@ import '../models/evaluation_result.dart';
 import '../models/training_spot.dart';
 import '../models/saved_hand.dart';
 import '../models/summary_result.dart';
+import '../models/mistake_severity.dart';
 
 /// Interface for evaluation execution logic.
 abstract class EvaluationExecutor {
@@ -132,5 +133,12 @@ class EvaluationExecutorService implements EvaluationExecutor {
       positionMistakeFrequencies: positionErrors,
       accuracyPerSession: sessionAcc,
     );
+  }
+
+  /// Classifies [mistakeCount] into a [MistakeSeverity] level.
+  MistakeSeverity classifySeverity(int mistakeCount) {
+    if (mistakeCount >= 10) return MistakeSeverity.high;
+    if (mistakeCount >= 4) return MistakeSeverity.medium;
+    return MistakeSeverity.low;
   }
 }


### PR DESCRIPTION
## Summary
- classify mistake counts via EvaluationExecutorService
- display severity badge next to each mistake list item

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b0b252b10832a935cb580d98e6b32