### PR TITLE
Add generated pack history feature

### DIFF
--- a/lib/services/generated_pack_history_service.dart
+++ b/lib/services/generated_pack_history_service.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class GeneratedPackHistoryService {
+  static const _key = 'generated_pack_history';
+
+  static Future<void> logPack({
+    required String id,
+    required String name,
+    required String type,
+    required DateTime ts,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    final info = GeneratedPackInfo(id: id, name: name, type: type, ts: ts);
+    list.insert(0, jsonEncode(info.toJson()));
+    if (list.length > 50) list.removeRange(50, list.length);
+    await prefs.setStringList(_key, list);
+  }
+
+  static Future<List<GeneratedPackInfo>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    return [
+      for (final e in list)
+        GeneratedPackInfo.fromJson(jsonDecode(e) as Map<String, dynamic>)
+    ];
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}
+
+class GeneratedPackInfo {
+  final String id;
+  final String name;
+  final String type;
+  final DateTime ts;
+
+  GeneratedPackInfo({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.ts,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'type': type,
+        'ts': ts.toIso8601String(),
+      };
+
+  factory GeneratedPackInfo.fromJson(Map<String, dynamic> j) => GeneratedPackInfo(
+        id: j['id'] as String,
+        name: j['name'] as String,
+        type: j['type'] as String,
+        ts: DateTime.parse(j['ts'] as String),
+      );
+}

--- a/test/services/generated_pack_history_service_test.dart
+++ b/test/services/generated_pack_history_service_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_ai_analyzer/services/generated_pack_history_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('log + reload keeps max 50 entries', () async {
+    SharedPreferences.setMockInitialValues({});
+    for (var i = 0; i < 60; i++) {
+      await GeneratedPackHistoryService.logPack(
+        id: 'id$i',
+        name: 'n$i',
+        type: 't',
+        ts: DateTime.now(),
+      );
+    }
+    final list = await GeneratedPackHistoryService.load();
+    expect(list.length, 50);
+    expect(list.first.id, 'id59');
+    expect(list.last.id, 'id10');
+  });
+}

--- a/test/widgets/generated_pack_history_test.dart
+++ b/test/widgets/generated_pack_history_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_list_screen.dart';
+import 'package:poker_ai_analyzer/services/training_spot_storage_service.dart';
+import 'package:poker_ai_analyzer/models/training_spot.dart';
+import 'package:poker_ai_analyzer/models/card_model.dart';
+import 'package:poker_ai_analyzer/models/action_entry.dart';
+import 'package:poker_ai_analyzer/models/player_model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeTrainingSpotService extends TrainingSpotStorageService {
+  _FakeTrainingSpotService(this.spots) : super();
+  final List<TrainingSpot> spots;
+  @override
+  Future<List<TrainingSpot>> load() async => spots;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('favorites generation logs history', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final spot = TrainingSpot(
+      playerCards: [
+        [CardModel(rank: 'A', suit: '♠'), CardModel(rank: 'K', suit: '♦')],
+        [CardModel(rank: 'Q', suit: '♠'), CardModel(rank: 'J', suit: '♣')],
+      ],
+      boardCards: const [],
+      actions: const [ActionEntry(0, 0, 'push')],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [PlayerType.unknown, PlayerType.unknown],
+      positions: const ['SB', 'BB'],
+      stacks: const [10, 10],
+      tags: const ['favorite'],
+    );
+    final service = _FakeTrainingSpotService([spot]);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<TrainingSpotStorageService>.value(
+        value: service,
+        child: const MaterialApp(home: TrainingPackTemplateListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Favorites Pack'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Recent Generated Packs'));
+    await tester.pumpAndSettle();
+    expect(find.text('Favorites'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `GeneratedPackHistoryService` for saving last 50 generated packs
- record history on template generation actions
- show 'Recent Generated Packs' list in training pack template list screen
- add unit and widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641edac858832a9edbc3829222fcf3