### PR TITLE
Add custom goal engine

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'services/training_spot_storage_service.dart';
 import 'services/evaluation_executor_service.dart';
 import "services/training_stats_service.dart";
 import "services/achievement_engine.dart";
+import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
 import 'user_preferences.dart';
 
@@ -77,6 +78,9 @@ void main() {
         ChangeNotifierProvider(
           create: (context) =>
               AchievementEngine(stats: context.read<TrainingStatsService>()),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => GoalEngine(stats: context.read<TrainingStatsService>()),
         ),
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),

--- a/lib/models/user_goal.dart
+++ b/lib/models/user_goal.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+class UserGoal {
+  final String id;
+  final String title;
+  final String type;
+  final int target;
+  final int base;
+  final DateTime createdAt;
+  final DateTime? completedAt;
+
+  const UserGoal({
+    required this.id,
+    required this.title,
+    required this.type,
+    required this.target,
+    required this.base,
+    required this.createdAt,
+    this.completedAt,
+  });
+
+  bool get completed => completedAt != null;
+
+  UserGoal copyWith({DateTime? completedAt}) => UserGoal(
+        id: id,
+        title: title,
+        type: type,
+        target: target,
+        base: base,
+        createdAt: createdAt,
+        completedAt: completedAt,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'type': type,
+        'target': target,
+        'base': base,
+        'createdAt': createdAt.toIso8601String(),
+        'completedAt': completedAt?.toIso8601String(),
+      };
+
+  factory UserGoal.fromJson(Map<String, dynamic> json) => UserGoal(
+        id: json['id'] as String,
+        title: json['title'] as String,
+        type: json['type'] as String,
+        target: json['target'] as int,
+        base: json['base'] as int,
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        completedAt: json['completedAt'] != null
+            ? DateTime.parse(json['completedAt'] as String)
+            : null,
+      );
+
+  static String encode(List<UserGoal> list) =>
+      jsonEncode([for (final g in list) g.toJson()]);
+
+  static List<UserGoal> decode(String raw) {
+    final data = jsonDecode(raw) as List;
+    return [for (final e in data) UserGoal.fromJson(Map<String, dynamic>.from(e as Map))];
+  }
+}

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -2,26 +2,70 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/achievement_engine.dart';
+import '../services/goal_engine.dart';
 import '../theme/app_colors.dart';
+import 'goal_editor_screen.dart';
 
 class AchievementsScreen extends StatelessWidget {
   const AchievementsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final data = context.watch<AchievementEngine>().achievements;
+    final ach = context.watch<AchievementEngine>().achievements;
+    final goalsEngine = context.watch<GoalEngine>();
+    final goals = goalsEngine.goals;
     final accent = Theme.of(context).colorScheme.secondary;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Достижения'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const GoalEditorScreen()),
+              );
+            },
+          )
+        ],
       ),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),
-        itemCount: data.length,
+        itemCount: ach.length + goals.length,
         itemBuilder: (context, index) {
-          final item = data[index];
-          final unlocked = item.completed;
+          if (index < ach.length) {
+            final item = ach[index];
+            final unlocked = item.completed;
+            final color = unlocked ? Colors.white : Colors.white54;
+            return Container(
+              margin: const EdgeInsets.only(bottom: 12),
+              decoration: BoxDecoration(
+                color: AppColors.cardBackground,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: ListTile(
+                leading: Icon(item.icon, color: accent),
+                title: Text(
+                  item.title,
+                  style: TextStyle(color: color, fontWeight: FontWeight.bold),
+                ),
+                trailing: Icon(
+                  unlocked ? Icons.check_circle : Icons.lock,
+                  color: unlocked ? Colors.green : Colors.grey,
+                ),
+                subtitle: LinearProgressIndicator(
+                  value: (item.progress / item.target).clamp(0.0, 1.0),
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation<Color>(accent),
+                ),
+              ),
+            );
+          }
+          final g = goals[index - ach.length];
+          final prog = goalsEngine.progress(g);
+          final unlocked = prog >= g.target;
           final color = unlocked ? Colors.white : Colors.white54;
           return Container(
             margin: const EdgeInsets.only(bottom: 12),
@@ -30,17 +74,17 @@ class AchievementsScreen extends StatelessWidget {
               borderRadius: BorderRadius.circular(8),
             ),
             child: ListTile(
-              leading: Icon(item.icon, color: accent),
+              leading: Icon(Icons.flag, color: accent),
               title: Text(
-                item.title,
+                g.title,
                 style: TextStyle(color: color, fontWeight: FontWeight.bold),
               ),
               trailing: Icon(
-                unlocked ? Icons.check_circle : Icons.lock,
+                unlocked ? Icons.check_circle : Icons.flag,
                 color: unlocked ? Colors.green : Colors.grey,
               ),
               subtitle: LinearProgressIndicator(
-                value: (item.progress / item.target).clamp(0.0, 1.0),
+                value: (prog / g.target).clamp(0.0, 1.0),
                 backgroundColor: Colors.white24,
                 valueColor: AlwaysStoppedAnimation<Color>(accent),
               ),

--- a/lib/screens/goal_editor_screen.dart
+++ b/lib/screens/goal_editor_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/goal_engine.dart';
+import '../models/user_goal.dart';
+
+class GoalEditorScreen extends StatefulWidget {
+  const GoalEditorScreen({super.key});
+
+  @override
+  State<GoalEditorScreen> createState() => _GoalEditorScreenState();
+}
+
+class _GoalEditorScreenState extends State<GoalEditorScreen> {
+  final _title = TextEditingController();
+  final _target = TextEditingController(text: '1');
+  String _type = 'mistakes';
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _target.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final title = _title.text.trim();
+    final target = int.tryParse(_target.text) ?? 1;
+    if (title.isEmpty) return;
+    final stats = context.read<GoalEngine>().stats;
+    final base = {
+      'sessions': stats.sessionsCompleted,
+      'hands': stats.handsReviewed,
+      'mistakes': stats.mistakesFixed,
+    }[_type]!;
+    final goal = UserGoal(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      type: _type,
+      target: target,
+      base: base,
+      createdAt: DateTime.now(),
+    );
+    await context.read<GoalEngine>().addGoal(goal);
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Новая цель'),
+        actions: [
+          IconButton(onPressed: _save, icon: const Icon(Icons.check))
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _title,
+              decoration: const InputDecoration(labelText: 'Название'),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    value: _type,
+                    items: const [
+                      DropdownMenuItem(value: 'mistakes', child: Text('Ошибки')),
+                      DropdownMenuItem(value: 'hands', child: Text('Раздачи')),
+                      DropdownMenuItem(value: 'sessions', child: Text('Сессии')),
+                    ],
+                    onChanged: (v) => setState(() => _type = v ?? _type),
+                    decoration: const InputDecoration(labelText: 'Тип'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                SizedBox(
+                  width: 80,
+                  child: TextField(
+                    controller: _target,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: 'Цель'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/goal_engine.dart
+++ b/lib/services/goal_engine.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/user_goal.dart';
+import '../widgets/confetti_overlay.dart';
+import '../main.dart';
+import 'training_stats_service.dart';
+
+class GoalEngine extends ChangeNotifier {
+  static const _prefsKey = 'user_goals';
+  final TrainingStatsService stats;
+  GoalEngine({required this.stats}) {
+    _init();
+  }
+
+  final List<UserGoal> _goals = [];
+
+  List<UserGoal> get goals => List.unmodifiable(_goals);
+
+  Future<void> _init() async {
+    await _load();
+    _update();
+    stats.sessionsStream.listen((_) => _update());
+    stats.handsStream.listen((_) => _update());
+    stats.mistakesStream.listen((_) => _update());
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      _goals
+        ..clear()
+        ..addAll(UserGoal.decode(raw));
+    }
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, UserGoal.encode(_goals));
+  }
+
+  int _statValue(String type) {
+    switch (type) {
+      case 'sessions':
+        return stats.sessionsCompleted;
+      case 'hands':
+        return stats.handsReviewed;
+      default:
+        return stats.mistakesFixed;
+    }
+  }
+
+  int progress(UserGoal g) => _statValue(g.type) - g.base;
+
+  void _update() {
+    for (var i = 0; i < _goals.length; i++) {
+      final g = _goals[i];
+      if (!g.completed && progress(g) >= g.target) {
+        _goals[i] = g.copyWith(completedAt: DateTime.now());
+        _save();
+        final ctx = navigatorKey.currentContext;
+        if (ctx != null) {
+          showConfettiOverlay(ctx);
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            SnackBar(content: Text('Goal completed: ${g.title}')),
+          );
+        }
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<void> addGoal(UserGoal g) async {
+    _goals.add(g);
+    await _save();
+    notifyListeners();
+  }
+
+  Future<void> removeGoal(String id) async {
+    _goals.removeWhere((g) => g.id == id);
+    await _save();
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GoalEngine` to store user-defined goals in `shared_preferences`
- add `GoalEditorScreen` for creating new goals
- display custom goals in `AchievementsScreen` with progress bars
- navigate to goal editor via plus button
- wire `GoalEngine` in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c45cdf900832a9ae7b7129129064b