### PR TITLE
Add retry mistakes feature

### DIFF
--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -46,6 +46,7 @@ class TrainingSessionService extends ChangeNotifier {
   int get correctCount => results.values.where((e) => e).length;
   int get totalCount => results.length;
   List<TrainingAction> get actionLog => List.unmodifiable(_actions);
+  List<TrainingPackSpot> get spots => List.unmodifiable(_spots);
 
   Future<void> _openBox() async {
     if (!Hive.isBoxOpen('sessions')) {


### PR DESCRIPTION
## Summary
- expose training session spots for reuse
- allow retrying missed spots from session results

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863150e3ca8832aa3f5549725c4531c