### PR TITLE
Add action badges to PokerTableView

### DIFF
--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -16,6 +16,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
   int _playerCount = 6;
   late List<String> _names;
   late List<double> _stacks;
+  late List<PlayerAction> _actions;
   int _heroIndex = 0;
   double _pot = 0.0;
   TableTheme _theme = TableTheme.green;
@@ -39,6 +40,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
   void _reset() {
     _names = List.generate(_playerCount, (i) => 'Player ${i + 1}');
     _stacks = List.filled(_playerCount, 0.0);
+    _actions = List.filled(_playerCount, PlayerAction.none);
     _heroIndex = 0;
     _pot = 0.0;
   }
@@ -59,6 +61,12 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
       } else if (_stacks.length > _playerCount) {
         _stacks = _stacks.sublist(0, _playerCount);
       }
+      if (_actions.length < _playerCount) {
+        _actions.addAll(
+            List.filled(_playerCount - _actions.length, PlayerAction.none));
+      } else if (_actions.length > _playerCount) {
+        _actions = _actions.sublist(0, _playerCount);
+      }
       if (_heroIndex >= _playerCount) _heroIndex = _playerCount - 1;
     });
   }
@@ -77,6 +85,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
       _playerCount = s.playerCount;
       _names = List<String>.from(s.names);
       _stacks = List<double>.from(s.stacks);
+      _actions = List.filled(_playerCount, PlayerAction.none);
       _heroIndex = s.heroIndex;
       _pot = s.pot;
     });
@@ -164,6 +173,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
               playerCount: _playerCount,
               playerNames: _names,
               playerStacks: _stacks,
+              playerActions: _actions,
               onHeroSelected: (i) {
                 _history.push(_state);
                 setState(() => _heroIndex = i);
@@ -176,6 +186,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
                 _history.push(_state);
                 setState(() => _names[i] = v);
               },
+              onActionChanged: (i, a) => setState(() => _actions[i] = a),
               potSize: _pot,
               onPotChanged: (v) {
                 _history.push(_state);

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -9,6 +9,15 @@ import 'pot_chip_stack_painter.dart';
 import 'dealer_button_indicator.dart';
 import 'blind_chip_indicator.dart';
 
+enum PlayerAction { none, fold, push, call, raise }
+
+const playerActionColors = {
+  PlayerAction.fold: Colors.grey,
+  PlayerAction.push: Colors.orange,
+  PlayerAction.call: Colors.blueAccent,
+  PlayerAction.raise: Colors.redAccent,
+};
+
 enum TableTheme { green, carbon, blue }
 
 class PokerTableView extends StatefulWidget {
@@ -16,9 +25,11 @@ class PokerTableView extends StatefulWidget {
   final int playerCount;
   final List<String> playerNames;
   final List<double> playerStacks;
+  final List<PlayerAction> playerActions;
   final void Function(int index) onHeroSelected;
   final void Function(int index, double newStack) onStackChanged;
   final void Function(int index, String newName) onNameChanged;
+  final void Function(int index, PlayerAction action) onActionChanged;
   final double potSize;
   final void Function(double newPot) onPotChanged;
   final double scale;
@@ -30,9 +41,11 @@ class PokerTableView extends StatefulWidget {
     required this.playerCount,
     required this.playerNames,
     required this.playerStacks,
+    required this.playerActions,
     required this.onHeroSelected,
     required this.onStackChanged,
     required this.onNameChanged,
+    required this.onActionChanged,
     required this.potSize,
     required this.onPotChanged,
     this.scale = 1.0,
@@ -150,6 +163,13 @@ class _PokerTableViewState extends State<PokerTableView> {
         top: offset.dy,
         child: GestureDetector(
           onTap: () => widget.onHeroSelected(i),
+          onDoubleTap: () {
+            final current = widget.playerActions[i];
+            final next = PlayerAction.values[
+                (current.index + 1) % PlayerAction.values.length];
+            widget.onActionChanged(i, next);
+            setState(() {});
+          },
           onLongPress: () async {
             final controller = TextEditingController(text: widget.playerNames[i]);
             final result = await showDialog<String>(
@@ -194,6 +214,32 @@ class _PokerTableViewState extends State<PokerTableView> {
           ),
         ),
       ));
+      final action = i < widget.playerActions.length
+          ? widget.playerActions[i]
+          : PlayerAction.none;
+      if (action != PlayerAction.none) {
+        items.add(Positioned(
+          left: offset.dx + 30 * widget.scale,
+          top: offset.dy - 4 * widget.scale,
+          child: Container(
+            width: 10 * widget.scale,
+            height: 10 * widget.scale,
+            decoration: BoxDecoration(
+              color: playerActionColors[action],
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              action.name[0].toUpperCase(),
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 6 * widget.scale,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ));
+      }
       items.add(Positioned(
         left: offset.dx,
         top: offset.dy - 18 * widget.scale,

--- a/test/widgets/poker_table_view_test.dart
+++ b/test/widgets/poker_table_view_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/widgets/poker_table_view.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('cycles player action on double tap', (tester) async {
+    final actions = [PlayerAction.none, PlayerAction.none];
+    PlayerAction? changed;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PokerTableView(
+          heroIndex: 0,
+          playerCount: 2,
+          playerNames: const ['A', 'B'],
+          playerStacks: const [0.0, 0.0],
+          playerActions: actions,
+          onHeroSelected: (_) {},
+          onStackChanged: (_, __) {},
+          onNameChanged: (_, __) {},
+          onActionChanged: (i, a) {
+            actions[i] = a;
+            changed = a;
+          },
+          potSize: 0,
+          onPotChanged: (_) {},
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('F'), findsNothing);
+
+    final finder = find.text('A');
+    await tester.tap(finder);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(finder);
+    await tester.pump();
+
+    expect(changed, PlayerAction.fold);
+    expect(find.text('F'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `PlayerAction` enum and color map
- allow PokerTableView to show and edit player actions
- update demo screen with action state
- add widget test for action cycling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca1a1fe0832abda275e33cb3f10a