### PR TITLE
Add select all and invert selection

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -243,6 +243,19 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   Future<void> _bulkMove() => _bulkTransfer(true);
   Future<void> _bulkCopy() => _bulkTransfer(false);
 
+  void _selectAll() {
+    setState(() {
+      _selectedSpotIds
+        ..clear()
+        ..addAll(widget.template.spots.map((e) => e.id));
+    });
+  }
+
+  void _invertSelection() {
+    final all = widget.template.spots.map((e) => e.id).toSet();
+    setState(() => _selectedSpotIds = all.difference(_selectedSpotIds));
+  }
+
   Future<void> _renameTag() async {
     final tags = widget.template.spots.expand((s) => s.tags).toSet().toList()
       ..sort((a, b) => a.compareTo(b));
@@ -399,6 +412,16 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
           ? BottomAppBar(
               child: Row(
                 children: [
+                  TextButton(
+                    onPressed: _selectAll,
+                    child: const Text('Select All'),
+                  ),
+                  const SizedBox(width: 12),
+                  TextButton(
+                    onPressed: _invertSelection,
+                    child: const Text('Invert Selection'),
+                  ),
+                  const SizedBox(width: 12),
                   TextButton(
                     onPressed: _bulkAddTag,
                     child: const Text('Add Tag'),


### PR DESCRIPTION
## Summary
- add functions to select all spots and invert selection
- add Select All and Invert Selection buttons to the multi-select bar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c8f5e960832a9ca88970c9f46977