### PR TITLE
Add game type field to training packs

### DIFF
--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -38,6 +38,7 @@ class TrainingPack {
   final String name;
   final String description;
   final String category;
+  final String gameType;
   final List<SavedHand> hands;
   final List<TrainingSessionResult> history;
 
@@ -45,6 +46,7 @@ class TrainingPack {
     required this.name,
     required this.description,
     this.category = 'Uncategorized',
+    this.gameType = 'Cash Game',
     required this.hands,
     List<TrainingSessionResult>? history,
   }) : history = history ?? [];
@@ -53,6 +55,7 @@ class TrainingPack {
         'name': name,
         'description': description,
         'category': category,
+        'gameType': gameType,
         'hands': [for (final h in hands) h.toJson()],
         'history': [for (final r in history) r.toJson()],
       };
@@ -61,6 +64,7 @@ class TrainingPack {
         name: json['name'] as String? ?? '',
         description: json['description'] as String? ?? '',
         category: json['category'] as String? ?? 'Uncategorized',
+        gameType: json['gameType'] as String? ?? 'Cash Game',
         hands: [
           for (final h in (json['hands'] as List? ?? []))
             SavedHand.fromJson(h as Map<String, dynamic>)

--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -882,6 +882,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
               name: newName,
               description: newDescription,
               category: p.category,
+              gameType: p.gameType,
               hands: p.hands,
               history: p.history,
             );
@@ -905,6 +906,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
           name: newName,
           description: newDescription,
           category: oldPack.category,
+          gameType: oldPack.gameType,
           hands: oldPack.hands,
           history: oldPack.history,
         );
@@ -1037,6 +1039,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
             if (pack.description.isNotEmpty) Text(pack.description),
             const SizedBox(height: 8),
             Text('Категория: ${pack.category}'),
+            Text('Тип: ${pack.gameType}'),
             Text('Кол-во рук: ${pack.hands.length}'),
             Text('Всего сессий: ${pack.history.length}'),
             Text('Средний % верных: ${avg.toStringAsFixed(0)}%'),

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -260,6 +260,7 @@ class _CloudTrainingSessionDetailsScreenState
     final pack = TrainingPack(
       name: 'Повторение',
       description: '',
+      gameType: 'Cash Game',
       hands: hands,
     );
     await Navigator.push(
@@ -292,6 +293,7 @@ class _CloudTrainingSessionDetailsScreenState
     final pack = TrainingPack(
       name: 'Повторение ошибок',
       description: '',
+      gameType: 'Cash Game',
       hands: hands,
     );
     await Navigator.push(

--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -18,6 +18,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
   final TextEditingController _categoryController = TextEditingController();
+  String _gameType = 'Cash Game';
   final TrainingSpotFileService _spotFileService = const TrainingSpotFileService();
   List<TrainingSpot> _spots = [];
   final GlobalKey<TrainingSpotListState> _spotListKey =
@@ -31,6 +32,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
       _nameController.text = pack.name;
       _descriptionController.text = pack.description;
       _categoryController.text = pack.category;
+      _gameType = pack.gameType;
     }
   }
 
@@ -42,6 +44,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
       name: name,
       description: _descriptionController.text.trim(),
       category: category.isEmpty ? 'Uncategorized' : category,
+      gameType: _gameType,
       hands: widget.initialPack?.hands ?? const [],
     );
     Navigator.pop(context, pack);
@@ -99,6 +102,21 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
                 labelStyle: TextStyle(color: Colors.white),
                 border: OutlineInputBorder(),
               ),
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _gameType,
+              decoration: const InputDecoration(
+                labelText: 'Тип игры',
+                labelStyle: TextStyle(color: Colors.white),
+                border: OutlineInputBorder(),
+              ),
+              dropdownColor: const Color(0xFF3A3B3E),
+              items: const [
+                DropdownMenuItem(value: 'Tournament', child: Text('Tournament')),
+                DropdownMenuItem(value: 'Cash Game', child: Text('Cash Game')),
+              ],
+              onChanged: (v) => setState(() => _gameType = v ?? 'Cash Game'),
             ),
             const SizedBox(height: 24),
             ElevatedButton(

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -476,6 +476,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
           name: updated.name,
           description: updated.description,
           category: updated.category,
+          gameType: updated.gameType,
           hands: _pack.hands,
         );
       });
@@ -1367,17 +1368,35 @@ body { font-family: sans-serif; padding: 16px; }
           const SizedBox(height: 8),
           Align(
             alignment: Alignment.centerLeft,
-            child: Container(
-              margin: const EdgeInsets.symmetric(horizontal: 16),
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              decoration: BoxDecoration(
-                color: const Color(0xFF3A3B3E),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                _pack.category,
-                style: const TextStyle(color: Colors.white70),
-              ),
+            child: Row(
+              children: [
+                Container(
+                  margin: const EdgeInsets.symmetric(horizontal: 16),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF3A3B3E),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    _pack.category,
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+                Container(
+                  margin: const EdgeInsets.only(right: 16),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF3A3B3E),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    _pack.gameType,
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+              ],
             ),
           ),
           const SizedBox(height: 8),

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -20,6 +20,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
   final TextEditingController _searchController = TextEditingController();
 
   bool _hideCompleted = false;
+  String _typeFilter = 'All';
   SharedPreferences? _prefs;
 
   @override
@@ -70,6 +71,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
         ? [for (final p in packs) if (!_isPackCompleted(p)) p]
         : packs;
 
+    if (_typeFilter != 'All') {
+      visible = [for (final p in visible) if (p.gameType == _typeFilter) p];
+    }
+
     final query = _searchController.text.toLowerCase();
     if (query.isNotEmpty) {
       visible = [
@@ -101,6 +106,19 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
             ),
           ),
           Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: DropdownButton<String>(
+              value: _typeFilter,
+              underline: const SizedBox.shrink(),
+              onChanged: (v) => setState(() => _typeFilter = v ?? 'All'),
+              items: const [
+                DropdownMenuItem(value: 'All', child: Text('Все')),
+                DropdownMenuItem(value: 'Tournament', child: Text('Tournament')),
+                DropdownMenuItem(value: 'Cash Game', child: Text('Cash Game')),
+              ],
+            ),
+          ),
+          Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Align(
               alignment: Alignment.centerLeft,
@@ -127,7 +145,11 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                       final completed = _isPackCompleted(pack);
                       return ListTile(
                         title: Text(pack.name),
-                        subtitle: Text(pack.description),
+                        subtitle: Text(
+                          pack.description.isEmpty
+                              ? pack.gameType
+                              : '${pack.description} • ${pack.gameType}',
+                        ),
                         trailing: completed
                             ? const Icon(Icons.check, color: Colors.green)
                             : null,

--- a/lib/services/drill_suggestion_engine.dart
+++ b/lib/services/drill_suggestion_engine.dart
@@ -57,6 +57,7 @@ class DrillSuggestionEngine extends ChangeNotifier {
     return TrainingPack(
       name: '${d.position} ${d.street}',
       description: 'Drill',
+      gameType: 'Cash Game',
       hands: hands,
     );
   }

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -103,6 +103,7 @@ class TrainingPackStorageService extends ChangeNotifier {
           name: name,
           description: pack.description,
           category: pack.category,
+          gameType: pack.gameType,
           hands: pack.hands,
           history: pack.history,
         );
@@ -125,6 +126,7 @@ class TrainingPackStorageService extends ChangeNotifier {
       name: trimmed,
       description: pack.description,
       category: pack.category,
+      gameType: pack.gameType,
       hands: pack.hands,
       history: pack.history,
     );


### PR DESCRIPTION
## Summary
- categorize TrainingPack with a new `gameType` field
- update creation screen with game type dropdown
- display game type in pack screens and session details
- filter packs by game type
- preserve game type across storage and utilities

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d126a4b18832a84b0ba42257d10bc