### PR TITLE
Refine training pack duplication

### DIFF
--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -208,7 +208,8 @@ class _PackDataSource extends DataTableSource {
                 const PopupMenuItem(value: 'rename', child: Text('Переименовать')),
               if (!s.pack.isBuiltIn)
                 const PopupMenuItem(value: 'delete', child: Text('Удалить')),
-              const PopupMenuItem(value: 'duplicate', child: Text('Дублировать')),
+              if (!s.pack.isBuiltIn)
+                const PopupMenuItem(value: 'duplicate', child: Text('Дублировать')),
             ],
           ),
         ),
@@ -343,18 +344,21 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
       builder: (ctx) => SimpleDialog(
         title: Text(s.pack.name),
         children: [
-          SimpleDialogOption(
-            onPressed: () => Navigator.pop(ctx, 'rename'),
-            child: const Text('Переименовать'),
-          ),
-          SimpleDialogOption(
-            onPressed: () => Navigator.pop(ctx, 'delete'),
-            child: const Text('Удалить'),
-          ),
-          SimpleDialogOption(
-            onPressed: () => Navigator.pop(ctx, 'duplicate'),
-            child: const Text('Дублировать'),
-          ),
+          if (!s.pack.isBuiltIn)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, 'rename'),
+              child: const Text('Переименовать'),
+            ),
+          if (!s.pack.isBuiltIn)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, 'delete'),
+              child: const Text('Удалить'),
+            ),
+          if (!s.pack.isBuiltIn)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, 'duplicate'),
+              child: const Text('Дублировать'),
+            ),
         ],
       ),
     );

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -530,12 +530,12 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     final service = context.read<TrainingPackStorageService>();
     final copy = await service.duplicatePack(_pack);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Копия «${copy.name}» создана')),
-    );
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (_) => TrainingPackScreen(pack: copy)),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Копия «${copy.name}» создана')),
     );
   }
 

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -215,7 +215,8 @@ class TrainingPackStorageService extends ChangeNotifier {
   }
 
   Future<TrainingPack> duplicatePack(TrainingPack pack) async {
-    String base = pack.name.replaceFirst(RegExp(r'-copy\d*\$'), '');
+    if (pack.isBuiltIn) return pack;
+    String base = pack.name.replaceAll(RegExp(r'(-copy\d*)+\$'), '');
     String name = '$base-copy';
     int idx = 1;
     while (_packs.any((p) => p.name == name)) {


### PR DESCRIPTION
## Summary
- fix regex for copy suffix removal and block built-in duplication
- show creation toast on new TrainingPack screen
- hide duplication menu for built-in packs

## Testing
- `dart test` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6e183ad0832a8c8fcf404e0b7460