### PR TITLE
Add WeeklyChallengeCard widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,6 +81,8 @@ void main() {
         ChangeNotifierProvider(
           create: (context) => WeeklyChallengeService(
             stats: context.read<TrainingStatsService>(),
+            xp: context.read<XPTrackerService>(),
+            packs: context.read<TrainingPackStorageService>(),
           )..load(),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/streak_chart.dart';
 import '../widgets/daily_progress_ring.dart';
 import '../widgets/repeat_mistakes_card.dart';
+import '../widgets/weekly_challenge_card.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
   const TrainingHomeScreen({super.key});
@@ -30,6 +31,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           SpotOfTheDayCard(),
           StreakChart(),
           DailyProgressRing(),
+          WeeklyChallengeCard(),
           RepeatMistakesCard(),
         ],
       ),

--- a/lib/services/weekly_challenge_service.dart
+++ b/lib/services/weekly_challenge_service.dart
@@ -3,6 +3,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/training_pack.dart';
+import 'training_pack_storage_service.dart';
+
 import 'training_stats_service.dart';
 import 'xp_tracker_service.dart';
 import '../main.dart';
@@ -22,10 +25,11 @@ class WeeklyChallengeService extends ChangeNotifier {
 
   final TrainingStatsService stats;
   final XPTrackerService xp;
+  final TrainingPackStorageService packs;
 
   static const _rewardXp = 50;
 
-  WeeklyChallengeService({required this.stats, required this.xp});
+  WeeklyChallengeService({required this.stats, required this.xp, required this.packs});
 
   static const _challenges = [
     WeeklyChallenge('Tag 5 mistakes', 'mistakes', 5),
@@ -68,6 +72,14 @@ class WeeklyChallengeService extends ChangeNotifier {
   }
 
   double get progress => (progressValue / current.target).clamp(0.0, 1.0);
+
+  int get daysLeft =>
+      (7 - DateTime.now().difference(_start).inDays).clamp(0, 7);
+
+  TrainingPack get currentPack =>
+      packs.packs.isNotEmpty
+          ? packs.packs.first
+          : TrainingPack(name: current.title, description: '', hands: []);
 
   Future<void> _onStats() async {
     if (progressValue >= current.target) {

--- a/lib/widgets/weekly_challenge_card.dart
+++ b/lib/widgets/weekly_challenge_card.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/weekly_challenge_service.dart';
+import '../screens/training_pack_review_screen.dart';
+
+class WeeklyChallengeCard extends StatelessWidget {
+  const WeeklyChallengeCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<WeeklyChallengeService>();
+    final challenge = service.current;
+    final progressValue = service.progressValue;
+    final target = challenge.target;
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.flag, color: Colors.greenAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  challenge.title,
+                  style:
+                      const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: service.progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation<Color>(accent),
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Text('$progressValue/$target',
+                        style:
+                            const TextStyle(color: Colors.white70, fontSize: 12)),
+                    const Spacer(),
+                    Text('${service.daysLeft} days left',
+                        style:
+                            const TextStyle(color: Colors.white70, fontSize: 12)),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (progressValue >= target)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+              decoration: BoxDecoration(
+                color: Colors.green,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text('Completed ✅',
+                  style: TextStyle(color: Colors.white)),
+            )
+          else
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        TrainingPackReviewScreen(pack: service.currentPack),
+                  ),
+                );
+              },
+              child: const Text('Start'),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- build WeeklyChallengeCard widget
- surface weekly challenge pack and days left in WeeklyChallengeService
- insert WeeklyChallengeCard on TrainingHomeScreen
- provide dependencies to WeeklyChallengeService

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd84b2458832aaa41b764748f0c21