### PR TITLE
Fix dependency conflicts

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -232,7 +232,7 @@ packages:
       sha256: bd21017e0415632c85f6b813c846bc8c9811742507776dcf6abf91a14d946e98
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.4"
   dio:
     dependency: transitive
     description:
@@ -1044,7 +1044,7 @@ packages:
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "0.5.1"
   web_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
 
 dependency_overrides:
   intl: ^0.20.2
-  web: ^0.4.1
+  web: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- resolve Firebase and desktop_drop dependency conflicts
- override web dependency version

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5b800664832a92acfc982969aa87