### PR TITLE
Add template revision info

### DIFF
--- a/assets/training_templates/default_cash_template.json
+++ b/assets/training_templates/default_cash_template.json
@@ -3,8 +3,11 @@
   "name": "Default Cash Template",
   "gameType": "Cash Game",
   "description": "Basic cash game spots",
-  "version": "1.0",
+  "version": "1.0.0",
   "author": "Poker Analyzer",
+  "revision": 1,
+  "createdAt": "2024-01-01T00:00:00.000",
+  "updatedAt": "2024-01-01T00:00:00.000",
   "isBuiltIn": true,
   "hands": [
     {

--- a/assets/training_templates/default_tournament_template.json
+++ b/assets/training_templates/default_tournament_template.json
@@ -3,8 +3,11 @@
   "name": "Default Tournament Template",
   "gameType": "Tournament",
   "description": "Basic tournament spots",
-  "version": "1.0",
+  "version": "1.0.0",
   "author": "Poker Analyzer",
+  "revision": 1,
+  "createdAt": "2024-01-01T00:00:00.000",
+  "updatedAt": "2024-01-01T00:00:00.000",
   "isBuiltIn": true,
   "hands": [
     {

--- a/lib/models/training_pack_template.dart
+++ b/lib/models/training_pack_template.dart
@@ -6,8 +6,15 @@ class TrainingPackTemplate {
   final String gameType;
   final String description;
   final List<SavedHand> hands;
+  /// семантическая версия шаблона (major.minor.patch)
   final String version;
+  /// имя или ник автора шаблона
   final String author;
+  /// уникальная ревизия (монотонно увеличивается, служит для обновлений)
+  final int revision;
+  /// дата создания и последнего обновления
+  final DateTime createdAt;
+  final DateTime updatedAt;
   final bool isBuiltIn;
 
   TrainingPackTemplate({
@@ -16,10 +23,14 @@ class TrainingPackTemplate {
     required this.gameType,
     required this.description,
     required this.hands,
-    this.version = '1.0',
+    this.version = '1.0.0',
     this.author = '',
+    this.revision = 1,
+    DateTime? createdAt,
+    DateTime? updatedAt,
     this.isBuiltIn = false,
-  });
+  })  : createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -29,6 +40,9 @@ class TrainingPackTemplate {
         'hands': [for (final h in hands) h.toJson()],
         'version': version,
         'author': author,
+        'revision': revision,
+        'createdAt': createdAt.toIso8601String(),
+        'updatedAt': updatedAt.toIso8601String(),
         'isBuiltIn': isBuiltIn,
       };
 
@@ -42,8 +56,11 @@ class TrainingPackTemplate {
         for (final h in (json['hands'] as List? ?? []))
           SavedHand.fromJson(Map<String, dynamic>.from(h))
       ],
-      version: json['version'] as String? ?? '1.0',
+      version: json['version'] as String? ?? '1.0.0',
       author: json['author'] as String? ?? '',
+      revision: json['revision'] as int? ?? 1,
+      createdAt: DateTime.tryParse(json['createdAt'] ?? '') ?? DateTime.now(),
+      updatedAt: DateTime.tryParse(json['updatedAt'] ?? '') ?? DateTime.now(),
       isBuiltIn: json['isBuiltIn'] as bool? ?? false,
     );
   }

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -61,8 +61,9 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setStateDialog) {
           final templates = [
-            for (final t in templateService.templates)
-              if (t.gameType == type) t
+            for (final t in templateService.templates
+                .where((tpl) => tpl.gameType == type))
+              t
           ];
           return AlertDialog(
             title: const Text('Шаблоны'),
@@ -82,6 +83,8 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                   for (final t in templates)
                     ListTile(
                       title: Text(t.name),
+                      subtitle: Text(
+                          'v${t.version} • rev ${t.revision} • ${t.author.isEmpty ? "anon" : t.author}'),
                       onTap: () {
                         selected = t;
                         Navigator.pop(ctx);

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -22,6 +22,12 @@ class TemplateStorageService extends ChangeNotifier {
           _templates.add(TrainingPackTemplate.fromJson(data));
         }
       }
+      // сортируем по type → revision ↓ → name
+      _templates.sort((a, b) {
+        if (a.gameType != b.gameType) return a.gameType.compareTo(b.gameType);
+        final rev = b.revision.compareTo(a.revision);
+        return rev == 0 ? a.name.compareTo(b.name) : rev;
+      });
     } catch (_) {}
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- store version history in `TrainingPackTemplate`
- order templates by type and revision
- show template info when selecting packs
- include revision data in built-in templates

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1fd68594832abd81ac83e3f89c9f