### PR TITLE
Enable decimal blind amounts in hand editor

### DIFF
--- a/lib/helpers/stack_manager.dart
+++ b/lib/helpers/stack_manager.dart
@@ -28,9 +28,9 @@ class StackManager {
           a.action == 'bet' ||
           a.action == 'raise' ||
           a.action == 'all-in') {
-        final int? amount = a.amount;
+        final double? amount = a.amount;
         if (amount != null) {
-          _currentStacks[a.playerIndex]?.addInvestment(a.street, amount);
+          _currentStacks[a.playerIndex]?.addInvestment(a.street, amount.round());
         }
       }
     }

--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -9,7 +9,7 @@ class ActionEntry {
   final String action;
 
   /// Размер ставки в фишках, если применимо
-  final int? amount;
+  final double? amount;
 
   /// Флаг, указывающий, что запись сгенерирована автоматически
   final bool generated;

--- a/lib/models/action_evaluation_request.dart
+++ b/lib/models/action_evaluation_request.dart
@@ -6,7 +6,7 @@ class ActionEvaluationRequest {
   final int street;
   final int playerIndex;
   final String action;
-  final int? amount;
+  final double? amount;
   final Map<String, dynamic>? metadata;
   int attempts;
 
@@ -37,7 +37,7 @@ class ActionEvaluationRequest {
       street: json['street'] as int? ?? 0,
       playerIndex: json['playerIndex'] as int? ?? 0,
       action: json['action'] as String? ?? '',
-      amount: json['amount'] as int?,
+      amount: (json['amount'] as num?)?.toDouble(),
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'] as Map)
           : null,

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -412,7 +412,7 @@ class SavedHand {
           a['street'] as int,
           a['playerIndex'] as int,
           a['action'] as String,
-          amount: a['amount'] as int?,
+          amount: (a['amount'] as num?)?.toDouble(),
           generated: a['generated'] as bool? ?? false,
           timestamp:
               DateTime.tryParse(a['timestamp'] as String? ?? '') ?? DateTime.now(),

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -176,7 +176,7 @@ class TrainingSpot {
           a['street'] as int,
           a['playerIndex'] as int,
           a['action'] as String,
-          amount: (a['amount'] as num?)?.toInt(),
+          amount: (a['amount'] as num?)?.toDouble(),
           manualEvaluation: a['manualEvaluation'] as String?,
         ));
       }

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -27,20 +27,20 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
   void initState() {
     super.initState();
     _names.addAll(List.generate(_playerCount, (i) => 'Player ${i + 1}'));
-    _stacks = List.filled(_playerCount, 100);
+    _stacks = List.filled(_playerCount, 100.0);
     _actions = List.filled(_playerCount, PlayerAction.none);
-    _bets = List.filled(_playerCount, 0);
+    _bets = List.filled(_playerCount, 0.0);
     _preflopActions = [
-      ActionEntry(0, 0, 'post', amount: 1),
-      ActionEntry(0, 1, 'post', amount: 2),
+      ActionEntry(0, 0, 'post', amount: 0.5),
+      ActionEntry(0, 1, 'post', amount: 1.0),
     ];
     _recompute();
   }
 
   void _recompute() {
-    _stacks = List.filled(_playerCount, 100);
+    _stacks = List.filled(_playerCount, 100.0);
     _actions = List.filled(_playerCount, PlayerAction.none);
-    _bets = List.filled(_playerCount, 0);
+    _bets = List.filled(_playerCount, 0.0);
     _pot = 0;
     for (final a in _preflopActions) {
       switch (a.action) {

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -683,7 +683,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               start: start,
               end: end,
               control: control,
-              amount: entry.amount!,
+              amount: entry.amount!.round(),
               scale: scale,
               onCompleted: () {
                 overlayEntry.remove();
@@ -694,7 +694,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
               start: start,
               end: end,
               control: control,
-              amount: entry.amount!,
+              amount: entry.amount!.round(),
               color: color,
               scale: scale,
               fadeStart: 0.8,
@@ -751,7 +751,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         start: start,
         end: end,
         control: control,
-        amount: entry.amount!,
+        amount: entry.amount!.round(),
         scale: scale * 1.2,
         duration: const Duration(milliseconds: 300),
         glowColor: Colors.redAccent,
@@ -770,7 +770,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         entry.amount == null ||
         entry.amount! <= 0 ||
         entry.generated) return;
-    _playFoldRefundAnimation(entry.playerIndex, entry.amount!);
+    _playFoldRefundAnimation(entry.playerIndex, entry.amount!.round());
   }
 
   void _startChipFlight(ActionEntry entry) {
@@ -802,7 +802,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         key: key,
         start: start,
         end: end,
-        amount: entry.amount!,
+        amount: entry.amount!.round(),
         color: color,
         scale: scale,
       ));
@@ -930,7 +930,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         start: start,
         end: end,
         control: control,
-        amount: entry.amount!,
+        amount: entry.amount!.round(),
         color: ActionFormattingHelper.actionColor(entry.action),
         scale: scale,
         onCompleted: () {
@@ -942,7 +942,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       child = BetChipAnimation(
         start: start,
         end: end,
-        amount: entry.amount!,
+        amount: entry.amount!.round(),
         scale: scale,
         onCompleted: () {
           overlayEntry.remove();
@@ -1389,7 +1389,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         start: start,
         end: end,
         control: control,
-        amount: entry.amount!,
+        amount: entry.amount!.round(),
         color: color,
         scale: scale,
         onCompleted: () => overlayEntry.remove(),
@@ -2397,7 +2397,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (!['bet', 'raise', 'call', 'all-in'].contains(entry.action)) return;
     final current = _displayedStacks[entry.playerIndex] ??
         _stackService.getStackForPlayer(entry.playerIndex);
-    final newValue = (current - entry.amount!).clamp(0, current);
+    final newValue = (current - entry.amount!.round()).clamp(0, current);
     lockService.safeSetState(this, () {
       _displayedStacks[entry.playerIndex] = newValue;
     });
@@ -2407,7 +2407,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     if (entry.amount == null) return;
     if (!['bet', 'raise', 'call', 'all-in'].contains(entry.action)) return;
     lockService.safeSetState(this, () {
-      _currentPot += entry.amount!;
+      _currentPot += entry.amount!.round();
     });
   }
 
@@ -2603,11 +2603,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       final int index = entry.playerIndex;
       _betTimers[index]?.cancel();
       setState(() {
-        final info = BetDisplayInfo(entry.amount!, color);
+        final info = BetDisplayInfo(entry.amount!.round(), color);
         _recentBets[index] = info;
         _betDisplays[index] = info;
         _centerBetStacks[index] = info;
-        _actionBetStacks[index] = entry.amount!;
+        _actionBetStacks[index] = entry.amount!.round();
       });
       final overlay = Overlay.of(context);
       if (overlay != null) {
@@ -2649,7 +2649,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
             start: start,
             end: end,
             control: control,
-            amount: entry.amount!,
+            amount: entry.amount!.round(),
             color: color,
             scale: tableScale,
             fadeStart: 0.8,
@@ -2672,7 +2672,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           builder: (_) => BetSlideChips(
             start: start,
             end: mid,
-            amount: entry.amount!,
+            amount: entry.amount!.round(),
             color: color,
             scale: tableScale,
             onCompleted: () {
@@ -3699,9 +3699,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      _sizeButton('50%', (pot / 2).round(), ctx, selected!),
-                      _sizeButton('66%', (pot * 2 / 3).round(), ctx, selected!),
-                      _sizeButton('Pot', pot, ctx, selected!),
+                      _sizeButton('50%', pot / 2, ctx, selected!),
+                      _sizeButton('66%', pot * 2 / 3, ctx, selected!),
+                      _sizeButton('Pot', pot.toDouble(), ctx, selected!),
                     ],
                   ),
                   Slider(
@@ -3712,11 +3712,11 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     label: sliderValue.round().toString(),
                     onChanged: (v) =>
                         setModal(() => sliderValue = v),
-                    onChangeEnd: (v) => _submitSize(v.round(), ctx, selected!),
+                    onChangeEnd: (v) => _submitSize(v, ctx, selected!),
                   ),
                   TextField(
                     controller: controller,
-                    keyboardType: TextInputType.number,
+                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
                     decoration: InputDecoration(
                       filled: true,
                       fillColor: Colors.white10,
@@ -3731,7 +3731,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: () {
-                      final int? amt = int.tryParse(controller.text);
+                      final double? amt = double.tryParse(controller.text);
                       if (amt != null) {
                         _submitSize(amt, ctx, selected!);
                       }
@@ -3752,17 +3752,17 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   Widget _sizeButton(
-      String label, int amount, BuildContext ctx, String action) {
+      String label, double amount, BuildContext ctx, String action) {
     return OutlinedButton(
       onPressed: () => _submitSize(amount, ctx, action),
       child: Text(label),
     );
   }
 
-  void _submitSize(int amount, BuildContext ctx, String action) {
+  void _submitSize(double amount, BuildContext ctx, String action) {
     Navigator.pop(ctx, {
       'action': action,
-      'amount': amount.clamp(1, _stackService.getStackForPlayer(activePlayerIndex ?? 0)),
+      'amount': amount.clamp(1, _stackService.getStackForPlayer(activePlayerIndex ?? 0).toDouble()),
     });
   }
 
@@ -3772,9 +3772,9 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final result = await _showActionPicker();
     if (result == null) return;
     String action = result['action'] as String;
-    int? amount = result['amount'] as int?;
+    double? amount = result['amount'] as double?;
     if (action == 'all-in') {
-      amount = _stackService.getStackForPlayer(index);
+      amount = _stackService.getStackForPlayer(index).toDouble();
     }
     final entry = ActionEntry(currentStreet, index, action, amount: amount);
     handlePlayerAction(entry);
@@ -8392,7 +8392,7 @@ class _StreetActionInputWidgetState extends State<StreetActionInputWidget> {
   }
 
   void _add() {
-    final amount = _needAmount ? int.tryParse(_controller.text) : null;
+    final amount = _needAmount ? double.tryParse(_controller.text) : null;
     widget.onAdd(ActionEntry(widget.currentStreet, _player, _action,
         amount: amount));
     _controller.clear();
@@ -8458,7 +8458,7 @@ class _StreetActionInputWidgetState extends State<StreetActionInputWidget> {
                 onPressed: () {
                   final amt =
                       (act == 'bet' || act == 'raise' || act == 'call')
-                          ? int.tryParse(c.text)
+                          ? double.tryParse(c.text)
                           : null;
                   widget.onEdit(index,
                       ActionEntry(widget.currentStreet, p, act, amount: amt));

--- a/lib/screens/training_spot_builder_screen.dart
+++ b/lib/screens/training_spot_builder_screen.dart
@@ -90,7 +90,7 @@ class _TrainingSpotBuilderScreenState extends State<TrainingSpotBuilderScreen> {
       if (parts.length < 2) continue;
       final p = int.tryParse(parts[0]);
       if (p == null || p < 1 || p > _tableSize) continue;
-      final amount = parts.length > 2 ? int.tryParse(parts[2]) : null;
+      final amount = parts.length > 2 ? double.tryParse(parts[2]) : null;
       actions
           .add(ActionEntry(0, p - 1, parts[1].toLowerCase(), amount: amount));
     }

--- a/lib/services/room_hand_history_importer.dart
+++ b/lib/services/room_hand_history_importer.dart
@@ -131,7 +131,7 @@ class RoomHandHistoryImporter {
       if (mCall != null) {
         final idx = nameToIndex[mCall.group(1)!.toLowerCase()];
         if (idx != null) {
-          final amt = double.tryParse(mCall.group(2)!.replaceAll(',', ''))?.round();
+          final amt = double.tryParse(mCall.group(2)!.replaceAll(',', ''));
           actions.add(ActionEntry(street, idx, 'call', amount: amt));
         }
         continue;
@@ -140,7 +140,7 @@ class RoomHandHistoryImporter {
       if (mBet != null) {
         final idx = nameToIndex[mBet.group(1)!.toLowerCase()];
         if (idx != null) {
-          final amt = double.tryParse(mBet.group(2)!.replaceAll(',', ''))?.round();
+          final amt = double.tryParse(mBet.group(2)!.replaceAll(',', ''));
           actions.add(ActionEntry(street, idx, 'bet', amount: amt));
         }
         continue;
@@ -149,7 +149,7 @@ class RoomHandHistoryImporter {
       if (mRaise != null) {
         final idx = nameToIndex[mRaise.group(1)!.toLowerCase()];
         if (idx != null) {
-          final amt = double.tryParse(mRaise.group(2)!.replaceAll(',', ''))?.round();
+          final amt = double.tryParse(mRaise.group(2)!.replaceAll(',', ''));
           actions.add(ActionEntry(street, idx, 'raise', amount: amt));
         }
         continue;

--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -39,17 +39,17 @@ class _ActionDialogState extends State<ActionDialog> {
     );
   }
 
-  void _selectBetAmount(int amount) {
+  void _selectBetAmount(double amount) {
     Navigator.pop(
       context,
       ActionEntry(widget.street, widget.playerIndex, _selected!.name,
-          amount: amount.clamp(1, widget.stackSize)),
+          amount: amount.clamp(1, widget.stackSize.toDouble())),
     );
   }
 
   void _onSliderChange(double value) {
     setState(() => _slider = value);
-    final amt = value.round();
+    final amt = value;
     if (amt > 0) {
       _selectBetAmount(amt);
     }
@@ -88,7 +88,7 @@ class _ActionDialogState extends State<ActionDialog> {
             for (final f in [1 / 3, 0.5, 0.75, 1.0])
               OutlinedButton(
                 onPressed: () {
-                  final amount = (widget.pot * f).round();
+                  final amount = widget.pot * f;
                   _selectBetAmount(amount);
                 },
                 child: Text('${(f * 100).round()}%'),

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -28,8 +28,8 @@ class _ActionListWidgetState extends State<ActionListWidget> {
 
   void _addAction() {
     setState(() {
-      _actions.add(ActionEntry(0, 0, 'call', amount: 0));
-      _controllers.add(TextEditingController(text: '0'));
+      _actions.add(ActionEntry(0, 0, 'call', amount: 0.0));
+      _controllers.add(TextEditingController(text: '0.0'));
     });
     _notify();
   }
@@ -51,7 +51,7 @@ class _ActionListWidgetState extends State<ActionListWidget> {
 
   void _updateAmount(int index, String value) {
     final a = _actions[index];
-    final amt = int.tryParse(value);
+    final amt = double.tryParse(value);
     setState(() => _actions[index] = ActionEntry(a.street, a.playerIndex, a.action, amount: amt));
     _notify();
   }
@@ -99,7 +99,7 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                         width: 60,
                         child: TextField(
                           controller: _controllers[i],
-                          keyboardType: TextInputType.number,
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
                           enabled: _actions[i].action != 'fold',
                           onChanged: (v) => _updateAmount(i, v),
                           decoration: const InputDecoration(isDense: true),

--- a/lib/widgets/edit_action_dialog.dart
+++ b/lib/widgets/edit_action_dialog.dart
@@ -51,7 +51,7 @@ Future<ActionEntry?> showEditActionDialog(
               if (needAmount)
                 TextField(
                   controller: controller,
-                  keyboardType: TextInputType.number,
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
                   decoration: const InputDecoration(labelText: 'Amount'),
                 ),
             ],
@@ -66,7 +66,7 @@ Future<ActionEntry?> showEditActionDialog(
                 final amount = (action == 'bet' ||
                         action == 'raise' ||
                         action == 'call')
-                    ? int.tryParse(controller.text)
+                    ? double.tryParse(controller.text)
                     : null;
                 Navigator.pop(
                   ctx,

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -2702,7 +2702,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     final result = await _showActionSheet();
     if (result == null) return;
     final String action = result['action'] as String;
-    final int? amount = result['amount'] as int?;
+    final double? amount = result['amount'] as double?;
     setState(() {
       _actionTagText = amount != null
           ? '${_capitalize(action)} $amount'
@@ -2724,7 +2724,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
     final result = await _showAddActionDialog();
     if (result == null) return;
     final String action = result['action'] as String;
-    final int? amount = result['amount'] as int?;
+    final double? amount = result['amount'] as double?;
     final text = amount != null
         ? '${_capitalize(action)} $amount'
         : _capitalize(action);

--- a/plugins/converters/pokerstars_hand_history_converter.dart
+++ b/plugins/converters/pokerstars_hand_history_converter.dart
@@ -100,7 +100,7 @@ class PokerStarsHandHistoryConverter extends ConverterPlugin {
         if (idx != null) {
           final amt = _parseAmount(m.group(2)!);
           final amount =
-              bigBlind != null && bigBlind > 0 ? (amt / bigBlind).round() : amt.round();
+              bigBlind != null && bigBlind > 0 ? (amt / bigBlind) : amt;
           final isAllIn = m.group(3)!.toLowerCase().contains('all-in');
           final action = isAllIn ? 'all-in' : 'call';
           actions.add(ActionEntry(street, idx, action, amount: amount));
@@ -117,7 +117,7 @@ class PokerStarsHandHistoryConverter extends ConverterPlugin {
         if (idx != null) {
           final amt = _parseAmount(m.group(3)!);
           final amount =
-              bigBlind != null && bigBlind > 0 ? (amt / bigBlind).round() : amt.round();
+              bigBlind != null && bigBlind > 0 ? (amt / bigBlind) : amt;
           final isAllIn = m.group(4)!.toLowerCase().contains('all-in');
           final action = isAllIn ? 'all-in' : 'raise';
           actions.add(ActionEntry(street, idx, action, amount: amount));


### PR DESCRIPTION
## Summary
- switch `HandEditorScreen` blind posts to 0.5/1.0 BB
- recompute stacks/pot using doubles
- support decimal amounts across action models and editors

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d9df9b34832a92d88577c98f10e0