### PR TITLE
Add hero avatar switch animation

### DIFF
--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -45,7 +45,18 @@ class _PokerTableViewState extends State<PokerTableView> {
       items.add(Positioned(
         left: offset.dx,
         top: offset.dy,
-        child: PlayerAvatar(name: widget.playerNames[i], isHero: i == widget.heroIndex),
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          transitionBuilder: (child, animation) => FadeTransition(
+            opacity: animation,
+            child: ScaleTransition(scale: animation, child: child),
+          ),
+          child: PlayerAvatar(
+            key: ValueKey('avatar_${widget.playerNames[i]}_${i == widget.heroIndex}'),
+            name: widget.playerNames[i],
+            isHero: i == widget.heroIndex,
+          ),
+        ),
       ));
       items.add(Positioned(
         left: offset.dx,


### PR DESCRIPTION
## Summary
- wrap table player avatars with `AnimatedSwitcher`
- fade and scale when hero changes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7fbe8dc832a8c65e267c81a1fdc