### PR TITLE
Update snackbar logic

### DIFF
--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -214,7 +214,9 @@ class _RoomHandHistoryImportScreenState
       action: SnackBarAction(label: 'Undo', onPressed: _undoAdd),
       duration: const Duration(seconds: 5),
     );
-    final controller = ScaffoldMessenger.of(context).showSnackBar(snack);
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    final controller = messenger.showSnackBar(snack);
     controller.closed.then((_) {
       if (mounted && _undoHands != null) setState(() => _undoHands = null);
     });


### PR DESCRIPTION
## Summary
- hide current snackbar before showing the "Add hands" message

## Testing
- `flutter format lib/screens/room_hand_history_import_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613a57e51c832a9588ee981fe0de69