### PR TITLE
Add undo overlay to import screen

### DIFF
--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -327,7 +327,7 @@ class _RoomHandHistoryImportScreenState
                   ? const Center(child: Text('No hands'))
                   : Builder(builder: (context) {
                       final list = _filteredHands();
-                      return list.isEmpty
+                      final content = list.isEmpty
                           ? const Center(child: Text('No hands found'))
                           : ListView.builder(
                               itemCount: list.length,
@@ -378,6 +378,16 @@ class _RoomHandHistoryImportScreenState
                                 );
                               },
                             );
+                      return Stack(
+                        children: [
+                          content,
+                          if (_undoActive)
+                            Positioned.fill(
+                              child: Container(
+                                  color: Colors.black.withOpacity(0.05)),
+                            ),
+                        ],
+                      );
                     }),
             ),
           ],


### PR DESCRIPTION
## Summary
- overlay list when undo action active in `RoomHandHistoryImportScreen`

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613a583ea8832aa27f9772beea1488