### PR TITLE
Implement streak bonus in goals screen

### DIFF
--- a/lib/screens/goals_screen.dart
+++ b/lib/screens/goals_screen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'dart:math' as math;
+
+import '../services/streak_service.dart';
 
 class Goal {
   final String title;
@@ -35,59 +39,94 @@ class GoalsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
+    final bonus = context.watch<StreakService>().hasBonus;
+    final multiplier = bonus ? StreakService.bonusMultiplier : 1.0;
+
+    List<Widget> children = [];
+    if (bonus) {
+      children.add(
+        Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.orange[700],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Row(
+            children: [
+              Icon(Icons.local_fire_department, color: Colors.white),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '🔥 Бонус за серию — ускоренный прогресс целей!',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    for (final goal in _goals) {
+      final adjusted = math.min((goal.progress * multiplier).round(), goal.target);
+      final progress = (adjusted / goal.target).clamp(0.0, 1.0);
+      children.add(
+        Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  if (goal.icon != null) ...[
+                    Icon(goal.icon, color: accent),
+                    const SizedBox(width: 8),
+                  ],
+                  Expanded(
+                    child: Text(
+                      goal.title,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  Text('$adjusted/${goal.target}'),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: progress,
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation<Color>(accent),
+                  minHeight: 6,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Мои цели'),
         centerTitle: true,
       ),
-      body: ListView.builder(
+      body: ListView(
         padding: const EdgeInsets.all(16),
-        itemCount: _goals.length,
-        itemBuilder: (context, index) {
-          final goal = _goals[index];
-          final progress = (goal.progress / goal.target).clamp(0.0, 1.0);
-          return Container(
-            margin: const EdgeInsets.only(bottom: 16),
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: Colors.grey[850],
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    if (goal.icon != null) ...[
-                      Icon(goal.icon, color: accent),
-                      const SizedBox(width: 8),
-                    ],
-                    Expanded(
-                      child: Text(
-                        goal.title,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                    Text('${goal.progress}/${goal.target}'),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    value: progress,
-                    backgroundColor: Colors.white24,
-                    valueColor: AlwaysStoppedAnimation<Color>(accent),
-                    minHeight: 6,
-                  ),
-                ),
-              ],
-            ),
-          );
-        },
+        children: children,
       ),
     );
   }

--- a/lib/services/streak_service.dart
+++ b/lib/services/streak_service.dart
@@ -4,11 +4,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 class StreakService extends ChangeNotifier {
   static const _lastOpenKey = 'streak_last_open';
   static const _countKey = 'streak_count';
+  static const bonusThreshold = 3;
+  static const bonusMultiplier = 1.5;
 
   DateTime? _lastOpen;
   int _count = 0;
 
   int get count => _count;
+  bool get hasBonus => _count >= bonusThreshold;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- expand `StreakService` with bonus constants and helper
- show streak bonus banner on `GoalsScreen`
- visually increase goal progress when streak bonus active

## Testing
- `flutter analyze` *(skipped: per instructions)*
- `flutter test` *(skipped: per instructions)*

------
https://chatgpt.com/codex/tasks/task_e_685b224a6414832a89eae5dab666fe32