### PR TITLE
Add NEW badge for recent templates

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -640,6 +640,11 @@ class _TrainingPackTemplateListScreenState
                           t.filters.equals(_spotStorage.activeFilters);
                       final selection = _selectedIds.isNotEmpty;
                       final selected = _selectedIds.contains(t.id);
+                      final isNew = t.lastGeneratedAt != null &&
+                          DateTime.now()
+                                  .difference(t.lastGeneratedAt!)
+                                  .inHours <
+                              48;
                       Widget tile = ListTile(
                         tileColor: isActive ? Colors.blueGrey.shade800 : null,
                         leading: Row(
@@ -687,6 +692,17 @@ class _TrainingPackTemplateListScreenState
                         title: Row(
                           children: [
                             Expanded(child: Text(t.name)),
+                            if (isNew)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Chip(
+                                  label: Text('NEW',
+                                      style: TextStyle(fontSize: 12)),
+                                  visualDensity: VisualDensity.compact,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                              ),
                             IconButton(
                               icon: Icon(t.isFavorite ? Icons.star : Icons.star_border),
                               color: t.isFavorite ? Colors.amber : Colors.white54,

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1240,11 +1240,27 @@ class _TrainingPackTemplateListScreenState
                       final t = shown[index];
                       final allEv = t.spots.isNotEmpty &&
                           t.spots.every((s) => s.heroEv != null);
+                      final isNew = t.lastGeneratedAt != null &&
+                          DateTime.now()
+                                  .difference(t.lastGeneratedAt!)
+                                  .inHours <
+                              48;
                       final tile = ListTile(
                         onLongPress: () => _duplicate(t),
                         title: Row(
                           children: [
                             Expanded(child: Text(t.name)),
+                            if (isNew)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Chip(
+                                  label: Text('NEW',
+                                      style: TextStyle(fontSize: 12)),
+                                  visualDensity: VisualDensity.compact,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                              ),
                             if (allEv)
                               const Padding(
                                 padding: EdgeInsets.only(left: 4),


### PR DESCRIPTION
## Summary
- highlight recently generated templates with a NEW chip in both template lists

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864860e07e0832a85c6e34ecd9e7205