### PR TITLE
Add EV border highlight for training pack cards

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -30,6 +30,9 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
       }
     }
     final double? heroEv = heroAct?.ev;
+    final borderColor = heroEv == null
+        ? Colors.grey
+        : (heroEv >= 0 ? Colors.green : Colors.red);
 
     final String? heroLabel = heroAct == null
         ? null
@@ -44,12 +47,17 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
           if (a.action == 'board' && a.customLabel?.isNotEmpty == true)
             ...a.customLabel!.split(' ')
     ];
-    return Card(
-      margin: EdgeInsets.zero,
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: borderColor, width: 1.5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Card(
+        margin: EdgeInsets.zero,
+        elevation: 2,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(


### PR DESCRIPTION
## Summary
- highlight TrainingPackSpotPreviewCard by hero EV

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a247cdc0832a93d8744f5f500be3