### PR TITLE
Persist TrainingPack templates

### DIFF
--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template.dart';
+
+class TrainingPackStorage {
+  static const _key = 'training_pack_templates';
+
+  static Future<List<TrainingPackTemplate>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return [];
+    final list = jsonDecode(raw) as List;
+    return [for (final m in list) TrainingPackTemplate.fromJson(m)];
+  }
+
+  static Future<void> save(List<TrainingPackTemplate> t) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode([for (final x in t) x.toJson()]));
+  }
+}

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 import '../../models/v2/training_pack_template.dart';
+import '../../helpers/training_pack_storage.dart';
 import 'training_pack_template_editor_screen.dart';
 
 class TrainingPackTemplateListScreen extends StatefulWidget {
@@ -12,6 +13,20 @@ class TrainingPackTemplateListScreen extends StatefulWidget {
 
 class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateListScreen> {
   final List<TrainingPackTemplate> _templates = [];
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loading = true;
+    TrainingPackStorage.load().then((list) {
+      if (!mounted) return;
+      setState(() {
+        _templates.addAll(list);
+        _loading = false;
+      });
+    });
+  }
 
   void _edit(TrainingPackTemplate template) async {
     await Navigator.push(
@@ -19,11 +34,13 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
       MaterialPageRoute(builder: (_) => TrainingPackTemplateEditorScreen(template: template)),
     );
     setState(() {});
+    TrainingPackStorage.save(_templates);
   }
 
   void _add() {
     final template = TrainingPackTemplate(id: const Uuid().v4(), name: 'New Pack');
     setState(() => _templates.add(template));
+    TrainingPackStorage.save(_templates);
     _edit(template);
   }
 
@@ -31,15 +48,52 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Training Packs')),
-      body: ListView.builder(
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
         itemCount: _templates.length,
         itemBuilder: (context, index) {
           final t = _templates[index];
           return ListTile(
             title: Text(t.name),
-            trailing: TextButton(
-              onPressed: () => _edit(t),
-              child: const Text('📝 Edit'),
+            subtitle: t.description.trim().isEmpty
+                ? null
+                : Text(
+                    t.description.split('\n').first,
+                    style: const TextStyle(fontSize: 12),
+                  ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextButton(
+                  onPressed: () => _edit(t),
+                  child: const Text('📝 Edit'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                  onPressed: () async {
+                    final ok = await showDialog<bool>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        title: const Text('Delete pack?'),
+                        content: Text('“${t.name}” will be removed.'),
+                        actions: [
+                          TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: const Text('Cancel')),
+                          TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: const Text('Delete')),
+                        ],
+                      ),
+                    );
+                    if (ok ?? false) {
+                      setState(() => _templates.removeAt(index));
+                      TrainingPackStorage.save(_templates);
+                    }
+                  },
+                ),
+              ],
             ),
           );
         },


### PR DESCRIPTION
## Summary
- store TrainingPack templates locally via `TrainingPackStorage`
- show description snippet in template list
- support editing and deleting templates with persistence

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626c48cccc832ab082bc79ff079d53