### PR TITLE
Add accuracy filter toggle to hand list

### DIFF
--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -302,7 +302,7 @@ class _PositionMistakeHandsScreen extends StatelessWidget {
       body: SavedHandListView(
         hands: hands,
         positions: [position],
-        accuracy: 'errors',
+        initialAccuracy: 'errors',
         filterKey: position,
         title: 'Ошибки: $position',
         onTap: (hand) {

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -165,11 +165,12 @@ class _SavedHandsScreenState extends State<SavedHandsScreen> {
               title: 'Раздачи',
               tags: _tagFilter != 'Все' ? [_tagFilter] : null,
               positions: _positionFilter != 'Все' ? [_positionFilter] : null,
-              accuracy: _accuracyFilter == 'Только верные'
+              initialAccuracy: _accuracyFilter == 'Только верные'
                   ? 'correct'
                   : _accuracyFilter == 'Только ошибки'
                       ? 'errors'
                       : null,
+              showAccuracyToggle: false,
               onTap: (hand) {
                 Navigator.push(
                   context,

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -305,7 +305,7 @@ class _StreetMistakeHandsScreen extends StatelessWidget {
       ),
       body: SavedHandListView(
         hands: filtered,
-        accuracy: 'errors',
+        initialAccuracy: 'errors',
         filterKey: street,
         title: 'Ошибки: $street',
         onTap: (hand) {

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -301,7 +301,7 @@ class _TagMistakeHandsScreen extends StatelessWidget {
       body: SavedHandListView(
         hands: hands,
         tags: [tag],
-        accuracy: 'errors',
+        initialAccuracy: 'errors',
         filterKey: tag,
         title: 'Ошибки: $tag',
         onTap: (hand) {


### PR DESCRIPTION
## Summary
- add a stateful SavedHandListView with an accuracy toggle
- allow toggling between all hands, only errors, and only correct actions
- hide the new toggle on SavedHandsScreen to keep the existing dropdown
- update mistake overview screens to use the new `initialAccuracy` parameter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b18aab428832a88b6bf23bb00f2b9