### PR TITLE
Add weekly challenge service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'services/drill_suggestion_engine.dart';
 import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
+import 'services/weekly_challenge_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 
@@ -61,6 +62,11 @@ void main() {
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
         ChangeNotifierProvider(create: (_) => XPTrackerService()..load()),
+        ChangeNotifierProvider(
+          create: (context) => WeeklyChallengeService(
+            stats: context.read<TrainingStatsService>(),
+          )..load(),
+        ),
         ChangeNotifierProvider(
           create: (context) => StreakCounterService(
             stats: context.read<TrainingStatsService>(),

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -7,6 +7,7 @@ import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../services/xp_tracker_service.dart';
 import '../services/daily_tip_service.dart';
+import '../services/weekly_challenge_service.dart';
 import '../theme/app_colors.dart';
 import 'daily_progress_history_screen.dart';
 import 'achievements_screen.dart';
@@ -38,6 +39,7 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
     final stats = context.watch<TrainingStatsService>();
     final targetService = context.watch<DailyTargetService>();
     final xpService = context.watch<XPTrackerService>();
+    final challengeService = context.watch<WeeklyChallengeService>();
     final tipService = context.watch<DailyTipService>();
     final tip = tipService.tip;
     final category = tipService.category;
@@ -52,6 +54,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
     final start = DateTime(now.year, now.month, now.day)
         .subtract(const Duration(days: 6));
     final days = [for (var i = 0; i < 7; i++) start.add(Duration(days: i))];
+    final challenge = challengeService.current;
+    final challengeProgress = challengeService.progressValue;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Goal'),
@@ -168,6 +172,34 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                     minHeight: 6,
                   ),
                 ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(challenge.title,
+                    style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 8),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: challengeService.progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.greenAccent),
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text('${challengeProgress}/${challenge.target}',
+                    style: const TextStyle(color: Colors.white70)),
               ],
             ),
           ),

--- a/lib/services/weekly_challenge_service.dart
+++ b/lib/services/weekly_challenge_service.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'training_stats_service.dart';
+
+class WeeklyChallenge {
+  final String title;
+  final String type;
+  final int target;
+  const WeeklyChallenge(this.title, this.type, this.target);
+}
+
+class WeeklyChallengeService extends ChangeNotifier {
+  static const _indexKey = 'weekly_challenge_index';
+  static const _startKey = 'weekly_challenge_start';
+  static const _handsKey = 'weekly_challenge_base_hands';
+  static const _mistakesKey = 'weekly_challenge_base_mistakes';
+
+  final TrainingStatsService stats;
+  WeeklyChallengeService({required this.stats});
+
+  static const _challenges = [
+    WeeklyChallenge('Tag 5 mistakes', 'mistakes', 5),
+    WeeklyChallenge('Play 100 hands', 'hands', 100),
+  ];
+
+  int _index = 0;
+  DateTime _start = DateTime.now();
+  int _baseHands = 0;
+  int _baseMistakes = 0;
+
+  WeeklyChallenge get current => _challenges[_index];
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _index = prefs.getInt(_indexKey) ?? 0;
+    final startStr = prefs.getString(_startKey);
+    _start = startStr != null ? DateTime.tryParse(startStr) ?? DateTime.now() : DateTime.now();
+    _baseHands = prefs.getInt(_handsKey) ?? stats.handsReviewed;
+    _baseMistakes = prefs.getInt(_mistakesKey) ?? stats.mistakesFixed;
+    _rotate();
+    stats.handsStream.listen((_) => _onStats());
+    stats.mistakesStream.listen((_) => _onStats());
+    notifyListeners();
+  }
+
+  int get progressValue {
+    _rotate();
+    switch (current.type) {
+      case 'hands':
+        return stats.handsReviewed - _baseHands;
+      default:
+        return stats.mistakesFixed - _baseMistakes;
+    }
+  }
+
+  double get progress => (progressValue / current.target).clamp(0.0, 1.0);
+
+  void _onStats() {
+    _rotate();
+    notifyListeners();
+  }
+
+  bool _rotate() {
+    final now = DateTime.now();
+    if (now.difference(_start).inDays >= 7) {
+      _index = (_index + 1) % _challenges.length;
+      _start = DateTime(now.year, now.month, now.day);
+      _baseHands = stats.handsReviewed;
+      _baseMistakes = stats.mistakesFixed;
+      _save();
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_indexKey, _index);
+    await prefs.setString(_startKey, _start.toIso8601String());
+    await prefs.setInt(_handsKey, _baseHands);
+    await prefs.setInt(_mistakesKey, _baseMistakes);
+  }
+}


### PR DESCRIPTION
## Summary
- create `WeeklyChallengeService` for rotating weekly tasks
- register the service in `main.dart`
- show challenge progress in `GoalOverviewScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8870c5b0832ab4d621ae9f91edd4