### PR TITLE
Add search by title/tag

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -604,7 +604,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               child: TextField(
                 controller: _searchCtrl,
                 decoration: InputDecoration(
-                  labelText: 'Search by tag or title',
+                  labelText: 'Search by title/tag',
                   prefixIcon: const Icon(Icons.search),
                   fillColor: _tagFilter == null ? null : Colors.yellow[50],
                   filled: _tagFilter != null,


### PR DESCRIPTION
## Summary
- update text to "Search by title/tag" on training pack template editor

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686333d3cb8c832a8219293d5ac7a5db