### PR TITLE
Add helper for template pack creation

### DIFF
--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -41,7 +41,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
 
   Future<void> _create() async {
     if (_selected.isEmpty) return;
-    await context.read<TrainingPackStorageService>().createFromTemplate(
+    await context.read<TrainingPackStorageService>().createFromTemplateWithOptions(
       widget.template,
       hands: _selected,
       categoryOverride: _category.text.trim(),

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -172,7 +172,15 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createFromTemplate(
+  Future<void> createFromTemplate(TrainingPackTemplate template) async {
+    await createFromTemplateWithOptions(
+      template,
+      hands: template.hands,
+      categoryOverride: null,
+    );
+  }
+
+  Future<void> createFromTemplateWithOptions(
     TrainingPackTemplate template, {
     List<SavedHand>? hands,
     String? categoryOverride,


### PR DESCRIPTION
## Summary
- add `createFromTemplateWithOptions` to `TrainingPackStorageService`
- delegate basic `createFromTemplate` call to new helper
- update wizard screen to use new method

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d88f4ab18832ab34e2bcc282aea57