### PR TITLE
Add pack export to CSV

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -33,6 +33,7 @@ import '../../widgets/ev_summary_card.dart';
 import '../../theme/app_colors.dart';
 import '../../services/room_hand_history_importer.dart';
 import '../../services/push_fold_ev_service.dart';
+import '../../services/pack_export_service.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
 
@@ -457,6 +458,21 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Не удалось поделиться пакетом')),
       );
+    }
+  }
+
+  Future<void> _exportCsv() async {
+    try {
+      final file = await PackExportService.exportToCsv(widget.template);
+      if (!mounted) return;
+      await Share.shareXFiles([XFile(file.path)]);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('CSV exported')));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Export failed: $e')));
+      }
     }
   }
 
@@ -1450,10 +1466,12 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             onSelected: (v) {
               if (v == 'regenEv') _regenerateEv();
               if (v == 'regenIcm') _regenerateIcm();
+              if (v == 'exportCsv') _exportCsv();
             },
             itemBuilder: (_) => const [
               PopupMenuItem(value: 'regenEv', child: Text('Regenerate EV')),
               PopupMenuItem(value: 'regenIcm', child: Text('Regenerate ICM')),
+              PopupMenuItem(value: 'exportCsv', child: Text('Export CSV')),
             ],
           ),
           IconButton(

--- a/lib/services/pack_export_service.dart
+++ b/lib/services/pack_export_service.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/v2/training_pack_template.dart';
+
+class PackExportService {
+  static Future<File> exportToCsv(TrainingPackTemplate tpl) async {
+    final rows = <List<dynamic>>[
+      ['Title', 'HeroPosition', 'HeroHand', 'StackBB', 'EV_BB', 'ICM_EV', 'Tags'],
+    ];
+    for (final spot in tpl.spots) {
+      final hand = spot.hand;
+      rows.add([
+        spot.title,
+        hand.position.label,
+        hand.heroCards,
+        hand.stacks['${hand.heroIndex}']?.toString() ?? '',
+        spot.heroEv?.toStringAsFixed(1) ?? '',
+        spot.heroIcmEv?.toStringAsFixed(3) ?? '',
+        spot.tags.join('|'),
+      ]);
+    }
+    final csvStr = const ListToCsvConverter().convert(rows);
+    final dir = await getTemporaryDirectory();
+    final base = _toSnakeCase(tpl.name);
+    var path = '${dir.path}/$base.csv';
+    if (await File(path).exists()) {
+      path = '${dir.path}/$base_${DateTime.now().millisecondsSinceEpoch}.csv';
+    }
+    final file = File(path);
+    await file.writeAsString(csvStr);
+    return file;
+  }
+
+  static String _toSnakeCase(String input) {
+    final snake = input
+        .replaceAll(RegExp(r'[^A-Za-z0-9]+'), '_')
+        .replaceAll(RegExp('_+'), '_')
+        .toLowerCase();
+    return snake.startsWith('_') ? snake.substring(1) : snake;
+  }
+}

--- a/test/services/pack_export_service_test.dart
+++ b/test/services/pack_export_service_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_ai_analyzer/services/pack_export_service.dart';
+import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
+import 'package:poker_ai_analyzer/models/v2/hero_position.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exportToCsv returns file with rows and columns', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    final tpl = PackGeneratorService.generatePushFoldPackSync(
+      id: 't',
+      name: 'Test Pack',
+      heroBbStack: 10,
+      playerStacksBb: [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: ['AA', 'KK', 'QQ'],
+    );
+    final file = await PackExportService.exportToCsv(tpl);
+    final lines = await file.readAsLines();
+    expect(lines.length, 4);
+    expect(lines.first.split(',').length, 7);
+    await dir.delete(recursive: true);
+  });
+}

--- a/test/widgets/export_csv_button_test.dart
+++ b/test/widgets/export_csv_button_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
+import 'package:poker_ai_analyzer/models/v2/hero_position.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+}
+
+class _FakeSharePlatform extends SharePlatform {
+  bool shared = false;
+  @override
+  Future<void> shareXFiles(List<XFile> files, {String? text, String? subject, ShareOptions? sharePositionOrigin}) async {
+    shared = true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Export CSV triggers share', (tester) async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    final share = _FakeSharePlatform();
+    SharePlatform.instance = share;
+    final tpl = PackGeneratorService.generatePushFoldPackSync(
+      id: 't',
+      name: 'Test',
+      heroBbStack: 10,
+      playerStacksBb: [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: ['AA'],
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Export CSV'));
+    await tester.pumpAndSettle();
+    expect(share.shared, true);
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `PackExportService.exportToCsv`
- hook CSV export into template editor
- cover CSV export with tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686401071e38832abca141d6529f3d1f