### PR TITLE
Add tooltips for severity dots

### DIFF
--- a/lib/models/mistake_severity.dart
+++ b/lib/models/mistake_severity.dart
@@ -29,3 +29,17 @@ extension MistakeSeverityText on MistakeSeverity {
     }
   }
 }
+
+extension MistakeSeverityTooltip on MistakeSeverity {
+  String get tooltip {
+    switch (this) {
+      case MistakeSeverity.high:
+        return 'High = серьёзная ошибка';
+      case MistakeSeverity.medium:
+        return 'Medium = ощутимая ошибка';
+      case MistakeSeverity.low:
+      default:
+        return 'Low = лёгкая ошибка';
+    }
+  }
+}

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -224,12 +224,15 @@ class _PositionMistakeOverviewScreenState extends State<PositionMistakeOverviewS
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Container(
-                          width: 10,
-                          height: 10,
-                          decoration: BoxDecoration(
-                            color: severity.color,
-                            shape: BoxShape.circle,
+                        Tooltip(
+                          message: severity.tooltip,
+                          child: Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: severity.color,
+                              shape: BoxShape.circle,
+                            ),
                           ),
                         ),
                         const SizedBox(width: 8),

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -225,12 +225,15 @@ class _StreetMistakeOverviewScreenState extends State<StreetMistakeOverviewScree
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Container(
-                          width: 10,
-                          height: 10,
-                          decoration: BoxDecoration(
-                            color: severity.color,
-                            shape: BoxShape.circle,
+                        Tooltip(
+                          message: severity.tooltip,
+                          child: Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: severity.color,
+                              shape: BoxShape.circle,
+                            ),
                           ),
                         ),
                         const SizedBox(width: 8),

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -223,12 +223,15 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Container(
-                          width: 10,
-                          height: 10,
-                          decoration: BoxDecoration(
-                            color: severity.color,
-                            shape: BoxShape.circle,
+                        Tooltip(
+                          message: severity.tooltip,
+                          child: Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: severity.color,
+                              shape: BoxShape.circle,
+                            ),
                           ),
                         ),
                         const SizedBox(width: 8),


### PR DESCRIPTION
## Summary
- add tooltip text to `MistakeSeverity`
- show tooltips on the colored severity dots for tag/position/street mistake screens

## Testing
- `flutter format lib/models/mistake_severity.dart lib/screens/tag_mistake_overview_screen.dart lib/screens/position_mistake_overview_screen.dart lib/screens/street_mistake_overview_screen.dart` *(fails: command not found)*
- `dart format lib/models/mistake_severity.dart lib/screens/tag_mistake_overview_screen.dart lib/screens/position_mistake_overview_screen.dart lib/screens/street_mistake_overview_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b111e56d0832abfb5ff481192f3c7