### PR TITLE
Add EV filter to template editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1299,9 +1299,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     final hasSpots = widget.template.spots.isNotEmpty;
     final shown = widget.template.spots.where((s) {
       if (_pinnedOnly && !s.pinned) return false;
-      final ev = _spotEv(s);
-      if (_evFilter == 'mistakes' && ev >= 0) return false;
-      if (_evFilter == 'profitable' && ev < 0) return false;
+      final res = s.evalResult;
+      if (_evFilter == 'ok' && !(res != null && res.correct)) return false;
+      if (_evFilter == 'error' && !(res != null && !res.correct)) return false;
+      if (_evFilter == 'empty' && res != null) return false;
       if (_selectedTags.isNotEmpty && !s.tags.any(_selectedTags.contains)) {
         return false;
       }
@@ -1744,8 +1745,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     SegmentedButton<String>(
                       segments: const [
                         ButtonSegment(value: 'all', label: Text('All')),
-                        ButtonSegment(value: 'mistakes', label: Text('Mistakes')),
-                        ButtonSegment(value: 'profitable', label: Text('Profitable')),
+                        ButtonSegment(value: 'ok', label: Text('OK')),
+                        ButtonSegment(value: 'error', label: Text('Errors')),
+                        ButtonSegment(value: 'empty', label: Text('Empty')),
                       ],
                       selected: {_evFilter},
                       onSelectionChanged: (v) async {
@@ -1760,8 +1762,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                       decoration: const InputDecoration(labelText: 'EV filter'),
                       items: const [
                         DropdownMenuItem(value: 'all', child: Text('All')),
-                        DropdownMenuItem(value: 'mistakes', child: Text('Mistakes only')),
-                        DropdownMenuItem(value: 'profitable', child: Text('Profitable only')),
+                        DropdownMenuItem(value: 'ok', child: Text('OK')),
+                        DropdownMenuItem(value: 'error', child: Text('Errors')),
+                        DropdownMenuItem(value: 'empty', child: Text('Empty')),
                       ],
                       onChanged: (v) async {
                         final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- update spot filtering logic in TrainingPackTemplateEditorScreen
- add EV dropdown with All/OK/Errors/Empty options

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ac426bc832abb0190dd464b1b40