### PR TITLE
Add seed training packs

### DIFF
--- a/lib/data/seed_packs.dart
+++ b/lib/data/seed_packs.dart
@@ -1,0 +1,268 @@
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hand_data.dart';
+import '../models/v2/hero_position.dart';
+import '../models/game_type.dart';
+import '../models/action_entry.dart';
+
+final List<TrainingPackTemplate> seedPacks = [
+  TrainingPackTemplate(
+    id: 'sb_vs_bb_10bb',
+    name: 'SB vs BB 10bb',
+    gameType: GameType.tournament,
+    spots: [
+      TrainingPackSpot(
+        id: 'sb10_1',
+        title: 'A9o push',
+        hand: HandData(
+          heroCards: 'As 9d',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: {'0': 10, '1': 10},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 10),
+              ActionEntry(0, 1, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'sb10_2',
+        title: 'Q6s fold',
+        hand: HandData(
+          heroCards: 'Qs 6s',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: {'0': 10, '1': 10},
+          actions: {
+            0: [ActionEntry(0, 0, 'fold')]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'sb10_3',
+        title: '22 push call',
+        hand: HandData(
+          heroCards: '2c 2d',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: {'0': 10, '1': 10},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 10),
+              ActionEntry(0, 1, 'call', amount: 9.5),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'sb10_4',
+        title: 'J9s push',
+        hand: HandData(
+          heroCards: 'Jh 9h',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: {'0': 10, '1': 10},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 10),
+              ActionEntry(0, 1, 'fold'),
+            ]
+          },
+        ),
+      ),
+    ],
+  ),
+  TrainingPackTemplate(
+    id: 'co_vs_btn_12bb',
+    name: 'CO vs BTN 12bb',
+    gameType: GameType.tournament,
+    spots: [
+      TrainingPackSpot(
+        id: 'co12_1',
+        title: 'KJo push',
+        hand: HandData(
+          heroCards: 'Kh Jd',
+          position: HeroPosition.co,
+          heroIndex: 0,
+          playerCount: 3,
+          stacks: {'0': 12, '1': 12, '2': 12},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 12),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'co12_2',
+        title: 'A8s push call',
+        hand: HandData(
+          heroCards: 'Ah 8h',
+          position: HeroPosition.co,
+          heroIndex: 0,
+          playerCount: 3,
+          stacks: {'0': 12, '1': 12, '2': 12},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 12),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'call', amount: 11.5),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'co12_3',
+        title: '55 push',
+        hand: HandData(
+          heroCards: '5s 5d',
+          position: HeroPosition.co,
+          heroIndex: 0,
+          playerCount: 3,
+          stacks: {'0': 12, '1': 12, '2': 12},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 12),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'co12_4',
+        title: 'JTo fold',
+        hand: HandData(
+          heroCards: 'Jh Td',
+          position: HeroPosition.co,
+          heroIndex: 0,
+          playerCount: 3,
+          stacks: {'0': 12, '1': 12, '2': 12},
+          actions: {
+            0: [ActionEntry(0, 0, 'fold')]
+          },
+        ),
+      ),
+    ],
+  ),
+  TrainingPackTemplate(
+    id: 'hj_vs_table_8bb',
+    name: 'HJ vs Table 8bb',
+    gameType: GameType.tournament,
+    spots: [
+      TrainingPackSpot(
+        id: 'hj8_1',
+        title: 'A5s push call',
+        hand: HandData(
+          heroCards: 'Ad 5d',
+          position: HeroPosition.mp,
+          heroIndex: 0,
+          playerCount: 6,
+          stacks: {
+            '0': 8,
+            '1': 8,
+            '2': 8,
+            '3': 8,
+            '4': 8,
+            '5': 8
+          },
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 8),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'fold'),
+              ActionEntry(0, 3, 'fold'),
+              ActionEntry(0, 4, 'call', amount: 7.5),
+              ActionEntry(0, 5, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'hj8_2',
+        title: '77 push',
+        hand: HandData(
+          heroCards: '7h 7c',
+          position: HeroPosition.mp,
+          heroIndex: 0,
+          playerCount: 6,
+          stacks: {
+            '0': 8,
+            '1': 8,
+            '2': 8,
+            '3': 8,
+            '4': 8,
+            '5': 8
+          },
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 8),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'fold'),
+              ActionEntry(0, 3, 'fold'),
+              ActionEntry(0, 4, 'fold'),
+              ActionEntry(0, 5, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'hj8_3',
+        title: 'KQs push',
+        hand: HandData(
+          heroCards: 'Ks Qs',
+          position: HeroPosition.mp,
+          heroIndex: 0,
+          playerCount: 6,
+          stacks: {
+            '0': 8,
+            '1': 8,
+            '2': 8,
+            '3': 8,
+            '4': 8,
+            '5': 8
+          },
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 8),
+              ActionEntry(0, 1, 'fold'),
+              ActionEntry(0, 2, 'fold'),
+              ActionEntry(0, 3, 'fold'),
+              ActionEntry(0, 4, 'fold'),
+              ActionEntry(0, 5, 'fold'),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: 'hj8_4',
+        title: 'T9s fold',
+        hand: HandData(
+          heroCards: 'Td 9d',
+          position: HeroPosition.mp,
+          heroIndex: 0,
+          playerCount: 6,
+          stacks: {
+            '0': 8,
+            '1': 8,
+            '2': 8,
+            '3': 8,
+            '4': 8,
+            '5': 8
+          },
+          actions: {
+            0: [ActionEntry(0, 0, 'fold')]
+          },
+        ),
+      ),
+    ],
+  ),
+];

--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/v2/training_pack_template.dart';
+import '../data/seed_packs.dart';
 
 class TrainingPackStorage {
   static const _key = 'training_pack_templates';
@@ -9,8 +10,9 @@ class TrainingPackStorage {
   static Future<List<TrainingPackTemplate>> load() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_key);
-    if (raw == null) return [];
+    if (raw == null) return List<TrainingPackTemplate>.from(seedPacks);
     final list = jsonDecode(raw) as List;
+    if (list.isEmpty) return List<TrainingPackTemplate>.from(seedPacks);
     return [for (final m in list) TrainingPackTemplate.fromJson(m)];
   }
 


### PR DESCRIPTION
## Summary
- provide built-in tournament seed packs with push/fold spots
- fallback to seed packs when no templates saved

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a18ac950832a94aea3f0331b789e