### PR TITLE
Add SPR HUD to Hand Editor

### DIFF
--- a/lib/widgets/street_hud_bar.dart
+++ b/lib/widgets/street_hud_bar.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class StreetHudBar extends StatelessWidget {
+  final List<double> spr;
+  final List<double> eff;
+  final int currentStreet;
+  const StreetHudBar({super.key, required this.spr, required this.eff, required this.currentStreet});
+
+  @override
+  Widget build(BuildContext ctx) => Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: List.generate(4, (i) {
+          final label = ['P', 'F', 'T', 'R'][i];
+          final color = i == currentStreet ? Colors.amber : Colors.white54;
+          final sprText = spr[i] <= 0 ? '–' : spr[i].toStringAsFixed(1);
+          return Column(children: [
+            Text('$label', style: TextStyle(color: color)),
+            Text('SPR: $sprText', style: TextStyle(color: color, fontSize: 12)),
+            Text('Eff: ${eff[i].toStringAsFixed(1)}',
+                style: TextStyle(color: color, fontSize: 12)),
+          ]);
+        }),
+      );
+}


### PR DESCRIPTION
## Summary
- compute Street SPR and effective stack
- save/restore SPR+Eff in hand snapshots
- add StreetHudBar widget and show under board

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f48c65b0832aa77a086dfe51216b