### PR TITLE
Add plugin scaffold test

### DIFF
--- a/test/tools/plugin_scaffold_test.dart
+++ b/test/tools/plugin_scaffold_test.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 void main() {
   test('plugin scaffold', () async {
     final dir = await Directory.systemTemp.createTemp('plugin_scaffold_test');
+    const pluginName = 'MyPlugin';
     try {
       final script = File('tools/plugin_scaffold.dart');
       await script.copy(p.join(dir.path, 'plugin_scaffold.dart'));
@@ -23,12 +24,12 @@ dependencies:
 ''');
       final pub = await Process.run('dart', ['pub', 'get'], workingDirectory: dir.path);
       expect(pub.exitCode, 0);
-      final res1 = await Process.run('dart', ['run', 'plugin_scaffold.dart', 'MyPlugin'], workingDirectory: dir.path);
+      final res1 = await Process.run('dart', ['run', 'plugin_scaffold.dart', pluginName], workingDirectory: dir.path);
       expect(res1.exitCode, 0);
-      final pluginFile = File(p.join(dir.path, 'plugins', 'MyPlugin.dart'));
+      final pluginFile = File(p.join(dir.path, 'plugins', '$pluginName.dart'));
       expect(pluginFile.existsSync(), isTrue);
-      expect(pluginFile.readAsStringSync(), contains('class MyPlugin implements Plugin'));
-      final res2 = await Process.run('dart', ['run', 'plugin_scaffold.dart', 'MyPlugin'], workingDirectory: dir.path);
+      expect(pluginFile.readAsStringSync(), contains('class $pluginName implements Plugin'));
+      final res2 = await Process.run('dart', ['run', 'plugin_scaffold.dart', pluginName], workingDirectory: dir.path);
       expect(res2.exitCode, 0);
       final output = '${res2.stdout}\n${res2.stderr}';
       expect(output, contains('Plugin already exists'));


### PR DESCRIPTION
## Summary
- verify plugin scaffold generation and warnings via a new test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/tools/plugin_scaffold_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe8fdcdfc832aa4812f58b83d4b45