### PR TITLE
Add tooltip for rating column

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -305,15 +305,18 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
                   onSort: (i, asc) => _onSort(i, asc),
                 ),
                 DataColumn(
-                  label: Row(
-                    children: [
-                      const Text('Рейтинг'),
-                      if (_sortColumn == 4)
-                        Icon(
-                          _ascending ? Icons.arrow_upward : Icons.arrow_downward,
-                          size: 12,
-                        ),
-                    ],
+                  label: Tooltip(
+                    message: 'Средний рейтинг всех рук в паке (1–5)',
+                    child: Row(
+                      children: [
+                        const Text('Рейтинг'),
+                        if (_sortColumn == 4)
+                          Icon(
+                            _ascending ? Icons.arrow_upward : Icons.arrow_downward,
+                            size: 12,
+                          ),
+                      ],
+                    ),
                   ),
                   numeric: true,
                   onSort: (i, asc) => _onSort(i, asc),


### PR DESCRIPTION
## Summary
- show hint for the rating column header

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc666ff48832aaf0f03c0a2c88b65