### PR TITLE
Add daily target streak counter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,12 @@ void main() {
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
+        ChangeNotifierProvider(
+          create: (context) => StreakCounterService(
+            stats: context.read<TrainingStatsService>(),
+            target: context.read<DailyTargetService>(),
+          ),
+        ),
         ChangeNotifierProvider(create: (_) => SpotOfTheDayService()..load()),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),

--- a/lib/services/streak_counter_service.dart
+++ b/lib/services/streak_counter_service.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'training_stats_service.dart';
+import 'daily_target_service.dart';
+
+class StreakCounterService extends ChangeNotifier {
+  static const _countKey = 'target_streak_count';
+  static const _lastKey = 'target_streak_last';
+
+  final TrainingStatsService stats;
+  final DailyTargetService target;
+
+  int _count = 0;
+  DateTime? _last;
+
+  int get count => _count;
+
+  StreakCounterService({required this.stats, required this.target}) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    final prefs = await SharedPreferences.getInstance();
+    _count = prefs.getInt(_countKey) ?? 0;
+    final lastStr = prefs.getString(_lastKey);
+    _last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    await _updateForToday();
+    stats.handsStream.listen((_) => _checkToday());
+    target.addListener(_checkToday);
+    _checkToday();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_countKey, _count);
+    if (_last != null) {
+      await prefs.setString(_lastKey, _last!.toIso8601String());
+    } else {
+      await prefs.remove(_lastKey);
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<void> _updateForToday() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    if (_last != null) {
+      final lastDay = DateTime(_last!.year, _last!.month, _last!.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 1) {
+        _count += 1;
+      } else if (diff > 1) {
+        _count = 0;
+      }
+    }
+    await _save();
+    notifyListeners();
+  }
+
+  Future<void> _checkToday() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final hands = stats.handsPerDay[today] ?? 0;
+    if (hands >= target.target && (_last == null || !_isSameDay(_last!, today))) {
+      _last = today;
+      await _save();
+    }
+  }
+
+  @override
+  void dispose() {
+    target.removeListener(_checkToday);
+    super.dispose();
+  }
+}

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
+import '../services/streak_counter_service.dart';
 
 class TodayProgressBanner extends StatelessWidget {
   const TodayProgressBanner({super.key});
@@ -10,6 +11,7 @@ class TodayProgressBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final stats = context.watch<TrainingStatsService>();
     final target = context.watch<DailyTargetService>().target;
+    final streak = context.watch<StreakCounterService>().count;
     final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
     final hands = stats.handsPerDay[today] ?? 0;
     final dailyMistakes = stats.mistakesDaily(1);
@@ -27,9 +29,24 @@ class TodayProgressBanner extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Today: $hands/$target hands \u00b7 $mistakes mistakes',
-            style: const TextStyle(color: Colors.white),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Today: $hands/$target hands \u00b7 $mistakes mistakes',
+                style: const TextStyle(color: Colors.white),
+              ),
+              if (streak > 0)
+                Row(
+                  children: [
+                    const Icon(Icons.local_fire_department,
+                        color: Colors.orange, size: 16),
+                    const SizedBox(width: 4),
+                    Text('$streak',
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+            ],
           ),
           const SizedBox(height: 4),
           ClipRRect(


### PR DESCRIPTION
## Summary
- implement `StreakCounterService` for tracking consecutive days the daily hand target is met
- show streak count with fire icon on `TodayProgressBanner`
- register `StreakCounterService` in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6bfa1830832aa8d795b7e666301c