### PR TITLE
UI: highlight hero actions by EV

### DIFF
--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -249,8 +249,15 @@ class _ActionListWidgetState extends State<ActionListWidget> {
           itemBuilder: (context, index) {
             final a = _actions[index];
             final isBlind = index < 2 && a.action == 'post';
-            final bg =
-                _errors[index] == null ? Colors.transparent : Colors.red.withOpacity(0.15);
+            final heroBg = (a.playerIndex == widget.heroIndex && a.ev != null)
+                ? (a.ev! >= 0
+                    ? Colors.green.withOpacity(0.1)
+                    : Colors.red.withOpacity(0.1))
+                : null;
+            final bg = heroBg ??
+                (_errors[index] == null
+                    ? Colors.transparent
+                    : Colors.red.withOpacity(0.15));
             return Container(
               key: ValueKey(a),
               color: bg,


### PR DESCRIPTION
## Summary
- highlight hero actions with a green/red background depending on EV value

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fac19218832ab10ea2ab5b9684b4