### PR TITLE
Implement EV coverage cache usage

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1262,8 +1262,8 @@ class _TrainingPackTemplateListScreenState
                     },
                     itemBuilder: (context, index) {
                       final t = shown[index];
-                      final allEv = t.spots.isNotEmpty &&
-                          t.spots.every((s) => s.heroEv != null);
+                      final total = t.spots.length;
+                      final allEv = total > 0 && t.evCovered >= total;
                       final isNew = t.lastGeneratedAt != null &&
                           DateTime.now()
                                   .difference(t.lastGeneratedAt!)


### PR DESCRIPTION
## Summary
- refactor v2 list to use cached EV coverage instead of scanning spots

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f3d9f8f4832aa8e342bb138edded