### PR TITLE
Add spot duplicate button

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1398,7 +1398,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                       }),
                                     ),
                                   Expanded(
-                                    child: TrainingPackSpotPreviewCard(
+                                  child: TrainingPackSpotPreviewCard(
                                       spot: spot,
                                       onHandEdited: () {
                                         setState(() {
@@ -1407,6 +1407,19 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                         TrainingPackStorage.save(widget.templates);
                                       },
                                       onTagTap: (tag) => setState(() => _tagFilter = tag),
+                                      onDuplicate: () {
+                                        final i = widget.template.spots.indexOf(spot);
+                                        if (i == -1) return;
+                                        final copy = spot.copyWith(
+                                          id: const Uuid().v4(),
+                                          editedAt: DateTime.now(),
+                                          hand: HandData.fromJson(spot.hand.toJson()),
+                                          tags: List.from(spot.tags),
+                                        );
+                                        setState(() => widget.template.spots.insert(i + 1, copy));
+                                        TrainingPackStorage.save(widget.templates);
+                                        _focusSpot(copy.id);
+                                      },
                                     ),
                                   ),
                                   const SizedBox(width: 8),

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -8,11 +8,13 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
   final TrainingPackSpot spot;
   final VoidCallback? onHandEdited;
   final ValueChanged<String>? onTagTap;
+  final VoidCallback? onDuplicate;
   const TrainingPackSpotPreviewCard({
     super.key,
     required this.spot,
     this.onHandEdited,
     this.onTagTap,
+    this.onDuplicate,
   });
 
   @override
@@ -168,7 +170,7 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                     ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
+                  children: [
                       TextButton(
                         onPressed: () async {
                           await Navigator.push(
@@ -178,6 +180,11 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                           onHandEdited?.call();
                         },
                         child: const Text('✏️ Edit Hand'),
+                      ),
+                      const SizedBox(width: 8),
+                      TextButton(
+                        onPressed: onDuplicate,
+                        child: const Text('📄 Duplicate'),
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- add `onDuplicate` callback to `TrainingPackSpotPreviewCard`
- show `📄 Duplicate` button next to `✏️ Edit Hand`
- implement duplication logic in `TrainingPackTemplateEditorScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391896e0c832a918ba21b18f1e09f