### PR TITLE
Add TrainingSpot detail screen

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -62,6 +62,7 @@ import '../models/result_entry.dart';
 import '../widgets/common/training_spot_list.dart';
 import 'markdown_preview_screen.dart';
 import 'package:markdown/markdown.dart' as md;
+import 'training_spot_detail_screen.dart';
 import 'dart:async';
 import '../services/cloud_training_history_service.dart';
 import '../helpers/color_utils.dart';
@@ -1029,6 +1030,14 @@ body { font-family: sans-serif; padding: 16px; }
     if (!mounted) return;
     if (count > 0) {
       await _loadSpots();
+      if (_spots.isNotEmpty) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TrainingSpotDetailScreen(spot: _spots.last),
+          ),
+        );
+      }
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Imported $count spots')),

--- a/lib/screens/training_spot_detail_screen.dart
+++ b/lib/screens/training_spot_detail_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_spot.dart';
+import '../widgets/action_history_widget.dart';
+import '../widgets/eval_result_view.dart';
+
+class TrainingSpotDetailScreen extends StatelessWidget {
+  final TrainingSpot spot;
+
+  const TrainingSpotDetailScreen({super.key, required this.spot});
+
+  Map<int, String> _posMap() => {
+        for (int i = 0; i < spot.numberOfPlayers; i++)
+          if (i < spot.positions.length) i: spot.positions[i]
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final heroCards = spot.heroIndex < spot.playerCards.length
+        ? spot.playerCards[spot.heroIndex].join(' ')
+        : '';
+    final board = spot.boardCards.map((c) => c.toString()).join(' ');
+    final pos = spot.heroIndex < spot.positions.length
+        ? spot.positions[spot.heroIndex]
+        : '';
+    final user = spot.userAction;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Spot Details'),
+        centerTitle: true,
+      ),
+      backgroundColor: Colors.black,
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Hero position: $pos',
+              style: const TextStyle(color: Colors.white)),
+          if (heroCards.isNotEmpty)
+            Text('Hero cards: $heroCards',
+                style: const TextStyle(color: Colors.white)),
+          if (board.isNotEmpty)
+            Text('Board: $board', style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 16),
+          ActionHistoryWidget(actions: spot.actions, playerPositions: _posMap()),
+          if (user != null) ...[
+            const SizedBox(height: 16),
+            Text('Your action: $user',
+                style: const TextStyle(color: Colors.white)),
+          ],
+          if (spot.recommendedAction != null) ...[
+            const SizedBox(height: 8),
+            EvalResultView(spot: spot, action: user ?? ''),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TrainingSpotDetailScreen` for viewing one spot
- show imported spot details automatically after history import

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860298d0928832aa032bfa174556a8a