### PR TITLE
Add generate spots button in template list

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1275,6 +1275,17 @@ class _TrainingPackTemplateListScreenState
                                 );
                               },
                             ),
+                            IconButton(
+                              icon: const Icon(Icons.auto_fix_high),
+                              tooltip: 'Generate spots',
+                              onPressed: () async {
+                                final generated =
+                                    await t.generateSpotsWithProgress(context);
+                                if (!mounted) return;
+                                setState(() => t.spots.addAll(generated));
+                                TrainingPackStorage.save(_templates);
+                              },
+                            ),
                             PopupMenuButton<String>(
                               onSelected: (v) {
                                 if (v == 'rename') _rename(t);


### PR DESCRIPTION
## Summary
- add new icon button in TrainingPackTemplateListScreen for generating spots

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647618c22c832ab339fa1880ac346b