### PR TITLE
Add duplicate template option

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -11,6 +11,7 @@ import '../models/training_pack_template_model.dart';
 import '../services/training_pack_template_storage_service.dart';
 import '../services/training_spot_storage_service.dart';
 import 'training_pack_template_editor_screen.dart';
+import 'package:uuid/uuid.dart';
 
 enum _SortOption { name, category, difficulty, createdAt }
 
@@ -338,12 +339,22 @@ class _TrainingPackTemplateListScreenState
                           case 'rename':
                             await _renameTemplate(t);
                             break;
+                          case 'duplicate':
+                            final copy = t.copyWith(
+                              id: const Uuid().v4(),
+                              name: 'Копия ${t.name}',
+                            );
+                            await context
+                                .read<TrainingPackTemplateStorageService>()
+                                .add(copy);
+                            break;
                         }
                       },
                       itemBuilder: (_) => const [
                         PopupMenuItem(value: 'apply', child: Text('Применить шаблон')),
                         PopupMenuItem(value: 'export', child: Text('📤 Экспортировать')),
                         PopupMenuItem(value: 'rename', child: Text('✏️ Переименовать')),
+                        PopupMenuItem(value: 'duplicate', child: Text('📄 Дублировать')),
                       ],
                     ),
                   ),


### PR DESCRIPTION
## Summary
- duplicate training pack templates from the list screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f179a5b70832ab3d331377376ec2c