### PR TITLE
Add last generated timestamp to template list

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -29,6 +29,7 @@ import '../../widgets/preset_range_buttons.dart';
 import '../training_session_screen.dart';
 import '../../services/training_session_service.dart';
 
+import 'package:timeago/timeago.dart' as timeago;
 class TrainingPackTemplateListScreen extends StatefulWidget {
   const TrainingPackTemplateListScreen({super.key});
 
@@ -1252,12 +1253,27 @@ class _TrainingPackTemplateListScreenState
                               ),
                           ],
                         ),
-                        subtitle: t.description.trim().isEmpty
-                            ? null
-                            : Text(
-                                t.description.split('\n').first,
-                                style: const TextStyle(fontSize: 12),
-                              ),
+                        subtitle: (() {
+                          final items = <Widget>[];
+                          if (t.description.trim().isNotEmpty) {
+                            items.add(Text(
+                              t.description.split('\n').first,
+                              style: const TextStyle(fontSize: 12),
+                            ));
+                          }
+                          if (t.lastGeneratedAt != null) {
+                            items.add(Text(
+                              'Last generated: ${timeago.format(t.lastGeneratedAt!)}',
+                              style: const TextStyle(fontSize: 12, color: Colors.white54),
+                            ));
+                          }
+                          if (items.isEmpty) return null;
+                          if (items.length == 1) return items.first;
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: items,
+                          );
+                        })(),
                         trailing: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   uuid: ^4.0.0
   synchronized: ^3.0.0
   csv: ^6.0.0
+  timeago: ^3.7.1
   file_saver: ^0.2.14
   confetti: ^0.7.0
   poker_solver: ^1.0.0


### PR DESCRIPTION
## Summary
- display last generated time on TrainingPackTemplateListScreen
- add timeago dependency for human friendly timestamps

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864774e8f64832aba1dcbf50d195776