### PR TITLE
Quick spot notes editing

### DIFF
--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -193,6 +193,17 @@ class TrainingSessionService extends ChangeNotifier {
     return currentSpot;
   }
 
+  Future<void> updateSpot(TrainingPackSpot spot) async {
+    final index = _spots.indexWhere((s) => s.id == spot.id);
+    if (index == -1) return;
+    _spots[index] = spot;
+    if (_session != null) {
+      await _box?.put(_session!.id, _session!.toJson());
+      _saveActive();
+    }
+    notifyListeners();
+  }
+
   @override
   void dispose() {
     _timer?.cancel();


### PR DESCRIPTION
## Summary
- allow spot notes editing from SpotViewerDialog
- expose `updateSpot` in session service
- add note button to action logs
- link spot notes editing inside action log dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686320842e18832a8e9ee308101166f7