### PR TITLE
Display estimated hand count in template list

### DIFF
--- a/lib/services/training_spot_storage_service.dart
+++ b/lib/services/training_spot_storage_service.dart
@@ -53,4 +53,36 @@ class TrainingSpotStorageService {
     spots.add(spot);
     await save(spots);
   }
+
+  Future<int?> evaluateFilterCount(Map<String, dynamic> filters) async {
+    try {
+      final spots = await load();
+      int count = 0;
+      for (final s in spots) {
+        if (!_matchesFilters(s, filters)) continue;
+        count++;
+      }
+      return count;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _matchesFilters(TrainingSpot spot, Map<String, dynamic> f) {
+    final tags = f['tags'];
+    if (tags is List && tags.isNotEmpty) {
+      if (!tags.every((t) => spot.tags.contains(t))) return false;
+    }
+    final pos = f['positions'];
+    if (pos is List && pos.isNotEmpty) {
+      final hero =
+          spot.positions.isNotEmpty ? spot.positions[spot.heroIndex] : '';
+      if (!pos.contains(hero)) return false;
+    }
+    final minDiff = f['minDifficulty'];
+    if (minDiff is int && spot.difficulty < minDiff) return false;
+    final maxDiff = f['maxDifficulty'];
+    if (maxDiff is int && spot.difficulty > maxDiff) return false;
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary
- add `evaluateFilterCount` helper to `TrainingSpotStorageService`
- cache hand counts per template and display them on `TrainingPackTemplateListScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efa78f194832ab188ccc26c058d2d