### PR TITLE
Add motivational message on streak milestone

### DIFF
--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -6,13 +6,37 @@ import '../screens/error_free_streak_screen.dart';
 
 /// Displays the current "Без ошибок подряд" streak as a small banner.
 /// Fades in and out when the value changes.
-class StreakBanner extends StatelessWidget {
+class StreakBanner extends StatefulWidget {
   const StreakBanner({super.key});
+
+  @override
+  State<StreakBanner> createState() => _StreakBannerState();
+}
+
+class _StreakBannerState extends State<StreakBanner> {
+  bool _motivationalShown = false;
 
   @override
   Widget build(BuildContext context) {
     final streak = context.watch<GoalsService>().errorFreeStreak;
     final accent = Theme.of(context).colorScheme.secondary;
+
+    if (streak == 0) {
+      _motivationalShown = false;
+    } else if (streak >= 5 && !_motivationalShown) {
+      _motivationalShown = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content:
+                  Text('🔥 5 раздач без ошибок! Отличная серия!'),
+              duration: Duration(seconds: 3),
+            ),
+          );
+        }
+      });
+    }
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),


### PR DESCRIPTION
## Summary
- convert `StreakBanner` to `StatefulWidget`
- show SnackBar with motivational text when error-free streak reaches 5 hands
- reset notification once streak breaks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b50a028b0832a8e59b9a40a19a09a