### PR TITLE
Add Stop Drill button

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -91,6 +91,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
 
   void _next(service) {
     final next = service.nextSpot();
+    if (!mounted) return;
     if (next == null) {
       if (widget.onSessionEnd != null) {
         _endlessStats.addDuration(service.elapsedTime);
@@ -132,6 +133,23 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         }
       });
     }
+  }
+
+  void _showEndlessSummary() {
+    final service = context.read<TrainingSessionService>();
+    _endlessStats.addDuration(service.elapsedTime);
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SessionResultScreen(
+          total: _endlessStats.total,
+          correct: _endlessStats.correct,
+          elapsed: _endlessStats.elapsed,
+          authorPreview: false,
+        ),
+      ),
+    );
+    _endlessStats.reset();
   }
 
   @override
@@ -278,6 +296,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                 ),
             ],
           ),
+          floatingActionButton: widget.onSessionEnd != null
+              ? FloatingActionButton(
+                  heroTag: 'stopDrillFab',
+                  tooltip: 'Stop Drill & show summary',
+                  child: const Icon(Icons.stop),
+                  onPressed: _showEndlessSummary,
+                )
+              : null,
         );
       },
     ),

--- a/tests/widgets/endless_stop_button_test.dart
+++ b/tests/widgets/endless_stop_button_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/models/action_entry.dart';
+import 'package:poker_ai_analyzer/models/v2/hand_data.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_list_screen.dart';
+import 'package:poker_ai_analyzer/screens/session_result_screen.dart';
+import 'package:poker_ai_analyzer/screens/training_session_screen.dart';
+import 'package:poker_ai_analyzer/services/training_session_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('endless drill stop shows summary', (tester) async {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(actions: {0: [ActionEntry(0, 0, 'fold')]}),
+    );
+    final tpl = TrainingPackTemplate(
+      id: 't1',
+      name: 'One',
+      spots: [spot],
+      createdAt: DateTime.now(),
+    );
+    SharedPreferences.setMockInitialValues({
+      'training_pack_templates': jsonEncode([tpl.toJson()]),
+    });
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => TrainingSessionService(),
+        child: const MaterialApp(home: TrainingPackTemplateListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Mixed Drill'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, '1');
+    await tester.tap(find.text('Endless Drill'));
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+    await tester.tap(find.text('FOLD'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Stop Drill & show summary'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SessionResultScreen), findsOneWidget);
+    expect(find.textContaining(' / 1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- allow stopping endless drill mid-session
- support summary screen for endless drill stop
- test stop button in endless drill

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642d4cccac832aa21a135911433747