### PR TITLE
Refactor: add modular PlayerZoneWidget

### DIFF
--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../widgets/player_zone_widget.dart';
+import '../widgets/analyzer/player_zone_widget.dart';
 import '../widgets/street_tabs.dart';
 import '../widgets/street_action_list_simple.dart';
 import '../models/card_model.dart';
@@ -44,23 +44,7 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
                   padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16),
                   child: PlayerZoneWidget(
                     player: player,
-                    playerName: player.name,
-                    street: kStreetNames[_street],
-                    position: null,
-                    cards: _cards[index],
-                    currentBet: player.bet,
-                    stackSize: player.stack,
-                    playerIndex: index,
-                    remainingStack: player.stack,
                     isHero: index == 0,
-                    isFolded: false,
-                    editMode: true,
-                    onStackChanged: (v) => setState(() => player.stack = v),
-                    onBetChanged: (v) => setState(() => player.bet = v),
-                    onCardsSelected: (i, c) {},
-                    onRevealRequest: (name) {
-                      debugPrint('Reveal requested for ' + name);
-                    },
                   ),
                 );
               },

--- a/lib/widgets/analyzer/player_zone_widget.dart
+++ b/lib/widgets/analyzer/player_zone_widget.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import '../../models/player_model.dart';
+
+class PlayerZoneWidget extends StatelessWidget {
+  final PlayerModel player;
+  final bool isHero;
+  final bool isActive;
+  final bool isFolded;
+  final bool isAllIn;
+  final VoidCallback? onEdit;
+  final VoidCallback? onRemove;
+  final VoidCallback? onTap;
+  final double scale;
+
+  const PlayerZoneWidget({
+    super.key,
+    required this.player,
+    this.isHero = false,
+    this.isActive = false,
+    this.isFolded = false,
+    this.isAllIn = false,
+    this.onEdit,
+    this.onRemove,
+    this.onTap,
+    this.scale = 1.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        PlayerAvatar(name: player.name, isHero: isHero, onTap: onTap),
+        PlayerStackDisplay(stack: player.stack, bet: player.bet, scale: scale),
+        PlayerActionButtons(onEdit: onEdit, onRemove: onRemove, scale: scale),
+        PlayerStatusIndicator(isFolded: isFolded, isAllIn: isAllIn),
+      ],
+    );
+  }
+}
+
+class PlayerAvatar extends StatelessWidget {
+  final String name;
+  final bool isHero;
+  final VoidCallback? onTap;
+
+  const PlayerAvatar({
+    super.key,
+    required this.name,
+    this.isHero = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isHero ? Colors.purpleAccent : Colors.blueGrey;
+    return GestureDetector(
+      onTap: onTap,
+      child: CircleAvatar(
+        backgroundColor: color,
+        child: Text(name.isNotEmpty ? name[0].toUpperCase() : '?'),
+      ),
+    );
+  }
+}
+
+class PlayerStackDisplay extends StatelessWidget {
+  final int stack;
+  final int bet;
+  final double scale;
+
+  const PlayerStackDisplay({
+    super.key,
+    required this.stack,
+    required this.bet,
+    this.scale = 1.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          '$stack BB',
+          style: TextStyle(color: Colors.white, fontSize: 12 * scale),
+        ),
+        if (bet > 0)
+          Text(
+            'Bet $bet',
+            style: TextStyle(color: Colors.amber, fontSize: 10 * scale),
+          ),
+      ],
+    );
+  }
+}
+
+class PlayerActionButtons extends StatelessWidget {
+  final VoidCallback? onEdit;
+  final VoidCallback? onRemove;
+  final double scale;
+
+  const PlayerActionButtons({
+    super.key,
+    this.onEdit,
+    this.onRemove,
+    this.scale = 1.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (onEdit != null)
+          IconButton(
+            iconSize: 16 * scale,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            onPressed: onEdit,
+            icon: const Icon(Icons.edit, color: Colors.white),
+          ),
+        if (onRemove != null)
+          IconButton(
+            iconSize: 16 * scale,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            onPressed: onRemove,
+            icon: const Icon(Icons.close, color: Colors.redAccent),
+          ),
+      ],
+    );
+  }
+}
+
+class PlayerStatusIndicator extends StatelessWidget {
+  final bool isFolded;
+  final bool isAllIn;
+
+  const PlayerStatusIndicator({
+    super.key,
+    this.isFolded = false,
+    this.isAllIn = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (isFolded) {
+      return const Text('FOLDED', style: TextStyle(color: Colors.white));
+    }
+    if (isAllIn) {
+      return const Text('ALL-IN', style: TextStyle(color: Colors.purpleAccent));
+    }
+    return const SizedBox.shrink();
+  }
+}


### PR DESCRIPTION
## Summary
- add `PlayerZoneWidget` and subcomponents under `lib/widgets/analyzer`
- use new widget in `PlayerZoneDemoScreen`

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbcc1ba68832aa67173bb9b78ff73