### PR TITLE
Add custom action support

### DIFF
--- a/lib/helpers/action_formatting_helper.dart
+++ b/lib/helpers/action_formatting_helper.dart
@@ -32,6 +32,8 @@ class ActionFormattingHelper {
         return Colors.purpleAccent;
       case 'check':
         return Colors.grey[700]!;
+      case 'custom':
+        return Colors.purple;
       default:
         return Colors.black;
     }
@@ -62,6 +64,8 @@ class ActionFormattingHelper {
         return Icons.flash_on;
       case 'check':
         return Icons.remove;
+      case 'custom':
+        return Icons.edit;
       default:
         return null;
     }
@@ -69,8 +73,12 @@ class ActionFormattingHelper {
 
   /// Formats the last action label for display.
   static String formatLastAction(ActionEntry entry) {
-    final String a = entry.action;
-    final String cap = a.isNotEmpty ? a[0].toUpperCase() + a.substring(1) : a;
+    final label = entry.action == 'custom'
+        ? (entry.customLabel ?? 'custom')
+        : entry.action;
+    final cap = label.isNotEmpty
+        ? label[0].toUpperCase() + label.substring(1)
+        : label;
     return entry.amount != null ? '$cap ${entry.amount}' : cap;
   }
 }

--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -17,6 +17,9 @@ class ActionEntry {
   /// Пользовательская оценка качества действия, заданная вручную
   String? manualEvaluation;
 
+  /// Пользовательская метка действия при типе 'custom'
+  String? customLabel;
+
   /// Размер банка после применения действия
   double potAfter;
 
@@ -30,6 +33,7 @@ class ActionEntry {
       {this.amount,
       this.generated = false,
       this.manualEvaluation,
+      this.customLabel,
       DateTime? timestamp,
       this.potAfter = 0})
       : timestamp = timestamp ?? DateTime.now();

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -322,6 +322,7 @@ class SavedHand {
               'timestamp': a.timestamp.toIso8601String(),
               if (a.manualEvaluation != null)
                 'manualEvaluation': a.manualEvaluation,
+              if (a.customLabel != null) 'customLabel': a.customLabel,
             }
         ],
         'stackSizes': stackSizes.map((k, v) => MapEntry(k.toString(), v)),
@@ -417,6 +418,7 @@ class SavedHand {
           timestamp:
               DateTime.tryParse(a['timestamp'] as String? ?? '') ?? DateTime.now(),
           manualEvaluation: a['manualEvaluation'] as String?,
+          customLabel: a['customLabel'] as String?,
         )
     ];
     final stack = <int, int>{};

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -121,6 +121,7 @@ class TrainingSpot {
               if (a.amount != null) 'amount': a.amount,
               if (a.manualEvaluation != null)
                 'manualEvaluation': a.manualEvaluation,
+              if (a.customLabel != null) 'customLabel': a.customLabel,
             }
         ],
         'heroIndex': heroIndex,
@@ -178,6 +179,7 @@ class TrainingSpot {
           a['action'] as String,
           amount: (a['amount'] as num?)?.toDouble(),
           manualEvaluation: a['manualEvaluation'] as String?,
+          customLabel: a['customLabel'] as String?,
         ));
       }
     }

--- a/lib/widgets/action_history_overlay.dart
+++ b/lib/widgets/action_history_overlay.dart
@@ -55,7 +55,7 @@ class ActionHistoryOverlay extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Text(
-              '$pos: ${a.action}',
+              '$pos: ${a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action}',
               style: TextStyle(
                 color: ActionFormattingHelper.actionTextColor(a.action),
                 fontSize: 11 * scale,

--- a/lib/widgets/action_history_widget.dart
+++ b/lib/widgets/action_history_widget.dart
@@ -71,7 +71,8 @@ class ActionHistoryWidget extends StatelessWidget {
 
   String _actionLine(ActionEntry a) {
     final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
-    final act = '${a.action}${a.amount != null ? ' ${a.amount}' : ''}';
+    final label = a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action;
+    final act = '$label${a.amount != null ? ' ${a.amount}' : ''}';
     return '$pos — $act';
   }
 }

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -34,6 +34,8 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
         return '❌';
       case 'all-in':
         return '💀';
+      case 'custom':
+        return '✏️';
       default:
         return '';
     }
@@ -86,7 +88,9 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
             Text(_iconForAction(a.action), style: style),
             const SizedBox(width: 4),
             Expanded(
-              child: Text('$pos ${a.action}$size', style: style),
+              child: Text(
+                  '$pos ${a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action}$size',
+                  style: style),
             ),
           ],
         );

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -53,6 +53,8 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
       case 'raise':
       case 'bet':
         return Colors.green;
+      case 'custom':
+        return Colors.purple;
       default:
         return Colors.white;
     }
@@ -61,8 +63,11 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
   String _buildSummary(List<ActionEntry> actions) {
     if (actions.isEmpty) return 'Нет действий';
     return actions
-        .map((a) =>
-            '${_capitalize(a.action)}${a.amount != null ? ' ${a.amount}' : ''}')
+        .map((a) {
+          final label =
+              a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action;
+          return '${_capitalize(label)}${a.amount != null ? ' ${a.amount}' : ''}';
+        })
         .join(' – ');
   }
 

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -46,6 +46,8 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
       case 'raise':
       case 'bet':
         return Colors.green;
+      case 'custom':
+        return Colors.purple;
       default:
         return Colors.white;
     }
@@ -64,8 +66,10 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
     final last = actions.last;
     final pos =
         widget.playerPositions[last.playerIndex] ?? 'P${last.playerIndex + 1}';
+    final label =
+        last.action == 'custom' ? (last.customLabel ?? 'custom') : last.action;
     final actionText =
-        '${_capitalize(last.action)}${last.amount != null ? ' ${last.amount}' : ''}';
+        '${_capitalize(label)}${last.amount != null ? ' ${last.amount}' : ''}';
     return Text(
       '$pos $actionText',
       style: TextStyle(color: _colorForAction(last.action)),

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -422,7 +422,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
         final comment = spot.userComment?.toLowerCase() ?? '';
         final history = spot.actionHistory?.toLowerCase() ?? '';
         final actions = spot.actions
-            .map((a) => '${a.action} ${a.amount ?? ''} ${a.street} ${a.playerIndex}')
+            .map((a) =>
+                '${a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action} ${a.amount ?? ''} ${a.street} ${a.playerIndex}')
             .join(' ')
             .toLowerCase();
         matchesQuery =

--- a/lib/widgets/saved_hand_detail_sheet.dart
+++ b/lib/widgets/saved_hand_detail_sheet.dart
@@ -114,7 +114,7 @@ class SavedHandDetailSheet extends StatelessWidget {
               const SizedBox(height: 4),
               for (final a in hand.actions)
                 Text(
-                  'S${a.street}: P${a.playerIndex} ${a.action}${a.amount != null ? ' • ${a.amount}' : ''}',
+                  'S${a.street}: P${a.playerIndex} ${a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action}${a.amount != null ? ' • ${a.amount}' : ''}',
                   style: const TextStyle(color: Colors.white70),
                 ),
             ],

--- a/lib/widgets/street_action_chip_row.dart
+++ b/lib/widgets/street_action_chip_row.dart
@@ -5,8 +5,8 @@ class StreetActionChipRow extends StatelessWidget {
   final List<ActionEntry> actions;
   const StreetActionChipRow({super.key, required this.actions});
 
-  Color _colorForAction(String action) {
-    switch (action) {
+  Color _colorForAction(ActionEntry a) {
+    switch (a.action) {
       case 'fold':
         return Colors.grey;
       case 'call':
@@ -15,12 +15,15 @@ class StreetActionChipRow extends StatelessWidget {
         return Colors.green;
       case 'raise':
         return Colors.orange;
+      case 'custom':
+        return Colors.purple;
       default:
         return Colors.white;
     }
   }
 
-  String _labelForAction(String action) {
+  String _labelForAction(ActionEntry a) {
+    final action = a.action;
     switch (action) {
       case 'fold':
         return 'F';
@@ -30,6 +33,11 @@ class StreetActionChipRow extends StatelessWidget {
         return 'B';
       case 'raise':
         return 'R';
+      case 'custom':
+        final label = a.customLabel;
+        return label != null && label.isNotEmpty
+            ? label[0].toUpperCase()
+            : 'C';
       default:
         return action.isNotEmpty ? action[0].toUpperCase() : '?';
     }
@@ -54,12 +62,12 @@ class StreetActionChipRow extends StatelessWidget {
                 width: 20,
                 height: 20,
                 decoration: BoxDecoration(
-                  color: _colorForAction(a.action),
+                  color: _colorForAction(a),
                   shape: BoxShape.circle,
                 ),
                 alignment: Alignment.center,
                 child: Text(
-                  _labelForAction(a.action),
+                  _labelForAction(a),
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 12,

--- a/lib/widgets/street_action_summary_bar.dart
+++ b/lib/widgets/street_action_summary_bar.dart
@@ -40,7 +40,7 @@ class StreetActionSummaryBar extends StatelessWidget {
                     backgroundColor: Colors.black54,
                     label: Text(
                       '${playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}'}: '
-                      '${a.action}${a.amount != null ? ' ${a.amount}' : ''}',
+                      '${a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action}${a.amount != null ? ' ${a.amount}' : ''}',
                       style: const TextStyle(color: Colors.white, fontSize: 12),
                     ),
                   ),

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -61,12 +61,15 @@ class StreetActionsList extends StatelessWidget {
       case 'check':
         color = Colors.grey;
         break;
+      case 'custom':
+        color = Colors.purple;
+        break;
       default:
         color = Colors.white;
     }
-    final pos =
-        playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
-    final baseTitle = '$pos — ${a.action}';
+    final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
+    final actLabel = a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action;
+    final baseTitle = '$pos — $actLabel';
     final title = a.generated ? '$baseTitle (auto)' : baseTitle;
 
     Color? qualityColor;

--- a/lib/widgets/training_spot_diagram.dart
+++ b/lib/widgets/training_spot_diagram.dart
@@ -37,7 +37,8 @@ class TrainingSpotDiagram extends StatelessWidget {
     final actions = List.filled(spot.numberOfPlayers, '');
     for (final a in spot.actions) {
       if (a.playerIndex >= 0 && a.playerIndex < spot.numberOfPlayers) {
-        final label = a.amount != null ? '${a.action.toUpperCase()} ${a.amount}' : a.action.toUpperCase();
+        final lab = a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action;
+        final label = a.amount != null ? '${lab.toUpperCase()} ${a.amount}' : lab.toUpperCase();
         actions[a.playerIndex] = label;
       }
     }


### PR DESCRIPTION
## Summary
- allow custom actions with labels in ActionListWidget
- include `customLabel` field in `ActionEntry` and serialization
- show custom labels in histories and summaries
- color and icon helpers for custom actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e4f3e4a8832aa8bec2e373b4383e