### PR TITLE
Add final table pack FAB

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -162,6 +162,13 @@ class _TrainingPackTemplateListScreenState
     _edit(template);
   }
 
+  void _generateFinalTable() {
+    final template = PackGeneratorService.generateFinalTablePack();
+    setState(() => _templates.add(template));
+    TrainingPackStorage.save(_templates);
+    _edit(template);
+  }
+
   Future<void> _pasteRange() async {
     final ctrl = TextEditingController();
     final ok = await showDialog<bool>(
@@ -869,6 +876,12 @@ class _TrainingPackTemplateListScreenState
             heroTag: 'quickGenTplFab',
             onPressed: _quickGenerate,
             label: const Text('Quick Generate'),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'finalTableTplFab',
+            onPressed: _generateFinalTable,
+            label: const Text('Final Table'),
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(


### PR DESCRIPTION
## Summary
- add a new Final Table generator FAB on the training pack template screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640dc7fa44832aa926ac5681f9faae