### PR TITLE
Add hand notes and tags editing

### DIFF
--- a/lib/models/cloud_training_session.dart
+++ b/lib/models/cloud_training_session.dart
@@ -6,6 +6,7 @@ class CloudTrainingSession {
   final List<ResultEntry> results;
   final String? comment;
   final Map<String, String>? handNotes;
+  final Map<String, List<String>>? handTags;
 
   CloudTrainingSession({
     required this.path,
@@ -13,6 +14,7 @@ class CloudTrainingSession {
     required this.results,
     this.comment,
     this.handNotes,
+    this.handTags,
   });
 
   factory CloudTrainingSession.fromJson(Map<String, dynamic> json,
@@ -27,6 +29,7 @@ class CloudTrainingSession {
       }
     }
     Map<String, String>? notes;
+    Map<String, List<String>>? tags;
     final notesJson = json['handNotes'];
     if (notesJson is Map) {
       notes = <String, String>{};
@@ -37,12 +40,23 @@ class CloudTrainingSession {
       });
       if (notes.isEmpty) notes = null;
     }
+    final tagsJson = json['handTags'];
+    if (tagsJson is Map) {
+      tags = <String, List<String>>{};
+      tagsJson.forEach((key, value) {
+        if (key is String && value is List) {
+          tags![key] = [for (final t in value) if (t is String) t];
+        }
+      });
+      if (tags.isEmpty) tags = null;
+    }
     return CloudTrainingSession(
       path: path,
       date: DateTime.parse(json['date'] as String),
       results: results,
       comment: json['comment'] as String?,
       handNotes: notes,
+      handTags: tags,
     );
   }
 
@@ -51,6 +65,7 @@ class CloudTrainingSession {
         'results': [for (final r in results) r.toJson()],
         if (comment != null && comment!.isNotEmpty) 'comment': comment,
         if (handNotes != null && handNotes!.isNotEmpty) 'handNotes': handNotes,
+        if (handTags != null && handTags!.isNotEmpty) 'handTags': handTags,
       };
 
   int get total => results.length;

--- a/lib/services/cloud_training_history_service.dart
+++ b/lib/services/cloud_training_history_service.dart
@@ -42,13 +42,21 @@ class CloudTrainingHistoryService {
         .delete();
   }
 
-  Future<void> updateSession(String id, Map<String, dynamic> data) async {
+  Future<void> updateSession(
+    String id, {
+    Map<String, dynamic>? data,
+    Map<String, String>? handNotes,
+    Map<String, List<String>>? handTags,
+  }) async {
     if (_uid == null) return;
+    final payload = <String, dynamic>{...?data};
+    if (handNotes != null) payload['handNotes'] = handNotes;
+    if (handTags != null) payload['handTags'] = handTags;
     await _db
         .collection('users')
         .doc(_uid)
         .collection('training_sessions')
         .doc(id)
-        .set(data, SetOptions(merge: true));
+        .set(payload, SetOptions(merge: true));
   }
 }


### PR DESCRIPTION
## Summary
- support hand tags in cloud training model
- allow updating hand notes/tags in details screen
- expose new parameters in CloudTrainingHistoryService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cf8e4fd8832a90b5c72de20c38ab