### PR TITLE
Add drill suggestion engine and card

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
 import 'services/reminder_service.dart';
 import 'services/next_step_engine.dart';
+import 'services/drill_suggestion_engine.dart';
 import 'services/daily_target_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
@@ -99,6 +100,12 @@ void main() {
             hands: context.read<SavedHandManagerService>(),
             goals: context.read<GoalEngine>(),
             streak: context.read<StreakService>(),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => DrillSuggestionEngine(
+            hands: context.read<SavedHandManagerService>(),
+            packs: context.read<TrainingPackStorageService>(),
           ),
         ),
         Provider(create: (_) => EvaluationExecutorService()),

--- a/lib/models/drill.dart
+++ b/lib/models/drill.dart
@@ -1,0 +1,6 @@
+class Drill {
+  final String position;
+  final String street;
+  final int count;
+  const Drill({required this.position, required this.street, required this.count});
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -8,6 +8,7 @@ import 'insights_screen.dart';
 import '../widgets/streak_banner.dart';
 import '../widgets/motivation_card.dart';
 import '../widgets/next_step_card.dart';
+import '../widgets/suggested_drill_card.dart';
 import '../widgets/today_progress_banner.dart';
 import '../services/user_action_logger.dart';
 
@@ -27,6 +28,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
         TodayProgressBanner(),
         MotivationCard(),
         NextStepCard(),
+        SuggestedDrillCard(),
         Expanded(child: AnalyzerTab()),
       ],
     );

--- a/lib/services/drill_suggestion_engine.dart
+++ b/lib/services/drill_suggestion_engine.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../helpers/poker_street_helper.dart';
+import '../models/drill.dart';
+import '../models/training_pack.dart';
+import '../models/saved_hand.dart';
+import 'saved_hand_manager_service.dart';
+import 'training_pack_storage_service.dart';
+
+class DrillSuggestionEngine extends ChangeNotifier {
+  final SavedHandManagerService _hands;
+  final TrainingPackStorageService _packs;
+  List<Drill> _drills = [];
+  List<Drill> get suggestedDrills => List.unmodifiable(_drills);
+
+  DrillSuggestionEngine({
+    required SavedHandManagerService hands,
+    required TrainingPackStorageService packs,
+  })  : _hands = hands,
+        _packs = packs {
+    _update();
+    _hands.addListener(_update);
+  }
+
+  void _update() {
+    final map = <String, Map<String, int>>{};
+    for (final h in _hands.hands) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp != null && gto != null && exp != gto) {
+        map.putIfAbsent(h.heroPosition, () => {});
+        final street = streetName(h.boardStreet);
+        map[h.heroPosition]![street] = (map[h.heroPosition]![street] ?? 0) + 1;
+      }
+    }
+    final list = <Drill>[];
+    for (final e in map.entries) {
+      for (final s in e.value.entries) {
+        list.add(Drill(position: e.key, street: s.key, count: s.value));
+      }
+    }
+    list.sort((a, b) => b.count.compareTo(a.count));
+    _drills = list.take(3).toList();
+    notifyListeners();
+  }
+
+  TrainingPack startDrill(Drill d) {
+    final hands = <SavedHand>[];
+    for (final p in _packs.packs) {
+      for (final h in p.hands) {
+        if (h.heroPosition == d.position &&
+            streetName(h.boardStreet) == d.street) {
+          hands.add(h);
+        }
+      }
+    }
+    return TrainingPack(
+      name: '${d.position} ${d.street}',
+      description: 'Drill',
+      hands: hands,
+    );
+  }
+}

--- a/lib/widgets/suggested_drill_card.dart
+++ b/lib/widgets/suggested_drill_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/drill_suggestion_engine.dart';
+import '../screens/training_pack_screen.dart';
+
+class SuggestedDrillCard extends StatelessWidget {
+  const SuggestedDrillCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final engine = context.watch<DrillSuggestionEngine>();
+    if (engine.suggestedDrills.isEmpty) return const SizedBox.shrink();
+    final drill = engine.suggestedDrills.first;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.fitness_center, color: Colors.greenAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Suggested Drill',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 4),
+                Text('${drill.position} • ${drill.street}',
+                    style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () {
+              final pack = context.read<DrillSuggestionEngine>().startDrill(drill);
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TrainingPackScreen(
+                    pack: pack,
+                    hands: pack.hands,
+                    persistResults: false,
+                  ),
+                ),
+              );
+            },
+            child: const Text('Start'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DrillSuggestionEngine`
- add suggested drill card in home tab
- wire up provider in main
- create Drill model

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c65fe0da4832a9a386538d7e48d9a