### PR TITLE
Add BB call hint in generator

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -259,6 +259,13 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
                     max: 100,
                     onChanged: (v) => setState(() => bbCall = v),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      'In SB vs BB, hands from top ${bbCall.round()}% will call instead of fold. This does not affect EV.',
+                      style: const TextStyle(fontSize: 12, fontStyle: FontStyle.italic, color: Colors.white54),
+                    ),
+                  ),
                   const SizedBox(height: 8),
                   Align(
                     alignment: Alignment.centerLeft,


### PR DESCRIPTION
## Summary
- show explanatory hint below BB-call slider in pack generator

## Testing
- `dart format lib/screens/v2/training_pack_template_list_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d9a554e8832a994c8156555de7bb