### PR TITLE
Add EV indicator in template list

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -584,9 +584,20 @@ class _TrainingPackTemplateListScreenState extends State<TrainingPackTemplateLis
                     },
                     itemBuilder: (context, index) {
                       final t = shown[index];
+                      final allEv = t.spots.isNotEmpty &&
+                          t.spots.every((s) => s.heroEv != null);
                       final tile = ListTile(
                         onLongPress: () => _duplicate(t),
-                        title: Text(t.name),
+                        title: Row(
+                          children: [
+                            Expanded(child: Text(t.name)),
+                            if (allEv)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Icon(Icons.trending_up, color: Colors.grey, size: 16),
+                              ),
+                          ],
+                        ),
                         subtitle: t.description.trim().isEmpty
                             ? null
                             : Text(


### PR DESCRIPTION
## Summary
- show EV icon in training pack template list when all spots contain EV values

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fb44025c832aba2e1ce61c568099