### PR TITLE
Show evaluation score on training result

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -55,6 +55,7 @@ import '../services/evaluation_executor_service.dart';
 import '../services/training_session_controller.dart';
 import '../services/goals_service.dart';
 import '../widgets/replay_spot_widget.dart';
+import '../widgets/eval_result_view.dart';
 import '../models/result_entry.dart';
 import '../widgets/common/training_spot_list.dart';
 import 'markdown_preview_screen.dart';
@@ -348,15 +349,19 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
             Text('Вы выбрали: $userAct',
                 style: const TextStyle(color: Colors.white70)),
             const SizedBox(height: 12),
-            Text(
-              matched ? 'Верно!' : 'Неверно.',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: matched ? Colors.green : Colors.red,
-                fontWeight: FontWeight.bold,
+              Text(
+                matched ? 'Верно!' : 'Неверно.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: matched ? Colors.green : Colors.red,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
-            if (original.feedbackText != null) ...[
+              EvalResultView(
+                spot: TrainingSpot.fromSavedHand(original),
+                action: userAct,
+              ),
+              if (original.feedbackText != null) ...[
               const SizedBox(height: 8),
               Text(
                 original.feedbackText!,

--- a/lib/widgets/eval_result_view.dart
+++ b/lib/widgets/eval_result_view.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../models/eval_request.dart';
+import '../models/eval_result.dart';
+import '../models/training_spot.dart';
+import '../services/evaluation_executor_service.dart';
+
+class EvalResultView extends StatefulWidget {
+  final TrainingSpot spot;
+  final String action;
+
+  const EvalResultView({super.key, required this.spot, required this.action});
+
+  @override
+  State<EvalResultView> createState() => _EvalResultViewState();
+}
+
+class _EvalResultViewState extends State<EvalResultView> {
+  late Future<EvalResult> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    final req = EvalRequest(
+      hash: widget.spot.createdAt.millisecondsSinceEpoch.toString(),
+      spot: widget.spot,
+      action: widget.action,
+    );
+    _future = EvaluationExecutorService().evaluate(req);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<EvalResult>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return const SizedBox.shrink();
+        final res = snapshot.data!;
+        if (res.isError) {
+          return Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: const [
+                Icon(Icons.warning, color: Colors.orange),
+                SizedBox(width: 4),
+                Text('Evaluation failed',
+                    style: TextStyle(color: Colors.orange)),
+              ],
+            ),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Column(
+            children: [
+              Text('Score: ${res.score.toStringAsFixed(2)}',
+                  style: const TextStyle(color: Colors.white)),
+              Text('Reason: ${res.reason ?? '–'}',
+                  style: const TextStyle(color: Colors.white70)),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/test/widgets/eval_result_view_test.dart
+++ b/test/widgets/eval_result_view_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/card_model.dart';
+import 'package:poker_ai_analyzer/models/training_spot.dart';
+import 'package:poker_ai_analyzer/widgets/eval_result_view.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows score from EvalResult', (WidgetTester tester) async {
+    final spot = TrainingSpot(
+      playerCards: [
+        [const CardModel(rank: 'A', suit: '♠'), const CardModel(rank: 'K', suit: '♠')],
+        [const CardModel(rank: '2', suit: '♣'), const CardModel(rank: '7', suit: '♦')],
+      ],
+      boardCards: const [],
+      actions: const [],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [],
+      positions: const ['BTN', 'BB'],
+      stacks: const [10, 10],
+      createdAt: DateTime.now(),
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: EvalResultView(spot: spot, action: 'push')),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Score: 1.00'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add EvalResultView widget for displaying evaluation
- integrate EvalResultView in training pack feedback screen
- test EvalResultView widget

## Testing
- `flutter --version` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601691d624832a8e3968a67bd9a57e