### PR TITLE
Add goal drill screen

### DIFF
--- a/lib/screens/goal_drill_screen.dart
+++ b/lib/screens/goal_drill_screen.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../models/training_spot.dart';
+import '../services/goals_service.dart';
+import '../services/training_pack_storage_service.dart';
+import '../widgets/replay_spot_widget.dart';
+
+class GoalDrillScreen extends StatefulWidget {
+  const GoalDrillScreen({super.key});
+
+  @override
+  State<GoalDrillScreen> createState() => _GoalDrillScreenState();
+}
+
+class _GoalDrillScreenState extends State<GoalDrillScreen> {
+  late final Goal? _goal;
+  late final List<SavedHand> _hands;
+  int _index = 0;
+  bool _show = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final goals = context.read<GoalsService>();
+    _goal = goals.currentGoal;
+    if (_goal != null) {
+      final packs = context.read<TrainingPackStorageService>().packs;
+      final list = <SavedHand>[];
+      for (final p in packs) {
+        for (final h in p.hands) {
+          if (_goal!.isViolatedBy(h)) {
+            list.add(h);
+            if (list.length >= 20) break;
+          }
+        }
+        if (list.length >= 20) break;
+      }
+      _hands = list;
+    } else {
+      _hands = [];
+    }
+  }
+
+  void _next() {
+    setState(() {
+      _index++;
+      _show = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_goal == null) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Отработка цели'),
+          centerTitle: true,
+        ),
+        body: const Center(
+          child: Text(
+            'Нет активной цели для отработки.',
+            style: TextStyle(color: Colors.white70),
+          ),
+        ),
+      );
+    }
+    if (_index >= _hands.length) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Отработка цели'),
+          centerTitle: true,
+        ),
+        body: const Center(
+          child: Text(
+            'Цель отработана! 💪 Продолжай в том же духе.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.white70),
+          ),
+        ),
+      );
+    }
+    final hand = _hands[_index];
+    final spot = TrainingSpot.fromSavedHand(hand);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_goal!.title),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Раздача ${_index + 1} / ${_hands.length}',
+            style: const TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 8),
+          ReplaySpotWidget(
+            spot: spot,
+            expectedAction: _show ? hand.expectedAction : null,
+            gtoAction: _show ? hand.gtoAction : null,
+            evLoss: _show ? hand.evLoss : null,
+            feedbackText: _show ? hand.feedbackText : null,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              ElevatedButton(
+                onPressed: () => setState(() => _show = true),
+                child: const Text('Ответ'),
+              ),
+              ElevatedButton(
+                onPressed: _next,
+                child: Text(
+                    _index + 1 >= _hands.length ? 'Завершить' : 'Далее'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/mistake_heatmap.dart';
 import 'goals_history_screen.dart';
 import 'achievements_screen.dart';
 import 'drill_history_screen.dart';
+import 'goal_drill_screen.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -759,6 +760,19 @@ class _ProgressScreenState extends State<ProgressScreen> {
         children: [
           _buildGoalCompletedBadge(),
           _buildAllGoalsCompletedBadge(),
+          Row(
+            children: [
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const GoalDrillScreen()),
+                  );
+                },
+                child: const Text('Отработать цель'),
+              ),
+            ],
+          ),
           const Text(
             'Результаты',
             style: TextStyle(


### PR DESCRIPTION
## Summary
- add goal violation check in `Goal`
- expose `currentGoal`
- implement `GoalDrillScreen`
- launch goal drill from Progress screen

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf56f4800832aa5ff6f897b18fcae