### PR TITLE
Replace badge PNGs with gradient icons

### DIFF
--- a/lib/widgets/badge_celebration_dialog.dart
+++ b/lib/widgets/badge_celebration_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'badge_icon.dart';
+
+class BadgeCelebrationDialog extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  const BadgeCelebrationDialog({super.key, required this.icon, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: Colors.black87,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          BadgeIcon(icon, size: 64),
+          const SizedBox(height: 16),
+          Text(title, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showBadgeCelebrationDialog(BuildContext context, IconData icon, String title) {
+  return showDialog(
+    context: context,
+    builder: (_) => BadgeCelebrationDialog(icon: icon, title: title),
+  );
+}

--- a/lib/widgets/badge_icon.dart
+++ b/lib/widgets/badge_icon.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class BadgeIcon extends StatelessWidget {
+  final IconData icon;
+  final double size;
+  const BadgeIcon(this.icon, {super.key, this.size = 40});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(boxShadow: [
+        BoxShadow(
+          color: Colors.orangeAccent.withOpacity(0.6),
+          blurRadius: 12,
+          spreadRadius: 2,
+        )
+      ]),
+      child: ShaderMask(
+        shaderCallback: (rect) => const LinearGradient(
+          colors: [Colors.orange, Colors.yellowAccent],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ).createShader(rect),
+        child: Icon(icon, size: size, color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/widgets/streak_chart.dart
+++ b/lib/widgets/streak_chart.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
 import '../theme/app_colors.dart';
+import 'badge_icon.dart';
 
 class StreakChart extends StatelessWidget {
   const StreakChart({super.key});
@@ -59,8 +60,14 @@ class StreakChart extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Text('\uD83D\uDD25 Streak: ${stats.currentStreak}',
-              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+          child: Row(
+            children: [
+              const BadgeIcon(Icons.local_fire_department, size: 20),
+              const SizedBox(width: 8),
+              Text('Streak: ${stats.currentStreak}',
+                  style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            ],
+          ),
         ),
         Container(
           height: 100,


### PR DESCRIPTION
## Summary
- implement BadgeIcon with gradient glow
- add BadgeCelebrationDialog using BadgeIcon
- use BadgeIcon in StreakChart header

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcd6fca5c832ab5e9a53ae9a36665