### PR TITLE
Add goals screen with basic progress tracking

### DIFF
--- a/lib/screens/goals_screen.dart
+++ b/lib/screens/goals_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class Goal {
+  final String title;
+  final int progress;
+  final int target;
+  final IconData? icon;
+
+  const Goal({
+    required this.title,
+    required this.progress,
+    required this.target,
+    this.icon,
+  });
+}
+
+class GoalsScreen extends StatelessWidget {
+  const GoalsScreen({super.key});
+
+  static const List<Goal> _goals = [
+    Goal(
+      title: 'Разобрать 5 ошибок',
+      progress: 2,
+      target: 5,
+      icon: Icons.bug_report,
+    ),
+    Goal(
+      title: 'Пройти 3 раздачи без ошибок подряд',
+      progress: 1,
+      target: 3,
+      icon: Icons.play_circle_fill,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Мои цели'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _goals.length,
+        itemBuilder: (context, index) {
+          final goal = _goals[index];
+          final progress = (goal.progress / goal.target).clamp(0.0, 1.0);
+          return Container(
+            margin: const EdgeInsets.only(bottom: 16),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    if (goal.icon != null) ...[
+                      Icon(goal.icon, color: accent),
+                      const SizedBox(width: 8),
+                    ],
+                    Expanded(
+                      child: Text(
+                        goal.title,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Text('${goal.progress}/${goal.target}'),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation<Color>(accent),
+                    minHeight: 6,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -28,6 +28,7 @@ import 'training_history_screen.dart';
 import 'session_stats_screen.dart';
 import 'training_stats_screen.dart';
 import '../services/streak_service.dart';
+import 'goals_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -207,6 +208,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildStreakCard(context),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const GoalsScreen()),
+                );
+              },
+              child: const Text('🎯 Мои цели'),
+            ),
+            const SizedBox(height: 16),
             _buildSpotOfDaySection(context),
             ElevatedButton(
               key: _newHandButtonKey,


### PR DESCRIPTION
## Summary
- show a new GoalsScreen listing hard-coded goals
- display progress bars for each goal
- link to GoalsScreen from the main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b1cf3ba4c832a9af10831ff5819a4