### PR TITLE
Add quick play for recent generated packs

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -25,6 +25,8 @@ import 'package:provider/provider.dart';
 import 'training_pack_template_editor_screen.dart';
 import '../../widgets/range_matrix_picker.dart';
 import '../../widgets/preset_range_buttons.dart';
+import '../training_session_screen.dart';
+import '../../services/training_session_service.dart';
 
 class TrainingPackTemplateListScreen extends StatefulWidget {
   const TrainingPackTemplateListScreen({super.key});
@@ -998,9 +1000,29 @@ class _TrainingPackTemplateListScreenState
                           title: Text(h.name),
                           subtitle: Text(
                               '${h.type} • ${DateFormat.yMMMd().add_Hm().format(h.ts)}'),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.play_arrow),
+                            tooltip: 'Start training',
+                            onPressed: () async {
+                              final tpl = _templates.firstWhereOrNull((t) => t.id == h.id);
+                              if (tpl == null) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Pack not found')));
+                                return;
+                              }
+                              await context
+                                  .read<TrainingSessionService>()
+                                  .startSession(tpl, persist: false);
+                              await Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (_) => const TrainingSessionScreen()),
+                              );
+                            },
+                          ),
                           onTap: () {
-                            final tpl = _templates.firstWhereOrNull(
-                                (t) => t.id == h.id);
+                            final tpl =
+                                _templates.firstWhereOrNull((t) => t.id == h.id);
                             if (tpl != null) {
                               _edit(tpl);
                             } else {

--- a/tests/widgets/generated_pack_play_test.dart
+++ b/tests/widgets/generated_pack_play_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_list_screen.dart';
+import 'package:poker_ai_analyzer/services/training_spot_storage_service.dart';
+import 'package:poker_ai_analyzer/services/training_session_service.dart';
+import 'package:poker_ai_analyzer/screens/training_session_screen.dart';
+import 'package:poker_ai_analyzer/models/training_spot.dart';
+import 'package:poker_ai_analyzer/models/card_model.dart';
+import 'package:poker_ai_analyzer/models/action_entry.dart';
+import 'package:poker_ai_analyzer/models/player_model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeTrainingSpotService extends TrainingSpotStorageService {
+  _FakeTrainingSpotService(this.spots) : super();
+  final List<TrainingSpot> spots;
+  @override
+  Future<List<TrainingSpot>> load() async => spots;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('history play opens training session', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final spot = TrainingSpot(
+      playerCards: [
+        [CardModel(rank: 'A', suit: '♠'), CardModel(rank: 'K', suit: '♦')],
+        [CardModel(rank: 'Q', suit: '♠'), CardModel(rank: 'J', suit: '♣')],
+      ],
+      boardCards: const [],
+      actions: const [ActionEntry(0, 0, 'push')],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [PlayerType.unknown, PlayerType.unknown],
+      positions: const ['SB', 'BB'],
+      stacks: const [10, 10],
+      tags: const ['favorite'],
+    );
+    final service = _FakeTrainingSpotService([spot]);
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<TrainingSpotStorageService>.value(value: service),
+          ChangeNotifierProvider(create: (_) => TrainingSessionService()),
+        ],
+        child: const MaterialApp(home: TrainingPackTemplateListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Favorites Pack'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Recent Generated Packs'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- show play button for recent packs
- allow training quick start from history
- test launching training session from history

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864259bcfc8832aa108e6b64083e505