### PR TITLE
Add GTO info dialog

### DIFF
--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -326,8 +326,9 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
             expectedAction: widget.hand.expectedAction,
             gtoAction: widget.hand.gtoAction,
             evLoss: widget.hand.evLoss,
+            feedbackText: widget.hand.feedbackText,
           ),
-            const SizedBox(height: 12),
+          const SizedBox(height: 12),
             if ((gto != null && gto.isNotEmpty) ||
                 (group != null && group.isNotEmpty))
               Column(

--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -409,6 +409,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
               expectedAction: hand.expectedAction,
               gtoAction: hand.gtoAction,
               evLoss: hand.evLoss,
+              feedbackText: hand.feedbackText,
             ),
           );
         },

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -424,6 +424,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
                               expectedAction: original.expectedAction,
                               gtoAction: original.gtoAction,
                               evLoss: original.evLoss,
+                              feedbackText: original.feedbackText,
                             ),
                           );
                         },

--- a/lib/widgets/replay_spot_widget.dart
+++ b/lib/widgets/replay_spot_widget.dart
@@ -15,6 +15,7 @@ class ReplaySpotWidget extends StatefulWidget {
   final String? expectedAction;
   final String? gtoAction;
   final double? evLoss;
+  final String? feedbackText;
 
   const ReplaySpotWidget({
     super.key,
@@ -22,6 +23,7 @@ class ReplaySpotWidget extends StatefulWidget {
     this.expectedAction,
     this.gtoAction,
     this.evLoss,
+    this.feedbackText,
   });
 
   @override
@@ -79,6 +81,38 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
       _index = value.clamp(0, widget.spot.actions.length);
       _isPlaying = false;
     });
+  }
+
+  Future<void> _showGto() async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Оптимальное действие'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (widget.gtoAction != null)
+              Text(widget.gtoAction!,
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+            if (widget.feedbackText != null) ...[
+              const SizedBox(height: 8),
+              Text(widget.feedbackText!),
+            ],
+            if ((widget.evLoss ?? 0) > 0.5) ...[
+              const SizedBox(height: 8),
+              Text('Потеря EV: –${widget.evLoss!.toStringAsFixed(1)} bb'),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _buildComparison() {
@@ -208,7 +242,14 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
                 icon: const Icon(Icons.restart_alt),
               ),
             ],
-          )
+          ),
+          if (widget.gtoAction != null || widget.feedbackText != null) ...[
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _showGto,
+              child: const Text('Показать GTO'),
+            ),
+          ]
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- extend `ReplaySpotWidget` with `feedbackText`
- show GTO info via dialog and button
- forward `feedbackText` to replay widget from screens

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be8cba274832aa343c09e64fe9d08