### PR TITLE
Add training pack JSON import/export

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -907,17 +907,11 @@ body { font-family: sans-serif; padding: 16px; }
   Future<void> _importPackFromFile() async {
     final service =
         Provider.of<TrainingPackStorageService>(context, listen: false);
-    final pack = await service.importPack();
+    final msg = await service.importPackFromFile();
     if (!mounted) return;
-    if (pack == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Ошибка загрузки пакета')),
-      );
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Пакет "${pack.name}" загружен')),
-      );
-    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg ?? 'Пак импортирован')),
+    );
   }
 
   Future<void> _importSpotsCsv() async {

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -43,14 +43,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
 
   Future<void> _importPack() async {
     final service = context.read<TrainingPackStorageService>();
-    final pack = await service.importPack();
+    final msg = await service.importPackFromFile();
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          pack == null ? 'Ошибка загрузки пакета' : 'Пакет "${pack.name}" загружен',
-        ),
-      ),
+      SnackBar(content: Text(msg ?? 'Пак импортирован')),
     );
   }
 


### PR DESCRIPTION
## Summary
- enable export/import of custom training packs
- add import FAB and export menu option
- ensure packs are saved in Downloads and imported with unique names

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba37bb88832a88ffce7c7cd703ee