### PR TITLE
Add mistake repeat screen

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -29,6 +29,7 @@ import 'session_stats_screen.dart';
 import 'training_stats_screen.dart';
 import '../services/streak_service.dart';
 import 'goals_screen.dart';
+import 'mistake_repeat_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -216,6 +217,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🎯 Мои цели'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MistakeRepeatScreen()),
+                );
+              },
+              child: const Text('🔁 Повторы ошибок'),
             ),
             const SizedBox(height: 16),
             _buildSpotOfDaySection(context),

--- a/lib/screens/mistake_repeat_screen.dart
+++ b/lib/screens/mistake_repeat_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/saved_hand_manager_service.dart';
+import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_tile.dart';
+
+class MistakeRepeatScreen extends StatelessWidget {
+  const MistakeRepeatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final Map<String, List<SavedHand>> grouped = {};
+
+    for (final h in hands) {
+      final expected = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (expected != null &&
+          gto != null &&
+          expected.isNotEmpty &&
+          gto.isNotEmpty &&
+          expected != gto) {
+        for (final tag in h.tags) {
+          grouped.putIfAbsent(tag, () => []).add(h);
+        }
+      }
+    }
+
+    final entries = grouped.entries
+        .where((e) => e.value.length > 1)
+        .toList()
+      ..sort((a, b) => b.value.length.compareTo(a.value.length));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Повторы ошибок'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: entries.length,
+        itemBuilder: (context, index) {
+          final entry = entries[index];
+          return Container(
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        entry.key,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        '${entry.value.length}',
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                for (final hand in entry.value)
+                  SavedHandTile(
+                    hand: hand,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              HandHistoryReviewScreen(hand: hand),
+                        ),
+                      );
+                    },
+                    onFavoriteToggle: () {
+                      final manager =
+                          context.read<SavedHandManagerService>();
+                      final idx = manager.hands.indexOf(hand);
+                      manager.update(idx, hand.copyWith(isFavorite: !hand.isFavorite));
+                    },
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `MistakeRepeatScreen` to show repeated mistakes grouped by tag
- link new screen from `MainMenuScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b1d9be8b0832a9d836742bf1db22c