### PR TITLE
Add training history JSON export

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -46,6 +46,7 @@ import '../services/saved_hand_import_export_service.dart';
 import '../services/training_import_export_service.dart';
 import '../services/training_spot_file_service.dart';
 import '../services/training_spot_storage_service.dart';
+import '../services/training_history_export_service.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/training_stats_service.dart';
 import '../services/error_logger_service.dart';
@@ -996,6 +997,25 @@ body { font-family: sans-serif; padding: 16px; }
     }
   }
 
+  Future<void> _exportHistoryJson() async {
+    try {
+      final service = TrainingHistoryExportService(
+          storage: context.read<TrainingSpotStorageService>());
+      final file = await service.exportToJson();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Файл сохранён: ${file.path}')),
+      );
+    } catch (e, st) {
+      ErrorLoggerService.instance
+          .logError('History export failed', e, st);
+      if (mounted) {
+        ErrorLoggerService.instance
+            .reportToUser(context, 'Ошибка экспорта');
+      }
+    }
+  }
+
   void _showSavedResults() {
     if (_previousResults.isEmpty) return;
     showModalBottomSheet(
@@ -1308,6 +1328,11 @@ body { font-family: sans-serif; padding: 16px; }
               ElevatedButton(
                 onPressed: _exportPdf,
                 child: const Text('Экспорт в PDF'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: _exportHistoryJson,
+                child: const Text('Export JSON'),
               ),
               const SizedBox(height: 12),
               ElevatedButton(

--- a/lib/services/training_history_export_service.dart
+++ b/lib/services/training_history_export_service.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import '../models/training_spot.dart';
+import 'training_spot_storage_service.dart';
+
+class TrainingHistoryExportService {
+  TrainingHistoryExportService({TrainingSpotStorageService? storage})
+      : _storage = storage ?? TrainingSpotStorageService();
+
+  final TrainingSpotStorageService _storage;
+
+  Future<File> exportToJson() async {
+    final spots = await _storage.load();
+    spots.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final recent = spots.take(100);
+    final data = [
+      for (final s in recent)
+        {
+          'playerCards': [
+            for (final list in s.playerCards)
+              [for (final c in list) {'rank': c.rank, 'suit': c.suit}]
+          ],
+          'actions': [
+            for (final a in s.actions)
+              {
+                'street': a.street,
+                'playerIndex': a.playerIndex,
+                'action': a.action,
+                if (a.amount != null) 'amount': a.amount,
+              }
+          ],
+          'heroIndex': s.heroIndex,
+          if (s.userAction != null) 'userAction': s.userAction,
+          if (s.recommendedAction != null)
+            'evalResult': {
+              'recommended': s.recommendedAction,
+              if (s.recommendedAmount != null)
+                'amount': s.recommendedAmount,
+              if (s.userAction != null)
+                'correct': s.userAction == s.recommendedAction,
+            },
+        }
+    ];
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/training_export.json');
+    await file.writeAsString(const JsonEncoder.withIndent('  ').convert(data));
+    return file;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrainingHistoryExportService` for training spot export
- enable history JSON export from training pack screen

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601ae5122c832aa960ce334d645e9e