### PR TITLE
Add playtest button

### DIFF
--- a/lib/models/v2/training_session.dart
+++ b/lib/models/v2/training_session.dart
@@ -1,3 +1,6 @@
+import 'package:uuid/uuid.dart';
+import 'training_pack_template.dart';
+
 class TrainingSession {
   final String id;
   final String templateId;
@@ -5,6 +8,7 @@ class TrainingSession {
   DateTime? completedAt;
   int index;
   final Map<String, bool> results;
+  final bool authorPreview;
 
   TrainingSession({
     required this.id,
@@ -13,6 +17,7 @@ class TrainingSession {
     this.completedAt,
     this.index = 0,
     Map<String, bool>? results,
+    this.authorPreview = false,
   })  : startedAt = startedAt ?? DateTime.now(),
         results = results ?? {};
 
@@ -28,6 +33,7 @@ class TrainingSession {
         results: j['results'] != null
             ? Map<String, bool>.from(j['results'] as Map)
             : {},
+        authorPreview: j['authorPreview'] == true,
       );
 
   Map<String, dynamic> toJson() => {
@@ -37,5 +43,16 @@ class TrainingSession {
         if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
         'index': index,
         if (results.isNotEmpty) 'results': results,
+        if (authorPreview) 'authorPreview': true,
       };
+
+  factory TrainingSession.fromTemplate(
+    TrainingPackTemplate template, {
+    bool authorPreview = false,
+  }) =>
+      TrainingSession(
+        id: const Uuid().v4(),
+        templateId: template.id,
+        authorPreview: authorPreview,
+      );
 }

--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -16,7 +16,14 @@ class SessionResultScreen extends StatefulWidget {
   final int total;
   final int correct;
   final Duration elapsed;
-  const SessionResultScreen({super.key, required this.total, required this.correct, required this.elapsed});
+  final bool authorPreview;
+  const SessionResultScreen({
+    super.key,
+    required this.total,
+    required this.correct,
+    required this.elapsed,
+    this.authorPreview = false,
+  });
 
   @override
   State<SessionResultScreen> createState() => _SessionResultScreenState();
@@ -191,8 +198,9 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
                   ),
                   const SizedBox(height: 8),
                   ElevatedButton(
-                    onPressed: () =>
-                        Navigator.of(context).popUntil((r) => r.isFirst),
+                    onPressed: () => widget.authorPreview
+                        ? Navigator.pop(context)
+                        : Navigator.of(context).popUntil((r) => r.isFirst),
                     child: const Text('Done'),
                   ),
                 ],

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -67,6 +67,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
             total: service.totalCount,
             correct: service.correctCount,
             elapsed: service.elapsedTime,
+            authorPreview: service.session?.authorPreview ?? false,
           ),
         ),
       );

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -9,6 +9,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:archive/archive.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'dart:ui' as ui;
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
@@ -18,6 +19,8 @@ import '../../models/v2/hand_data.dart';
 import 'training_pack_spot_editor_screen.dart';
 import '../../widgets/v2/training_pack_spot_preview_card.dart';
 import '../../widgets/spot_viewer_dialog.dart';
+import '../../services/training_session_service.dart';
+import '../training_session_screen.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
 
@@ -670,6 +673,19 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
           IconButton(icon: const Icon(Icons.upload), onPressed: _import),
           IconButton(icon: const Icon(Icons.download), onPressed: _export),
           IconButton(icon: const Icon(Icons.archive), onPressed: _exportBundle),
+          IconButton(
+            onPressed: () async {
+              await context
+                  .read<TrainingSessionService>()
+                  .startSession(widget.template, persist: false);
+              await Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const TrainingSessionScreen()),
+              );
+            },
+            icon: const Text('▶️ Playtest'),
+          ),
           IconButton(icon: const Icon(Icons.save), onPressed: _save)
         ],
       ),


### PR DESCRIPTION
## Summary
- add author preview support in `TrainingSession`
- allow ephemeral sessions in `TrainingSessionService`
- show playtest results without leaving editor
- add Playtest button in template editor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633c0e9528832aa872bb3f641db000