### PR TITLE
Enable inline rename for packs

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -105,4 +105,20 @@ class TrainingPackStorageService extends ChangeNotifier {
       return null;
     }
   }
+
+  Future<void> renamePack(TrainingPack pack, String newName) async {
+    final index = _packs.indexOf(pack);
+    if (index == -1) return;
+    final trimmed = newName.trim();
+    if (trimmed.isEmpty || trimmed == pack.name) return;
+    _packs[index] = TrainingPack(
+      name: trimmed,
+      description: pack.description,
+      category: pack.category,
+      hands: pack.hands,
+      history: pack.history,
+    );
+    await _persist();
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- allow training packs to be renamed inline in comparison table
- support renaming packs in storage service

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc737ed7c832a85910f18aef675fa