### PR TITLE
Add side pot logic to Hand Editor

### DIFF
--- a/lib/services/hand_evaluator.dart
+++ b/lib/services/hand_evaluator.dart
@@ -30,5 +30,77 @@ class HandEvaluator {
     const map = {'♠': 's', '♥': 'h', '♦': 'd', '♣': 'c'};
     return '${c.rank}${map[c.suit] ?? c.suit}';
   }
+
+  static Map<int, Hand> buildHands(
+    List<List<CardModel>> revealed,
+    List<CardModel> board,
+  ) {
+    if (board.length < 5) return {};
+    final boardStr = board.take(5).map(_s).toList();
+    final Map<int, Hand> hands = {};
+    for (int i = 0; i < revealed.length; i++) {
+      final cards = revealed[i];
+      if (cards.length < 2) continue;
+      hands[i] = Hand.solveHand([
+        ...boardStr,
+        ...cards.map(_s),
+      ]);
+    }
+    return hands;
+  }
+
+  static Map<int, double> splitWithSidePots({
+    required Map<int, Hand> showdownHands,
+    required List<double> bets,
+    required List<double> allInAt,
+    required double mainPot,
+  }) {
+    final result = <int, double>{};
+    final active = showdownHands.keys.toSet();
+    final levels = [
+      for (final v in allInAt)
+        if (v.isFinite) v
+    ]..sort();
+    double remaining = mainPot;
+    double prev = 0;
+    for (final level in levels) {
+      final participants = [
+        for (int i = 0; i < allInAt.length; i++)
+          if (allInAt[i] >= level || !allInAt[i].isFinite) i
+      ];
+      if (participants.isEmpty) continue;
+      double pot = (level - prev) * participants.length;
+      if (pot > remaining) pot = remaining;
+      remaining -= pot;
+      final eligibles = [
+        for (final p in participants)
+          if (showdownHands.containsKey(p)) p
+      ];
+      if (pot > 0 && eligibles.isNotEmpty) {
+        final hands = {for (final p in eligibles) p: showdownHands[p]!};
+        final winners = Hand.winners(hands.values.toList());
+        final share = pot / winners.length;
+        for (final e in hands.entries) {
+          if (winners.contains(e.value)) {
+            result[e.key] = (result[e.key] ?? 0) + share;
+          }
+        }
+      }
+      active.removeWhere((p) => allInAt[p] == level);
+      prev = level;
+      if (remaining <= 0) break;
+    }
+    if (remaining > 0 && active.isNotEmpty) {
+      final hands = {for (final p in active) p: showdownHands[p]!};
+      final winners = Hand.winners(hands.values.toList());
+      final share = remaining / winners.length;
+      for (final e in hands.entries) {
+        if (winners.contains(e.value)) {
+          result[e.key] = (result[e.key] ?? 0) + share;
+        }
+      }
+    }
+    return result;
+  }
 }
 

--- a/lib/widgets/showdown_tab.dart
+++ b/lib/widgets/showdown_tab.dart
@@ -6,6 +6,7 @@ class ShowdownTab extends StatelessWidget {
   final List<List<CardModel>> revealed;
   final List<double> stacks;
   final List<double> winnings;
+  final List<List<double>> parts;
   final double pot;
   const ShowdownTab({
     super.key,
@@ -13,6 +14,7 @@ class ShowdownTab extends StatelessWidget {
     required this.revealed,
     required this.stacks,
     required this.winnings,
+    required this.parts,
     required this.pot,
   });
 
@@ -49,11 +51,18 @@ class ShowdownTab extends StatelessWidget {
             final before = stacks[i] - winnings[i];
             final after = stacks[i];
             final win = winnings[i];
+            final partsText = parts[i].isNotEmpty
+                ? ' = ' +
+                    List.generate(parts[i].length, (j) {
+                      final label = j == 0 ? 'main' : 'side';
+                      return '${parts[i][j].toStringAsFixed(1)} $label';
+                    }).join(' + ')
+                : '';
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 2),
               child: Text(
                 'Player ${i + 1}: ${before.toStringAsFixed(1)} ⇒ ${after.toStringAsFixed(1)}' +
-                    (win > 0 ? ' (+${win.toStringAsFixed(1)})' : ''),
+                    (win > 0 ? ' (+${win.toStringAsFixed(1)}$partsText)' : ''),
                 style: TextStyle(
                   color: Colors.white70,
                   decoration: win > 0 ? TextDecoration.underline : null,


### PR DESCRIPTION
## Summary
- track all-in amounts for each player during recompute
- implement side pot splitting helper in `HandEvaluator`
- show detailed pot breakdown in showdown tab
- auto showdown now splits pots using side-pot logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f2291058832a9e4542b8a456ee3c