### PR TITLE
Add daily spot statistics

### DIFF
--- a/lib/screens/daily_spot_screen.dart
+++ b/lib/screens/daily_spot_screen.dart
@@ -29,7 +29,11 @@ class _DailySpotScreenState extends State<DailySpotScreen> {
         break;
       }
     }
-    await prefs.setString('daily_spot_date', DateTime.now().toIso8601String());
+    final now = DateTime.now();
+    await prefs.setString('daily_spot_date', now.toIso8601String());
+    final history = prefs.getStringList('daily_spot_history') ?? [];
+    history.add(now.toIso8601String());
+    await prefs.setStringList('daily_spot_history', history);
     if (id != null) await prefs.setString('daily_spot_id', id);
     if (mounted) {
       Navigator.pushReplacement(

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -41,6 +41,8 @@ class _ProgressScreenState extends State<ProgressScreen> {
   bool _goalCompleted = false;
   bool _allGoalsCompleted = false;
   bool _dailySpotDone = false;
+  int _dailyWeekCount = 0;
+  int _dailyMonthCount = 0;
 
   @override
   void initState() {
@@ -50,6 +52,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
     _goalCompleted = goals.anyCompleted;
     _allGoalsCompleted = goals.goals.every((g) => g.completed);
     _loadDailySpot();
+    _loadDailySpotStats();
     goals.addListener(_onGoalsChanged);
   }
 
@@ -170,6 +173,25 @@ class _ProgressScreenState extends State<ProgressScreen> {
         date.day == now.day) {
       setState(() => _dailySpotDone = true);
     }
+  }
+
+  Future<void> _loadDailySpotStats() async {
+    final service = context.read<GoalsService>();
+    final history = await service.getDailySpotHistory();
+    final now = DateTime.now();
+    final weekStart = now.subtract(const Duration(days: 6));
+    final monthStart = now.subtract(const Duration(days: 29));
+    int week = 0;
+    int month = 0;
+    for (final d in history) {
+      final day = DateTime(d.year, d.month, d.day);
+      if (!day.isBefore(weekStart)) week++;
+      if (!day.isBefore(monthStart)) month++;
+    }
+    setState(() {
+      _dailyWeekCount = week;
+      _dailyMonthCount = month;
+    });
   }
 
   Widget _buildPieChart() {
@@ -828,6 +850,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
                       ),
                     );
                     _loadDailySpot();
+                    _loadDailySpotStats();
                   },
             child: Text(_dailySpotDone ? '✅ Выполнено' : 'Спот дня'),
           ),
@@ -895,6 +918,33 @@ class _ProgressScreenState extends State<ProgressScreen> {
           Text(
             'Всего разобрано раздач: $totalHands',
             style: const TextStyle(color: Colors.white),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '📅 Статистика спотов дня',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _dailyWeekCount > 0
+                ? 'За неделю: $_dailyWeekCount / 7 дней'
+                : 'Нет активности за период',
+            style: TextStyle(
+              color: _dailyWeekCount > 0 ? Colors.white : Colors.white70,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _dailyMonthCount > 0
+                ? 'За месяц: $_dailyMonthCount / 30 дней'
+                : 'Нет активности за период',
+            style: TextStyle(
+              color: _dailyMonthCount > 0 ? Colors.white : Colors.white70,
+            ),
           ),
         ],
       ),

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -85,6 +85,7 @@ class GoalsService extends ChangeNotifier {
   static const _achievementShownPrefix = 'ach_shown_';
   static const _historyPrefix = 'goal_history_';
   static const _drillResultsKey = 'drill_results';
+  static const _dailySpotHistoryKey = 'daily_spot_history';
 
   int _errorFreeStreak = 0;
   int _handStreak = 0;
@@ -100,6 +101,7 @@ class GoalsService extends ChangeNotifier {
   late List<bool> _achievementShown;
   late List<List<GoalProgressEntry>> _history;
   List<DrillSessionResult> _drillResults = [];
+  List<DateTime> _dailySpotHistory = [];
 
   static GoalsService? _instance;
   static GoalsService? get instance => _instance;
@@ -139,6 +141,7 @@ class GoalsService extends ChangeNotifier {
   int get mistakeReviewStreak => _mistakeReviewStreak;
 
   List<DrillSessionResult> get drillResults => List.unmodifiable(_drillResults);
+  List<DateTime> get dailySpotHistory => List.unmodifiable(_dailySpotHistory);
 
   List<GoalProgressEntry> historyFor(int index) =>
       index >= 0 && index < _history.length
@@ -216,6 +219,11 @@ class GoalsService extends ChangeNotifier {
         }
       } catch (_) {}
     }
+    final spotRaw = prefs.getStringList(_dailySpotHistoryKey) ?? [];
+    _dailySpotHistory = [
+      for (final s in spotRaw)
+        if (DateTime.tryParse(s) != null) DateTime.parse(s)
+    ];
     _errorFreeStreak = prefs.getInt(_streakKey) ?? 0;
     _handStreak = prefs.getInt(_handsKey) ?? 0;
     _mistakeReviewStreak = prefs.getInt(_mistakeStreakKey) ?? 0;
@@ -622,5 +630,14 @@ class GoalsService extends ChangeNotifier {
     if (candidates.isEmpty) return null;
     final rnd = Random().nextInt(candidates.length);
     return candidates[rnd];
+  }
+
+  Future<List<DateTime>> getDailySpotHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_dailySpotHistoryKey) ?? [];
+    return [
+      for (final s in raw)
+        if (DateTime.tryParse(s) != null) DateTime.parse(s)
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- track daily spot history in GoalsService
- record daily spot dates
- show daily spot stats on ProgressScreen

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3115db20832ab9ac6f7ab1f45335