### PR TITLE
Implement autoGenerateSpots

### DIFF
--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -98,6 +98,30 @@ class PackGeneratorService {
     );
   }
 
+  static Future<List<TrainingPackSpot>> autoGenerateSpots({
+    required String id,
+    required int stack,
+    required List<int> players,
+    required HeroPosition pos,
+    int count = 20,
+    int bbCallPct = 20,
+    int anteBb = 0,
+    List<String>? range,
+  }) async {
+    final tpl = generatePushFoldPackSync(
+      id: id,
+      name: '',
+      heroBbStack: stack,
+      playerStacksBb: players,
+      heroPos: pos,
+      heroRange: range ?? topNHands(25).toList(),
+      anteBb: anteBb,
+      bbCallPct: bbCallPct,
+      createdAt: DateTime.now(),
+    );
+    return tpl.spots.take(count).toList();
+  }
+
   static TrainingPackTemplate generatePushFoldPackSync({
     required String id,
     required String name,

--- a/test/services/pack_generator_service_test.dart
+++ b/test/services/pack_generator_service_test.dart
@@ -93,4 +93,19 @@ void main() {
       expect(s.tags.contains('finaltable'), isTrue);
     }
   });
+
+  test('autoGenerateSpots returns expected count', () async {
+    final spots = await PackGeneratorService.autoGenerateSpots(
+      id: 'a',
+      stack: 10,
+      players: [10, 10],
+      pos: HeroPosition.sb,
+      count: 5,
+    );
+    expect(spots.length, 5);
+    for (final s in spots) {
+      expect(s.hand.stacks, {'0': 10.0, '1': 10.0});
+      expect(s.tags.contains('pushfold'), isTrue);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- add `autoGenerateSpots` for programmatic spot generation
- cover new API with tests

## Testing
- `dart format -o write lib/services/pack_generator_service.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686477574d5c832a8f22bb4f9d3818b6