### PR TITLE
Add custom template import

### DIFF
--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -102,6 +102,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     }
   }
 
+  Future<void> _importTemplate() async {
+    await context.read<TemplateStorageService>().importTemplateFromFile();
+  }
+
   bool _isPackCompleted(TrainingPack pack) {
     final progress = _prefs?.getInt('training_progress_${pack.name}') ?? 0;
     return progress >= pack.hands.length;
@@ -227,6 +231,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                   ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _importTemplate,
+        child: const Icon(Icons.upload),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- support importing training pack templates from JSON files
- allow importing templates via a FAB on training packs screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d20bdf294832a94e232f96f3417e9