### PR TITLE
Add range preview in pack editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -34,6 +34,7 @@ import '../../theme/app_colors.dart';
 import '../../services/room_hand_history_importer.dart';
 import '../../services/push_fold_ev_service.dart';
 import '../../services/pack_export_service.dart';
+import '../../widgets/range_matrix_picker.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
 
@@ -82,6 +83,15 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   late final UndoRedoService _history;
   bool get _canUndo => _history.canUndo;
   bool get _canRedo => _history.canRedo;
+
+  Set<String> _templateRange() {
+    final set = <String>{};
+    for (final s in widget.template.spots) {
+      final hand = _handCode(s.hand.heroCards);
+      if (hand != null) set.add(hand);
+    }
+    return set;
+  }
 
   void _focusSpot(String id) {
     final key = _itemKeys[id];
@@ -1287,6 +1297,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     }).toList();
     final chipVals = [for (final s in shown) if (s.heroEv != null) s.heroEv!];
     final icmVals = [for (final s in shown) if (s.heroIcmEv != null) s.heroIcmEv!];
+    final range = _templateRange();
     List<TrainingPackSpot> sorted;
     if (_sortBy == SortBy.manual) {
       sorted = shown;
@@ -1615,6 +1626,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                 values: _summaryIcm ? icmVals : chipVals,
                 isIcm: _summaryIcm,
                 onToggle: () => set(() => _summaryIcm = !_summaryIcm),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: RangeMatrixPicker(
+                  selected: range,
+                  onChanged: (_) {},
+                  readOnly: true,
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/widgets/range_matrix_picker.dart
+++ b/lib/widgets/range_matrix_picker.dart
@@ -3,8 +3,14 @@ import 'package:flutter/material.dart';
 class RangeMatrixPicker extends StatelessWidget {
   final Set<String> selected;
   final ValueChanged<Set<String>> onChanged;
+  final bool readOnly;
 
-  const RangeMatrixPicker({super.key, required this.selected, required this.onChanged});
+  const RangeMatrixPicker({
+    super.key,
+    required this.selected,
+    required this.onChanged,
+    this.readOnly = false,
+  });
 
   static const _ranks = [
     'A',
@@ -50,6 +56,7 @@ class RangeMatrixPicker extends StatelessWidget {
                   label: _label(row, col),
                   color: _baseColor(row, col),
                   selected: selected.contains(_label(row, col)),
+                  readOnly: readOnly,
                   onTap: () {
                     final newSet = Set<String>.from(selected);
                     final hand = _label(row, col);
@@ -69,15 +76,22 @@ class _Cell extends StatelessWidget {
   final Color color;
   final bool selected;
   final VoidCallback onTap;
+  final bool readOnly;
 
-  const _Cell({required this.label, required this.color, required this.selected, required this.onTap});
+  const _Cell({
+    required this.label,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+    this.readOnly = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     final bg = selected ? color : color.withOpacity(0.4);
     return GestureDetector(
-      onTap: onTap,
-      onLongPress: onTap,
+      onTap: readOnly ? null : onTap,
+      onLongPress: readOnly ? null : onTap,
       child: Container(
         width: 24,
         height: 24,


### PR DESCRIPTION
## Summary
- support read-only mode for RangeMatrixPicker
- show hero range preview in TrainingPackTemplateEditor

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686414a2b694832a92fb0034ff00888d