### PR TITLE
Add pinned label to editor cards

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -58,111 +58,135 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
         border: Border.all(color: borderColor, width: 1.5),
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Card(
-        margin: EdgeInsets.zero,
-        elevation: 2,
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                if (spot.pinned) const Text('📌 '),
-                Expanded(
-                  child: Text(
-                    spot.title.isEmpty ? 'Untitled spot' : spot.title,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                  decoration: BoxDecoration(
-                    color: badgeColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    badgeText,
-                    style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 12,
-                        fontWeight: FontWeight.bold),
-                  ),
-                ),
-              ],
-            ),
-          if (hero.isNotEmpty || pos != HeroPosition.unknown || legacy)
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Text(
-                legacy ? '(legacy)' : '$hero ${pos.label}'.trim(),
-                style: const TextStyle(fontSize: 16),
-              ),
-            ),
-          if (heroLabel != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                heroLabel.length > 40 ? heroLabel.substring(0, 40) : heroLabel,
-                style: const TextStyle(fontSize: 14, fontStyle: FontStyle.italic),
-              ),
-            ),
-          if (board.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Wrap(
-                spacing: 6,
-                children: [for (final c in board) Text(c)],
-              ),
-            ),
-          if (heroEv != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                heroEv >= 0
-                    ? '+${heroEv.toStringAsFixed(2)} BB EV'
-                    : '${heroEv.toStringAsFixed(2)} BB EV',
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: heroEv >= 0 ? Colors.greenAccent : Colors.redAccent,
-                ),
-              ),
-            ),
-          if (spot.tags.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Wrap(
-                spacing: 6,
+      child: Stack(
+        children: [
+          Card(
+            margin: EdgeInsets.zero,
+            elevation: 2,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  for (final tag in spot.tags)
-                    InputChip(
-                      label: Text(tag, style: const TextStyle(fontSize: 12)),
-                      onPressed: () => onTagTap?.call(tag.toLowerCase()),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          spot.title.isEmpty ? 'Untitled spot' : spot.title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: badgeColor,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          badgeText,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (hero.isNotEmpty || pos != HeroPosition.unknown || legacy)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        legacy ? '(legacy)' : '$hero ${pos.label}'.trim(),
+                        style: const TextStyle(fontSize: 16),
+                      ),
                     ),
+                  if (heroLabel != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        heroLabel.length > 40 ? heroLabel.substring(0, 40) : heroLabel,
+                        style: const TextStyle(fontSize: 14, fontStyle: FontStyle.italic),
+                      ),
+                    ),
+                  if (board.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Wrap(
+                        spacing: 6,
+                        children: [for (final c in board) Text(c)],
+                      ),
+                    ),
+                  if (heroEv != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        heroEv >= 0
+                            ? '+${heroEv.toStringAsFixed(2)} BB EV'
+                            : '${heroEv.toStringAsFixed(2)} BB EV',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: heroEv >= 0 ? Colors.greenAccent : Colors.redAccent,
+                        ),
+                      ),
+                    ),
+                  if (spot.tags.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Wrap(
+                        spacing: 6,
+                        children: [
+                          for (final tag in spot.tags)
+                            InputChip(
+                              label: Text(tag, style: const TextStyle(fontSize: 12)),
+                              onPressed: () => onTagTap?.call(tag.toLowerCase()),
+                            ),
+                        ],
+                      ),
+                    ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () async {
+                          await Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (_) => HandEditorScreen(spot: spot)),
+                          );
+                          onHandEdited?.call();
+                        },
+                        child: const Text('✏️ Edit Hand'),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () async {
-                  await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (_) => HandEditorScreen(spot: spot)),
-                  );
-                  onHandEdited?.call();
-                },
-                child: const Text('✏️ Edit Hand'),
-              ),
-            ],
           ),
+          if (spot.pinned)
+            Positioned(
+              top: 4,
+              right: 4,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.orange,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: const Text(
+                  '📌 Pinned',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
-    ),
-  );
+    );
   }
 }


### PR DESCRIPTION
## Summary
- show pinned `📌 Pinned` label on training pack spot cards in the editor

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632f81a4d4832ab3d384473d8e9a7f