### PR TITLE
Enable spot editing in pack screen

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -1501,11 +1501,55 @@ body { font-family: sans-serif; padding: 16px; }
         TrainingSpotList(
           key: _spotListKey,
           spots: _spots,
-          onRemove: (index) {
+          onEdit: (index) async {
+            final spot = _spots[index];
+            final updated = await Navigator.push<TrainingSpot>(
+              context,
+              MaterialPageRoute(builder: (_) => SpotEditorScreen(initial: spot)),
+            );
+            if (updated == null) return;
+            setState(() => _spots[index] = updated);
+            await _saveSpots();
+            final newPack = TrainingPack(
+              name: _pack.name,
+              description: _pack.description,
+              category: _pack.category,
+              gameType: _pack.gameType,
+              colorTag: _pack.colorTag,
+              isBuiltIn: _pack.isBuiltIn,
+              tags: _pack.tags,
+              hands: _pack.hands,
+              spots: _spots,
+              difficulty: _pack.difficulty,
+              history: _pack.history,
+            );
+            await context
+                .read<TrainingPackStorageService>()
+                .updatePack(_pack, newPack);
+            setState(() => _pack = newPack);
+          },
+          onRemove: (index) async {
             setState(() {
               _spots.removeAt(index);
             });
-            _saveSpots();
+            await _saveSpots();
+            final newPack = TrainingPack(
+              name: _pack.name,
+              description: _pack.description,
+              category: _pack.category,
+              gameType: _pack.gameType,
+              colorTag: _pack.colorTag,
+              isBuiltIn: _pack.isBuiltIn,
+              tags: _pack.tags,
+              hands: _pack.hands,
+              spots: _spots,
+              difficulty: _pack.difficulty,
+              history: _pack.history,
+            );
+            await context
+                .read<TrainingPackStorageService>()
+                .updatePack(_pack, newPack);
+            setState(() => _pack = newPack);
           },
           onChanged: _saveSpots,
           onReorder: (oldIndex, newIndex) {

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -60,6 +60,7 @@ class _FilterState {
 class TrainingSpotList extends StatefulWidget {
   final List<TrainingSpot> spots;
   final ValueChanged<int>? onRemove;
+  final ValueChanged<int>? onEdit;
   final VoidCallback? onChanged;
   final ReorderCallback? onReorder;
   final bool icmOnly;
@@ -68,6 +69,7 @@ class TrainingSpotList extends StatefulWidget {
     super.key,
     required this.spots,
     this.onRemove,
+    this.onEdit,
     this.onChanged,
     this.onReorder,
     this.icmOnly = false,
@@ -2839,6 +2841,13 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                             ],
                                           ),
                                         ),
+                                        if (widget.onEdit != null)
+                                          IconButton(
+                                            icon: const Icon(Icons.edit_square,
+                                                color: Colors.white70),
+                                            onPressed: () => widget.onEdit!(
+                                                widget.spots.indexOf(spot)),
+                                          ),
                                         IconButton(
                                           icon: const Icon(Icons.edit,
                                               color: Colors.white70),
@@ -3059,6 +3068,13 @@ class TrainingSpotListState extends State<TrainingSpotList>
                                           ],
                                         ),
                                       ),
+                                      if (widget.onEdit != null)
+                                        IconButton(
+                                          icon: const Icon(Icons.edit_square,
+                                              color: Colors.white70),
+                                          onPressed: () => widget.onEdit!(
+                                              widget.spots.indexOf(spot)),
+                                        ),
                                       IconButton(
                                         icon: const Icon(Icons.edit,
                                             color: Colors.white70),
@@ -3317,31 +3333,37 @@ class TrainingSpotListState extends State<TrainingSpotList>
                               style: TextButton.styleFrom(
                                 padding: EdgeInsets.zero,
                               ),
-                              child: const Text(
-                                '+Тег',
-                                style: TextStyle(color: Colors.white70),
-                              ),
-                            ),
-                          ],
+                        child: const Text(
+                          '+Тег',
+                          style: TextStyle(color: Colors.white70),
                         ),
                       ),
-                      IconButton(
-                        icon: const Icon(Icons.edit, color: Colors.white70),
-                        onPressed: () => _editComment(spot),
-                      ),
+                    ],
+                  ),
+                ),
+                if (widget.onEdit != null)
+                  IconButton(
+                    icon: const Icon(Icons.edit_square, color: Colors.white70),
+                    onPressed: () =>
+                        widget.onEdit!(widget.spots.indexOf(spot)),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.edit, color: Colors.white70),
+                  onPressed: () => _editComment(spot),
+                ),
                       IconButton(
                         icon: const Icon(Icons.history, color: Colors.white70),
                         onPressed: () => _editActionHistory(spot),
                       ),
-                      IconButton(
-                        icon: const Icon(Icons.copy, color: Colors.white70),
-                        onPressed: () => _duplicateSpot(spot),
-                      ),
-                      if (widget.onRemove != null)
-                        IconButton(
-                          icon: const Icon(Icons.delete, color: Colors.red),
-                          onPressed: () => _deleteSpot(spot),
-                        ),
+                          IconButton(
+                            icon: const Icon(Icons.copy, color: Colors.white70),
+                            onPressed: () => _duplicateSpot(spot),
+                          ),
+                          if (widget.onRemove != null)
+                            IconButton(
+                              icon: const Icon(Icons.delete, color: Colors.red),
+                              onPressed: () => _deleteSpot(spot),
+                            ),
                     ],
                   ),
                   );


### PR DESCRIPTION
## Summary
- add optional `onEdit` handler to `TrainingSpotList`
- update spot management in `TrainingPackScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610500fb08832a86d749a3d97c1cb0