### PR TITLE
room hand import fix duplicates

### DIFF
--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -28,7 +28,7 @@ class RoomHandHistoryImportScreen extends StatefulWidget {
 class _RoomHandHistoryImportScreenState extends State<RoomHandHistoryImportScreen> {
   final TextEditingController _controller = TextEditingController();
   final TextEditingController _searchController = TextEditingController();
-  List<_Entry> _hands = [];
+  final List<_Entry> _hands = [];
   late TrainingPack _pack;
   RoomHandHistoryImporter? _importer;
   final Set<SavedHand> _selected = {};
@@ -74,7 +74,9 @@ class _RoomHandHistoryImportScreenState extends State<RoomHandHistoryImportScree
       items.add(_Entry(h, dup));
     }
     setState(() {
-      _hands = items;
+      _hands
+        ..clear()
+        ..addAll(items);
       _selected.clear();
       _searchController.clear();
       _filter = items.every((e) => e.duplicate) ? _Filter.dup : _Filter.newOnly;
@@ -137,7 +139,9 @@ class _RoomHandHistoryImportScreenState extends State<RoomHandHistoryImportScree
   }
 
   Future<void> _addSelected() async {
-    final count = _selected.length;
+    final unique =
+        _selected.where((h) => !_pack.hands.any((e) => e.name == h.name)).toList();
+    final count = unique.length;
     if (count == 0) return;
     final updated = TrainingPack(
       name: _pack.name,
@@ -147,7 +151,7 @@ class _RoomHandHistoryImportScreenState extends State<RoomHandHistoryImportScree
       colorTag: _pack.colorTag,
       isBuiltIn: _pack.isBuiltIn,
       tags: _pack.tags,
-      hands: [..._pack.hands, ..._selected],
+      hands: [..._pack.hands, ...unique],
       spots: _pack.spots,
       difficulty: _pack.difficulty,
       history: _pack.history,
@@ -274,7 +278,9 @@ class _RoomHandHistoryImportScreenState extends State<RoomHandHistoryImportScree
                                 final entry = list[i];
                                 final h = entry.hand;
                                 return Card(
-                          color: AppColors.cardBackground,
+                          color: entry.duplicate
+                              ? AppColors.errorBg
+                              : AppColors.cardBackground,
                           margin: const EdgeInsets.symmetric(vertical: 6),
                           child: ListTile(
                             leading: Checkbox(

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -4,4 +4,5 @@ class AppColors {
   static const background = Color(0xFF1B1C1E);
   static const cardBackground = Color(0xFF2A2B2E);
   static const accent = Colors.orangeAccent;
+  static final errorBg = Colors.red.withOpacity(.2);
 }


### PR DESCRIPTION
## Summary
- tint duplicate hands red
- keep a final hands list and reuse it across parses
- prevent duplicate hands on bulk add
- add AppColors.errorBg

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686131e6be64832ab921af883514b0df