### PR TITLE
Add difficulty color indicator to pack template list

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -161,6 +161,19 @@ class _TrainingPackTemplateListScreenState
     }
   }
 
+  Color _difficultyColor(int value) {
+    switch (value) {
+      case 1:
+        return Colors.green.shade400;
+      case 2:
+        return Colors.amber.shade400;
+      case 3:
+        return Colors.red.shade400;
+      default:
+        return Colors.grey;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final all = context.watch<TrainingPackTemplateStorageService>().templates;
@@ -237,6 +250,14 @@ class _TrainingPackTemplateListScreenState
                   onDismissed: (_) =>
                       context.read<TrainingPackTemplateStorageService>().remove(t),
                   child: ListTile(
+                    leading: Center(
+                      child: Container(
+                        width: 8,
+                        height: 32,
+                        color: _difficultyColor(t.difficulty),
+                      ),
+                    ),
+                    minLeadingWidth: 8,
                     onTap: () async {
                       final model = await Navigator.push<TrainingPackTemplateModel>(
                         context,


### PR DESCRIPTION
## Summary
- show a vertical color bar in training pack template list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f10f8b640832a9ccf96d9cb75e6f8