### PR TITLE
Fix Final Table pack ID and add tooltip

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -162,8 +162,10 @@ class _TrainingPackTemplateListScreenState
     _edit(template);
   }
 
-  void _generateFinalTable() {
-    final template = PackGeneratorService.generateFinalTablePack();
+  Future<void> _generateFinalTable() async {
+    await Future.delayed(Duration.zero);
+    final template =
+        PackGeneratorService.generateFinalTablePack().copyWith(id: const Uuid().v4());
     setState(() => _templates.add(template));
     TrainingPackStorage.save(_templates);
     _edit(template);
@@ -880,7 +882,8 @@ class _TrainingPackTemplateListScreenState
           const SizedBox(height: 12),
           FloatingActionButton.extended(
             heroTag: 'finalTableTplFab',
-            onPressed: _generateFinalTable,
+            onPressed: () => _generateFinalTable(),
+            tooltip: 'Generate Final Table Pack',
             label: const Text('Final Table'),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- avoid duplicate IDs when generating Final Table packs
- make generation async and add tooltip for accessibility

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640e9b3364832a8ca8c58cca8bf5cf