### PR TITLE
Add duplicate and delete options for training packs

### DIFF
--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -300,12 +300,12 @@ class TrainingPackStorageService extends ChangeNotifier {
 
   Future<TrainingPack> duplicatePack(TrainingPack pack) async {
     assert(!pack.isBuiltIn);
-    String base = pack.name.replaceAll(RegExp(r'(-copy\d*)+\$'), '');
-    String name = '$base-copy';
-    int idx = 1;
+    String base = pack.name.replaceAll(RegExp(r'\s*\(copy\d*\)\$'), '');
+    String name = '$base (copy)';
+    int idx = 2;
     while (_packs.any((p) => p.name == name)) {
+      name = '$base (copy$idx)';
       idx++;
-      name = '$base-copy$idx';
     }
     final map = {
       ...pack.toJson(),


### PR DESCRIPTION
## Summary
- enable duplicating custom packs with `(copy)` names
- allow deleting custom packs with undo
- update popup menu for packs to include duplicate and delete actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc3c3314832a858444c03897b0c9