### PR TITLE
Add showdown auto evaluator

### DIFF
--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -8,6 +8,7 @@ import '../widgets/showdown_tab.dart';
 import '../models/card_model.dart';
 import '../models/action_entry.dart';
 import '../helpers/poker_position_helper.dart';
+import '../services/hand_evaluator.dart';
 
 class HandEditorScreen extends StatefulWidget {
   const HandEditorScreen({super.key});
@@ -531,6 +532,25 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     }
   }
 
+  void _autoShowdown() {
+    final winners = HandEvaluator.evaluateShowdown(
+      _revealedCards,
+      _boardCards,
+    );
+    if (winners.isEmpty) return;
+    final share = _pot / winners.length;
+    setState(() {
+      for (int i = 0; i < _playerCount; i++) {
+        _winnings[i] = winners.contains(i) ? share : 0;
+        if (winners.contains(i)) {
+          _stacks[i] += share;
+        }
+      }
+      _pot = 0;
+    });
+    _pushHistory();
+  }
+
   Widget _buildBoardRow() {
     final cards =
         List.generate(5, (i) => i < _boardCards.length ? _boardCards[i] : null);
@@ -690,6 +710,14 @@ class _HandEditorScreenState extends State<HandEditorScreen>
             icon: const Icon(Icons.visibility),
             onPressed:
                 _tabController.index == 4 ? _revealCards : null,
+          ),
+          TextButton(
+            onPressed: _tabController.index == 4 &&
+                    _boardCards.length >= 5 &&
+                    _revealedCards.where((c) => c.length == 2).length >= 2
+                ? _autoShowdown
+                : null,
+            child: const Text('🧠 Auto'),
           ),
           IconButton(
             icon: const Icon(Icons.paid),

--- a/lib/services/hand_evaluator.dart
+++ b/lib/services/hand_evaluator.dart
@@ -1,0 +1,34 @@
+import 'package:poker_solver/poker_solver.dart';
+
+import '../models/card_model.dart';
+
+class HandEvaluator {
+  static List<int> evaluateShowdown(
+    List<List<CardModel>> revealed,
+    List<CardModel> board,
+  ) {
+    if (board.length < 5) return [];
+    final boardStr = board.take(5).map(_s).toList();
+    final Map<int, Hand> hands = {};
+    for (int i = 0; i < revealed.length; i++) {
+      final cards = revealed[i];
+      if (cards.length < 2) continue;
+      hands[i] = Hand.solveHand([
+        ...boardStr,
+        ...cards.map(_s),
+      ]);
+    }
+    if (hands.isEmpty) return [];
+    final winners = Hand.winners(hands.values.toList());
+    return [
+      for (final e in hands.entries)
+        if (winners.contains(e.value)) e.key
+    ];
+  }
+
+  static String _s(CardModel c) {
+    const map = {'♠': 's', '♥': 'h', '♦': 'd', '♣': 'c'};
+    return '${c.rank}${map[c.suit] ?? c.suit}';
+  }
+}
+


### PR DESCRIPTION
## Summary
- create hand evaluator service using poker_solver
- add Auto showdown button in hand editor
- split pot among winners automatically

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f10f1a7c832ab761b38d17601d29