### PR TITLE
Refine comment update

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -2315,10 +2315,9 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                                 if (!mounted) return;
                                 if (result != null) {
                                   final old = _hands[idx].comment;
-                                  final trimmed = result.trim();
                                   setState(() {
                                     _hands[idx] = _hands[idx].copyWith(
-                                      comment: trimmed.isNotEmpty ? trimmed : null,
+                                      comment: result.isNotEmpty ? result : null,
                                     );
                                     _modified = true;
                                   });


### PR DESCRIPTION
## Summary
- skip extra trim call when updating a hand comment

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686184e2ec38832a8e196f0b9e8bf3a0