### PR TITLE
Implement template import duplicate check

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -46,7 +46,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   }
 
   Future<void> _importTemplate() async {
-    await context.read<TemplateStorageService>().importTemplateFromFile();
+    await context.read<TemplateStorageService>().importTemplateFromFile(context);
   }
 
   Future<void> _createTemplate() async {

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:file_picker/file_picker.dart';
+import 'package:uuid/uuid.dart';
 import 'dart:io';
 
 import '../models/training_pack_template.dart';
@@ -45,7 +47,7 @@ class TemplateStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<TrainingPackTemplate?> importTemplateFromFile() async {
+  Future<TrainingPackTemplate?> importTemplateFromFile(BuildContext context) async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['json'],
@@ -59,12 +61,127 @@ class TemplateStorageService extends ChangeNotifier {
       final data = jsonDecode(content);
       if (data is! Map<String, dynamic>) return null;
       if (!data.containsKey('name') || !data.containsKey('hands')) return null;
-      final template =
+      var template =
           TrainingPackTemplate.fromJson(Map<String, dynamic>.from(data));
+      final index = _templates.indexWhere((t) => t.id == template.id);
+      if (index != -1) {
+        final existing = _templates[index];
+        if (template.revision > existing.revision) {
+          final replace = await showDialog<bool>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('Найдена новая ревизия. Обновить?'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('Пропустить'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, true),
+                  child: const Text('Обновить'),
+                ),
+              ],
+            ),
+          );
+          if (replace == true) {
+            _templates[index] = template;
+            notifyListeners();
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('Шаблон обновлён'),
+                  action: SnackBarAction(
+                    label: 'Отмена',
+                    onPressed: () {
+                      _templates[index] = existing;
+                      notifyListeners();
+                    },
+                  ),
+                ),
+              );
+            }
+            return template;
+          }
+          return null;
+        } else if (template.revision == existing.revision) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Такой шаблон уже есть')),
+            );
+          }
+          return null;
+        } else {
+          final action = await showDialog<String>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('Импортировать старую версию?'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, 'skip'),
+                  child: const Text('Пропустить'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, 'keep'),
+                  child: const Text('Оставить обе'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, 'replace'),
+                  child: const Text('Заменить'),
+                ),
+              ],
+            ),
+          );
+          if (action == 'replace') {
+            _templates[index] = template;
+            notifyListeners();
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('Шаблон обновлён'),
+                  action: SnackBarAction(
+                    label: 'Отмена',
+                    onPressed: () {
+                      _templates[index] = existing;
+                      notifyListeners();
+                    },
+                  ),
+                ),
+              );
+            }
+            return template;
+          } else if (action == 'keep') {
+            template = TrainingPackTemplate(
+              id: const Uuid().v4(),
+              name: template.name,
+              gameType: template.gameType,
+              description: template.description,
+              hands: template.hands,
+              version: template.version,
+              author: template.author,
+              revision: template.revision,
+              createdAt: template.createdAt,
+              updatedAt: template.updatedAt,
+              isBuiltIn: template.isBuiltIn,
+            );
+          } else {
+            return null;
+          }
+        }
+      }
       _templates.add(template);
       notifyListeners();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Шаблон импортирован')),
+        );
+      }
       return template;
     } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Ошибка импорта файла')),
+        );
+      }
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- check revision conflicts when importing training templates
- trigger dialogs and snackbars for replace/skip/keep options

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2bc85bc4832a9985f3a12c4a33cb