### PR TITLE
Add undo snackbar for template deletion

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -42,7 +42,21 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       ),
     );
     if (confirm == true) {
-      context.read<TemplateStorageService>().removeTemplate(t);
+      final service = context.read<TemplateStorageService>();
+      final index = service.templates.indexOf(t);
+      service.removeTemplate(t);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Шаблон удалён'),
+            action: SnackBarAction(
+              label: 'Отмена',
+              onPressed: () => service.restoreTemplate(t, index),
+            ),
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      }
     }
   }
 

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -50,6 +50,12 @@ class TemplateStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  void restoreTemplate(TrainingPackTemplate template, int index) {
+    final insertIndex = index.clamp(0, _templates.length);
+    _templates.insert(insertIndex, template);
+    notifyListeners();
+  }
+
   Future<void> load() async {
     try {
       final manifest =


### PR DESCRIPTION
## Summary
- allow restoring templates with `restoreTemplate`
- show SnackBar with undo on delete in TemplateLibraryScreen

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d818aae50832aa1dfd7ac44bde181