### PR TITLE
Implement undo delete for training packs

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -174,12 +174,28 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
       ),
     );
     if (confirm == true) {
-      await context.read<TrainingPackStorageService>().removePack(pack);
+      final result = await context.read<TrainingPackStorageService>().removePack(pack);
+      if (result != null) {
+        _showUndoDelete(result.\$1, result.\$2);
+      }
     }
   }
 
   Future<void> _duplicatePack(TrainingPack pack) async {
     await context.read<TrainingPackStorageService>().duplicatePack(pack);
+  }
+
+  void _showUndoDelete(TrainingPack pack, int index) {
+    final snack = SnackBar(
+      content: const Text('Пакет удалён'),
+      action: SnackBarAction(
+        label: 'Отмена',
+        onPressed: () =>
+            context.read<TrainingPackStorageService>().restorePack(pack, index),
+      ),
+      duration: const Duration(seconds: 5),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(snack);
   }
 
   Future<void> _showRowMenu(TrainingPackStats s) async {

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -51,8 +51,18 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> removePack(TrainingPack pack) async {
-    _packs.remove(pack);
+  Future<(TrainingPack pack, int index)?> removePack(TrainingPack pack) async {
+    final index = _packs.indexOf(pack);
+    if (index == -1) return null;
+    final removed = _packs.removeAt(index);
+    await _persist();
+    notifyListeners();
+    return (removed, index);
+  }
+
+  Future<void> restorePack(TrainingPack pack, int index) async {
+    final insertIndex = index.clamp(0, _packs.length);
+    _packs.insert(insertIndex, pack);
     await _persist();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- add undo SnackBar for deleting packs
- support restoring packs via TrainingPackStorageService
- return removed pack info from removePack

## Testing
- `flutter test --no-pub --coverage -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd9a96a7c832ab45285f42db047d9