### PR TITLE
Add push EV computation and filter UI

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1536,17 +1536,20 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         prefs.setString(_prefsEvFilterKey, val);
                       },
                     ),
-                    CheckboxListTile(
-                      title: const Text('Filter: Mistakes only'),
-                      value: _evFilter == 'mistakes',
+                    DropdownButtonFormField<String>(
+                      value: _evFilter,
+                      decoration: const InputDecoration(labelText: 'EV filter'),
+                      items: const [
+                        DropdownMenuItem(value: 'all', child: Text('All')),
+                        DropdownMenuItem(value: 'mistakes', child: Text('Mistakes only')),
+                        DropdownMenuItem(value: 'profitable', child: Text('Profitable only')),
+                      ],
                       onChanged: (v) async {
                         final prefs = await SharedPreferences.getInstance();
-                        final val = v == true ? 'mistakes' : 'all';
+                        final val = v ?? 'all';
                         setState(() => _evFilter = val);
                         prefs.setString(_prefsEvFilterKey, val);
                       },
-                      controlAffinity: ListTileControlAffinity.leading,
-                      contentPadding: EdgeInsets.zero,
                     ),
                   ],
                 );

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -4,6 +4,7 @@ import '../models/v2/hand_data.dart';
 import '../models/v2/hero_position.dart';
 import '../models/action_entry.dart';
 import '../models/game_type.dart';
+import 'push_fold_ev_service.dart';
 
 class PackGeneratorService {
   static const _ranks = [
@@ -78,6 +79,7 @@ class PackGeneratorService {
     required List<int> playerStacksBb,
     required HeroPosition heroPos,
     required List<String> heroRange,
+    int anteBb = 0,
   }) async {
     return generatePushFoldPackSync(
       id: id,
@@ -86,6 +88,7 @@ class PackGeneratorService {
       playerStacksBb: playerStacksBb,
       heroPos: heroPos,
       heroRange: heroRange,
+      anteBb: anteBb,
     );
   }
 
@@ -96,6 +99,7 @@ class PackGeneratorService {
     required List<int> playerStacksBb,
     required HeroPosition heroPos,
     required List<String> heroRange,
+    int anteBb = 0,
   }) {
     final spots = <TrainingPackSpot>[];
     for (var i = 0; i < heroRange.length; i++) {
@@ -108,6 +112,13 @@ class PackGeneratorService {
             ActionEntry(0, j, 'fold'),
         ]
       };
+      final ev = computePushEV(
+        heroBbStack: heroBbStack,
+        bbCount: playerStacksBb.length,
+        heroHand: hand,
+        anteBb: anteBb,
+      );
+      actions[0]![0].ev = ev;
       final stacks = {
         for (var j = 0; j < playerStacksBb.length; j++)
           '$j': playerStacksBb[j].toDouble()

--- a/lib/services/push_fold_ev_service.dart
+++ b/lib/services/push_fold_ev_service.dart
@@ -1,0 +1,19 @@
+import 'pack_generator_service.dart';
+
+final Map<String, double> _equity = {
+  for (int i = 0; i < PackGeneratorService.handRanking.length; i++)
+    PackGeneratorService.handRanking[i]:
+        0.85 - i * (0.55 / (PackGeneratorService.handRanking.length - 1))
+};
+
+double computePushEV({
+  required int heroBbStack,
+  required int bbCount,
+  required String heroHand,
+  required int anteBb,
+}) {
+  final eq = _equity[heroHand] ?? 0.5;
+  final pot = bbCount * anteBb + 1.5;
+  final bet = heroBbStack.toDouble();
+  return eq * pot - (1 - eq) * bet;
+}

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -34,13 +34,13 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
     final double? heroEv = heroAct?.ev;
     final borderColor = heroEv == null
         ? Colors.grey
-        : (heroEv >= 0 ? Colors.green : Colors.red);
-    final badgeColor = heroEv == null
-        ? Colors.grey
-        : (heroEv >= 0 ? Colors.green : Colors.red);
+        : (heroEv.abs() <= 0.01
+            ? Colors.grey
+            : (heroEv > 0 ? Colors.green : Colors.red));
+    final badgeColor = borderColor;
     final badgeText = heroEv == null
-        ? '--'
-        : '${heroEv >= 0 ? '+' : ''}${heroEv.toStringAsFixed(1)} BB';
+        ? ''
+        : '${heroEv > 0 ? '+' : ''}${heroEv.toStringAsFixed(1)}';
 
     final String? heroLabel = heroAct == null
         ? null
@@ -82,22 +82,25 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                           style: const TextStyle(fontWeight: FontWeight.bold),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: badgeColor,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          badgeText,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 12,
-                            fontWeight: FontWeight.bold,
+                      if (heroEv != null) ...[
+                        const SizedBox(width: 8),
+                        Container(
+                          key: const ValueKey('evBadge'),
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: badgeColor,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            badgeText,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                   if (hero.isNotEmpty || pos != HeroPosition.unknown || legacy)

--- a/test/services/push_fold_ev_service_test.dart
+++ b/test/services/push_fold_ev_service_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/services/push_fold_ev_service.dart';
+
+void main() {
+  test('AA push EV positive', () {
+    final ev = computePushEV(heroBbStack: 10, bbCount: 2, heroHand: 'AA', anteBb: 0);
+    expect(ev, greaterThan(0.8));
+  });
+
+  test('72o push EV negative', () {
+    final ev = computePushEV(heroBbStack: 10, bbCount: 2, heroHand: '72o', anteBb: 0);
+    expect(ev, lessThan(-5));
+  });
+}

--- a/test/widgets/training_pack_ev_badge_test.dart
+++ b/test/widgets/training_pack_ev_badge_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
+import 'package:poker_ai_analyzer/models/v2/hero_position.dart';
+import 'package:poker_ai_analyzer/widgets/v2/training_pack_spot_preview_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('badge colors reflect EV', (tester) async {
+    final tpl = PackGeneratorService.generatePushFoldPackSync(
+      id: 't',
+      name: 't',
+      heroBbStack: 10,
+      playerStacksBb: [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: ['A8s', 'Q4o'],
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: [
+          for (final s in tpl.spots) TrainingPackSpotPreviewCard(spot: s),
+        ],
+      ),
+    ));
+    await tester.pump();
+    final badges = tester.widgetList<Container>(find.byKey(const ValueKey('evBadge'))).toList();
+    expect((badges.first.decoration as BoxDecoration).color, Colors.green);
+    expect((badges.last.decoration as BoxDecoration).color, Colors.red);
+  });
+}


### PR DESCRIPTION
## Summary
- implement push EV calculator and integrate with pack generator
- color-coded EV badge for pack preview cards
- EV filter dropdown with 'Profitable only'
- tests for push EV logic and badge colors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863af10408c832a82d9265ceca30e7f