### PR TITLE
Wrap accuracy cell tooltip

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -55,8 +55,15 @@ class _PackDataSource extends DataTableSource {
       cells: [
         DataCell(Tooltip(message: 'Открыть обзор пака', child: Text(s.pack.name))),
         DataCell(Text(s.total.toString())),
-        DataCell(Text('${s.accuracy.toStringAsFixed(1).padLeft(5)}%',
-            style: TextStyle(color: color))),
+        DataCell(
+          Tooltip(
+            message: '${s.total - s.mistakes} из ${s.total} верно',
+            child: Text(
+              '${s.accuracy.toStringAsFixed(1).padLeft(5)}%',
+              style: TextStyle(color: color),
+            ),
+          ),
+        ),
         DataCell(Text(s.mistakes.toString())),
         DataCell(Text(s.rating.toStringAsFixed(1).padLeft(4))),
         DataCell(Tooltip(


### PR DESCRIPTION
## Summary
- show correctness detail via tooltip in TrainingPackComparisonScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbfef66cc832ab558704c6177bf9b