### PR TITLE
Enable JSON import for poker table demo

### DIFF
--- a/lib/models/table_state.dart
+++ b/lib/models/table_state.dart
@@ -28,4 +28,14 @@ class TableState {
         'heroIndex': heroIndex,
         'pot': pot,
       };
+
+  factory TableState.fromJson(Map<String, dynamic> json) => TableState(
+        playerCount: json['playerCount'] as int? ?? 0,
+        names: [for (final n in (json['names'] as List? ?? [])) n as String],
+        stacks: [
+          for (final s in (json['stacks'] as List? ?? [])) (s as num).toDouble()
+        ],
+        heroIndex: json['heroIndex'] as int? ?? 0,
+        pot: (json['pot'] as num?)?.toDouble() ?? 0.0,
+      );
 }

--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -49,8 +49,8 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
       _playerCount = (_playerCount + delta).clamp(2, 10);
       if (_names.length < _playerCount) {
         final start = _names.length;
-        _names.addAll(
-            List.generate(_playerCount - start, (i) => 'Player ${start + i + 1}'));
+        _names.addAll(List.generate(
+            _playerCount - start, (i) => 'Player ${start + i + 1}'));
       } else if (_names.length > _playerCount) {
         _names = _names.sublist(0, _playerCount);
       }
@@ -102,6 +102,31 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
     }
   }
 
+  Future<void> _pasteJson() async {
+    final data = await Clipboard.getData('text/plain');
+    final text = data?.text ?? '';
+    if (text.isEmpty) return;
+    try {
+      final json = jsonDecode(text);
+      final state = TableState.fromJson(Map<String, dynamic>.from(json as Map));
+      _applyState(state);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Table pasted')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            backgroundColor: Colors.red,
+            content: Text('Invalid JSON'),
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -120,6 +145,11 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
             icon: const Icon(Icons.copy),
             onPressed: _copyJson,
             tooltip: 'Copy JSON',
+          ),
+          IconButton(
+            icon: const Icon(Icons.paste),
+            onPressed: _pasteJson,
+            tooltip: 'Paste JSON',
           ),
           IconButton(icon: const Icon(Icons.color_lens), onPressed: _nextTheme),
           IconButton(icon: const Icon(Icons.clear), onPressed: _clear),
@@ -162,7 +192,8 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
                   onPressed: () => _changeCount(-1),
                   icon: const Icon(Icons.remove),
                 ),
-                Text('$_playerCount', style: const TextStyle(color: Colors.white)),
+                Text('$_playerCount',
+                    style: const TextStyle(color: Colors.white)),
                 IconButton(
                   onPressed: () => _changeCount(1),
                   icon: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- add `fromJson` factory to `TableState`
- implement paste JSON flow in poker table demo screen
- add button in the app bar to trigger paste

## Testing
- `dart analyze lib/models/table_state.dart lib/screens/poker_table_demo_screen.dart`

------
https://chatgpt.com/codex/tasks/task_e_6861c7ef6750832aaf97bbe31df8cd22