### PR TITLE
Add game info prompt on save

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -292,9 +292,8 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     SavedHand? played;
     if (state != null) {
       try {
-        final jsonStr = state.saveHand() as String;
-        played =
-            SavedHandImportExportService.decode(jsonStr);
+        final jsonStr = await state.saveHand() as String;
+        played = SavedHandImportExportService.decode(jsonStr);
       } catch (_) {}
     }
     final original = _sessionHands[_currentIndex];

--- a/lib/services/current_hand_context_service.dart
+++ b/lib/services/current_hand_context_service.dart
@@ -17,6 +17,7 @@ class CurrentHandContextService {
   final TextEditingController totalPrizePoolController = TextEditingController();
   final TextEditingController numberOfEntrantsController = TextEditingController();
   final TextEditingController gameTypeController = TextEditingController();
+  final TextEditingController categoryController = TextEditingController();
 
   /// Current comment text or `null` if empty.
   String? get comment =>
@@ -65,6 +66,10 @@ class CurrentHandContextService {
       gameTypeController.text.isNotEmpty ? gameTypeController.text : null;
   set gameType(String? value) => gameTypeController.text = value ?? '';
 
+  String? get category =>
+      categoryController.text.isNotEmpty ? categoryController.text : null;
+  set category(String? value) => categoryController.text = value ?? '';
+
   /// Cursor offset inside the tag field.
   int? get tagsCursor => tagsController.selection.baseOffset >= 0
       ? tagsController.selection.baseOffset
@@ -87,6 +92,7 @@ class CurrentHandContextService {
     totalPrizePoolController.clear();
     numberOfEntrantsController.clear();
     gameTypeController.clear();
+    categoryController.clear();
   }
 
   /// Restore context from persisted data.
@@ -101,6 +107,7 @@ class CurrentHandContextService {
     int? totalPrizePool,
     int? numberOfEntrants,
     String? gameType,
+    String? category,
   }) {
     _currentHandName = name;
     this.comment = comment;
@@ -112,6 +119,7 @@ class CurrentHandContextService {
     this.totalPrizePool = totalPrizePool;
     this.numberOfEntrants = numberOfEntrants;
     this.gameType = gameType;
+    this.category = category;
   }
 
   /// Restore context directly from a [SavedHand].
@@ -127,6 +135,7 @@ class CurrentHandContextService {
       totalPrizePool: hand.totalPrizePool,
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
+      category: hand.category,
     );
   }
 
@@ -143,6 +152,7 @@ class CurrentHandContextService {
       totalPrizePool: totalPrizePool,
       numberOfEntrants: numberOfEntrants,
       gameType: gameType,
+      category: category,
     );
   }
 
@@ -159,5 +169,6 @@ class CurrentHandContextService {
     totalPrizePoolController.dispose();
     numberOfEntrantsController.dispose();
     gameTypeController.dispose();
+    categoryController.dispose();
   }
 }

--- a/lib/services/undo_redo_service.dart
+++ b/lib/services/undo_redo_service.dart
@@ -114,6 +114,12 @@ class UndoRedoService {
       commentCursor: snap.commentCursor,
       tags: snap.tags,
       tagsCursor: snap.tagsCursor,
+      tournamentId: snap.tournamentId,
+      buyIn: snap.buyIn,
+      totalPrizePool: snap.totalPrizePool,
+      numberOfEntrants: snap.numberOfEntrants,
+      gameType: snap.gameType,
+      category: snap.category,
     );
     playerManager.restoreFromHand(snap);
     boardManager.setBoardCards(snap.boardCards);


### PR DESCRIPTION
## Summary
- track hand category in current hand context
- ask for game type and category when saving hands
- store metadata during undo restore
- update training pack screen for new async saveHand

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da2230fe0832a83c3fba0b5299d66