### PR TITLE
Implement pack split by table

### DIFF
--- a/lib/screens/my_training_packs_screen.dart
+++ b/lib/screens/my_training_packs_screen.dart
@@ -231,25 +231,37 @@ class _MyTrainingPacksScreenState extends State<MyTrainingPacksScreen> {
 
   Future<void> _showPackMenu(TrainingPack pack) async {
     if (pack.isBuiltIn || pack.history.isEmpty) return;
-    final reset = await showDialog<bool>(
+    final action = await showDialog<String>(
       context: context,
       builder: (ctx) => SimpleDialog(
         title: Text(pack.name),
         children: [
           SimpleDialogOption(
-            onPressed: () => Navigator.pop(ctx, true),
+            onPressed: () => Navigator.pop(ctx, 'reset'),
             child: const Text('Сбросить прогресс'),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx, 'split'),
+            child: const Text('Разбить по столам'),
           ),
         ],
       ),
     );
-    if (reset == true) {
+    if (action == 'reset') {
       await context.read<TrainingPackStorageService>().clearProgress(pack);
       if (mounted) {
         await _loadDates();
         setState(() {});
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Прогресс сброшен')));
+      }
+    } else if (action == 'split') {
+      final packs = await context.read<TrainingPackStorageService>().splitByTable(pack);
+      if (mounted && packs.length > 1) {
+        await _loadDates();
+        setState(() {});
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Прогресс сброшен')),
+          SnackBar(content: Text('Создано паков: ${packs.length}')),
         );
       }
     }

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -287,7 +287,7 @@ class _TrainingPackTemplateListScreenState
     final actions = <ActionEntry>[for (final a in hand.actions) if (a.street == 0) a];
     for (final a in actions) {
       if (a.playerIndex == hand.heroIndex) {
-        a.ev = -(hand.evLoss ?? 0);
+        a.ev = hand.evLoss ?? 0;
         break;
       }
     }
@@ -353,7 +353,7 @@ class _TrainingPackTemplateListScreenState
     final hands = manager.hands
         .where((h) => h.evLoss != null)
         .toList()
-      ..sort((a, b) => (b.evLoss ?? 0).compareTo(a.evLoss ?? 0));
+      ..sort((a, b) => (a.evLoss ?? 0).compareTo(b.evLoss ?? 0));
     if (hands.isEmpty) {
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -361,10 +361,22 @@ class _TrainingPackTemplateListScreenState
       }
       return;
     }
-    final spots = [for (final h in hands.take(10)) _spotFromHand(h)];
+    final seen = <String>{};
+    final spots = <TrainingPackSpot>[];
+    for (final h in hands) {
+      if (seen.add(h.id)) spots.add(_spotFromHand(h));
+      if (spots.length == 10) break;
+    }
+    if (spots.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Недостаточно данных')));
+      }
+      return;
+    }
     final template = TrainingPackTemplate(
       id: const Uuid().v4(),
-      name: 'Top Mistakes',
+      name: 'Top ${spots.length} Mistakes',
       createdAt: DateTime.now(),
       spots: spots,
     );
@@ -1133,6 +1145,7 @@ class _TrainingPackTemplateListScreenState
           FloatingActionButton.extended(
             heroTag: 'topMistakesTplFab',
             onPressed: _generateTopMistakes,
+            tooltip: 'Generate Top Mistakes Pack',
             label: const Text('Top 10 Mistakes'),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- split training packs by table name using comment field
- allow splitting from pack menu
- improve Top Mistakes pack generation

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641dd5406c832a977fdb1572245d68