### PR TITLE
Enable tag-based spot filtering

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -5,10 +5,12 @@ import '../../screens/v2/hand_editor_screen.dart';
 class TrainingPackSpotPreviewCard extends StatelessWidget {
   final TrainingPackSpot spot;
   final VoidCallback? onHandEdited;
+  final ValueChanged<String>? onTagTap;
   const TrainingPackSpotPreviewCard({
     super.key,
     required this.spot,
     this.onHandEdited,
+    this.onTagTap,
   });
 
   @override
@@ -43,11 +45,9 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                 spacing: 6,
                 children: [
                   for (final tag in spot.tags)
-                    Chip(
-                      label: Text(
-                        tag,
-                        style: const TextStyle(fontSize: 12),
-                      ),
+                    InputChip(
+                      label: Text(tag, style: const TextStyle(fontSize: 12)),
+                      onPressed: () => onTagTap?.call(tag.toLowerCase()),
                     ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- filter training pack editor spots by clicking tags
- highlight search field when a tag filter is active
- allow spot preview cards to emit tag taps

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686289e43e84832aaf542e718280c734