### PR TITLE
Add last attempt sort option

### DIFF
--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -212,6 +212,11 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
         return db.compareTo(da);
       case 'category':
         return a.category.compareTo(b.category);
+      case 'lastAttempt':
+        final da = a.lastAttemptDate;
+        final db = b.lastAttemptDate;
+        if (da.isAtSameMomentAs(db)) return a.name.compareTo(b.name);
+        return db.compareTo(da);
       default:
         return a.name.compareTo(b.name);
     }
@@ -315,6 +320,7 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
             onChanged: (v) => _setSort(v ?? 'name'),
             items: const [
               DropdownMenuItem(value: 'name', child: Text('По имени')),
+              DropdownMenuItem(value: 'lastAttempt', child: Text('Последняя попытка')),
               DropdownMenuItem(value: 'date', child: Text('По дате')),
               DropdownMenuItem(value: 'category', child: Text('По категории')),
             ],


### PR DESCRIPTION
## Summary
- sort training packs by last attempt date

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8bc91154832a9b83995fc2de7d95