### PR TITLE
Add achievements list with badge

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -1,12 +1,14 @@
 import "package:flutter/material.dart";
 class Achievement {
   final String title;
+  final String description;
   final IconData icon;
   final int progress;
   final int target;
 
   const Achievement({
     required this.title,
+    required this.description,
     required this.icon,
     required this.progress,
     required this.target,
@@ -16,6 +18,7 @@ class Achievement {
 
   Achievement copyWith({int? progress}) => Achievement(
         title: title,
+        description: description,
         icon: icon,
         progress: progress ?? this.progress,
         target: target,

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
-import 'dart:math' as math;
-import '../services/streak_service.dart';
-import '../services/training_stats_service.dart';
+import '../services/achievement_engine.dart';
 import '../services/user_action_logger.dart';
 
 class AchievementsScreen extends StatefulWidget {
@@ -18,104 +15,66 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
   void initState() {
     super.initState();
     UserActionLogger.instance.log('viewed_achievements');
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AchievementEngine>().markSeen();
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    final streak = context.watch<StreakService>().count;
-    final stats = context.watch<TrainingStatsService>();
-    final today = stats.mistakesDaily(1);
-    final mistakesToday = today.isNotEmpty ? today.first.value : 0;
+    final engine = context.watch<AchievementEngine>();
     final accent = Theme.of(context).colorScheme.secondary;
-
-    final items = [
-      _AchievementItem(
-        title: '7-day Streak',
-        icon: Icons.emoji_events,
-        progress: math.min(streak, 7),
-        target: 7,
-      ),
-      _AchievementItem(
-        title: '30-day Streak',
-        icon: Icons.emoji_events,
-        progress: math.min(streak, 30),
-        target: 30,
-      ),
-      _AchievementItem(
-        title: 'No Mistakes Today',
-        icon: Icons.check_circle,
-        progress: mistakesToday == 0 ? 1 : 0,
-        target: 1,
-      ),
-    ];
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('Achievements'),
         centerTitle: true,
       ),
-      body: GridView.builder(
+      body: ListView.builder(
         padding: const EdgeInsets.all(16),
-        itemCount: items.length,
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          crossAxisSpacing: 12,
-          mainAxisSpacing: 12,
-          childAspectRatio: 1.2,
-        ),
+        itemCount: engine.achievements.length,
         itemBuilder: (context, index) {
-          final item = items[index];
-          final completed = item.progress >= item.target;
-          final color = completed ? Colors.white : Colors.white54;
+          final a = engine.achievements[index];
+          final done = a.completed;
           return Container(
+            margin: const EdgeInsets.only(bottom: 12),
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               color: Colors.grey[850],
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Column(
+            child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(item.icon, size: 40, color: accent),
-                const SizedBox(height: 8),
-                Text(
-                  item.title,
-                  style: TextStyle(
-                    color: color,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const Spacer(),
-                Row(
-                  children: [
-                    Expanded(
-                      child: ClipRRect(
+                Icon(a.icon, color: accent),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(a.title, style: const TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 4),
+                      Text(a.description, style: const TextStyle(color: Colors.white70)),
+                      const SizedBox(height: 8),
+                      ClipRRect(
                         borderRadius: BorderRadius.circular(4),
                         child: LinearProgressIndicator(
-                          value:
-                              (item.progress / item.target).clamp(0.0, 1.0),
+                          value: (a.progress / a.target).clamp(0.0, 1.0),
                           backgroundColor: Colors.white24,
-                          valueColor:
-                              AlwaysStoppedAnimation<Color>(accent),
+                          valueColor: AlwaysStoppedAnimation<Color>(accent),
                           minHeight: 6,
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      '${item.progress}/${item.target}',
-                      style: TextStyle(color: color),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-                const SizedBox(height: 4),
-                if (!completed)
-                  const Text(
-                    'Incomplete',
-                    style: TextStyle(color: Colors.white54, fontSize: 12),
-                  )
-                else
-                  const Icon(Icons.check_circle, color: Colors.green),
+                const SizedBox(width: 12),
+                Column(
+                  children: [
+                    Text(done ? '✅' : '⏳'),
+                    const SizedBox(height: 4),
+                    Text('${a.progress}/${a.target}')
+                  ],
+                )
               ],
             ),
           );
@@ -123,17 +82,4 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
       ),
     );
   }
-}
-
-class _AchievementItem {
-  final String title;
-  final IconData icon;
-  final int progress;
-  final int target;
-  const _AchievementItem({
-    required this.title,
-    required this.icon,
-    required this.progress,
-    required this.target,
-  });
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../user_preferences.dart';
 import 'tag_management_screen.dart';
 import 'cloud_sync_screen.dart';
+import '../services/achievement_engine.dart';
+import 'achievements_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -80,6 +82,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 context,
                 MaterialPageRoute(
                     builder: (_) => const TagManagementScreen()),
+              );
+            },
+          ),
+          Consumer<AchievementEngine>(
+            builder: (context, engine, child) {
+              final count = engine.unseenCount;
+              Widget icon = const Icon(Icons.emoji_events);
+              if (count > 0) {
+                icon = Stack(
+                  children: [
+                    const Icon(Icons.emoji_events),
+                    Positioned(
+                      right: 0,
+                      top: 0,
+                      child: Container(
+                        padding: const EdgeInsets.all(2),
+                        decoration: const BoxDecoration(
+                          color: Colors.red,
+                          shape: BoxShape.circle,
+                        ),
+                        constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+                        child: Text(
+                          '$count',
+                          style: const TextStyle(fontSize: 10),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              }
+              return IconButton(
+                icon: icon,
+                tooltip: 'Achievements',
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const AchievementsScreen()),
+                  );
+                },
               );
             },
           ),

--- a/lib/services/achievement_engine.dart
+++ b/lib/services/achievement_engine.dart
@@ -20,8 +20,10 @@ class AchievementEngine extends ChangeNotifier {
 
   final List<Achievement> _achievements = [];
   final Map<String, bool> _shown = {};
+  int _unseen = 0;
 
   List<Achievement> get achievements => List.unmodifiable(_achievements);
+  int get unseenCount => _unseen;
 
   Future<void> _init() async {
     await _load();
@@ -36,11 +38,18 @@ class AchievementEngine extends ChangeNotifier {
     for (final k in ['s', 'h', 'm']) {
       _shown[k] = prefs.getBool('ach_shown_$k') ?? false;
     }
+    _unseen = prefs.getInt('ach_unseen') ?? 0;
   }
 
   Future<void> _save(String key) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('ach_shown_$key', true);
+    await prefs.setInt('ach_unseen', _unseen);
+  }
+
+  Future<void> _saveUnseen() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('ach_unseen', _unseen);
   }
 
   void _sync() {
@@ -49,18 +58,21 @@ class AchievementEngine extends ChangeNotifier {
       ..addAll([
         Achievement(
           title: '10 тренировок',
+          description: 'Завершите 10 тренировочных сессий',
           icon: Icons.play_circle_fill,
           progress: stats.sessionsCompleted,
           target: 10,
         ),
         Achievement(
           title: '50 раздач разобрано',
+          description: 'Разберите 50 раздач',
           icon: Icons.menu_book,
           progress: stats.handsReviewed,
           target: 50,
         ),
         Achievement(
           title: '10 ошибок исправлено',
+          description: 'Исправьте 10 ошибок',
           icon: Icons.build,
           progress: stats.mistakesFixed,
           target: 10,
@@ -75,6 +87,7 @@ class AchievementEngine extends ChangeNotifier {
     final ach = _achievements[index];
     if (!_shown[key]! && ach.completed) {
       _shown[key] = true;
+      _unseen += 1;
       _save(key);
       UserActionLogger.instance.log('unlocked_achievement:${ach.title}');
       final ctx = navigatorKey.currentContext;
@@ -85,5 +98,12 @@ class AchievementEngine extends ChangeNotifier {
         );
       }
     }
+  }
+
+  Future<void> markSeen() async {
+    if (_unseen == 0) return;
+    _unseen = 0;
+    await _saveUnseen();
+    notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- expand `Achievement` model with a description field
- update `AchievementEngine` with unseen counter and markSeen()
- redesign `AchievementsScreen` to list achievements from `AchievementEngine`
- show achievements badge on the settings screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd55cf844832aa9d185cc341027dc