### PR TITLE
Add Mistake only filter

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -77,6 +77,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   bool _autoSortEv = false;
   bool _pinnedOnly = false;
   bool _heroPushOnly = false;
+  bool _mistakeOnly = false;
   bool _filtersShown = false;
   List<TrainingPackSpot>? _lastRemoved;
   static const _prefsAutoSortKey = 'auto_sort_ev';
@@ -118,6 +119,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       if (_evFilter == 'ok' && !(res != null && res.correct)) return false;
       if (_evFilter == 'error' && !(res != null && !res.correct)) return false;
       if (_evFilter == 'empty' && res != null) return false;
+      if (_mistakeOnly && !(res != null && !res.correct)) return false;
       if (_quickFilter == 'BTN' && s.hand.position != HeroPosition.btn) {
         return false;
       }
@@ -2478,6 +2480,11 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               title: const Text('Hero push only'),
               value: _heroPushOnly,
               onChanged: (v) => setState(() => _heroPushOnly = v),
+            ),
+            SwitchListTile(
+              title: const Text('Mistake only'),
+              value: _mistakeOnly,
+              onChanged: (v) => setState(() => _mistakeOnly = v),
             ),
             const SizedBox(height: 16),
             Expanded(

--- a/tests/widgets/mistake_only_filter_test.dart
+++ b/tests/widgets/mistake_only_filter_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/models/v2/hand_data.dart';
+import 'package:poker_ai_analyzer/models/evaluation_result.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+
+void main() {
+  testWidgets('mistake only filter shows only incorrect spots', (tester) async {
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 'Test',
+      spots: [
+        TrainingPackSpot(
+          id: 's1',
+          title: 'Spot 1',
+          hand: HandData(),
+          evalResult: EvaluationResult(correct: true, expectedAction: '-', userEquity: 0, expectedEquity: 0),
+        ),
+        TrainingPackSpot(
+          id: 's2',
+          title: 'Spot 2',
+          hand: HandData(),
+          evalResult: EvaluationResult(correct: false, expectedAction: '-', userEquity: 0, expectedEquity: 0),
+        ),
+      ],
+      createdAt: DateTime.now(),
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Spot 1'), findsOneWidget);
+    expect(find.text('Spot 2'), findsOneWidget);
+    await tester.tap(find.text('Mistake only'));
+    await tester.pumpAndSettle();
+    expect(find.text('Spot 1'), findsNothing);
+    expect(find.text('Spot 2'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `Mistake only` toggle in template editor
- filter spots by mistakes when enabled
- test Mistake only filter

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6864fbb87ddc832aada8b1e3f34e475e