### PR TITLE
Add severity info to mistake PDF exports

### DIFF
--- a/lib/models/mistake_severity.dart
+++ b/lib/models/mistake_severity.dart
@@ -15,3 +15,17 @@ extension MistakeSeverityColor on MistakeSeverity {
     }
   }
 }
+
+extension MistakeSeverityText on MistakeSeverity {
+  String get label {
+    switch (this) {
+      case MistakeSeverity.high:
+        return 'Критичный';
+      case MistakeSeverity.medium:
+        return 'Средний';
+      case MistakeSeverity.low:
+      default:
+        return 'Лёгкий';
+    }
+  }
+}

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -41,6 +41,12 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
     final pdf = pw.Document();
     final date = formatDateTime(DateTime.now());
 
+    final service = context.read<EvaluationExecutorService>();
+    final rows = [
+      for (final e in entries)
+        [e.key, e.value.toString(), service.classifySeverity(e.value).label]
+    ];
+
     if (entries.isEmpty) {
       pdf.addPage(
         pw.MultiPage(
@@ -81,8 +87,8 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
                 style: pw.TextStyle(font: regularFont)),
             pw.SizedBox(height: 16),
             pw.Table.fromTextArray(
-              headers: const ['Позиция', 'Ошибки'],
-              data: [for (final e in entries) [e.key, e.value.toString()]],
+              headers: const ['Позиция', 'Ошибки', 'Уровень'],
+              data: rows,
             ),
           ],
         ),

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -42,6 +42,12 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
     final pdf = pw.Document();
     final date = formatDateTime(DateTime.now());
 
+    final service = context.read<EvaluationExecutorService>();
+    final rows = [
+      for (final e in entries)
+        [e.key, e.value.toString(), service.classifySeverity(e.value).label]
+    ];
+
     if (entries.isEmpty) {
       pdf.addPage(
         pw.MultiPage(
@@ -82,8 +88,8 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
                 style: pw.TextStyle(font: regularFont)),
             pw.SizedBox(height: 16),
             pw.Table.fromTextArray(
-              headers: const ['Улица', 'Ошибки'],
-              data: [for (final e in entries) [e.key, e.value.toString()]],
+              headers: const ['Улица', 'Ошибки', 'Уровень'],
+              data: rows,
             ),
           ],
         ),

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -40,6 +40,12 @@ class TagMistakeOverviewScreen extends StatelessWidget {
 
     final pdf = pw.Document();
     final date = formatDateTime(DateTime.now());
+    final service = context.read<EvaluationExecutorService>();
+    final rows = [
+      for (final e in entries)
+        [e.key, e.value.toString(), service.classifySeverity(e.value).label]
+    ];
+
     if (entries.isEmpty) {
       pdf.addPage(
         pw.MultiPage(
@@ -80,8 +86,8 @@ class TagMistakeOverviewScreen extends StatelessWidget {
                 style: pw.TextStyle(font: regularFont)),
             pw.SizedBox(height: 16),
             pw.Table.fromTextArray(
-              headers: const ['Тег', 'Ошибки'],
-              data: [for (final e in entries) [e.key, e.value.toString()]],
+              headers: const ['Тег', 'Ошибки', 'Уровень'],
+              data: rows,
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- show mistake severity in all PDF exports from `MistakeOverviewScreen` tabs
- add `MistakeSeverityText` extension for localized labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b0d0a8508832ab51fefb12b54acba