### PR TITLE
Implement snapshot management in pack editor

### DIFF
--- a/lib/models/pack_editor_snapshot.dart
+++ b/lib/models/pack_editor_snapshot.dart
@@ -1,0 +1,57 @@
+import "package:uuid/uuid.dart";
+import "saved_hand.dart";
+import "view_preset.dart";
+
+class PackEditorSnapshot {
+  final String id;
+  final String name;
+  final DateTime timestamp;
+  final List<SavedHand> hands;
+  final List<ViewPreset> views;
+  final Map<String, dynamic> filters;
+
+  PackEditorSnapshot({
+    String? id,
+    required this.name,
+    DateTime? timestamp,
+    required this.hands,
+    required this.views,
+    required this.filters,
+  })  : id = id ?? const Uuid().v4(),
+        timestamp = timestamp ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'timestamp': timestamp.toIso8601String(),
+        'hands': [for (final h in hands) h.toJson()],
+        'views': [for (final v in views) v.toJson()],
+        'filters': filters,
+      };
+
+  factory PackEditorSnapshot.fromJson(Map<String, dynamic> json) =>
+      PackEditorSnapshot(
+        id: json['id'] as String?,
+        name: json['name'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+        hands: [
+          for (final h in (json['hands'] as List? ?? []))
+            SavedHand.fromJson(Map<String, dynamic>.from(h as Map))
+        ],
+        views: [
+          for (final v in (json['views'] as List? ?? []))
+            ViewPreset.fromJson(Map<String, dynamic>.from(v as Map))
+        ],
+        filters: Map<String, dynamic>.from(json['filters'] as Map? ?? {}),
+      );
+
+  PackEditorSnapshot copyWith({String? name}) => PackEditorSnapshot(
+        id: id,
+        name: name ?? this.name,
+        timestamp: timestamp,
+        hands: hands,
+        views: views,
+        filters: filters,
+      );
+}

--- a/lib/widgets/snapshot_manager_dialog.dart
+++ b/lib/widgets/snapshot_manager_dialog.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/pack_editor_snapshot.dart';
+
+class SnapshotManagerDialog extends StatefulWidget {
+  final List<PackEditorSnapshot> snapshots;
+  const SnapshotManagerDialog({super.key, required this.snapshots});
+
+  @override
+  State<SnapshotManagerDialog> createState() => _SnapshotManagerDialogState();
+}
+
+class _SnapshotManagerDialogState extends State<SnapshotManagerDialog> {
+  late List<PackEditorSnapshot> _snaps;
+
+  @override
+  void initState() {
+    super.initState();
+    _snaps = List.from(widget.snapshots);
+  }
+
+  Future<void> _rename(int index) async {
+    final c = TextEditingController(text: _snaps[index].name);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Rename Snapshot'),
+        content: TextField(controller: c, autofocus: true),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, c.text.trim()), child: const Text('Save')),
+        ],
+      ),
+    );
+    if (name != null && name.isNotEmpty) {
+      setState(() => _snaps[index] = _snaps[index].copyWith(name: name));
+    }
+  }
+
+  void _delete(int index) => setState(() => _snaps.removeAt(index));
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Snapshots'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 400,
+        child: ListView.builder(
+          itemCount: _snaps.length,
+          itemBuilder: (ctx, i) {
+            final s = _snaps[i];
+            return ListTile(
+              title: Text(s.name),
+              subtitle: Text(DateFormat('yyyy-MM-dd HH:mm').format(s.timestamp)),
+              onTap: () => _rename(i),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(icon: const Icon(Icons.restore), onPressed: () => Navigator.pop(context, s)),
+                  IconButton(icon: const Icon(Icons.delete), onPressed: () => _delete(i)),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context, _snaps), child: const Text('Close')),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `PackEditorSnapshot` model
- add `SnapshotManagerDialog`
- integrate snapshot storage in `PackEditorScreen` with SharedPreferences
- extend export menu with snapshot option

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 2238 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686193a92dc0832a9057177def8fc5eb