### PR TITLE
Add EV badge to training pack spot preview

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -33,6 +33,12 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
     final borderColor = heroEv == null
         ? Colors.grey
         : (heroEv >= 0 ? Colors.green : Colors.red);
+    final badgeColor = heroEv == null
+        ? Colors.grey
+        : (heroEv >= 0 ? Colors.green : Colors.red);
+    final badgeText = heroEv == null
+        ? '--'
+        : '${heroEv >= 0 ? '+' : ''}${heroEv.toStringAsFixed(1)} BB';
 
     final String? heroLabel = heroAct == null
         ? null
@@ -67,6 +73,21 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                   child: Text(
                     spot.title.isEmpty ? 'Untitled spot' : spot.title,
                     style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: badgeColor,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    badgeText,
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold),
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- show EV badge with hero first-street EV on TrainingPackSpotPreviewCard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8482118832a966ae238e31115ea