### PR TITLE
Add EV calculation and display

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -25,6 +25,10 @@ class ActionEntry {
 
   double? potOdds;
 
+  double? equity;
+
+  double? ev;
+
   /// Время, когда было совершено действие
   final DateTime timestamp;
 
@@ -38,6 +42,8 @@ class ActionEntry {
       this.customLabel,
       DateTime? timestamp,
       this.potAfter = 0,
-      this.potOdds})
+      this.potOdds,
+      this.equity,
+      this.ev})
       : timestamp = timestamp ?? DateTime.now();
 }

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -68,6 +68,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
   List<double> _streetSpr = List.filled(4, 0);
   List<double> _streetEff = List.filled(4, 0);
   List<double?> _streetPotOdds = List.filled(4, null);
+  List<double?> _streetEv = List.filled(4, null);
   double _pot = 0;
   late TabController _tabController;
   final List<_HandSnapshot> _undo = [];
@@ -105,6 +106,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     final spr = List<double>.filled(4, 0);
     final eff = List<double>.filled(4, 0);
     final heroPo = List<double?>.filled(4, null);
+    final heroEv = List<double?>.filled(4, null);
     int street = 0;
     void apply(List<ActionEntry> list) {
       for (final a in list) {
@@ -158,8 +160,14 @@ class _HandEditorScreenState extends State<HandEditorScreen>
           final toCall = (bets[a.playerIndex] - prevBet).clamp(0, double.infinity);
           a.potOdds = toCall == 0 ? null : (toCall / pot * 100);
           heroPo[street] = a.potOdds;
+          final potAfter = pot;
+          a.ev = a.equity == null
+              ? null
+              : (a.equity! / 100) * (potAfter) - toCall;
+          heroEv[street] = a.ev;
         } else {
           a.potOdds = null;
+          a.ev = null;
         }
       }
     }
@@ -192,6 +200,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
       _streetSpr = spr;
       _streetEff = eff;
       _streetPotOdds = heroPo;
+      _streetEv = heroEv;
     });
     if (pushHistory && !_skipHistory) _pushHistory();
   }
@@ -225,6 +234,8 @@ class _HandEditorScreenState extends State<HandEditorScreen>
         timestamp: a.timestamp,
         potAfter: a.potAfter,
         potOdds: a.potOdds,
+        equity: a.equity,
+        ev: a.ev,
       );
 
   void _pushHistory() {
@@ -878,6 +889,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
               spr: _streetSpr,
               eff: _streetEff,
               potOdds: _streetPotOdds,
+              ev: _streetEv,
               currentStreet: _tabController.index.clamp(0, 3),
             ),
             Expanded(
@@ -904,6 +916,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
                         const SizedBox(height: 12),
                         ActionListWidget(
                           playerCount: _playerCount,
+                          heroIndex: _heroIndex,
                           initial: _preflopActions,
                           showPot: true,
                           currentStacks: _stacks,
@@ -920,6 +933,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
                         const SizedBox(height: 12),
                         ActionListWidget(
                           playerCount: _playerCount,
+                          heroIndex: _heroIndex,
                           initial: _flopActions,
                           showPot: true,
                           currentStacks: _stacks,
@@ -936,6 +950,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
                         const SizedBox(height: 12),
                         ActionListWidget(
                           playerCount: _playerCount,
+                          heroIndex: _heroIndex,
                           initial: _turnActions,
                           showPot: true,
                           currentStacks: _stacks,
@@ -952,6 +967,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
                     const SizedBox(height: 12),
                     ActionListWidget(
                       playerCount: _playerCount,
+                      heroIndex: _heroIndex,
                       initial: _riverActions,
                       showPot: true,
                       currentStacks: _stacks,

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 class ActionListWidget extends StatefulWidget {
   final int playerCount;
+  final int heroIndex;
   final ValueChanged<List<ActionEntry>> onChanged;
   final List<ActionEntry>? initial;
   final bool showPot;
@@ -11,6 +12,7 @@ class ActionListWidget extends StatefulWidget {
   const ActionListWidget({
     super.key,
     required this.playerCount,
+    required this.heroIndex,
     required this.onChanged,
     this.initial,
     this.showPot = false,
@@ -99,12 +101,16 @@ class _ActionListWidgetState extends State<ActionListWidget> {
         TextEditingController(text: entry.amount?.toString() ?? '');
     final labelController =
         TextEditingController(text: entry.customLabel ?? '');
+    final equityController =
+        TextEditingController(text: entry.equity?.toString() ?? '');
     return showDialog<ActionEntry>(
       context: context,
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setState) {
           final needAmount = act != 'fold';
           final needLabel = act == 'custom';
+          final needEquity =
+              player == widget.heroIndex && (act == 'call' || act == 'push');
           return AlertDialog(
             title: const Text('Edit action'),
             content: Column(
@@ -139,6 +145,15 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                     decoration: const InputDecoration(labelText: 'Amount'),
                   ),
                 ],
+                if (needEquity) ...[
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: equityController,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(labelText: 'Equity %'),
+                  ),
+                ],
                 if (needLabel) ...[
                   const SizedBox(height: 8),
                   TextField(
@@ -161,7 +176,10 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                         amount: needAmount
                             ? double.tryParse(amountController.text)
                             : null,
-                        customLabel: needLabel ? labelController.text : null),
+                        customLabel: needLabel ? labelController.text : null,
+                        equity: needEquity
+                            ? double.tryParse(equityController.text)
+                            : null),
                   );
                 },
                 child: const Text('OK'),
@@ -257,6 +275,15 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                           Text(
                             'Pot odds: ${a.potOdds!.toStringAsFixed(1)} %',
                             style: const TextStyle(color: Colors.white54, fontSize: 12),
+                          ),
+                        if (a.ev != null)
+                          Text(
+                            'EV: ${a.ev!.toStringAsFixed(2)} BB',
+                            style: TextStyle(
+                                color: a.ev! >= 0
+                                    ? Colors.lightGreenAccent
+                                    : Colors.redAccent,
+                                fontSize: 12),
                           ),
                       ],
                     ),

--- a/lib/widgets/street_hud_bar.dart
+++ b/lib/widgets/street_hud_bar.dart
@@ -4,8 +4,9 @@ class StreetHudBar extends StatelessWidget {
   final List<double> spr;
   final List<double> eff;
   final List<double?> potOdds;
+  final List<double?> ev;
   final int currentStreet;
-  const StreetHudBar({super.key, required this.spr, required this.eff, required this.potOdds, required this.currentStreet});
+  const StreetHudBar({super.key, required this.spr, required this.eff, required this.potOdds, required this.ev, required this.currentStreet});
 
   @override
   Widget build(BuildContext ctx) => Row(
@@ -16,12 +17,15 @@ class StreetHudBar extends StatelessWidget {
           final sprText = spr[i] <= 0 ? '–' : spr[i].toStringAsFixed(1);
           final po = potOdds[i];
           final poText = po == null ? '–' : '${po.toStringAsFixed(1)} %';
+          final evVal = ev[i];
+          final evText = evVal == null ? '–' : (evVal >= 0 ? '+' : '') + evVal.toStringAsFixed(2);
           return Column(children: [
             Text('$label', style: TextStyle(color: color)),
             Text('SPR: $sprText', style: TextStyle(color: color, fontSize: 12)),
             Text('Eff: ${eff[i].toStringAsFixed(1)}',
                 style: TextStyle(color: color, fontSize: 12)),
             Text('PO: $poText', style: TextStyle(color: color, fontSize: 12)),
+            Text('EV: $evText', style: TextStyle(color: color, fontSize: 12)),
           ]);
         }),
       );


### PR DESCRIPTION
## Summary
- extend `ActionEntry` with equity and EV fields
- compute EV of hero call/push actions in HandEditorScreen
- show EV in action list and HUD
- accept hero index in ActionListWidget to edit equity

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f799c454832a90d46a93d4416d20