### PR TITLE
Add player count option in hand editor

### DIFF
--- a/lib/models/v2/hand_data.dart
+++ b/lib/models/v2/hand_data.dart
@@ -6,15 +6,16 @@ class HandData {
   String position;
   Map<String, double> stacks;
   int heroIndex;
+  int playerCount;
 
   HandData({
     this.heroCards = '',
     this.position = '',
     this.heroIndex = 0,
+    this.playerCount = 6,
     Map<int, List<ActionEntry>>? actions,
     Map<String, double>? stacks,
-  })  : actions =
-            actions ?? {for (var s = 0; s < 4; s++) s: <ActionEntry>[]},
+  })  : actions = actions ?? {for (var s = 0; s < 4; s++) s: <ActionEntry>[]},
         stacks = stacks ?? {};
 
   factory HandData.fromJson(Map<String, dynamic> j) {
@@ -39,6 +40,7 @@ class HandData {
       heroCards: j['heroCards'] as String? ?? '',
       position: j['position'] as String? ?? '',
       heroIndex: j['heroIndex'] as int? ?? 0,
+      playerCount: j['playerCount'] as int? ?? 6,
       actions: acts,
       stacks: Map<String, double>.from(j['stacks'] ?? {}),
     );
@@ -48,6 +50,7 @@ class HandData {
         'heroCards': heroCards,
         'position': position,
         'heroIndex': heroIndex,
+        'playerCount': playerCount,
         if (actions.values.any((l) => l.isNotEmpty))
           'actions': {
             for (final kv in actions.entries)

--- a/lib/screens/v2/hand_editor_screen.dart
+++ b/lib/screens/v2/hand_editor_screen.dart
@@ -75,7 +75,10 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
         leading: IconButton(
             icon: const Icon(Icons.arrow_back),
             onPressed: () => Navigator.pop(context)),
-        actions: [IconButton(icon: const Icon(Icons.save), onPressed: () => _save(context))],
+        actions: [
+          IconButton(
+              icon: const Icon(Icons.save), onPressed: () => _save(context))
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -101,17 +104,50 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
             const SizedBox(height: 16),
             Row(
               children: [
+                const Text('Player count'),
+                const SizedBox(width: 16),
+                DropdownButton<int>(
+                  value: widget.spot.hand.playerCount,
+                  items: [
+                    for (int i = 2; i <= 9; i++)
+                      DropdownMenuItem(value: i, child: Text('$i'))
+                  ],
+                  onChanged: (v) {
+                    if (v == null) return;
+                    setState(() {
+                      widget.spot.hand.playerCount = v;
+                      if (widget.spot.hand.heroIndex >= v) {
+                        widget.spot.hand.heroIndex = 0;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              content: Text(
+                                  'Hero index выходит за пределы — сброшен в 0')),
+                        );
+                      }
+                    });
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
                 const Text('Hero index'),
                 const SizedBox(width: 16),
                 DropdownButton<int>(
                   value: widget.spot.hand.heroIndex,
-                  items: [for (int i = 0; i < 6; i++) DropdownMenuItem(value: i, child: Text('$i'))],
-                  onChanged: (v) => setState(() => widget.spot.hand.heroIndex = v ?? 0),
+                  items: [
+                    for (int i = 0; i < widget.spot.hand.playerCount; i++)
+                      DropdownMenuItem(value: i, child: Text('$i'))
+                  ],
+                  onChanged: (v) =>
+                      setState(() => widget.spot.hand.heroIndex = v ?? 0),
                 ),
                 const SizedBox(width: 8),
                 const Tooltip(
                   message: '0 — SB, 1 — BB, 2 — UTG, 3 — MP, 4 — CO, 5 — BTN',
-                  child: Icon(Icons.info_outline, size: 16, color: Colors.white54),
+                  child:
+                      Icon(Icons.info_outline, size: 16, color: Colors.white54),
                 ),
               ],
             ),
@@ -127,7 +163,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
             const SizedBox(height: 8),
             Expanded(
               child: ActionListWidget(
-                playerCount: 6,
+                playerCount: widget.spot.hand.playerCount,
                 heroIndex: widget.spot.hand.heroIndex,
                 initial: widget.spot.hand.actions[_street],
                 onChanged: (list) => widget.spot.hand.actions[_street] = list,
@@ -139,4 +175,3 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- store player count in `HandData`
- allow editing player count in `HandEditorScreen`
- use the configured player count in `ActionListWidget`

## Testing
- `dart format lib/models/v2/hand_data.dart lib/screens/v2/hand_editor_screen.dart`
- `flutter pub get` *(passed)*
- `flutter test` *(failed: missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68628fdcde18832a86165fdd1d2c0fb4