### PR TITLE
Add view preset delete confirmation

### DIFF
--- a/lib/widgets/view_manager_dialog.dart
+++ b/lib/widgets/view_manager_dialog.dart
@@ -38,9 +38,21 @@ class _ViewManagerDialogState extends State<ViewManagerDialog> {
     }
   }
 
-  void _delete(int index) {
-    setState(() => _views.removeAt(index));
-    widget.onChanged(_views);
+  Future<void> _delete(int index) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete View?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Delete')),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      setState(() => _views.removeAt(index));
+      widget.onChanged(_views);
+    }
   }
 
   void _reorder(int oldIndex, int newIndex) {


### PR DESCRIPTION
## Summary
- prompt users to confirm deletion of a view preset

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a28dc13c832a93a73282f9f9e5e9