### PR TITLE
Add running pot display in HandEditor

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -17,6 +17,9 @@ class ActionEntry {
   /// Пользовательская оценка качества действия, заданная вручную
   String? manualEvaluation;
 
+  /// Размер банка после применения действия
+  double potAfter;
+
   /// Время, когда было совершено действие
   final DateTime timestamp;
 
@@ -27,6 +30,7 @@ class ActionEntry {
       {this.amount,
       this.generated = false,
       this.manualEvaluation,
-      DateTime? timestamp})
+      DateTime? timestamp,
+      this.potAfter = 0})
       : timestamp = timestamp ?? DateTime.now();
 }

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -90,6 +90,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
             actions[a.playerIndex] = PlayerAction.push;
             break;
         }
+        a.potAfter = pot;
       }
     }
 
@@ -287,6 +288,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
                         ActionListWidget(
                           playerCount: _playerCount,
                           initial: _preflopActions,
+                          showPot: true,
                           onChanged: _onPreflopChanged,
                         ),
                       ],
@@ -301,6 +303,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
                         ActionListWidget(
                           playerCount: _playerCount,
                           initial: _flopActions,
+                          showPot: true,
                           onChanged: _onFlopChanged,
                         ),
                       ],
@@ -315,6 +318,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
                         ActionListWidget(
                           playerCount: _playerCount,
                           initial: _turnActions,
+                          showPot: true,
                           onChanged: _onTurnChanged,
                         ),
                       ],
@@ -329,6 +333,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
                         ActionListWidget(
                           playerCount: _playerCount,
                           initial: _riverActions,
+                          showPot: true,
                           onChanged: _onRiverChanged,
                         ),
                       ],

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -5,7 +5,14 @@ class ActionListWidget extends StatefulWidget {
   final int playerCount;
   final ValueChanged<List<ActionEntry>> onChanged;
   final List<ActionEntry>? initial;
-  const ActionListWidget({super.key, required this.playerCount, required this.onChanged, this.initial});
+  final bool showPot;
+  const ActionListWidget({
+    super.key,
+    required this.playerCount,
+    required this.onChanged,
+    this.initial,
+    this.showPot = false,
+  });
 
   @override
   State<ActionListWidget> createState() => _ActionListWidgetState();
@@ -79,6 +86,13 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                       const Text('post'),
                       const SizedBox(width: 8),
                       Text('${_actions[i].amount}'),
+                      if (widget.showPot) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          'Pot: ${_actions[i].potAfter.toStringAsFixed(1)} BB',
+                          style: const TextStyle(color: Colors.grey),
+                        )
+                      ]
                     ]
                   : [
                       DropdownButton<int>(
@@ -111,6 +125,13 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                           decoration: const InputDecoration(isDense: true),
                         ),
                       ),
+                      if (widget.showPot) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          'Pot: ${_actions[i].potAfter.toStringAsFixed(1)} BB',
+                          style: const TextStyle(color: Colors.grey),
+                        )
+                      ]
                     ],
             ),
           ),


### PR DESCRIPTION
## Summary
- keep pot value for each action with `potAfter`
- display running pot next to amounts in `ActionListWidget`
- compute running pot for every action in hand editor

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861e2d06d60832abcdfc15f2c38a824