### PR TITLE
Add default blinds for new hands

### DIFF
--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -51,10 +51,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
   int _heroIndex = 0;
   final List<String> _names = [];
   late List<double> _initialStacks;
-  List<ActionEntry> _preflopActions = [
-    ActionEntry(0, 0, 'post', amount: 1),
-    ActionEntry(0, 1, 'post', amount: 2),
-  ];
+  List<ActionEntry> _preflopActions = [];
   List<ActionEntry> _flopActions = [];
   List<ActionEntry> _turnActions = [];
   List<ActionEntry> _riverActions = [];

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -92,6 +92,14 @@ class _ActionListWidgetState extends State<ActionListWidget> {
   void initState() {
     super.initState();
     _actions = List<ActionEntry>.from(widget.initial ?? []);
+    if (_actions.isEmpty) {
+      _actions
+        ..add(ActionEntry(0, 0, 'post', amount: 0.5))
+        ..add(ActionEntry(0, 1, 'post', amount: 1.0));
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => widget.onChanged(List<ActionEntry>.from(_actions)),
+      );
+    }
     _recalcErrors();
   }
 


### PR DESCRIPTION
## Summary
- auto-create small/big blinds in `ActionListWidget`
- start new hands without predefined actions

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862351e0808832abdb8b6ed154b9ef9