### PR TITLE
Add EV indicator for templates

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -33,6 +33,7 @@ class _TrainingPackTemplateListScreenState
   static const _prefsFavKey = 'tpl_show_fav_only';
   _SortOption _sort = _SortOption.name;
   final Map<String, int?> _counts = {};
+  final Map<String, bool?> _allEv = {};
   final Map<String, bool> _collapsed = {};
   final TextEditingController _searchController = TextEditingController();
   late TrainingSpotStorageService _spotStorage;
@@ -129,6 +130,14 @@ class _TrainingPackTemplateListScreenState
     _counts[id] = null;
     _spotStorage.evaluateFilterCount(filters).then((value) {
       if (mounted) setState(() => _counts[id] = value);
+    });
+  }
+
+  void _ensureAllEv(String id, Map<String, dynamic> filters) {
+    if (_allEv.containsKey(id)) return;
+    _allEv[id] = null;
+    _spotStorage.filterAllHaveEv(filters).then((value) {
+      if (mounted) setState(() => _allEv[id] = value);
     });
   }
   Future<void> _add() async {
@@ -636,6 +645,7 @@ class _TrainingPackTemplateListScreenState
                     if (!collapsed && index < count + list.length) {
                       final t = list[index - count];
                       _ensureCount(t.id, t.filters);
+                      _ensureAllEv(t.id, t.filters);
                       final isActive =
                           t.filters.equals(_spotStorage.activeFilters);
                       final selection = _selectedIds.isNotEmpty;
@@ -702,6 +712,11 @@ class _TrainingPackTemplateListScreenState
                                   materialTapTargetSize:
                                       MaterialTapTargetSize.shrinkWrap,
                                 ),
+                              ),
+                            if (_allEv[t.id] == true)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Text('📈', style: TextStyle(fontSize: 16)),
                               ),
                             IconButton(
                               icon: Icon(t.isFavorite ? Icons.star : Icons.star_border),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1264,8 +1264,8 @@ class _TrainingPackTemplateListScreenState
                             if (allEv)
                               const Padding(
                                 padding: EdgeInsets.only(left: 4),
-                                child: Icon(Icons.trending_up,
-                                    color: Colors.grey, size: 16),
+                                child:
+                                    Text('📈', style: TextStyle(fontSize: 16)),
                               ),
                           ],
                         ),

--- a/lib/services/training_spot_storage_service.dart
+++ b/lib/services/training_spot_storage_service.dart
@@ -75,6 +75,28 @@ class TrainingSpotStorageService extends ChangeNotifier {
     }
   }
 
+  Future<bool?> filterAllHaveEv(Map<String, dynamic> filters) async {
+    try {
+      final spots = await load();
+      bool any = false;
+      for (final s in spots) {
+        if (!_matchesFilters(s, filters)) continue;
+        any = true;
+        bool hasEv = false;
+        for (final a in s.actions) {
+          if (a.playerIndex == s.heroIndex && a.ev != null) {
+            hasEv = true;
+            break;
+          }
+        }
+        if (!hasEv) return false;
+      }
+      return any;
+    } catch (_) {
+      return null;
+    }
+  }
+
   bool _matchesFilters(TrainingSpot spot, Map<String, dynamic> f) {
     final tags = f['tags'];
     if (tags is List && tags.isNotEmpty) {


### PR DESCRIPTION
## Summary
- show EV icon in template list when all spots have evaluation
- support filterAllHaveEv in spot storage service
- show EV icon in v2 template list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648747d6cc832aa5ee0aac51feed34