### PR TITLE
Add template library screen

### DIFF
--- a/lib/screens/create_template_screen.dart
+++ b/lib/screens/create_template_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/training_pack_template.dart';
+
+class CreateTemplateScreen extends StatefulWidget {
+  const CreateTemplateScreen({super.key});
+
+  @override
+  State<CreateTemplateScreen> createState() => _CreateTemplateScreenState();
+}
+
+class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _descController = TextEditingController();
+  String _gameType = 'Cash Game';
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    final template = TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: name,
+      gameType: _gameType,
+      description: _descController.text.trim(),
+      hands: const [],
+      isBuiltIn: false,
+    );
+    Navigator.pop(context, template);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Новый шаблон'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Название'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _descController,
+              decoration: const InputDecoration(labelText: 'Описание'),
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _gameType,
+              decoration: const InputDecoration(labelText: 'Тип игры'),
+              items: const [
+                DropdownMenuItem(value: 'Tournament', child: Text('Tournament')),
+                DropdownMenuItem(value: 'Cash Game', child: Text('Cash Game')),
+              ],
+              onChanged: (v) => setState(() => _gameType = v ?? 'Cash Game'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Сохранить'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -13,6 +13,7 @@ import 'daily_hand_screen.dart';
 import 'spot_of_the_day_screen.dart';
 import 'create_pack_screen.dart';
 import 'edit_pack_screen.dart';
+import 'template_library_screen.dart';
 import 'training_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/hand_history_file_service.dart';
@@ -623,6 +624,18 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('✏️ Редактировать тренировку'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TemplateLibraryScreen(),
+                  ),
+                );
+              },
+              child: const Text('📑 Шаблоны'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_pack_template.dart';
+import '../services/template_storage_service.dart';
+
+import 'create_template_screen.dart';
+
+class TemplateLibraryScreen extends StatefulWidget {
+  const TemplateLibraryScreen({super.key});
+
+  @override
+  State<TemplateLibraryScreen> createState() => _TemplateLibraryScreenState();
+}
+
+class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  String _typeFilter = 'All';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _deleteTemplate(TrainingPackTemplate t) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Удалить шаблон «${t.name}»?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      context.read<TemplateStorageService>().removeTemplate(t);
+    }
+  }
+
+  Future<void> _importTemplate() async {
+    await context.read<TemplateStorageService>().importTemplateFromFile();
+  }
+
+  Future<void> _createTemplate() async {
+    final template = await Navigator.push<TrainingPackTemplate>(
+      context,
+      MaterialPageRoute(builder: (_) => const CreateTemplateScreen()),
+    );
+    if (template != null) {
+      context.read<TemplateStorageService>().addTemplate(template);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final templates = context.watch<TemplateStorageService>().templates;
+    List<TrainingPackTemplate> visible = [...templates];
+    visible.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    if (_typeFilter != 'All') {
+      visible = [for (final t in visible) if (t.gameType == _typeFilter) t];
+    }
+    final query = _searchController.text.toLowerCase();
+    if (query.isNotEmpty) {
+      visible = [
+        for (final t in visible)
+          if (t.name.toLowerCase().contains(query) ||
+              t.description.toLowerCase().contains(query))
+            t
+      ];
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Шаблоны тренировок'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(hintText: 'Поиск'),
+              onChanged: (_) => setState(() {}),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: DropdownButton<String>(
+              value: _typeFilter,
+              underline: const SizedBox.shrink(),
+              onChanged: (v) => setState(() => _typeFilter = v ?? 'All'),
+              items: const [
+                DropdownMenuItem(value: 'All', child: Text('Все')),
+                DropdownMenuItem(value: 'Tournament', child: Text('Tournament')),
+                DropdownMenuItem(value: 'Cash Game', child: Text('Cash Game')),
+              ],
+            ),
+          ),
+          Expanded(
+            child: visible.isEmpty
+                ? const Center(child: Text('Нет шаблонов'))
+                : ListView.builder(
+                    itemCount: visible.length,
+                    itemBuilder: (context, index) {
+                      final t = visible[index];
+                      return ListTile(
+                        leading: t.isBuiltIn ? const Text('📦') : null,
+                        title: Text(t.name),
+                        subtitle: Text(
+                          '${t.gameType} • ${t.author.isEmpty ? 'anon' : t.author}',
+                        ),
+                        onLongPress:
+                            t.isBuiltIn ? null : () => _deleteTemplate(t),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton(
+            heroTag: 'import',
+            onPressed: _importTemplate,
+            child: const Icon(Icons.upload),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton(
+            heroTag: 'create',
+            onPressed: _createTemplate,
+            child: const Icon(Icons.add),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -3,9 +3,8 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/training_pack.dart';
-import '../models/training_pack_template.dart';
 import '../services/training_pack_storage_service.dart';
-import '../services/template_storage_service.dart';
+import 'template_library_screen.dart';
 import 'training_pack_screen.dart';
 import 'training_pack_comparison_screen.dart';
 
@@ -51,60 +50,6 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     await prefs.setBool(_hideKey, value);
   }
 
-  Future<void> _createFromTemplate() async {
-    final packService = context.read<TrainingPackStorageService>();
-    final templateService = context.read<TemplateStorageService>();
-    String type = 'Tournament';
-    TrainingPackTemplate? selected;
-    await showDialog<void>(
-      context: context,
-      builder: (ctx) => StatefulBuilder(
-        builder: (ctx, setStateDialog) {
-          final templates = [
-            for (final t in templateService.templates
-                .where((tpl) => tpl.gameType == type))
-              t
-          ];
-          return AlertDialog(
-            title: const Text('Шаблоны'),
-            content: SizedBox(
-              width: double.maxFinite,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  DropdownButton<String>(
-                    value: type,
-                    onChanged: (v) => setStateDialog(() => type = v ?? 'Tournament'),
-                    items: const [
-                      DropdownMenuItem(value: 'Tournament', child: Text('Tournament')),
-                      DropdownMenuItem(value: 'Cash Game', child: Text('Cash Game')),
-                    ],
-                  ),
-                  for (final t in templates)
-                    ListTile(
-                      title: Text(t.name),
-                      subtitle: Text(
-                          'v${t.version} • rev ${t.revision} • ${t.author.isEmpty ? "anon" : t.author}'),
-                      onTap: () {
-                        selected = t;
-                        Navigator.pop(ctx);
-                      },
-                    ),
-                ],
-              ),
-            ),
-          );
-        },
-      ),
-    );
-    if (selected != null) {
-      await packService.createFromTemplate(selected!);
-    }
-  }
-
-  Future<void> _importTemplate() async {
-    await context.read<TemplateStorageService>().importTemplateFromFile();
-  }
 
   bool _isPackCompleted(TrainingPack pack) {
     final progress = _prefs?.getInt('training_progress_${pack.name}') ?? 0;
@@ -192,8 +137,15 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                 ),
                 const SizedBox(width: 12),
                 ElevatedButton(
-                  onPressed: _createFromTemplate,
-                  child: const Text('✚ Создать из шаблона'),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const TemplateLibraryScreen(),
+                      ),
+                    );
+                  },
+                  child: const Text('📑 Шаблоны'),
                 ),
               ],
             ),
@@ -232,10 +184,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _importTemplate,
-        child: const Icon(Icons.upload),
-      ),
+      floatingActionButton: null,
     );
   }
 }

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -11,6 +11,17 @@ class TemplateStorageService extends ChangeNotifier {
   final List<TrainingPackTemplate> _templates = [];
   List<TrainingPackTemplate> get templates => List.unmodifiable(_templates);
 
+  void addTemplate(TrainingPackTemplate template) {
+    _templates.add(template);
+    notifyListeners();
+  }
+
+  void removeTemplate(TrainingPackTemplate template) {
+    if (template.isBuiltIn) return;
+    _templates.remove(template);
+    notifyListeners();
+  }
+
   Future<void> load() async {
     try {
       final manifest =


### PR DESCRIPTION
## Summary
- add TemplateLibraryScreen with search and filters
- add CreateTemplateScreen to make templates
- support adding and removing templates
- link TemplateLibrary from TrainingPacksScreen and MainMenu
- remove template UI from TrainingPacksScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d29c57488832a9f2deb7287840fa3