### PR TITLE
Enable renaming of saved hands

### DIFF
--- a/lib/screens/saved_hand_history_screen.dart
+++ b/lib/screens/saved_hand_history_screen.dart
@@ -57,6 +57,38 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
     manager.update(index, updated);
   }
 
+  Future<void> _renameHand(
+      SavedHand hand, SavedHandManagerService manager) async {
+    final controller = TextEditingController(text: hand.name);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.cardBackground,
+        title:
+            const Text('Переименовать', style: TextStyle(color: Colors.white)),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          style: const TextStyle(color: Colors.white),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (name != null && name.isNotEmpty && name != hand.name) {
+      final index = manager.hands.indexOf(hand);
+      await manager.update(index, hand.copyWith(name: name));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final manager = context.watch<SavedHandManagerService>();
@@ -154,6 +186,7 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
                   title: 'Раздачи',
                   onTap: _openHand,
                   onFavoriteToggle: (hand) => _toggleFavorite(hand, manager),
+                  onRename: (hand) => _renameHand(hand, manager),
                   showGameFilters: false,
                 ),
                 SavedHandListView(
@@ -161,6 +194,7 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
                   title: 'Избранные',
                   onTap: _openHand,
                   onFavoriteToggle: (hand) => _toggleFavorite(hand, manager),
+                  onRename: (hand) => _renameHand(hand, manager),
                   showGameFilters: false,
                 ),
                 SavedHandListView(
@@ -168,6 +202,7 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
                   title: 'Сессии',
                   onTap: _openHand,
                   onFavoriteToggle: (hand) => _toggleFavorite(hand, manager),
+                  onRename: (hand) => _renameHand(hand, manager),
                   showGameFilters: false,
                 ),
               ],

--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -32,6 +32,7 @@ class SavedHandListView extends StatefulWidget {
   final String title;
   final ValueChanged<SavedHand> onTap;
   final ValueChanged<SavedHand>? onFavoriteToggle;
+  final ValueChanged<SavedHand>? onRename;
   final String? filterKey;
 
   const SavedHandListView({
@@ -45,6 +46,7 @@ class SavedHandListView extends StatefulWidget {
     this.showAccuracyToggle = true,
     this.showGameFilters = true,
     this.onFavoriteToggle,
+    this.onRename,
     this.filterKey,
   });
 
@@ -318,6 +320,9 @@ class _SavedHandListViewState extends State<SavedHandListView> {
                       onFavoriteToggle: widget.onFavoriteToggle == null
                           ? null
                           : () => widget.onFavoriteToggle!(hand),
+                      onRename: widget.onRename == null
+                          ? null
+                          : () => widget.onRename!(hand),
                     );
                   },
                 ),

--- a/lib/widgets/saved_hand_tile.dart
+++ b/lib/widgets/saved_hand_tile.dart
@@ -8,12 +8,14 @@ class SavedHandTile extends StatelessWidget {
   final SavedHand hand;
   final VoidCallback onTap;
   final VoidCallback? onFavoriteToggle;
+  final VoidCallback? onRename;
 
   const SavedHandTile({
     super.key,
     required this.hand,
     required this.onTap,
     this.onFavoriteToggle,
+    this.onRename,
   });
 
   String _formatDate(DateTime date) {
@@ -123,7 +125,17 @@ class SavedHandTile extends StatelessWidget {
             ],
           ],
         ),
-        trailing: const Icon(Icons.chevron_right, color: Colors.white),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (onRename != null)
+              IconButton(
+                icon: const Icon(Icons.edit, color: Colors.white),
+                onPressed: onRename,
+              ),
+            const Icon(Icons.chevron_right, color: Colors.white),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add `onRename` callback to `SavedHandTile`
- wire rename action through `SavedHandListView`
- expose rename in `SavedHandHistoryScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da7afacc4832ab8230b35d6cfc330