### PR TITLE
Enable hand list editing when creating pack from template

### DIFF
--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/color_utils.dart';
 import '../widgets/color_picker_dialog.dart';
 import '../models/training_pack_template.dart';
+import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
 
@@ -19,7 +20,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
   late TextEditingController _name;
   bool _addTags = true;
   Color _color = Colors.blue;
-  final Set<int> _selected = {};
+  final List<SavedHand> _selected = [];
   SharedPreferences? _prefs;
   static const _colorKey = 'template_last_color';
   static const _tagsKey = 'template_add_tags';
@@ -29,7 +30,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
     super.initState();
     _name = TextEditingController(text: 'Новый пак: ${widget.template.name}');
     _color = colorFromHex(widget.template.defaultColor);
-    _selected.addAll(List.generate(widget.template.hands.length, (i) => i));
+    _selected.addAll(widget.template.hands);
     _loadPrefs();
   }
 
@@ -54,13 +55,108 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
   }
 
   void _toggle(int index) {
+    final hand = widget.template.hands[index];
     setState(() {
-      if (_selected.contains(index)) {
-        _selected.remove(index);
+      if (_selected.contains(hand)) {
+        _selected.remove(hand);
       } else {
-        _selected.add(index);
+        _selected.add(hand);
       }
     });
+  }
+
+  Future<void> _editSelected() async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setStateDialog) {
+          Future<void> rename(int index) async {
+            final controller =
+                TextEditingController(text: _selected[index].name);
+            final name = await showDialog<String>(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('Переименовать'),
+                content: TextField(
+                  controller: controller,
+                  autofocus: true,
+                  maxLength: 50,
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Отмена'),
+                  ),
+                  TextButton(
+                    onPressed: () =>
+                        Navigator.pop(context, controller.text.trim()),
+                    child: const Text('OK'),
+                  ),
+                ],
+              ),
+            );
+            if (name != null && name.isNotEmpty) {
+              setStateDialog(() =>
+                  _selected[index] = _selected[index].copyWith(name: name));
+              setState(() {});
+            }
+          }
+
+          void remove(int index) {
+            setStateDialog(() => _selected.removeAt(index));
+            setState(() {});
+          }
+
+          void reorder(int oldIndex, int newIndex) {
+            if (newIndex > oldIndex) newIndex -= 1;
+            final item = _selected.removeAt(oldIndex);
+            _selected.insert(newIndex, item);
+            setStateDialog(() {});
+            setState(() {});
+          }
+
+          return AlertDialog(
+            title: const Text('Редактировать руки'),
+            content: SizedBox(
+              width: 300,
+              height: 400,
+              child: ReorderableListView.builder(
+                onReorder: reorder,
+                itemCount: _selected.length,
+                itemBuilder: (context, index) {
+                  final hand = _selected[index];
+                  final title = hand.name.isEmpty ? 'Без названия' : hand.name;
+                  return ListTile(
+                    key: ValueKey(hand),
+                    leading: const Icon(Icons.drag_handle),
+                    title: Text(title, overflow: TextOverflow.ellipsis),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: () => rename(index),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => remove(index),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Закрыть'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
   }
 
   Future<void> _create() async {
@@ -68,7 +164,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
     final prefs = _prefs ?? await SharedPreferences.getInstance();
     await prefs.setString(_colorKey, colorToHex(_color));
     await prefs.setBool(_tagsKey, _addTags);
-    final hands = [for (final i in _selected) widget.template.hands[i]];
+    final hands = List<SavedHand>.from(_selected);
     var pack = await service.createFromTemplateWithOptions(
       widget.template,
       hands: hands,
@@ -111,14 +207,24 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
                 itemBuilder: (_, i) {
                   final h = widget.template.hands[i];
                   return CheckboxListTile(
-                    value: _selected.contains(i),
+                    value: _selected.contains(h),
                     onChanged: (_) => _toggle(i),
                     title: Text(h.name),
                   );
                 },
               ),
             ),
-            Text('Выбрано: ${_selected.length} / ${widget.template.hands.length}'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Выбрано: ${_selected.length} / ${widget.template.hands.length}'),
+                const SizedBox(width: 8),
+                IconButton(
+                  icon: const Icon(Icons.edit, size: 16),
+                  onPressed: _selected.isEmpty ? null : _editSelected,
+                ),
+              ],
+            ),
             const SizedBox(height: 16),
             Opacity(
               opacity: _selected.isNotEmpty ? 1 : 0.5,


### PR DESCRIPTION
## Summary
- allow selecting custom hands when creating a pack from template
- support drag & drop reordering, renaming and removing hands
- add edit button to open selected hand editor

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 2033 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685eae2f8ab0832aaa0782db93bead7a