### PR TITLE
Add undo/redo for table demo

### DIFF
--- a/lib/models/table_state.dart
+++ b/lib/models/table_state.dart
@@ -1,0 +1,23 @@
+class TableState {
+  final int playerCount;
+  final List<String> names;
+  final List<double> stacks;
+  final int heroIndex;
+  final double pot;
+
+  TableState({
+    required this.playerCount,
+    required this.names,
+    required this.stacks,
+    required this.heroIndex,
+    required this.pot,
+  });
+
+  TableState copy() => TableState(
+        playerCount: playerCount,
+        names: List<String>.from(names),
+        stacks: List<double>.from(stacks),
+        heroIndex: heroIndex,
+        pot: pot,
+      );
+}

--- a/lib/services/table_edit_history.dart
+++ b/lib/services/table_edit_history.dart
@@ -1,0 +1,39 @@
+import '../models/table_state.dart';
+
+class TableEditHistory {
+  TableEditHistory._();
+  static final TableEditHistory _instance = TableEditHistory._();
+  factory TableEditHistory() => _instance;
+  static TableEditHistory get instance => _instance;
+
+  final List<TableState> _undo = [];
+  final List<TableState> _redo = [];
+
+  bool get canUndo => _undo.isNotEmpty;
+  bool get canRedo => _redo.isNotEmpty;
+
+  void push(TableState state) {
+    _undo.add(state.copy());
+    if (_undo.length > 20) _undo.removeAt(0);
+    _redo.clear();
+  }
+
+  TableState? undo(TableState current) {
+    if (_undo.isEmpty) return null;
+    final state = _undo.removeLast();
+    _redo.add(current.copy());
+    return state;
+  }
+
+  TableState? redo(TableState current) {
+    if (_redo.isEmpty) return null;
+    final state = _redo.removeLast();
+    _undo.add(current.copy());
+    return state;
+  }
+
+  void clear() {
+    _undo.clear();
+    _redo.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TableEditHistory` singleton to track table changes
- store table state in new `TableState` model
- hook history into `PokerTableDemoScreen` and add undo/redo buttons

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861c6154c40832abe1935a45620bb8a