### PR TITLE
Add progress history grid

### DIFF
--- a/lib/screens/daily_progress_history_screen.dart
+++ b/lib/screens/daily_progress_history_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/training_stats_service.dart';
+import '../services/daily_target_service.dart';
+
+class DailyProgressHistoryScreen extends StatelessWidget {
+  const DailyProgressHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>();
+    final target = context.watch<DailyTargetService>().target;
+    final map = stats.handsPerDay;
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day)
+        .subtract(const Duration(days: 29));
+    final days = [for (var i = 0; i < 30; i++) start.add(Duration(days: i))];
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Daily Progress'),
+        centerTitle: true,
+      ),
+      body: GridView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: days.length,
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 7,
+          mainAxisSpacing: 4,
+          crossAxisSpacing: 4,
+        ),
+        itemBuilder: (context, index) {
+          final d = days[index];
+          final count = map[d] ?? 0;
+          final met = count >= target;
+          return Container(
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: met ? Colors.greenAccent : Colors.redAccent,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('${d.day}',
+                    style: const TextStyle(color: Colors.white, fontSize: 12)),
+                Text('$count',
+                    style: const TextStyle(color: Colors.white70, fontSize: 10)),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -6,6 +6,7 @@ import '../services/streak_service.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../theme/app_colors.dart';
+import 'daily_progress_history_screen.dart';
 
 class GoalOverviewScreen extends StatelessWidget {
   const GoalOverviewScreen({super.key});
@@ -35,6 +36,19 @@ class GoalOverviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Goal'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.calendar_today),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const DailyProgressHistoryScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- add DailyProgressHistoryScreen to show hands for the last month
- open the new screen from GoalOverviewScreen via calendar button

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7bba340c832a8afa45d4335a4c7e