### PR TITLE
Add Insights screen with charts

### DIFF
--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../services/training_stats_service.dart';
+import '../services/goal_engine.dart';
+import '../services/streak_service.dart';
+import '../theme/app_colors.dart';
+
+enum _Mode { daily, weekly }
+
+class InsightsScreen extends StatefulWidget {
+  const InsightsScreen({super.key});
+
+  @override
+  State<InsightsScreen> createState() => _InsightsScreenState();
+}
+
+class _InsightsScreenState extends State<InsightsScreen> {
+  _Mode _mode = _Mode.daily;
+
+  List<MapEntry<DateTime, int>> _hands(TrainingStatsService s) =>
+      _mode == _Mode.daily ? s.handsDaily(7) : s.handsWeekly(6);
+  List<MapEntry<DateTime, int>> _sessions(TrainingStatsService s) =>
+      _mode == _Mode.daily ? s.sessionsDaily(7) : s.sessionsWeekly(6);
+  List<MapEntry<DateTime, int>> _mistakes(TrainingStatsService s) =>
+      _mode == _Mode.daily ? s.mistakesDaily(7) : s.mistakesWeekly(6);
+
+  Widget _chart(List<MapEntry<DateTime, int>> data) {
+    if (data.length < 2) return const SizedBox(height: 200);
+    final spots = <FlSpot>[];
+    for (var i = 0; i < data.length; i++) {
+      spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
+    }
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: 0,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 1,
+            getDrawingHorizontalLine: (value) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: data.map((e) => e.value).reduce((a, b) => a > b ? a : b) / 4,
+                reservedSize: 30,
+                getTitlesWidget: (v, meta) => Text(v.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10)),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[i].key;
+                  final label = _mode == _Mode.weekly
+                      ? '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}'
+                      : '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                  return Text(label,
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 10));
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: false,
+              color: Colors.orangeAccent,
+              barWidth: 2,
+              dotData: FlDotData(show: false),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _streakChart(StreakService s) {
+    final data = s.history;
+    if (data.length < 2) return const SizedBox(height: 200);
+    final spots = <FlSpot>[];
+    for (var i = 0; i < data.length; i++) {
+      spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
+    }
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: 0,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 1,
+            getDrawingHorizontalLine: (value) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: data.map((e) => e.value).reduce((a, b) => a > b ? a : b) / 4,
+                reservedSize: 30,
+                getTitlesWidget: (v, meta) => Text(v.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10)),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[i].key;
+                  final label = '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}';
+                  return Text(label,
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 10));
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              color: Colors.greenAccent,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _pie(GoalEngine g) {
+    final goals = g.goals;
+    if (goals.isEmpty) return const SizedBox(height: 200);
+    final completed = goals.where((gg) => gg.completed).length;
+    final sections = [
+      PieChartSectionData(
+        value: completed.toDouble(),
+        color: Colors.green,
+        radius: 80,
+        title: goals.isNotEmpty
+            ? '${(completed * 100 / goals.length).round()}%'
+            : '0%',
+        titleStyle:
+            const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+      ),
+      PieChartSectionData(
+        value: (goals.length - completed).toDouble(),
+        color: Colors.red,
+        radius: 80,
+        title: goals.isNotEmpty
+            ? '${((goals.length - completed) * 100 / goals.length).round()}%'
+            : '0%',
+        titleStyle:
+            const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+      ),
+    ];
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 0,
+          centerSpaceRadius: 0,
+          sections: sections,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>();
+    final goals = context.watch<GoalEngine>();
+    final streak = context.watch<StreakService>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Insights'),
+        actions: [
+          ToggleButtons(
+            isSelected: [_mode == _Mode.daily, _mode == _Mode.weekly],
+            onPressed: (i) => setState(() => _mode = _Mode.values[i]),
+            children: const [Text('День'), Text('Неделя')],
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _chart(_hands(stats)),
+          const SizedBox(height: 12),
+          _chart(_mistakes(stats)),
+          const SizedBox(height: 12),
+          _chart(_sessions(stats)),
+          const SizedBox(height: 12),
+          _streakChart(streak),
+          const SizedBox(height: 12),
+          _pie(goals),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -4,6 +4,7 @@ import 'analyzer_tab.dart';
 import 'spot_of_the_day_screen.dart';
 import 'spot_of_the_day_history_screen.dart';
 import 'settings_placeholder_screen.dart';
+import 'insights_screen.dart';
 import '../widgets/streak_banner.dart';
 import '../widgets/motivation_card.dart';
 import '../services/user_action_logger.dart';
@@ -40,6 +41,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       _home(),
       const SpotOfTheDayScreen(),
       const SpotOfTheDayHistoryScreen(),
+      const InsightsScreen(),
       const SettingsPlaceholderScreen(),
     ];
     return Scaffold(
@@ -67,6 +69,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               BottomNavigationBarItem(
                 icon: Icon(Icons.history),
                 label: 'История',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.insights),
+                label: '📊 Insights',
               ),
               BottomNavigationBarItem(
                 icon: Icon(Icons.more_horiz),

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,10 +13,17 @@ class TrainingStatsService extends ChangeNotifier {
   static const _sessionsKey = 'stats_sessions';
   static const _handsKey = 'stats_hands';
   static const _mistakesKey = 'stats_mistakes';
+  static const _sessionsHistKey = 'stats_sessions_hist';
+  static const _handsHistKey = 'stats_hands_hist';
+  static const _mistakesHistKey = 'stats_mistakes_hist';
 
   int _sessions = 0;
   int _hands = 0;
   int _mistakes = 0;
+
+  Map<String, int> _sessionsPerDay = {};
+  Map<String, int> _handsPerDay = {};
+  Map<String, int> _mistakesPerDay = {};
 
   final _sessionController = StreamController<int>.broadcast();
   final _handsController = StreamController<int>.broadcast();
@@ -29,11 +37,83 @@ class TrainingStatsService extends ChangeNotifier {
   Stream<int> get handsStream => _handsController.stream;
   Stream<int> get mistakesStream => _mistakeController.stream;
 
+  List<MapEntry<DateTime, int>> _entries(Map<String, int> map) {
+    return map.entries
+        .map((e) => MapEntry(DateTime.parse(e.key), e.value))
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+  }
+
+  List<MapEntry<DateTime, int>> handsDaily([int days = 7]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(Duration(days: days - 1));
+    return [for (final e in _entries(_handsPerDay)) if (!e.key.isBefore(start)) e];
+  }
+
+  List<MapEntry<DateTime, int>> sessionsDaily([int days = 7]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(Duration(days: days - 1));
+    return [for (final e in _entries(_sessionsPerDay)) if (!e.key.isBefore(start)) e];
+  }
+
+  List<MapEntry<DateTime, int>> mistakesDaily([int days = 7]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(Duration(days: days - 1));
+    return [for (final e in _entries(_mistakesPerDay)) if (!e.key.isBefore(start)) e];
+  }
+
+  List<MapEntry<DateTime, int>> _groupWeekly(List<MapEntry<DateTime, int>> daily) {
+    final Map<DateTime, int> grouped = {};
+    for (final e in daily) {
+      final w = e.key.subtract(Duration(days: e.key.weekday - 1));
+      grouped.update(w, (v) => v + e.value, ifAbsent: () => e.value);
+    }
+    final list = grouped.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+    return list;
+  }
+
+  List<MapEntry<DateTime, int>> handsWeekly([int weeks = 4]) {
+    final daily = handsDaily(weeks * 7);
+    return _groupWeekly(daily);
+  }
+
+  List<MapEntry<DateTime, int>> sessionsWeekly([int weeks = 4]) {
+    final daily = sessionsDaily(weeks * 7);
+    return _groupWeekly(daily);
+  }
+
+  List<MapEntry<DateTime, int>> mistakesWeekly([int weeks = 4]) {
+    final daily = mistakesDaily(weeks * 7);
+    return _groupWeekly(daily);
+  }
+
+  Map<String, int> _loadMap(SharedPreferences prefs, String key) {
+    final raw = prefs.getString(key);
+    if (raw == null) return {};
+    final data = jsonDecode(raw) as Map<String, dynamic>;
+    return {for (final e in data.entries) e.key: e.value as int};
+  }
+
+  Future<void> _saveMap(SharedPreferences prefs, String key, Map<String, int> map) async {
+    await prefs.setString(key, jsonEncode(map));
+  }
+
+  void _trim(Map<String, int> map) {
+    final keys = map.keys.toList()..sort();
+    while (keys.length > 30) {
+      map.remove(keys.first);
+      keys.removeAt(0);
+    }
+  }
+
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
     _sessions = prefs.getInt(_sessionsKey) ?? 0;
     _hands = prefs.getInt(_handsKey) ?? 0;
     _mistakes = prefs.getInt(_mistakesKey) ?? 0;
+    _sessionsPerDay = _loadMap(prefs, _sessionsHistKey);
+    _handsPerDay = _loadMap(prefs, _handsHistKey);
+    _mistakesPerDay = _loadMap(prefs, _mistakesHistKey);
     notifyListeners();
   }
 
@@ -42,10 +122,16 @@ class TrainingStatsService extends ChangeNotifier {
     await prefs.setInt(_sessionsKey, _sessions);
     await prefs.setInt(_handsKey, _hands);
     await prefs.setInt(_mistakesKey, _mistakes);
+    await _saveMap(prefs, _sessionsHistKey, _sessionsPerDay);
+    await _saveMap(prefs, _handsHistKey, _handsPerDay);
+    await _saveMap(prefs, _mistakesHistKey, _mistakesPerDay);
   }
 
   Future<void> incrementSessions() async {
     _sessions += 1;
+    final key = DateTime.now().toIso8601String().split('T').first;
+    _sessionsPerDay.update(key, (v) => v + 1, ifAbsent: () => 1);
+    _trim(_sessionsPerDay);
     await _save();
     notifyListeners();
     _sessionController.add(_sessions);
@@ -53,6 +139,9 @@ class TrainingStatsService extends ChangeNotifier {
 
   Future<void> incrementHands([int count = 1]) async {
     _hands += count;
+    final key = DateTime.now().toIso8601String().split('T').first;
+    _handsPerDay.update(key, (v) => v + count, ifAbsent: () => count);
+    _trim(_handsPerDay);
     await _save();
     notifyListeners();
     _handsController.add(_hands);
@@ -60,6 +149,9 @@ class TrainingStatsService extends ChangeNotifier {
 
   Future<void> incrementMistakes([int count = 1]) async {
     _mistakes += count;
+    final key = DateTime.now().toIso8601String().split('T').first;
+    _mistakesPerDay.update(key, (v) => v + count, ifAbsent: () => count);
+    _trim(_mistakesPerDay);
     await _save();
     notifyListeners();
     _mistakeController.add(_mistakes);


### PR DESCRIPTION
## Summary
- add interactive Insights screen with graphs and goal pie
- store daily stats history in TrainingStatsService
- track streak history in StreakService
- show new Insights tab in MainNavigationScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c51cc1770832aa615850fcc08b04f