### PR TITLE
fix pack library filters

### DIFF
--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -162,6 +162,8 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
         if (da == null) return 1;
         if (db == null) return -1;
         return db.compareTo(da);
+      case 'category':
+        return a.category.compareTo(b.category);
       default:
         return a.name.compareTo(b.name);
     }
@@ -357,7 +359,7 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: DropdownButton<String>(
-            value: _tagFilter,
+            value: allTags.contains(_tagFilter) ? _tagFilter : 'All',
             underline: const SizedBox.shrink(),
             onChanged: (v) => _setTagFilter(v ?? 'All'),
             items: [


### PR DESCRIPTION
## Summary
- sort packs by category
- handle stored tag values that no longer exist

## Testing
- `flutter analyze` *(fails: analysis server exited with code -2)*

------
https://chatgpt.com/codex/tasks/task_e_685e76402b40832a88c5a7469cabacdc