### PR TITLE
Resolve snackbar flow and built-in assert

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -530,13 +530,12 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     final service = context.read<TrainingPackStorageService>();
     final copy = await service.duplicatePack(_pack);
     if (!mounted) return;
-    Navigator.pushReplacement(
+    await Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (_) => TrainingPackScreen(pack: copy)),
     );
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Копия «${copy.name}» создана')),
-    );
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Копия «${copy.name}» создана')));
   }
 
   void _previousHand() {

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -215,13 +215,13 @@ class TrainingPackStorageService extends ChangeNotifier {
   }
 
   Future<TrainingPack> duplicatePack(TrainingPack pack) async {
-    if (pack.isBuiltIn) return pack;
+    assert(!pack.isBuiltIn);
     String base = pack.name.replaceAll(RegExp(r'(-copy\d*)+\$'), '');
     String name = '$base-copy';
     int idx = 1;
     while (_packs.any((p) => p.name == name)) {
       idx++;
-      name = '$base-copy${idx > 1 ? idx : ''}';
+      name = '$base-copy$idx';
     }
     final map = {
       ...pack.toJson(),


### PR DESCRIPTION
## Summary
- trigger snackbar after navigating to the duplicated pack
- assert that pack isn't built-in before duplicating
- fix copy index to avoid skipping numbers

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f62e910832a916c24d15b9d6b27