### PR TITLE
Add daily reminder service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import "services/achievement_engine.dart";
 import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
 import 'services/reminder_service.dart';
+import 'services/daily_reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/daily_target_service.dart';
@@ -119,6 +120,13 @@ void main() {
             spotService: context.read<SpotOfTheDayService>(),
             goalEngine: context.read<GoalEngine>(),
             streakService: context.read<StreakService>(),
+          )..load(),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => DailyReminderService(
+            spot: context.read<SpotOfTheDayService>(),
+            target: context.read<DailyTargetService>(),
+            stats: context.read<TrainingStatsService>(),
           )..load(),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart';
 
 import '../helpers/date_utils.dart';
 import '../services/reminder_service.dart';
+import '../services/daily_reminder_service.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 
@@ -53,12 +54,14 @@ class SettingsPlaceholderScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final reminder = context.watch<ReminderService>();
+    final dailyReminder = context.watch<DailyReminderService>();
     final dailyTarget = context.watch<DailyTargetService>();
     final dismissed = reminder.lastDismissed;
     final status = reminder.enabled ? 'Включены' : 'Выключены';
     final info = dismissed != null
         ? '$status, последний отказ: ${formatDateTime(dismissed)}'
         : status;
+    final drInfo = '${dailyReminder.hour.toString().padLeft(2, '0')}:00';
     return Scaffold(
       backgroundColor: const Color(0xFF121212),
       appBar: AppBar(
@@ -86,6 +89,25 @@ class SettingsPlaceholderScreen extends StatelessWidget {
               info,
               style: const TextStyle(color: Colors.white70),
             ),
+          ),
+          SwitchListTile(
+            value: dailyReminder.enabled,
+            onChanged: (v) => dailyReminder.setEnabled(v),
+            title: const Text('Daily Reminder'),
+            activeColor: Colors.orange,
+          ),
+          ListTile(
+            title: const Text('Time', style: TextStyle(color: Colors.white)),
+            subtitle: Text(drInfo, style: const TextStyle(color: Colors.white70)),
+            onTap: () async {
+              final picked = await showTimePicker(
+                context: context,
+                initialTime: TimeOfDay(hour: dailyReminder.hour, minute: 0),
+              );
+              if (picked != null) {
+                dailyReminder.setHour(picked.hour);
+              }
+            },
           ),
           const Padding(
             padding: EdgeInsets.all(16),

--- a/lib/services/daily_reminder_service.dart
+++ b/lib/services/daily_reminder_service.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'spot_of_the_day_service.dart';
+import 'daily_target_service.dart';
+import 'training_stats_service.dart';
+
+class DailyReminderService extends ChangeNotifier {
+  static const _enabledKey = 'daily_reminder_enabled';
+  static const _hourKey = 'daily_reminder_hour';
+  static const _id = 7;
+
+  final SpotOfTheDayService spot;
+  final DailyTargetService target;
+  final TrainingStatsService stats;
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+
+  bool _enabled = true;
+  int _hour = 20;
+  Timer? _timer;
+  StreamSubscription<int>? _handsSub;
+
+  bool get enabled => _enabled;
+  int get hour => _hour;
+
+  DailyReminderService({required this.spot, required this.target, required this.stats});
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_enabledKey) ?? true;
+    _hour = prefs.getInt(_hourKey) ?? 20;
+    await _initPlugin();
+    spot.addListener(_schedule);
+    _handsSub = stats.handsStream.listen((_) => _schedule());
+    _schedule();
+    _scheduleMidnight();
+  }
+
+  Future<void> _initPlugin() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    if (_enabled == value) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+    _enabled = value;
+    if (!value) await _plugin.cancel(_id);
+    _schedule();
+    notifyListeners();
+  }
+
+  Future<void> setHour(int value) async {
+    if (_hour == value) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_hourKey, value);
+    _hour = value;
+    _schedule();
+    notifyListeners();
+  }
+
+  void _scheduleMidnight() {
+    _timer?.cancel();
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day + 1);
+    _timer = Timer(next.difference(now), () {
+      _schedule();
+      _scheduleMidnight();
+    });
+  }
+
+  int get _progress {
+    final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+    return stats.handsPerDay[today] ?? 0;
+  }
+
+  Future<void> _schedule() async {
+    await _plugin.cancel(_id);
+    if (!_enabled) return;
+    final needSpot = spot.result == null;
+    final needTarget = _progress < target.target;
+    if (!needSpot && !needTarget) return;
+    final now = DateTime.now();
+    var when = tz.TZDateTime.local(now.year, now.month, now.day, _hour);
+    if (when.isBefore(tz.TZDateTime.now(tz.local))) return;
+    await _plugin.zonedSchedule(
+      _id,
+      'Poker Analyzer',
+      needSpot ? "Don't forget today's Spot!" : 'Finish your daily hands!',
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('daily_reminder', 'Daily Reminder', importance: Importance.defaultImportance),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _handsSub?.cancel();
+    spot.removeListener(_schedule);
+    super.dispose();
+  }
+}

--- a/lib/services/daily_target_service.dart
+++ b/lib/services/daily_target_service.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'training_stats_service.dart';
 
 class DailyTargetService extends ChangeNotifier {
   static const _key = 'daily_hands_target';
   int _target = 10;
   int get target => _target;
+
+  int get progress {
+    final stats = TrainingStatsService.instance;
+    if (stats == null) return 0;
+    final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+    return stats.handsPerDay[today] ?? 0;
+  }
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- implement `DailyReminderService` for progress notifications
- expose progress on `DailyTargetService`
- wire the new service in app initialization
- add settings controls to enable and configure reminders

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2abc300832a87c5382606854e69