### PR TITLE
Add MotivationCard on home tab

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -5,6 +5,7 @@ import 'spot_of_the_day_screen.dart';
 import 'spot_of_the_day_history_screen.dart';
 import 'settings_placeholder_screen.dart';
 import '../widgets/streak_banner.dart';
+import '../widgets/motivation_card.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -16,12 +17,14 @@ class MainNavigationScreen extends StatefulWidget {
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
   int _currentIndex = 0;
 
-  final List<Widget> _pages = const [
-    AnalyzerTab(),
-    SpotOfTheDayScreen(),
-    SpotOfTheDayHistoryScreen(),
-    SettingsPlaceholderScreen(),
-  ];
+  Widget _home() {
+    return const Column(
+      children: [
+        MotivationCard(),
+        Expanded(child: AnalyzerTab()),
+      ],
+    );
+  }
 
   void _onTap(int index) {
     setState(() {
@@ -31,8 +34,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final pages = [
+      _home(),
+      const SpotOfTheDayScreen(),
+      const SpotOfTheDayHistoryScreen(),
+      const SettingsPlaceholderScreen(),
+    ];
     return Scaffold(
-      body: IndexedStack(index: _currentIndex, children: _pages),
+      body: IndexedStack(index: _currentIndex, children: pages),
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/widgets/motivation_card.dart
+++ b/lib/widgets/motivation_card.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/goal_engine.dart';
+import '../services/achievement_engine.dart';
+import '../screens/achievements_screen.dart';
+import '../models/user_goal.dart';
+import '../models/achievement.dart';
+
+class MotivationCard extends StatelessWidget {
+  const MotivationCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final goals = context.watch<GoalEngine>().goals;
+    final engine = context.watch<GoalEngine>();
+    UserGoal? bestGoal;
+    int goalRemain = 1 << 30;
+    for (final g in goals) {
+      final remain = g.target - engine.progress(g);
+      if (remain > 0 && remain < goalRemain) {
+        bestGoal = g;
+        goalRemain = remain;
+      }
+    }
+
+    final achievements = context.watch<AchievementEngine>().achievements;
+    Achievement? bestAch;
+    int achRemain = 1 << 30;
+    for (final a in achievements) {
+      final remain = a.target - a.progress;
+      if (remain > 0 && remain < achRemain) {
+        bestAch = a;
+        achRemain = remain;
+      }
+    }
+
+    if (bestGoal == null && bestAch == null) {
+      return const SizedBox.shrink();
+    }
+
+    final showGoal = bestGoal != null && (bestAch == null || goalRemain <= achRemain);
+    final title = showGoal ? bestGoal!.title : bestAch!.title;
+    final icon = showGoal ? Icons.flag : bestAch!.icon;
+    final progress = showGoal ? engine.progress(bestGoal!) : bestAch!.progress;
+    final target = showGoal ? bestGoal!.target : bestAch!.target;
+    final accent = Theme.of(context).colorScheme.secondary;
+
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AchievementsScreen()),
+        );
+      },
+      child: Container(
+        margin: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: accent),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: (progress / target).clamp(0.0, 1.0),
+                      backgroundColor: Colors.white24,
+                      valueColor: AlwaysStoppedAnimation<Color>(accent),
+                      minHeight: 6,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            Text('$progress/$target'),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add MotivationCard widget for nearest goal/achievement
- show MotivationCard on home tab of MainNavigationScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c47edb6d4832aaddd2f5267a637a0