### PR TITLE
Fix pack name duplicate check

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -256,10 +256,10 @@ class TrainingPackStorageService extends ChangeNotifier {
         (template.category?.isNotEmpty == true ? template.category! : 'custom');
     String base = 'Новый пак: $category';
     String name = base;
-    int idx = 1;
+    int idx = 2;
     while (_packs.any((p) => p.name == name)) {
-      idx++;
       name = '$base ($idx)';
+      idx++;
     }
     final pack = TrainingPack(
       name: name,


### PR DESCRIPTION
## Summary
- improve training pack name auto generation by adjusting the index logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e741420ec832a9686e4aa16f7e37a