### PR TITLE
Add sync status widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'services/category_usage_service.dart';
 import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 import 'services/mistake_review_pack_service.dart';
+import 'widgets/sync_status_widget.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -231,20 +232,24 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      navigatorKey: navigatorKey,
-      title: 'Poker AI Analyzer',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData.dark().copyWith(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.greenAccent),
-        scaffoldBackgroundColor: Colors.black,
-        textTheme: ThemeData.dark().textTheme.apply(
-              fontFamily: 'Roboto',
-              bodyColor: Colors.white,
-              displayColor: Colors.white,
-            ),
+    return SyncStatusWidget(
+      sync: _sync,
+      cloud: context.read<CloudSyncService>(),
+      child: MaterialApp(
+        navigatorKey: navigatorKey,
+        title: 'Poker AI Analyzer',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData.dark().copyWith(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.greenAccent),
+          scaffoldBackgroundColor: Colors.black,
+          textTheme: ThemeData.dark().textTheme.apply(
+                fontFamily: 'Roboto',
+                bodyColor: Colors.white,
+                displayColor: Colors.white,
+              ),
+        ),
+        home: const MainNavigationScreen(),
       ),
-      home: const MainNavigationScreen(),
     );
   }
 }

--- a/lib/screens/accuracy_mistake_overview_screen.dart
+++ b/lib/screens/accuracy_mistake_overview_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../helpers/poker_street_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Shows accuracy percentages grouped by tag, street and hero position.
 ///
@@ -73,6 +74,7 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Точность по группам'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/achievements_catalog_screen.dart
+++ b/lib/screens/achievements_catalog_screen.dart
@@ -5,6 +5,7 @@ import '../services/goals_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../services/streak_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class AchievementsCatalogScreen extends StatelessWidget {
   const AchievementsCatalogScreen({super.key});
@@ -16,6 +17,7 @@ class AchievementsCatalogScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Каталог достижений'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Builder(
         builder: (context) {

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/achievement_engine.dart';
 import '../services/user_action_logger.dart';
+import '../widgets/sync_status_widget.dart';
 
 class AchievementsScreen extends StatefulWidget {
   const AchievementsScreen({super.key});
@@ -28,6 +29,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
       appBar: AppBar(
         title: const Text('Achievements'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -15,6 +15,7 @@ import '../helpers/accuracy_utils.dart';
 import '../models/training_pack.dart';
 import '../models/game_type.dart';
 import 'session_detail_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class AllSessionsScreen extends StatefulWidget {
   const AllSessionsScreen({super.key});
@@ -1114,6 +1115,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
       appBar: AppBar(
         title: const Text('История тренировок'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
       body: Column(

--- a/lib/screens/cloud_sync_screen.dart
+++ b/lib/screens/cloud_sync_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'dart:async';
 
 import '../services/cloud_sync_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CloudSyncScreen extends StatefulWidget {
   const CloudSyncScreen({super.key});
@@ -26,6 +27,7 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
       appBar: AppBar(
         title: const Text('Cloud Sync'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -16,6 +16,7 @@ import '../services/saved_hand_manager_service.dart';
 import 'training_pack_screen.dart';
 import '../widgets/common/accuracy_trend_chart.dart';
 import 'cloud_training_session_details_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   const TrainingHistoryScreen({super.key});
@@ -243,7 +244,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       appBar: AppBar(
         title: const Text('История тренировок'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.download),
             tooltip: 'Экспорт',

--- a/lib/screens/cloud_training_history_service_screen.dart
+++ b/lib/screens/cloud_training_history_service_screen.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import '../helpers/date_utils.dart';
 import '../models/cloud_history_entry.dart';
 import '../services/cloud_training_history_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 enum _SortOption { newest, oldest, accuracyDesc, accuracyAsc }
 
@@ -82,7 +83,7 @@ class _CloudTrainingHistoryScreenState extends State<CloudTrainingHistoryScreen>
       appBar: AppBar(
         title: const Text('Cloud History'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.download),
             tooltip: 'Export',

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -17,6 +17,7 @@ import '../models/saved_hand.dart';
 import '../models/training_pack.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'training_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CloudTrainingSessionDetailsScreen extends StatefulWidget {
   final CloudTrainingSession session;
@@ -358,7 +359,7 @@ class _CloudTrainingSessionDetailsScreenState
           ],
         ),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.download),
             tooltip: 'Экспорт',

--- a/lib/screens/compare_sessions_screen.dart
+++ b/lib/screens/compare_sessions_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/session_note_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CompareSessionsScreen extends StatelessWidget {
   final int firstId;
@@ -88,6 +89,7 @@ class CompareSessionsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Сравнение сессий'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/create_custom_pack_screen.dart
+++ b/lib/screens/create_custom_pack_screen.dart
@@ -14,6 +14,7 @@ import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
 import '../widgets/color_picker_dialog.dart';
 import 'my_training_packs_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CreateCustomPackScreen extends StatefulWidget {
   const CreateCustomPackScreen({super.key});
@@ -221,7 +222,7 @@ class _CreateCustomPackScreenState extends State<CreateCustomPackScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Новый кастомный пак'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             onPressed: _hands.isEmpty ? null : _save,
             icon: const Icon(Icons.check),

--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -7,6 +7,7 @@ import '../models/training_pack_template.dart';
 import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CreatePackFromTemplateScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -479,6 +480,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
             ),
           ],
         ),
+      actions: [SyncStatusIcon.of(context)],
       ),
     );
   }

--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -5,6 +5,7 @@ import '../models/training_pack.dart';
 import '../models/training_spot.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/training_spot_storage_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CreatePackScreen extends StatefulWidget {
   const CreatePackScreen({super.key});
@@ -68,6 +69,7 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Новый пакет'),
+        actions: [SyncStatusIcon.of(context)],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _save,

--- a/lib/screens/create_template_screen.dart
+++ b/lib/screens/create_template_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/training_pack_template.dart';
+import '../widgets/sync_status_widget.dart';
 
 class CreateTemplateScreen extends StatefulWidget {
   const CreateTemplateScreen({super.key});
@@ -46,6 +47,7 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Создать шаблон'),
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/daily_hand_screen.dart
+++ b/lib/screens/daily_hand_screen.dart
@@ -5,6 +5,7 @@ import '../services/daily_hand_service.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../widgets/saved_hand_detail_sheet.dart';
 import '../helpers/date_utils.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DailyHandScreen extends StatelessWidget {
   const DailyHandScreen({super.key});
@@ -17,7 +18,7 @@ class DailyHandScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Ежедневная раздача'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.history),
             onPressed: () {
@@ -72,6 +73,7 @@ class PastDailyHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('История ежедневных раздач'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF121212),
       body: history.isEmpty

--- a/lib/screens/daily_progress_history_screen.dart
+++ b/lib/screens/daily_progress_history_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DailyProgressHistoryScreen extends StatelessWidget {
   const DailyProgressHistoryScreen({super.key});
@@ -20,6 +21,7 @@ class DailyProgressHistoryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Daily Progress'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: GridView.builder(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/daily_spot_history_calendar_screen.dart
+++ b/lib/screens/daily_spot_history_calendar_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DailySpotHistoryCalendarScreen extends StatefulWidget {
   const DailySpotHistoryCalendarScreen({super.key});
@@ -43,7 +44,7 @@ class _DailySpotHistoryCalendarScreenState extends State<DailySpotHistoryCalenda
       appBar: AppBar(
         title: const Text('История спотов дня'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.close),
             onPressed: () => Navigator.pop(context),

--- a/lib/screens/daily_spot_history_screen.dart
+++ b/lib/screens/daily_spot_history_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DailySpotHistoryScreen extends StatefulWidget {
   const DailySpotHistoryScreen({super.key});
@@ -41,6 +42,7 @@ class _DailySpotHistoryScreenState extends State<DailySpotHistoryScreen> {
       appBar: AppBar(
         title: const Text('История спотов дня'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/daily_spot_screen.dart
+++ b/lib/screens/daily_spot_screen.dart
@@ -6,6 +6,7 @@ import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import '../widgets/replay_spot_widget.dart';
 import '../services/training_import_export_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DailySpotScreen extends StatefulWidget {
   final SavedHand hand;
@@ -50,6 +51,7 @@ class _DailySpotScreenState extends State<DailySpotScreen> {
       appBar: AppBar(
         title: const Text('Спот дня'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF121212),
       body: ListView(
@@ -80,6 +82,8 @@ class DailySpotDoneScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Спот дня')),
+      actions: [SyncStatusIcon.of(context)],
+      actions: [SyncStatusIcon.of(context)],
       backgroundColor: const Color(0xFF121212),
       body: const Center(
         child: Text(

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 class DrillHistoryScreen extends StatelessWidget {
   const DrillHistoryScreen({super.key});
@@ -18,6 +19,7 @@ class DrillHistoryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('История тренировок'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: results.isEmpty
           ? const Center(

--- a/lib/screens/edit_pack_screen.dart
+++ b/lib/screens/edit_pack_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
 import 'create_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class EditPackScreen extends StatelessWidget {
   const EditPackScreen({super.key});
@@ -23,6 +24,7 @@ class EditPackScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Редактировать тренировку'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
       body: packs.isEmpty

--- a/lib/screens/error_free_streak_screen.dart
+++ b/lib/screens/error_free_streak_screen.dart
@@ -6,6 +6,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import 'streak_history_screen.dart';
 import 'hand_history_review_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays hands from the current error-free streak.
 class ErrorFreeStreakScreen extends StatelessWidget {
@@ -20,7 +21,7 @@ class ErrorFreeStreakScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Серия без ошибок'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.history),
             onPressed: () {

--- a/lib/screens/goal_drill_screen.dart
+++ b/lib/screens/goal_drill_screen.dart
@@ -6,6 +6,7 @@ import '../models/training_spot.dart';
 import '../services/goals_service.dart';
 import '../services/training_pack_storage_service.dart';
 import '../widgets/replay_spot_widget.dart';
+import '../widgets/sync_status_widget.dart';
 
 class GoalDrillScreen extends StatefulWidget {
   const GoalDrillScreen({super.key});
@@ -57,6 +58,7 @@ class _GoalDrillScreenState extends State<GoalDrillScreen> {
         appBar: AppBar(
           title: const Text('Отработка цели'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: const Center(
           child: Text(
@@ -71,6 +73,7 @@ class _GoalDrillScreenState extends State<GoalDrillScreen> {
         appBar: AppBar(
           title: const Text('Отработка цели'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: const Center(
           child: Text(
@@ -87,6 +90,7 @@ class _GoalDrillScreenState extends State<GoalDrillScreen> {
       appBar: AppBar(
         title: Text(_goal!.title),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/goal_editor_screen.dart
+++ b/lib/screens/goal_editor_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/goal_engine.dart';
 import '../models/user_goal.dart';
+import '../widgets/sync_status_widget.dart';
 
 class GoalEditorScreen extends StatefulWidget {
   final UserGoal? goal;
@@ -78,7 +79,7 @@ class _GoalEditorScreenState extends State<GoalEditorScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.goal == null ? 'Новая цель' : 'Редактирование цели'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(onPressed: _save, icon: const Icon(Icons.check))
         ],
       ),

--- a/lib/screens/goal_history_screen.dart
+++ b/lib/screens/goal_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class GoalHistoryScreen extends StatelessWidget {
   final int index;
@@ -22,6 +23,7 @@ class GoalHistoryScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(goal.title),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: history.isEmpty
           ? const Center(child: Text('Нет данных'))

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -11,6 +11,7 @@ import '../services/weekly_challenge_service.dart';
 import '../theme/app_colors.dart';
 import 'daily_progress_history_screen.dart';
 import 'achievements_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class GoalOverviewScreen extends StatefulWidget {
   const GoalOverviewScreen({super.key});
@@ -60,7 +61,7 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
       appBar: AppBar(
         title: const Text('Goal'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.calendar_today),
             onPressed: () {

--- a/lib/screens/goals_history_screen.dart
+++ b/lib/screens/goals_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 enum _GoalFilter { all, completed, active }
 
@@ -43,6 +44,7 @@ class _GoalsHistoryScreenState extends State<GoalsHistoryScreen> {
       appBar: AppBar(
         title: const Text('История целей'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/goals_overview_screen.dart
+++ b/lib/screens/goals_overview_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class GoalsOverviewScreen extends StatelessWidget {
   const GoalsOverviewScreen({super.key});
@@ -121,6 +122,7 @@ class GoalsOverviewScreen extends StatelessWidget {
               onEdit: () => _editAccuracy(context),
               percent: true),
         ],
+      actions: [SyncStatusIcon.of(context)],
       ),
     );
   }

--- a/lib/screens/goals_screen.dart
+++ b/lib/screens/goals_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'dart:math' as math;
 
 import '../services/streak_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class Goal {
   final String title;
@@ -286,6 +287,7 @@ class _GoalsScreenState extends State<GoalsScreen> {
       appBar: AppBar(
         title: const Text('Мои цели'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -13,6 +13,7 @@ import '../services/goals_service.dart';
 import '../helpers/date_utils.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../helpers/mistake_advice.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays a saved hand with simple playback controls.
 /// Shows GTO recommendation and range group when available.
@@ -281,7 +282,7 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
           '${widget.hand.name} \u2022 ${formatLongDate(widget.hand.savedAt)}',
         ),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.share),
             onPressed: _showExportOptions,

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -9,6 +9,7 @@ import '../theme/app_colors.dart';
 import '../widgets/training_calendar_widget.dart';
 import 'streak_calendar_screen.dart';
 import '../widgets/mistake_summary_card.dart';
+import '../widgets/sync_status_widget.dart';
 
 enum _Mode { daily, weekly }
 
@@ -235,7 +236,7 @@ class _InsightsScreenState extends State<InsightsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Insights'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           ToggleButtons(
             isSelected: [_mode == _Mode.daily, _mode == _Mode.weekly],
             onPressed: (i) => setState(() => _mode = _Mode.values[i]),

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -36,6 +36,7 @@ import 'mistake_repeat_screen.dart';
 import 'achievements_screen.dart';
 import '../services/goals_service.dart';
 import '../widgets/focus_of_the_week_card.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -503,7 +504,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           _buildStreakIndicator(context),
           if (!_tutorialCompleted)
             IconButton(

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -20,6 +20,7 @@ import '../services/daily_target_service.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'package:provider/provider.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -123,7 +124,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           PopupMenuButton<String>(
             onSelected: (value) {
               switch (value) {

--- a/lib/screens/markdown_preview_screen.dart
+++ b/lib/screens/markdown_preview_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:markdown/markdown.dart' as md;
+import '../widgets/sync_status_widget.dart';
 
 class MarkdownPreviewScreen extends StatefulWidget {
   final String path;
@@ -58,6 +59,7 @@ body { font-family: sans-serif; padding: 16px; }
       appBar: AppBar(
         title: const Text('Markdown Preview'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: WebViewWidget(controller: _controller),
       backgroundColor: const Color(0xFF1B1C1E),

--- a/lib/screens/mistake_overview_screen.dart
+++ b/lib/screens/mistake_overview_screen.dart
@@ -7,6 +7,7 @@ import '../services/ignored_mistake_service.dart';
 import 'tag_mistake_overview_screen.dart';
 import 'position_mistake_overview_screen.dart';
 import 'street_mistake_overview_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MistakeOverviewScreen extends StatefulWidget {
   const MistakeOverviewScreen({super.key});
@@ -44,7 +45,7 @@ class _MistakeOverviewScreenState extends State<MistakeOverviewScreen>
       appBar: AppBar(
         title: const Text('Ошибки'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           if (context.watch<IgnoredMistakeService>().ignored.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.restore),

--- a/lib/screens/mistake_repeat_screen.dart
+++ b/lib/screens/mistake_repeat_screen.dart
@@ -11,6 +11,7 @@ import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'hand_history_review_screen.dart';
 import '../widgets/saved_hand_tile.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MistakeRepeatScreen extends StatelessWidget {
   const MistakeRepeatScreen({super.key});
@@ -258,7 +259,7 @@ class MistakeRepeatScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Повторы ошибок'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.save_alt),
             tooltip: 'Экспорт',

--- a/lib/screens/my_achievements_screen.dart
+++ b/lib/screens/my_achievements_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MyAchievementsScreen extends StatelessWidget {
   const MyAchievementsScreen({super.key});
@@ -13,6 +14,7 @@ class MyAchievementsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Мои достижения'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Builder(
         builder: (context) {

--- a/lib/screens/my_training_history_screen.dart
+++ b/lib/screens/my_training_history_screen.dart
@@ -9,6 +9,7 @@ import '../models/session_summary.dart';
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MyTrainingHistoryScreen extends StatefulWidget {
   const MyTrainingHistoryScreen({super.key});
@@ -69,6 +70,7 @@ class _MyTrainingHistoryScreenState extends State<MyTrainingHistoryScreen> {
       appBar: AppBar(
         title: const Text('Мои тренировки'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
       body: _entries.isEmpty

--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/color_picker_dialog.dart';
 import 'package:intl/intl.dart';
 import '../services/tag_service.dart';
 import 'training_pack_template_list_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class MyTrainingPacksScreen extends StatefulWidget {
   const MyTrainingPacksScreen({super.key});
@@ -413,6 +414,8 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
     }
     return Scaffold(
       appBar: AppBar(title: const Text('Мои паки'), centerTitle: true),
+      actions: [SyncStatusIcon.of(context)],
+      actions: [SyncStatusIcon.of(context)],
       backgroundColor: AppColors.background,
       bottomNavigationBar: _selectionMode
           ? BottomAppBar(

--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../models/saved_hand.dart';
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class PackEditorScreen extends StatefulWidget {
   final TrainingPack pack;
@@ -221,7 +222,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: Text(widget.pack.name),
-          actions: [
+          actions: [SyncStatusIcon.of(context), 
             IconButton(
               onPressed: _hands.isEmpty ? null : _save,
               icon: const Icon(Icons.check),

--- a/lib/screens/player_input_screen.dart
+++ b/lib/screens/player_input_screen.dart
@@ -20,6 +20,7 @@ import '../services/transition_lock_service.dart';
 import '../services/board_reveal_service.dart';
 import '../services/all_in_players_service.dart';
 import '../services/folded_players_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class PlayerInputScreen extends StatefulWidget {
   const PlayerInputScreen({super.key});
@@ -40,7 +41,7 @@ class _PlayerInputScreenState extends State<PlayerInputScreen> {
         backgroundColor: Colors.black,
         title: const Text('Poker AI Analyzer'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {

--- a/lib/screens/player_zone_demo_screen.dart
+++ b/lib/screens/player_zone_demo_screen.dart
@@ -8,6 +8,7 @@ import '../models/card_model.dart';
 import '../services/action_sync_service.dart';
 import '../models/player_model.dart';
 import '../helpers/poker_street_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 class PlayerZoneDemoScreen extends StatefulWidget {
   const PlayerZoneDemoScreen({super.key});
@@ -71,6 +72,7 @@ class _PlayerZoneDemoScreenState extends State<PlayerZoneDemoScreen> {
             ),
           ),
         ],
+      actions: [SyncStatusIcon.of(context)],
       ),
     );
   }

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -8,6 +8,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../plugins/plugin_loader.dart';
 import '../../plugins/plugin_manager.dart';
 import '../services/service_registry.dart';
+import '../widgets/sync_status_widget.dart';
 
 class PluginManagerScreen extends StatefulWidget {
   const PluginManagerScreen({super.key});
@@ -86,6 +87,7 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
       appBar: AppBar(
         title: const Text('Plugins'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
 import 'hand_history_review_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays a list of hero positions sorted by mistake count.
 ///
@@ -298,6 +299,7 @@ class _PositionMistakeHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(position),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: SavedHandListView(
         hands: hands,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/streak_service.dart';
 import '../services/evaluation_executor_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -40,6 +41,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       appBar: AppBar(
         title: const Text('Profile'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -27,6 +27,7 @@ import 'daily_spot_history_calendar_screen.dart';
 import 'achievements_screen.dart';
 import 'drill_history_screen.dart';
 import 'goal_drill_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -777,7 +778,7 @@ class _ProgressScreenState extends State<ProgressScreen>
       appBar: AppBar(
         title: const Text('Прогресс'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.history),
             tooltip: 'История целей',

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/action_entry.dart';
+import '../widgets/sync_status_widget.dart';
 
 class ResultScreen extends StatelessWidget {
   final int winnerIndex;
@@ -25,6 +26,7 @@ class ResultScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Результат раздачи'),
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -8,6 +8,7 @@ import '../widgets/common/summary_card.dart';
 
 import '../models/error_entry.dart';
 import '../models/training_result.dart';
+import '../widgets/sync_status_widget.dart';
 
 class RetryTrainingScreen extends StatefulWidget {
   final List<ErrorEntry> errors;
@@ -210,6 +211,7 @@ class _RetryTrainingScreenState extends State<RetryTrainingScreen> {
       appBar: AppBar(
         title: const Text('Retry Mistakes'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: AppColors.background,
       body: Padding(

--- a/lib/screens/saved_hand_history_screen.dart
+++ b/lib/screens/saved_hand_history_screen.dart
@@ -7,6 +7,7 @@ import '../theme/app_colors.dart';
 import '../theme/constants.dart';
 import '../widgets/saved_hand_list_view.dart';
 import 'hand_history_review_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SavedHandHistoryScreen extends StatefulWidget {
   const SavedHandHistoryScreen({super.key});
@@ -150,6 +151,7 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
             ),
           ),
         ),
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -10,6 +10,7 @@ import '../theme/constants.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../screens/hand_history_review_screen.dart';
 import '../helpers/poker_street_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SavedHandsScreen extends StatefulWidget {
   final String? initialTag;
@@ -98,6 +99,7 @@ class _SavedHandsScreenState extends State<SavedHandsScreen> {
       appBar: AppBar(
         title: const Text('Сохранённые раздачи'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -9,6 +9,7 @@ import '../helpers/date_utils.dart';
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import 'training_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SessionDetailScreen extends StatelessWidget {
   final String packName;
@@ -86,6 +87,7 @@ class SessionDetailScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(packName),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
       body: Column(

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -12,6 +12,7 @@ import '../helpers/date_utils.dart';
 import '../theme/app_colors.dart';
 import '../theme/constants.dart';
 import 'hand_history_review_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SessionHandsScreen extends StatefulWidget {
   final int sessionId;
@@ -276,6 +277,7 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
         appBar: AppBar(
           title: Text('Сессия ${widget.sessionId}'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: hands.isEmpty
           ? const Center(

--- a/lib/screens/session_history_screen.dart
+++ b/lib/screens/session_history_screen.dart
@@ -10,6 +10,7 @@ import '../helpers/date_utils.dart';
 import '../theme/constants.dart';
 import 'session_hands_screen.dart';
 import 'compare_sessions_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SessionHistoryScreen extends StatefulWidget {
   const SessionHistoryScreen({super.key});
@@ -246,7 +247,7 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
       appBar: AppBar(
         title: const Text('История сессий'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           if (_selectionMode)
             IconButton(
               icon: const Icon(Icons.close),

--- a/lib/screens/session_review_screen.dart
+++ b/lib/screens/session_review_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/error_entry.dart';
 import 'retry_training_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 const _filterOptions = [
   'All',
@@ -79,7 +80,7 @@ class _SessionReviewScreenState extends State<SessionReviewScreen> {
       appBar: AppBar(
         title: const Text('Ошибки сессии'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           PopupMenuButton<String>(
             onSelected: (v) {
               setState(() {

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -19,6 +19,7 @@ import '../helpers/poker_street_helper.dart';
 import 'saved_hands_screen.dart';
 import 'mistake_overview_screen.dart';
 import 'accuracy_mistake_overview_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SessionStatsScreen extends StatefulWidget {
   const SessionStatsScreen({super.key});
@@ -713,7 +714,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
       appBar: AppBar(
         title: const Text('Статистика сессий'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.save_alt),
             tooltip: 'Экспорт',

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -12,6 +12,7 @@ import '../services/reminder_service.dart';
 import '../services/daily_reminder_service.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -67,6 +68,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Ещё'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView(
         children: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import 'achievements_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/auth_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -66,7 +67,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       appBar: AppBar(
         title: const Text('Settings'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.cloud),
             tooltip: 'Cloud Sync',

--- a/lib/screens/spot_of_the_day_history_screen.dart
+++ b/lib/screens/spot_of_the_day_history_screen.dart
@@ -5,6 +5,7 @@ import '../models/training_spot.dart';
 import '../services/spot_of_the_day_service.dart';
 import '../screens/training_screen.dart';
 import 'package:intl/intl.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SpotOfTheDayHistoryScreen extends StatefulWidget {
   const SpotOfTheDayHistoryScreen({super.key});
@@ -37,6 +38,7 @@ class _SpotOfTheDayHistoryScreenState extends State<SpotOfTheDayHistoryScreen> {
       appBar: AppBar(
         title: const Text('История "Спот дня"'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: FutureBuilder<List<TrainingSpot>>(
         future: _spotsFuture,

--- a/lib/screens/spot_of_the_day_retry_screen.dart
+++ b/lib/screens/spot_of_the_day_retry_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/board_cards_widget.dart';
 import '../widgets/player_info_widget.dart';
 import '../widgets/poker_table_painter.dart';
 import '../helpers/table_geometry_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SpotOfTheDayRetryScreen extends StatefulWidget {
   const SpotOfTheDayRetryScreen({super.key});
@@ -74,6 +75,7 @@ class _SpotOfTheDayRetryScreenState extends State<SpotOfTheDayRetryScreen> {
         appBar: AppBar(
           title: const Text('Повтор ошибок'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         backgroundColor: const Color(0xFF121212),
         body: const Center(
@@ -102,6 +104,7 @@ class _SpotOfTheDayRetryScreenState extends State<SpotOfTheDayRetryScreen> {
           appBar: AppBar(
             title: const Text('Повтор ошибок'),
             centerTitle: true,
+            actions: [SyncStatusIcon.of(context)],
           ),
           backgroundColor: const Color(0xFF121212),
           body: LayoutBuilder(

--- a/lib/screens/spot_of_the_day_screen.dart
+++ b/lib/screens/spot_of_the_day_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/poker_table_painter.dart';
 import '../widgets/player_info_widget.dart';
 import '../helpers/table_geometry_helper.dart';
 import '../models/card_model.dart';
+import '../widgets/sync_status_widget.dart';
 
 class SpotOfTheDayScreen extends StatefulWidget {
   const SpotOfTheDayScreen({super.key});
@@ -54,7 +55,7 @@ class _SpotOfTheDayScreenState extends State<SpotOfTheDayScreen> {
         appBar: AppBar(
           title: const Text('Спот дня'),
           centerTitle: true,
-          actions: [
+          actions: [SyncStatusIcon.of(context), 
             IconButton(
               icon: const Icon(Icons.history),
               onPressed: () {
@@ -74,7 +75,7 @@ class _SpotOfTheDayScreenState extends State<SpotOfTheDayScreen> {
       appBar: AppBar(
         title: const Text('Спот дня'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.history),
             onPressed: () {

--- a/lib/screens/streak_calendar_screen.dart
+++ b/lib/screens/streak_calendar_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class StreakCalendarScreen extends StatelessWidget {
   const StreakCalendarScreen({super.key});
@@ -59,6 +60,7 @@ class StreakCalendarScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Календарь тренировок'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: GridView.builder(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/streak_history_screen.dart
+++ b/lib/screens/streak_history_screen.dart
@@ -6,6 +6,7 @@ import 'package:fl_chart/fl_chart.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 class StreakHistoryScreen extends StatelessWidget {
   const StreakHistoryScreen({super.key});
@@ -52,6 +53,7 @@ class StreakHistoryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Streak History'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/street_mistake_overview_screen.dart
+++ b/lib/screens/street_mistake_overview_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../helpers/poker_street_helper.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'saved_hands_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class StreetMistakeOverviewScreen extends StatelessWidget {
   final String dateFilter;
@@ -42,6 +43,7 @@ class StreetMistakeOverviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Ошибки по улицам'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/tag_management_screen.dart
+++ b/lib/screens/tag_management_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/tag_service.dart';
 import '../helpers/color_utils.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TagManagementScreen extends StatelessWidget {
   const TagManagementScreen({super.key});
@@ -81,7 +82,7 @@ class TagManagementScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Теги'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.download),
             tooltip: 'Экспорт',

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/common/mistake_trend_chart.dart';
 enum _ChartMode { daily, weekly }
 import 'hand_history_review_screen.dart';
 import '../widgets/saved_hand_tile.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays a list of tags sorted by mistake count.
 ///
@@ -1069,6 +1070,7 @@ class _TagMistakeHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(tag),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: SavedHandListView(
         hands: hands,
@@ -1227,6 +1229,7 @@ class _DailySeverityHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(formatLongDate(day)),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/template_hands_editor_screen.dart
+++ b/lib/screens/template_hands_editor_screen.dart
@@ -5,6 +5,7 @@ import '../models/saved_hand.dart';
 import '../models/training_pack_template.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/template_storage_service.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TemplateHandsEditorScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -86,7 +87,7 @@ class _TemplateHandsEditorScreenState extends State<TemplateHandsEditorScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Редактор шаблона'),
-        actions: [IconButton(onPressed: _save, icon: const Icon(Icons.check))],
+        actions: [SyncStatusIcon.of(context), IconButton(onPressed: _save, icon: const Icon(Icons.check))],
       ),
       body: Column(
         children: [

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -13,6 +13,7 @@ import 'create_pack_from_template_screen.dart';
 import 'create_template_screen.dart';
 import 'template_hands_editor_screen.dart';
 import 'template_preview_dialog.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -202,6 +203,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
             ),
           ),
         ],
+      actions: [SyncStatusIcon.of(context)],
       ),
       floatingActionButton: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/screens/top_mistakes_overview_screen.dart
+++ b/lib/screens/top_mistakes_overview_screen.dart
@@ -5,6 +5,7 @@ import 'package:fl_chart/fl_chart.dart';
 
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TopMistakesOverviewScreen extends StatelessWidget {
   static const route = '/training/analytics/top-mistakes';
@@ -58,6 +59,7 @@ class TopMistakesOverviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Частые ошибки'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: entries.isEmpty
           ? const Center(child: Text('Нет данных', style: TextStyle(color: Colors.white70)))

--- a/lib/screens/training_activity_by_weekday_screen.dart
+++ b/lib/screens/training_activity_by_weekday_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingActivityByWeekdayScreen extends StatelessWidget {
   static const route = '/training/activity/weekdays';
@@ -29,6 +30,7 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Активность по дням недели'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: const Padding(
           padding: EdgeInsets.all(16),
@@ -69,6 +71,7 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Активность по дням недели'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/training_detail_screen.dart
+++ b/lib/screens/training_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:pie_chart/pie_chart.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:printing/printing.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingDetailScreen extends StatelessWidget {
   final TrainingResult result;
@@ -132,6 +133,7 @@ class TrainingDetailScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Session Details'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: AppColors.background,
       body: Padding(

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -32,6 +32,7 @@ import '../models/training_session.dart';
 import '../helpers/date_utils.dart';
 import '../helpers/accuracy_utils.dart';
 import '../tutorial/tutorial_flow.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   final TutorialFlow? tutorial;
@@ -2181,7 +2182,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       appBar: AppBar(
         title: const Text('Training History'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.upload),
             tooltip: 'Import',

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import 'training_progress_analytics_screen.dart';
 import 'template_library_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
   const TrainingHomeScreen({super.key});
@@ -32,7 +33,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Training'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.analytics),
             onPressed: () {

--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/difficulty_chip.dart';
 import '../widgets/info_tooltip.dart';
 import '../helpers/color_utils.dart';
 import '../widgets/color_picker_dialog.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingPackComparisonScreen extends StatefulWidget {
   const TrainingPackComparisonScreen({super.key});
@@ -647,6 +648,7 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
       appBar: AppBar(
         title: const Text('Сравнение паков'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _exportCsv,

--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -22,6 +22,7 @@ import '../models/training_pack_template_model.dart';
 import '../services/training_pack_template_storage_service.dart';
 import 'training_pack_template_editor_screen.dart';
 import 'package:uuid/uuid.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays all spots from [pack] with option to show only mistaken ones.
 class TrainingPackReviewScreen extends StatefulWidget {
@@ -521,7 +522,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
       appBar: AppBar(
         title: Text(widget.pack.name),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.picture_as_pdf),
             tooltip: 'Export to PDF',

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -67,6 +67,7 @@ import 'dart:async';
 import '../services/cloud_training_history_service.dart';
 import '../helpers/color_utils.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 
 class _SessionSummary {
@@ -1809,7 +1810,7 @@ body { font-family: sans-serif; padding: 16px; }
             ],
           ),
           centerTitle: true,
-          actions: [
+          actions: [SyncStatusIcon.of(context), 
             if (_pack.pctComplete > 0 && _pack.pctComplete < 1)
               IconButton(
                 icon: const Icon(Icons.play_arrow),
@@ -2028,7 +2029,7 @@ class _TrainingAnalysisScreenState extends State<TrainingAnalysisScreen> {
       appBar: AppBar(
         title: const Text('Анализ тренировки'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           IconButton(
             icon: const Icon(Icons.save_alt),
             tooltip: 'Экспорт',

--- a/lib/screens/training_pack_template_editor_screen.dart
+++ b/lib/screens/training_pack_template_editor_screen.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 const _validStreets = ['preflop', 'flop', 'turn', 'river'];
 
 import '../models/training_pack_template_model.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingPackTemplateEditorScreen extends StatefulWidget {
   final TrainingPackTemplateModel? initial;
@@ -155,6 +156,7 @@ class _TrainingPackTemplateEditorScreenState
           ],
         ),
       ),
+      actions: [SyncStatusIcon.of(context)],
     );
   }
 }

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -15,6 +15,7 @@ import 'template_library_screen.dart';
 import 'training_pack_screen.dart';
 import 'training_pack_comparison_screen.dart';
 import 'create_pack_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingPacksScreen extends StatefulWidget {
   const TrainingPacksScreen({super.key});
@@ -142,6 +143,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       return Scaffold(
         appBar: AppBar(
           title: const Text('Тренировочные споты'),
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: const Center(child: CircularProgressIndicator()),
       );
@@ -196,6 +198,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       return Scaffold(
         appBar: AppBar(
           title: const Text('Тренировочные споты'),
+          actions: [SyncStatusIcon.of(context)],
         ),
         body: Center(
           child: Column(
@@ -240,6 +243,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Тренировочные споты'),
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: Column(
         children: [

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -5,6 +5,7 @@ import '../models/evaluation_result.dart';
 import '../services/training_session_controller.dart';
 import '../widgets/training_spot_diagram.dart';
 import '../widgets/replay_spot_widget.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingPlayScreen extends StatefulWidget {
   const TrainingPlayScreen({super.key});
@@ -33,6 +34,7 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
       appBar: AppBar(
         title: const Text('Training'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: const Color(0xFF121212),
       body: SingleChildScrollView(

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -5,6 +5,7 @@ import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
 import 'training_activity_by_weekday_screen.dart';
 import 'top_mistakes_overview_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -30,7 +31,7 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Аналитика по категориям'),
         centerTitle: true,
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           TextButton(
             onPressed: () {
               Navigator.push(

--- a/lib/screens/training_progress_overview_screen.dart
+++ b/lib/screens/training_progress_overview_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingProgressOverviewScreen extends StatelessWidget {
   static const route = '/training/progress';
@@ -21,6 +22,7 @@ class TrainingProgressOverviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Прогресс по тренировкам'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: ListView.separated(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/training_review_screen.dart
+++ b/lib/screens/training_review_screen.dart
@@ -4,6 +4,7 @@ import '../models/training_spot.dart';
 import '../theme/app_colors.dart';
 import '../widgets/training_spot_diagram.dart';
 import '../models/action_entry.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingReviewScreen extends StatelessWidget {
   final String title;
@@ -126,6 +127,7 @@ class TrainingReviewScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Spot Review'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: AppColors.background,
       body: SingleChildScrollView(

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/replay_spot_widget.dart';
 import '../services/goals_service.dart';
 import '../models/drill_session_result.dart';
 import '../helpers/poker_street_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Simple screen that shows a single [TrainingSpot].
 class TrainingScreen extends StatefulWidget {
@@ -153,6 +154,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
         appBar: AppBar(
           title: const Text('Training'),
           centerTitle: true,
+          actions: [SyncStatusIcon.of(context)],
         ),
         backgroundColor: const Color(0xFF121212),
         body: SingleChildScrollView(

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -9,6 +9,7 @@ import '../models/action_entry.dart';
 import '../services/user_preferences_service.dart';
 import 'package:provider/provider.dart';
 import '../helpers/poker_street_helper.dart';
+import '../widgets/sync_status_widget.dart';
 
 /// Displays actions for a [TrainingSpot] grouped by street in collapsible sections.
 class TrainingSpotAnalysisScreen extends StatefulWidget {
@@ -120,6 +121,7 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
       appBar: AppBar(
         title: const Text('Spot Analysis'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: Colors.black,
       body: ListView(

--- a/lib/screens/training_spot_builder_screen.dart
+++ b/lib/screens/training_spot_builder_screen.dart
@@ -10,6 +10,7 @@ import '../services/training_spot_storage_service.dart';
 import '../services/template_storage_service.dart';
 import '../widgets/board_cards_widget.dart';
 import '../widgets/template_selection_dialog.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingSpotBuilderScreen extends StatefulWidget {
   const TrainingSpotBuilderScreen({super.key});
@@ -179,6 +180,8 @@ class _TrainingSpotBuilderScreenState extends State<TrainingSpotBuilderScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Создание спота'), centerTitle: true),
+      actions: [SyncStatusIcon.of(context)],
+      actions: [SyncStatusIcon.of(context)],
       backgroundColor: const Color(0xFF1B1C1E),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/training_spot_detail_screen.dart
+++ b/lib/screens/training_spot_detail_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/eval_result_view.dart';
 import 'package:provider/provider.dart';
 import '../services/training_session_controller.dart';
 import 'training_play_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingSpotDetailScreen extends StatelessWidget {
   final TrainingSpot spot;
@@ -31,6 +32,7 @@ class TrainingSpotDetailScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Spot Details'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       backgroundColor: Colors.black,
       body: ListView(

--- a/lib/screens/training_spot_library_screen.dart
+++ b/lib/screens/training_spot_library_screen.dart
@@ -13,6 +13,7 @@ import '../services/training_spot_storage_service.dart';
 import 'training_pack_template_editor_screen.dart';
 import 'training_spot_builder_screen.dart';
 import 'package:uuid/uuid.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingSpotLibraryScreen extends StatefulWidget {
   const TrainingSpotLibraryScreen({super.key});
@@ -226,7 +227,7 @@ class _TrainingSpotLibraryScreenState extends State<TrainingSpotLibraryScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Spots'),
-        actions: [
+        actions: [SyncStatusIcon.of(context), 
           if (context.watch<TrainingSpotStorageService>().activeFilters.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.filter_alt_off),

--- a/lib/screens/training_stats_screen.dart
+++ b/lib/screens/training_stats_screen.dart
@@ -10,6 +10,7 @@ import 'package:share_plus/share_plus.dart';
 import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import 'saved_hands_screen.dart';
+import '../widgets/sync_status_widget.dart';
 
 class TrainingStatsScreen extends StatefulWidget {
   const TrainingStatsScreen({super.key});
@@ -214,7 +215,7 @@ class _TrainingStatsScreenState extends State<TrainingStatsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Training Stats'),
-        actions: [IconButton(icon: Icon(Icons.share), onPressed: _exportPdf)],
+        actions: [SyncStatusIcon.of(context), IconButton(icon: Icon(Icons.share), onPressed: _exportPdf)],
         centerTitle: true,
       ),
       body: ListView(

--- a/lib/services/connectivity_sync_controller.dart
+++ b/lib/services/connectivity_sync_controller.dart
@@ -7,15 +7,17 @@ class ConnectivitySyncController with WidgetsBindingObserver {
   ConnectivitySyncController({required this.cloud}) {
     WidgetsBinding.instance.addObserver(this);
     _sub = Connectivity().onConnectivityChanged.listen(_onResult);
+    Connectivity().checkConnectivity().then(_onResult);
   }
 
   final CloudSyncService cloud;
   late final StreamSubscription<ConnectivityResult> _sub;
+  final ValueNotifier<bool> online = ValueNotifier(true);
 
   void _onResult(ConnectivityResult result) {
-    if (result == ConnectivityResult.mobile || result == ConnectivityResult.wifi) {
-      _sync();
-    }
+    final on = result == ConnectivityResult.mobile || result == ConnectivityResult.wifi;
+    online.value = on;
+    if (on) _sync();
   }
 
   @override

--- a/lib/widgets/focus_of_the_week_card.dart
+++ b/lib/widgets/focus_of_the_week_card.dart
@@ -8,6 +8,7 @@ import '../models/saved_hand.dart';
 import 'saved_hand_list_view.dart';
 import '../screens/hand_history_review_screen.dart';
 import '../screens/training_screen.dart';
+import 'sync_status_widget.dart';
 
 class FocusOfTheWeekCard extends StatelessWidget {
   const FocusOfTheWeekCard({super.key});
@@ -134,6 +135,7 @@ class _FocusMistakeHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text('$position • $street'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: SavedHandListView(
         hands: filtered,

--- a/lib/widgets/mistake_heatmap.dart
+++ b/lib/widgets/mistake_heatmap.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'saved_hand_list_view.dart';
 import '../screens/hand_history_review_screen.dart';
+import 'sync_status_widget.dart';
 
 class MistakeHeatmap extends StatelessWidget {
   final Map<String, Map<String, int>> data;
@@ -95,6 +96,7 @@ class _HeatmapMistakeHandsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text('$position • $street'),
         centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
       ),
       body: SavedHandListView(
         hands: filtered,

--- a/lib/widgets/sync_status_widget.dart
+++ b/lib/widgets/sync_status_widget.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import '../services/connectivity_sync_controller.dart';
+import '../services/cloud_sync_service.dart';
+
+class SyncStatusIcon extends InheritedWidget {
+  const SyncStatusIcon({required this.icon, required super.child, super.key});
+
+  final Widget icon;
+
+  static Widget of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<SyncStatusIcon>()!.icon;
+
+  @override
+  bool updateShouldNotify(covariant SyncStatusIcon oldWidget) => icon != oldWidget.icon;
+}
+
+class SyncStatusWidget extends StatefulWidget {
+  const SyncStatusWidget({required this.child, required this.sync, required this.cloud, super.key});
+
+  final Widget child;
+  final ConnectivitySyncController sync;
+  final CloudSyncService cloud;
+
+  @override
+  State<SyncStatusWidget> createState() => _SyncStatusWidgetState();
+}
+
+class _SyncStatusWidgetState extends State<SyncStatusWidget> {
+  late IconData _icon;
+
+  @override
+  void initState() {
+    super.initState();
+    _icon = Icons.cloud_off;
+    widget.sync.online.addListener(_update);
+    widget.cloud.progress.addListener(_update);
+    widget.cloud.lastSync.addListener(_update);
+    _update();
+  }
+
+  void _update() {
+    setState(() {
+      if (!widget.sync.online.value) {
+        _icon = Icons.cloud_off;
+      } else if (widget.cloud.progress.value < 0) {
+        _icon = Icons.cloud_error;
+      } else if (widget.cloud.progress.value > 0) {
+        _icon = Icons.cloud_sync;
+      } else {
+        _icon = Icons.cloud_done;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.sync.online.removeListener(_update);
+    widget.cloud.progress.removeListener(_update);
+    widget.cloud.lastSync.removeListener(_update);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SyncStatusIcon(
+      icon: Icon(_icon, color: Colors.greenAccent),
+      child: widget.child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- track sync progress in `CloudSyncService`
- report connection status in `ConnectivitySyncController`
- provide `SyncStatusWidget` with `SyncStatusIcon` inherited widget
- insert `SyncStatusIcon` into app bars
- wrap app with `SyncStatusWidget`

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6860d4349928832a93186431932e2a70