### PR TITLE
Implement street filter for Mixed Drill

### DIFF
--- a/lib/models/v2/hand_data.dart
+++ b/lib/models/v2/hand_data.dart
@@ -8,15 +8,18 @@ class HandData {
   Map<String, double> stacks;
   int heroIndex;
   int playerCount;
+  List<String> board;
 
   HandData({
     this.heroCards = '',
     this.position = HeroPosition.unknown,
     this.heroIndex = 0,
     this.playerCount = 6,
+    List<String>? board,
     Map<int, List<ActionEntry>>? actions,
     Map<String, double>? stacks,
-  })  : actions = actions ?? {for (var s = 0; s < 4; s++) s: <ActionEntry>[]},
+  })  : board = board ?? [],
+        actions = actions ?? {for (var s = 0; s < 4; s++) s: <ActionEntry>[]},
         stacks = stacks ?? {};
 
   factory HandData.fromJson(Map<String, dynamic> j) {
@@ -45,6 +48,7 @@ class HandData {
       ),
       heroIndex: j['heroIndex'] as int? ?? 0,
       playerCount: j['playerCount'] as int? ?? 6,
+      board: [for (final c in (j['board'] as List? ?? [])) c as String],
       actions: acts,
       stacks: Map<String, double>.from(j['stacks'] ?? {}),
     );
@@ -61,5 +65,6 @@ class HandData {
               kv.key.toString(): [for (final a in kv.value) a.toJson()]
           },
         if (stacks.isNotEmpty) 'stacks': stacks,
+        if (board.isNotEmpty) 'board': board,
       };
 }

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -53,6 +53,7 @@ class _TrainingPackTemplateListScreenState
   int _mixedCount = 20;
   bool _mixedAutoOnly = false;
   bool _endlessDrill = false;
+  String _mixedStreet = 'any';
 
   void _sortTemplates() {
     switch (_sort) {
@@ -897,6 +898,7 @@ class _TrainingPackTemplateListScreenState
     final countCtrl = TextEditingController(text: _mixedCount.toString());
     bool autoOnly = _mixedAutoOnly;
     bool endless = _endlessDrill;
+    String street = _mixedStreet;
     final ok = await showDialog<bool>(
       context: context,
       builder: (_) => StatefulBuilder(
@@ -909,6 +911,17 @@ class _TrainingPackTemplateListScreenState
                 controller: countCtrl,
                 decoration: const InputDecoration(labelText: 'Spots count'),
                 keyboardType: TextInputType.number,
+              ),
+              DropdownButton<String>(
+                value: street,
+                onChanged: (v) => setState(() => street = v ?? 'any'),
+                items: const [
+                  DropdownMenuItem(value: 'any', child: Text('Any')),
+                  DropdownMenuItem(value: 'preflop', child: Text('Preflop')),
+                  DropdownMenuItem(value: 'flop', child: Text('Flop')),
+                  DropdownMenuItem(value: 'turn', child: Text('Turn')),
+                  DropdownMenuItem(value: 'river', child: Text('River')),
+                ],
               ),
               CheckboxListTile(
                 value: autoOnly,
@@ -939,6 +952,7 @@ class _TrainingPackTemplateListScreenState
     _mixedCount = int.tryParse(countCtrl.text.trim()) ?? 0;
     _mixedAutoOnly = autoOnly;
     _endlessDrill = endless;
+    _mixedStreet = street;
     await _runMixedDrill();
   }
 
@@ -961,7 +975,21 @@ class _TrainingPackTemplateListScreenState
           ];
     final list =
         autoOnly ? [for (final t in shown) if (t.tags.contains('auto')) t] : shown;
-    final spots = <TrainingPackSpot>[for (final t in list) ...t.spots];
+    final spots = <TrainingPackSpot>[
+      for (final t in list)
+        for (final s in t.spots)
+          if (_mixedStreet == 'any')
+            s
+          else
+            {
+              'preflop': 0,
+              'flop': 3,
+              'turn': 4,
+              'river': 5
+            }[_mixedStreet] == s.hand.board.length
+                ? s
+                : null
+        ].whereType<TrainingPackSpot>().toList();
     if (spots.isEmpty) {
       if (mounted) {
         ScaffoldMessenger.of(context)


### PR DESCRIPTION
## Summary
- extend `HandData` to include a `board` list
- add street selection dropdown for Mixed Drill
- filter Mixed Drill spots by selected street

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643c50ac20832a9d2093f74bcd1464