### PR TITLE
Add training pack duplication

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -526,6 +526,18 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     }
   }
 
+  Future<void> _duplicatePack() async {
+    final service = context.read<TrainingPackStorageService>();
+    final copy = await service.duplicatePack(_pack);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Копия создана')));
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TrainingPackScreen(pack: copy)),
+    );
+  }
+
   void _previousHand() {
     if (_currentIndex > 0) {
       setState(() {
@@ -1754,12 +1766,17 @@ body { font-family: sans-serif; padding: 16px; }
             PopupMenuButton<String>(
               onSelected: (v) {
                 if (v == 'reset') _clearProgress();
+                if (v == 'duplicate') _duplicatePack();
               },
               itemBuilder: (_) => [
                 PopupMenuItem(
                   value: 'reset',
                   enabled: _pack.history.isNotEmpty,
                   child: const Text('Сбросить прогресс'),
+                ),
+                const PopupMenuItem(
+                  value: 'duplicate',
+                  child: Text('Создать копию'),
                 ),
               ],
             ),

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -214,7 +214,7 @@ class TrainingPackStorageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> duplicatePack(TrainingPack pack) async {
+  Future<TrainingPack> duplicatePack(TrainingPack pack) async {
     String base = pack.name;
     String name = '${base}-copy';
     int idx = 1;
@@ -227,6 +227,7 @@ class TrainingPackStorageService extends ChangeNotifier {
     _packs.add(copy);
     await _persist();
     notifyListeners();
+    return copy;
   }
 
   Future<void> createFromTemplate(TrainingPackTemplate template) async {


### PR DESCRIPTION
## Summary
- return a copy from `duplicatePack`
- allow duplicating packs from TrainingPackScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6b6ee5fc832a82d3a8f8a1b05f77