### PR TITLE
feat(ui): show streak banner

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -4,6 +4,7 @@ import 'analyzer_tab.dart';
 import 'spot_of_the_day_screen.dart';
 import 'spot_of_the_day_history_screen.dart';
 import 'settings_placeholder_screen.dart';
+import '../widgets/streak_banner.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -32,29 +33,35 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _currentIndex, children: _pages),
-      bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: Colors.black,
-        selectedItemColor: Colors.greenAccent,
-        unselectedItemColor: Colors.white70,
-        currentIndex: _currentIndex,
-        onTap: _onTap,
-        type: BottomNavigationBarType.fixed,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.assessment),
-            label: 'Раздачи',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.today),
-            label: 'Спот дня',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.history),
-            label: 'История',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.more_horiz),
-            label: 'Ещё',
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const StreakBanner(),
+          BottomNavigationBar(
+            backgroundColor: Colors.black,
+            selectedItemColor: Colors.greenAccent,
+            unselectedItemColor: Colors.white70,
+            currentIndex: _currentIndex,
+            onTap: _onTap,
+            type: BottomNavigationBarType.fixed,
+            items: const [
+              BottomNavigationBarItem(
+                icon: Icon(Icons.assessment),
+                label: 'Раздачи',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.today),
+                label: 'Спот дня',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.history),
+                label: 'История',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.more_horiz),
+                label: 'Ещё',
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/goals_service.dart';
+
+/// Displays the current "Без ошибок подряд" streak as a small banner.
+/// Fades in and out when the value changes.
+class StreakBanner extends StatelessWidget {
+  const StreakBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final streak = context.watch<GoalsService>().errorFreeStreak;
+    final accent = Theme.of(context).colorScheme.secondary;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) =>
+          FadeTransition(opacity: animation, child: child),
+      child: streak >= 1
+          ? Container(
+              key: ValueKey<int>(streak),
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.flash_on, color: accent, size: 18),
+                  const SizedBox(width: 6),
+                  Text(
+                    '$streak',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  const Text(
+                    'Держите темп!',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ],
+              ),
+            )
+          : const SizedBox.shrink(key: ValueKey('empty')),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show streak banner in the main navigation screen
- implement `StreakBanner` widget pulling streak from `GoalsService`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b39ac4a4c832aa8dd8817546ce4a6