### PR TITLE
Fix search filter init

### DIFF
--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -64,6 +64,9 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
       _groupByColor = prefs.getBool(_groupKey) ?? false;
       _lastColor = colorFromHex(prefs.getString(_lastColorKey) ?? '#2196F3');
     });
+    if (_searchController.text.isNotEmpty) {
+      await _setSearch(_searchController.text);
+    }
   }
 
   Future<void> _loadDates() async {


### PR DESCRIPTION
## Summary
- apply search filter automatically when restoring preferences

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e782f12f0832a890dd354a8f19e28