### PR TITLE
Update spot editedAt on tag/note changes

### DIFF
--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -91,7 +91,8 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
       ),
     );
     if (res != null) {
-      final updated = spot.copyWith(note: res.trim());
+      final updated =
+          spot.copyWith(note: res.trim(), editedAt: DateTime.now());
       await context.read<TrainingSessionService>().updateSpot(updated);
     }
   }

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -102,7 +102,8 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
       ),
     );
     if (result != null) {
-      final updated = spot.copyWith(note: result.trim());
+      final updated =
+          spot.copyWith(note: result.trim(), editedAt: DateTime.now());
       await context.read<TrainingSessionService>().updateSpot(updated);
       setState(() => spot = updated);
     }
@@ -153,7 +154,8 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
       ),
     );
     if (result != null) {
-      final updated = spot.copyWith(tags: result);
+      final updated =
+          spot.copyWith(tags: result, editedAt: DateTime.now());
       await context.read<TrainingSessionService>().updateSpot(updated);
       if (!mounted) return;
       setState(() => spot = updated);

--- a/lib/widgets/training_action_log_dialog.dart
+++ b/lib/widgets/training_action_log_dialog.dart
@@ -83,7 +83,8 @@ class TrainingActionLogDialog extends StatelessWidget {
                               },
                             );
                             if (res != null) {
-                              final updated = spot!.copyWith(note: res.trim());
+                              final updated = spot!
+                                  .copyWith(note: res.trim(), editedAt: DateTime.now());
                               await context.read<TrainingSessionService>().updateSpot(updated);
                             }
                           },


### PR DESCRIPTION
## Summary
- refresh editedAt on spot note edits in session result screen
- refresh editedAt on spot note edits in training action log
- refresh editedAt on spot note/tag edits in spot viewer dialog

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686326b15428832aa5d987dbec1b9339