### PR TITLE
Implement async EvaluationExecutorService

### DIFF
--- a/lib/models/eval_request.dart
+++ b/lib/models/eval_request.dart
@@ -1,0 +1,8 @@
+import "training_spot.dart";
+class EvalRequest {
+  final String hash;
+  final TrainingSpot spot;
+  final String action;
+
+  EvalRequest({required this.hash, required this.spot, required this.action});
+}

--- a/lib/models/eval_result.dart
+++ b/lib/models/eval_result.dart
@@ -1,0 +1,7 @@
+class EvalResult {
+  final bool isError;
+  final String? reason;
+  final double score;
+
+  EvalResult({required this.isError, this.reason, required this.score});
+}

--- a/lib/services/training_session_controller.dart
+++ b/lib/services/training_session_controller.dart
@@ -19,7 +19,7 @@ class TrainingSessionController {
     var tryCount = 0;
     while (true) {
       try {
-        return _executor.evaluate(context, spot, userAction);
+        return _executor.evaluateSpot(context, spot, userAction);
       } catch (_) {
         if (++tryCount >= attempts) rethrow;
         await Future.delayed(const Duration(milliseconds: 100));

--- a/test/evaluation_executor_service_test.dart
+++ b/test/evaluation_executor_service_test.dart
@@ -3,6 +3,7 @@ import 'package:poker_ai_analyzer/services/evaluation_executor_service.dart';
 import 'package:poker_ai_analyzer/models/training_spot.dart';
 import 'package:poker_ai_analyzer/models/card_model.dart';
 import 'package:poker_ai_analyzer/models/action_entry.dart';
+import 'package:poker_ai_analyzer/models/eval_request.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -23,7 +24,7 @@ void main() {
       createdAt: DateTime.now(),
     );
     final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
-    final res = EvaluationExecutorService().evaluate(ctx, spot, 'push');
+    final res = EvaluationExecutorService().evaluateSpot(ctx, spot, 'push');
     expect(res.expectedAction, 'push');
     expect(res.correct, isTrue);
   });
@@ -44,7 +45,7 @@ void main() {
       createdAt: DateTime.now(),
     );
     final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
-    final res = EvaluationExecutorService().evaluate(ctx, spot, 'push');
+    final res = EvaluationExecutorService().evaluateSpot(ctx, spot, 'push');
     expect(res.expectedAction, 'fold');
     expect(res.correct, isFalse);
   });
@@ -65,8 +66,30 @@ void main() {
       createdAt: DateTime.now(),
     );
     final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
-    final res = EvaluationExecutorService().evaluate(ctx, spot, 'call');
+    final res = EvaluationExecutorService().evaluateSpot(ctx, spot, 'call');
     expect(res.expectedAction, 'call');
     expect(res.correct, isTrue);
+  });
+
+  test('async evaluate returns score', () async {
+    final spot = TrainingSpot(
+      playerCards: [
+        [CardModel(rank: 'A', suit: '♠'), CardModel(rank: 'K', suit: '♠')],
+        [CardModel(rank: '2', suit: '♣'), CardModel(rank: '7', suit: '♦')],
+      ],
+      boardCards: const [],
+      actions: const [],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [],
+      positions: const ['BTN', 'BB'],
+      stacks: const [10, 10],
+      createdAt: DateTime.now(),
+    );
+    final req = EvalRequest(hash: 'h', spot: spot, action: 'push');
+    final res = await EvaluationExecutorService().evaluate(req);
+    expect(res.score, 1);
+    final cached = await EvaluationExecutorService().evaluate(req);
+    expect(cached.score, 1);
   });
 }


### PR DESCRIPTION
## Summary
- add EvalRequest and EvalResult models
- support queued async evaluation with caching in EvaluationExecutorService
- adjust TrainingSessionController to call evaluateSpot
- update unit tests for new API

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_68600f72385c832aa8cca76df4dae978