### PR TITLE
Show template counts

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -402,10 +402,14 @@ class _TrainingPackTemplateListScreenState
                             child: Row(
                               children: [
                                 Expanded(
-                                  child: Text(cat,
-                                      style: const TextStyle(
-                                          color: Colors.white,
-                                          fontWeight: FontWeight.bold)),
+                                  child: Text(
+                                    list.isEmpty || cat.trim().isEmpty
+                                        ? cat
+                                        : '$cat (${list.length})',
+                                    style: const TextStyle(
+                                        color: Colors.white,
+                                        fontWeight: FontWeight.bold),
+                                  ),
                                 ),
                                 Icon(
                                   collapsed


### PR DESCRIPTION
## Summary
- show a template count next to the category header in `TrainingPackTemplateListScreen`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f22de33ac832a9b6064fe64e5d753