### PR TITLE
Add template button in spot builder

### DIFF
--- a/lib/widgets/template_selection_dialog.dart
+++ b/lib/widgets/template_selection_dialog.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack_template.dart';
+
+class TemplateSelectionDialog extends StatefulWidget {
+  final List<TrainingPackTemplate> templates;
+  const TemplateSelectionDialog({super.key, required this.templates});
+
+  @override
+  State<TemplateSelectionDialog> createState() => _TemplateSelectionDialogState();
+}
+
+class _TemplateSelectionDialogState extends State<TemplateSelectionDialog> {
+  String _filter = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = [
+      for (final t in widget.templates)
+        if (t.name.toLowerCase().contains(_filter.toLowerCase()) ||
+            t.description.toLowerCase().contains(_filter.toLowerCase()))
+          t
+    ];
+    return AlertDialog(
+      title: const Text('Выберите шаблон'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              decoration: const InputDecoration(hintText: 'Поиск'),
+              onChanged: (v) => setState(() => _filter = v),
+            ),
+            const SizedBox(height: 8),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: visible.length,
+                itemBuilder: (context, index) {
+                  final t = visible[index];
+                  return ListTile(
+                    title: Text(t.name),
+                    subtitle: Text(t.description),
+                    onTap: () => Navigator.pop(context, t),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add TemplateSelectionDialog widget
- allow selecting template in TrainingSpotBuilderScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e42398a38832ab6fe2df3aa56da4b