### PR TITLE
Add drill session history

### DIFF
--- a/lib/models/drill_session_result.dart
+++ b/lib/models/drill_session_result.dart
@@ -1,0 +1,42 @@
+import 'saved_hand.dart';
+
+class DrillSessionResult {
+  final DateTime date;
+  final String position;
+  final String street;
+  final int total;
+  final int correct;
+  final List<SavedHand> hands;
+
+  DrillSessionResult({
+    required this.date,
+    required this.position,
+    required this.street,
+    required this.total,
+    required this.correct,
+    required this.hands,
+  });
+
+  double get accuracy => total == 0 ? 0 : correct / total;
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'position': position,
+        'street': street,
+        'total': total,
+        'correct': correct,
+        'hands': [for (final h in hands) h.toJson()],
+      };
+
+  factory DrillSessionResult.fromJson(Map<String, dynamic> json) => DrillSessionResult(
+        date: DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now(),
+        position: json['position'] as String? ?? '',
+        street: json['street'] as String? ?? '',
+        total: json['total'] as int? ?? 0,
+        correct: json['correct'] as int? ?? 0,
+        hands: [
+          for (final h in (json['hands'] as List? ?? []))
+            SavedHand.fromJson(Map<String, dynamic>.from(h as Map))
+        ],
+      );
+}

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../services/goals_service.dart';
+import '../widgets/saved_hand_list_view.dart';
+import '../screens/hand_history_review_screen.dart';
+import '../models/saved_hand.dart';
+import 'package:provider/provider.dart';
+
+class DrillHistoryScreen extends StatelessWidget {
+  const DrillHistoryScreen({super.key});
+
+  String _fmt(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}.${d.year}';
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final results = context.watch<GoalsService>().drillResults.reversed.take(20).toList();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Drill История'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: results.length,
+        itemBuilder: (context, index) {
+          final r = results[index];
+          final perc = (r.accuracy * 100).round();
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: ListTile(
+              title: Text(
+                '${_fmt(r.date)} • ${r.position} / ${r.street}',
+                style: const TextStyle(color: Colors.white),
+              ),
+              subtitle: Text(
+                '${r.correct}/${r.total} верно ($perc%)',
+                style: TextStyle(color: accent),
+              ),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => _DrillSessionHandsScreen(hands: r.hands),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _DrillSessionHandsScreen extends StatelessWidget {
+  final List<SavedHand> hands;
+  const _DrillSessionHandsScreen({required this.hands});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Руки'),
+        centerTitle: true,
+      ),
+      body: SavedHandListView(
+        hands: hands,
+        title: 'Drill Hands',
+        showAccuracyToggle: false,
+        onTap: (hand) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => HandHistoryReviewScreen(hand: hand),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -16,6 +16,7 @@ import '../helpers/poker_street_helper.dart';
 import '../widgets/mistake_heatmap.dart';
 import 'goals_history_screen.dart';
 import 'achievements_screen.dart';
+import 'drill_history_screen.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -470,6 +471,16 @@ class _ProgressScreenState extends State<ProgressScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const GoalsHistoryScreen()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.history_edu),
+            tooltip: 'Drill-История',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const DrillHistoryScreen()),
               );
             },
           ),

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -8,6 +8,8 @@ import '../widgets/training_spot_diagram.dart';
 import '../widgets/training_spot_preview.dart';
 import '../widgets/replay_spot_widget.dart';
 import '../services/goals_service.dart';
+import '../models/drill_session_result.dart';
+import '../helpers/poker_street_helper.dart';
 
 /// Simple screen that shows a single [TrainingSpot].
 class TrainingScreen extends StatefulWidget {
@@ -68,6 +70,16 @@ class _TrainingScreenState extends State<TrainingScreen> {
 
   Future<void> _showSummary() async {
     final total = widget.hands!.length;
+    final result = DrillSessionResult(
+      date: DateTime.now(),
+      position: widget.hands!.first.heroPosition,
+      street: streetName(widget.hands!.first.boardStreet),
+      total: total,
+      correct: _correctCount,
+      hands: widget.hands!,
+    );
+    await GoalsService.instance!
+        .saveDrillResult(result, context: context);
     final repeat = await showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(


### PR DESCRIPTION
## Summary
- save drill results via `GoalsService`
- track drill achievement progress
- add drill session model and screen
- show drill history in Progress screen
- persist drill sessions in shared prefs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b69ece7f0832abee3f5a2cb2d3e24