### PR TITLE
Implement multi-select actions for saved hands

### DIFF
--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -35,6 +35,9 @@ class SavedHandListView extends StatefulWidget {
   final ValueChanged<SavedHand> onTap;
   final ValueChanged<SavedHand>? onFavoriteToggle;
   final ValueChanged<SavedHand>? onRename;
+  final Set<SavedHand>? selected;
+  final bool selectionMode;
+  final ValueChanged<SavedHand>? onToggleSelection;
   final String? filterKey;
 
   const SavedHandListView({
@@ -49,6 +52,9 @@ class SavedHandListView extends StatefulWidget {
     this.showGameFilters = true,
     this.onFavoriteToggle,
     this.onRename,
+    this.selected,
+    this.selectionMode = false,
+    this.onToggleSelection,
     this.filterKey,
   });
 
@@ -293,13 +299,22 @@ class _SavedHandListViewState extends State<SavedHandListView> {
               for (final h in hands)
                 SavedHandTile(
                   hand: h,
-                  onTap: () => widget.onTap(h),
-                  onFavoriteToggle: widget.onFavoriteToggle == null
+                  onTap: widget.selectionMode
+                      ? () => widget.onToggleSelection?.call(h)
+                      : () => widget.onTap(h),
+                  onLongPress: () => widget.onToggleSelection?.call(h),
+                  selectionMode: widget.selectionMode,
+                  selected: widget.selected?.contains(h) ?? false,
+                  onFavoriteToggle: widget.selectionMode
                       ? null
-                      : () => widget.onFavoriteToggle!(h),
-                  onRename: widget.onRename == null
+                      : widget.onFavoriteToggle == null
+                          ? null
+                          : () => widget.onFavoriteToggle!(h),
+                  onRename: widget.selectionMode
                       ? null
-                      : () => widget.onRename!(h),
+                      : widget.onRename == null
+                          ? null
+                          : () => widget.onRename!(h),
                 )
             ],
           ),

--- a/lib/widgets/saved_hand_tile.dart
+++ b/lib/widgets/saved_hand_tile.dart
@@ -9,6 +9,9 @@ class SavedHandTile extends StatelessWidget {
   final VoidCallback onTap;
   final VoidCallback? onFavoriteToggle;
   final VoidCallback? onRename;
+  final VoidCallback? onLongPress;
+  final bool selected;
+  final bool selectionMode;
 
   const SavedHandTile({
     super.key,
@@ -16,6 +19,9 @@ class SavedHandTile extends StatelessWidget {
     required this.onTap,
     this.onFavoriteToggle,
     this.onRename,
+    this.onLongPress,
+    this.selected = false,
+    this.selectionMode = false,
   });
 
   String _formatDate(DateTime date) {
@@ -99,14 +105,21 @@ class SavedHandTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final actionWidget = _buildActionWidget();
     return Card(
-      color: const Color(0xFF2A2B2E),
+      color:
+          selected ? Colors.blue.withOpacity(0.3) : const Color(0xFF2A2B2E),
       child: ListTile(
         onTap: onTap,
-        leading: IconButton(
-          icon: Icon(hand.isFavorite ? Icons.star : Icons.star_border),
-          color: hand.isFavorite ? Colors.amber : Colors.white54,
-          onPressed: onFavoriteToggle,
-        ),
+        onLongPress: onLongPress,
+        leading: selectionMode
+            ? Checkbox(
+                value: selected,
+                onChanged: (_) => onLongPress?.call(),
+              )
+            : IconButton(
+                icon: Icon(hand.isFavorite ? Icons.star : Icons.star_border),
+                color: hand.isFavorite ? Colors.amber : Colors.white54,
+                onPressed: onFavoriteToggle,
+              ),
         title: Text(hand.name, style: const TextStyle(color: Colors.white)),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- support exporting selected hands to markdown or json
- implement multi-select tiles and list view for SavedHandHistory
- handle bulk delete and favorite toggle actions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daab33dd0832aa82da488b18e39fa