### PR TITLE
Track training pack progress per attempt

### DIFF
--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -71,6 +71,11 @@ class TrainingPack {
         spots = spots ?? const [],
         history = history ?? [];
 
+  int get solved => history.isNotEmpty ? history.last.correct : 0;
+  int get lastAttempted => history.isNotEmpty ? history.last.total : 0;
+  DateTime get lastAttemptDate =>
+      history.isNotEmpty ? history.last.date : DateTime.fromMillisecondsSinceEpoch(0);
+
   Map<String, dynamic> toJson() => {
         'name': name,
         'description': description,

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -558,6 +558,12 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     } else {
       _results.add(result);
     }
+    if (!_pack.isBuiltIn) {
+      final updated = await context
+          .read<TrainingPackStorageService>()
+          .recordAttempt(_pack, result.correct);
+      if (updated != null) _pack = updated;
+    }
     setState(() {
       _currentIndex++;
     });


### PR DESCRIPTION
## Summary
- store last attempt progress inside `TrainingPack`
- add `recordAttempt` API in `TrainingPackStorageService`
- update `_nextHand` to log each try
- expose progress helpers on `TrainingPack`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e81555a20832ab975159b09421394