### PR TITLE
feat: allow applying template filters

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,7 @@ void main() {
       providers: [
         Provider(create: (_) => CloudSyncService()),
         Provider(create: (_) => CloudTrainingHistoryService()),
-        Provider(
+        ChangeNotifierProvider(
           create: (context) =>
               TrainingSpotStorageService(cloud: context.read<CloudSyncService>()),
         ),

--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -151,6 +151,19 @@ class _TrainingPackTemplateListScreenState
                           ? 'Невозможно оценить'
                           : '≈ ${_counts[t.id]} рук',
                     ),
+                    trailing: PopupMenuButton<String>(
+                      onSelected: (_) {
+                        _spotStorage.activeFilters
+                          ..clear()
+                          ..addAll(t.filters);
+                        _spotStorage.notifyListeners();
+                        ScaffoldMessenger.of(context)
+                            .showSnackBar(const SnackBar(content: Text('Шаблон применён')));
+                      },
+                      itemBuilder: (_) => const [
+                        PopupMenuItem(value: 'apply', child: Text('Применить шаблон')),
+                      ],
+                    ),
                   ),
                 );
               },

--- a/lib/services/training_spot_storage_service.dart
+++ b/lib/services/training_spot_storage_service.dart
@@ -2,16 +2,19 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
+import 'package:flutter/foundation.dart';
 
 import '../models/training_spot.dart';
 import 'cloud_sync_service.dart';
 
-class TrainingSpotStorageService {
+class TrainingSpotStorageService extends ChangeNotifier {
   static const String _fileName = 'training_spots.json';
 
-  const TrainingSpotStorageService({this.cloud});
+  TrainingSpotStorageService({this.cloud});
 
   final CloudSyncService? cloud;
+
+  final Map<String, dynamic> activeFilters = {};
 
   Future<File> _getFile() async {
     final dir = await getApplicationDocumentsDirectory();


### PR DESCRIPTION
## Summary
- enable applying template filters to current training spots
- update template list items with popup menus
- expose filter state via TrainingSpotStorageService

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f022a93b8832a821aa3032b13d8f1