### PR TITLE
Add XP tracker and progress bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'services/reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/daily_target_service.dart';
+import 'services/xp_tracker_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 
@@ -57,10 +58,12 @@ void main() {
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
+        ChangeNotifierProvider(create: (_) => XPTrackerService()..load()),
         ChangeNotifierProvider(
           create: (context) => StreakCounterService(
             stats: context.read<TrainingStatsService>(),
             target: context.read<DailyTargetService>(),
+            xp: context.read<XPTrackerService>(),
           ),
         ),
         ChangeNotifierProvider(create: (_) => SpotOfTheDayService()..load()),

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../services/streak_service.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
+import '../services/xp_tracker_service.dart';
 import '../theme/app_colors.dart';
 import 'daily_progress_history_screen.dart';
 import 'achievements_screen.dart';
@@ -23,6 +24,7 @@ class GoalOverviewScreen extends StatelessWidget {
     final streakService = context.watch<StreakService>();
     final stats = context.watch<TrainingStatsService>();
     final targetService = context.watch<DailyTargetService>();
+    final xpService = context.watch<XPTrackerService>();
     final streak = streakService.count;
     final history = streakService.history;
     final maxStreak = history.isEmpty
@@ -77,6 +79,26 @@ class GoalOverviewScreen extends StatelessWidget {
                 const SizedBox(height: 4),
                 Text('Max: $maxStreak',
                     style: const TextStyle(color: Colors.white70)),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Level ${xpService.level}',
+                        style: const TextStyle(color: Colors.white)),
+                    Text('${xpService.xp}/${xpService.nextLevelXp} XP',
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: xpService.progress.clamp(0.0, 1.0),
+                    backgroundColor: Colors.white24,
+                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.blueAccent),
+                    minHeight: 6,
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:math';
 import 'dart:convert';
+import 'xp_tracker_service.dart';
 import '../screens/progress_screen.dart';
 import '../models/goal_progress_entry.dart';
 import '../models/drill_session_result.dart';
@@ -391,6 +392,7 @@ class GoalsService extends ChangeNotifier {
       if (!_achievementShown[i] && _achievements[i].completed) {
         _achievementShown[i] = true;
         _saveAchievementShown(i);
+        context.read<XPTrackerService>().addXp(XPTrackerService.achievementXp);
         if (context.mounted) {
           showAchievementUnlockedOverlay(
               context, _achievements[i].icon, _achievements[i].title);

--- a/lib/services/streak_counter_service.dart
+++ b/lib/services/streak_counter_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'training_stats_service.dart';
 import 'daily_target_service.dart';
+import 'xp_tracker_service.dart';
 
 class StreakCounterService extends ChangeNotifier {
   static const _countKey = 'target_streak_count';
@@ -11,6 +12,7 @@ class StreakCounterService extends ChangeNotifier {
 
   final TrainingStatsService stats;
   final DailyTargetService target;
+  final XPTrackerService xp;
 
   int _count = 0;
   DateTime? _last;
@@ -24,7 +26,7 @@ class StreakCounterService extends ChangeNotifier {
   DateTime? get lastSuccess => _last;
   int get max => _max;
 
-  StreakCounterService({required this.stats, required this.target}) {
+  StreakCounterService({required this.stats, required this.target, required this.xp}) {
     _init();
   }
 
@@ -81,6 +83,7 @@ class StreakCounterService extends ChangeNotifier {
     if (hands >= target.target && (_last == null || !_isSameDay(_last!, today))) {
       _last = today;
       await _save();
+      await xp.addXp(XPTrackerService.targetXp);
     }
   }
 

--- a/lib/services/xp_tracker_service.dart
+++ b/lib/services/xp_tracker_service.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class XPTrackerService extends ChangeNotifier {
+  static const _xpKey = 'xp_total';
+  static const targetXp = 10;
+  static const achievementXp = 50;
+
+  int _xp = 0;
+
+  int get xp => _xp;
+  int get level => _xp ~/ 100 + 1;
+  int get nextLevelXp => level * 100;
+  double get progress => (_xp % 100) / 100;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _xp = prefs.getInt(_xpKey) ?? 0;
+    notifyListeners();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_xpKey, _xp);
+  }
+
+  Future<void> addXp(int value) async {
+    _xp += value;
+    await _save();
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `XPTrackerService`
- update `StreakCounterService` to award XP when daily target met
- record XP for achievements in `GoalsService`
- provide service in `main.dart`
- display XP level progress in `GoalOverviewScreen`

## Testing
- `dart pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685c816b9758832ab71e75d921cd67db