### PR TITLE
Add accuracy chart to session result

### DIFF
--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_session_service.dart';
 import '../widgets/training_action_log_dialog.dart';
+import '../widgets/common/action_accuracy_chart.dart';
 import '../theme/app_colors.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
@@ -88,6 +89,8 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
                 ],
               ),
             ),
+            const SizedBox(height: 16),
+            ActionAccuracyChart(actions: actions),
             const SizedBox(height: 16),
             Expanded(
               child: actions.isEmpty

--- a/lib/widgets/common/action_accuracy_chart.dart
+++ b/lib/widgets/common/action_accuracy_chart.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../theme/app_colors.dart';
+import '../../models/v2/training_action.dart';
+
+class ActionAccuracyChart extends StatelessWidget {
+  final List<TrainingAction> actions;
+
+  const ActionAccuracyChart({super.key, required this.actions});
+
+  @override
+  Widget build(BuildContext context) {
+    if (actions.length < 2) {
+      return const SizedBox.shrink();
+    }
+
+    final spots = <FlSpot>[];
+    int correct = 0;
+    for (var i = 0; i < actions.length; i++) {
+      if (actions[i].isCorrect) correct++;
+      final acc = correct * 100 / (i + 1);
+      spots.add(FlSpot(i.toDouble(), acc));
+    }
+    final step = (actions.length / 6).ceil();
+    final line = LineChartBarData(
+      spots: spots,
+      isCurved: true,
+      color: Theme.of(context).colorScheme.secondary,
+      barWidth: 2,
+      dotData: FlDotData(show: false),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        height: 200,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: 20,
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: Colors.white24, strokeWidth: 1),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 20,
+                  reservedSize: 30,
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 1,
+                  getTitlesWidget: (value, meta) {
+                    final index = value.toInt();
+                    if (index < 0 || index >= actions.length) {
+                      return const SizedBox.shrink();
+                    }
+                    if (index % step != 0 && index != actions.length - 1) {
+                      return const SizedBox.shrink();
+                    }
+                    return Text(
+                      '${index + 1}',
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: const Border(
+                left: BorderSide(color: Colors.white24),
+                bottom: BorderSide(color: Colors.white24),
+              ),
+            ),
+            lineBarsData: [line],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show cumulative accuracy trend in session result view
- draw line chart of action log accuracy

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631624d64c832a8ebba3eef059719c