### PR TITLE
Implement progress reset fixes

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -519,6 +519,11 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
         history: history,
       );
     });
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Прогресс сброшен')),
+      );
+    }
   }
 
   void _previousHand() {
@@ -1724,7 +1729,7 @@ body { font-family: sans-serif; padding: 16px; }
           ),
           centerTitle: true,
           actions: [
-            if (_pack.pctComplete < 1)
+            if (_pack.pctComplete > 0 && _pack.pctComplete < 1)
               IconButton(
                 icon: const Icon(Icons.play_arrow),
                 tooltip: 'Resume',
@@ -1750,8 +1755,12 @@ body { font-family: sans-serif; padding: 16px; }
               onSelected: (v) {
                 if (v == 'reset') _clearProgress();
               },
-              itemBuilder: (_) => const [
-                PopupMenuItem(value: 'reset', child: Text('Сбросить прогресс')),
+              itemBuilder: (_) => [
+                PopupMenuItem(
+                  value: 'reset',
+                  enabled: _pack.history.isNotEmpty,
+                  child: const Text('Сбросить прогресс'),
+                ),
               ],
             ),
           ],

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/training_pack.dart';
 import '../models/training_pack_template.dart';
@@ -202,6 +203,8 @@ class TrainingPackStorageService extends ChangeNotifier {
       difficulty: pack.difficulty,
       history: history,
     );
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('training_progress_${pack.name}');
     await _persist();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- remove training progress from prefs when clearing a session
- show a snackbar on reset
- hide resume button when no progress
- disable reset menu item if history is empty

## Testing
- `flutter analyze` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6a781d6c832a9dce6be5b5f3e302