### PR TITLE
Add Next Step block for training packs

### DIFF
--- a/lib/widgets/pack_next_step_card.dart
+++ b/lib/widgets/pack_next_step_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../models/training_pack.dart';
+import '../screens/training_pack_review_screen.dart';
+import '../theme/app_colors.dart';
+
+class PackNextStepCard extends StatelessWidget {
+  final TrainingPack pack;
+  final double progress;
+  const PackNextStepCard({super.key, required this.pack, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final percent = (progress.clamp(0.0, 1.0) * 100).round();
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.flag, color: Colors.lightGreenAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(pack.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: progress.clamp(0.0, 1.0),
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation<Color>(accent),
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text('$percent%', style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => TrainingPackReviewScreen(pack: pack)),
+              );
+            },
+            child: const Text('Продолжить'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- display motivational card with least completed pack in TrainingPackComparisonScreen
- add PackNextStepCard widget

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d0ce7fd58832aae3443573125013c