### PR TITLE
Add plugin scaffold test

### DIFF
--- a/test/tools/plugin_scaffold_test.dart
+++ b/test/tools/plugin_scaffold_test.dart
@@ -26,6 +26,8 @@ dependencies:
       expect(pub.exitCode, 0);
       final res1 = await Process.run('dart', ['run', 'plugin_scaffold.dart', pluginName], workingDirectory: dir.path);
       expect(res1.exitCode, 0);
+      final output1 = '${res1.stdout}\n${res1.stderr}';
+      expect(output1, contains('Created plugin'));
       final pluginFile = File(p.join(dir.path, 'plugins', '$pluginName.dart'));
       expect(pluginFile.existsSync(), isTrue);
       expect(pluginFile.readAsStringSync(), contains('class $pluginName implements Plugin'));


### PR DESCRIPTION
## Summary
- ensure the plugin scaffold tool logs creation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/tools/plugin_scaffold_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9f46f64832ab5f5da9c5cf4257b