### PR TITLE
Add daily tip service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'services/reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/daily_target_service.dart';
+import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
@@ -58,6 +59,7 @@ void main() {
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
+        ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
         ChangeNotifierProvider(create: (_) => XPTrackerService()..load()),
         ChangeNotifierProvider(
           create: (context) => StreakCounterService(

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -6,12 +6,25 @@ import '../services/streak_service.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../services/xp_tracker_service.dart';
+import '../services/daily_tip_service.dart';
 import '../theme/app_colors.dart';
 import 'daily_progress_history_screen.dart';
 import 'achievements_screen.dart';
 
-class GoalOverviewScreen extends StatelessWidget {
+class GoalOverviewScreen extends StatefulWidget {
   const GoalOverviewScreen({super.key});
+
+  @override
+  State<GoalOverviewScreen> createState() => _GoalOverviewScreenState();
+}
+
+class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<DailyTipService>().ensureTodayTip();
+  }
 
   Color _color(int count, int target) {
     if (count >= target) return Colors.greenAccent;
@@ -25,6 +38,7 @@ class GoalOverviewScreen extends StatelessWidget {
     final stats = context.watch<TrainingStatsService>();
     final targetService = context.watch<DailyTargetService>();
     final xpService = context.watch<XPTrackerService>();
+    final tip = context.watch<DailyTipService>().tip;
     final streak = streakService.count;
     final history = streakService.history;
     final maxStreak = history.isEmpty
@@ -65,6 +79,35 @@ class GoalOverviewScreen extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          if (tip.isNotEmpty)
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.lightbulb, color: Colors.greenAccent),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Tip of the Day',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(tip, style: const TextStyle(color: Colors.white)),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          if (tip.isNotEmpty) const SizedBox(height: 16),
           Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(

--- a/lib/services/daily_tip_service.dart
+++ b/lib/services/daily_tip_service.dart
@@ -1,0 +1,60 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DailyTipService extends ChangeNotifier {
+  static const _indexKey = 'daily_tip_index';
+  static const _dateKey = 'daily_tip_date';
+
+  static const _tips = [
+    'Review your big hands after each session.',
+    'Stay patient and wait for good spots.',
+    'Focus on playing in position.',
+    'Manage your bankroll wisely.',
+    'Take breaks to avoid tilt.',
+    'Study opponents\' tendencies.',
+    "Don't bluff too often.",
+    'Keep emotions in check.',
+    'Analyze your mistakes regularly.',
+    'Stay disciplined with starting hands.'
+  ];
+
+  String _tip = '';
+  DateTime? _date;
+
+  String get tip => _tip;
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final index = prefs.getInt(_indexKey);
+    final dateStr = prefs.getString(_dateKey);
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    if (index != null && _date != null && _sameDay(_date!, DateTime.now())) {
+      if (index >= 0 && index < _tips.length) {
+        _tip = _tips[index];
+      }
+    } else {
+      await _select();
+    }
+    notifyListeners();
+  }
+
+  Future<void> _select() async {
+    final rnd = Random().nextInt(_tips.length);
+    _tip = _tips[rnd];
+    _date = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_indexKey, rnd);
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+  }
+
+  Future<void> ensureTodayTip() async {
+    if (_date == null || !_sameDay(_date!, DateTime.now())) {
+      await _select();
+      notifyListeners();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DailyTipService`
- show tip of the day in goal overview
- register service in provider setup

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c842d5d1c832aa04fdbc2963d4b31