### PR TITLE
Add undo snackbar on pack deletion

### DIFF
--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -63,7 +63,19 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
       ),
     );
     if (confirm == true) {
-      await context.read<TrainingPackStorageService>().removePack(pack);
+      final result = await context.read<TrainingPackStorageService>().removePack(pack);
+      if (result != null && mounted) {
+        final snack = SnackBar(
+          content: const Text('Пак удалён'),
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () =>
+                context.read<TrainingPackStorageService>().restorePack(result.\$1, result.\$2),
+          ),
+          duration: const Duration(seconds: 5),
+        );
+        ScaffoldMessenger.of(context).showSnackBar(snack);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- show SnackBar with undo action after deleting a pack

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611825e3f8832aa1810f155e210e0f