### PR TITLE
Add training action logging

### DIFF
--- a/lib/models/v2/training_action.dart
+++ b/lib/models/v2/training_action.dart
@@ -1,0 +1,28 @@
+class TrainingAction {
+  final String spotId;
+  final String chosenAction;
+  final bool isCorrect;
+  final DateTime timestamp;
+
+  TrainingAction({
+    required this.spotId,
+    required this.chosenAction,
+    required this.isCorrect,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  factory TrainingAction.fromJson(Map<String, dynamic> j) => TrainingAction(
+        spotId: j['spotId'] as String? ?? '',
+        chosenAction: j['chosenAction'] as String? ?? '',
+        isCorrect: j['isCorrect'] as bool? ?? false,
+        timestamp:
+            DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'spotId': spotId,
+        'chosenAction': chosenAction,
+        'isCorrect': isCorrect,
+        'timestamp': timestamp.toIso8601String(),
+      };
+}

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -50,7 +50,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final expected = _expectedAction(spot);
     final ok =
         expected != null && action.toLowerCase() == expected.toLowerCase();
-    service.submitResult(spot.id, ok);
+    service.submitResult(spot.id, action, ok);
     setState(() {
       _selected = action;
       _correct = ok;


### PR DESCRIPTION
## Summary
- track chosen actions for training spots
- persist the log of actions in active session storage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686312e88fc0832aa6e8963b955743e2