### PR TITLE
Update coverage recalculation

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -971,6 +971,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     for (final s in spots) {
       if (s.heroEv != null) continue;
       await const PushFoldEvService().evaluate(s);
+      if (!mounted) return;
+      setState(() {
+        if (_autoSortEv) _sortSpots();
+      });
     }
     await TrainingPackStorage.save(widget.templates);
     if (!mounted) return;
@@ -983,6 +987,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     for (final s in spots) {
       if (s.heroIcmEv != null) continue;
       await const PushFoldEvService().evaluateIcm(s);
+      if (!mounted) return;
+      setState(() {
+        if (_autoSortEv) _sortSpots();
+      });
     }
     await TrainingPackStorage.save(widget.templates);
     if (!mounted) return;


### PR DESCRIPTION
## Summary
- refresh coverage instantly after spot EV/ICM generation

## Testing
- `flutter test` *(fails: plugin and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864e11380a4832ab08ca9fcf1618860