### PR TITLE
Add EV preview in spot editor

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'hand_data.dart';
+import '../evaluation_result.dart';
 
 class TrainingPackSpot {
   final String id;
@@ -9,6 +10,7 @@ class TrainingPackSpot {
   List<String> tags;
   DateTime editedAt;
   bool pinned;
+  EvaluationResult? evalResult;
 
   TrainingPackSpot({
     required this.id,
@@ -18,6 +20,7 @@ class TrainingPackSpot {
     List<String>? tags,
     DateTime? editedAt,
     this.pinned = false,
+    this.evalResult,
   })  : hand = hand ?? HandData(),
         tags = tags ?? [],
         editedAt = editedAt ?? DateTime.now();
@@ -30,6 +33,7 @@ class TrainingPackSpot {
     List<String>? tags,
     DateTime? editedAt,
     bool? pinned,
+    EvaluationResult? evalResult,
   }) =>
       TrainingPackSpot(
         id: id ?? this.id,
@@ -39,6 +43,7 @@ class TrainingPackSpot {
         tags: tags ?? List<String>.from(this.tags),
         editedAt: editedAt ?? this.editedAt,
         pinned: pinned ?? this.pinned,
+        evalResult: evalResult ?? this.evalResult,
       );
 
   factory TrainingPackSpot.fromJson(Map<String, dynamic> j) => TrainingPackSpot(
@@ -52,6 +57,10 @@ class TrainingPackSpot {
         editedAt:
             DateTime.tryParse(j['editedAt'] as String? ?? '') ?? DateTime.now(),
         pinned: j['pinned'] == true,
+        evalResult: j['evalResult'] != null
+            ? EvaluationResult.fromJson(
+                Map<String, dynamic>.from(j['evalResult']))
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -62,6 +71,7 @@ class TrainingPackSpot {
         if (tags.isNotEmpty) 'tags': tags,
         'editedAt': editedAt.toIso8601String(),
         if (pinned) 'pinned': true,
+        if (evalResult != null) 'evalResult': evalResult!.toJson(),
       };
 
   double? get heroEv {
@@ -90,9 +100,11 @@ class TrainingPackSpot {
           note == other.note &&
           hand == other.hand &&
           const ListEquality().equals(tags, other.tags) &&
-          pinned == other.pinned;
+          pinned == other.pinned &&
+          evalResult == other.evalResult;
 
   @override
   int get hashCode =>
-      Object.hash(id, title, note, hand, const ListEquality().hash(tags), pinned);
+      Object.hash(id, title, note, hand, const ListEquality().hash(tags), pinned,
+          evalResult);
 }

--- a/lib/screens/v2/training_pack_spot_editor_screen.dart
+++ b/lib/screens/v2/training_pack_spot_editor_screen.dart
@@ -4,6 +4,7 @@ import '../../helpers/training_pack_storage.dart';
 import '../../helpers/title_utils.dart';
 import '../../models/card_model.dart';
 import '../../widgets/card_picker_widget.dart';
+import '../../models/evaluation_result.dart';
 
 class TrainingPackSpotEditorScreen extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -59,6 +60,47 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
           disabledCards: _usedCards(),
         ),
       ],
+    );
+  }
+
+  Widget _evPreviewBox() {
+    final EvaluationResult? res = widget.spot.evalResult;
+    final bg = Colors.grey.shade800;
+    if (res == null) {
+      return Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: const [
+            Text('EV Preview',
+                style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white70)),
+            Spacer(),
+            Text('Not evaluated', style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      );
+    }
+    final ev = (res.expectedEquity * 100).toStringAsFixed(1);
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Text('EV Preview',
+              style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white70)),
+          const Spacer(),
+          Text('$ev%', style: const TextStyle(color: Colors.greenAccent)),
+          const SizedBox(width: 8),
+          Text(res.expectedAction,
+              style: const TextStyle(color: Colors.white)),
+        ],
+      ),
     );
   }
 
@@ -162,6 +204,8 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
             _streetPicker('Turn', 3, 1),
             const SizedBox(height: 16),
             _streetPicker('River', 4, 1),
+            const SizedBox(height: 16),
+            _evPreviewBox(),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- support eval result field in `TrainingPackSpot`
- preview computed EV and recommended action when editing a spot

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686444106d1c832ab6b229168b83f804