### PR TITLE
Update goals on each evaluation

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -7,6 +7,7 @@ import '../models/training_spot.dart';
 import '../models/saved_hand.dart';
 import '../models/summary_result.dart';
 import '../models/mistake_severity.dart';
+import 'goals_service.dart';
 
 /// Interface for evaluation execution logic.
 abstract class EvaluationExecutor {
@@ -50,13 +51,25 @@ class EvaluationExecutorService implements EvaluationExecutor {
     final userEquity = correct
         ? expectedEquity
         : (expectedEquity - 0.1).clamp(0.0, 1.0);
-    return EvaluationResult(
+    final result = EvaluationResult(
       correct: correct,
       expectedAction: expectedAction,
       userEquity: userEquity,
       expectedEquity: expectedEquity,
       hint: correct ? null : 'Подумай о диапазоне оппонента',
     );
+
+    final goals = GoalsService.instance;
+    if (goals != null) {
+      if (correct) {
+        final progress = goals.goals.length > 1 ? goals.goals[1].progress + 1 : 1;
+        goals.setProgress(1, progress);
+      } else {
+        goals.setProgress(1, 0);
+      }
+    }
+
+    return result;
   }
 
   /// Generates a summary for a list of saved hands.

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -26,7 +26,12 @@ class Goal {
 class GoalsService extends ChangeNotifier {
   static const _prefPrefix = 'goal_progress_';
 
-  GoalsService();
+  static GoalsService? _instance;
+  static GoalsService? get instance => _instance;
+
+  GoalsService() {
+    _instance = this;
+  }
 
   late List<Goal> _goals;
 


### PR DESCRIPTION
## Summary
- expose GoalsService singleton for easy access
- bump goal progress when hands evaluated correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2d896478832a8e70c6fc4f08c7b9