### PR TITLE
Add progress indicator in training session

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -89,6 +89,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
             padding: const EdgeInsets.all(16),
             child: Column(
               children: [
+                Align(
+                  alignment: Alignment.center,
+                  child: Text(
+                    '${(service.session?.index ?? 0) + 1} / ${service.totalCount}',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+                const SizedBox(height: 8),
                 Expanded(child: SpotQuizWidget(spot: spot)),
                 if (_selected == null) ...[
                   const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- display session progress indicator above the current spot

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686309286d1c832ab5708b091906b727