### PR TITLE
Add record toast for streaks

### DIFF
--- a/lib/services/streak_counter_service.dart
+++ b/lib/services/streak_counter_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'training_stats_service.dart';
@@ -14,6 +15,10 @@ class StreakCounterService extends ChangeNotifier {
   int _count = 0;
   DateTime? _last;
   int _max = 0;
+
+  final _recordController = StreamController<int>.broadcast();
+
+  Stream<int> get recordStream => _recordController.stream;
 
   int get count => _count;
   DateTime? get lastSuccess => _last;
@@ -57,7 +62,10 @@ class StreakCounterService extends ChangeNotifier {
       final diff = today.difference(lastDay).inDays;
       if (diff == 1) {
         _count += 1;
-        if (_count > _max) _max = _count;
+        if (_count > _max) {
+          _max = _count;
+          _recordController.add(_max);
+        }
       } else if (diff > 1) {
         _count = 0;
       }
@@ -86,6 +94,7 @@ class StreakCounterService extends ChangeNotifier {
   @override
   void dispose() {
     target.removeListener(_checkToday);
+    _recordController.close();
     super.dispose();
   }
 }

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -23,6 +24,7 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
   bool _celebrated = false;
   DateTime? _lastCelebration;
   static const _prefKey = 'today_progress_banner_confetti';
+  StreamSubscription<int>? _recordSub;
 
   @override
   void initState() {
@@ -45,6 +47,17 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
         weight: 50,
       ),
     ]).animate(_controller);
+    _recordSub =
+        context.read<StreakCounterService>().recordStream.listen((_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('🏆 New record!'),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    });
     SharedPreferences.getInstance().then((prefs) {
       final str = prefs.getString(_prefKey);
       if (str != null) {
@@ -79,6 +92,7 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
 
   @override
   void dispose() {
+    _recordSub?.cancel();
     _controller.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- add recordStream to StreakCounterService
- trigger snack bar on new streak record in TodayProgressBanner

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7945b2fc832a93731114dec733dd