### PR TITLE
feat: confirm template deletion

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -130,6 +130,25 @@ class _TrainingPackTemplateListScreenState
                 _ensureCount(t.id, t.filters);
                 return Dismissible(
                   key: ValueKey(t.id),
+                  confirmDismiss: (_) async {
+                    final ok = await showDialog<bool>(
+                      context: context,
+                      builder: (ctx) => AlertDialog(
+                        title: const Text('Удалить шаблон?'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(ctx, false),
+                            child: const Text('Отмена'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.pop(ctx, true),
+                            child: const Text('Удалить'),
+                          ),
+                        ],
+                      ),
+                    );
+                    return ok == true;
+                  },
                   onDismissed: (_) =>
                       context.read<TrainingPackTemplateStorageService>().remove(t),
                   child: ListTile(


### PR DESCRIPTION
## Summary
- add confirmation dialog on template dismiss in TrainingPackTemplateListScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0d68e308832ab8749f774a169f11