### PR TITLE
Add runtime plugin loading support

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -763,7 +763,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
               onPressed: () async {
                 final manager =
                     Provider.of<SavedHandManagerService>(context, listen: false);
-                final service = HandHistoryFileService(manager);
+                final service = await HandHistoryFileService.create(manager);
                 await service.importFromFiles(context);
               },
               child: const Text('Импортировать Hand History'),

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3279,13 +3279,14 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   @override
   void initState() {
     super.initState();
+    unawaited(_init());
+  }
+
+  Future<void> _init() async {
     _serviceRegistry = ServiceRegistry();
-    final PluginManager pluginManager = PluginManager();
-    final PluginLoader loader = PluginLoader();
-    for (final Plugin plugin in loader.loadBuiltInPlugins()) {
-      pluginManager.load(plugin);
-    }
-    pluginManager.initializeAll(_serviceRegistry);
+    final pluginManager = PluginManager();
+    final loader = PluginLoader();
+    await loader.loadAll(_serviceRegistry, pluginManager);
 
     _serviceRegistry.register<CurrentHandContextService>(
         widget.handContext ?? CurrentHandContextService());

--- a/lib/services/hand_history_file_service.dart
+++ b/lib/services/hand_history_file_service.dart
@@ -12,16 +12,17 @@ import 'saved_hand_manager_service.dart';
 
 /// Handles importing external hand history files using available converters.
 class HandHistoryFileService {
-  HandHistoryFileService(this._handManager) {
+  HandHistoryFileService._(this._handManager, this._pipeline);
+
+  static Future<HandHistoryFileService> create(
+      SavedHandManagerService manager) async {
     final loader = PluginLoader();
-    final manager = PluginManager();
+    final pluginManager = PluginManager();
     final registry = ServiceRegistry();
-    for (final plugin in loader.loadBuiltInPlugins()) {
-      manager.load(plugin);
-    }
-    manager.initializeAll(registry);
+    await loader.loadAll(registry, pluginManager);
     final converterRegistry = registry.get<ConverterRegistry>();
-    _pipeline = ConverterPipeline(converterRegistry);
+    final pipeline = ConverterPipeline(converterRegistry);
+    return HandHistoryFileService._(manager, pipeline);
   }
 
   final SavedHandManagerService _handManager;


### PR DESCRIPTION
## Summary
- create `HandHistoryFileService.create` for async plugin load
- load plugins in `PokerAnalyzerScreen` and use async helper
- construct `HandHistoryFileService` through async factory

## Testing
- `dart --version`
- `dart test -r expanded` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_685fc7578134832aa7524f939bce6743