### PR TITLE
Add Showdown tab

### DIFF
--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -40,6 +40,7 @@ class PokerTableView extends StatefulWidget {
   final double potSize;
   final void Function(double newPot) onPotChanged;
   final List<CardModel> heroCards;
+  final List<List<CardModel>> revealedCards;
   final double scale;
   final TableTheme theme;
   final void Function(TableTheme)? onThemeChanged;
@@ -59,6 +60,7 @@ class PokerTableView extends StatefulWidget {
     required this.potSize,
     required this.onPotChanged,
     this.heroCards = const [],
+    this.revealedCards = const [],
     this.scale = 1.0,
     this.theme = TableTheme.green,
     this.onThemeChanged,
@@ -400,6 +402,44 @@ class _PokerTableViewState extends State<PokerTableView> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: widget.heroCards.take(2).map((c) {
+              final isRed = c.suit == '♥' || c.suit == '♦';
+              return Container(
+                margin: EdgeInsets.symmetric(horizontal: 2 * widget.scale),
+                width: 18 * widget.scale,
+                height: 26 * widget.scale,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(4),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.25),
+                      blurRadius: 3,
+                      offset: const Offset(1, 2),
+                    )
+                  ],
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '${c.rank}${c.suit}',
+                  style: TextStyle(
+                    color: isRed ? Colors.red : Colors.black,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 12 * widget.scale,
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+        ));
+      } else if (i < widget.revealedCards.length &&
+          widget.revealedCards[i].isNotEmpty) {
+        final dx = cos(angle) < 0 ? -40 * widget.scale : 40 * widget.scale;
+        items.add(Positioned(
+          left: offset.dx + dx,
+          top: offset.dy - 18 * widget.scale,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: widget.revealedCards[i].take(2).map((c) {
               final isRed = c.suit == '♥' || c.suit == '♦';
               return Container(
                 margin: EdgeInsets.symmetric(horizontal: 2 * widget.scale),

--- a/lib/widgets/showdown_tab.dart
+++ b/lib/widgets/showdown_tab.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+
+class ShowdownTab extends StatelessWidget {
+  final List<String> names;
+  final List<List<CardModel>> revealed;
+  final List<double> stacks;
+  final List<double> winnings;
+  final double pot;
+  const ShowdownTab({
+    super.key,
+    required this.names,
+    required this.revealed,
+    required this.stacks,
+    required this.winnings,
+    required this.pot,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Revealed cards:', style: TextStyle(color: Colors.white)),
+          const SizedBox(height: 8),
+          ...List.generate(names.length, (i) {
+            final cards = i < revealed.length ? revealed[i] : <CardModel>[];
+            final text = cards.isEmpty
+                ? '—'
+                : cards.map((c) => '${c.rank}${c.suit}').join(' ');
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text('Player ${i + 1} – $text',
+                  style: const TextStyle(color: Colors.white70)),
+            );
+          }),
+          const SizedBox(height: 16),
+          const Text('Result:', style: TextStyle(color: Colors.white)),
+          if (pot > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text('Unclaimed pot: ${pot.toStringAsFixed(1)} BB',
+                  style: const TextStyle(color: Colors.white38)),
+            ),
+          const SizedBox(height: 8),
+          ...List.generate(names.length, (i) {
+            final before = stacks[i] - winnings[i];
+            final after = stacks[i];
+            final win = winnings[i];
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text(
+                'Player ${i + 1}: ${before.toStringAsFixed(1)} ⇒ ${after.toStringAsFixed(1)}' +
+                    (win > 0 ? ' (+${win.toStringAsFixed(1)})' : ''),
+                style: TextStyle(
+                  color: Colors.white70,
+                  decoration: win > 0 ? TextDecoration.underline : null,
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add ShowdownTab widget
- support revealed cards in PokerTableView
- extend HandEditorScreen with Showdown tab, reveal/distribute actions and history

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ef0d09a4832abb2965e8ab49d92a