### PR TITLE
Add categorized daily tips

### DIFF
--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -38,7 +38,10 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
     final stats = context.watch<TrainingStatsService>();
     final targetService = context.watch<DailyTargetService>();
     final xpService = context.watch<XPTrackerService>();
-    final tip = context.watch<DailyTipService>().tip;
+    final tipService = context.watch<DailyTipService>();
+    final tip = tipService.tip;
+    final category = tipService.category;
+    final categories = tipService.categories;
     final streak = streakService.count;
     final history = streakService.history;
     final maxStreak = history.isEmpty
@@ -95,9 +98,25 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
-                          'Tip of the Day',
-                          style: TextStyle(fontWeight: FontWeight.bold),
+                        Row(
+                          children: [
+                            const Text(
+                              'Tip of the Day',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(width: 8),
+                            DropdownButton<String>(
+                              value: category,
+                              dropdownColor: const Color(0xFF2A2B2E),
+                              underline: const SizedBox(),
+                              onChanged: (v) =>
+                                  context.read<DailyTipService>().setCategory(v!),
+                              items: categories
+                                  .map((c) =>
+                                      DropdownMenuItem(value: c, child: Text(c)))
+                                  .toList(),
+                            ),
+                          ],
                         ),
                         const SizedBox(height: 4),
                         Text(tip, style: const TextStyle(color: Colors.white)),

--- a/lib/services/daily_tip_service.dart
+++ b/lib/services/daily_tip_service.dart
@@ -1,60 +1,115 @@
+import 'dart:convert';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class DailyTipService extends ChangeNotifier {
-  static const _indexKey = 'daily_tip_index';
-  static const _dateKey = 'daily_tip_date';
+  static const _dataKey = 'daily_tip_data';
+  static const _categoryKey = 'daily_tip_category';
 
-  static const _tips = [
-    'Review your big hands after each session.',
-    'Stay patient and wait for good spots.',
-    'Focus on playing in position.',
-    'Manage your bankroll wisely.',
-    'Take breaks to avoid tilt.',
-    'Study opponents\' tendencies.',
-    "Don't bluff too often.",
-    'Keep emotions in check.',
-    'Analyze your mistakes regularly.',
-    'Stay disciplined with starting hands.'
-  ];
+  static const Map<String, List<String>> _tips = {
+    'Strategy': [
+      'Review your big hands after each session.',
+      'Focus on playing in position.',
+      'Study opponents\' tendencies.',
+      "Don't bluff too often.",
+      'Analyze your mistakes regularly.'
+    ],
+    'Discipline': [
+      'Stay patient and wait for good spots.',
+      'Manage your bankroll wisely.',
+      'Take breaks to avoid tilt.',
+      'Keep emotions in check.',
+      'Stay disciplined with starting hands.'
+    ],
+    'Motivation': [
+      'Believe in your edge and stay confident.',
+      'Small improvements lead to big wins.',
+      'Stick to your plan and keep grinding.',
+      'Every session is a chance to learn.',
+      'Focus on progress, not perfection.'
+    ]
+  };
 
+  final Map<String, int> _indexes = {};
+  final Map<String, DateTime> _dates = {};
+  String _category = 'Strategy';
   String _tip = '';
-  DateTime? _date;
 
+  List<String> get categories => List.unmodifiable(_tips.keys);
   String get tip => _tip;
+  String get category => _category;
 
   bool _sameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
-    final index = prefs.getInt(_indexKey);
-    final dateStr = prefs.getString(_dateKey);
-    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
-    if (index != null && _date != null && _sameDay(_date!, DateTime.now())) {
-      if (index >= 0 && index < _tips.length) {
-        _tip = _tips[index];
-      }
-    } else {
-      await _select();
+    _category = prefs.getString(_categoryKey) ?? _category;
+    final raw = prefs.getString(_dataKey);
+    if (raw != null) {
+      try {
+        final map = jsonDecode(raw) as Map<String, dynamic>;
+        for (final e in map.entries) {
+          final m = e.value;
+          if (m is Map) {
+            final i = m['i'];
+            final d = m['d'];
+            if (i is int) _indexes[e.key] = i;
+            if (d is String) {
+              final dt = DateTime.tryParse(d);
+              if (dt != null) _dates[e.key] = dt;
+            }
+          }
+        }
+      } catch (_) {}
     }
+    await ensureTodayTip();
     notifyListeners();
   }
 
-  Future<void> _select() async {
-    final rnd = Random().nextInt(_tips.length);
-    _tip = _tips[rnd];
-    _date = DateTime.now();
+  Future<void> _save() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_indexKey, rnd);
-    await prefs.setString(_dateKey, _date!.toIso8601String());
+    final data = {
+      for (final c in _indexes.keys)
+        c: {
+          'i': _indexes[c],
+          'd': _dates[c]?.toIso8601String(),
+        }
+    };
+    await prefs.setString(_dataKey, jsonEncode(data));
+    await prefs.setString(_categoryKey, _category);
+  }
+
+  Future<void> _select(String cat) async {
+    final list = _tips[cat]!;
+    final rnd = Random().nextInt(list.length);
+    _indexes[cat] = rnd;
+    _dates[cat] = DateTime.now();
+    _tip = list[rnd];
+    await _save();
   }
 
   Future<void> ensureTodayTip() async {
-    if (_date == null || !_sameDay(_date!, DateTime.now())) {
-      await _select();
-      notifyListeners();
+    final cat = _category;
+    final idx = _indexes[cat];
+    final date = _dates[cat];
+    final list = _tips[cat]!;
+    if (idx != null && date != null && _sameDay(date, DateTime.now())) {
+      if (idx >= 0 && idx < list.length) {
+        _tip = list[idx];
+        return;
+      }
     }
+    await _select(cat);
+    notifyListeners();
+  }
+
+  Future<void> setCategory(String cat) async {
+    if (!_tips.containsKey(cat) || _category == cat) return;
+    _category = cat;
+    await ensureTodayTip();
+    await _save();
+    notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- support multiple tip categories with DailyTipService
- allow users to select tip category on GoalOverviewScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c86d863ec832a9857cf835cab5dbf