### PR TITLE
feat: remember last color for new packs

### DIFF
--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -163,6 +163,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
     final service = context.read<TrainingPackStorageService>();
     final prefs = _prefs ?? await SharedPreferences.getInstance();
     await prefs.setString(_colorKey, colorToHex(_color));
+    await prefs.setString('pack_last_color', colorToHex(_color));
     await prefs.setBool(_tagsKey, _addTags);
     final hands = List<SavedHand>.from(_selected);
     var pack = await service.createFromTemplateWithOptions(

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -329,20 +329,23 @@ class TrainingPackStorageService extends ChangeNotifier {
       name = '$base ($idx)';
       idx++;
     }
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getString('pack_last_color');
+    final reg = RegExp(r'^#[0-9A-Fa-f]{6}\$');
+    final color = last != null && reg.hasMatch(last) ? last : tpl.defaultColor;
     final pack = TrainingPack(
       name: name,
       description: tpl.description,
       category: tpl.category ?? 'Uncategorized',
       gameType: parseGameType(tpl.gameType),
-      colorTag: tpl.defaultColor,
+      colorTag: color,
       tags: List.from(tpl.tags),
       hands: tpl.hands,
       spots: const [],
       difficulty: 1,
     );
     _packs.add(pack);
-    await _persist();
-    notifyListeners();
+    await save();
     return pack;
   }
 


### PR DESCRIPTION
## Summary
- persist last selected color when creating custom pack from template
- apply that color automatically when creating new packs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3521e3c832aa676fecf5c7e7a9f