### PR TITLE
Add reminder controls

### DIFF
--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -1,17 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/date_utils.dart';
+import '../services/reminder_service.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      backgroundColor: Color(0xFF121212),
-      body: Center(
-        child: Text(
-          'Настройки будут доступны позже',
-          style: TextStyle(color: Colors.white70),
-        ),
+    final reminder = context.watch<ReminderService>();
+    final dismissed = reminder.lastDismissed;
+    final status = reminder.enabled ? 'Включены' : 'Выключены';
+    final info = dismissed != null
+        ? '$status, последний отказ: ${formatDateTime(dismissed)}'
+        : status;
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Ещё'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text(
+              'Notifications',
+              style: TextStyle(color: Colors.white70, fontSize: 18),
+            ),
+          ),
+          SwitchListTile(
+            value: reminder.enabled,
+            onChanged: (v) => reminder.setEnabled(v),
+            title: const Text('Напоминания'),
+            activeColor: Colors.orange,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              info,
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ),
+          const SizedBox(height: 32),
+          const Center(
+            child: Text(
+              'Настройки будут доступны позже',
+              style: TextStyle(color: Colors.white70),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/reminder_service.dart
+++ b/lib/services/reminder_service.dart
@@ -25,6 +25,7 @@ class ReminderService extends ChangeNotifier {
   DateTime? _dismissed;
 
   bool get enabled => _enabled;
+  DateTime? get lastDismissed => _dismissed;
 
   ReminderService({
     required this.spotService,
@@ -76,6 +77,7 @@ class ReminderService extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     _dismissed = DateTime.now();
     await prefs.setString(_dismissKey, _dismissed!.toIso8601String());
+    notifyListeners();
   }
 
   bool _sameDay(DateTime a, DateTime b) =>


### PR DESCRIPTION
## Summary
- expose reminder dismissal time
- show notification section in settings placeholder with switch and status

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c4b1db630832a950c6059dc02d8e3