### PR TITLE
Show active filter pack

### DIFF
--- a/lib/helpers/map_utils.dart
+++ b/lib/helpers/map_utils.dart
@@ -1,0 +1,5 @@
+import 'package:collection/collection.dart';
+
+extension MapEqualsExtension on Map<String, dynamic> {
+  bool equals(Map<String, dynamic> other) => const DeepCollectionEquality().equals(this, other);
+}

--- a/lib/screens/training_spot_library_screen.dart
+++ b/lib/screens/training_spot_library_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
+import '../helpers/map_utils.dart';
 import 'package:provider/provider.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -285,7 +285,7 @@ class _TrainingSpotLibraryScreenState extends State<TrainingSpotLibraryScreen> {
                       .templates;
                   TrainingPackTemplateModel? tpl;
                   for (final t in templates) {
-                    if (mapEquals(t.filters, filters)) {
+                    if (t.filters.equals(filters)) {
                       tpl = t;
                       break;
                     }


### PR DESCRIPTION
## Summary
- add simple Map equality extension
- show active filter with template match in the library screen

## Testing
- `flutter format lib/helpers/map_utils.dart lib/screens/training_spot_library_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0bc872c4832abe5fb28c0a4b48b9