### PR TITLE
Improve preset list reorder UI

### DIFF
--- a/lib/widgets/view_manager_dialog.dart
+++ b/lib/widgets/view_manager_dialog.dart
@@ -104,15 +104,14 @@ class _ViewManagerDialogState extends State<ViewManagerDialog> {
                   for (int i = 0; i < filtered.length; i++)
                     ListTile(
                       key: ValueKey(filtered[i].id),
+                      leading: ReorderableDragStartListener(
+                        index: i,
+                        child: const Icon(Icons.drag_handle),
+                      ),
                       title: Text(filtered[i].name),
                       trailing: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          ReorderableDragStartListener(
-                            key: Key(filtered[i].id),
-                            index: i,
-                            child: const Icon(Icons.drag_handle),
-                          ),
                           IconButton(icon: const Icon(Icons.edit), onPressed: () => _rename(filtered[i])),
                           IconButton(icon: const Icon(Icons.delete), onPressed: () => _delete(filtered[i])),
                         ],


### PR DESCRIPTION
## Summary
- move drag handle to leading edge of preset list items
- drop unneeded key from ReorderableDragStartListener

## Testing
- `flutter analyze` *(fails: command runs but environment times out)*

------
https://chatgpt.com/codex/tasks/task_e_6861aefa37f4832a8601ea846b47321e