### PR TITLE
Add chip stack painter to PokerTableView

### DIFF
--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -4,6 +4,7 @@ import '../helpers/poker_position_helper.dart';
 import 'poker_table_painter.dart';
 import 'analyzer/player_zone_widget.dart';
 import 'position_label.dart';
+import 'pot_chip_stack_painter.dart';
 
 class PokerTableView extends StatefulWidget {
   final int heroIndex;
@@ -52,13 +53,25 @@ class _PokerTableViewState extends State<PokerTableView> {
       Positioned.fill(child: CustomPaint(painter: PokerTablePainter())),
       Positioned.fill(
         child: Center(
-          child: GestureDetector(
-            onTap: () async {
-              final controller =
-                  TextEditingController(text: widget.potSize.toString());
-              final result = await showDialog<double>(
-                context: context,
-                builder: (context) => AlertDialog(
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: 24 * widget.scale,
+                height:
+                    24 * widget.scale + 3 * 24 * widget.scale * 0.35,
+                child: CustomPaint(
+                  painter:
+                      PotChipStackPainter(chipCount: 4, color: Colors.orange),
+                ),
+              ),
+              GestureDetector(
+                onTap: () async {
+                  final controller =
+                      TextEditingController(text: widget.potSize.toString());
+                  final result = await showDialog<double>(
+                    context: context,
+                    builder: (context) => AlertDialog(
                   backgroundColor: Colors.black.withOpacity(0.3),
                   title:
                       const Text('Edit Pot', style: TextStyle(color: Colors.white)),
@@ -97,13 +110,18 @@ class _PokerTableViewState extends State<PokerTableView> {
                 setState(() {});
               }
             },
-            child: Text(
-              'Pot: ${widget.potSize.toStringAsFixed(1)} BB',
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
+                child: Padding(
+                  padding: EdgeInsets.only(top: 12 * widget.scale),
+                  child: Text(
+                    'Pot: ${widget.potSize.toStringAsFixed(1)} BB',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
         ),
       ),

--- a/lib/widgets/pot_chip_stack_painter.dart
+++ b/lib/widgets/pot_chip_stack_painter.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class PotChipStackPainter extends CustomPainter {
+  final int chipCount;
+  final Color color;
+  PotChipStackPainter({this.chipCount = 4, this.color = Colors.orange});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = size.width / 2;
+    final spacing = radius * 0.7;
+    for (int i = 0; i < chipCount; i++) {
+      final center = Offset(
+        size.width / 2,
+        size.height - radius - i * spacing,
+      );
+      final rect = Rect.fromCircle(center: center, radius: radius);
+      final paint = Paint()
+        ..shader = LinearGradient(
+          colors: [color, Colors.black],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ).createShader(rect);
+      final shadow = Paint()
+        ..color = Colors.black.withOpacity(0.6)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, radius / 2);
+      canvas.drawCircle(center.translate(1, 2), radius, shadow);
+      canvas.drawCircle(center, radius, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant PotChipStackPainter oldDelegate) {
+    return oldDelegate.chipCount != chipCount || oldDelegate.color != color;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PotChipStackPainter` to render chip pile
- display chip stack behind pot in `PokerTableView`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c0bfd398832a942ae669c129809f