### PR TITLE
Add DailySpot history calendar

### DIFF
--- a/lib/screens/daily_spot_history_calendar_screen.dart
+++ b/lib/screens/daily_spot_history_calendar_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+import '../services/goals_service.dart';
+
+class DailySpotHistoryCalendarScreen extends StatefulWidget {
+  const DailySpotHistoryCalendarScreen({super.key});
+
+  @override
+  State<DailySpotHistoryCalendarScreen> createState() => _DailySpotHistoryCalendarScreenState();
+}
+
+class _DailySpotHistoryCalendarScreenState extends State<DailySpotHistoryCalendarScreen> {
+  late final DateTime _firstDay;
+  late final DateTime _lastDay;
+  DateTime _focusedDay = DateTime.now();
+  Set<DateTime> _history = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _firstDay = DateTime(now.year, now.month, 1);
+    _lastDay = DateTime(now.year, now.month + 1, 0);
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final list = await context.read<GoalsService>().getDailySpotHistory();
+      setState(() {
+        _history = {for (final d in list) DateTime(d.year, d.month, d.day)};
+      });
+    });
+  }
+
+  List _eventsForDay(DateTime day) {
+    final d = DateTime(day.year, day.month, day.day);
+    return _history.contains(d) ? [d] : [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История спотов дня'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ],
+      ),
+      body: TableCalendar(
+        locale: 'ru_RU',
+        firstDay: _firstDay,
+        lastDay: _lastDay,
+        focusedDay: _focusedDay,
+        eventLoader: _eventsForDay,
+        headerStyle: const HeaderStyle(
+          formatButtonVisible: false,
+          titleCentered: true,
+          titleTextStyle: TextStyle(color: Colors.white),
+        ),
+        calendarStyle: CalendarStyle(
+          defaultTextStyle: const TextStyle(color: Colors.white),
+          weekendTextStyle: const TextStyle(color: Colors.white70),
+          outsideTextStyle: const TextStyle(color: Colors.white38),
+          todayDecoration: BoxDecoration(color: accent, shape: BoxShape.circle),
+          markerDecoration: const BoxDecoration(
+            color: Colors.green,
+            shape: BoxShape.circle,
+          ),
+          markersAlignment: Alignment.bottomCenter,
+          markersMaxCount: 1,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/mistake_heatmap.dart';
 import 'goals_history_screen.dart';
 import 'daily_spot_screen.dart';
 import 'daily_spot_history_screen.dart';
+import 'daily_spot_history_calendar_screen.dart';
 import 'achievements_screen.dart';
 import 'drill_history_screen.dart';
 import 'goal_drill_screen.dart';
@@ -975,6 +976,17 @@ class _ProgressScreenState extends State<ProgressScreen>
               );
             },
             child: const Text('История'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const DailySpotHistoryCalendarScreen(),
+                ),
+              );
+            },
+            child: const Text('Календарь'),
           ),
           const SizedBox(height: 8),
           AnimatedSwitcher(


### PR DESCRIPTION
## Summary
- add a calendar view for Daily Spot history
- link calendar screen from Progress stats

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c40551c2c832a88e1bedcf8f02a9a