### PR TITLE
Implement reusable PositionLabel

### DIFF
--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -3,6 +3,7 @@ import '../helpers/table_geometry_helper.dart';
 import '../helpers/poker_position_helper.dart';
 import 'poker_table_painter.dart';
 import 'analyzer/player_zone_widget.dart';
+import 'position_label.dart';
 
 class PokerTableView extends StatefulWidget {
   final int heroIndex;
@@ -49,13 +50,10 @@ class _PokerTableViewState extends State<PokerTableView> {
       items.add(Positioned(
         left: offset.dx,
         top: offset.dy - 18 * widget.scale,
-        child: Text(
-          positions[i],
-          style: TextStyle(
-            color: i == widget.heroIndex ? Colors.white : Colors.grey,
-            fontSize: (i == widget.heroIndex ? 12 : 10) * widget.scale,
-            fontWeight: i == widget.heroIndex ? FontWeight.bold : FontWeight.normal,
-          ),
+        child: PositionLabel(
+          label: positions[i],
+          isHero: i == widget.heroIndex,
+          scale: widget.scale,
         ),
       ));
     }

--- a/lib/widgets/position_label.dart
+++ b/lib/widgets/position_label.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class PositionLabel extends StatelessWidget {
+  final String label;
+  final bool isHero;
+  final double scale;
+  const PositionLabel({super.key, required this.label, required this.isHero, this.scale = 1.0});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      label,
+      key: ValueKey('${label}_$isHero'),
+      style: TextStyle(
+        color: isHero ? Colors.white : Colors.grey,
+        fontSize: (isHero ? 12 : 10) * scale,
+        fontWeight: isHero ? FontWeight.bold : FontWeight.normal,
+      ),
+    );
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: text,
+    );
+  }
+}

--- a/test/widgets/position_label_test.dart
+++ b/test/widgets/position_label_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/widgets/position_label.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows label text', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PositionLabel(label: 'BTN', isHero: false)));
+    expect(find.text('BTN'), findsOneWidget);
+  });
+
+  testWidgets('uses hero style', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PositionLabel(label: 'BTN', isHero: true)));
+    final text = tester.widget<Text>(find.text('BTN'));
+    expect(text.style?.fontWeight, FontWeight.bold);
+  });
+}
+


### PR DESCRIPTION
## Summary
- create `PositionLabel` widget for player seat labels with fade animation
- refactor `PokerTableView` to use new widget
- add widget test

## Testing
- `flutter test test/widgets/position_label_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b734ea10832a89aaf9419f39dca5