### PR TITLE
Add share spot dialog

### DIFF
--- a/lib/widgets/share_dialog.dart
+++ b/lib/widgets/share_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+
+class ShareDialog extends StatelessWidget {
+  final String text;
+  const ShareDialog({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Share Spot'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: SelectableText(text, style: const TextStyle(color: Colors.white)),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Clipboard.setData(ClipboardData(text: text));
+            Navigator.pop(context);
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Copied to clipboard')),
+            );
+          },
+          child: const Text('Copy'),
+        ),
+        TextButton(
+          onPressed: () => Share.share(text),
+          child: const Text('Share'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showShareDialog(BuildContext context, String text) {
+  return showDialog(
+    context: context,
+    builder: (_) => ShareDialog(text: text),
+  );
+}


### PR DESCRIPTION
## Summary
- share dialog with copy and share actions
- view spot dialog now supports sharing formatted summary

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631edf8cd8832a8b7f9af8760f4d86