### PR TITLE
Implement plugin enable flag

### DIFF
--- a/plugins/plugin_config.json
+++ b/plugins/plugin_config.json
@@ -1,0 +1,4 @@
+{
+  "SampleLoggingPlugin": true,
+  "ConverterDiscoveryPlugin": true
+}


### PR DESCRIPTION
## Summary
- allow optional plugin config via `plugin_config.json`
- skip loading plugins marked disabled

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff88cc474832a95041709ec41be2f