### PR TITLE
Fix SuggestedDrillCard build

### DIFF
--- a/lib/widgets/suggested_drill_card.dart
+++ b/lib/widgets/suggested_drill_card.dart
@@ -11,9 +11,9 @@ class SuggestedDrillCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final engine = context.watch<DrillSuggestionEngine>();
+    final reminder = context.watch<ReminderService>();
     if (engine.suggestedDrills.isEmpty) return const SizedBox.shrink();
     final drill = engine.suggestedDrills.first;
-    final reminder = context.watch<ReminderService>();
     final key = '${drill.position}_${drill.street}';
     if (reminder.isDrillDismissed(key)) return const SizedBox.shrink();
     final card = Container(


### PR DESCRIPTION
## Summary
- move reminder initialization before building the widget tree
- keep the widget tree wrapped in a single return

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c6965ff84832ab95b5cdfd4077934