### PR TITLE
Handle Esc in command palette

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -1519,7 +1519,9 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
             autofocus: true,
             onKey: (e) {
               if (e is RawKeyDownEvent) {
-                if (e.logicalKey == LogicalKeyboardKey.arrowDown) {
+                if (e.logicalKey == LogicalKeyboardKey.escape) {
+                  Navigator.of(ctx).pop();
+                } else if (e.logicalKey == LogicalKeyboardKey.arrowDown) {
                   if (index < list.length - 1) setStateDialog(() => index++);
                 } else if (e.logicalKey == LogicalKeyboardKey.arrowUp) {
                   if (index > 0) setStateDialog(() => index--);


### PR DESCRIPTION
## Summary
- close the command palette dialog when Esc is pressed

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 12810 issues found)*
- `flutter test` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68615d68c090832aa1032e9dcd4c0913