### PR TITLE
Fix pack average computation

### DIFF
--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -22,6 +22,8 @@ class PackOverviewScreen extends StatefulWidget {
 
 class _PackOverviewScreenState extends State<PackOverviewScreen> {
   StreamSubscription? _sub;
+  List<TrainingPack> _packs = [];
+  double _avg = 0;
 
   @override
   void initState() {
@@ -104,26 +106,37 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
     );
   }
 
+  double _calcAverage(List<TrainingPack> packs) {
+    var sum = 0.0;
+    var count = 0;
+    for (final p in packs) {
+      if (p.history.isNotEmpty) {
+        final h = p.history.last;
+        if (h.total > 0) {
+          sum += h.correct * 100 / h.total;
+          count++;
+        }
+      }
+    }
+    return count > 0 ? sum / count : 0;
+  }
+
   @override
-  Widget build(BuildContext context) {
-    final packs = context
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _packs = context
         .watch<TrainingPackStorageService>()
         .packs
         .where((p) => !p.isBuiltIn)
         .toList()
       ..sort((a, b) => a.name.compareTo(b.name));
-    double avg = 0;
-    int count = 0;
-    for (final p in packs) {
-      if (p.history.isNotEmpty) {
-        final h = p.history.last;
-        if (h.total > 0) {
-          avg += h.correct * 100 / h.total;
-          count++;
-        }
-      }
-    }
-    if (count > 0) avg /= count;
+    _avg = _calcAverage(_packs);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final packs = _packs;
+    final avg = _avg;
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Packs'),


### PR DESCRIPTION
## Summary
- compute average accuracy for packs in `_calcAverage`
- avoid computing inside the widget tree

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686118251ba8832abdbe8e963afe065a