### PR TITLE
Add duplicate plugin check

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -71,7 +71,7 @@ Future<void> _reload() async {
   final registry = ServiceRegistry();
   final manager = PluginManager();
   final loader = PluginLoader();
-  await loader.loadAll(registry, manager);
+  await loader.loadAll(registry, manager, context: context);
   if (mounted) {
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Plugins reloaded')));

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -60,7 +60,7 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
     final registry = ServiceRegistry();
     final manager = PluginManager();
     final loader = PluginLoader();
-    await loader.loadAll(registry, manager);
+    await loader.loadAll(registry, manager, context: context);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugins reloaded')));
     }

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3286,7 +3286,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _serviceRegistry = ServiceRegistry();
     final pluginManager = PluginManager();
     final loader = PluginLoader();
-    await loader.loadAll(_serviceRegistry, pluginManager);
+    await loader.loadAll(_serviceRegistry, pluginManager, context: context);
 
     _serviceRegistry.register<CurrentHandContextService>(
         widget.handContext ?? CurrentHandContextService());


### PR DESCRIPTION
## Summary
- check for duplicate plugins in `PluginLoader.loadAll`
- pass `context` when loading plugins so snackbars work
- update plugin docs for new API

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600b3c3324832a9d5c58f9ebd1879b