### PR TITLE
Add accuracy tracking

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/streak_service.dart';
+import '../services/evaluation_executor_service.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  late int _evaluated;
+  late int _correct;
+
+  void _load() {
+    final service = EvaluationExecutorService();
+    _evaluated = service.totalEvaluated;
+    _correct = service.totalCorrect;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _reset() async {
+    await EvaluationExecutorService().resetAccuracy();
+    setState(_load);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final streak = context.watch<StreakService>().count;
+    final acc = _evaluated == 0 ? 0 : _correct / _evaluated;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Streak: $streak',
+                style: const TextStyle(color: Colors.white, fontSize: 16)),
+            const SizedBox(height: 8),
+            Text('Accuracy: ${(acc * 100).toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white, fontSize: 16)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _reset,
+              child: const Text('Reset Accuracy'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/action_evaluation_request.dart';
 import '../models/evaluation_result.dart';
@@ -22,7 +23,9 @@ abstract class EvaluationExecutor {
 
 /// Handles execution of a single evaluation request.
 class EvaluationExecutorService implements EvaluationExecutor {
-  EvaluationExecutorService._internal();
+  EvaluationExecutorService._internal() {
+    _initFuture;
+  }
   static final EvaluationExecutorService _instance =
       EvaluationExecutorService._internal();
 
@@ -32,8 +35,26 @@ class EvaluationExecutorService implements EvaluationExecutor {
   final Map<String, EvalResult> _cache = {};
   bool _processing = false;
 
+  static const _evaluatedKey = 'eval_total_evaluated';
+  static const _correctKey = 'eval_total_correct';
+  int _totalEvaluated = 0;
+  int _totalCorrect = 0;
+  late final Future<void> _initFuture = _loadStats();
+
+  int get totalEvaluated => _totalEvaluated;
+  int get totalCorrect => _totalCorrect;
+  double get accuracy =>
+      _totalEvaluated == 0 ? 0 : _totalCorrect / _totalEvaluated;
+
+  Future<void> resetAccuracy() async {
+    _totalEvaluated = 0;
+    _totalCorrect = 0;
+    await _saveStats();
+  }
+
   @override
-  Future<EvalResult> evaluate(EvalRequest request) {
+  Future<EvalResult> evaluate(EvalRequest request) async {
+    await _initFuture;
     final cached = _cache[request.hash];
     if (cached != null) return Future.value(cached);
     final completer = Completer<EvalResult>();
@@ -49,6 +70,11 @@ class EvaluationExecutorService implements EvaluationExecutor {
     _evaluate(item.request).then((res) {
       _cache[item.request.hash] = res;
       item.completer.complete(res);
+      if (!res.isError) {
+        _totalEvaluated += 1;
+        if (res.score == 1) _totalCorrect += 1;
+        unawaited(_saveStats());
+      }
     }).catchError((e) {
       item.completer
           .complete(EvalResult(isError: true, reason: '$e', score: 0));
@@ -56,6 +82,18 @@ class EvaluationExecutorService implements EvaluationExecutor {
       _processing = false;
       _processQueue();
     });
+  }
+
+  Future<void> _loadStats() async {
+    final prefs = await SharedPreferences.getInstance();
+    _totalEvaluated = prefs.getInt(_evaluatedKey) ?? 0;
+    _totalCorrect = prefs.getInt(_correctKey) ?? 0;
+  }
+
+  Future<void> _saveStats() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_evaluatedKey, _totalEvaluated);
+    await prefs.setInt(_correctKey, _totalCorrect);
   }
 
   Future<EvalResult> _evaluate(EvalRequest request) async {


### PR DESCRIPTION
## Summary
- track evaluation stats in `EvaluationExecutorService`
- add a simple profile screen showing streak and accuracy

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860190a221c832a9754dfc274f4c68b