### PR TITLE
Add Train button to template library

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,6 +203,7 @@ Future<void> main() async {
             packs: context.read<TrainingPackStorageService>(),
           ),
         ),
+        ChangeNotifierProvider(create: (_) => TrainingSessionService()),
         Provider(create: (_) => EvaluationExecutorService()),
         ChangeNotifierProvider(create: (_) => UserActionLogger()..load()),
       ],

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -9,6 +9,8 @@ import 'package:file_picker/file_picker.dart';
 import '../helpers/color_utils.dart';
 import '../services/template_storage_service.dart';
 import '../models/training_pack_template.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
 import 'create_pack_from_template_screen.dart';
 import 'create_template_screen.dart';
 import 'template_hands_editor_screen.dart';
@@ -203,6 +205,17 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     title: Text(t.name),
                     subtitle: Text(
                         '${t.category ?? 'Без категории'} • ${t.hands.length} рук • v$version'),
+                    trailing: TextButton(
+                      onPressed: () {
+                        context.read<TrainingSessionService>().startSession(t);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const TrainingSessionScreen()),
+                        );
+                      },
+                      child: const Text('▶️ Train'),
+                    ),
                     onTap: () async {
                       final create = await showDialog<bool>(
                         context: context,


### PR DESCRIPTION
## Summary
- provide `TrainingSessionService` globally
- add `▶️ Train` button in `TemplateLibraryScreen` to start training sessions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e71642dc832a804fdddacdff6c94