### PR TITLE
Add tooltip for last session

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -59,9 +59,15 @@ class _PackDataSource extends DataTableSource {
             style: TextStyle(color: color))),
         DataCell(Text(s.mistakes.toString())),
         DataCell(Text(s.rating.toStringAsFixed(1).padLeft(4))),
-        DataCell(Text(s.lastSession != null
-            ? DateFormat('dd.MM').format(s.lastSession!)
-            : '-')),
+        DataCell(Tooltip(
+          message: s.lastSession != null
+              ? 'Последняя сессия: '
+                  '${DateFormat('d MMMM yyyy', 'ru').format(s.lastSession!)}'
+              : 'Нет данных',
+          child: Text(s.lastSession != null
+              ? DateFormat('dd.MM').format(s.lastSession!)
+              : '-'),
+        )),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- show detailed date tooltip in pack comparison table

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf2b2460832abfa5a3f16ee9e3b1