### PR TITLE
Implement CSV import for training packs

### DIFF
--- a/test/services/pack_import_service_test.dart
+++ b/test/services/pack_import_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/services/pack_import_service.dart';
+
+void main() {
+  test('importFromCsv parses rows', () {
+    const csv = 'Title,HeroPosition,HeroHand,StackBB,EV_BB,ICM_EV,Tags\n'
+        'A,SB,AA,10,0.8,1.234,foo|bar\n'
+        'B,BB,KK,10,,0.1,baz\n'
+        'C,CO,22,8,,,';
+    final tpl = PackImportService.importFromCsv(
+      csv: csv,
+      templateId: 't',
+      templateName: 'Test',
+    );
+    expect(tpl.spots.length, 3);
+    expect(tpl.spots.first.heroEv, 0.8);
+    expect(tpl.spots.first.tags.contains('imported'), true);
+  });
+}

--- a/test/widgets/import_csv_button_test.dart
+++ b/test/widgets/import_csv_button_test.dart
@@ -1,0 +1,72 @@
+import 'dart:typed_data';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_list_screen.dart';
+
+class _FakeFilePicker extends FilePicker {
+  _FakeFilePicker(this.result);
+  final FilePickerResult result;
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    bool allowCompression = false,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async {
+    return result;
+  }
+
+  @override
+  Future<List<String>?> pickFileAndDirectoryPaths({
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+  }) async => null;
+
+  @override
+  Future<bool?> clearTemporaryFiles() async => true;
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    bool lockParentWindow = false,
+    String? initialDirectory,
+  }) async => null;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('import csv adds template', (tester) async {
+    const csv = 'Title,HeroPosition,HeroHand,StackBB,EV_BB,ICM_EV,Tags\nA,SB,AA,10,0.1,,\n';
+    final file = PlatformFile(name: 'test.csv', size: csv.length, bytes: Uint8List.fromList(csv.codeUnits));
+    FilePicker.platform = _FakeFilePicker(FilePickerResult([file]));
+    await tester.pumpWidget(const MaterialApp(home: TrainingPackTemplateListScreen()));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.upload_file));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.text('test'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add PackImportService to parse CSV into TrainingPackTemplate
- integrate CSV import into TrainingPackTemplateListScreen with new FAB
- unit test for PackImportService
- widget test for CSV import button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686402f454fc832a877b55be926240b1