### PR TITLE
Add Spot of the Day card

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/suggested_drill_card.dart';
 import '../widgets/today_progress_banner.dart';
 import '../widgets/streak_mini_card.dart';
 import '../widgets/streak_chart.dart';
+import '../widgets/spot_of_the_day_card.dart';
 import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
@@ -76,6 +77,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   Widget _home() {
     return Column(
       children: [
+        const SpotOfTheDayCard(),
         const StreakChart(),
         const TodayProgressBanner(),
         const StreakMiniCard(),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/spot_of_the_day_service.dart';
+import '../widgets/spot_of_the_day_card.dart';
+
+class TrainingHomeScreen extends StatefulWidget {
+  const TrainingHomeScreen({super.key});
+
+  @override
+  State<TrainingHomeScreen> createState() => _TrainingHomeScreenState();
+}
+
+class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<SpotOfTheDayService>().ensureTodaySpot();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Training')),
+      body: ListView(
+        children: const [
+          SpotOfTheDayCard(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/spot_of_the_day_card.dart
+++ b/lib/widgets/spot_of_the_day_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/spot_of_the_day_service.dart';
+import '../screens/training_screen.dart';
+import 'training_spot_preview.dart';
+
+class SpotOfTheDayCard extends StatelessWidget {
+  const SpotOfTheDayCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final spot = context.watch<SpotOfTheDayService>().currentSpot;
+    if (spot == null) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Spot of the Day',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Text('Hero stack: ${spot.stacks[spot.heroIndex]}',
+              style: const TextStyle(color: Colors.white70)),
+          Text('Positions: ${spot.positions.join(', ')}',
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          TrainingSpotPreview(spot: spot),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => TrainingScreen(spot: spot)),
+                );
+              },
+              child: const Text('Play'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show Spot of the Day card on training home
- provide SpotOfTheDay card widget and screen
- update SpotOfTheDayService to select a new spot daily and expose currentSpot

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685dd0293a0c832a921a4f20e792dab4