### PR TITLE
Add active filter chips to pack editor

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -2445,6 +2445,51 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
         ),
         body: Column(
           children: [
+            if (_tagFilter != null ||
+                _heroPosFilter != null ||
+                _mistakeFilter != _MistakeFilter.any)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    if (_tagFilter != null)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Chip(
+                          label: Text(_tagFilter!),
+                          backgroundColor: colorFromHex(
+                              context.read<TagService>().colorOf(_tagFilter!)),
+                          onDeleted: () => _setTagFilter(null),
+                        ),
+                      ),
+                    if (_heroPosFilter != null)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Chip(
+                          label: Text(_heroPosFilter!),
+                          onDeleted: () => _setHeroFilter(null),
+                        ),
+                      ),
+                    if (_mistakeFilter != _MistakeFilter.any)
+                      Chip(
+                        label: Text(() {
+                          switch (_mistakeFilter) {
+                            case _MistakeFilter.zero:
+                              return '0';
+                            case _MistakeFilter.oneTwo:
+                              return '1-2';
+                            case _MistakeFilter.threePlus:
+                              return '3+';
+                            case _MistakeFilter.any:
+                              return 'Any';
+                          }
+                        }()),
+                        onDeleted: () =>
+                            _setMistakeFilter(_MistakeFilter.any),
+                      ),
+                  ],
+                ),
+              ),
             if (_showSearch)
               Padding(
                 padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- show active tag, hero position and mistake filters in pack editor

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619fdb0654832a81a8bc1dad1bf3bf