### PR TITLE
Implement daily drill dismissal

### DIFF
--- a/lib/widgets/suggested_drill_card.dart
+++ b/lib/widgets/suggested_drill_card.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/drill_suggestion_engine.dart';
 import '../screens/training_pack_screen.dart';
+import '../services/reminder_service.dart';
 
 class SuggestedDrillCard extends StatelessWidget {
   const SuggestedDrillCard({super.key});
@@ -12,8 +13,10 @@ class SuggestedDrillCard extends StatelessWidget {
     final engine = context.watch<DrillSuggestionEngine>();
     if (engine.suggestedDrills.isEmpty) return const SizedBox.shrink();
     final drill = engine.suggestedDrills.first;
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    final reminder = context.watch<ReminderService>();
+    final key = '${drill.position}_${drill.street}';
+    if (reminder.isDrillDismissed(key)) return const SizedBox.shrink();
+    final card = Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: Colors.grey[850],
@@ -53,6 +56,25 @@ class SuggestedDrillCard extends StatelessWidget {
               );
             },
             child: const Text('Start'),
+          ),
+        ],
+      ),
+    );
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Stack(
+        children: [
+          card,
+          Positioned(
+            right: 0,
+            top: 0,
+            child: IconButton(
+              icon: const Icon(Icons.close, size: 16, color: Colors.white70),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+              onPressed: () =>
+                  context.read<ReminderService>().dismissDrillForToday(key),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- extend ReminderService with per-drill dismissals and midnight reset
- allow closing SuggestedDrillCard for the day

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c67895c08832a9616db1e49964723