### PR TITLE
Add clear all templates option

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -187,6 +187,31 @@ class _TrainingPackTemplateListScreenState
     }
   }
 
+  Future<void> _deleteAllTemplates() async {
+    final bool? confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить все шаблоны?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    await context.read<TrainingPackTemplateStorageService>().clear();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Все шаблоны удалены')),
+    );
+  }
+
   int _compare(TrainingPackTemplateModel a, TrainingPackTemplateModel b) {
     switch (_sort) {
       case _SortOption.category:
@@ -237,6 +262,17 @@ class _TrainingPackTemplateListScreenState
         actions: [
           IconButton(onPressed: _export, icon: const Icon(Icons.upload_file)),
           IconButton(onPressed: _import, icon: const Icon(Icons.download)),
+          PopupMenuButton<String>(
+            onSelected: (v) {
+              if (v == 'delete_all') _deleteAllTemplates();
+            },
+            itemBuilder: (_) => const [
+              PopupMenuItem(
+                value: 'delete_all',
+                child: Text('🗑️ Удалить все шаблоны'),
+              ),
+            ],
+          ),
           PopupMenuButton<_SortOption>(
             icon: const Icon(Icons.sort),
             padding: EdgeInsets.zero,

--- a/lib/services/training_pack_template_storage_service.dart
+++ b/lib/services/training_pack_template_storage_service.dart
@@ -68,4 +68,10 @@ class TrainingPackTemplateStorageService extends ChangeNotifier {
     await _persist();
     notifyListeners();
   }
+
+  Future<void> clear() async {
+    _templates.clear();
+    await _persist();
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- allow clearing all templates in TrainingPackTemplateStorageService
- add Delete All action to TrainingPackTemplateListScreen

## Testing
- `flutter analyze --no-version-check --no-pub` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_685f18d99308832ab30b9d3f2464e804