### PR TITLE
Add pretty JSON display for training pack filters

### DIFF
--- a/lib/screens/training_pack_template_editor_screen.dart
+++ b/lib/screens/training_pack_template_editor_screen.dart
@@ -30,7 +30,10 @@ class _TrainingPackTemplateEditorScreenState
     _desc = TextEditingController(text: m?.description ?? '');
     _category = TextEditingController(text: m?.category ?? '');
     _filters = TextEditingController(
-        text: m != null && m.filters.isNotEmpty ? jsonEncode(m.filters) : '');
+      text: m != null && m.filters.isNotEmpty
+          ? const JsonEncoder.withIndent('  ').convert(m.filters)
+          : '',
+    );
     _difficulty = m?.difficulty ?? 1;
   }
 


### PR DESCRIPTION
## Summary
- improve TrainingPackTemplateEditorScreen by pretty-printing JSON filters

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2bfbf84832a8a9780a5a986c7b8