### PR TITLE
Add QuickFocusDrill flow

### DIFF
--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -1,15 +1,28 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
 import '../models/training_spot.dart';
+import '../models/saved_hand.dart';
 import '../widgets/training_spot_diagram.dart';
 import '../widgets/training_spot_preview.dart';
 import '../widgets/replay_spot_widget.dart';
+import '../services/goals_service.dart';
 
 /// Simple screen that shows a single [TrainingSpot].
 class TrainingScreen extends StatefulWidget {
-  final TrainingSpot spot;
+  final TrainingSpot? spot;
+  final List<SavedHand>? hands;
+  final bool drillMode;
 
-  const TrainingScreen({super.key, required this.spot});
+  const TrainingScreen({super.key, required TrainingSpot trainingSpot})
+      : spot = trainingSpot,
+        hands = null,
+        drillMode = false;
+
+  const TrainingScreen.drill({super.key, required this.hands})
+      : spot = null,
+        drillMode = true;
 
   @override
   State<TrainingScreen> createState() => _TrainingScreenState();
@@ -17,107 +30,210 @@ class TrainingScreen extends StatefulWidget {
 
 class _TrainingScreenState extends State<TrainingScreen> {
   String? _selected;
+  int _index = 0;
+  int _correctCount = 0;
+
+  bool get _drill => widget.drillMode;
+
+  bool get _finished =>
+      _drill && _index >= (widget.hands?.length ?? 0);
+
+  TrainingSpot get _spot =>
+      _drill ? TrainingSpot.fromSavedHand(widget.hands![_index]) : widget.spot!;
 
   void _choose(String action) {
     if (_selected != null) return;
     setState(() => _selected = action);
+    if (_drill) {
+      final hand = widget.hands![_index];
+      final expected = hand.gtoAction?.trim().toUpperCase();
+      final correct = expected != null && action == expected;
+      if (correct) _correctCount++;
+      final goals = context.read<GoalsService>();
+      goals.recordHandCompleted(context);
+      goals.updateMistakeReviewStreak(!correct, context: context);
+    }
   }
 
   void _reset() => setState(() => _selected = null);
 
+  void _next() {
+    setState(() {
+      _index++;
+    });
+    if (_index >= widget.hands!.length) {
+      _showSummary();
+    }
+  }
+
+  Future<void> _showSummary() async {
+    final total = widget.hands!.length;
+    final repeat = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Сессия завершена'),
+        content: Text('$_correctCount из $total решений верны'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Повторить'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Закрыть'),
+          ),
+        ],
+      ),
+    );
+    if (repeat == true) {
+      setState(() {
+        _index = 0;
+        _correctCount = 0;
+        _selected = null;
+      });
+    } else {
+      if (mounted) Navigator.pop(context);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final spot = widget.spot;
-    final expected = spot.strategyAdvice != null &&
-            spot.heroIndex < spot.strategyAdvice!.length
-        ? spot.strategyAdvice![spot.heroIndex].toUpperCase()
-        : null;
+    final spot = _spot;
+    String? expected;
+    if (_drill) {
+      expected = widget.hands![_index].gtoAction?.trim().toUpperCase();
+    } else if (spot.strategyAdvice != null &&
+        spot.heroIndex < spot.strategyAdvice!.length) {
+      expected = spot.strategyAdvice![spot.heroIndex].toUpperCase();
+    }
     final isCorrect =
         _selected != null && expected != null && _selected == expected;
 
     double? ev;
-    if (spot.equities != null && spot.heroIndex < spot.equities!.length) {
+    if (!_drill &&
+        spot.equities != null &&
+        spot.heroIndex < spot.equities!.length) {
       ev = spot.equities![spot.heroIndex].toDouble();
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Training'),
-        centerTitle: true,
-      ),
-      backgroundColor: const Color(0xFF121212),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TrainingSpotDiagram(
-              spot: spot,
-              size: MediaQuery.of(context).size.width - 32,
-            ),
-            const SizedBox(height: 16),
-            if (_selected == null) ...[
-              const Text(
-                'Your action?',
-                style: TextStyle(color: Colors.white70),
+    return WillPopScope(
+      onWillPop: () async {
+        if (!_drill || _finished) return true;
+        final confirm = await showDialog<bool>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Прервать тренировку?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Отмена'),
               ),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  ElevatedButton(
-                    onPressed: () => _choose('PUSH'),
-                    child: const Text('PUSH'),
-                  ),
-                  ElevatedButton(
-                    onPressed: () => _choose('FOLD'),
-                    child: const Text('FOLD'),
-                  ),
-                ],
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Выйти'),
               ),
-            ] else ...[
-              Text(
-                isCorrect ? 'Correct!' : 'Incorrect. Expected $expected',
-                style: TextStyle(
-                  color: isCorrect ? Colors.green : Colors.red,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              if (ev != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Text(
-                    'EV: ${ev.toStringAsFixed(2)}',
-                    style: const TextStyle(color: Colors.white70),
-                  ),
-                ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _reset,
-                child: const Text('Try Again'),
-              ),
-              if (spot.actions.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: ElevatedButton(
-                    onPressed: () {
-                      showModalBottomSheet(
-                        context: context,
-                        backgroundColor: Colors.grey[900],
-                        isScrollControlled: true,
-                        shape: const RoundedRectangleBorder(
-                          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                        ),
-                        builder: (_) => ReplaySpotWidget(spot: spot),
-                      );
-                    },
-                    child: const Text('Replay Hand'),
-                  ),
-                ),
             ],
-            const SizedBox(height: 16),
-            TrainingSpotPreview(spot: spot),
-          ],
+          ),
+        );
+        return confirm ?? false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Training'),
+          centerTitle: true,
+        ),
+        backgroundColor: const Color(0xFF121212),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (_drill)
+                Text(
+                  'Раздача ${_index + 1} / ${widget.hands!.length}',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              if (_drill) const SizedBox(height: 8),
+              TrainingSpotDiagram(
+                spot: spot,
+                size: MediaQuery.of(context).size.width - 32,
+              ),
+              const SizedBox(height: 16),
+              if (_selected == null) ...[
+                const Text(
+                  'Ваше действие?',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => _choose('PUSH'),
+                      child: const Text('PUSH'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _choose('FOLD'),
+                      child: const Text('FOLD'),
+                    ),
+                  ],
+                ),
+              ] else ...[
+                Text(
+                  isCorrect ? 'Верно!' : 'Неверно. Надо $expected',
+                  style: TextStyle(
+                    color: isCorrect ? Colors.green : Colors.red,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (ev != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      'EV: ${ev.toStringAsFixed(2)}',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ),
+                const SizedBox(height: 8),
+                if (_drill)
+                  ElevatedButton(
+                    onPressed: () {
+                      setState(() => _selected = null);
+                      _next();
+                    },
+                    child: Text(
+                        _index + 1 >= widget.hands!.length ? 'Завершить' : 'Далее'),
+                  )
+                else
+                  ElevatedButton(
+                    onPressed: _reset,
+                    child: const Text('Try Again'),
+                  ),
+                if (!_drill && spot.actions.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: ElevatedButton(
+                      onPressed: () {
+                        showModalBottomSheet(
+                          context: context,
+                          backgroundColor: Colors.grey[900],
+                          isScrollControlled: true,
+                          shape: const RoundedRectangleBorder(
+                            borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                          ),
+                          builder: (_) => ReplaySpotWidget(spot: spot),
+                        );
+                      },
+                      child: const Text('Replay Hand'),
+                    ),
+                  ),
+              ],
+              if (!_drill) ...[
+                const SizedBox(height: 16),
+                TrainingSpotPreview(spot: spot),
+              ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/focus_of_the_week_card.dart
+++ b/lib/widgets/focus_of_the_week_card.dart
@@ -7,6 +7,7 @@ import '../helpers/poker_street_helper.dart';
 import '../models/saved_hand.dart';
 import 'saved_hand_list_view.dart';
 import '../screens/hand_history_review_screen.dart';
+import '../screens/training_screen.dart';
 
 class FocusOfTheWeekCard extends StatelessWidget {
   const FocusOfTheWeekCard({super.key});
@@ -85,6 +86,27 @@ class FocusOfTheWeekCard extends StatelessWidget {
               );
             },
             child: const Text('Тренировать'),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () {
+              final manager = context.read<SavedHandManagerService>();
+              final cutoff = DateTime.now().subtract(const Duration(days: 7));
+              final filteredHands = [
+                for (final h in manager.hands)
+                  if (h.heroPosition == pos! &&
+                      streetName(h.boardStreet) == street! &&
+                      h.date.isAfter(cutoff))
+                    h
+              ];
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TrainingScreen.drill(hands: filteredHands),
+                ),
+              );
+            },
+            child: const Text('Начать сессию'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- extend `TrainingScreen` with `drill` constructor
- count correct answers and show session summary
- confirm exit while drill active
- launch drill from FocusOfTheWeekCard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b682d2a50832ab669d38b1dfb3f13