### PR TITLE
Add timeout for runtime plugin loading

### DIFF
--- a/plugins/plugin_loader.dart
+++ b/plugins/plugin_loader.dart
@@ -46,7 +46,7 @@ class PluginLoader {
             final port = ReceivePort();
             try {
               await Isolate.spawnUri(entity.uri, <String>[], port.sendPort);
-              await port.first;
+              await port.first.timeout(const Duration(seconds: 2));
               print('Plugin loaded: $name');
             } catch (_) {
               print('Plugin failed: $name');


### PR DESCRIPTION
## Summary
- wait for runtime plugins with a 2 second timeout

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fca113cbc832a8673703ff5097407