### PR TITLE
Fix override annotation

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -91,7 +91,6 @@ class EvaluationExecutorService implements EvaluationExecutor {
   /// The initial implementation simply checks if the action matches the
   /// expected action for the hero at the given training spot.
   @override
-  @override
   EvaluationResult evaluateSpot(BuildContext context, TrainingSpot spot, String userAction) {
     final expectedAction =
         spot.recommendedAction ?? _evaluatePushFold(spot) ?? _heroAction(spot) ?? '-';


### PR DESCRIPTION
## Summary
- fix duplicate override annotation in `EvaluationExecutorService`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686015626efc832ab164dc1279edc350