### PR TITLE
Add chart sort dropdown

### DIFF
--- a/lib/models/pack_chart_sort_option.dart
+++ b/lib/models/pack_chart_sort_option.dart
@@ -1,0 +1,15 @@
+enum PackChartSort { progress, lastSession, handsPlayed }
+
+extension PackChartSortLabel on PackChartSort {
+  String get label {
+    switch (this) {
+      case PackChartSort.lastSession:
+        return 'Последняя сессия';
+      case PackChartSort.handsPlayed:
+        return 'Кол-во рук';
+      case PackChartSort.progress:
+      default:
+        return 'Прогресс %';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `PackChartSort` enum for chart sorting
- sort the bar chart based on user selection
- add dropdown menu to `TrainingPackComparisonScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0be7f628832abe4f73642405c7e6