### PR TITLE
Add popular categories dropdown

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
 import 'services/weekly_challenge_service.dart';
+import 'services/category_usage_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 
@@ -60,6 +61,12 @@ void main() {
         ),
         ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
+        ChangeNotifierProvider(
+          create: (context) => CategoryUsageService(
+            templates: context.read<TemplateStorageService>(),
+            packs: context.read<TrainingPackStorageService>(),
+          ),
+        ),
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTipService()..load()),

--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../models/training_pack.dart';
 import '../models/training_spot.dart';
 import '../services/training_spot_file_service.dart';
+import '../services/category_usage_service.dart';
 import '../widgets/common/training_spot_list.dart';
 
 class CreatePackScreen extends StatefulWidget {
@@ -63,6 +65,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final categories = context.watch<CategoryUsageService>().categories;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.initialPack == null ? 'Новый пакет' : 'Редактирование'),
@@ -94,6 +97,23 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
               ),
             ),
             const SizedBox(height: 16),
+            if (categories.isNotEmpty)
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(
+                  labelText: 'Популярные категории',
+                  labelStyle: TextStyle(color: Colors.white),
+                  border: OutlineInputBorder(),
+                ),
+                dropdownColor: const Color(0xFF3A3B3E),
+                items: [
+                  for (final c in categories)
+                    DropdownMenuItem(value: c, child: Text(c)),
+                ],
+                onChanged: (v) {
+                  if (v != null) setState(() => _categoryController.text = v);
+                },
+              ),
+            if (categories.isNotEmpty) const SizedBox(height: 16),
             TextField(
               controller: _categoryController,
               style: const TextStyle(color: Colors.white),

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../models/training_pack_template.dart';
 import '../services/template_storage_service.dart';
+import '../services/category_usage_service.dart';
 
 import 'create_template_screen.dart';
 import 'template_hands_editor_screen.dart';
@@ -18,6 +19,7 @@ class TemplateLibraryScreen extends StatefulWidget {
 class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   final TextEditingController _searchController = TextEditingController();
   String _typeFilter = 'All';
+  String _categoryFilter = 'All';
 
   @override
   void dispose() {
@@ -149,10 +151,17 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   @override
   Widget build(BuildContext context) {
     final templates = context.watch<TemplateStorageService>().templates;
+    final categories = context.watch<CategoryUsageService>().categories;
     List<TrainingPackTemplate> visible = [...templates];
     visible.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
     if (_typeFilter != 'All') {
       visible = [for (final t in visible) if (t.gameType == _typeFilter) t];
+    }
+    if (_categoryFilter != 'All') {
+      visible = [
+        for (final t in visible)
+          if ((t.category ?? 'Uncategorized') == _categoryFilter) t
+      ];
     }
     final query = _searchController.text.toLowerCase();
     if (query.isNotEmpty) {
@@ -192,6 +201,21 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               ],
             ),
           ),
+          if (categories.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: DropdownButton<String>(
+                value: _categoryFilter,
+                underline: const SizedBox.shrink(),
+                onChanged: (v) => setState(() => _categoryFilter = v ?? 'All'),
+                items: [
+                  const DropdownMenuItem(value: 'All', child: Text('Все категории')),
+                  ...categories.map(
+                    (c) => DropdownMenuItem(value: c, child: Text(c)),
+                  ),
+                ],
+              ),
+            ),
           Expanded(
             child: visible.isEmpty
                 ? const Center(child: Text('Нет шаблонов'))

--- a/lib/services/category_usage_service.dart
+++ b/lib/services/category_usage_service.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+
+import 'template_storage_service.dart';
+import 'training_pack_storage_service.dart';
+
+class CategoryUsageService extends ChangeNotifier {
+  final TemplateStorageService templates;
+  final TrainingPackStorageService packs;
+
+  List<String> _categories = [];
+  List<String> get categories => List.unmodifiable(_categories);
+
+  CategoryUsageService({required this.templates, required this.packs}) {
+    templates.addListener(_recompute);
+    packs.addListener(_recompute);
+    _recompute();
+  }
+
+  void _recompute() {
+    final counts = <String, int>{};
+    for (final t in templates.templates) {
+      final c = (t.category?.isNotEmpty == true) ? t.category! : 'Uncategorized';
+      counts[c] = (counts[c] ?? 0) + 1;
+    }
+    for (final p in packs.packs) {
+      final c = p.category.isNotEmpty ? p.category : 'Uncategorized';
+      counts[c] = (counts[c] ?? 0) + 1;
+    }
+    final list = counts.keys.toList()
+      ..sort((a, b) => counts[b]!.compareTo(counts[a]!));
+    _categories = list;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    templates.removeListener(_recompute);
+    packs.removeListener(_recompute);
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- compute category usage statistics
- provide service for popular categories
- add category filter to template library screen
- offer category suggestions in create pack screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c5680f4832aa74982aacf478b72