### PR TITLE
Implement EV=0 hint for hero actions

### DIFF
--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -116,8 +116,10 @@ class _ActionListWidgetState extends State<ActionListWidget> {
                   final pa = entry.potAfter;
                   final po = entry.potOdds;
                   if (pa == 0 || po == null) return null;
-                  if (po == 0) return null;
-                  return 100 * po / (po + 100);
+                  final pot = pa / (1 + po / 100);
+                  final tc = pa - pot;
+                  if (tc == 0) return null;
+                  return 100 * tc / pa;
                 })()
               : null;
           return AlertDialog(


### PR DESCRIPTION
## Summary
- compute equity threshold from pot amount and odds
- show EV=0 hint under equity field when editing hero calls or pushes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fde0a56c832aa503329e453646d1