### PR TITLE
Add session result summary screen

### DIFF
--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -3,11 +3,19 @@ import 'package:flutter/material.dart';
 class SessionResultScreen extends StatelessWidget {
   final int total;
   final int correct;
-  const SessionResultScreen({super.key, required this.total, required this.correct});
+  final Duration elapsed;
+  const SessionResultScreen({super.key, required this.total, required this.correct, required this.elapsed});
+
+  String _format(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
 
   @override
   Widget build(BuildContext context) {
-    final accuracy = total == 0 ? 0 : correct * 100 / total;
+    final rate = total == 0 ? 0 : correct * 100 / total;
     return Scaffold(
       appBar: AppBar(title: const Text('Session Result')),
       backgroundColor: const Color(0xFF1B1C1E),
@@ -18,12 +26,15 @@ class SessionResultScreen extends StatelessWidget {
             Text('$correct / $total',
                 style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            Text('Accuracy: ${accuracy.toStringAsFixed(1)}%',
+            Text('Accuracy: ${rate.toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 8),
+            Text('Time: ${_format(elapsed)}',
                 style: const TextStyle(color: Colors.white70)),
             const SizedBox(height: 24),
             ElevatedButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Close'),
+              onPressed: () => Navigator.of(context).popUntil((r) => r.isFirst),
+              child: const Text('Done'),
             ),
           ],
         ),

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -66,6 +66,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
           builder: (_) => SessionResultScreen(
             total: service.totalCount,
             correct: service.correctCount,
+            elapsed: service.elapsedTime,
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- show SessionResultScreen after finishing a training session
- display elapsed time along with score and accuracy
- provide Done button to return home

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863104b88c0832aacaa5a7172be96e3