### PR TITLE
Add EV=0 equity hint

### DIFF
--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -116,9 +116,8 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                   final pa = entry.potAfter;
                   final po = entry.potOdds;
                   if (pa == 0 || po == null) return null;
-                  final tc = pa * po / 100;
-                  if (tc == 0) return null;
-                  return 100 * tc / pa;
+                  if (po == 0) return null;
+                  return 100 * po / (po + 100);
                 })()
               : null;
           return AlertDialog(


### PR DESCRIPTION
## Summary
- calculate EV=0 threshold from pot odds
- show EV=0 hint when editing hero call or push actions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fcf65230832abf1fb57e2f153aad