### PR TITLE
Add bulk color tagging

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -165,6 +165,31 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setColorTag(TrainingPack pack, String color) async {
+    final index = _packs.indexOf(pack);
+    if (index == -1) return;
+    _packs[index] = TrainingPack(
+      name: pack.name,
+      description: pack.description,
+      category: pack.category,
+      gameType: pack.gameType,
+      colorTag: color,
+      isBuiltIn: pack.isBuiltIn,
+      tags: pack.tags,
+      hands: pack.hands,
+      spots: pack.spots,
+      difficulty: pack.difficulty,
+      history: pack.history,
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> save() async {
+    await _persist();
+    notifyListeners();
+  }
+
   Future<void> duplicatePack(TrainingPack pack) async {
     String base = pack.name;
     String name = '${base}-copy';


### PR DESCRIPTION
## Summary
- allow setting color tag for multiple packs
- add color circle indicators in pack comparison rows
- show color selection bar in MyTrainingPacksScreen
- update TrainingPackStorageService with color support

## Testing
- `dart` and `flutter` commands were unavailable, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_685e5563d96c832abe6d328007792640