### PR TITLE
Implement logging for spot generation parameters

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -141,6 +141,8 @@ class TrainingPackTemplate {
 
   Future<List<TrainingPackSpot>> generateSpotsWithProgress(
       BuildContext context) async {
+    debugPrint(
+        'templateId: $id, heroBbStack: $heroBbStack, playerStacksBb: $playerStacksBb, heroPos: ${heroPos.name}, spotCount: $spotCount, bbCallPct: $bbCallPct, heroRange: ${heroRange ?? 'null'}');
     final range = heroRange ?? PackGeneratorService.topNHands(25).toList();
     final total = spotCount;
     final generated = <TrainingPackSpot>[];


### PR DESCRIPTION
## Summary
- log key parameters before generating training pack spots

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646714b840832a999904e6c23478bf