### PR TITLE
Adjust dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   path_provider: ^2.0.15
   open_filex: ^4.7.0
   file_picker: ^5.2.10
-  desktop_drop: ^0.6.0
+  desktop_drop: ^0.5.4
   fl_chart: ^0.64.0
   pie_chart: ^5.4.0
   pdf: ^3.10.4
@@ -43,11 +43,12 @@ dependencies:
   timezone: ^0.9.2
   firebase_core: ^2.24.2
   firebase_database: ^10.2.2
-  firebase_auth: ^4.17.4
+  firebase_auth: ^4.16.0
   cloud_firestore: ^4.15.9
 
 dependency_overrides:
   intl: ^0.20.2
+  web: ^0.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- downgrade desktop_drop
- pin firebase_auth
- override web version

## Testing
- `flutter pub get` *(fails: version solving failed for desktop_drop 0.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_685c58a91470832aae57948f030a32ab