### PR TITLE
Add template tags

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -8,6 +8,7 @@ class TrainingPackTemplate {
   String description;
   GameType gameType;
   List<TrainingPackSpot> spots;
+  List<String> tags;
 
   TrainingPackTemplate({
     required this.id,
@@ -15,7 +16,9 @@ class TrainingPackTemplate {
     this.description = '',
     this.gameType = GameType.tournament,
     List<TrainingPackSpot>? spots,
-  }) : spots = spots ?? [];
+    List<String>? tags,
+  })  : spots = spots ?? [],
+        tags = tags ?? [];
 
   TrainingPackTemplate copyWith({
     String? id,
@@ -23,6 +26,7 @@ class TrainingPackTemplate {
     String? description,
     GameType? gameType,
     List<TrainingPackSpot>? spots,
+    List<String>? tags,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -30,6 +34,7 @@ class TrainingPackTemplate {
       description: description ?? this.description,
       gameType: gameType ?? this.gameType,
       spots: spots ?? List<TrainingPackSpot>.from(this.spots),
+      tags: tags ?? List<String>.from(this.tags),
     );
   }
 
@@ -43,6 +48,7 @@ class TrainingPackTemplate {
         for (final s in (json['spots'] as List? ?? []))
           TrainingPackSpot.fromJson(Map<String, dynamic>.from(s))
       ],
+      tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
     );
   }
 
@@ -52,5 +58,6 @@ class TrainingPackTemplate {
         'description': description,
         'gameType': gameType.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
+        if (tags.isNotEmpty) 'tags': tags,
       };
 }

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -95,6 +95,25 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     TrainingPackStorage.save(widget.templates);
   }
 
+  Future<void> _addPackTag() async {
+    final c = TextEditingController();
+    final tag = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Add Tag'),
+        content: TextField(controller: c, autofocus: true),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context, c.text.trim()), child: const Text('OK')),
+        ],
+      ),
+    );
+    c.dispose();
+    if (tag == null || tag.isEmpty) return;
+    setState(() => widget.template.tags.add(tag));
+    TrainingPackStorage.save(widget.templates);
+  }
+
   void _saveName() {
     final value = _nameCtr.text.trim();
     if (value.isEmpty) return;
@@ -850,6 +869,24 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                 setState(() => widget.template.description = v);
                 TrainingPackStorage.save(widget.templates);
               },
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final tag in widget.template.tags)
+                  InputChip(
+                    label: Text(tag),
+                    onDeleted: () {
+                      setState(() => widget.template.tags.remove(tag));
+                      TrainingPackStorage.save(widget.templates);
+                    },
+                  ),
+                InputChip(
+                  label: const Text('+ Add'),
+                  onPressed: _addPackTag,
+                ),
+              ],
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<GameType>(

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -111,6 +111,7 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
       id: const Uuid().v4(),
       name: '${template.name} (copy)',
       description: template.description,
+      tags: List<String>.from(template.tags),
       spots: [
         for (final s in template.spots)
           s.copyWith(


### PR DESCRIPTION
## Summary
- support tags in `TrainingPackTemplate` model
- copy template tags when duplicating
- manage template tags in template editor UI

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686345d6364c832a90a96230fe560500