### PR TITLE
Add filter on goal history

### DIFF
--- a/lib/screens/goal_history_screen.dart
+++ b/lib/screens/goal_history_screen.dart
@@ -3,8 +3,17 @@ import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
 
-class GoalHistoryScreen extends StatelessWidget {
+enum _GoalFilter { all, completed, active }
+
+class GoalHistoryScreen extends StatefulWidget {
   const GoalHistoryScreen({super.key});
+
+  @override
+  State<GoalHistoryScreen> createState() => _GoalHistoryScreenState();
+}
+
+class _GoalHistoryScreenState extends State<GoalHistoryScreen> {
+  _GoalFilter _filter = _GoalFilter.all;
 
   String _formatDate(DateTime date) {
     return '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}.${date.year}';
@@ -16,16 +25,64 @@ class GoalHistoryScreen extends StatelessWidget {
     final accent = Theme.of(context).colorScheme.secondary;
     final goals = service.goals;
 
+    List<Goal> filteredGoals;
+    switch (_filter) {
+      case _GoalFilter.completed:
+        filteredGoals = goals.where((g) => g.completed).toList();
+        break;
+      case _GoalFilter.active:
+        filteredGoals = goals.where((g) => !g.completed).toList();
+        break;
+      case _GoalFilter.all:
+      default:
+        filteredGoals = goals;
+        break;
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('История целей'),
         centerTitle: true,
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.all(16),
-        itemCount: goals.length,
-        itemBuilder: (context, index) {
-          final g = goals[index];
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: ToggleButtons(
+              isSelected: [
+                _filter == _GoalFilter.all,
+                _filter == _GoalFilter.completed,
+                _filter == _GoalFilter.active,
+              ],
+              onPressed: (index) {
+                setState(() => _filter = _GoalFilter.values[index]);
+              },
+              borderRadius: BorderRadius.circular(4),
+              selectedColor: Colors.white,
+              fillColor: Colors.blueGrey,
+              color: Colors.white70,
+              children: const [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Все'),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Завершённые'),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Активные'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: filteredGoals.length,
+              itemBuilder: (context, index) {
+                final g = filteredGoals[index];
           final completed = g.progress >= g.target;
           return Container(
             margin: const EdgeInsets.only(bottom: 12),
@@ -70,6 +127,9 @@ class GoalHistoryScreen extends StatelessWidget {
           );
         },
       ),
+    ),
+  ],
+),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add `_GoalFilter` enum and manage filter state
- show a `ToggleButtons` segmented control on GoalHistoryScreen
- filter the list to show all, completed, or active goals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4a0ae774832a84c7a3bd41161522