### PR TITLE
Animate flame icon when streak grows

### DIFF
--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -13,13 +13,48 @@ class StreakBanner extends StatefulWidget {
   State<StreakBanner> createState() => _StreakBannerState();
 }
 
-class _StreakBannerState extends State<StreakBanner> {
+class _StreakBannerState extends State<StreakBanner>
+    with SingleTickerProviderStateMixin {
   bool _motivationalShown = false;
+  late final AnimationController _iconController;
+  late final Animation<double> _iconScale;
+  int _previousStreak = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _iconController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _iconScale = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.3), weight: 50),
+      TweenSequenceItem(tween: Tween(begin: 1.3, end: 1.0), weight: 50),
+    ]).animate(CurvedAnimation(
+      parent: _iconController,
+      curve: Curves.easeOut,
+    ));
+  }
+
+  @override
+  void dispose() {
+    _iconController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final streak = context.watch<GoalsService>().errorFreeStreak;
     final accent = Theme.of(context).colorScheme.secondary;
+
+    if (streak > _previousStreak && streak > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _iconController.forward(from: 0);
+        }
+      });
+    }
+    _previousStreak = streak;
 
     if (streak == 0) {
       _motivationalShown = false;
@@ -70,7 +105,10 @@ class _StreakBannerState extends State<StreakBanner> {
                       mainAxisSize: MainAxisSize.min,
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.flash_on, color: accent, size: 18),
+                        ScaleTransition(
+                          scale: _iconScale,
+                          child: Icon(Icons.flash_on, color: accent, size: 18),
+                        ),
                         const SizedBox(width: 6),
                         Text(
                           '$streak',


### PR DESCRIPTION
## Summary
- pulse the flame icon in `StreakBanner` whenever the streak value increases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b515e0628832a93112805951e9691