### PR TITLE
Update CSV tests and generator

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -347,7 +347,7 @@ class _TrainingPackTemplateListScreenState
           nameCtrl.text.trim().isEmpty ? 'New Pack' : nameCtrl.text.trim();
       final hero = int.tryParse(heroStackCtrl.text.trim()) ?? 0;
       final stacks = [
-        for (final s in playerStacksCtrl.text.split(','))
+        for (final s in playerStacksCtrl.text.split(RegExp(r'[,/]+')))
           if (s.trim().isNotEmpty) int.tryParse(s.trim()) ?? hero
       ];
       if (stacks.isEmpty) stacks.add(hero);

--- a/lib/services/pack_export_service.dart
+++ b/lib/services/pack_export_service.dart
@@ -28,10 +28,14 @@ class PackExportService {
           hand.stacks['$i']?.toString() ?? ''
       ].join('/');
       final pre = hand.actions[0] ?? [];
-      final callsMask = [
-        for (var i = 0; i < hand.playerCount; i++)
-          pre.any((a) => a.playerIndex == i && a.action == 'call') ? '1' : '0'
-      ].join();
+      final callsMask = hand.playerCount == 2
+          ? ''
+          : [
+              for (var i = 0; i < hand.playerCount; i++)
+                pre.any((a) => a.playerIndex == i && a.action == 'call')
+                    ? '1'
+                    : '0'
+            ].join();
       rows.add([
         spot.title,
         hand.position.label,
@@ -59,6 +63,7 @@ class PackExportService {
 
   static String _toSnakeCase(String input) {
     final snake = input
+        .trim()
         .replaceAll(RegExp(r'[^A-Za-z0-9]+'), '_')
         .replaceAll(RegExp('_+'), '_')
         .toLowerCase();

--- a/test/services/pack_import_service_test.dart
+++ b/test/services/pack_import_service_test.dart
@@ -3,10 +3,11 @@ import 'package:poker_ai_analyzer/services/pack_import_service.dart';
 
 void main() {
   test('importFromCsv parses rows', () {
-    const csv = 'Title,HeroPosition,HeroHand,StackBB,EV_BB,ICM_EV,Tags\n'
-        'A,SB,AA,10,0.8,1.234,foo|bar\n'
-        'B,BB,KK,10,,0.1,baz\n'
-        'C,CO,22,8,,,';
+    const csv =
+        'Title,HeroPosition,HeroHand,StackBB,StacksBB,HeroIndex,CallsMask,EV_BB,ICM_EV,Tags\n'
+        'A,SB,AA,10,,0,,0.8,1.234,foo|bar\n'
+        'B,BB,KK,10,,0,,,0.1,baz\n'
+        'C,CO,22,8,,0,,,,';
     final tpl = PackImportService.importFromCsv(
       csv: csv,
       templateId: 't',

--- a/test/widgets/import_csv_button_test.dart
+++ b/test/widgets/import_csv_button_test.dart
@@ -58,7 +58,8 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('import csv adds template', (tester) async {
-    const csv = 'Title,HeroPosition,HeroHand,StackBB,EV_BB,ICM_EV,Tags\nA,SB,AA,10,0.1,,\n';
+    const csv =
+        'Title,HeroPosition,HeroHand,StackBB,StacksBB,HeroIndex,CallsMask,EV_BB,ICM_EV,Tags\nA,SB,AA,10,,0,,0.1,,\n';
     final file = PlatformFile(name: 'test.csv', size: csv.length, bytes: Uint8List.fromList(csv.codeUnits));
     FilePicker.platform = _FakeFilePicker(FilePickerResult([file]));
     await tester.pumpWidget(const MaterialApp(home: TrainingPackTemplateListScreen()));


### PR DESCRIPTION
## Summary
- include new columns in import CSV tests
- adjust generator to parse stacks separated by slashes
- skip CallsMask for heads-up exports
- trim input before converting pack names to snake_case

## Testing
- `flutter test` *(fails: unable to run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68640a00e860832aad0bede27156073c