### PR TITLE
Implement preset pack generation

### DIFF
--- a/lib/models/v2/training_pack_preset.dart
+++ b/lib/models/v2/training_pack_preset.dart
@@ -1,0 +1,71 @@
+import 'hero_position.dart';
+import '../game_type.dart';
+
+class TrainingPackPreset {
+  final String id;
+  final String name;
+  final String description;
+  final GameType gameType;
+  final int heroBbStack;
+  final List<int> playerStacksBb;
+  final HeroPosition heroPos;
+  final int spotCount;
+  final int bbCallPct;
+  final int anteBb;
+  final List<String>? heroRange;
+  final DateTime createdAt;
+
+  TrainingPackPreset({
+    required this.id,
+    required this.name,
+    this.description = '',
+    this.gameType = GameType.tournament,
+    this.heroBbStack = 10,
+    List<int>? playerStacksBb,
+    this.heroPos = HeroPosition.sb,
+    this.spotCount = 20,
+    this.bbCallPct = 20,
+    this.anteBb = 0,
+    this.heroRange,
+    DateTime? createdAt,
+  })  : playerStacksBb = playerStacksBb ?? const [10, 10],
+        createdAt = createdAt ?? DateTime.now();
+
+  factory TrainingPackPreset.fromJson(Map<String, dynamic> j) => TrainingPackPreset(
+        id: j['id'] as String? ?? '',
+        name: j['name'] as String? ?? '',
+        description: j['description'] as String? ?? '',
+        gameType: GameType.values.firstWhere(
+          (e) => e.name == j['gameType'],
+          orElse: () => GameType.tournament,
+        ),
+        heroBbStack: j['heroBbStack'] as int? ?? 10,
+        playerStacksBb: [
+          for (final v in (j['playerStacksBb'] as List? ?? [10, 10])) (v as num).toInt()
+        ],
+        heroPos: HeroPosition.values.firstWhere(
+          (e) => e.name == j['heroPos'],
+          orElse: () => HeroPosition.sb,
+        ),
+        spotCount: j['spotCount'] as int? ?? 20,
+        bbCallPct: j['bbCallPct'] as int? ?? 20,
+        anteBb: j['anteBb'] as int? ?? 0,
+        heroRange: (j['heroRange'] as List?)?.map((e) => e as String).toList(),
+        createdAt: DateTime.tryParse(j['createdAt'] as String? ?? '') ?? DateTime.now(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'gameType': gameType.name,
+        'heroBbStack': heroBbStack,
+        'playerStacksBb': playerStacksBb,
+        'heroPos': heroPos.name,
+        'spotCount': spotCount,
+        'bbCallPct': bbCallPct,
+        'anteBb': anteBb,
+        if (heroRange != null) 'heroRange': heroRange,
+        'createdAt': createdAt.toIso8601String(),
+      };
+}

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -2,6 +2,7 @@ import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hand_data.dart';
 import '../models/v2/hero_position.dart';
+import '../models/v2/training_pack_preset.dart';
 import '../models/action_entry.dart';
 import '../models/game_type.dart';
 import 'push_fold_ev_service.dart';
@@ -120,6 +121,36 @@ class PackGeneratorService {
       createdAt: DateTime.now(),
     );
     return tpl.spots.take(count).toList();
+  }
+
+  static Future<TrainingPackTemplate> generatePackFromPreset(
+      TrainingPackPreset p) async {
+    final spots = await autoGenerateSpots(
+      id: p.id,
+      stack: p.heroBbStack,
+      players: p.playerStacksBb,
+      pos: p.heroPos,
+      count: p.spotCount,
+      bbCallPct: p.bbCallPct,
+      anteBb: p.anteBb,
+      range: p.heroRange,
+    );
+    return TrainingPackTemplate(
+      id: p.id,
+      name: p.name,
+      description: p.description,
+      gameType: p.gameType,
+      spots: spots,
+      heroBbStack: p.heroBbStack,
+      playerStacksBb: List<int>.from(p.playerStacksBb),
+      heroPos: p.heroPos,
+      spotCount: p.spotCount,
+      bbCallPct: p.bbCallPct,
+      anteBb: p.anteBb,
+      heroRange: p.heroRange,
+      createdAt: p.createdAt,
+      lastGeneratedAt: DateTime.now(),
+    );
   }
 
   static TrainingPackTemplate generatePushFoldPackSync({

--- a/test/services/pack_generator_service_test.dart
+++ b/test/services/pack_generator_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
 import 'package:poker_ai_analyzer/models/v2/hero_position.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_preset.dart';
 
 void main() {
   test('generatePushFoldPack creates correct spots', () async {
@@ -108,4 +109,24 @@ void main() {
       expect(s.tags.contains('pushfold'), isTrue);
     }
   });
+
+  test('generatePackFromPreset builds template', () async {
+    final preset = TrainingPackPreset(
+      id: 'pr',
+      name: 'Preset',
+      description: 'd',
+      heroBbStack: 10,
+      playerStacksBb: const [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: const ['AA'],
+      spotCount: 1,
+    );
+    final tpl = await PackGeneratorService.generatePackFromPreset(preset);
+    expect(tpl.id, preset.id);
+    expect(tpl.name, preset.name);
+    expect(tpl.description, preset.description);
+    expect(tpl.spots.length, 1);
+    expect(tpl.heroRange, preset.heroRange);
+  });
 }
+


### PR DESCRIPTION
## Summary
- add `TrainingPackPreset` model
- implement `generatePackFromPreset` in `PackGeneratorService`
- cover new logic with tests

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647873ab50832a894c6f9791e36ec3