### PR TITLE
Add hero index selection to editor

### DIFF
--- a/lib/models/v2/hand_data.dart
+++ b/lib/models/v2/hand_data.dart
@@ -5,10 +5,12 @@ class HandData {
   Map<int, List<ActionEntry>> actions;
   String position;
   Map<String, double> stacks;
+  int heroIndex;
 
   HandData({
     this.heroCards = '',
     this.position = '',
+    this.heroIndex = 0,
     Map<int, List<ActionEntry>>? actions,
     Map<String, double>? stacks,
   })  : actions =
@@ -36,6 +38,7 @@ class HandData {
     return HandData(
       heroCards: j['heroCards'] as String? ?? '',
       position: j['position'] as String? ?? '',
+      heroIndex: j['heroIndex'] as int? ?? 0,
       actions: acts,
       stacks: Map<String, double>.from(j['stacks'] ?? {}),
     );
@@ -44,6 +47,7 @@ class HandData {
   Map<String, dynamic> toJson() => {
         'heroCards': heroCards,
         'position': position,
+        'heroIndex': heroIndex,
         if (actions.values.any((l) => l.isNotEmpty))
           'actions': {
             for (final kv in actions.entries)

--- a/lib/screens/v2/hand_editor_screen.dart
+++ b/lib/screens/v2/hand_editor_screen.dart
@@ -99,6 +99,23 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
               onChanged: onChanged,
             ),
             const SizedBox(height: 16),
+            Row(
+              children: [
+                const Text('Hero index'),
+                const SizedBox(width: 16),
+                DropdownButton<int>(
+                  value: widget.spot.hand.heroIndex,
+                  items: [for (int i = 0; i < 6; i++) DropdownMenuItem(value: i, child: Text('$i'))],
+                  onChanged: (v) => setState(() => widget.spot.hand.heroIndex = v ?? 0),
+                ),
+                const SizedBox(width: 8),
+                const Tooltip(
+                  message: '0 — SB, 1 — BB, 2 — UTG, 3 — MP, 4 — CO, 5 — BTN',
+                  child: Icon(Icons.info_outline, size: 16, color: Colors.white54),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
             DropdownButton<int>(
               value: _street,
               items: [
@@ -111,7 +128,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
             Expanded(
               child: ActionListWidget(
                 playerCount: 6,
-                heroIndex: 0,
+                heroIndex: widget.spot.hand.heroIndex,
                 initial: widget.spot.hand.actions[_street],
                 onChanged: (list) => widget.spot.hand.actions[_street] = list,
               ),


### PR DESCRIPTION
## Summary
- add `heroIndex` property to `HandData`
- let users choose hero index in `HandEditorScreen`
- forward hero index to `ActionListWidget`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628e8aa820832a86d5c82076d7c13e