### PR TITLE
Add achievements progress grid

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -111,7 +111,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                 const SizedBox(height: 4),
                 if (!completed)
                   const Text(
-                    'Не выполнено',
+                    'Incomplete',
                     style: TextStyle(color: Colors.white54, fontSize: 12),
                   )
                 else


### PR DESCRIPTION
## Summary
- show progress-based achievements in a grid view
- open achievements from the Goal tab via trophy icon
- localize incomplete achievement label

## Testing
- `dart format lib/screens/achievements_screen.dart lib/screens/goal_overview_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/achievements_screen.dart lib/screens/goal_overview_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7eb943b4832abcbe38296ecf1e00