### PR TITLE
Implement EV sorting update

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -74,7 +74,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       context,
       MaterialPageRoute(builder: (_) => TrainingPackSpotEditorScreen(spot: spot)),
     );
-    setState(() {});
+    setState(() {
+      if (_autoSortEv) _sortSpots();
+    });
     TrainingPackStorage.save(widget.templates);
   }
 
@@ -715,6 +717,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         child: InkWell(
                           onTap: () async {
                             await showSpotViewerDialog(context, spot);
+                            if (_autoSortEv) setState(() => _sortSpots());
                             _focusSpot(spot.id);
                           },
                           onLongPress: () => setState(() => _selectedSpotIds.add(spot.id)),
@@ -797,7 +800,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                             context,
                                             MaterialPageRoute(builder: (_) => TrainingPackSpotEditorScreen(spot: spot)),
                                           );
-                                          setState(() {});
+                                          setState(() {
+                                            if (_autoSortEv) _sortSpots();
+                                          });
                                           TrainingPackStorage.save(widget.templates);
                                         },
                                         child: const Text('📝 Edit'),


### PR DESCRIPTION
## Summary
- auto sort spots by EV after editing them or returning from spot editor

## Testing
- `flutter format lib/screens/v2/training_pack_template_editor_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686330b48388832ab7ccd4d88ef0d345