### PR TITLE
feat: show EV histogram in pack summary

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -64,6 +64,14 @@ class TrainingPackSpot {
         if (pinned) 'pinned': true,
       };
 
+  double? get heroEv {
+    final acts = hand.actions[0] ?? [];
+    for (final a in acts) {
+      if (a.playerIndex == hand.heroIndex && a.ev != null) return a.ev;
+    }
+    return null;
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -506,16 +506,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     final spots = widget.template.spots;
     final total = spots.length;
     final tags = spots.expand((s) => s.tags).toList();
-    final heroEvs = <double>[];
-    for (final s in spots) {
-      final acts = s.hand.actions[0] ?? [];
-      for (final a in acts) {
-        if (a.playerIndex == s.hand.heroIndex && a.ev != null) {
-          heroEvs.add(a.ev!);
-          break;
-        }
-      }
-    }
+    final heroEvs = [for (final s in spots) if (s.heroEv != null) s.heroEv!];
     final uniqueTags = tags.toSet();
     final counts = <String, int>{};
     for (final t in tags) {


### PR DESCRIPTION
## Summary
- compute hero EV for each spot with a new getter
- use hero EV list to render `EvDistributionChart` in the template summary

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638d846ab4832a8221991cb3bc3614