### PR TITLE
Add 7-day daily spot achievement

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -47,64 +47,110 @@ class AchievementsScreen extends StatelessWidget {
           );
 
           final data = goals.achievements;
-
-          return ListView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: data.length,
-            itemBuilder: (context, index) {
-              final item = data[index];
-              final completed = item.completed;
-              final color = completed ? Colors.white : Colors.white54;
-              return Container(
-                margin: const EdgeInsets.only(bottom: 12),
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Colors.grey[850],
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Icon(item.icon, size: 32, color: accent),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            item.title,
-                            style: TextStyle(
-                              color: color,
-                              fontWeight: FontWeight.bold,
+          final list = <Widget>[];
+          for (final item in data) {
+            final completed = item.completed;
+            final color = completed ? Colors.white : Colors.white54;
+            list.add(Container(
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(item.icon, size: 32, color: accent),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.title,
+                          style: TextStyle(
+                            color: color,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: (item.progress / item.target).clamp(0.0, 1.0),
+                            backgroundColor: Colors.white24,
+                            valueColor: AlwaysStoppedAnimation<Color>(accent),
+                            minHeight: 6,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${item.progress}/${item.target}',
+                          style: TextStyle(color: color),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Icon(
+                    Icons.check_circle,
+                    color: completed ? Colors.green : Colors.grey,
+                  ),
+                ],
+              ),
+            ));
+            if (item.title == '7 дней подряд') {
+              final unlocked = goals.hasSevenDayGoalUnlocked;
+              list.add(AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                child: Container(
+                  key: ValueKey(unlocked),
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[850],
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(Icons.local_fire_department, size: 32, color: accent),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: const [
+                            Text(
+                              '🔥 Серия 7 дней',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
-                          ),
-                          const SizedBox(height: 8),
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
-                              value: (item.progress / item.target).clamp(0.0, 1.0),
-                              backgroundColor: Colors.white24,
-                              valueColor: AlwaysStoppedAnimation<Color>(accent),
-                              minHeight: 6,
+                            SizedBox(height: 4),
+                            Text(
+                              'Выполняйте Спот дня семь дней подряд',
+                              style: TextStyle(color: Colors.white70, fontSize: 12),
                             ),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            '${item.progress}/${item.target}',
-                            style: TextStyle(color: color),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    Icon(
-                      Icons.check_circle,
-                      color: completed ? Colors.green : Colors.grey,
-                    ),
-                  ],
+                      const SizedBox(width: 12),
+                      Icon(
+                        Icons.check_circle,
+                        color: unlocked ? Colors.green : Colors.grey,
+                      ),
+                    ],
+                  ),
                 ),
-              );
-            },
+              ));
+            }
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: list,
           );
         },
       ),

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -200,6 +200,9 @@ class _ProgressScreenState extends State<ProgressScreen>
       _dailyMonthCount = month;
     });
     final streak = await service.hasWeeklyStreak();
+    if (streak && !service.hasSevenDayGoalUnlocked) {
+      await service.setSevenDayGoalUnlocked(true);
+    }
     if (streak && !_weeklyConfettiPlayed) {
       _weeklyConfetti.play();
       _weeklyConfettiPlayed = true;

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -86,6 +86,7 @@ class GoalsService extends ChangeNotifier {
   static const _historyPrefix = 'goal_history_';
   static const _drillResultsKey = 'drill_results';
   static const _dailySpotHistoryKey = 'daily_spot_history';
+  static const _sevenDayGoalKey = 'seven_day_goal_unlocked';
 
   int _errorFreeStreak = 0;
   int _handStreak = 0;
@@ -102,6 +103,7 @@ class GoalsService extends ChangeNotifier {
   late List<List<GoalProgressEntry>> _history;
   List<DrillSessionResult> _drillResults = [];
   List<DateTime> _dailySpotHistory = [];
+  bool _hasSevenDayGoalUnlocked = false;
 
   static GoalsService? _instance;
   static GoalsService? get instance => _instance;
@@ -142,6 +144,7 @@ class GoalsService extends ChangeNotifier {
 
   List<DrillSessionResult> get drillResults => List.unmodifiable(_drillResults);
   List<DateTime> get dailySpotHistory => List.unmodifiable(_dailySpotHistory);
+  bool get hasSevenDayGoalUnlocked => _hasSevenDayGoalUnlocked;
 
   List<GoalProgressEntry> historyFor(int index) =>
       index >= 0 && index < _history.length
@@ -228,6 +231,7 @@ class GoalsService extends ChangeNotifier {
     _handStreak = prefs.getInt(_handsKey) ?? 0;
     _mistakeReviewStreak = prefs.getInt(_mistakeStreakKey) ?? 0;
     _hintShown = prefs.getBool(_hintShownKey) ?? false;
+    _hasSevenDayGoalUnlocked = prefs.getBool(_sevenDayGoalKey) ?? false;
     _dailyGoalIndex = prefs.getInt(_dailyIndexKey);
     final dateStr = prefs.getString(_dailyDateKey);
     _dailyGoalDate = dateStr != null ? DateTime.tryParse(dateStr) : null;
@@ -361,6 +365,18 @@ class GoalsService extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     final list = [for (final r in _drillResults) jsonEncode(r.toJson())];
     await prefs.setStringList(_drillResultsKey, list);
+  }
+
+  Future<void> _saveSevenDayGoalUnlocked() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_sevenDayGoalKey, _hasSevenDayGoalUnlocked);
+  }
+
+  Future<void> setSevenDayGoalUnlocked(bool value) async {
+    if (_hasSevenDayGoalUnlocked == value) return;
+    _hasSevenDayGoalUnlocked = value;
+    await _saveSevenDayGoalUnlocked();
+    notifyListeners();
   }
 
   void _checkAchievements(BuildContext context) {


### PR DESCRIPTION
## Summary
- persist seven-day streak status in `GoalsService`
- unlock streak goal in progress screen
- show new card on Achievements screen

## Testing
- `flutter analyze` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c373cb308832a9d359b10de616b8d