### PR TITLE
Add pushfold tag to generator

### DIFF
--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -146,6 +146,7 @@ class PackGeneratorService {
             stacks: stacks,
             actions: actions,
           ),
+          tags: const ['pushfold'],
         ),
       );
     }

--- a/test/services/pack_generator_service_test.dart
+++ b/test/services/pack_generator_service_test.dart
@@ -42,6 +42,7 @@ void main() {
       expect(s.hand.heroCards.isNotEmpty, isTrue);
       expect(s.hand.actions[0]?.first.action, 'push');
       expect(s.hand.actions[0]?.length, 2);
+      expect(s.tags.contains('pushfold'), isTrue);
     }
   });
 


### PR DESCRIPTION
## Summary
- add `'pushfold'` tag to each spot generated in `PackGeneratorService`
- verify tag in pack generator unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa2e5e3c832a8de079add9c67cf5