### PR TITLE
Add pack creation wizard

### DIFF
--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_pack_template.dart';
+import '../models/saved_hand.dart';
+import '../services/training_pack_storage_service.dart';
+
+class CreatePackFromTemplateScreen extends StatefulWidget {
+  final TrainingPackTemplate template;
+  const CreatePackFromTemplateScreen({super.key, required this.template});
+
+  @override
+  State<CreatePackFromTemplateScreen> createState() => _CreatePackFromTemplateScreenState();
+}
+
+class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScreen> {
+  late List<SavedHand> _selected;
+  final TextEditingController _category = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = List.from(widget.template.hands);
+  }
+
+  void _toggle(SavedHand h) {
+    setState(() {
+      if (_selected.contains(h)) {
+        _selected.remove(h);
+      } else {
+        _selected.add(h);
+      }
+    });
+  }
+
+  Future<void> _create() async {
+    if (_selected.isEmpty) return;
+    await context.read<TrainingPackStorageService>().createFromTemplate(
+      widget.template,
+      hands: _selected,
+      categoryOverride: _category.text.trim(),
+    );
+    if (!mounted) return;
+    Navigator.pop(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Пакет создан из шаблона')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.template.name),
+        actions: [IconButton(onPressed: _create, icon: const Icon(Icons.check))],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _category,
+              decoration: const InputDecoration(labelText: 'Категория (опц.)'),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: widget.template.hands.length,
+              itemBuilder: (_, i) {
+                final h = widget.template.hands[i];
+                return CheckboxListTile(
+                  value: _selected.contains(h),
+                  onChanged: (_) => _toggle(h),
+                  title: Text(h.name.isNotEmpty ? h.name : 'Раздача ${i + 1}'),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -7,6 +7,7 @@ import '../services/training_pack_storage_service.dart';
 
 import 'create_template_screen.dart';
 import 'template_hands_editor_screen.dart';
+import 'create_pack_from_template_screen.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -160,15 +161,15 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                           ],
                         ),
                         trailing: IconButton(
-                          tooltip: 'Создать тренировку',
+                          tooltip: 'Мастер создания',
                           icon: const Icon(Icons.arrow_forward),
-                          onPressed: () async {
-                            await context
-                                .read<TrainingPackStorageService>()
-                                .createFromTemplate(t);
-                            if (!context.mounted) return;
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Пакет создан')),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) =>
+                                    CreatePackFromTemplateScreen(template: t),
+                              ),
                             );
                           },
                         ),

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -44,6 +44,7 @@ class TemplateStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// replaces existing template by id, keeps ordering
   void updateTemplate(TrainingPackTemplate template) {
     final index = _templates.indexWhere((t) => t.id == template.id);
     if (index == -1) return;

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -172,7 +172,12 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createFromTemplate(TrainingPackTemplate template) async {
+  Future<void> createFromTemplate(
+    TrainingPackTemplate template, {
+    List<SavedHand>? hands,
+    String? categoryOverride,
+  }) async {
+    final selected = hands ?? template.hands;
     String base = template.name;
     String name = base;
     int idx = 1;
@@ -183,8 +188,11 @@ class TrainingPackStorageService extends ChangeNotifier {
     final pack = TrainingPack(
       name: name,
       description: template.description,
+      category: categoryOverride?.isNotEmpty == true
+          ? categoryOverride!
+          : 'Uncategorized',
       gameType: template.gameType,
-      hands: template.hands,
+      hands: selected,
     );
     _packs.add(pack);
     await _persist();


### PR DESCRIPTION
## Summary
- allow partial template selection when creating a pack
- support optional category for new packs
- open a creation wizard from template library
- clarify template updating comment

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8589e064832a9c5eb5dcb149dace