### PR TITLE
Add reset to GoalHistoryScreen

### DIFF
--- a/lib/screens/goal_history_screen.dart
+++ b/lib/screens/goal_history_screen.dart
@@ -122,6 +122,39 @@ class _GoalHistoryScreenState extends State<GoalHistoryScreen> {
                   completed ? Icons.check_circle : Icons.timelapse,
                   color: completed ? Colors.green : Colors.grey,
                 ),
+                if (!completed)
+                  IconButton(
+                    icon: const Icon(Icons.refresh, size: 20),
+                    tooltip: 'Сбросить',
+                    onPressed: () async {
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (ctx) => AlertDialog(
+                          backgroundColor: Colors.grey[900],
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          title: const Text('Сбросить цель?'),
+                          content:
+                              const Text('Прогресс будет обнулён.'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, false),
+                              child: const Text('Отмена'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, true),
+                              child: const Text('OK'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirm == true) {
+                        final originalIndex = goals.indexOf(g);
+                        await service.resetGoal(originalIndex);
+                      }
+                    },
+                  ),
               ],
             ),
           );


### PR DESCRIPTION
## Summary
- add a refresh icon for active goals on `GoalHistoryScreen`
- confirm before resetting a goal with `GoalsService`

## Testing
- `dart format lib/screens/goal_history_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4b257608832a94549aaf337c0d1a