### PR TITLE
Add switchable table themes

### DIFF
--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -14,6 +14,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
   late List<double> _stacks;
   int _heroIndex = 0;
   double _pot = 0.0;
+  TableTheme _theme = TableTheme.green;
 
   @override
   void initState() {
@@ -49,12 +50,22 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
 
   void _clear() => setState(_reset);
 
+  void _nextTheme() {
+    setState(() {
+      final values = TableTheme.values;
+      _theme = values[(_theme.index + 1) % values.length];
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Poker Table Demo'),
-        actions: [IconButton(icon: const Icon(Icons.clear), onPressed: _clear)],
+        actions: [
+          IconButton(icon: const Icon(Icons.color_lens), onPressed: _nextTheme),
+          IconButton(icon: const Icon(Icons.clear), onPressed: _clear),
+        ],
       ),
       body: Center(
         child: Column(
@@ -70,6 +81,8 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
               onNameChanged: (i, v) => setState(() => _names[i] = v),
               potSize: _pot,
               onPotChanged: (v) => setState(() => _pot = v),
+              theme: _theme,
+              onThemeChanged: (t) => setState(() => _theme = t),
             ),
             const SizedBox(height: 8),
             Row(

--- a/lib/widgets/poker_table_painter.dart
+++ b/lib/widgets/poker_table_painter.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
+import 'poker_table_view.dart' show TableTheme;
 
 class PokerTablePainter extends CustomPainter {
-  final Color feltColor;
-  final Color borderColor;
+  final TableTheme theme;
 
-  PokerTablePainter({
-    this.feltColor = const Color(0xFF35654D),
-    this.borderColor = const Color(0xFFBDBDBD),
-  });
+  PokerTablePainter({this.theme = TableTheme.green});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -16,19 +13,53 @@ class PokerTablePainter extends CustomPainter {
 
     canvas.drawShadow(path, Colors.black.withOpacity(0.5), 12.0, true);
 
-    final feltPaint = Paint()..color = feltColor;
+    final gradient = _gradientForTheme();
+    final feltPaint = Paint()..shader = gradient.createShader(rect);
     canvas.drawOval(rect, feltPaint);
 
     final borderPaint = Paint()
-      ..color = borderColor.withOpacity(0.3)
+      ..color = _borderColor().withOpacity(0.3)
       ..style = PaintingStyle.stroke
       ..strokeWidth = size.shortestSide * 0.03;
     canvas.drawOval(rect.deflate(borderPaint.strokeWidth / 2), borderPaint);
   }
 
+  Gradient _gradientForTheme() {
+    switch (theme) {
+      case TableTheme.green:
+        return const LinearGradient(
+          colors: [Color(0xFF497A5E), Color(0xFF24432E)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
+      case TableTheme.carbon:
+        return const LinearGradient(
+          colors: [Color(0xFF444444), Color(0xFF222222)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
+      case TableTheme.blue:
+        return const LinearGradient(
+          colors: [Color(0xFF00577C), Color(0xFF001F3F)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
+    }
+  }
+
+  Color _borderColor() {
+    switch (theme) {
+      case TableTheme.green:
+        return const Color(0xFFBDBDBD);
+      case TableTheme.carbon:
+        return Colors.grey;
+      case TableTheme.blue:
+        return Colors.lightBlueAccent;
+    }
+  }
+
   @override
   bool shouldRepaint(covariant PokerTablePainter oldDelegate) {
-    return oldDelegate.feltColor != feltColor ||
-        oldDelegate.borderColor != borderColor;
+    return oldDelegate.theme != theme;
   }
 }

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -9,6 +9,8 @@ import 'pot_chip_stack_painter.dart';
 import 'dealer_button_indicator.dart';
 import 'blind_chip_indicator.dart';
 
+enum TableTheme { green, carbon, blue }
+
 class PokerTableView extends StatefulWidget {
   final int heroIndex;
   final int playerCount;
@@ -20,6 +22,8 @@ class PokerTableView extends StatefulWidget {
   final double potSize;
   final void Function(double newPot) onPotChanged;
   final double scale;
+  final TableTheme theme;
+  final void Function(TableTheme)? onThemeChanged;
   const PokerTableView({
     super.key,
     required this.heroIndex,
@@ -32,6 +36,8 @@ class PokerTableView extends StatefulWidget {
     required this.potSize,
     required this.onPotChanged,
     this.scale = 1.0,
+    this.theme = TableTheme.green,
+    this.onThemeChanged,
   });
 
   @override
@@ -42,8 +48,12 @@ class _PokerTableViewState extends State<PokerTableView> {
   @override
   void didUpdateWidget(covariant PokerTableView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.heroIndex != oldWidget.heroIndex) {
+    if (widget.heroIndex != oldWidget.heroIndex ||
+        widget.theme != oldWidget.theme) {
       setState(() {});
+    }
+    if (widget.theme != oldWidget.theme) {
+      widget.onThemeChanged?.call(widget.theme);
     }
   }
 
@@ -53,7 +63,7 @@ class _PokerTableViewState extends State<PokerTableView> {
     final width = 220.0 * widget.scale;
     final height = width * 0.55;
     final items = <Widget>[
-      Positioned.fill(child: CustomPaint(painter: PokerTablePainter())),
+      Positioned.fill(child: CustomPaint(painter: PokerTablePainter(theme: widget.theme))),
       Positioned.fill(
         child: Center(
           child: Stack(


### PR DESCRIPTION
## Summary
- add `TableTheme` enum and theme callbacks to `PokerTableView`
- render gradients per theme in `PokerTablePainter`
- allow theme cycling in demo screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c4215998832a9b051cae164485b4