### PR TITLE
Add leaderboard with Firebase

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'screens/main_navigation_screen.dart';
 import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
@@ -29,9 +30,12 @@ import 'services/reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
+import 'services/leaderboard_service.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(
     MultiProvider(
       providers: [
@@ -98,6 +102,11 @@ void main() {
             goals: context.read<GoalEngine>(),
             streak: context.read<StreakService>(),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) =>
+              LeaderboardService(stats: context.read<TrainingStatsService>())
+                ..load(),
         ),
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/leaderboard_service.dart';
+import '../theme/app_colors.dart';
+
+class LeaderboardScreen extends StatelessWidget {
+  const LeaderboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = context.watch<LeaderboardService>().entries;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('🏆 Leaderboard'),
+        centerTitle: true,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: entries.length,
+        itemBuilder: (_, i) {
+          final e = entries[i];
+          final name = e.uuid.length >= 4
+              ? e.uuid.substring(e.uuid.length - 4)
+              : e.uuid;
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            decoration: BoxDecoration(
+              color: AppColors.cardBackground,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: ListTile(
+              leading: Text(
+                '#${i + 1}',
+                style: const TextStyle(color: Colors.white, fontSize: 16),
+              ),
+              title: Text(
+                'User $name',
+                style: const TextStyle(color: Colors.white),
+              ),
+              trailing: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'H: ${e.handsReviewed}',
+                    style: const TextStyle(color: Colors.orangeAccent),
+                  ),
+                  Text(
+                    'M: ${e.mistakesFixed}',
+                    style: const TextStyle(color: Colors.greenAccent),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -5,6 +5,7 @@ import 'spot_of_the_day_screen.dart';
 import 'spot_of_the_day_history_screen.dart';
 import 'settings_placeholder_screen.dart';
 import 'insights_screen.dart';
+import 'leaderboard_screen.dart';
 import '../widgets/streak_banner.dart';
 import '../widgets/motivation_card.dart';
 import '../widgets/next_step_card.dart';
@@ -44,6 +45,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       const SpotOfTheDayScreen(),
       const SpotOfTheDayHistoryScreen(),
       const InsightsScreen(),
+      const LeaderboardScreen(),
       const SettingsPlaceholderScreen(),
     ];
     return Scaffold(
@@ -75,6 +77,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               BottomNavigationBarItem(
                 icon: Icon(Icons.insights),
                 label: '📊 Insights',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.emoji_events),
+                label: '🏆 Leaderboard',
               ),
               BottomNavigationBarItem(
                 icon: Icon(Icons.more_horiz),

--- a/lib/services/leaderboard_service.dart
+++ b/lib/services/leaderboard_service.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:firebase_database/firebase_database.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import 'training_stats_service.dart';
+
+class LeaderboardEntry {
+  final String uuid;
+  final int handsReviewed;
+  final int mistakesFixed;
+
+  LeaderboardEntry({
+    required this.uuid,
+    required this.handsReviewed,
+    required this.mistakesFixed,
+  });
+
+  factory LeaderboardEntry.fromMap(Map<dynamic, dynamic> map) => LeaderboardEntry(
+        uuid: map['uuid'] as String? ?? '',
+        handsReviewed: map['handsReviewed'] as int? ?? 0,
+        mistakesFixed: map['mistakesFixed'] as int? ?? 0,
+      );
+}
+
+class LeaderboardService extends ChangeNotifier {
+  static const _idKey = 'leaderboard_user_id';
+  final TrainingStatsService stats;
+  late final DatabaseReference _ref;
+  late final String _id;
+  List<LeaderboardEntry> _entries = [];
+  List<LeaderboardEntry> get entries => List.unmodifiable(_entries);
+  StreamSubscription<DatabaseEvent>? _sub;
+
+  LeaderboardService({required this.stats});
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_idKey);
+    if (id == null) {
+      id = const Uuid().v4();
+      await prefs.setString(_idKey, id);
+    }
+    _id = id;
+    _ref = FirebaseDatabase.instance.ref('leaderboard');
+    await _push();
+    _listen();
+    stats.handsStream.listen((_) => _push());
+    stats.mistakesStream.listen((_) => _push());
+  }
+
+  Future<void> _push() async {
+    final data = {
+      'uuid': _id,
+      'handsReviewed': stats.handsReviewed,
+      'mistakesFixed': stats.mistakesFixed,
+    };
+    await _ref.child(_id).set(data);
+  }
+
+  void _listen() {
+    _sub = _ref
+        .orderByChild('handsReviewed')
+        .limitToLast(50)
+        .onValue
+        .listen((event) {
+      final value = event.snapshot.value;
+      if (value is Map) {
+        final list = <LeaderboardEntry>[];
+        value.forEach((key, val) {
+          if (val is Map) list.add(LeaderboardEntry.fromMap(val));
+        });
+        list.sort((a, b) => b.handsReviewed.compareTo(a.handsReviewed));
+        _entries = list;
+        notifyListeners();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   table_calendar: ^3.0.9
   flutter_local_notifications: ^17.0.0
   timezone: ^0.9.2
+  firebase_core: ^2.24.2
+  firebase_database: ^10.2.2
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- add Firebase packages
- implement `LeaderboardService` syncing stats to Realtime DB
- add `LeaderboardScreen`
- initialize Firebase and register the service
- show "🏆 Leaderboard" tab in the main navigation

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c54d2e1cc832a993d2ae5ac270036