### PR TITLE
Add filter reset to TrainingSpotLibraryScreen

### DIFF
--- a/lib/screens/training_spot_library_screen.dart
+++ b/lib/screens/training_spot_library_screen.dart
@@ -197,7 +197,22 @@ class _TrainingSpotLibraryScreenState extends State<TrainingSpotLibraryScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('My Spots')),
+      appBar: AppBar(
+        title: const Text('My Spots'),
+        actions: [
+          if (context.watch<TrainingSpotStorageService>().activeFilters.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.filter_alt_off),
+              onPressed: () {
+                final service = context.read<TrainingSpotStorageService>();
+                service.activeFilters.clear();
+                service.notifyListeners();
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(const SnackBar(content: Text('Фильтр сброшен')));
+              },
+            ),
+        ],
+      ),
       body: Column(
         children: [
           Padding(


### PR DESCRIPTION
## Summary
- add action to clear filters in TrainingSpotLibraryScreen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f05807118832a9c6061bd9b7d0305