### PR TITLE
Implement spot title normalization

### DIFF
--- a/lib/helpers/title_utils.dart
+++ b/lib/helpers/title_utils.dart
@@ -1,0 +1,17 @@
+String normalizeSpotTitle(String title) {
+  final words = title.trim().split(RegExp(r'\s+'));
+  final result = <String>[];
+  for (final w in words) {
+    if (w.isEmpty) continue;
+    final lower = w.toLowerCase();
+    if (lower == 'vs') {
+      result.add('vs');
+    } else if (w.length <= 2) {
+      result.add(w.toUpperCase());
+    } else {
+      result.add(lower[0].toUpperCase() + lower.substring(1));
+    }
+  }
+  return result.join(' ');
+}
+

--- a/lib/screens/v2/training_pack_spot_editor_screen.dart
+++ b/lib/screens/v2/training_pack_spot_editor_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../helpers/training_pack_storage.dart';
+import '../../helpers/title_utils.dart';
 
 class TrainingPackSpotEditorScreen extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -36,6 +37,7 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
   @override
   void initState() {
     super.initState();
+    widget.spot.title = normalizeSpotTitle(widget.spot.title);
     _titleCtr = TextEditingController(text: widget.spot.title);
     _noteCtr = TextEditingController(text: widget.spot.note);
   }
@@ -48,7 +50,10 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
   }
 
   Future<void> _save() async {
-    if (widget.spot.title.trim().isEmpty) {
+    final normalized = normalizeSpotTitle(_titleCtr.text);
+    widget.spot.title = normalized;
+    _titleCtr.text = normalized;
+    if (widget.spot.title.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Title is required')));
       return;
     }

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../helpers/training_pack_storage.dart';
+import '../../helpers/title_utils.dart';
 import '../../models/v2/hand_data.dart';
 import 'training_pack_spot_editor_screen.dart';
 import '../../widgets/v2/training_pack_spot_preview_card.dart';
@@ -47,7 +48,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   String? _highlightId;
 
   void _addSpot() async {
-    final spot = TrainingPackSpot(id: const Uuid().v4(), title: 'New spot');
+    final spot = TrainingPackSpot(
+      id: const Uuid().v4(),
+      title: normalizeSpotTitle('New spot'),
+    );
     setState(() => widget.template.spots.add(spot));
     TrainingPackStorage.save(widget.templates);
     await Navigator.push(

--- a/tests/title_utils_test.dart
+++ b/tests/title_utils_test.dart
@@ -1,0 +1,12 @@
+import 'package:test/test.dart';
+import 'package:poker_ai_analyzer/helpers/title_utils.dart';
+
+void main() {
+  group('normalizeSpotTitle', () {
+    test('formats title correctly', () {
+      expect(normalizeSpotTitle('  hero bb vs sb  '), 'Hero BB vs SB');
+      expect(normalizeSpotTitle('utg  vs  bb'), 'UTG vs BB');
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- normalize spot titles via `normalizeSpotTitle`
- auto-normalize on spot editor init and save
- create spots with normalized default title
- add unit tests for normalization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863253f2974832a9799a830bda2227b