### PR TITLE
Fix CSV column mismatch

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -138,7 +138,9 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
       sumMistakes,
       avgRating.toStringAsFixed(1),
     ]);
-    final csvStr = '\uFEFF${const ListToCsvConverter(fieldDelimiter: ';').convert(rows, eol: '\r\n')}';
+    assert(rows.every((r) => r.length == rows.first.length));
+    final csvStr =
+        '\uFEFF${const ListToCsvConverter(fieldDelimiter: ';').convert(rows, eol: '\r\n')}';
     final dir = await getTemporaryDirectory();
     final name =
         'pack_comparison_${DateFormat("yyyy-MM-dd_HH-mm").format(DateTime.now())}.csv';


### PR DESCRIPTION
## Summary
- assert all rows have the same column count before exporting pack comparison CSV

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b811f4ad8832a9f4b1f5a0aaad804