### PR TITLE
Add daily hands target settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
 import 'services/reminder_service.dart';
 import 'services/next_step_engine.dart';
+import 'services/daily_target_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 
@@ -54,6 +55,7 @@ void main() {
         ),
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
+        ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => SpotOfTheDayService()..load()),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -10,6 +10,7 @@ import 'package:intl/intl.dart';
 import '../helpers/date_utils.dart';
 import '../services/reminder_service.dart';
 import '../services/user_action_logger.dart';
+import '../services/daily_target_service.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -52,6 +53,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final reminder = context.watch<ReminderService>();
+    final dailyTarget = context.watch<DailyTargetService>();
     final dismissed = reminder.lastDismissed;
     final status = reminder.enabled ? 'Включены' : 'Выключены';
     final info = dismissed != null
@@ -84,6 +86,22 @@ class SettingsPlaceholderScreen extends StatelessWidget {
               info,
               style: const TextStyle(color: Colors.white70),
             ),
+          ),
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text(
+              'Daily hands target',
+              style: TextStyle(color: Colors.white70, fontSize: 18),
+            ),
+          ),
+          Slider(
+            value: dailyTarget.target.toDouble(),
+            min: 5,
+            max: 50,
+            divisions: 45,
+            label: dailyTarget.target.toString(),
+            activeColor: Colors.orange,
+            onChanged: (v) => dailyTarget.setTarget(v.round()),
           ),
           const SizedBox(height: 32),
           const Center(

--- a/lib/services/daily_target_service.dart
+++ b/lib/services/daily_target_service.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DailyTargetService extends ChangeNotifier {
+  static const _key = 'daily_hands_target';
+  int _target = 10;
+  int get target => _target;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _target = prefs.getInt(_key) ?? 10;
+    notifyListeners();
+  }
+
+  Future<void> setTarget(int value) async {
+    if (_target == value) return;
+    _target = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_key, value);
+    notifyListeners();
+  }
+}

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/training_stats_service.dart';
+import '../services/daily_target_service.dart';
 
 class TodayProgressBanner extends StatelessWidget {
   const TodayProgressBanner({super.key});
@@ -8,6 +9,7 @@ class TodayProgressBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final stats = context.watch<TrainingStatsService>();
+    final target = context.watch<DailyTargetService>().target;
     final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
     final hands = stats.handsPerDay[today] ?? 0;
     final dailyMistakes = stats.mistakesDaily(1);
@@ -26,14 +28,14 @@ class TodayProgressBanner extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Today: $hands hands \u00b7 $mistakes mistakes',
+            'Today: $hands/$target hands \u00b7 $mistakes mistakes',
             style: const TextStyle(color: Colors.white),
           ),
           const SizedBox(height: 4),
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
             child: LinearProgressIndicator(
-              value: (hands / 10).clamp(0.0, 1.0),
+              value: (hands / target).clamp(0.0, 1.0),
               backgroundColor: Colors.white24,
               valueColor: AlwaysStoppedAnimation<Color>(color),
               minHeight: 6,


### PR DESCRIPTION
## Summary
- implement `DailyTargetService`
- register the service in `main.dart`
- show daily hands target progress
- add a slider for daily target in the placeholder settings screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c644254a8832a9c3cae4f569a4c13