### PR TITLE
Add duplicate option to template menu

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -306,11 +306,16 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
                             PopupMenuButton<String>(
                               onSelected: (v) {
                                 if (v == 'rename') _rename(t);
+                                if (v == 'duplicate') _duplicate(t);
                               },
                               itemBuilder: (_) => const [
                                 PopupMenuItem(
                                   value: 'rename',
                                   child: Text('✏️ Rename'),
+                                ),
+                                PopupMenuItem(
+                                  value: 'duplicate',
+                                  child: Text('📄 Duplicate'),
                                 ),
                               ],
                             ),


### PR DESCRIPTION
## Summary
- add "📄 Duplicate" popup menu item in TrainingPackTemplateListScreen

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634534f088832a8f8e02526b643a3a