### PR TITLE
Add daily spot history calendar

### DIFF
--- a/lib/screens/daily_spot_history_screen.dart
+++ b/lib/screens/daily_spot_history_screen.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+import '../services/goals_service.dart';
+
+class DailySpotHistoryScreen extends StatefulWidget {
+  const DailySpotHistoryScreen({super.key});
+
+  @override
+  State<DailySpotHistoryScreen> createState() => _DailySpotHistoryScreenState();
+}
+
+class _DailySpotHistoryScreenState extends State<DailySpotHistoryScreen> {
+  DateTime _focusedDay = DateTime.now();
+  DateTime? _selectedDay;
+  Set<DateTime> _history = {};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final list = await context.read<GoalsService>().getDailySpotHistory();
+      setState(() {
+        _history = {
+          for (final d in list) DateTime(d.year, d.month, d.day)
+        };
+      });
+    });
+  }
+
+  List<dynamic> _eventsForDay(DateTime day) {
+    final d = DateTime(day.year, day.month, day.day);
+    return _history.contains(d) ? [d] : [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История спотов дня'),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          TableCalendar(
+            locale: 'ru_RU',
+            firstDay: DateTime.utc(2020, 1, 1),
+            lastDay: DateTime.utc(2100, 12, 31),
+            focusedDay: _focusedDay,
+            selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+            eventLoader: _eventsForDay,
+            calendarFormat: CalendarFormat.month,
+            onDaySelected: (sel, foc) {
+              setState(() {
+                _selectedDay = sel;
+                _focusedDay = foc;
+              });
+            },
+            headerStyle: const HeaderStyle(
+              formatButtonVisible: false,
+              titleCentered: true,
+              titleTextStyle: TextStyle(color: Colors.white),
+            ),
+            calendarStyle: CalendarStyle(
+              defaultTextStyle: const TextStyle(color: Colors.white),
+              weekendTextStyle: const TextStyle(color: Colors.white70),
+              outsideTextStyle: const TextStyle(color: Colors.white38),
+              todayDecoration: BoxDecoration(
+                color: accent,
+                shape: BoxShape.circle,
+              ),
+              selectedDecoration: const BoxDecoration(
+                color: Colors.blueGrey,
+                shape: BoxShape.circle,
+              ),
+              markerDecoration: const BoxDecoration(
+                color: Colors.green,
+                shape: BoxShape.circle,
+              ),
+              markersAlignment: Alignment.bottomCenter,
+              markersMaxCount: 1,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            _selectedDay == null
+                ? '—'
+                : _history.contains(
+                        DateTime(_selectedDay!.year, _selectedDay!.month, _selectedDay!.day))
+                    ? '✅ Выполнено'
+                    : '—',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -20,6 +20,7 @@ import '../helpers/poker_street_helper.dart';
 import '../widgets/mistake_heatmap.dart';
 import 'goals_history_screen.dart';
 import 'daily_spot_screen.dart';
+import 'daily_spot_history_screen.dart';
 import 'achievements_screen.dart';
 import 'drill_history_screen.dart';
 import 'goal_drill_screen.dart';
@@ -945,6 +946,17 @@ class _ProgressScreenState extends State<ProgressScreen> {
             style: TextStyle(
               color: _dailyMonthCount > 0 ? Colors.white : Colors.white70,
             ),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const DailySpotHistoryScreen(),
+                ),
+              );
+            },
+            child: const Text('История'),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   poker_solver: ^1.0.0
   webview_flutter: ^4.2.2
   markdown: ^7.1.1
+  table_calendar: ^3.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add dependency for `table_calendar`
- implement `DailySpotHistoryScreen` with calendar UI
- link history screen from `ProgressScreen`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3425c488832aa5a89bda1dfdbc3b