### PR TITLE
Implement Firestore backups

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'services/next_step_engine.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 import 'services/leaderboard_service.dart';
+import 'services/cloud_backup_service.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -111,6 +112,14 @@ Future<void> main() async {
         Provider(create: (_) => EvaluationExecutorService()),
         Provider(create: (_) => CloudSyncService()),
         ChangeNotifierProvider(create: (_) => UserActionLogger()..load()),
+        ChangeNotifierProvider(
+          create: (context) => CloudBackupService(
+            stats: context.read<TrainingStatsService>(),
+            streak: context.read<StreakService>(),
+            goals: context.read<GoalsService>(),
+            log: context.read<UserActionLogger>(),
+          )..load(),
+        ),
       ],
       child: const PokerAIAnalyzerApp(),
     ),

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -10,6 +10,7 @@ import 'package:intl/intl.dart';
 import '../helpers/date_utils.dart';
 import '../services/reminder_service.dart';
 import '../services/user_action_logger.dart';
+import '../services/cloud_backup_service.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -46,6 +47,20 @@ class SettingsPlaceholderScreen extends StatelessWidget {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+    }
+  }
+
+  Future<void> _syncNow(BuildContext context) async {
+    final service = context.read<CloudBackupService>();
+    try {
+      await service.syncNow();
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Sync complete')));
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Sync failed')));
     }
   }
 
@@ -97,6 +112,13 @@ class SettingsPlaceholderScreen extends StatelessWidget {
             child: ElevatedButton(
               onPressed: () => _exportLog(context),
               child: const Text('Export Activity Log'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Center(
+            child: ElevatedButton(
+              onPressed: () => _syncNow(context),
+              child: const Text('Sync now'),
             ),
           ),
         ],

--- a/lib/services/cloud_backup_service.dart
+++ b/lib/services/cloud_backup_service.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+
+import 'training_stats_service.dart';
+import 'streak_service.dart';
+import 'goals_service.dart';
+import 'user_action_logger.dart';
+
+class CloudBackupService extends ChangeNotifier {
+  final TrainingStatsService stats;
+  final StreakService streak;
+  final GoalsService goals;
+  final UserActionLogger log;
+
+  CloudBackupService({
+    required this.stats,
+    required this.streak,
+    required this.goals,
+    required this.log,
+  });
+
+  late final CollectionReference<Map<String, dynamic>> _ref;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _statsSub;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _streakSub;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _goalsSub;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _logSub;
+
+  Future<void> load() async {
+    await FirebaseAuth.instance.signInAnonymously();
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    _ref = FirebaseFirestore.instance.collection('users').doc(uid).collection('backup');
+    _listen();
+    await syncNow();
+  }
+
+  void _listen() {
+    _statsSub = _ref.doc('stats').snapshots().listen((snap) {
+      final data = snap.data();
+      if (data != null) stats.applyMap(data);
+    });
+    _streakSub = _ref.doc('streak').snapshots().listen((snap) {
+      final data = snap.data();
+      if (data != null) streak.applyMap(data);
+    });
+    _goalsSub = _ref.doc('goals').snapshots().listen((snap) {
+      final data = snap.data();
+      if (data != null) goals.applyMap(data);
+    });
+    _logSub = _ref.doc('user_action_log').snapshots().listen((snap) {
+      final data = snap.data();
+      if (data != null) log.applyMap(data);
+    });
+    stats.addListener(_pushStats);
+    streak.addListener(_pushStreak);
+    goals.addListener(_pushGoals);
+    log.addListener(_pushLog);
+  }
+
+  Future<void> _pushStats() => _ref.doc('stats').set(stats.toMap(), SetOptions(merge: true));
+  Future<void> _pushStreak() => _ref.doc('streak').set(streak.toMap(), SetOptions(merge: true));
+  Future<void> _pushGoals() => _ref.doc('goals').set(goals.toMap(), SetOptions(merge: true));
+  Future<void> _pushLog() => _ref.doc('user_action_log').set(log.toMap(), SetOptions(merge: true));
+
+  Future<void> syncNow() async {
+    await Future.wait([
+      _pushStats(),
+      _pushStreak(),
+      _pushGoals(),
+      _pushLog(),
+    ]);
+  }
+
+  @override
+  void dispose() {
+    _statsSub?.cancel();
+    _streakSub?.cancel();
+    _goalsSub?.cancel();
+    _logSub?.cancel();
+    stats.removeListener(_pushStats);
+    streak.removeListener(_pushStreak);
+    goals.removeListener(_pushGoals);
+    log.removeListener(_pushLog);
+    super.dispose();
+  }
+}

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -678,4 +678,52 @@ class GoalsService extends ChangeNotifier {
     }
     return true;
   }
+
+  Map<String, dynamic> toMap() => {
+        'errorFreeStreak': _errorFreeStreak,
+        'handStreak': _handStreak,
+        'mistakeReviewStreak': _mistakeReviewStreak,
+        'goals': [for (final g in _goals) g.progress],
+        'hasSevenDayGoalUnlocked': _hasSevenDayGoalUnlocked,
+      };
+
+  Future<void> applyMap(Map<String, dynamic> data) async {
+    bool changed = false;
+    final goals = data['goals'];
+    if (goals is List) {
+      for (var i = 0; i < goals.length && i < _goals.length; i++) {
+        final p = goals[i];
+        if (p is int && p > _goals[i].progress) {
+          _goals[i] = _goals[i].copyWith(progress: p);
+          await _saveProgress(i);
+          changed = true;
+        }
+      }
+    }
+    final err = data['errorFreeStreak'];
+    if (err is int && err > _errorFreeStreak) {
+      _errorFreeStreak = err;
+      await _saveErrorFreeStreak();
+      changed = true;
+    }
+    final hand = data['handStreak'];
+    if (hand is int && hand > _handStreak) {
+      _handStreak = hand;
+      await _saveHandStreak();
+      changed = true;
+    }
+    final mr = data['mistakeReviewStreak'];
+    if (mr is int && mr > _mistakeReviewStreak) {
+      _mistakeReviewStreak = mr;
+      await _saveMistakeReviewStreak();
+      changed = true;
+    }
+    final seven = data['hasSevenDayGoalUnlocked'];
+    if (seven is bool && seven && !_hasSevenDayGoalUnlocked) {
+      _hasSevenDayGoalUnlocked = true;
+      await _saveSevenDayGoalUnlocked();
+      changed = true;
+    }
+    if (changed) notifyListeners();
+  }
 }

--- a/lib/services/streak_service.dart
+++ b/lib/services/streak_service.dart
@@ -115,4 +115,45 @@ class StreakService extends ChangeNotifier {
     await _save();
     notifyListeners();
   }
+
+  Map<String, dynamic> toMap() => {
+        'lastOpen': _lastOpen?.toIso8601String(),
+        'count': _count,
+        'errorFreeStreak': _errorFreeStreak,
+        'history': _history,
+      };
+
+  Future<void> applyMap(Map<String, dynamic> data) async {
+    bool changed = false;
+    final count = data['count'];
+    if (count is int && count > _count) {
+      _count = count;
+      changed = true;
+    }
+    final error = data['errorFreeStreak'];
+    if (error is int && error > _errorFreeStreak) {
+      _errorFreeStreak = error;
+      changed = true;
+    }
+    final last = data['lastOpen'];
+    if (last is String) {
+      final t = DateTime.tryParse(last);
+      if (t != null && (_lastOpen == null || t.isAfter(_lastOpen!))) {
+        _lastOpen = t;
+        changed = true;
+      }
+    }
+    final hist = data['history'];
+    if (hist is Map) {
+      for (final e in hist.entries) {
+        final v = e.value is int ? e.value as int : int.tryParse('${e.value}') ?? 0;
+        _history.update(e.key, (val) => v > val ? v : val, ifAbsent: () => v);
+      }
+      changed = true;
+    }
+    if (changed) {
+      await _save();
+      notifyListeners();
+    }
+  }
 }

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -157,6 +157,62 @@ class TrainingStatsService extends ChangeNotifier {
     _mistakeController.add(_mistakes);
   }
 
+  Map<String, dynamic> toMap() => {
+        'sessions': _sessions,
+        'hands': _hands,
+        'mistakes': _mistakes,
+        'sessionsPerDay': _sessionsPerDay,
+        'handsPerDay': _handsPerDay,
+        'mistakesPerDay': _mistakesPerDay,
+      };
+
+  Future<void> applyMap(Map<String, dynamic> data) async {
+    bool changed = false;
+    final s = data['sessions'];
+    if (s is int && s > _sessions) {
+      _sessions = s;
+      changed = true;
+    }
+    final h = data['hands'];
+    if (h is int && h > _hands) {
+      _hands = h;
+      changed = true;
+    }
+    final m = data['mistakes'];
+    if (m is int && m > _mistakes) {
+      _mistakes = m;
+      changed = true;
+    }
+    final spd = data['sessionsPerDay'];
+    if (spd is Map) {
+      for (final e in spd.entries) {
+        final v = e.value is int ? e.value as int : int.tryParse('${e.value}') ?? 0;
+        _sessionsPerDay.update(e.key, (val) => v > val ? v : val, ifAbsent: () => v);
+      }
+      changed = true;
+    }
+    final hpd = data['handsPerDay'];
+    if (hpd is Map) {
+      for (final e in hpd.entries) {
+        final v = e.value is int ? e.value as int : int.tryParse('${e.value}') ?? 0;
+        _handsPerDay.update(e.key, (val) => v > val ? v : val, ifAbsent: () => v);
+      }
+      changed = true;
+    }
+    final mpd = data['mistakesPerDay'];
+    if (mpd is Map) {
+      for (final e in mpd.entries) {
+        final v = e.value is int ? e.value as int : int.tryParse('${e.value}') ?? 0;
+        _mistakesPerDay.update(e.key, (val) => v > val ? v : val, ifAbsent: () => v);
+      }
+      changed = true;
+    }
+    if (changed) {
+      await _save();
+      notifyListeners();
+    }
+  }
+
   @override
   void dispose() {
     _sessionController.close();

--- a/lib/services/user_action_logger.dart
+++ b/lib/services/user_action_logger.dart
@@ -36,4 +36,32 @@ class UserActionLogger extends ChangeNotifier {
   }
 
   List<Map<String, dynamic>> export() => events;
+
+  Map<String, dynamic> toMap() => {'events': _events};
+
+  Future<void> applyMap(Map<String, dynamic> data) async {
+    final list = data['events'];
+    if (list is List) {
+      final existing = {for (final e in _events) jsonEncode(e)};
+      bool changed = false;
+      for (final item in list) {
+        if (item is Map) {
+          final map = Map<String, dynamic>.from(item);
+          final enc = jsonEncode(map);
+          if (!existing.contains(enc)) {
+            _events.add(map);
+            changed = true;
+          }
+        }
+      }
+      if (changed) {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setStringList(
+          _prefsKey,
+          _events.map((e) => jsonEncode(e)).toList(),
+        );
+        notifyListeners();
+      }
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   timezone: ^0.9.2
   firebase_core: ^2.24.2
   firebase_database: ^10.2.2
+  firebase_auth: ^4.17.4
+  cloud_firestore: ^4.15.9
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- add CloudBackupService with Firebase Auth and Firestore
- hook into TrainingStatsService, StreakService, GoalsService and UserActionLogger
- expose sync button in settings
- provide provider in main
- add firebase_auth and cloud_firestore deps

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c56053310832ab4eb4437bd9f85bf