### PR TITLE
Add goal history detail screen

### DIFF
--- a/lib/models/goal_progress_entry.dart
+++ b/lib/models/goal_progress_entry.dart
@@ -1,0 +1,17 @@
+class GoalProgressEntry {
+  final DateTime date;
+  final int progress;
+
+  GoalProgressEntry({required this.date, required this.progress});
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'progress': progress,
+      };
+
+  factory GoalProgressEntry.fromJson(Map<String, dynamic> json) =>
+      GoalProgressEntry(
+        date: DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now(),
+        progress: json['progress'] as int? ?? 0,
+      );
+}

--- a/lib/screens/goal_history_screen.dart
+++ b/lib/screens/goal_history_screen.dart
@@ -3,188 +3,41 @@ import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
 
-enum _GoalFilter { all, completed, active }
+class GoalHistoryScreen extends StatelessWidget {
+  final int index;
+  const GoalHistoryScreen({super.key, required this.index});
 
-class GoalHistoryScreen extends StatefulWidget {
-  const GoalHistoryScreen({super.key});
-
-  @override
-  State<GoalHistoryScreen> createState() => _GoalHistoryScreenState();
-}
-
-class _GoalHistoryScreenState extends State<GoalHistoryScreen> {
-  _GoalFilter _filter = _GoalFilter.all;
-
-  String _formatDate(DateTime date) {
-    return '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}.${date.year}';
+  String _format(DateTime d) {
+    final day = d.day.toString().padLeft(2, '0');
+    final mon = d.month.toString().padLeft(2, '0');
+    return '$day.$mon.${d.year}';
   }
 
   @override
   Widget build(BuildContext context) {
     final service = context.watch<GoalsService>();
-    final accent = Theme.of(context).colorScheme.secondary;
-    final goals = service.goals;
-
-    List<Goal> filteredGoals;
-    switch (_filter) {
-      case _GoalFilter.completed:
-        filteredGoals = goals.where((g) => g.completed).toList();
-        break;
-      case _GoalFilter.active:
-        filteredGoals = goals.where((g) => !g.completed).toList();
-        break;
-      case _GoalFilter.all:
-      default:
-        filteredGoals = goals;
-        break;
-    }
-
+    final goal = service.goals[index];
+    final history = service.historyFor(index);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('История целей'),
+        title: Text(goal.title),
         centerTitle: true,
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-            child: ToggleButtons(
-              isSelected: [
-                _filter == _GoalFilter.all,
-                _filter == _GoalFilter.completed,
-                _filter == _GoalFilter.active,
-              ],
-              onPressed: (index) {
-                setState(() => _filter = _GoalFilter.values[index]);
+      body: history.isEmpty
+          ? const Center(child: Text('Нет данных'))
+          : ListView.separated(
+              itemCount: history.length,
+              separatorBuilder: (_, __) => const Divider(),
+              itemBuilder: (context, i) {
+                final entry = history[i];
+                return ListTile(
+                  title: Text(_format(entry.date),
+                      style: const TextStyle(color: Colors.white)),
+                  trailing: Text('${entry.progress}/${goal.target}',
+                      style: const TextStyle(color: Colors.white70)),
+                );
               },
-              borderRadius: BorderRadius.circular(4),
-              selectedColor: Colors.white,
-              fillColor: Colors.blueGrey,
-              color: Colors.white70,
-              children: const [
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
-                  child: Text('Все'),
-                ),
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
-                  child: Text('Завершённые'),
-                ),
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
-                  child: Text('Активные'),
-                ),
-              ],
             ),
-          ),
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: filteredGoals.length,
-              itemBuilder: (context, index) {
-                final g = filteredGoals[index];
-          final completed = g.progress >= g.target;
-          return Container(
-            margin: const EdgeInsets.only(bottom: 12),
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: Colors.grey[850],
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (g.icon != null) ...[
-                  Icon(g.icon, color: accent),
-                  const SizedBox(width: 12),
-                ],
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: Text(
-                              g.title,
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                          if (DateTime.now().difference(g.createdAt).inHours <
-                              24)
-                            Container(
-                              margin: const EdgeInsets.only(left: 6),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 6, vertical: 2),
-                              decoration: BoxDecoration(
-                                color: accent,
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: const Text(
-                                'Новая',
-                                style: TextStyle(
-                                    fontSize: 12, color: Colors.white),
-                              ),
-                            ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      if (completed && g.completedAt != null)
-                        Text('Завершено: ${_formatDate(g.completedAt!)}')
-                      else
-                        Text('${g.progress}/${g.target}')
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Icon(
-                  completed ? Icons.check_circle : Icons.timelapse,
-                  color: completed ? Colors.green : Colors.grey,
-                ),
-                if (!completed)
-                  IconButton(
-                    icon: const Icon(Icons.refresh, size: 20),
-                    tooltip: 'Сбросить',
-                    onPressed: () async {
-                      final confirm = await showDialog<bool>(
-                        context: context,
-                        builder: (ctx) => AlertDialog(
-                          backgroundColor: Colors.grey[900],
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(16),
-                          ),
-                          title: const Text('Сбросить цель?'),
-                          content:
-                              const Text('Прогресс будет обнулён.'),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(ctx, false),
-                              child: const Text('Отмена'),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.pop(ctx, true),
-                              child: const Text('OK'),
-                            ),
-                          ],
-                        ),
-                      );
-                      if (confirm == true) {
-                        final originalIndex = goals.indexOf(g);
-                        await service.resetGoal(originalIndex);
-                      }
-                    },
-                  ),
-              ],
-            ),
-          );
-        },
-      ),
-    ),
-  ],
-),
     );
   }
 }

--- a/lib/screens/goals_history_screen.dart
+++ b/lib/screens/goals_history_screen.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/goals_service.dart';
+
+enum _GoalFilter { all, completed, active }
+
+class GoalsHistoryScreen extends StatefulWidget {
+  const GoalsHistoryScreen({super.key});
+
+  @override
+  State<GoalsHistoryScreen> createState() => _GoalsHistoryScreenState();
+}
+
+class _GoalsHistoryScreenState extends State<GoalsHistoryScreen> {
+  _GoalFilter _filter = _GoalFilter.all;
+
+  String _formatDate(DateTime date) {
+    return '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}.${date.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<GoalsService>();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final goals = service.goals;
+
+    List<Goal> filteredGoals;
+    switch (_filter) {
+      case _GoalFilter.completed:
+        filteredGoals = goals.where((g) => g.completed).toList();
+        break;
+      case _GoalFilter.active:
+        filteredGoals = goals.where((g) => !g.completed).toList();
+        break;
+      case _GoalFilter.all:
+      default:
+        filteredGoals = goals;
+        break;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История целей'),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: ToggleButtons(
+              isSelected: [
+                _filter == _GoalFilter.all,
+                _filter == _GoalFilter.completed,
+                _filter == _GoalFilter.active,
+              ],
+              onPressed: (index) {
+                setState(() => _filter = _GoalFilter.values[index]);
+              },
+              borderRadius: BorderRadius.circular(4),
+              selectedColor: Colors.white,
+              fillColor: Colors.blueGrey,
+              color: Colors.white70,
+              children: const [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Все'),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Завершённые'),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Text('Активные'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: filteredGoals.length,
+              itemBuilder: (context, index) {
+                final g = filteredGoals[index];
+          final completed = g.progress >= g.target;
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (g.icon != null) ...[
+                  Icon(g.icon, color: accent),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              g.title,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          if (DateTime.now().difference(g.createdAt).inHours <
+                              24)
+                            Container(
+                              margin: const EdgeInsets.only(left: 6),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: accent,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: const Text(
+                                'Новая',
+                                style: TextStyle(
+                                    fontSize: 12, color: Colors.white),
+                              ),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      if (completed && g.completedAt != null)
+                        Text('Завершено: ${_formatDate(g.completedAt!)}')
+                      else
+                        Text('${g.progress}/${g.target}')
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Icon(
+                  completed ? Icons.check_circle : Icons.timelapse,
+                  color: completed ? Colors.green : Colors.grey,
+                ),
+                if (!completed)
+                  IconButton(
+                    icon: const Icon(Icons.refresh, size: 20),
+                    tooltip: 'Сбросить',
+                    onPressed: () async {
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (ctx) => AlertDialog(
+                          backgroundColor: Colors.grey[900],
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          title: const Text('Сбросить цель?'),
+                          content:
+                              const Text('Прогресс будет обнулён.'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, false),
+                              child: const Text('Отмена'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, true),
+                              child: const Text('OK'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirm == true) {
+                        final originalIndex = goals.indexOf(g);
+                        await service.resetGoal(originalIndex);
+                      }
+                    },
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    ),
+  ],
+),
+    );
+  }
+}

--- a/lib/screens/goals_overview_screen.dart
+++ b/lib/screens/goals_overview_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/goals_service.dart';
+import 'goal_history_screen.dart';
 
 class GoalsOverviewScreen extends StatelessWidget {
   const GoalsOverviewScreen({super.key});
@@ -28,19 +29,28 @@ class GoalsOverviewScreen extends StatelessWidget {
           final g = goals[index];
           final progress = (g.progress / g.target).clamp(0.0, 1.0);
           final completed = g.completedAt != null;
-          return Container(
-            margin: const EdgeInsets.only(bottom: 12),
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: Colors.grey[850],
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (g.icon != null) ...[
-                  Icon(g.icon, color: accent),
-                  const SizedBox(width: 12),
+          return InkWell(
+            onTap: completed
+                ? () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => GoalHistoryScreen(index: index)),
+                    )
+                : null,
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (g.icon != null) ...[
+                    Icon(g.icon, color: accent),
+                    const SizedBox(width: 12),
                 ],
                 Expanded(
                   child: Column(
@@ -80,6 +90,7 @@ class GoalsOverviewScreen extends StatelessWidget {
                   color: completed ? Colors.green : Colors.grey,
                 ),
               ],
+              ),
             ),
           );
         },

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -12,7 +12,7 @@ import '../services/evaluation_executor_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../models/summary_result.dart';
 import '../theme/app_colors.dart';
-import 'goal_history_screen.dart';
+import 'goals_history_screen.dart';
 import 'achievements_screen.dart';
 
 class ProgressScreen extends StatefulWidget {
@@ -417,7 +417,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const GoalHistoryScreen()),
+                MaterialPageRoute(builder: (_) => const GoalsHistoryScreen()),
               );
             },
           ),


### PR DESCRIPTION
## Summary
- add model for goal progress history entries
- track goal progress milestones in GoalsService
- add GoalsHistoryScreen and wire up ProgressScreen
- show per-goal history in GoalHistoryScreen
- open GoalHistoryScreen from GoalsOverviewScreen when a goal is completed

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5b8c5d48832a8d7d7c9e905b3c0e