### PR TITLE
Add clear all spots action

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -58,12 +58,36 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     Navigator.pop(context);
   }
 
+  Future<void> _clearAll() async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Remove all spots from this template?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Remove')),
+        ],
+      ),
+    );
+    if (ok ?? false) {
+      setState(() => widget.template.spots.clear());
+      TrainingPackStorage.save(widget.templates);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Edit pack'),
-        actions: [IconButton(icon: const Icon(Icons.save), onPressed: _save)],
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_sweep),
+            tooltip: 'Clear All Spots',
+            onPressed: _clearAll,
+          ),
+          IconButton(icon: const Icon(Icons.save), onPressed: _save)
+        ],
       ),
       floatingActionButton:
           FloatingActionButton(onPressed: _addSpot, child: const Icon(Icons.add)),


### PR DESCRIPTION
## Summary
- add `Clear All Spots` action to training pack editor

## Testing
- `dart format -o none lib/screens/v2/training_pack_template_editor_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862793a5864832a8ab948977f089668