### PR TITLE
Show overlay on achievement unlock

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -5,6 +5,7 @@ import '../services/streak_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../services/goals_service.dart';
+import '../widgets/achievement_unlocked_overlay.dart';
 
 class Achievement {
   final String title;
@@ -38,9 +39,21 @@ class _AchievementsScreenState extends State<AchievementsScreen>
   final GlobalKey<AnimatedListState> _listKey = GlobalKey<AnimatedListState>();
   final List<Achievement> _achievements = [];
   bool _animationPlayed = false;
+  final Set<String> _shownOverlays = {};
 
   void _updateAchievements({bool playAnimation = false}) async {
     final items = _buildAchievements();
+    for (var i = 0; i < items.length; i++) {
+      final now = items[i];
+      final wasCompleted =
+          i < _achievements.length && _achievements[i].completed;
+      if (now.completed && !wasCompleted && !_shownOverlays.contains(now.title)) {
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => showAchievementUnlockedOverlay(context, now.icon, now.title),
+        );
+        _shownOverlays.add(now.title);
+      }
+    }
     if (playAnimation && !_animationPlayed) {
       _achievements.clear();
       for (var i = 0; i < items.length; i++) {

--- a/lib/widgets/achievement_unlocked_overlay.dart
+++ b/lib/widgets/achievement_unlocked_overlay.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+class AchievementUnlockedOverlay extends StatefulWidget {
+  final IconData icon;
+  final String title;
+  final VoidCallback onCompleted;
+
+  const AchievementUnlockedOverlay({
+    Key? key,
+    required this.icon,
+    required this.title,
+    required this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  State<AchievementUnlockedOverlay> createState() => _AchievementUnlockedOverlayState();
+}
+
+class _AchievementUnlockedOverlayState extends State<AchievementUnlockedOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _offset;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _offset = Tween<Offset>(
+      begin: const Offset(0, 1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    _opacity = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
+    _controller.forward();
+    Future.delayed(const Duration(seconds: 2), () {
+      if (mounted) {
+        _controller.reverse().then((_) => widget.onCompleted());
+      } else {
+        widget.onCompleted();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 40),
+        child: SlideTransition(
+          position: _offset,
+          child: FadeTransition(
+            opacity: _opacity,
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.black87,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(widget.icon, color: Colors.orangeAccent),
+                    const SizedBox(width: 8),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Достижение разблокировано!',
+                          style: TextStyle(
+                            color: Colors.white70,
+                            fontSize: 12,
+                          ),
+                        ),
+                        Text(
+                          widget.title,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void showAchievementUnlockedOverlay(BuildContext context, IconData icon, String title) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => AchievementUnlockedOverlay(
+      icon: icon,
+      title: title,
+      onCompleted: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}
+


### PR DESCRIPTION
## Summary
- add `AchievementUnlockedOverlay` widget for bottom popups
- trigger overlay in `AchievementsScreen` when a goal completes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b3078f750832a8fc943e71507a4a3