### PR TITLE
Add ignore feature to mistake overview

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'services/folded_players_service.dart';
 import 'services/all_in_players_service.dart';
 import 'services/user_preferences_service.dart';
 import 'services/tag_service.dart';
+import 'services/ignored_mistake_service.dart';
 import 'services/cloud_sync_service.dart';
 import 'services/cloud_training_history_service.dart';
 import 'services/training_spot_storage_service.dart';
@@ -60,6 +61,9 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (_) => TagService()..load(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => IgnoredMistakeService()..load(),
         ),
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -19,6 +19,7 @@ import 'services/pot_sync_service.dart';
 import 'services/stack_manager_service.dart';
 import 'services/transition_lock_service.dart';
 import 'services/action_history_service.dart';
+import 'services/ignored_mistake_service.dart';
 import 'services/training_import_export_service.dart';
 import 'services/demo_playback_controller.dart';
 
@@ -96,6 +97,9 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
           ),
         ),
         Provider(create: (_) => ActionHistoryService()),
+        ChangeNotifierProvider(
+          create: (_) => IgnoredMistakeService()..load(),
+        ),
         Provider(create: (_) => const TrainingImportExportService()),
       ],
       child: Builder(

--- a/lib/screens/mistake_overview_screen.dart
+++ b/lib/screens/mistake_overview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../theme/app_colors.dart';
 import '../theme/constants.dart';
+import '../services/ignored_mistake_service.dart';
 
 import 'tag_mistake_overview_screen.dart';
 import 'position_mistake_overview_screen.dart';
@@ -43,6 +44,15 @@ class _MistakeOverviewScreenState extends State<MistakeOverviewScreen>
       appBar: AppBar(
         title: const Text('Ошибки'),
         centerTitle: true,
+        actions: [
+          if (context.watch<IgnoredMistakeService>().ignored.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'Сбросить игнор',
+              onPressed: () =>
+                  context.read<IgnoredMistakeService>().reset(),
+            ),
+        ],
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(48),
           child: Padding(

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -12,6 +12,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
+import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -120,7 +121,10 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
     ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
-    final entries = summary.positionMistakeFrequencies.entries.toList()
+    final ignored = context.watch<IgnoredMistakeService>().ignored;
+    final entries = summary.positionMistakeFrequencies.entries
+        .where((e) => !ignored.contains('position:${e.key}'))
+        .toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
     return CustomScrollView(
@@ -176,6 +180,14 @@ class PositionMistakeOverviewScreen extends StatelessWidget {
                         const SizedBox(width: 8),
                         Text(e.value.toString(),
                             style: const TextStyle(color: Colors.white)),
+                        IconButton(
+                          icon: const Icon(Icons.cleaning_services,
+                              size: 20, color: Colors.white54),
+                          tooltip: 'Игнорировать',
+                          onPressed: () => context
+                              .read<IgnoredMistakeService>()
+                              .ignore('position:${e.key}'),
+                        ),
                       ],
                     ),
                     onTap: () {

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -13,6 +13,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
+import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -121,7 +122,10 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
     ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
-    final entries = summary.streetBreakdown.entries.toList()
+    final ignored = context.watch<IgnoredMistakeService>().ignored;
+    final entries = summary.streetBreakdown.entries
+        .where((e) => !ignored.contains('street:${e.key}'))
+        .toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
     return CustomScrollView(
@@ -177,6 +181,14 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
                         const SizedBox(width: 8),
                         Text(e.value.toString(),
                             style: const TextStyle(color: Colors.white)),
+                        IconButton(
+                          icon: const Icon(Icons.cleaning_services,
+                              size: 20, color: Colors.white54),
+                          tooltip: 'Игнорировать',
+                          onPressed: () => context
+                              .read<IgnoredMistakeService>()
+                              .ignore('street:${e.key}'),
+                        ),
                       ],
                     ),
                     onTap: () {

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -13,6 +13,7 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
+import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
@@ -119,7 +120,10 @@ class TagMistakeOverviewScreen extends StatelessWidget {
     ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
-    final entries = summary.mistakeTagFrequencies.entries.toList()
+    final ignored = context.watch<IgnoredMistakeService>().ignored;
+    final entries = summary.mistakeTagFrequencies.entries
+        .where((e) => !ignored.contains('tag:${e.key}'))
+        .toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
     return CustomScrollView(
@@ -175,6 +179,14 @@ class TagMistakeOverviewScreen extends StatelessWidget {
                         const SizedBox(width: 8),
                         Text(e.value.toString(),
                             style: const TextStyle(color: Colors.white)),
+                        IconButton(
+                          icon: const Icon(Icons.cleaning_services,
+                              size: 20, color: Colors.white54),
+                          tooltip: 'Игнорировать',
+                          onPressed: () => context
+                              .read<IgnoredMistakeService>()
+                              .ignore('tag:${e.key}'),
+                        ),
                       ],
                     ),
                     onTap: () {

--- a/lib/services/ignored_mistake_service.dart
+++ b/lib/services/ignored_mistake_service.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class IgnoredMistakeService extends ChangeNotifier {
+  static const _prefsKey = 'ignored_mistakes';
+
+  final Set<String> _ignored = {};
+
+  Set<String> get ignored => _ignored;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_prefsKey);
+    _ignored
+      ..clear()
+      ..addAll(list ?? []);
+    notifyListeners();
+  }
+
+  Future<void> ignore(String key) async {
+    if (_ignored.contains(key)) return;
+    _ignored.add(key);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, _ignored.toList());
+    notifyListeners();
+  }
+
+  Future<void> reset() async {
+    if (_ignored.isEmpty) return;
+    _ignored.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- add `IgnoredMistakeService` for persisting ignored mistake groups
- show reset button in `MistakeOverviewScreen`
- allow ignoring rows in tag, position and street mistake lists
- wire service in main apps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b0e4013dc832aa8628f2aae1aa5c9