### PR TITLE
Add batch generation CLI

### DIFF
--- a/bin/batch_generate.dart
+++ b/bin/batch_generate.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:poker_ai_analyzer/core/error_logger.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_preset.dart';
+import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
+
+Future<void> main(List<String> args) async {
+  String? src;
+  String out = '.';
+  for (var i = 0; i < args.length; i++) {
+    final a = args[i];
+    if (a == '--src' && i + 1 < args.length) {
+      src = args[++i];
+    } else if (a == '--out' && i + 1 < args.length) {
+      out = args[++i];
+    }
+  }
+  if (src == null) {
+    ErrorLogger.instance.logError('Missing --src');
+    exit(1);
+  }
+  final file = File(src!);
+  if (!file.existsSync()) {
+    ErrorLogger.instance.logError('File not found: ${file.path}');
+    exit(1);
+  }
+  final data = jsonDecode(await file.readAsString());
+  if (data is! List) {
+    ErrorLogger.instance.logError('Invalid presets file');
+    exit(1);
+  }
+  await Directory(out).create(recursive: true);
+  for (final item in data.whereType<Map>()) {
+    final preset = TrainingPackPreset.fromJson(Map<String, dynamic>.from(item));
+    final tpl = await PackGeneratorService.generatePackFromPreset(preset);
+    final path = p.join(out, '${preset.id}.json');
+    await File(path).writeAsString(jsonEncode(tpl.toJson()));
+    ErrorLogger.instance.logError('Generated ${preset.id}');
+  }
+}

--- a/docs/README_batch.md
+++ b/docs/README_batch.md
@@ -1,0 +1,7 @@
+# Batch Generation
+
+Generate multiple training packs from presets.
+
+```bash
+dart run batch_generate --src presets.json --out ./packs
+```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,9 @@ version: 1.0.0+1
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+executables:
+  batch_generate: bin/batch_generate.dart
+
 dependencies:
   flutter:
     sdk: flutter
@@ -57,6 +60,7 @@ dependency_overrides:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: any
 
   flutter_lints: ^2.0.0
   build_runner: ^2.4.6

--- a/test/tools/batch_generate_test.dart
+++ b/test/tools/batch_generate_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+import 'package:poker_ai_analyzer/models/v2/training_pack_preset.dart';
+
+void main() {
+  test('batch generate presets', () async {
+    final dir = await Directory.systemTemp.createTemp('batch_generate_test');
+    try {
+      final p1 = TrainingPackPreset(id: 'a', name: 'A');
+      final p2 = TrainingPackPreset(id: 'b', name: 'B');
+      await File(p.join(dir.path, 'presets.json'))
+          .writeAsString(jsonEncode([p1.toJson(), p2.toJson()]));
+      final res = await Process.run('dart', [
+        'run',
+        'bin/batch_generate.dart',
+        '--src',
+        p.join(dir.path, 'presets.json'),
+        '--out',
+        dir.path
+      ]);
+      expect(res.exitCode, 0);
+      expect(File(p.join(dir.path, 'a.json')).existsSync(), isTrue);
+      expect(File(p.join(dir.path, 'b.json')).existsSync(), isTrue);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- implement `batch_generate` CLI
- map CLI executable in `pubspec.yaml`
- document batch usage
- test CLI via `batch_generate_test.dart`

## Testing
- `dart format -l 80 bin/batch_generate.dart test/tools/batch_generate_test.dart`
- `dart analyze` *(fails: 34413 issues)*
- `flutter test` *(fails: many compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_686479a80ff8832ab420c37d5ea68b75