### PR TITLE
Add cloud sync for training packs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'services/saved_hand_manager_service.dart';
 import 'services/session_note_service.dart';
 import 'services/session_pin_service.dart';
 import 'services/training_pack_storage_service.dart';
+import 'services/training_pack_cloud_sync_service.dart';
 import 'services/template_storage_service.dart';
 import 'services/training_pack_template_storage_service.dart';
 import 'services/daily_hand_service.dart';
@@ -77,6 +78,10 @@ Future<void> main() async {
   await cloud.init();
   await cloud.syncDown();
   cloud.watchChanges();
+  final packStorage = TrainingPackStorageService(cloud: cloud);
+  await packStorage.load();
+  final packCloud = TrainingPackCloudSyncService();
+  await packCloud.syncDown(packStorage);
   runApp(
     MultiProvider(
       providers: [
@@ -111,7 +116,8 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (_) => SessionPinService()..load(),
         ),
-        ChangeNotifierProvider(create: (_) => TrainingPackStorageService()..load()),
+        ChangeNotifierProvider<TrainingPackStorageService>.value(value: packStorage),
+        Provider<TrainingPackCloudSyncService>.value(value: packCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
         ChangeNotifierProvider(create: (_) => TrainingPackTemplateStorageService()..load()),
         ChangeNotifierProvider(

--- a/lib/models/training_pack.dart
+++ b/lib/models/training_pack.dart
@@ -2,6 +2,7 @@ import 'saved_hand.dart';
 import 'training_spot.dart';
 import 'session_task_result.dart';
 import 'game_type.dart';
+import 'package:uuid/uuid.dart';
 
 GameType parseGameType(dynamic v) {
   final s = (v as String? ?? '').toLowerCase();
@@ -43,6 +44,7 @@ class TrainingSessionResult {
 }
 
 class TrainingPack {
+  final String id;
   final String name;
   final String description;
   final String category;
@@ -56,6 +58,7 @@ class TrainingPack {
   final List<TrainingSessionResult> history;
 
   TrainingPack({
+    String? id,
     required this.name,
     required this.description,
     this.category = 'Uncategorized',
@@ -67,7 +70,8 @@ class TrainingPack {
     List<TrainingSpot>? spots,
     this.difficulty = 1,
     List<TrainingSessionResult>? history,
-  })  : tags = tags ?? const [],
+  })  : id = id ?? const Uuid().v4(),
+        tags = tags ?? const [],
         spots = spots ?? const [],
         history = history ?? [];
 
@@ -77,6 +81,7 @@ class TrainingPack {
       history.isNotEmpty ? history.last.date : DateTime.fromMillisecondsSinceEpoch(0);
 
   Map<String, dynamic> toJson() => {
+        'id': id,
         'name': name,
         'description': description,
         'category': category,
@@ -91,6 +96,7 @@ class TrainingPack {
       };
 
   factory TrainingPack.fromJson(Map<String, dynamic> json) => TrainingPack(
+        id: json['id'] as String?,
         name: json['name'] as String? ?? '',
         description: json['description'] as String? ?? '',
         category: json['category'] as String? ?? 'Uncategorized',

--- a/lib/services/training_pack_cloud_sync_service.dart
+++ b/lib/services/training_pack_cloud_sync_service.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/training_pack.dart';
+import 'training_pack_storage_service.dart';
+
+class TrainingPackCloudSyncService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  String? get _uid => FirebaseAuth.instance.currentUser?.uid;
+
+  Future<List<TrainingPack>> loadPacks() async {
+    if (_uid == null) return [];
+    final snap = await _db
+        .collection('users')
+        .doc(_uid)
+        .collection('training_packs')
+        .get();
+    return [
+      for (final d in snap.docs)
+        TrainingPack.fromJson({...d.data(), 'id': d.id})
+    ];
+  }
+
+  Future<void> savePack(TrainingPack pack) async {
+    if (_uid == null) return;
+    await _db
+        .collection('users')
+        .doc(_uid)
+        .collection('training_packs')
+        .doc(pack.id)
+        .set(pack.toJson());
+  }
+
+  Future<void> deletePack(String id) async {
+    if (_uid == null) return;
+    await _db
+        .collection('users')
+        .doc(_uid)
+        .collection('training_packs')
+        .doc(id)
+        .delete();
+  }
+
+  Future<void> syncDown(TrainingPackStorageService storage) async {
+    final remote = await loadPacks();
+    storage.merge(remote);
+    await storage.save();
+  }
+}


### PR DESCRIPTION
## Summary
- assign persistent IDs to training packs
- integrate cloud sync in `TrainingPackStorageService`
- add `TrainingPackCloudSyncService` for Firestore storage
- load remote packs on app start

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610d02d2c8832a968053379fd6d946