### PR TITLE
Add progress bar for error-free streak

### DIFF
--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -38,23 +38,62 @@ class StreakBanner extends StatelessWidget {
                   color: Colors.grey[850],
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: Row(
+                child: Column(
                   mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Icon(Icons.flash_on, color: accent, size: 18),
-                    const SizedBox(width: 6),
-                    Text(
-                      '$streak',
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.flash_on, color: accent, size: 18),
+                        const SizedBox(width: 6),
+                        Text(
+                          '$streak',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        const Text(
+                          'Держите темп!',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ],
                     ),
-                    const SizedBox(width: 8),
-                    const Text(
-                      'Держите темп!',
-                      style: TextStyle(color: Colors.white),
+                    const SizedBox(height: 4),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(
+                          width: 80,
+                          child: TweenAnimationBuilder<double>(
+                            tween: Tween<double>(
+                              begin: 0,
+                              end: (streak >= 5 ? 5 : streak) / 5,
+                            ),
+                            duration: const Duration(milliseconds: 300),
+                            builder: (context, value, _) {
+                              return ClipRRect(
+                                borderRadius: BorderRadius.circular(4),
+                                child: LinearProgressIndicator(
+                                  value: value,
+                                  backgroundColor: Colors.white24,
+                                  valueColor:
+                                      AlwaysStoppedAnimation<Color>(accent),
+                                  minHeight: 4,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          '${streak >= 5 ? 5 : streak}/5',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ],
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- show current streak progress out of five in the bottom StreakBanner

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b4fe4149c832a858bb09caf1e2e2a