### PR TITLE
Add bulk color tagging

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -180,6 +180,14 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> save(TrainingPack pack) async {
+    final index = _packs.indexWhere((p) => p.name == pack.name);
+    if (index == -1) return;
+    _packs[index] = pack;
+    await _persist();
+    notifyListeners();
+  }
+
   Future<void> createFromTemplate(TrainingPackTemplate template) async {
     await createFromTemplateWithOptions(
       template,

--- a/lib/widgets/color_tag_dialog.dart
+++ b/lib/widgets/color_tag_dialog.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../helpers/color_utils.dart';
+
+Future<String?> showColorTagDialog(BuildContext context) {
+  const colors = [
+    Colors.red,
+    Colors.blue,
+    Colors.orange,
+    Colors.green,
+    Colors.purple,
+    Colors.grey,
+    Colors.teal,
+    Colors.pink,
+  ];
+  return showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Color Tag'),
+      content: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          for (final c in colors)
+            GestureDetector(
+              onTap: () => Navigator.pop(context, colorToHex(c)),
+              child: CircleAvatar(backgroundColor: c),
+            ),
+        ],
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add save() helper in TrainingPackStorageService
- implement color tag dialog
- enable bulk color tagging in MyTrainingPacksScreen
- show color badges in TrainingPackComparisonScreen and allow bulk tagging

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5287ac44832a911f23ff7b596ae2