### PR TITLE
Add session-wide weekly streak confetti

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -47,7 +47,6 @@ class _ProgressScreenState extends State<ProgressScreen>
   int _dailyWeekCount = 0;
   int _dailyMonthCount = 0;
   bool _weeklyStreak = false;
-  bool _weeklyConfettiPlayed = false;
   late final ConfettiController _weeklyConfetti;
 
   @override
@@ -203,9 +202,9 @@ class _ProgressScreenState extends State<ProgressScreen>
     if (streak && !service.hasSevenDayGoalUnlocked) {
       await service.setSevenDayGoalUnlocked(true);
     }
-    if (streak && !_weeklyConfettiPlayed) {
+    if (streak && !service.weeklyStreakCelebrated) {
       _weeklyConfetti.play();
-      _weeklyConfettiPlayed = true;
+      service.markWeeklyStreakCelebrated();
     }
     if (mounted) {
       setState(() => _weeklyStreak = streak);

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -104,6 +104,7 @@ class GoalsService extends ChangeNotifier {
   List<DrillSessionResult> _drillResults = [];
   List<DateTime> _dailySpotHistory = [];
   bool _hasSevenDayGoalUnlocked = false;
+  bool _weeklyStreakCelebrated = false;
 
   static GoalsService? _instance;
   static GoalsService? get instance => _instance;
@@ -145,6 +146,7 @@ class GoalsService extends ChangeNotifier {
   List<DrillSessionResult> get drillResults => List.unmodifiable(_drillResults);
   List<DateTime> get dailySpotHistory => List.unmodifiable(_dailySpotHistory);
   bool get hasSevenDayGoalUnlocked => _hasSevenDayGoalUnlocked;
+  bool get weeklyStreakCelebrated => _weeklyStreakCelebrated;
 
   List<GoalProgressEntry> historyFor(int index) =>
       index >= 0 && index < _history.length
@@ -377,6 +379,10 @@ class GoalsService extends ChangeNotifier {
     _hasSevenDayGoalUnlocked = value;
     await _saveSevenDayGoalUnlocked();
     notifyListeners();
+  }
+
+  void markWeeklyStreakCelebrated() {
+    _weeklyStreakCelebrated = true;
   }
 
   void _checkAchievements(BuildContext context) {


### PR DESCRIPTION
## Summary
- track weekly streak celebration in `GoalsService`
- trigger confetti only once per app session

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c405a97c8832ab8f6a97e0850ef30