### PR TITLE
Add local reminder notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import "services/training_stats_service.dart";
 import "services/achievement_engine.dart";
 import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
+import 'services/reminder_service.dart';
 import 'user_preferences.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -81,6 +82,13 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (context) => GoalEngine(stats: context.read<TrainingStatsService>()),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => ReminderService(
+            spotService: context.read<SpotOfTheDayService>(),
+            goalEngine: context.read<GoalEngine>(),
+            streakService: context.read<StreakService>(),
+          )..load(),
         ),
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),

--- a/lib/services/reminder_service.dart
+++ b/lib/services/reminder_service.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import '../models/user_goal.dart';
+import 'goal_engine.dart';
+import 'spot_of_the_day_service.dart';
+import 'streak_service.dart';
+
+class ReminderService extends ChangeNotifier {
+  static const _enabledKey = 'reminders_enabled';
+  static const _dismissKey = 'reminder_last_dismiss';
+  static const _channelId = 'reminders';
+
+  final SpotOfTheDayService spotService;
+  final GoalEngine goalEngine;
+  final StreakService streakService;
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _enabled = true;
+  DateTime? _dismissed;
+
+  bool get enabled => _enabled;
+
+  ReminderService({
+    required this.spotService,
+    required this.goalEngine,
+    required this.streakService,
+  });
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_enabledKey) ?? true;
+    final str = prefs.getString(_dismissKey);
+    _dismissed = str != null ? DateTime.tryParse(str) : null;
+    await _initPlugin();
+    spotService.addListener(_schedule);
+    goalEngine.addListener(_schedule);
+    streakService.addListener(_schedule);
+    _schedule();
+  }
+
+  Future<void> _initPlugin() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(
+      const InitializationSettings(android: android, iOS: ios),
+      onDidReceiveNotificationResponse: (r) {
+        if (r.notificationResponseType ==
+            NotificationResponseType.dismissed) {
+          _onDismiss();
+        }
+      },
+    );
+    tz.initializeTimeZones();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    if (_enabled == value) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+    _enabled = value;
+    if (!value) {
+      await _plugin.cancelAll();
+    } else {
+      _schedule();
+    }
+    notifyListeners();
+  }
+
+  Future<void> _onDismiss() async {
+    final prefs = await SharedPreferences.getInstance();
+    _dismissed = DateTime.now();
+    await prefs.setString(_dismissKey, _dismissed!.toIso8601String());
+  }
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<void> _schedule() async {
+    await _plugin.cancelAll();
+    if (!_enabled) return;
+    final now = DateTime.now();
+    if (_dismissed != null && _sameDay(_dismissed!, now)) return;
+    final needSpot = spotService.result == null;
+    UserGoal? activeGoal;
+    for (final g in goalEngine.goals) {
+      if (!g.completed) {
+        activeGoal = g;
+        break;
+      }
+    }
+    if (!needSpot && activeGoal == null) return;
+    final streak = streakService.count;
+    var body = '';
+    if (streak > 1) {
+      body = 'Maintain your ${streak}-day streak!';
+    }
+    if (activeGoal != null) {
+      if (body.isNotEmpty) body += '\n';
+      body += "Don't forget your goal: ${activeGoal.title}";
+    } else if (needSpot) {
+      if (body.isNotEmpty) body += '\n';
+      body += "Complete today's Spot of the Day!";
+    }
+    var when = tz.TZDateTime.local(now.year, now.month, now.day, 10);
+    if (when.isBefore(tz.TZDateTime.now(tz.local))) {
+      when = when.add(const Duration(days: 1));
+    }
+    await _plugin.zonedSchedule(
+      1,
+      'Poker Analyzer',
+      body,
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          _channelId,
+          'Reminders',
+          importance: Importance.defaultImportance,
+        ),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   webview_flutter: ^4.2.2
   markdown: ^7.1.1
   table_calendar: ^3.0.9
+  flutter_local_notifications: ^17.0.0
+  timezone: ^0.9.2
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- schedule daily reminders about active goals, streaks and Spot of the Day
- wire up ReminderService in the provider tree
- include flutter_local_notifications and timezone dependencies

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_685c48ec8c7c832a8593aacbfe198421