### PR TITLE
Add blind chip indicators

### DIFF
--- a/lib/widgets/blind_chip_indicator.dart
+++ b/lib/widgets/blind_chip_indicator.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class BlindChipIndicator extends StatefulWidget {
+  final String label;
+  final Color color;
+  final double scale;
+  const BlindChipIndicator({super.key, required this.label, required this.color, this.scale = 1.0});
+
+  @override
+  State<BlindChipIndicator> createState() => _BlindChipIndicatorState();
+}
+
+class _BlindChipIndicatorState extends State<BlindChipIndicator> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 300))..forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(
+        width: 20 * widget.scale,
+        height: 20 * widget.scale,
+        decoration: BoxDecoration(
+          color: widget.color,
+          shape: BoxShape.circle,
+          boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 2)],
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          widget.label,
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 10 * widget.scale,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -7,6 +7,7 @@ import 'analyzer/player_zone_widget.dart';
 import 'position_label.dart';
 import 'pot_chip_stack_painter.dart';
 import 'dealer_button_indicator.dart';
+import 'blind_chip_indicator.dart';
 
 class PokerTableView extends StatefulWidget {
   final int heroIndex;
@@ -197,6 +198,15 @@ class _PokerTableViewState extends State<PokerTableView> {
           left: offset.dx + dx,
           top: offset.dy - 28 * widget.scale,
           child: DealerButtonIndicator(scale: widget.scale),
+        ));
+      }
+      if (positions[i] == 'SB' || positions[i] == 'BB') {
+        final dx = cos(angle) < 0 ? -24 * widget.scale : 24 * widget.scale;
+        final color = positions[i] == 'SB' ? Colors.blueAccent : Colors.redAccent;
+        items.add(Positioned(
+          left: offset.dx + dx,
+          top: offset.dy - 28 * widget.scale,
+          child: BlindChipIndicator(label: positions[i], color: color, scale: widget.scale),
         ));
       }
       items.add(Positioned(


### PR DESCRIPTION
## Summary
- show SB and BB icons on PokerTableView

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c3619794832aa2e6c0d7bd24e1b8