### PR TITLE
Add single template export

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -141,6 +141,23 @@ class _TrainingPackTemplateListScreenState
     );
   }
 
+  Future<void> _exportTemplate(TrainingPackTemplateModel t) async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/pack_template_${t.id}.json');
+      await file.writeAsString(jsonEncode(t.toJson()));
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Файл сохранён')));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('⚠️ Ошибка экспорта')));
+      }
+    }
+  }
+
   int _compare(TrainingPackTemplateModel a, TrainingPackTemplateModel b) {
     switch (_sort) {
       case _SortOption.category:
@@ -277,16 +294,24 @@ class _TrainingPackTemplateListScreenState
                           : '≈ ${_counts[t.id]} рук',
                     ),
                     trailing: PopupMenuButton<String>(
-                      onSelected: (_) {
-                        _spotStorage.activeFilters
-                          ..clear()
-                          ..addAll(t.filters);
-                        _spotStorage.notifyListeners();
-                        ScaffoldMessenger.of(context)
-                            .showSnackBar(const SnackBar(content: Text('Шаблон применён')));
+                      onSelected: (value) async {
+                        switch (value) {
+                          case 'apply':
+                            _spotStorage.activeFilters
+                              ..clear()
+                              ..addAll(t.filters);
+                            _spotStorage.notifyListeners();
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(const SnackBar(content: Text('Шаблон применён')));
+                            break;
+                          case 'export':
+                            await _exportTemplate(t);
+                            break;
+                        }
                       },
                       itemBuilder: (_) => const [
                         PopupMenuItem(value: 'apply', child: Text('Применить шаблон')),
+                        PopupMenuItem(value: 'export', child: Text('📤 Экспортировать')),
                       ],
                     ),
                   ),


### PR DESCRIPTION
## Summary
- export individual pack templates to JSON
- add export action in training pack template list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f129bef00832ab6b4a370e31390ef