### PR TITLE
Add player count controls to table demo

### DIFF
--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -9,7 +9,7 @@ class PokerTableDemoScreen extends StatefulWidget {
 }
 
 class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
-  static const _playerCount = 6;
+  int _playerCount = 6;
   late List<String> _names;
   late List<double> _stacks;
   int _heroIndex = 0;
@@ -26,6 +26,25 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
     _heroIndex = 0;
   }
 
+  void _changeCount(int delta) {
+    setState(() {
+      _playerCount = (_playerCount + delta).clamp(2, 10);
+      if (_names.length < _playerCount) {
+        final start = _names.length;
+        _names.addAll(
+            List.generate(_playerCount - start, (i) => 'Player ${start + i + 1}'));
+      } else if (_names.length > _playerCount) {
+        _names = _names.sublist(0, _playerCount);
+      }
+      if (_stacks.length < _playerCount) {
+        _stacks.addAll(List.filled(_playerCount - _stacks.length, 0.0));
+      } else if (_stacks.length > _playerCount) {
+        _stacks = _stacks.sublist(0, _playerCount);
+      }
+      if (_heroIndex >= _playerCount) _heroIndex = _playerCount - 1;
+    });
+  }
+
   void _clear() => setState(_reset);
 
   @override
@@ -36,14 +55,34 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
         actions: [IconButton(icon: const Icon(Icons.clear), onPressed: _clear)],
       ),
       body: Center(
-        child: PokerTableView(
-          heroIndex: _heroIndex,
-          playerCount: _playerCount,
-          playerNames: _names,
-          playerStacks: _stacks,
-          onHeroSelected: (i) => setState(() => _heroIndex = i),
-          onStackChanged: (i, v) => setState(() => _stacks[i] = v),
-          onNameChanged: (i, v) => setState(() => _names[i] = v),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            PokerTableView(
+              heroIndex: _heroIndex,
+              playerCount: _playerCount,
+              playerNames: _names,
+              playerStacks: _stacks,
+              onHeroSelected: (i) => setState(() => _heroIndex = i),
+              onStackChanged: (i, v) => setState(() => _stacks[i] = v),
+              onNameChanged: (i, v) => setState(() => _names[i] = v),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  onPressed: () => _changeCount(-1),
+                  icon: const Icon(Icons.remove),
+                ),
+                Text('$_playerCount', style: const TextStyle(color: Colors.white)),
+                IconButton(
+                  onPressed: () => _changeCount(1),
+                  icon: const Icon(Icons.add),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add +/- player count buttons in the poker table demo
- resize names/stacks when player count changes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bf170dec832aacaa99bf2377006c