### PR TITLE
Add errors button in training analytics

### DIFF
--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
 import 'training_activity_by_weekday_screen.dart';
+import 'top_mistakes_overview_screen.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -40,6 +41,19 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
             },
             child: const Text(
               'Дни недели',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const TopMistakesOverviewScreen()),
+              );
+            },
+            child: const Text(
+              'Ошибки',
               style: TextStyle(color: Colors.white),
             ),
           ),


### PR DESCRIPTION
## Summary
- show "Ошибки" action in TrainingProgressAnalyticsScreen to open TopMistakesOverviewScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea024c0f4832ab55064c4df2bfed5