### PR TITLE
Add streak history screen

### DIFF
--- a/lib/screens/error_free_streak_screen.dart
+++ b/lib/screens/error_free_streak_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../widgets/saved_hand_list_view.dart';
+import 'streak_history_screen.dart';
 import 'hand_history_review_screen.dart';
 
 /// Displays hands from the current error-free streak.
@@ -19,6 +20,19 @@ class ErrorFreeStreakScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Серия без ошибок'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const StreakHistoryScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: SavedHandListView(
         hands: hands,

--- a/lib/screens/streak_history_screen.dart
+++ b/lib/screens/streak_history_screen.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../widgets/saved_hand_list_view.dart';
+import 'hand_history_review_screen.dart';
+
+class StreakHistoryScreen extends StatelessWidget {
+  const StreakHistoryScreen({super.key});
+
+  String _formatDate(DateTime date) {
+    final d = date.day.toString().padLeft(2, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    return '$d.$m.${date.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final manager = context.watch<SavedHandManagerService>();
+    final streaks = manager.completedErrorFreeStreaks();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История стриков'),
+        centerTitle: true,
+      ),
+      body: streaks.isEmpty
+          ? const Center(child: Text('Нет завершённых серий'))
+          : ListView.separated(
+              itemCount: streaks.length,
+              separatorBuilder: (_, __) => const Divider(),
+              itemBuilder: (context, index) {
+                final streak = streaks[index];
+                final startDate = streak.first.date;
+                return ListTile(
+                  title: Text(
+                    _formatDate(startDate),
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  subtitle: Text(
+                    'Длина: ${streak.length}',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => _StreakDetailScreen(hands: streak),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _StreakDetailScreen extends StatelessWidget {
+  final List<SavedHand> hands;
+  const _StreakDetailScreen({required this.hands});
+
+  String _format(DateTime d) {
+    final day = d.day.toString().padLeft(2, '0');
+    final mon = d.month.toString().padLeft(2, '0');
+    return '$day.$mon.${d.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Серия от ${_format(hands.first.date)}'),
+        centerTitle: true,
+      ),
+      body: SavedHandListView(
+        hands: hands,
+        title: 'Серия',
+        initialAccuracy: 'correct',
+        showAccuracyToggle: false,
+        onTap: (hand) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => HandHistoryReviewScreen(hand: hand),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -1038,4 +1038,34 @@ class SavedHandManagerService extends ChangeNotifier {
     }
     return result;
   }
+
+  /// Returns all completed error-free streaks of 5+ correct hands.
+  ///
+  /// Each streak is represented as a list of [SavedHand] objects in
+  /// chronological order. Only sequences terminated by a mistake are
+  /// included – the current ongoing streak (if any) is omitted.
+  List<List<SavedHand>> completedErrorFreeStreaks() {
+    final List<List<SavedHand>> streaks = [];
+    final List<SavedHand> current = [];
+
+    bool isCorrect(SavedHand h) {
+      final expected = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      return expected != null && gto != null && expected == gto;
+    }
+
+    for (final h in hands) {
+      if (isCorrect(h)) {
+        current.add(h);
+      } else {
+        if (current.length >= 5) {
+          streaks.add(List<SavedHand>.from(current));
+        }
+        current.clear();
+      }
+    }
+
+    // Only completed streaks are returned, so the trailing streak is ignored.
+    return streaks.reversed.toList();
+  }
 }


### PR DESCRIPTION
## Summary
- list all completed error-free streaks
- view details for a streak via SavedHandListView
- open history screen from the current streak screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b51ef3da8832ab072d417e4c16743