### PR TITLE
Add filter conflict warning

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -98,6 +98,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
   List<ViewPreset> _views = [];
   List<_Command> _commands = [];
   bool _filtersVisible = true;
+  bool _filterConflict = false;
 
   @override
   void setState(VoidCallback fn) {
@@ -905,6 +906,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
     _mist3 = m3;
     _posCount = pos;
     _dupCount = _hands.where((h) => h.isDuplicate).length;
+    _filterConflict = _hands.isNotEmpty && indices.isEmpty;
   }
 
   Future<bool> _onWillPop() async {
@@ -1534,6 +1536,14 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
 
   void _toggleFilters() {
     setState(() => _filtersVisible = !_filtersVisible);
+    if (_filterConflict &&
+        _tagFilter != null &&
+        _heroPosFilter != null &&
+        _mistakeFilter != _MistakeFilter.any) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No hands match current filters')),
+      );
+    }
   }
 
   Future<void> _showCommandPalette() async {
@@ -2334,6 +2344,14 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                 },
               ),
             ),
+            if (_filterConflict)
+              const Padding(
+                padding: EdgeInsets.all(8),
+                child: Text(
+                  'No hands match current filters',
+                  style: TextStyle(color: Colors.red),
+                ),
+              ),
             Padding(
               padding: const EdgeInsets.all(16),
               child: Row(


### PR DESCRIPTION
## Summary
- show red footer text when filters hide all hands
- warn via snackbar when toggling filters with incompatible active filters

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686167826dec832a981119afb5a71bfa