### PR TITLE
Implement view preset management dialog

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -24,7 +24,7 @@ import 'room_hand_history_import_screen.dart';
 import 'room_hand_history_editor_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import 'snapshot_manager_screen.dart';
-import 'view_manager_screen.dart';
+import '../widgets/view_manager_dialog.dart';
 
 enum _SortOption { newest, oldest, position, tags, mistakes }
 
@@ -1188,16 +1188,14 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
   }
 
   Future<void> _manageViews() async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => ViewManagerScreen(
-          views: _views,
-          onChanged: (v) async {
-            setState(() => _views = List.from(v));
-            await _saveViews();
-          },
-        ),
+    await showDialog(
+      context: context,
+      builder: (_) => ViewManagerDialog(
+        views: _views,
+        onChanged: (v) async {
+          setState(() => _views = List.from(v));
+          await _saveViews();
+        },
       ),
     );
   }

--- a/lib/widgets/view_manager_dialog.dart
+++ b/lib/widgets/view_manager_dialog.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import '../models/view_preset.dart';
 
-class ViewManagerScreen extends StatefulWidget {
+class ViewManagerDialog extends StatefulWidget {
   final List<ViewPreset> views;
   final ValueChanged<List<ViewPreset>> onChanged;
-  const ViewManagerScreen({super.key, required this.views, required this.onChanged});
+  const ViewManagerDialog({super.key, required this.views, required this.onChanged});
 
   @override
-  State<ViewManagerScreen> createState() => _ViewManagerScreenState();
+  State<ViewManagerDialog> createState() => _ViewManagerDialogState();
 }
 
-class _ViewManagerScreenState extends State<ViewManagerScreen> {
+class _ViewManagerDialogState extends State<ViewManagerDialog> {
   late List<ViewPreset> _views;
 
   @override
@@ -54,17 +54,12 @@ class _ViewManagerScreenState extends State<ViewManagerScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        Navigator.pop(context);
-        return false;
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Views'),
-          leading: BackButton(onPressed: () => Navigator.pop(context)),
-        ),
-        body: ReorderableListView(
+    return AlertDialog(
+      title: const Text('Views'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 400,
+        child: ReorderableListView(
           onReorder: _reorder,
           children: [
             for (int i = 0; i < _views.length; i++)
@@ -82,6 +77,9 @@ class _ViewManagerScreenState extends State<ViewManagerScreen> {
           ],
         ),
       ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Close')),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- import new dialog for managing views
- show the dialog when selecting **Manage Views…**
- move `ViewManagerScreen` to `ViewManagerDialog`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861911b84f4832aafb18f3f5d9bccc4