### PR TITLE
Implement basic training pack template list

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -1,0 +1,12 @@
+class TrainingPackTemplate {
+  final String id;
+  String name;
+  TrainingPackTemplate({required this.id, required this.name});
+  TrainingPackTemplate copyWith({String? id, String? name}) {
+    return TrainingPackTemplate(id: id ?? this.id, name: name ?? this.name);
+  }
+  factory TrainingPackTemplate.fromJson(Map<String, dynamic> json) {
+    return TrainingPackTemplate(id: json['id'] as String? ?? '', name: json['name'] as String? ?? '');
+  }
+  Map<String, dynamic> toJson() => {'id': id, 'name': name};
+}

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../../models/v2/training_pack_template.dart';
+
+class TrainingPackTemplateEditorScreen extends StatelessWidget {
+  final TrainingPackTemplate template;
+  const TrainingPackTemplateEditorScreen({super.key, required this.template});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(template.name)),
+      body: const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+import '../../models/v2/training_pack_template.dart';
+import 'training_pack_template_editor_screen.dart';
+
+class TrainingPackTemplateListScreen extends StatefulWidget {
+  const TrainingPackTemplateListScreen({super.key});
+
+  @override
+  State<TrainingPackTemplateListScreen> createState() => _TrainingPackTemplateListScreenState();
+}
+
+class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateListScreen> {
+  final List<TrainingPackTemplate> _templates = [];
+
+  void _edit(TrainingPackTemplate template) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TrainingPackTemplateEditorScreen(template: template)),
+    );
+    setState(() {});
+  }
+
+  void _add() {
+    final template = TrainingPackTemplate(id: const Uuid().v4(), name: 'New Pack');
+    setState(() => _templates.add(template));
+    _edit(template);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Training Packs')),
+      body: ListView.builder(
+        itemCount: _templates.length,
+        itemBuilder: (context, index) {
+          final t = _templates[index];
+          return ListTile(
+            title: Text(t.name),
+            trailing: TextButton(
+              onPressed: () => _edit(t),
+              child: const Text('📝 Edit'),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _add,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal model `TrainingPackTemplate`
- implement blank `TrainingPackTemplateEditorScreen`
- show templates in new `TrainingPackTemplateListScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626a240ff0832a87f8c74e9e25af53