### PR TITLE
Implement game type filter

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -4,12 +4,14 @@ class TrainingPackTemplate {
   final String id;
   String name;
   String description;
+  String gameType;
   List<TrainingPackSpot> spots;
 
   TrainingPackTemplate({
     required this.id,
     required this.name,
     this.description = '',
+    this.gameType = 'tournament',
     List<TrainingPackSpot>? spots,
   }) : spots = spots ?? [];
 
@@ -17,12 +19,14 @@ class TrainingPackTemplate {
     String? id,
     String? name,
     String? description,
+    String? gameType,
     List<TrainingPackSpot>? spots,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
       name: name ?? this.name,
       description: description ?? this.description,
+      gameType: gameType ?? this.gameType,
       spots: spots ?? List<TrainingPackSpot>.from(this.spots),
     );
   }
@@ -32,6 +36,7 @@ class TrainingPackTemplate {
       id: json['id'] as String? ?? '',
       name: json['name'] as String? ?? '',
       description: json['description'] as String? ?? '',
+      gameType: json['gameType'] as String? ?? 'tournament',
       spots: [
         for (final s in (json['spots'] as List? ?? []))
           TrainingPackSpot.fromJson(Map<String, dynamic>.from(s))
@@ -43,6 +48,7 @@ class TrainingPackTemplate {
         'id': id,
         'name': name,
         'description': description,
+        'gameType': gameType,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
       };
 }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -23,7 +23,7 @@ class TemplateLibraryScreen extends StatefulWidget {
 }
 
 class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
-  static const _key = 'template_filter_game_type';
+  static const _key = 'lib_game_type';
   static const _sortKey = 'lib_sort';
   final TextEditingController _searchCtrl = TextEditingController();
   String _filter = 'all';
@@ -151,10 +151,27 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     visible = _applySorting(visible);
     return Scaffold(
       appBar: AppBar(
-        title: TextField(
-          controller: _searchCtrl,
-          decoration: const InputDecoration(hintText: 'Поиск', border: InputBorder.none),
-          style: const TextStyle(color: Colors.white),
+        title: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _searchCtrl,
+                decoration: const InputDecoration(hintText: 'Поиск', border: InputBorder.none),
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
+            const SizedBox(width: 8),
+            DropdownButton<String>(
+              value: _filter,
+              underline: const SizedBox.shrink(),
+              onChanged: (v) => v != null ? _setFilter(v) : null,
+              items: const [
+                DropdownMenuItem(value: 'all', child: Text('All')),
+                DropdownMenuItem(value: 'tournament', child: Text('Tournament')),
+                DropdownMenuItem(value: 'cash', child: Text('Cash')),
+              ],
+            ),
+          ],
         ),
         actions: [
           PopupMenuButton<String>(
@@ -171,19 +188,6 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       ),
       body: Column(
         children: [
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: DropdownButton<String>(
-              value: _filter,
-              underline: const SizedBox.shrink(),
-              onChanged: (v) => v != null ? _setFilter(v) : null,
-              items: const [
-                DropdownMenuItem(value: 'all', child: Text('Все')),
-                DropdownMenuItem(value: 'tournament', child: Text('Tournament')),
-                DropdownMenuItem(value: 'cash', child: Text('Cash')),
-              ],
-            ),
-          ),
           Expanded(
             child: ListView.builder(
               itemCount: visible.length,


### PR DESCRIPTION
## Summary
- add gameType to v2 TrainingPackTemplate model
- move game type filter into TemplateLibraryScreen AppBar and persist via `lib_game_type`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6862e219ff68832aa73131de0fa9cadc