### PR TITLE
Add one-tap play for templates

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1124,6 +1124,20 @@ class _TrainingPackTemplateListScreenState
                         trailing: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
+                            IconButton(
+                              icon: const Icon(Icons.play_arrow),
+                              tooltip: 'Start training',
+                              onPressed: () async {
+                                await context
+                                    .read<TrainingSessionService>()
+                                    .startSession(t, persist: false);
+                                await Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) => const TrainingSessionScreen()),
+                                );
+                              },
+                            ),
                             PopupMenuButton<String>(
                               onSelected: (v) {
                                 if (v == 'rename') _rename(t);
@@ -1140,10 +1154,16 @@ class _TrainingPackTemplateListScreenState
                                 ),
                               ],
                             ),
-                            TextButton(
-                              onPressed: () => _edit(t),
-                              child: const Text('📝 Edit'),
-                            ),
+                            if (narrow)
+                              IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () => _edit(t),
+                              )
+                            else
+                              TextButton(
+                                onPressed: () => _edit(t),
+                                child: const Text('📝 Edit'),
+                              ),
                             IconButton(
                               icon: const Icon(Icons.copy),
                               onPressed: () => _duplicate(t),

--- a/tests/widgets/template_play_button_test.dart
+++ b/tests/widgets/template_play_button_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/models/v2/hand_data.dart';
+import 'package:poker_ai_analyzer/services/training_session_service.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_list_screen.dart';
+import 'package:poker_ai_analyzer/screens/training_session_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('play button opens training session', (tester) async {
+    final template = TrainingPackTemplate(
+      id: 't1',
+      name: 'Test',
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      createdAt: DateTime.now(),
+    );
+    SharedPreferences.setMockInitialValues({
+      'training_pack_templates': jsonEncode([template.toJson()]),
+    });
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => TrainingSessionService(),
+        child: const MaterialApp(home: TrainingPackTemplateListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add direct play button in `TrainingPackTemplateListScreen`
- hide text label on edit button when screen is narrow
- test that play button opens TrainingSessionScreen

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686426f248bc832aaa35f30a647317f8