### PR TITLE
Add TrainingCalendarWidget

### DIFF
--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -6,6 +6,7 @@ import '../services/training_stats_service.dart';
 import '../services/goal_engine.dart';
 import '../services/streak_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/training_calendar_widget.dart';
 
 enum _Mode { daily, weekly }
 
@@ -243,6 +244,8 @@ class _InsightsScreenState extends State<InsightsScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          const TrainingCalendarWidget(),
+          const SizedBox(height: 12),
           _chart(_hands(stats)),
           const SizedBox(height: 12),
           _chart(_mistakes(stats)),

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -25,6 +25,9 @@ class TrainingStatsService extends ChangeNotifier {
   Map<String, int> _handsPerDay = {};
   Map<String, int> _mistakesPerDay = {};
 
+  Map<DateTime, int> get handsPerDay =>
+      {for (final e in _handsPerDay.entries) DateTime.parse(e.key): e.value};
+
   final _sessionController = StreamController<int>.broadcast();
   final _handsController = StreamController<int>.broadcast();
   final _mistakeController = StreamController<int>.broadcast();

--- a/lib/widgets/training_calendar_widget.dart
+++ b/lib/widgets/training_calendar_widget.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/training_stats_service.dart';
+import '../theme/app_colors.dart';
+
+class TrainingCalendarWidget extends StatelessWidget {
+  const TrainingCalendarWidget({super.key});
+
+  Color _color(int count) {
+    if (count >= 10) return Colors.redAccent;
+    if (count >= 5) return Colors.yellowAccent;
+    if (count >= 1) return Colors.greenAccent;
+    return Colors.white10;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>();
+    final map = stats.handsPerDay;
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day)
+        .subtract(const Duration(days: 41));
+    final days = [for (var i = 0; i < 42; i++) start.add(Duration(days: i))];
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: GridView.builder(
+        itemCount: 42,
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 7,
+          mainAxisSpacing: 4,
+          crossAxisSpacing: 4,
+        ),
+        itemBuilder: (context, i) {
+          final d = days[i];
+          final count = map[d] ?? 0;
+          return Container(
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: _color(count),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              '${d.day}',
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- new TrainingCalendarWidget visualizes last 42 days of activity
- expose handsPerDay from TrainingStatsService
- show calendar on InsightsScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5feecdcc832a8b21474bd2055a5b