### PR TITLE
Add error-free streak achievement

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -64,8 +64,10 @@ class EvaluationExecutorService implements EvaluationExecutor {
       if (correct) {
         final progress = goals.goals.length > 1 ? goals.goals[1].progress + 1 : 1;
         goals.setProgress(1, progress);
+        goals.updateErrorFreeStreak(true);
       } else {
         goals.setProgress(1, 0);
+        goals.updateErrorFreeStreak(false);
       }
     }
 


### PR DESCRIPTION
## Summary
- track consecutive error-free hands in `GoalsService`
- persist streak with `SharedPreferences`
- update streak when evaluating a hand

## Testing
- `dart`/`flutter` not installed; no tests run

------
https://chatgpt.com/codex/tasks/task_e_685b3712c764832a90d87189ce05e3c5