### PR TITLE
Add ICM badge for templates

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1264,6 +1264,7 @@ class _TrainingPackTemplateListScreenState
                       final t = shown[index];
                       final total = t.spots.length;
                       final allEv = total > 0 && t.evCovered >= total;
+                      final allIcm = total > 0 && t.icmCovered >= total;
                       final isNew = t.lastGeneratedAt != null &&
                           DateTime.now()
                                   .difference(t.lastGeneratedAt!)
@@ -1282,6 +1283,17 @@ class _TrainingPackTemplateListScreenState
                                 padding: EdgeInsets.only(left: 4),
                                 child: Chip(
                                   label: Text('NEW',
+                                      style: TextStyle(fontSize: 12)),
+                                  visualDensity: VisualDensity.compact,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                              ),
+                            if (allIcm)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Chip(
+                                  label: Text('ICM',
                                       style: TextStyle(fontSize: 12)),
                                   visualDensity: VisualDensity.compact,
                                   materialTapTargetSize:


### PR DESCRIPTION
## Summary
- show an `ICM` chip for fully evaluated templates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f6c0d4c4832a980a11cc17a1504b