### PR TITLE
Add Hand Editor screen

### DIFF
--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../widgets/poker_table_view.dart';
+
+class HandEditorScreen extends StatelessWidget {
+  const HandEditorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final names = List.generate(6, (i) => 'Player ${i + 1}');
+    final stacks = List.filled(6, 0.0);
+    final actions = List.filled(6, PlayerAction.none);
+    final bets = List.filled(6, 0.0);
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Hand Editor'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Preflop'),
+              Tab(text: 'Flop'),
+              Tab(text: 'Turn'),
+              Tab(text: 'River'),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            IgnorePointer(
+              child: PokerTableView(
+                heroIndex: 0,
+                playerCount: 6,
+                playerNames: names,
+                playerStacks: stacks,
+                playerActions: actions,
+                playerBets: bets,
+                onHeroSelected: (_) {},
+                onStackChanged: (_, __) {},
+                onNameChanged: (_, __) {},
+                onBetChanged: (_, __) {},
+                onActionChanged: (_, __) {},
+                potSize: 0,
+                onPotChanged: (_) {},
+              ),
+            ),
+            const Expanded(
+              child: TabBarView(
+                children: [
+                  Center(child: Text('Coming soon')),
+                  Center(child: Text('Coming soon')),
+                  Center(child: Text('Coming soon')),
+                  Center(child: Text('Coming soon')),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -9,6 +9,7 @@ import 'my_training_history_screen.dart';
 import 'cloud_training_history_service_screen.dart';
 import 'player_zone_demo_screen.dart';
 import 'poker_table_demo_screen.dart';
+import 'hand_editor_screen.dart';
 import 'settings_screen.dart';
 import 'daily_hand_screen.dart';
 import 'spot_of_the_day_screen.dart';
@@ -756,6 +757,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🧪 Poker Table Demo'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const HandEditorScreen()),
+                );
+              },
+              child: const Text('✍️ Hand Editor'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- create `HandEditorScreen` with read-only `PokerTableView` and tab bar
- link screen from main menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d325f40c832ab098968d6aab707e