### PR TITLE
Add weekday analytics chart

### DIFF
--- a/lib/screens/training_activity_by_weekday_screen.dart
+++ b/lib/screens/training_activity_by_weekday_screen.dart
@@ -24,6 +24,17 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
       }
     }
     final maxCount = counts.reduce(max);
+    if (maxCount == 0) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Активность по дням недели'),
+          centerTitle: true,
+        ),
+        body: const Center(
+          child: Text('Нет данных за последнюю неделю'),
+        ),
+      );
+    }
     const labels = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
     final groups = <BarChartGroupData>[];
     for (var i = 0; i < counts.length; i++) {
@@ -63,7 +74,6 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
           ),
           child: BarChart(
             BarChartData(
-              rotationQuarterTurns: 1,
               maxY: maxCount.toDouble(),
               minY: 0,
               gridData: FlGridData(
@@ -74,44 +84,52 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
                     FlLine(color: Colors.white24, strokeWidth: 1),
               ),
               titlesData: FlTitlesData(
-                topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                leftTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                bottomTitles: AxisTitles(
+                topTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    getTitlesWidget: (value, meta) {
+                      final index = value.toInt();
+                      if (index < 0 || index >= counts.length) {
+                        return const SizedBox.shrink();
+                      }
+                      final c = counts[index];
+                      return c > 0
+                          ? Text('$c',
+                              style: const TextStyle(
+                                  color: Colors.white, fontSize: 10))
+                          : const SizedBox.shrink();
+                    },
+                  ),
+                ),
+                leftTitles: AxisTitles(
                   sideTitles: SideTitles(
                     showTitles: true,
                     interval: interval,
                     reservedSize: 28,
-                    getTitlesWidget: (value, meta) => Transform.rotate(
-                      angle: -pi / 2,
-                      child: Text(
-                        value.toInt().toString(),
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 10),
-                      ),
+                    getTitlesWidget: (value, meta) => Text(
+                      value.toInt().toString(),
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
                     ),
                   ),
                 ),
-                rightTitles: AxisTitles(
+                bottomTitles: AxisTitles(
                   sideTitles: SideTitles(
                     showTitles: true,
-                    reservedSize: 70,
+                    reservedSize: 28,
                     getTitlesWidget: (value, meta) {
                       final index = value.toInt();
                       if (index < 0 || index >= labels.length) {
                         return const SizedBox.shrink();
                       }
-                      final text = '${labels[index]} (${counts[index]})';
-                      return Transform.rotate(
-                        angle: -pi / 2,
-                        child: Text(
-                          text,
-                          style:
-                              const TextStyle(color: Colors.white, fontSize: 10),
-                        ),
+                      return Text(
+                        labels[index],
+                        style: const TextStyle(color: Colors.white, fontSize: 10),
                       );
                     },
                   ),
                 ),
+                rightTitles:
+                    AxisTitles(sideTitles: SideTitles(showTitles: false)),
               ),
               borderData: FlBorderData(
                 show: true,

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
+import 'training_activity_by_weekday_screen.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -28,6 +29,21 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Аналитика по категориям'),
         centerTitle: true,
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const TrainingActivityByWeekdayScreen()),
+              );
+            },
+            child: const Text(
+              'Дни недели',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+        ],
       ),
       body: ListView.separated(
         padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- show placeholder if no data is available for weekday chart
- draw vertical bar chart with counts above bars
- link "Дни недели" from analytics screen to weekday activity screen

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e951435b0832abcf3f4950d88f678