### PR TITLE
Add 'Новая' badge for recently added goals

### DIFF
--- a/lib/screens/goal_history_screen.dart
+++ b/lib/screens/goal_history_screen.dart
@@ -102,12 +102,34 @@ class _GoalHistoryScreenState extends State<GoalHistoryScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        g.title,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              g.title,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          if (DateTime.now().difference(g.createdAt).inHours <
+                              24)
+                            Container(
+                              margin: const EdgeInsets.only(left: 6),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: accent,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: const Text(
+                                'Новая',
+                                style: TextStyle(
+                                    fontSize: 12, color: Colors.white),
+                              ),
+                            ),
+                        ],
                       ),
                       const SizedBox(height: 4),
                       if (completed && g.completedAt != null)


### PR DESCRIPTION
## Summary
- track creation timestamps in `GoalsService`
- persist goal creation timestamps using `SharedPreferences`
- highlight goals created within 24 hours in `GoalHistoryScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4c265c00832ab93023db039088da