### PR TITLE
Add achievements catalog screen

### DIFF
--- a/lib/screens/achievements_catalog_screen.dart
+++ b/lib/screens/achievements_catalog_screen.dart
@@ -122,6 +122,12 @@ class AchievementsCatalogScreen extends StatelessWidget {
                         ),
                       ],
                     ),
+                    const SizedBox(height: 4),
+                    if (!completed)
+                      const Text(
+                        'Не выполнено',
+                        style: TextStyle(color: Colors.white54, fontSize: 12),
+                      ),
                   ],
                 ),
                 if (completed)

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -5,6 +5,7 @@ import '../services/goals_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../services/streak_service.dart';
+import 'achievements_catalog_screen.dart';
 
 class AchievementsScreen extends StatelessWidget {
   const AchievementsScreen({super.key});
@@ -16,6 +17,19 @@ class AchievementsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Достижения'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.menu_book),
+            tooltip: 'Каталог',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const AchievementsCatalogScreen()),
+              );
+            },
+          ),
+        ],
       ),
       body: Builder(
         builder: (context) {


### PR DESCRIPTION
## Summary
- update achievements catalog entries to show `Не выполнено` for locked items
- allow opening catalog from achievements screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b56aab29c832a894c5950a094ab10