### PR TITLE
Highlight hero seat and position

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -241,18 +241,33 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (_playerAction() != null &&
-                gto != null &&
-                _playerAction()!.trim().toLowerCase() !=
-                    gto.trim().toLowerCase()) ...[
-              _buildMistakeCard(
-                widget.hand.feedbackText ??
-                    'Ваше действие отличается от GTO',
-                advice: _deriveAdvice(),
+          if (_playerAction() != null &&
+              gto != null &&
+              _playerAction()!.trim().toLowerCase() !=
+                  gto.trim().toLowerCase()) ...[
+            _buildMistakeCard(
+              widget.hand.feedbackText ??
+                  'Ваше действие отличается от GTO',
+              advice: _deriveAdvice(),
+            ),
+            const SizedBox(height: 12),
+          ],
+          Row(
+            children: [
+              const Text('Позиция:',
+                  style: TextStyle(color: Colors.white70)),
+              const SizedBox(width: 8),
+              Chip(
+                label: Text(widget.hand.heroPosition),
+                backgroundColor:
+                    Theme.of(context).colorScheme.secondary,
+                labelStyle: const TextStyle(
+                    color: Colors.black, fontWeight: FontWeight.bold),
               ),
-              const SizedBox(height: 12),
             ],
-            ReplaySpotWidget(spot: spot),
+          ),
+          const SizedBox(height: 12),
+          ReplaySpotWidget(spot: spot),
             const SizedBox(height: 12),
             if ((gto != null && gto.isNotEmpty) ||
                 (group != null && group.isNotEmpty))

--- a/lib/widgets/replay_spot_widget.dart
+++ b/lib/widgets/replay_spot_widget.dart
@@ -125,6 +125,16 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
             actionCount: widget.spot.actions.length,
             onSeek: _seek,
           ),
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: Chip(
+              label: Text(widget.spot.positions[widget.spot.heroIndex]),
+              backgroundColor:
+                  Theme.of(context).colorScheme.secondary,
+              labelStyle: const TextStyle(
+                  color: Colors.black, fontWeight: FontWeight.bold),
+            ),
+          ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [

--- a/lib/widgets/training_spot_diagram.dart
+++ b/lib/widgets/training_spot_diagram.dart
@@ -58,17 +58,18 @@ class TrainingSpotDiagram extends StatelessWidget {
           final seatWidgets = <Widget>[];
 
           for (int i = 0; i < spot.numberOfPlayers; i++) {
-            final seatIndex = (i - spot.heroIndex + spot.numberOfPlayers) % spot.numberOfPlayers;
-            final pos = TableGeometryHelper.positionForPlayer(
-              seatIndex,
-              spot.numberOfPlayers,
-              tableSize.width,
-              tableSize.height,
-            );
-            final offset = Offset(center.dx + pos.dx, center.dy + pos.dy);
-            final isHero = i == spot.heroIndex;
-            final stack = i < spot.stacks.length ? spot.stacks[i] : 0;
-            final action = actions[i];
+          final seatIndex = (i - spot.heroIndex + spot.numberOfPlayers) % spot.numberOfPlayers;
+          final pos = TableGeometryHelper.positionForPlayer(
+            seatIndex,
+            spot.numberOfPlayers,
+            tableSize.width,
+            tableSize.height,
+          );
+          final offset = Offset(center.dx + pos.dx, center.dy + pos.dy);
+          final isHero = i == spot.heroIndex;
+          final highlightColor = Theme.of(context).colorScheme.secondary;
+          final stack = i < spot.stacks.length ? spot.stacks[i] : 0;
+          final action = actions[i];
 
             String? advice;
             if (spot.strategyAdvice != null && i < spot.strategyAdvice!.length) {
@@ -130,16 +131,16 @@ class TrainingSpotDiagram extends StatelessWidget {
                         color: Colors.black.withOpacity(0.6),
                         borderRadius: BorderRadius.circular(8),
                         border: Border.all(
-                          color: isHero ? Colors.orangeAccent : Colors.white30,
-                          width: 2,
+                          color: isHero ? highlightColor : Colors.white30,
+                          width: isHero ? 3 : 2,
                         ),
                         boxShadow: [
                           BoxShadow(
                             color: isHero
-                                ? Colors.orangeAccent.withOpacity(0.7)
+                                ? highlightColor.withOpacity(0.7)
                                 : Colors.black54,
-                            blurRadius: isHero ? 8 : 2,
-                            spreadRadius: isHero ? 2 : 0,
+                            blurRadius: isHero ? 10 : 2,
+                            spreadRadius: isHero ? 3 : 0,
                           ),
                         ],
                       ),


### PR DESCRIPTION
## Summary
- highlight the hero's position chip on HandHistoryReviewScreen
- show the hero position badge in ReplaySpotWidget
- use theme highlight color and stronger glow for the hero seat in TrainingSpotDiagram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b1b165c5c832a9dd4e0817c9c3b9a