### PR TITLE
Implement blind auto-posting

### DIFF
--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -30,6 +30,10 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
     _stacks = List.filled(_playerCount, 100);
     _actions = List.filled(_playerCount, PlayerAction.none);
     _bets = List.filled(_playerCount, 0);
+    _preflopActions = [
+      ActionEntry(0, 0, 'post', amount: 1),
+      ActionEntry(0, 1, 'post', amount: 2),
+    ];
     _recompute();
   }
 
@@ -42,6 +46,13 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
       switch (a.action) {
         case 'fold':
           _actions[a.playerIndex] = PlayerAction.fold;
+          break;
+        case 'post':
+          final amt = (a.amount ?? 0).toDouble();
+          _stacks[a.playerIndex] -= amt;
+          _bets[a.playerIndex] += amt;
+          _pot += amt;
+          _actions[a.playerIndex] = PlayerAction.post;
           break;
         case 'call':
           final amt = (a.amount ?? 0).toDouble();
@@ -205,6 +216,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
                         ActionListWidget(
                           playerCount: _playerCount,
                           onChanged: _onActionsChanged,
+                          initial: _preflopActions,
                         ),
                       ],
                     ),

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -4,15 +4,25 @@ import '../models/action_entry.dart';
 class ActionListWidget extends StatefulWidget {
   final int playerCount;
   final ValueChanged<List<ActionEntry>> onChanged;
-  const ActionListWidget({super.key, required this.playerCount, required this.onChanged});
+  final List<ActionEntry>? initial;
+  const ActionListWidget({super.key, required this.playerCount, required this.onChanged, this.initial});
 
   @override
   State<ActionListWidget> createState() => _ActionListWidgetState();
 }
 
 class _ActionListWidgetState extends State<ActionListWidget> {
-  final List<ActionEntry> _actions = [];
-  final List<TextEditingController> _controllers = [];
+  late List<ActionEntry> _actions;
+  late List<TextEditingController> _controllers;
+
+  @override
+  void initState() {
+    super.initState();
+    _actions = List<ActionEntry>.from(widget.initial ?? []);
+    _controllers = [
+      for (final a in _actions) TextEditingController(text: '${a.amount ?? 0}')
+    ];
+  }
 
   void _notify() => widget.onChanged(List<ActionEntry>.from(_actions));
 
@@ -53,40 +63,50 @@ class _ActionListWidgetState extends State<ActionListWidget> {
         for (int i = 0; i < _actions.length; i++)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Row(
-              children: [
-                DropdownButton<int>(
-                  value: _actions[i].playerIndex,
-                  items: [
-                    for (int p = 0; p < widget.playerCount; p++)
-                      DropdownMenuItem(value: p, child: Text('$p')),
-                  ],
-                  onChanged: (v) => _updatePlayer(i, v ?? 0),
-                ),
-                const SizedBox(width: 8),
-                DropdownButton<String>(
-                  value: _actions[i].action,
-                  items: const [
-                    DropdownMenuItem(value: 'fold', child: Text('fold')),
-                    DropdownMenuItem(value: 'call', child: Text('call')),
-                    DropdownMenuItem(value: 'raise', child: Text('raise')),
-                    DropdownMenuItem(value: 'push', child: Text('push')),
-                  ],
-                  onChanged: (v) => _updateAction(i, v ?? 'call'),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  width: 60,
-                  child: TextField(
-                    controller: _controllers[i],
-                    keyboardType: TextInputType.number,
-                    enabled: _actions[i].action != 'fold',
-                    onChanged: (v) => _updateAmount(i, v),
-                    decoration: const InputDecoration(isDense: true),
+            child: _actions[i].action == 'post'
+                ? Row(
+                    children: [
+                      Text('${_actions[i].playerIndex}'),
+                      const SizedBox(width: 8),
+                      const Text('post'),
+                      const SizedBox(width: 8),
+                      Text('${_actions[i].amount}'),
+                    ],
+                  )
+                : Row(
+                    children: [
+                      DropdownButton<int>(
+                        value: _actions[i].playerIndex,
+                        items: [
+                          for (int p = 0; p < widget.playerCount; p++)
+                            DropdownMenuItem(value: p, child: Text('$p')),
+                        ],
+                        onChanged: (v) => _updatePlayer(i, v ?? 0),
+                      ),
+                      const SizedBox(width: 8),
+                      DropdownButton<String>(
+                        value: _actions[i].action,
+                        items: const [
+                          DropdownMenuItem(value: 'fold', child: Text('fold')),
+                          DropdownMenuItem(value: 'call', child: Text('call')),
+                          DropdownMenuItem(value: 'raise', child: Text('raise')),
+                          DropdownMenuItem(value: 'push', child: Text('push')),
+                        ],
+                        onChanged: (v) => _updateAction(i, v ?? 'call'),
+                      ),
+                      const SizedBox(width: 8),
+                      SizedBox(
+                        width: 60,
+                        child: TextField(
+                          controller: _controllers[i],
+                          keyboardType: TextInputType.number,
+                          enabled: _actions[i].action != 'fold',
+                          onChanged: (v) => _updateAmount(i, v),
+                          decoration: const InputDecoration(isDense: true),
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-              ],
-            ),
           ),
         TextButton(
           onPressed: _addAction,

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -13,13 +13,14 @@ import '../models/table_state.dart';
 import '../services/table_edit_history.dart';
 import '../models/card_model.dart';
 
-enum PlayerAction { none, fold, push, call, raise }
+enum PlayerAction { none, fold, push, call, raise, post }
 
 const playerActionColors = {
   PlayerAction.fold: Colors.grey,
   PlayerAction.push: Colors.orange,
   PlayerAction.call: Colors.blueAccent,
   PlayerAction.raise: Colors.redAccent,
+  PlayerAction.post: Colors.grey,
 };
 
 enum TableTheme { green, carbon, blue }


### PR DESCRIPTION
## Summary
- add PlayerAction.post type and color
- initialize HandEditorScreen with SB/BB post actions
- recompute stacks/pot including post actions
- populate ActionListWidget with initial actions and show posts as read-only

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d8238f38832a83fc7dd5f7ea842e