### PR TITLE
Improve training pack progress widgets

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -1345,7 +1345,7 @@ body { font-family: sans-serif; padding: 16px; }
                   : pct >= .5
                       ? Colors.amber
                       : Colors.red,
-              minHeight: 4,
+              minHeight: 6,
             ),
           ],
         ),
@@ -1707,12 +1707,10 @@ body { font-family: sans-serif; padding: 16px; }
               IconButton(
                 icon: const Icon(Icons.play_arrow),
                 tooltip: 'Resume',
-                onPressed: () async {
-                  await _saveProgress();
+                onPressed: () {
                   setState(() {
-                    _currentIndex = _pack.history.isNotEmpty
-                        ? _pack.history.last.total
-                        : 0;
+                    _currentIndex =
+                        _pack.history.isNotEmpty ? _pack.history.last.total : 0;
                     _sessionHands = _pack.hands;
                     _isMistakeReviewMode = false;
                   });

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -250,7 +250,7 @@ class TrainingPackStorageService extends ChangeNotifier {
 
 extension PackProgress on TrainingPack {
   int get solved => history.isNotEmpty ? history.last.correct : 0;
-  int get attempted => history.isNotEmpty ? history.last.total : 0;
+  int get lastAttempted => history.isNotEmpty ? history.last.total : 0;
   double get pctComplete =>
-      (attempted == 0 ? 0 : solved / hands.length).clamp(0, 1);
+      (hands.isEmpty ? 0 : solved / hands.length).clamp(0, 1);
 }

--- a/lib/widgets/progress_chip.dart
+++ b/lib/widgets/progress_chip.dart
@@ -2,18 +2,25 @@ import "package:flutter/material.dart";
 class ProgressChip extends StatelessWidget {
   final double pct;
   const ProgressChip(this.pct, {super.key});
+
   @override
-  Widget build(BuildContext ctx) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-        decoration: BoxDecoration(
-          color: pct >= 1
-              ? Colors.green
-              : pct >= .5
-                  ? Colors.amber
-                  : Colors.red,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Text('${(pct * 100).round()}%',
-            style: const TextStyle(color: Colors.black, fontSize: 12)),
-      );
+  Widget build(BuildContext ctx) {
+    final tint = Theme.of(ctx).colorScheme.surfaceTint;
+    final color = pct >= 1
+        ? tint.withOpacity(.9)
+        : pct >= .5
+            ? tint.withOpacity(.7)
+            : tint.withOpacity(.5);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '${(pct * 100).round()}%',
+        style: const TextStyle(color: Colors.black, fontSize: 12),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- prevent divide-by-zero in `PackProgress`
- tweak progress chip styling
- enlarge info card progress bar
- fix resume button behavior

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e685d00cc832aad1c6b59e0277782