### PR TITLE
Add Spot Editor feature

### DIFF
--- a/lib/screens/spot_editor_screen.dart
+++ b/lib/screens/spot_editor_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/training_spot.dart';
+import '../models/action_entry.dart';
+import '../models/card_model.dart';
+import '../helpers/poker_position_helper.dart';
+import '../widgets/card_picker_widget.dart';
+import '../widgets/action_editor_list.dart';
+import '../services/training_spot_storage_service.dart';
+
+class SpotEditorScreen extends StatefulWidget {
+  final TrainingSpot? initial;
+  const SpotEditorScreen({super.key, this.initial});
+
+  @override
+  State<SpotEditorScreen> createState() => _SpotEditorScreenState();
+}
+
+class _SpotEditorScreenState extends State<SpotEditorScreen> {
+  late int _heroIndex;
+  late TextEditingController _stack;
+  late List<CardModel> _cards;
+  late List<ActionEntry> _actions;
+  late List<String> _positions;
+
+  @override
+  void initState() {
+    super.initState();
+    final m = widget.initial;
+    _heroIndex = m?.heroIndex ?? 0;
+    _stack = TextEditingController(
+        text: (m?.stacks.isNotEmpty == true ? m!.stacks[m.heroIndex] : 100).toString());
+    _cards = m?.heroIndex != null && m!.playerCards.length > m.heroIndex
+        ? List<CardModel>.from(m.playerCards[m.heroIndex])
+        : <CardModel>[];
+    _actions = List<ActionEntry>.from(m?.actions ?? []);
+    final size = m?.numberOfPlayers ?? 6;
+    _positions = getPositionList(size);
+  }
+
+  @override
+  void dispose() {
+    _stack.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final stack = int.tryParse(_stack.text) ?? 0;
+    if (stack <= 0 || _cards.length < 2) return;
+    final size = _positions.length;
+    final spot = TrainingSpot(
+      playerCards: List.generate(size, (i) => i == _heroIndex ? List.from(_cards) : <CardModel>[]),
+      boardCards: const [],
+      actions: List.from(_actions),
+      heroIndex: _heroIndex,
+      numberOfPlayers: size,
+      playerTypes: List.filled(size, PlayerType.unknown),
+      positions: List.from(_positions),
+      stacks: List.generate(size, (i) => i == _heroIndex ? stack : 0),
+    );
+    await context.read<TrainingSpotStorageService>().addSpot(spot);
+    if (mounted) Navigator.pop(context, spot);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Spot Editor')),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            DropdownButtonFormField<int>(
+              value: _heroIndex,
+              decoration: const InputDecoration(labelText: 'Hero position'),
+              dropdownColor: const Color(0xFF3A3B3E),
+              items: [for (int i = 0; i < _positions.length; i++) DropdownMenuItem(value: i, child: Text(_positions[i]))],
+              onChanged: (v) => setState(() => _heroIndex = v ?? 0),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _stack,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Stack (bb)'),
+            ),
+            const SizedBox(height: 12),
+            CardPickerWidget(cards: _cards, onChanged: (i, c) {
+              if (_cards.length > i) {
+                _cards[i] = c;
+              } else {
+                _cards.add(c);
+              }
+              setState(() {});
+            }),
+            const SizedBox(height: 12),
+            Expanded(
+              child: SingleChildScrollView(
+                child: ActionEditorList(
+                  initial: _actions,
+                  players: _positions.length,
+                  positions: _positions,
+                  onChanged: (v) {
+                    _actions = v;
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -63,6 +63,7 @@ import '../widgets/common/training_spot_list.dart';
 import 'markdown_preview_screen.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'training_spot_detail_screen.dart';
+import 'spot_editor_screen.dart';
 import 'dart:async';
 import '../services/cloud_training_history_service.dart';
 import '../helpers/color_utils.dart';
@@ -546,6 +547,30 @@ class _TrainingPackScreenState extends State<TrainingPackScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Копия «${copy.name}» создана')),
     );
+  }
+
+  Future<void> _addSpot() async {
+    final spot = await Navigator.push<TrainingSpot>(
+      context,
+      MaterialPageRoute(builder: (_) => const SpotEditorScreen()),
+    );
+    if (spot == null) return;
+    final newSpots = List<TrainingSpot>.from(_pack.spots)..add(spot);
+    final updated = TrainingPack(
+      name: _pack.name,
+      description: _pack.description,
+      category: _pack.category,
+      gameType: _pack.gameType,
+      colorTag: _pack.colorTag,
+      isBuiltIn: _pack.isBuiltIn,
+      tags: _pack.tags,
+      hands: _pack.hands,
+      spots: newSpots,
+      difficulty: _pack.difficulty,
+      history: _pack.history,
+    );
+    await context.read<TrainingPackStorageService>().updatePack(_pack, updated);
+    setState(() => _pack = updated);
   }
 
   void _previousHand() {
@@ -1860,6 +1885,10 @@ body { font-family: sans-serif; padding: 16px; }
           ],
         ),
         backgroundColor: const Color(0xFF1B1C1E),
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: _addSpot,
+          label: const Text('＋ Spot'),
+        ),
       ),
     );
   }

--- a/lib/widgets/action_editor_list.dart
+++ b/lib/widgets/action_editor_list.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import '../models/action_entry.dart';
+import 'edit_action_dialog.dart';
+
+class ActionEditorList extends StatefulWidget {
+  final List<ActionEntry> initial;
+  final int players;
+  final List<String> positions;
+  final ValueChanged<List<ActionEntry>> onChanged;
+  const ActionEditorList({
+    super.key,
+    required this.initial,
+    required this.players,
+    required this.positions,
+    required this.onChanged,
+  });
+
+  @override
+  State<ActionEditorList> createState() => _ActionEditorListState();
+}
+
+class _ActionEditorListState extends State<ActionEditorList> {
+  late List<ActionEntry> _actions;
+
+  @override
+  void initState() {
+    super.initState();
+    _actions = List.from(widget.initial);
+  }
+
+  Future<void> _addAction() async {
+    final entry = await showEditActionDialog(
+      context,
+      entry: ActionEntry(0, 0, 'call'),
+      numberOfPlayers: widget.players,
+      playerPositions: {for (int i = 0; i < widget.positions.length; i++) i: widget.positions[i]},
+    );
+    if (entry != null) {
+      setState(() {
+        _actions.add(entry);
+      });
+      widget.onChanged(List.from(_actions));
+    }
+  }
+
+  Future<void> _edit(int index) async {
+    final edited = await showEditActionDialog(
+      context,
+      entry: _actions[index],
+      numberOfPlayers: widget.players,
+      playerPositions: {for (int i = 0; i < widget.positions.length; i++) i: widget.positions[i]},
+    );
+    if (edited != null) {
+      setState(() {
+        _actions[index] = edited;
+      });
+      widget.onChanged(List.from(_actions));
+    }
+  }
+
+  void _delete(int index) {
+    setState(() => _actions.removeAt(index));
+    widget.onChanged(List.from(_actions));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (int i = 0; i < _actions.length; i++)
+          ListTile(
+            title: Text(
+              '${widget.positions[_actions[i].playerIndex]}: ${_actions[i].action}${_actions[i].amount != null ? ' ${_actions[i].amount}' : ''}',
+              style: const TextStyle(color: Colors.white),
+            ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit, color: Colors.white70),
+                  onPressed: () => _edit(i),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                  onPressed: () => _delete(i),
+                ),
+              ],
+            ),
+          ),
+        TextButton.icon(
+          onPressed: _addAction,
+          icon: const Icon(Icons.add),
+          label: const Text('Add action'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/card_picker_widget.dart
+++ b/lib/widgets/card_picker_widget.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+import 'card_selector.dart';
+
+class CardPickerWidget extends StatelessWidget {
+  final List<CardModel> cards;
+  final void Function(int, CardModel) onChanged;
+  final double scale;
+  const CardPickerWidget({
+    super.key,
+    required this.cards,
+    required this.onChanged,
+    this.scale = 1,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(2, (i) {
+        final card = i < cards.length ? cards[i] : null;
+        final isRed = card?.suit == '♥' || card?.suit == '♦';
+        return GestureDetector(
+          onTap: () async {
+            final disabled = <String>{for (final c in cards) '${c.rank}${c.suit}'};
+            if (card != null) disabled.remove('${card.rank}${card.suit}');
+            final selected = await showCardSelector(context, disabledCards: disabled);
+            if (selected != null) onChanged(i, selected);
+          },
+          child: Container(
+            margin: const EdgeInsets.symmetric(horizontal: 4),
+            width: 36 * scale,
+            height: 52 * scale,
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+              borderRadius: BorderRadius.circular(6),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.25),
+                  blurRadius: 3,
+                  offset: const Offset(1, 2),
+                )
+              ],
+            ),
+            alignment: Alignment.center,
+            child: card != null
+                ? Text(
+                    '${card.rank}${card.suit}',
+                    style: TextStyle(
+                      color: isRed ? Colors.red : Colors.black,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18 * scale,
+                    ),
+                  )
+                : const Icon(Icons.add, color: Colors.grey),
+          ),
+        );
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `SpotEditorScreen` to create or edit a training spot
- add `CardPickerWidget` and `ActionEditorList`
- enable adding spots from `TrainingPackScreen` via FAB

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686103688da8832a9e5c75cd8b2f8f66