### PR TITLE
Improve Paste Range parsing

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -188,7 +188,11 @@ class _TrainingPackTemplateListScreenState
     );
     if (ok == true) {
       final range = PackGeneratorService.parseRangeString(ctrl.text).toList();
-      if (range.isNotEmpty) {
+      if (range.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('No valid hands found.')),
+        );
+      } else {
         final template = await PackGeneratorService.generatePushFoldPack(
           id: const Uuid().v4(),
           name: 'Pasted Range',

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -176,7 +176,7 @@ class PackGeneratorService {
 
   static Set<String> parseRangeString(String raw) {
     return {
-      for (final t in raw.split(RegExp('[,\n ]+')))
+      for (final t in raw.split(RegExp('[,;\s]+')))
         if (t.trim().isNotEmpty) t.trim()
     };
   }


### PR DESCRIPTION
## Summary
- parse semicolons when reading ranges
- show snackbar on empty paste result

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640d1a7478832a8914e0769a7e2d84