### PR TITLE
Add pack context actions

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -121,4 +121,18 @@ class TrainingPackStorageService extends ChangeNotifier {
     await _persist();
     notifyListeners();
   }
+
+  Future<void> duplicatePack(TrainingPack pack) async {
+    String base = pack.name;
+    String name = '${base}-copy';
+    int idx = 1;
+    while (_packs.any((p) => p.name == name)) {
+      name = '${base}-copy${idx > 1 ? idx : ''}';
+      idx++;
+    }
+    final copy = TrainingPack.fromJson({...pack.toJson(), 'name': name});
+    _packs.add(copy);
+    await _persist();
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- add `duplicatePack` to `TrainingPackStorageService`
- support row actions in `TrainingPackComparisonScreen`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd14e1884832ab491e9be0bfcffff