### PR TITLE
Add mistakes filter checkbox

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -651,6 +651,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         prefs.setString(_prefsEvFilterKey, val);
                       },
                     ),
+                    CheckboxListTile(
+                      title: const Text('Filter: Mistakes only'),
+                      value: _evFilter == 'mistakes',
+                      onChanged: (v) async {
+                        final prefs = await SharedPreferences.getInstance();
+                        final val = v == true ? 'mistakes' : 'all';
+                        setState(() => _evFilter = val);
+                        prefs.setString(_prefsEvFilterKey, val);
+                      },
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding: EdgeInsets.zero,
+                    ),
                   ],
                 );
               },


### PR DESCRIPTION
## Summary
- add a checkbox to quickly filter mistakes in TrainingPackTemplateEditorScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863319b02dc832a8d09be8b3e74f56f