### PR TITLE
Implement training pack comparison

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/training_pack_storage_service.dart';
+import '../models/training_pack.dart';
+
+class TrainingPackComparisonScreen extends StatefulWidget {
+  const TrainingPackComparisonScreen({super.key});
+
+  @override
+  State<TrainingPackComparisonScreen> createState() => _TrainingPackComparisonScreenState();
+}
+
+class _PackStats {
+  final String name;
+  final int total;
+  final int mistakes;
+  final double accuracy;
+  final double rating;
+
+  _PackStats({
+    required this.name,
+    required this.total,
+    required this.mistakes,
+    required this.accuracy,
+    required this.rating,
+  });
+
+  factory _PackStats.fromPack(TrainingPack p) {
+    final history = p.history;
+    final total = history.fold<int>(0, (p0, r) => p0 + r.total);
+    final correct = history.fold<int>(0, (p0, r) => p0 + r.correct);
+    final mistakes = total - correct;
+    final accuracy = total > 0 ? correct * 100 / total : 0.0;
+    final ratingAvg = p.hands.isNotEmpty
+        ? p.hands.map((h) => h.rating).reduce((a, b) => a + b) / p.hands.length
+        : 0.0;
+    return _PackStats(
+      name: p.name,
+      total: total,
+      mistakes: mistakes,
+      accuracy: accuracy,
+      rating: ratingAvg,
+    );
+  }
+}
+
+class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScreen> {
+  int _sortColumn = 0;
+  bool _ascending = true;
+
+  void _onSort(int columnIndex, bool ascending) {
+    setState(() {
+      _sortColumn = columnIndex;
+      _ascending = ascending;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final packs = context.watch<TrainingPackStorageService>().packs;
+    final stats = [for (final p in packs) _PackStats.fromPack(p)]..sort((a, b) {
+        int cmp;
+        switch (_sortColumn) {
+          case 0:
+            cmp = a.name.compareTo(b.name);
+            break;
+          case 1:
+            cmp = a.total.compareTo(b.total);
+            break;
+          case 2:
+            cmp = a.accuracy.compareTo(b.accuracy);
+            break;
+          case 3:
+            cmp = a.mistakes.compareTo(b.mistakes);
+            break;
+          case 4:
+            cmp = a.rating.compareTo(b.rating);
+            break;
+          default:
+            cmp = 0;
+        }
+        return _ascending ? cmp : -cmp;
+      });
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Сравнение паков'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        scrollDirection: Axis.vertical,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            sortColumnIndex: _sortColumn,
+            sortAscending: _ascending,
+            columns: [
+              DataColumn(
+                label: const Text('Название'),
+                onSort: _onSort,
+              ),
+              DataColumn(
+                label: const Text('Рук'),
+                numeric: true,
+                onSort: _onSort,
+              ),
+              DataColumn(
+                label: const Text('Точность'),
+                numeric: true,
+                onSort: _onSort,
+              ),
+              DataColumn(
+                label: const Text('Ошибки'),
+                numeric: true,
+                onSort: _onSort,
+              ),
+              DataColumn(
+                label: const Text('Рейтинг'),
+                numeric: true,
+                onSort: _onSort,
+              ),
+            ],
+            rows: [
+              for (final s in stats)
+                DataRow(cells: [
+                  DataCell(Text(s.name)),
+                  DataCell(Text(s.total.toString())),
+                  DataCell(Text('${s.accuracy.toStringAsFixed(1)}%')),
+                  DataCell(Text(s.mistakes.toString())),
+                  DataCell(Text(s.rating.toStringAsFixed(1))),
+                ]),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
+import 'training_pack_comparison_screen.dart';
 
 class TrainingPacksScreen extends StatefulWidget {
   const TrainingPacksScreen({super.key});
@@ -72,6 +73,23 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
             value: _hideCompleted,
             onChanged: _toggleHideCompleted,
             activeColor: Colors.orange,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const TrainingPackComparisonScreen(),
+                    ),
+                  );
+                },
+                child: const Text('📊 Сравнить паки'),
+              ),
+            ),
           ),
           Expanded(
             child: visible.isEmpty


### PR DESCRIPTION
## Summary
- create `TrainingPackComparisonScreen` for comparing packs
- allow navigating to comparison from pack list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b6fd80f84832aa6cb09e50293a139