### PR TITLE
Add editor sort and position filter menus

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -2063,6 +2063,40 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                     onPressed: _saveCurrentView,
                     icon: const Icon(Icons.star_outline),
                   ),
+                  PopupMenuButton<_SortOption>(
+                    icon: const Icon(Icons.sort),
+                    initialValue: _sort,
+                    onSelected: _setSort,
+                    itemBuilder: (_) => const [
+                      PopupMenuItem(
+                        value: _SortOption.newest,
+                        child: Text('Newest'),
+                      ),
+                      PopupMenuItem(
+                        value: _SortOption.oldest,
+                        child: Text('Oldest'),
+                      ),
+                      PopupMenuItem(
+                        value: _SortOption.mistakes,
+                        child: Text('Most Mistakes'),
+                      ),
+                    ],
+                  ),
+                  PopupMenuButton<String?>(
+                    icon: const Icon(Icons.filter_list),
+                    onSelected: _setHeroFilter,
+                    itemBuilder: (_) => [
+                      const PopupMenuItem<String?>(
+                        value: null,
+                        child: Text('All'),
+                      ),
+                      for (final p in ['UTG', 'MP', 'CO', 'BTN', 'SB', 'BB'])
+                        PopupMenuItem<String?>(
+                          value: p,
+                          child: Text(p),
+                        ),
+                    ],
+                  ),
                   PopupMenuButton<String>(
                     icon: const Icon(Icons.star),
                     onSelected: (v) {


### PR DESCRIPTION
## Summary
- add sort and filter dropdowns to `PackEditorScreen` AppBar

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68618db3b910832a8649cb94063b943a