### PR TITLE
Add empty template warning

### DIFF
--- a/lib/screens/template_hands_editor_screen.dart
+++ b/lib/screens/template_hands_editor_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../models/training_pack_template.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/template_storage_service.dart';
+
+class TemplateHandsEditorScreen extends StatefulWidget {
+  final TrainingPackTemplate template;
+  const TemplateHandsEditorScreen({super.key, required this.template});
+
+  @override
+  State<TemplateHandsEditorScreen> createState() => _TemplateHandsEditorScreenState();
+}
+
+class _TemplateHandsEditorScreenState extends State<TemplateHandsEditorScreen> {
+  late List<SavedHand> _hands;
+
+  @override
+  void initState() {
+    super.initState();
+    _hands = List.from(widget.template.hands);
+  }
+
+  Future<void> _addHand() async {
+    final manager = context.read<SavedHandManagerService>();
+    final hand = await manager.selectHand(context);
+    if (hand != null && mounted && !_hands.contains(hand)) {
+      setState(() => _hands.add(hand));
+    }
+  }
+
+  void _removeHand(int index) {
+    setState(() => _hands.removeAt(index));
+  }
+
+  void _save() {
+    final updated = TrainingPackTemplate(
+      id: widget.template.id,
+      name: widget.template.name,
+      gameType: widget.template.gameType,
+      description: widget.template.description,
+      hands: _hands,
+      version: widget.template.version,
+      author: widget.template.author,
+      revision: widget.template.revision,
+      createdAt: widget.template.createdAt,
+      updatedAt: DateTime.now(),
+      isBuiltIn: widget.template.isBuiltIn,
+    );
+    context.read<TemplateStorageService>().updateTemplate(updated);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Раздачи шаблона'),
+        actions: [IconButton(onPressed: _save, icon: const Icon(Icons.check))],
+      ),
+      body: ListView.builder(
+        itemCount: _hands.length,
+        itemBuilder: (context, index) {
+          final hand = _hands[index];
+          final title = hand.name.isEmpty ? 'Без названия' : hand.name;
+          return ListTile(
+            title: Text(title),
+            subtitle: hand.tags.isEmpty ? null : Text(hand.tags.join(', ')),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => _removeHand(index),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addHand,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -6,6 +6,7 @@ import '../services/template_storage_service.dart';
 import '../services/training_pack_storage_service.dart';
 
 import 'create_template_screen.dart';
+import 'template_hands_editor_screen.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -71,6 +72,24 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     );
     if (template != null) {
       context.read<TemplateStorageService>().addTemplate(template);
+      if (template.hands.isEmpty && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Шаблон пуст — не забудьте добавить раздачи'),
+            action: SnackBarAction(
+              label: 'Добавить сейчас',
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => TemplateHandsEditorScreen(template: template),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      }
     }
   }
 

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -44,6 +44,14 @@ class TemplateStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  void updateTemplate(TrainingPackTemplate template) {
+    final index = _templates.indexWhere((t) => t.id == template.id);
+    if (index == -1) return;
+    _templates[index] = template;
+    _resort();
+    notifyListeners();
+  }
+
   void removeTemplate(TrainingPackTemplate template) {
     if (template.isBuiltIn) return;
     _templates.remove(template);


### PR DESCRIPTION
## Summary
- warn if creating a template without hands
- allow editing template hands

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d82740a34832abf30c4789993a559