### PR TITLE
Add favorites to training templates

### DIFF
--- a/lib/models/training_pack_template_model.dart
+++ b/lib/models/training_pack_template_model.dart
@@ -6,6 +6,7 @@ class TrainingPackTemplateModel {
   final int difficulty;
   final Map<String, dynamic> filters;
   final bool isTournament;
+  final bool isFavorite;
   final DateTime createdAt;
 
   const TrainingPackTemplateModel({
@@ -16,6 +17,7 @@ class TrainingPackTemplateModel {
     this.difficulty = 1,
     Map<String, dynamic>? filters,
     this.isTournament = false,
+    this.isFavorite = false,
     DateTime? createdAt,
   })  : filters = filters ?? const {},
         createdAt = createdAt ?? DateTime.now();
@@ -28,6 +30,7 @@ class TrainingPackTemplateModel {
     int? difficulty,
     Map<String, dynamic>? filters,
     bool? isTournament,
+    bool? isFavorite,
     DateTime? createdAt,
   }) {
     return TrainingPackTemplateModel(
@@ -38,6 +41,7 @@ class TrainingPackTemplateModel {
       difficulty: difficulty ?? this.difficulty,
       filters: filters ?? Map<String, dynamic>.from(this.filters),
       isTournament: isTournament ?? this.isTournament,
+      isFavorite: isFavorite ?? this.isFavorite,
       createdAt: createdAt ?? this.createdAt,
     );
   }
@@ -51,6 +55,7 @@ class TrainingPackTemplateModel {
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 1,
       filters: Map<String, dynamic>.from(json['filters'] as Map? ?? {}),
       isTournament: json['isTournament'] as bool? ?? false,
+      isFavorite: json['isFavorite'] as bool? ?? false,
       createdAt:
           DateTime.tryParse(json['createdAt'] as String? ?? '') ?? DateTime.now(),
     );
@@ -64,6 +69,7 @@ class TrainingPackTemplateModel {
         'difficulty': difficulty,
         'filters': filters,
         'isTournament': isTournament,
+        'isFavorite': isFavorite,
         'createdAt': createdAt.toIso8601String(),
       };
 }

--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -299,6 +299,12 @@ class _TrainingPackTemplateListScreenState
     }
   }
 
+  int _compareWithFavorites(
+      TrainingPackTemplateModel a, TrainingPackTemplateModel b) {
+    if (a.isFavorite != b.isFavorite) return a.isFavorite ? -1 : 1;
+    return _compare(a, b);
+  }
+
   Color _difficultyColor(int value) {
     switch (value) {
       case 1:
@@ -336,7 +342,7 @@ class _TrainingPackTemplateListScreenState
       groups.putIfAbsent(t.category, () => []).add(t);
     }
     for (final g in groups.values) {
-      g.sort(_compare);
+      g.sort(_compareWithFavorites);
     }
     final categories = groups.keys.toList()
       ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
@@ -514,7 +520,19 @@ class _TrainingPackTemplateListScreenState
                                   .update(model);
                             }
                           },
-                          title: Text(t.name),
+                          title: Row(
+                            children: [
+                              Expanded(child: Text(t.name)),
+                              IconButton(
+                                icon: Icon(t.isFavorite ? Icons.star : Icons.star_border),
+                                color: t.isFavorite ? Colors.amber : Colors.white54,
+                                onPressed: () {
+                                  final updated = t.copyWith(isFavorite: !t.isFavorite);
+                                  context.read<TrainingPackTemplateStorageService>().update(updated);
+                                },
+                              ),
+                            ],
+                          ),
                           subtitle: Text(
                             _counts[t.id] == null
                                 ? 'Невозможно оценить'


### PR DESCRIPTION
## Summary
- support favorite templates in model and storage
- sort template list with favorites first
- toggle favorite status from template list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f28a4788c832a982cad1de91df6e5