### PR TITLE
Add sorting to mistake overview screens

### DIFF
--- a/lib/models/mistake_sort_option.dart
+++ b/lib/models/mistake_sort_option.dart
@@ -1,0 +1,13 @@
+enum MistakeSortOption { count, severity }
+
+extension MistakeSortOptionLabel on MistakeSortOption {
+  String get label {
+    switch (this) {
+      case MistakeSortOption.severity:
+        return 'По уровню';
+      case MistakeSortOption.count:
+      default:
+        return 'По количеству';
+    }
+  }
+}

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -13,6 +13,8 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
+import '../models/mistake_sort_option.dart';
+import '../theme/app_colors.dart';
 import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
@@ -26,9 +28,16 @@ import 'hand_history_review_screen.dart';
 /// tile shows how many errors were made on that street. Selecting a street opens
 /// a filtered [SavedHandListView] showing only the mistaken hands for the chosen
 /// street.
-class StreetMistakeOverviewScreen extends StatelessWidget {
+class StreetMistakeOverviewScreen extends StatefulWidget {
   final String dateFilter;
   const StreetMistakeOverviewScreen({super.key, required this.dateFilter});
+
+  @override
+  State<StreetMistakeOverviewScreen> createState() => _StreetMistakeOverviewScreenState();
+}
+
+class _StreetMistakeOverviewScreenState extends State<StreetMistakeOverviewScreen> {
+  MistakeSortOption _sort = MistakeSortOption.count;
 
   bool _sameDay(DateTime a, DateTime b) {
     return a.year == b.year && a.month == b.month && a.day == b.day;
@@ -112,21 +121,44 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
     final now = DateTime.now();
     final hands = [
       for (final h in allHands)
-        if (dateFilter == 'Все' ||
-            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
-            (dateFilter == '7 дней' &&
+        if (widget.dateFilter == 'Все' ||
+            (widget.dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (widget.dateFilter == '7 дней' &&
                 h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
-            (dateFilter == '30 дней' &&
+            (widget.dateFilter == '30 дней' &&
                 h.date.isAfter(now.subtract(const Duration(days: 30)))))
           h
     ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
     final ignored = context.watch<IgnoredMistakeService>().ignored;
+    final service = context.read<EvaluationExecutorService>();
     final entries = summary.streetBreakdown.entries
         .where((e) => !ignored.contains('street:${e.key}'))
-        .toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+        .toList();
+
+    int _score(MapEntry<String, int> e) {
+      final severity = service.classifySeverity(e.value);
+      switch (severity) {
+        case MistakeSeverity.high:
+          return 2;
+        case MistakeSeverity.medium:
+          return 1;
+        case MistakeSeverity.low:
+        default:
+          return 0;
+      }
+    }
+
+    if (_sort == MistakeSortOption.severity) {
+      entries.sort((a, b) {
+        final cmp = _score(b).compareTo(_score(a));
+        if (cmp != 0) return cmp;
+        return b.value.compareTo(a.value);
+      });
+    } else {
+      entries.sort((a, b) => b.value.compareTo(a.value));
+    }
 
     return CustomScrollView(
       slivers: [
@@ -147,6 +179,29 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
           padding: const EdgeInsets.all(16),
           sliver: SliverToBoxAdapter(
             child: MistakeSummarySection(summary: summary),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          sliver: SliverToBoxAdapter(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: DropdownButton<MistakeSortOption>(
+                value: _sort,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                items: const [
+                  DropdownMenuItem(
+                      value: MistakeSortOption.count,
+                      child: Text('По количеству')),
+                  DropdownMenuItem(
+                      value: MistakeSortOption.severity,
+                      child: Text('По уровню')),
+                ],
+                onChanged: (v) =>
+                    setState(() => _sort = v ?? MistakeSortOption.count),
+              ),
+            ),
           ),
         ),
         if (entries.isEmpty)
@@ -197,7 +252,7 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
                         MaterialPageRoute(
                           builder: (_) => _StreetMistakeHandsScreen(
                             street: e.key,
-                            dateFilter: dateFilter,
+                            dateFilter: widget.dateFilter,
                           ),
                         ),
                       );

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -13,6 +13,8 @@ import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
+import '../models/mistake_sort_option.dart';
+import '../theme/app_colors.dart';
 import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
@@ -25,9 +27,16 @@ import 'hand_history_review_screen.dart';
 /// tile shows how many errors were made for that tag. Selecting a tag opens a
 /// filtered [SavedHandListView] showing only the mistaken hands for the chosen
 /// tag.
-class TagMistakeOverviewScreen extends StatelessWidget {
+class TagMistakeOverviewScreen extends StatefulWidget {
   final String dateFilter;
   const TagMistakeOverviewScreen({super.key, required this.dateFilter});
+
+  @override
+  State<TagMistakeOverviewScreen> createState() => _TagMistakeOverviewScreenState();
+}
+
+class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
+  MistakeSortOption _sort = MistakeSortOption.count;
 
   bool _sameDay(DateTime a, DateTime b) {
     return a.year == b.year && a.month == b.month && a.day == b.day;
@@ -110,21 +119,44 @@ class TagMistakeOverviewScreen extends StatelessWidget {
     final now = DateTime.now();
     final hands = [
       for (final h in allHands)
-        if (dateFilter == 'Все' ||
-            (dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
-            (dateFilter == '7 дней' &&
+        if (widget.dateFilter == 'Все' ||
+            (widget.dateFilter == 'Сегодня' && _sameDay(h.date, now)) ||
+            (widget.dateFilter == '7 дней' &&
                 h.date.isAfter(now.subtract(const Duration(days: 7)))) ||
-            (dateFilter == '30 дней' &&
+            (widget.dateFilter == '30 дней' &&
                 h.date.isAfter(now.subtract(const Duration(days: 30)))))
           h
     ];
     final summary =
         context.read<EvaluationExecutorService>().summarizeHands(hands);
     final ignored = context.watch<IgnoredMistakeService>().ignored;
+    final service = context.read<EvaluationExecutorService>();
     final entries = summary.mistakeTagFrequencies.entries
         .where((e) => !ignored.contains('tag:${e.key}'))
-        .toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+        .toList();
+
+    int _score(MapEntry<String, int> e) {
+      final severity = service.classifySeverity(e.value);
+      switch (severity) {
+        case MistakeSeverity.high:
+          return 2;
+        case MistakeSeverity.medium:
+          return 1;
+        case MistakeSeverity.low:
+        default:
+          return 0;
+      }
+    }
+
+    if (_sort == MistakeSortOption.severity) {
+      entries.sort((a, b) {
+        final cmp = _score(b).compareTo(_score(a));
+        if (cmp != 0) return cmp;
+        return b.value.compareTo(a.value);
+      });
+    } else {
+      entries.sort((a, b) => b.value.compareTo(a.value));
+    }
 
     return CustomScrollView(
       slivers: [
@@ -145,6 +177,29 @@ class TagMistakeOverviewScreen extends StatelessWidget {
           padding: const EdgeInsets.all(16),
           sliver: SliverToBoxAdapter(
             child: MistakeSummarySection(summary: summary),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          sliver: SliverToBoxAdapter(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: DropdownButton<MistakeSortOption>(
+                value: _sort,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                items: const [
+                  DropdownMenuItem(
+                      value: MistakeSortOption.count,
+                      child: Text('По количеству')),
+                  DropdownMenuItem(
+                      value: MistakeSortOption.severity,
+                      child: Text('По уровню')),
+                ],
+                onChanged: (v) =>
+                    setState(() => _sort = v ?? MistakeSortOption.count),
+              ),
+            ),
           ),
         ),
         if (entries.isEmpty)
@@ -195,7 +250,7 @@ class TagMistakeOverviewScreen extends StatelessWidget {
                         MaterialPageRoute(
                           builder: (_) => _TagMistakeHandsScreen(
                             tag: e.key,
-                            dateFilter: dateFilter,
+                            dateFilter: widget.dateFilter,
                           ),
                         ),
                       );


### PR DESCRIPTION
## Summary
- add `MistakeSortOption` model to represent sorting modes
- convert mistake overview screens to StatefulWidgets
- implement sorting by count or severity and add dropdown controls

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b0f91ae6c832a92f9b5b1095c371d