### PR TITLE
Add template pack import/export

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -1,6 +1,10 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../models/training_pack_template_model.dart';
 import '../services/training_pack_template_storage_service.dart';
@@ -25,11 +29,77 @@ class _TrainingPackTemplateListScreenState
     }
   }
 
+  Future<void> _export() async {
+    final service = context.read<TrainingPackTemplateStorageService>();
+    try {
+      final dir =
+          await getDownloadsDirectory() ?? await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/training_pack_templates.json');
+      await file.writeAsString(
+        jsonEncode([for (final t in service.templates) t.toJson()]),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Файл экспортирован в Загрузки')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('⚠️ Ошибка экспорта')),
+        );
+      }
+    }
+  }
+
+  Future<void> _import() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.single;
+    final bytes = file.bytes ?? await File(file.path!).readAsBytes();
+    final service = context.read<TrainingPackTemplateStorageService>();
+    bool ok = true;
+    try {
+      final decoded = jsonDecode(utf8.decode(bytes));
+      if (decoded is List) {
+        final list = <TrainingPackTemplateModel>[];
+        for (final e in decoded) {
+          if (e is Map<String, dynamic>) {
+            try {
+              list.add(TrainingPackTemplateModel.fromJson(e));
+            } catch (_) {}
+          }
+        }
+        service.merge(list);
+        await service.saveAll();
+      } else {
+        ok = false;
+      }
+    } catch (_) {
+      ok = false;
+    }
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(ok ? 'Шаблоны импортированы' : '⚠️ Ошибка импорта'),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final templates = context.watch<TrainingPackTemplateStorageService>().templates;
     return Scaffold(
-      appBar: AppBar(title: const Text('Шаблоны паков')),
+      appBar: AppBar(
+        title: const Text('Шаблоны паков'),
+        actions: [
+          IconButton(onPressed: _export, icon: const Icon(Icons.upload_file)),
+          IconButton(onPressed: _import, icon: const Icon(Icons.download)),
+        ],
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _add,
         child: const Icon(Icons.add),

--- a/lib/services/training_pack_template_storage_service.dart
+++ b/lib/services/training_pack_template_storage_service.dart
@@ -52,4 +52,20 @@ class TrainingPackTemplateStorageService extends ChangeNotifier {
     await _persist();
     notifyListeners();
   }
+
+  void merge(List<TrainingPackTemplateModel> list) {
+    for (final m in list) {
+      final index = _templates.indexWhere((t) => t.id == m.id);
+      if (index == -1) {
+        _templates.add(m);
+      } else {
+        _templates[index] = m;
+      }
+    }
+  }
+
+  Future<void> saveAll() async {
+    await _persist();
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- support bulk import/export of training pack templates

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef90c0ae4832a93fd365d5da8d4cf