### PR TITLE
Add streak tracker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'services/cloud_sync_service.dart';
 import 'services/cloud_training_history_service.dart';
 import 'services/training_spot_storage_service.dart';
 import 'services/evaluation_executor_service.dart';
+import 'services/streak_service.dart';
 import 'user_preferences.dart';
 
 void main() {
@@ -65,6 +66,7 @@ void main() {
         ChangeNotifierProvider(
           create: (_) => IgnoredMistakeService()..load(),
         ),
+        ChangeNotifierProvider(create: (_) => StreakService()..load()),
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),
       ],

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -27,6 +27,7 @@ import '../tutorial/tutorial_completion_screen.dart';
 import 'training_history_screen.dart';
 import 'session_stats_screen.dart';
 import 'training_stats_screen.dart';
+import '../services/streak_service.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -49,6 +50,11 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     _demoMode = UserPreferences.instance.demoMode;
     _tutorialCompleted = UserPreferences.instance.tutorialCompleted;
     _loadSpot();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<StreakService>().updateStreak();
+      }
+    });
   }
 
   Future<void> _loadSpot() async {
@@ -57,6 +63,23 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     if (mounted) {
       setState(() => _spotOfDay = spot);
     }
+  }
+
+  Widget _buildStreakCard(BuildContext context) {
+    final streak = context.watch<StreakService>().count;
+    if (streak <= 0) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.only(bottom: 24),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Streak: $streak \u0434\u043d\u0435\u0439 \u043f\u043e\u0434\u0440\u044f\u0434',
+        style: const TextStyle(fontSize: 16, color: Colors.white),
+      ),
+    );
   }
 
   Widget _buildSpotOfDaySection(BuildContext context) {
@@ -183,6 +206,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            _buildStreakCard(context),
             _buildSpotOfDaySection(context),
             ElevatedButton(
               key: _newHandButtonKey,

--- a/lib/services/streak_service.dart
+++ b/lib/services/streak_service.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StreakService extends ChangeNotifier {
+  static const _lastOpenKey = 'streak_last_open';
+  static const _countKey = 'streak_count';
+
+  DateTime? _lastOpen;
+  int _count = 0;
+
+  int get count => _count;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastOpenKey);
+    _lastOpen = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    _count = prefs.getInt(_countKey) ?? 0;
+    await updateStreak();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (_lastOpen != null) {
+      await prefs.setString(_lastOpenKey, _lastOpen!.toIso8601String());
+    } else {
+      await prefs.remove(_lastOpenKey);
+    }
+    await prefs.setInt(_countKey, _count);
+  }
+
+  Future<void> updateStreak() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    if (_lastOpen == null) {
+      _lastOpen = today;
+      _count = 1;
+    } else {
+      final last = DateTime(_lastOpen!.year, _lastOpen!.month, _lastOpen!.day);
+      final diff = today.difference(last).inDays;
+      if (diff == 0) {
+        // same day, no change
+      } else if (diff == 1) {
+        _count += 1;
+        _lastOpen = today;
+      } else if (diff > 1) {
+        _count = 1;
+        _lastOpen = today;
+      }
+    }
+    await _save();
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- track days in a streak with `StreakService`
- provide `StreakService` in `main.dart`
- show streak card in `MainMenuScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b1c12bcf0832a8d185eadfbbaec67