### PR TITLE
Add training session flow

### DIFF
--- a/lib/screens/session_summary_screen.dart
+++ b/lib/screens/session_summary_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class SessionSummaryScreen extends StatelessWidget {
+  final int total;
+  final int correct;
+  const SessionSummaryScreen({super.key, required this.total, required this.correct});
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = total == 0 ? 0 : correct * 100 / total;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Session Summary')),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('$correct / $total',
+                style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Text('Accuracy: ${accuracy.toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/training_session_service.dart';
+import '../widgets/spot_quiz_widget.dart';
+import 'session_summary_screen.dart';
+
+class TrainingSessionScreen extends StatelessWidget {
+  const TrainingSessionScreen({super.key});
+
+  void _submit(BuildContext context, bool correct) {
+    final service = context.read<TrainingSessionService>();
+    final spot = service.currentSpot!;
+    service.submitResult(spot.id, correct);
+    final next = service.nextSpot();
+    if (next == null) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => SessionSummaryScreen(
+            total: service.totalCount,
+            correct: service.correctCount,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<TrainingSessionService>(
+      builder: (context, service, _) {
+        final spot = service.currentSpot;
+        if (spot == null) {
+          return const Scaffold(
+            backgroundColor: Color(0xFF1B1C1E),
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('Training Session')),
+          backgroundColor: const Color(0xFF1B1C1E),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Expanded(child: SpotQuizWidget(spot: spot)),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => _submit(context, true),
+                      child: const Text('✅ Correct'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _submit(context, false),
+                      child: const Text('❌ Mistake'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -16,6 +16,10 @@ class TrainingSessionService extends ChangeNotifier {
           ? _spots[_session!.index]
           : null;
 
+  Map<String, bool> get results => _session?.results ?? {};
+  int get correctCount => results.values.where((e) => e).length;
+  int get totalCount => results.length;
+
   Future<void> _openBox() async {
     if (!Hive.isBoxOpen('sessions')) {
       await Hive.initFlutter();

--- a/lib/widgets/spot_quiz_widget.dart
+++ b/lib/widgets/spot_quiz_widget.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+import '../models/action_entry.dart';
+
+class SpotQuizWidget extends StatelessWidget {
+  final TrainingPackSpot spot;
+  const SpotQuizWidget({super.key, required this.spot});
+
+  @override
+  Widget build(BuildContext context) {
+    final hero = spot.hand.heroCards;
+    final pos = spot.hand.position;
+    final h = spot.hand.heroIndex;
+    final pre = spot.hand.actions[0] ?? [];
+    ActionEntry? heroAct;
+    for (final a in pre) {
+      if (a.playerIndex == h) {
+        heroAct = a;
+        break;
+      }
+    }
+    final double? heroEv = heroAct?.ev;
+    final borderColor = heroEv == null
+        ? Colors.grey
+        : (heroEv >= 0 ? Colors.green : Colors.red);
+    final badgeColor = heroEv == null
+        ? Colors.grey
+        : (heroEv >= 0 ? Colors.green : Colors.red);
+    final badgeText = heroEv == null
+        ? '--'
+        : '${heroEv >= 0 ? '+' : ''}${heroEv.toStringAsFixed(1)} BB';
+
+    final String? heroLabel = heroAct == null
+        ? null
+        : (heroAct.customLabel?.isNotEmpty == true
+            ? heroAct.customLabel!
+            : '${heroAct.action}${heroAct.amount != null && heroAct.amount! > 0 ? ' ${heroAct.amount!.toStringAsFixed(1)} BB' : ''}');
+    final legacy = hero.isEmpty && spot.note.trim().isNotEmpty;
+    final actions = spot.hand.actions;
+    final board = [
+      for (final street in [1, 2, 3])
+        for (final a in actions[street] ?? [])
+          if (a.action == 'board' && a.customLabel?.isNotEmpty == true)
+            ...a.customLabel!.split(' ')
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: borderColor, width: 1.5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Card(
+        margin: EdgeInsets.zero,
+        elevation: 2,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  if (spot.pinned) const Text('📌 '),
+                  Expanded(
+                    child: Text(
+                      spot.title.isEmpty ? 'Untitled spot' : spot.title,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: badgeColor,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      badgeText,
+                      style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+              if (hero.isNotEmpty || pos != HeroPosition.unknown || legacy)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    legacy ? '(legacy)' : '$hero ${pos.label}'.trim(),
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+              if (heroLabel != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    heroLabel.length > 40 ? heroLabel.substring(0, 40) : heroLabel,
+                    style: const TextStyle(fontSize: 14, fontStyle: FontStyle.italic),
+                  ),
+                ),
+              if (board.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Wrap(
+                    spacing: 6,
+                    children: [for (final c in board) Text(c)],
+                  ),
+                ),
+              if (heroEv != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    heroEv >= 0
+                        ? '+${heroEv.toStringAsFixed(2)} BB EV'
+                        : '${heroEv.toStringAsFixed(2)} BB EV',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: heroEv >= 0 ? Colors.greenAccent : Colors.redAccent,
+                    ),
+                  ),
+                ),
+              if (spot.tags.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Wrap(
+                    spacing: 6,
+                    children: [
+                      for (final tag in spot.tags)
+                        InputChip(
+                          label: Text(tag, style: const TextStyle(fontSize: 12)),
+                          onPressed: () {},
+                        ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SpotQuizWidget` for spot display
- add `TrainingSessionScreen` with correct/mistake buttons
- add `SessionSummaryScreen` to show totals
- expose results info in `TrainingSessionService`

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e59eabb8832ab74bcace032b8246