### PR TITLE
Add training pack progress indicators

### DIFF
--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -10,6 +10,7 @@ import 'training_pack_screen.dart';
 import '../widgets/difficulty_chip.dart';
 import '../widgets/info_tooltip.dart';
 import '../helpers/color_utils.dart';
+import "../widgets/progress_chip.dart";
 import '../widgets/color_picker_dialog.dart';
 
 class MyTrainingPacksScreen extends StatefulWidget {
@@ -327,6 +328,7 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
                   if (index < count + list.length) {
                     final p = list[index - count];
                     final date = _dates[p.name];
+                    final pct = p.pctComplete;
                     return ListTile(
                       leading: InfoTooltip(
                         message: p.colorTag.isEmpty
@@ -361,6 +363,13 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
                           Expanded(child: Text(p.name)),
                           const SizedBox(width: 4),
                           DifficultyChip(p.difficulty),
+                          const SizedBox(width: 4),
+                          InfoTooltip(
+                            message: pct == 1
+                                ? 'Completed!'
+                                : 'Solved ${p.solved} of ${p.hands.length} hands',
+                            child: ProgressChip(pct),
+                          ),
                         ],
                       ),
                       subtitle: Column(

--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import "../widgets/progress_chip.dart";
 import 'package:provider/provider.dart';
 import 'package:csv/csv.dart';
 import 'package:path_provider/path_provider.dart';
@@ -78,6 +79,7 @@ class _PackDataSource extends DataTableSource {
             ? Colors.redAccent
             : null;
     final progress = s.total > 0 ? (s.total - s.mistakes) / s.total : 0.0;
+    final pct = s.pack.pctComplete;
     final progressColor = progress < 0.5
         ? Colors.redAccent
         : progress < 0.8
@@ -133,6 +135,13 @@ class _PackDataSource extends DataTableSource {
                       Expanded(child: Text(s.pack.isBuiltIn ? '📦 ${s.pack.name}' : s.pack.name)),
                       const SizedBox(width: 4),
                       DifficultyChip(s.pack.difficulty),
+                      const SizedBox(width: 4),
+                      InfoTooltip(
+                        message: pct == 1
+                            ? 'Completed!'
+                            : 'Solved ${s.pack.solved} of ${s.pack.hands.length} hands',
+                        child: ProgressChip(pct),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -1308,6 +1308,7 @@ body { font-family: sans-serif; padding: 16px; }
                     ),
                   ),
           );
+    final pct = _pack.pctComplete;
     return Card(
       color: AppColors.cardBackground,
       margin: const EdgeInsets.all(16),
@@ -1320,16 +1321,32 @@ body { font-family: sans-serif; padding: 16px; }
             DifficultyChip(_pack.difficulty),
           ],
         ),
-        subtitle: Row(
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            InfoTooltip(
-              message: _pack.gameType == GameType.tournament
-                  ? 'Blind levels, ICM pressure.'
-                  : '100 BB deep, no blind escalation.',
-              child: Text(_pack.gameType.label),
+            Row(
+              children: [
+                InfoTooltip(
+                  message: _pack.gameType == GameType.tournament
+                      ? 'Blind levels, ICM pressure.'
+                      : '100 BB deep, no blind escalation.',
+                  child: Text(_pack.gameType.label),
+                ),
+                const Text(' • '),
+                Text(subtitleCount),
+              ],
             ),
-            const Text(' • '),
-            Text(subtitleCount),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(
+              value: pct,
+              backgroundColor: Colors.white12,
+              color: pct >= 1
+                  ? Colors.green
+                  : pct >= .5
+                      ? Colors.amber
+                      : Colors.red,
+              minHeight: 4,
+            ),
           ],
         ),
       ),
@@ -1686,6 +1703,21 @@ body { font-family: sans-serif; padding: 16px; }
           ),
           centerTitle: true,
           actions: [
+            if (_pack.pctComplete < 1)
+              IconButton(
+                icon: const Icon(Icons.play_arrow),
+                tooltip: 'Resume',
+                onPressed: () async {
+                  await _saveProgress();
+                  setState(() {
+                    _currentIndex = _pack.history.isNotEmpty
+                        ? _pack.history.last.total
+                        : 0;
+                    _sessionHands = _pack.hands;
+                    _isMistakeReviewMode = false;
+                  });
+                },
+              ),
             IconButton(
               icon: const Icon(Icons.edit),
               onPressed: _editPack,

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -9,6 +9,7 @@ import '../helpers/color_utils.dart';
 import '../widgets/difficulty_chip.dart';
 import '../widgets/info_tooltip.dart';
 import '../theme/app_colors.dart';
+import "../widgets/progress_chip.dart";
 import '../widgets/color_picker_dialog.dart';
 import 'template_library_screen.dart';
 import 'training_pack_screen.dart';
@@ -391,6 +392,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                         itemCount: visible.length,
                         itemBuilder: (context, index) {
                           final pack = visible[index];
+                          final pct = pack.pctComplete;
                           final completed = _isPackCompleted(pack);
                           return ListTile(
                             leading: pack.isBuiltIn
@@ -415,6 +417,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                                 Expanded(child: Text(pack.name)),
                                 const SizedBox(width: 4),
                                 DifficultyChip(pack.difficulty),
+                                const SizedBox(width: 4),
+                                InfoTooltip(
+                                  message: pct == 1
+                                      ? 'Completed!'
+                                      : 'Solved ${pack.solved} of ${pack.hands.length} hands',
+                                  child: ProgressChip(pct),
+                                ),
                               ],
                             ),
                             subtitle: Row(
@@ -489,6 +498,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           final list = groups[color]!;
           if (index < count + list.length) {
             final pack = list[index - count];
+            final pct = pack.pctComplete;
             final completed = _isPackCompleted(pack);
             return ListTile(
               leading: pack.isBuiltIn
@@ -513,6 +523,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                   Expanded(child: Text(pack.name)),
                   const SizedBox(width: 4),
                   DifficultyChip(pack.difficulty),
+                  const SizedBox(width: 4),
+                  InfoTooltip(
+                    message: pct == 1
+                        ? 'Completed!'
+                        : 'Solved ${pack.solved} of ${pack.hands.length} hands',
+                    child: ProgressChip(pct),
+                  ),
                 ],
               ),
               subtitle: Row(

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -247,3 +247,10 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 }
+
+extension PackProgress on TrainingPack {
+  int get solved => history.isNotEmpty ? history.last.correct : 0;
+  int get attempted => history.isNotEmpty ? history.last.total : 0;
+  double get pctComplete =>
+      (attempted == 0 ? 0 : solved / hands.length).clamp(0, 1);
+}

--- a/lib/widgets/progress_chip.dart
+++ b/lib/widgets/progress_chip.dart
@@ -1,0 +1,19 @@
+import "package:flutter/material.dart";
+class ProgressChip extends StatelessWidget {
+  final double pct;
+  const ProgressChip(this.pct, {super.key});
+  @override
+  Widget build(BuildContext ctx) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: pct >= 1
+              ? Colors.green
+              : pct >= .5
+                  ? Colors.amber
+                  : Colors.red,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text('${(pct * 100).round()}%',
+            style: const TextStyle(color: Colors.black, fontSize: 12)),
+      );
+}


### PR DESCRIPTION
## Summary
- show solved/attempted getters via `PackProgress` extension
- new `ProgressChip` widget for % completion
- display progress chip in pack list screens
- add progress bar and quick resume in pack screen

## Testing
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_685e661854c0832ab36aa98b54bf11cf