### PR TITLE
Add goal editing and deletion

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -74,6 +74,54 @@ class AchievementsScreen extends StatelessWidget {
               borderRadius: BorderRadius.circular(8),
             ),
             child: ListTile(
+              onLongPress: () async {
+                final action = await showDialog<String>(
+                  context: context,
+                  builder: (ctx) => SimpleDialog(
+                    title: Text(g.title),
+                    children: [
+                      SimpleDialogOption(
+                        onPressed: () => Navigator.pop(ctx, 'edit'),
+                        child: const Text('Edit'),
+                      ),
+                      SimpleDialogOption(
+                        onPressed: () => Navigator.pop(ctx, 'delete'),
+                        child: const Text('Delete'),
+                      ),
+                    ],
+                  ),
+                );
+                if (action == 'edit') {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => GoalEditorScreen(goal: g),
+                    ),
+                  );
+                } else if (action == 'delete') {
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('Удалить цель?'),
+                      content: const Text(
+                          'Вы уверены, что хотите удалить эту цель?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          child: const Text('Отмена'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          child: const Text('Удалить'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirm == true) {
+                    await goalsEngine.removeGoal(g.id);
+                  }
+                }
+              },
               leading: Icon(Icons.flag, color: accent),
               title: Text(
                 g.title,

--- a/lib/services/goal_engine.dart
+++ b/lib/services/goal_engine.dart
@@ -81,4 +81,12 @@ class GoalEngine extends ChangeNotifier {
     await _save();
     notifyListeners();
   }
+
+  Future<void> updateGoal(UserGoal goal) async {
+    final index = _goals.indexWhere((g) => g.id == goal.id);
+    if (index == -1) return;
+    _goals[index] = goal;
+    await _save();
+    _update();
+  }
 }


### PR DESCRIPTION
## Summary
- add updateGoal in GoalEngine
- enable editing existing goals
- long press on goal to edit or delete

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c47257a88832ab4e7e5a76b71bea6