### PR TITLE
Add runtime plugin loading support

### DIFF
--- a/plugins/plugin_loader.dart
+++ b/plugins/plugin_loader.dart
@@ -46,8 +46,13 @@ class PluginLoader {
           final port = ReceivePort();
           try {
             await Isolate.spawnUri(entity.uri, <String>[], port.sendPort);
-            await port.first.timeout(const Duration(seconds: 2));
-            print('Plugin loaded: $name');
+            final dynamic plugin = await port.first.timeout(const Duration(seconds: 2));
+            if (plugin is Plugin) {
+              manager.load(plugin);
+              print('Plugin loaded: $name');
+            } else {
+              print('Plugin failed: $name');
+            }
           } catch (_) {
             print('Plugin failed: $name');
           } finally {


### PR DESCRIPTION
## Summary
- load runtime plugins from the application support directory
- integrate loaded plugins with the PluginManager

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcbdf7978832a9818e7d29a1ad41a