### PR TITLE
Add mistake streak achievement

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -65,13 +65,17 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
     final goal = service.dailyGoal;
     final action = widget.hand.expectedAction?.trim().toLowerCase();
     final gto = widget.hand.gtoAction?.trim().toLowerCase();
-    final mistake =
-        goal != null && service.dailyGoalIndex == 0 && action != null && gto != null && action != gto;
-    if (mistake) {
+    final isMistake = action != null && gto != null && action != gto;
+    final dailyMistake =
+        goal != null && service.dailyGoalIndex == 0 && isMistake;
+    if (dailyMistake) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         service.recordMistakeReviewed();
       });
     }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      service.updateMistakeReviewStreak(isMistake, context: context);
+    });
   }
 
   @override


### PR DESCRIPTION
## Summary
- introduce tracking of consecutive mistake reviews
- award achievement "5 ошибок подряд исправлены" when player reviews five mistakes in a row
- update HandHistoryReviewScreen to update the streak when reviewing hands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b54bf34a4832ab3e42232b31311d4