### PR TITLE
Add color tag when creating pack from template

### DIFF
--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -39,6 +39,7 @@ class TrainingPack {
   final String description;
   final String category;
   final String gameType;
+  final String colorTag;
   final bool isBuiltIn;
   final List<SavedHand> hands;
   final List<TrainingSessionResult> history;
@@ -48,6 +49,7 @@ class TrainingPack {
     required this.description,
     this.category = 'Uncategorized',
     this.gameType = 'Cash Game',
+    this.colorTag = '#2196F3',
     this.isBuiltIn = false,
     required this.hands,
     List<TrainingSessionResult>? history,
@@ -58,6 +60,7 @@ class TrainingPack {
         'description': description,
         'category': category,
         'gameType': gameType,
+        'colorTag': colorTag,
         'isBuiltIn': isBuiltIn,
         'hands': [for (final h in hands) h.toJson()],
         'history': [for (final r in history) r.toJson()],
@@ -68,6 +71,7 @@ class TrainingPack {
         description: json['description'] as String? ?? '',
         category: json['category'] as String? ?? 'Uncategorized',
         gameType: json['gameType'] as String? ?? 'Cash Game',
+        colorTag: json['colorTag'] as String? ?? '#2196F3',
         isBuiltIn: json['isBuiltIn'] as bool? ?? false,
         hands: [
           for (final h in (json['hands'] as List? ?? []))

--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -883,6 +883,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
               description: newDescription,
               category: p.category,
               gameType: p.gameType,
+              colorTag: p.colorTag,
               hands: p.hands,
               history: p.history,
             );
@@ -907,6 +908,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
           description: newDescription,
           category: oldPack.category,
           gameType: oldPack.gameType,
+          colorTag: oldPack.colorTag,
           hands: oldPack.hands,
           history: oldPack.history,
         );

--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import '../helpers/color_utils.dart';
 
 import '../models/training_pack_template.dart';
 import '../models/saved_hand.dart';
@@ -16,6 +18,32 @@ class CreatePackFromTemplateScreen extends StatefulWidget {
 class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScreen> {
   late List<SavedHand> _selected;
   final TextEditingController _category = TextEditingController();
+  Color _color = Colors.blue;
+
+  Future<void> _pickColor() async {
+    Color pickerColor = _color;
+    final result = await showDialog<Color>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Цвет пакета'),
+        content: BlockPicker(
+          pickerColor: pickerColor,
+          onColorChanged: (c) => pickerColor = c,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, pickerColor),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (result != null) setState(() => _color = result);
+  }
 
   @override
   void dispose() {
@@ -45,6 +73,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
       widget.template,
       hands: _selected,
       categoryOverride: _category.text.trim(),
+      colorTag: colorToHex(_color),
     );
     if (!mounted) return;
     Navigator.pop(context);
@@ -67,6 +96,21 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
             child: TextField(
               controller: _category,
               decoration: const InputDecoration(labelText: 'Категория (опц.)'),
+            ),
+          ),
+          ListTile(
+            leading: Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                color: _color,
+                shape: BoxShape.circle,
+              ),
+            ),
+            title: const Text('Цвет пакета'),
+            trailing: IconButton(
+              icon: const Icon(Icons.edit),
+              onPressed: _pickColor,
             ),
           ),
           Expanded(

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -477,6 +477,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
           description: updated.description,
           category: updated.category,
           gameType: updated.gameType,
+          colorTag: _pack.colorTag,
           hands: _pack.hands,
         );
       });

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
+import '../helpers/color_utils.dart';
 import 'template_library_screen.dart';
 import 'training_pack_screen.dart';
 import 'training_pack_comparison_screen.dart';
@@ -159,7 +160,16 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                       final pack = visible[index];
                       final completed = _isPackCompleted(pack);
                       return ListTile(
-                        leading: pack.isBuiltIn ? const Text('📦') : null,
+                        leading: pack.isBuiltIn
+                            ? const Text('📦')
+                            : Container(
+                                width: 16,
+                                height: 16,
+                                decoration: BoxDecoration(
+                                  color: colorFromHex(pack.colorTag),
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
                         title: Text(pack.name),
                         subtitle: Text(
                           pack.description.isEmpty

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -149,6 +149,7 @@ class TrainingPackStorageService extends ChangeNotifier {
       description: pack.description,
       category: pack.category,
       gameType: pack.gameType,
+      colorTag: pack.colorTag,
       isBuiltIn: pack.isBuiltIn,
       hands: pack.hands,
       history: pack.history,
@@ -177,6 +178,7 @@ class TrainingPackStorageService extends ChangeNotifier {
       template,
       hands: template.hands,
       categoryOverride: null,
+      colorTag: '#2196F3',
     );
   }
 
@@ -184,6 +186,7 @@ class TrainingPackStorageService extends ChangeNotifier {
     TrainingPackTemplate template, {
     List<SavedHand>? hands,
     String? categoryOverride,
+    String? colorTag,
   }) async {
     final selected = hands ?? template.hands;
     String base = template.name;
@@ -200,6 +203,7 @@ class TrainingPackStorageService extends ChangeNotifier {
           ? categoryOverride!
           : 'Uncategorized',
       gameType: template.gameType,
+      colorTag: colorTag ?? '#2196F3',
       hands: selected,
     );
     _packs.add(pack);


### PR DESCRIPTION
## Summary
- extend TrainingPack with `colorTag`
- allow choosing a color in CreatePackFromTemplateScreen
- handle colorTag in TrainingPackStorageService
- preserve colorTag on rename
- show color marker in training pack list

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bc13558832ab4ef95f569fff4b4