### PR TITLE
feat: template preview and import

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1,11 +1,18 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:file_picker/file_picker.dart';
 
 import '../helpers/color_utils.dart';
 import '../services/template_storage_service.dart';
 import '../models/training_pack_template.dart';
 import 'create_pack_from_template_screen.dart';
+import 'create_template_screen.dart';
+import 'template_hands_editor_screen.dart';
+import 'template_preview_dialog.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -16,7 +23,9 @@ class TemplateLibraryScreen extends StatefulWidget {
 
 class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   static const _key = 'template_filter_game_type';
+  static const _sortKey = 'template_sort_order';
   String _filter = 'all';
+  String _sort = 'updatedAt';
 
   @override
   void initState() {
@@ -26,7 +35,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    setState(() => _filter = prefs.getString(_key) ?? 'all');
+    setState(() {
+      _filter = prefs.getString(_key) ?? 'all';
+      _sort = prefs.getString(_sortKey) ?? 'updatedAt';
+    });
   }
 
   Future<void> _setFilter(String value) async {
@@ -37,6 +49,70 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     } else {
       await prefs.setString(_key, value);
     }
+  }
+
+  Future<void> _setSort(String value) async {
+    setState(() => _sort = value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_sortKey, value);
+  }
+
+  List<TrainingPackTemplate> _applySorting(List<TrainingPackTemplate> list) {
+    final copy = [...list];
+    switch (_sort) {
+      case 'name':
+        copy.sort((a, b) => a.name.compareTo(b.name));
+        break;
+      case 'hands':
+        copy.sort((a, b) {
+          final cmp = b.hands.length.compareTo(a.hands.length);
+          return cmp == 0 ? a.name.compareTo(b.name) : cmp;
+        });
+        break;
+      default:
+        copy.sort((a, b) {
+          final cmp = b.updatedAt.compareTo(a.updatedAt);
+          return cmp == 0 ? a.name.compareTo(b.name) : cmp;
+        });
+    }
+    return copy;
+  }
+
+  Future<void> _importTemplate() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return;
+    Uint8List? data = result.files.single.bytes;
+    final path = result.files.single.path;
+    if (data == null && path != null) data = await File(path).readAsBytes();
+    if (data == null) return;
+    final service = context.read<TemplateStorageService>();
+    final error = service.importTemplate(data);
+    if (!mounted) return;
+    if (error != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('⚠️ $error')));
+    } else {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Шаблон импортирован')));
+    }
+  }
+
+  Future<void> _createTemplate() async {
+    final template = await Navigator.push<TrainingPackTemplate?>(
+      context,
+      MaterialPageRoute(builder: (_) => const CreateTemplateScreen()),
+    );
+    if (template == null) return;
+    context.read<TemplateStorageService>().addTemplate(template);
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TemplateHandsEditorScreen(template: template),
+      ),
+    );
   }
 
   @override
@@ -54,20 +130,40 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           if (t.gameType.toLowerCase().contains('cash')) t
       ];
     }
+    visible = _applySorting(visible);
     return Scaffold(
       appBar: AppBar(title: const Text('Шаблоны')),
       body: Column(
         children: [
           Padding(
             padding: const EdgeInsets.all(16),
-            child: DropdownButton<String>(
-              value: _filter,
-              underline: const SizedBox.shrink(),
-              onChanged: (v) => v != null ? _setFilter(v) : null,
-              items: const [
-                DropdownMenuItem(value: 'all', child: Text('Все')),
-                DropdownMenuItem(value: 'tournament', child: Text('Tournament')),
-                DropdownMenuItem(value: 'cash', child: Text('Cash')),
+            child: Row(
+              children: [
+                Expanded(
+                  child: DropdownButton<String>(
+                    value: _filter,
+                    underline: const SizedBox.shrink(),
+                    onChanged: (v) => v != null ? _setFilter(v) : null,
+                    items: const [
+                      DropdownMenuItem(value: 'all', child: Text('Все')),
+                      DropdownMenuItem(value: 'tournament', child: Text('Tournament')),
+                      DropdownMenuItem(value: 'cash', child: Text('Cash')),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: DropdownButton<String>(
+                    value: _sort,
+                    underline: const SizedBox.shrink(),
+                    onChanged: (v) => v != null ? _setSort(v) : null,
+                    items: const [
+                      DropdownMenuItem(value: 'updatedAt', child: Text('По дате')),
+                      DropdownMenuItem(value: 'name', child: Text('По имени')),
+                      DropdownMenuItem(value: 'hands', child: Text('По рукам')),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),
@@ -86,16 +182,41 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     title: Text(t.name),
                     subtitle: Text(
                         '${t.category ?? 'Без категории'} • ${t.hands.length} рук • v$version'),
-                    onTap: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (_) =>
-                              CreatePackFromTemplateScreen(template: t)),
-                    ),
+                    onTap: () async {
+                      final create = await showDialog<bool>(
+                        context: context,
+                        builder: (_) => TemplatePreviewDialog(template: t),
+                      );
+                      if (create == true && context.mounted) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) =>
+                                  CreatePackFromTemplateScreen(template: t)),
+                        );
+                      }
+                    },
                   ),
                 );
               },
             ),
+          ),
+        ],
+      ),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          FloatingActionButton(
+            heroTag: 'importTemplateFab',
+            onPressed: _importTemplate,
+            child: const Icon(Icons.upload_file),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton(
+            heroTag: 'createTemplateFab',
+            onPressed: _createTemplate,
+            child: const Icon(Icons.add),
           ),
         ],
       ),

--- a/lib/screens/template_preview_dialog.dart
+++ b/lib/screens/template_preview_dialog.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../models/training_pack_template.dart';
+import '../helpers/color_utils.dart';
+
+class TemplatePreviewDialog extends StatelessWidget {
+  final TrainingPackTemplate template;
+  const TemplatePreviewDialog({super.key, required this.template});
+
+  @override
+  Widget build(BuildContext context) {
+    final parts = template.version.split('.');
+    final version = parts.length >= 2 ? '${parts[0]}.${parts[1]}' : template.version;
+    final names = [
+      for (final h in template.hands.take(5))
+        h.name.isEmpty ? 'Без названия' : h.name
+    ];
+    final rest = template.hands.length - names.length;
+    return AlertDialog(
+      title: Text(template.name),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 16,
+                height: 16,
+                decoration: BoxDecoration(
+                  color: colorFromHex(template.defaultColor),
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(template.category ?? 'Без категории'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text('Тип: ${template.gameType}'),
+          Text('Версия: $version'),
+          if (template.author.isNotEmpty) Text('Автор: ${template.author}'),
+          const SizedBox(height: 8),
+          Text('${template.hands.length} раздач / ${template.tags.length} тегов'),
+          const SizedBox(height: 8),
+          for (final n in names) Text('• $n', overflow: TextOverflow.ellipsis),
+          if (rest > 0) Text('… +$rest'),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Отмена'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Создать пак'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show detailed template preview dialog before creating packs
- sort template library with persisted order
- add JSON import with error handling
- store templates with new import function

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb176e8c0832ab7e4717b168a5636