### PR TITLE
Add action comparison to replay widget

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -321,7 +321,12 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
             ],
           ),
           const SizedBox(height: 12),
-          ReplaySpotWidget(spot: spot),
+          ReplaySpotWidget(
+            spot: spot,
+            expectedAction: widget.hand.expectedAction,
+            gtoAction: widget.hand.gtoAction,
+            evLoss: widget.hand.evLoss,
+          ),
             const SizedBox(height: 12),
             if ((gto != null && gto.isNotEmpty) ||
                 (group != null && group.isNotEmpty))

--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -404,8 +404,12 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
             ),
-            builder: (_) =>
-                ReplaySpotWidget(spot: TrainingSpot.fromSavedHand(hand)),
+            builder: (_) => ReplaySpotWidget(
+              spot: TrainingSpot.fromSavedHand(hand),
+              expectedAction: hand.expectedAction,
+              gtoAction: hand.gtoAction,
+              evLoss: hand.evLoss,
+            ),
           );
         },
         onLongPress: () => _showHandOptions(hand),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -419,8 +419,12 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                               borderRadius:
                                   BorderRadius.vertical(top: Radius.circular(16)),
                             ),
-                            builder: (_) =>
-                                ReplaySpotWidget(spot: TrainingSpot.fromSavedHand(original)),
+                            builder: (_) => ReplaySpotWidget(
+                              spot: TrainingSpot.fromSavedHand(original),
+                              expectedAction: original.expectedAction,
+                              gtoAction: original.gtoAction,
+                              evLoss: original.evLoss,
+                            ),
                           );
                         },
                         child: const Text('Replay Hand'),

--- a/lib/widgets/replay_spot_widget.dart
+++ b/lib/widgets/replay_spot_widget.dart
@@ -12,7 +12,17 @@ import 'training_spot_diagram.dart';
 /// Simple hand replay widget for [TrainingSpot].
 class ReplaySpotWidget extends StatefulWidget {
   final TrainingSpot spot;
-  const ReplaySpotWidget({super.key, required this.spot});
+  final String? expectedAction;
+  final String? gtoAction;
+  final double? evLoss;
+
+  const ReplaySpotWidget({
+    super.key,
+    required this.spot,
+    this.expectedAction,
+    this.gtoAction,
+    this.evLoss,
+  });
 
   @override
   State<ReplaySpotWidget> createState() => _ReplaySpotWidgetState();
@@ -71,6 +81,56 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
     });
   }
 
+  Widget _buildComparison() {
+    if (widget.expectedAction == null && widget.gtoAction == null) {
+      return const SizedBox.shrink();
+    }
+    final highlight = (widget.evLoss ?? 0) > 0.5;
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: highlight ? Colors.redAccent.withOpacity(0.2) : Colors.white10,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Вы выбрали',
+                    style: TextStyle(color: Colors.white70, fontSize: 12)),
+                const SizedBox(height: 4),
+                Text(
+                  widget.expectedAction ?? '-',
+                  style: const TextStyle(
+                      color: Colors.white, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Оптимально',
+                    style: TextStyle(color: Colors.white70, fontSize: 12)),
+                const SizedBox(height: 4),
+                Text(
+                  widget.gtoAction ?? '-',
+                  style: const TextStyle(
+                      color: Colors.white, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final street = _currentActions.isNotEmpty ? _currentActions.last.street : 0;
@@ -94,6 +154,7 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          _buildComparison(),
           SizedBox(
             height: 260,
             child: Stack(


### PR DESCRIPTION
## Summary
- show expected vs GTO actions in `ReplaySpotWidget`
- supply expected action, GTO action and EV loss from saved hands

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be0164f28832aa8dffe4084c492be