### PR TITLE
Add streak mini card

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/motivation_card.dart';
 import '../widgets/next_step_card.dart';
 import '../widgets/suggested_drill_card.dart';
 import '../widgets/today_progress_banner.dart';
+import '../widgets/streak_mini_card.dart';
 import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
@@ -74,6 +75,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return Column(
       children: [
         const TodayProgressBanner(),
+        const StreakMiniCard(),
         TextButton(
           onPressed: _setDailyGoal,
           child: const Text('Set Daily Goal'),

--- a/lib/services/streak_counter_service.dart
+++ b/lib/services/streak_counter_service.dart
@@ -6,15 +6,18 @@ import 'daily_target_service.dart';
 class StreakCounterService extends ChangeNotifier {
   static const _countKey = 'target_streak_count';
   static const _lastKey = 'target_streak_last';
+  static const _maxKey = 'target_streak_max';
 
   final TrainingStatsService stats;
   final DailyTargetService target;
 
   int _count = 0;
   DateTime? _last;
+  int _max = 0;
 
   int get count => _count;
   DateTime? get lastSuccess => _last;
+  int get max => _max;
 
   StreakCounterService({required this.stats, required this.target}) {
     _init();
@@ -23,6 +26,7 @@ class StreakCounterService extends ChangeNotifier {
   Future<void> _init() async {
     final prefs = await SharedPreferences.getInstance();
     _count = prefs.getInt(_countKey) ?? 0;
+    _max = prefs.getInt(_maxKey) ?? 0;
     final lastStr = prefs.getString(_lastKey);
     _last = lastStr != null ? DateTime.tryParse(lastStr) : null;
     await _updateForToday();
@@ -34,6 +38,7 @@ class StreakCounterService extends ChangeNotifier {
   Future<void> _save() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_countKey, _count);
+    await prefs.setInt(_maxKey, _max);
     if (_last != null) {
       await prefs.setString(_lastKey, _last!.toIso8601String());
     } else {
@@ -52,6 +57,7 @@ class StreakCounterService extends ChangeNotifier {
       final diff = today.difference(lastDay).inDays;
       if (diff == 1) {
         _count += 1;
+        if (_count > _max) _max = _count;
       } else if (diff > 1) {
         _count = 0;
       }

--- a/lib/widgets/streak_mini_card.dart
+++ b/lib/widgets/streak_mini_card.dart
@@ -1,0 +1,43 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/streak_counter_service.dart';
+
+class StreakMiniCard extends StatelessWidget {
+  const StreakMiniCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<StreakCounterService>();
+    final accent = Theme.of(context).colorScheme.secondary;
+    const messages = ['Keep it up!', 'Great focus!', 'Stay sharp!'];
+    final quote = messages[service.count % messages.length];
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Text('🔥', style: TextStyle(fontSize: 20, color: accent)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Streak: ${service.count}',
+                    style: const TextStyle(color: Colors.white)),
+                Text('Best: ${service.max}',
+                    style: const TextStyle(color: Colors.white70, fontSize: 12)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(quote, style: const TextStyle(color: Colors.white)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- track max streak in `StreakCounterService`
- show a short streak card after today's progress banner

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c78179ae4832a964d13ce68cca9a1