### PR TITLE
Improve pack duplication

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -530,9 +530,10 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     final service = context.read<TrainingPackStorageService>();
     final copy = await service.duplicatePack(_pack);
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Копия создана')));
-    Navigator.push(
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Копия «${copy.name}» создана')),
+    );
+    Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (_) => TrainingPackScreen(pack: copy)),
     );
@@ -1774,9 +1775,10 @@ body { font-family: sans-serif; padding: 16px; }
                   enabled: _pack.history.isNotEmpty,
                   child: const Text('Сбросить прогресс'),
                 ),
-                const PopupMenuItem(
+                PopupMenuItem(
                   value: 'duplicate',
-                  child: Text('Создать копию'),
+                  enabled: !_pack.isBuiltIn,
+                  child: const Text('Создать копию'),
                 ),
               ],
             ),

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -215,14 +215,19 @@ class TrainingPackStorageService extends ChangeNotifier {
   }
 
   Future<TrainingPack> duplicatePack(TrainingPack pack) async {
-    String base = pack.name;
-    String name = '${base}-copy';
+    String base = pack.name.replaceFirst(RegExp(r'-copy\d*\$'), '');
+    String name = '$base-copy';
     int idx = 1;
     while (_packs.any((p) => p.name == name)) {
-      name = '${base}-copy${idx > 1 ? idx : ''}';
       idx++;
+      name = '$base-copy${idx > 1 ? idx : ''}';
     }
-    final map = {...pack.toJson(), 'name': name, 'isBuiltIn': false};
+    final map = {
+      ...pack.toJson(),
+      'name': name,
+      'isBuiltIn': false,
+      'history': []
+    };
     final copy = TrainingPack.fromJson(map);
     _packs.add(copy);
     await _persist();


### PR DESCRIPTION
## Summary
- reset history when duplicating training pack
- disable duplication for read‑only packs
- show final name in snackbar and open copy with pushReplacement

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6c78ccb8832ab91db7955416afe2