### PR TITLE
Fix table_calendar compat

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   poker_solver: ^1.0.0
   webview_flutter: ^4.2.2
   markdown: ^7.1.1
-  table_calendar: ^3.2.0
+  table_calendar: ^3.0.9
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- pin `table_calendar` to 3.0.9 for intl 0.18 compatibility

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3dacb08c832a924c28e7ae32116e