### PR TITLE
Add runtime plugin loader support

### DIFF
--- a/plugins/plugin_loader.dart
+++ b/plugins/plugin_loader.dart
@@ -42,7 +42,7 @@ class PluginLoader {
       await for (final entity in dir.list()) {
         if (entity is File) {
           final name = p.basename(entity.path);
-          if (name.endsWith('.dart') && name.contains('Plugin')) {
+          if (name.endsWith('Plugin.dart')) {
             final port = ReceivePort();
             try {
               await Isolate.spawnUri(entity.uri, <String>[], port.sendPort);


### PR DESCRIPTION
## Summary
- check for `Plugin.dart` suffix when scanning runtime plugins

## Testing
- `dart --version` *(fails: command not found)*
- `dart test -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc8fc3b84832aada54a89928b25a5