### PR TITLE
Add basic Achievements screen

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/streak_service.dart';
+
+class Achievement {
+  final String title;
+  final IconData icon;
+  final bool completed;
+
+  const Achievement({
+    required this.title,
+    required this.icon,
+    required this.completed,
+  });
+}
+
+class AchievementsScreen extends StatelessWidget {
+  const AchievementsScreen({super.key});
+
+  List<Achievement> _buildAchievements(BuildContext context) {
+    final streak = context.watch<StreakService>().count;
+    return [
+      const Achievement(
+        title: 'Разобрано 5 ошибок',
+        icon: Icons.bug_report,
+        completed: false,
+      ),
+      Achievement(
+        title: '3 дня подряд',
+        icon: Icons.local_fire_department,
+        completed: streak >= 3,
+      ),
+      const Achievement(
+        title: 'Цель выполнена',
+        icon: Icons.flag,
+        completed: false,
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final achievements = _buildAchievements(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Достижения'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: achievements.length,
+        itemBuilder: (context, index) {
+          final a = achievements[index];
+          final color = a.completed ? Colors.white : Colors.white54;
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Icon(a.icon, color: color),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    a.title,
+                    style: TextStyle(
+                      color: color,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.check_circle,
+                  color: a.completed ? Colors.green : Colors.grey,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -30,6 +30,7 @@ import 'training_stats_screen.dart';
 import '../services/streak_service.dart';
 import 'goals_screen.dart';
 import 'mistake_repeat_screen.dart';
+import 'achievements_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -319,6 +320,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🎯 Мои цели'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AchievementsScreen()),
+                );
+              },
+              child: const Text('🏆 Достижения'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- add `AchievementsScreen` with three demo achievements
- link Achievements screen from main menu

## Testing
- `flutter format lib/screens/achievements_screen.dart lib/screens/main_menu_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b27c5e008832ab944e6966d17583b