### PR TITLE
Add progress snapshot card to main menu

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -377,6 +377,58 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     );
   }
 
+  Widget _buildProgressCard(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final goals = context.watch<GoalsService>();
+    final executor = EvaluationExecutorService();
+    final total = executor.summarizeHands(hands).totalHands;
+    final cutoff = DateTime.now().subtract(const Duration(days: 7));
+    final recent = [for (final h in hands) if (h.date.isAfter(cutoff)) h];
+    final recentSummary = executor.summarizeHands(recent);
+    final accuracy = recentSummary.totalHands > 0 ? recentSummary.accuracy : null;
+    final completed = goals.goals.where((g) => g.completed).length;
+    final streak = goals.errorFreeStreak;
+    final show = total > 0 || accuracy != null || completed > 0 || streak > 0;
+    if (!show) return const SizedBox.shrink();
+    Widget line(IconData icon, String text) => Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Row(
+            children: [
+              Icon(icon, color: Colors.white),
+              const SizedBox(width: 8),
+              Text(text),
+            ],
+          ),
+        );
+    return Container(
+      margin: const EdgeInsets.only(bottom: 24),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: const [
+              Icon(Icons.bar_chart, color: Colors.white),
+              SizedBox(width: 8),
+              Text('📈 Мой прогресс',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            ],
+          ),
+          if (total > 0) line(Icons.stacked_bar_chart, '$total раздач'),
+          if (accuracy != null)
+            line(Icons.check, 'Точность: ${accuracy.toStringAsFixed(0)}%'),
+          if (completed > 0)
+            line(Icons.flag, 'Целей достигнуто: $completed'),
+          if (streak > 0) line(Icons.flash_on, 'Стрик: $streak рук'),
+        ],
+      ),
+    );
+  }
+
   Future<void> _toggleDemoMode(bool value) async {
     setState(() => _demoMode = value);
     await UserPreferences.instance.setDemoMode(value);
@@ -465,6 +517,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             _buildStreakCard(context),
             _buildDailyGoalCard(context),
             const FocusOfTheWeekCard(),
+            _buildProgressCard(context),
             ElevatedButton(
               onPressed: () {
                 Navigator.push(


### PR DESCRIPTION
## Summary
- show "📈 Мой прогресс" card on main menu
- list hands solved, weekly accuracy, goals completed and streak

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6c23bc50832aaeaf21733d1377ec