### PR TITLE
Add tags to preview card

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -36,6 +36,22 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
+          if (spot.tags.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Wrap(
+                spacing: 6,
+                children: [
+                  for (final tag in spot.tags)
+                    Chip(
+                      label: Text(
+                        tag,
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                    ),
+                ],
+              ),
+            ),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [


### PR DESCRIPTION
## Summary
- show tags in `TrainingPackSpotPreviewCard`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627b096958832a84ce99b7090585f6