### PR TITLE
Add interactive streak banner

### DIFF
--- a/lib/screens/error_free_streak_screen.dart
+++ b/lib/screens/error_free_streak_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../widgets/saved_hand_list_view.dart';
+import 'hand_history_review_screen.dart';
+
+/// Displays hands from the current error-free streak.
+class ErrorFreeStreakScreen extends StatelessWidget {
+  const ErrorFreeStreakScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<SavedHand> hands =
+        context.watch<SavedHandManagerService>().currentErrorFreeStreak();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Серия без ошибок'),
+        centerTitle: true,
+      ),
+      body: SavedHandListView(
+        hands: hands,
+        title: 'Серия без ошибок',
+        initialAccuracy: 'correct',
+        showAccuracyToggle: false,
+        onTap: (hand) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => HandHistoryReviewScreen(hand: hand),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -1020,4 +1020,22 @@ class SavedHandManagerService extends ChangeNotifier {
     }
     return grouped;
   }
+
+  /// Return the list of hands in the current error-free streak.
+  ///
+  /// Hands are returned in chronological order and only include
+  /// those with correct user action compared to GTO.
+  List<SavedHand> currentErrorFreeStreak() {
+    final result = <SavedHand>[];
+    for (int i = hands.length - 1; i >= 0; i--) {
+      final h = hands[i];
+      final expected = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (expected == null || gto == null || expected != gto) {
+        break;
+      }
+      result.insert(0, h);
+    }
+    return result;
+  }
 }

--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
+import '../screens/error_free_streak_screen.dart';
 
 /// Displays the current "Без ошибок подряд" streak as a small banner.
 /// Fades in and out when the value changes.
@@ -18,33 +19,45 @@ class StreakBanner extends StatelessWidget {
       transitionBuilder: (child, animation) =>
           FadeTransition(opacity: animation, child: child),
       child: streak >= 1
-          ? Container(
+          ? GestureDetector(
               key: ValueKey<int>(streak),
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              decoration: BoxDecoration(
-                color: Colors.grey[850],
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.flash_on, color: accent, size: 18),
-                  const SizedBox(width: 6),
-                  Text(
-                    '$streak',
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ErrorFreeStreakScreen(),
+                  ),
+                );
+              },
+              child: Container(
+                margin:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: Colors.grey[850],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.flash_on, color: accent, size: 18),
+                    const SizedBox(width: 6),
+                    Text(
+                      '$streak',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  const Text(
-                    'Держите темп!',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                ],
+                    const SizedBox(width: 8),
+                    const Text(
+                      'Держите темп!',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ],
+                ),
               ),
             )
           : const SizedBox.shrink(key: ValueKey('empty')),


### PR DESCRIPTION
## Summary
- make streak banner tappable to open list of correct hands
- show error-free streak hands using new screen
- compute current streak hands in SavedHandManagerService

## Testing
- `git commit -m "feat: show current streak hands"`

------
https://chatgpt.com/codex/tasks/task_e_685b3fc21e20832a9398cc297d8ba7fa