### PR TITLE
Implement generate missing spots

### DIFF
--- a/lib/helpers/hand_utils.dart
+++ b/lib/helpers/hand_utils.dart
@@ -1,0 +1,33 @@
+int _rankVal(String r) {
+  const order = [
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    'T',
+    'J',
+    'Q',
+    'K',
+    'A'
+  ];
+  return order.indexOf(r);
+}
+
+String? handCode(String twoCardString) {
+  final parts = twoCardString.split(RegExp(r'\s+'));
+  if (parts.length < 2) return null;
+  final r1 = parts[0][0].toUpperCase();
+  final s1 = parts[0].substring(1);
+  final r2 = parts[1][0].toUpperCase();
+  final s2 = parts[1].substring(1);
+  if (r1 == r2) return '$r1$r2';
+  final firstHigh = _rankVal(r1) >= _rankVal(r2);
+  final high = firstHigh ? r1 : r2;
+  final low = firstHigh ? r2 : r1;
+  final suited = s1 == s2;
+  return '$high$low${suited ? 's' : 'o'}';
+}

--- a/test/models/generate_missing_spots_test.dart
+++ b/test/models/generate_missing_spots_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/services/pack_generator_service.dart';
+import 'package:poker_ai_analyzer/models/v2/hero_position.dart';
+import 'package:poker_ai_analyzer/helpers/hand_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('generateMissingSpotsWithProgress adds missing hands',
+      (tester) async {
+    final range = PackGeneratorService.topNHands(25).toList();
+    final initial = PackGeneratorService.generatePushFoldPackSync(
+      id: 'i',
+      name: 'i',
+      heroBbStack: 10,
+      playerStacksBb: const [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: range.take(5).toList(),
+    ).spots;
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 't',
+      spotCount: 8,
+      playerStacksBb: const [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: range,
+      spots: List<TrainingPackSpot>.from(initial),
+    );
+    late BuildContext ctx;
+    await tester.pumpWidget(MaterialApp(home: Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    })));
+    final future = tpl.generateMissingSpotsWithProgress(ctx);
+    await tester.pumpAndSettle();
+    final missing = await future;
+    expect(missing.length, 3);
+    final existing = {for (final s in initial) handCode(s.hand.heroCards)!};
+    for (final s in missing) {
+      final code = handCode(s.hand.heroCards)!;
+      expect(existing.contains(code), isFalse);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add handCode helper
- generate only missing spots
- support generating missing spots from UI
- test generating missing spots

## Testing
- `dart format lib/helpers/hand_utils.dart` *(fails: dart: command not found)*
- `dart analyze lib/helpers/hand_utils.dart` *(fails: dart: command not found)*
- `dart test test/models/generate_missing_spots_test.dart` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ceef2bc0832a87b2fa0075fbb7b4