### PR TITLE
Add spot title logging in history

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -177,7 +177,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       if (_autoSortEv) _sortSpots();
     });
     await _persist();
-    _history.log('Edited');
+    setState(() => _history.log('Edited', spot.title));
   }
 
   Future<void> _persist() async {
@@ -219,7 +219,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     );
     setState(() => widget.template.spots.add(spot));
     await _persist();
-    _history.log('Added');
+    setState(() => _history.log('Added', spot.title));
     await _openEditor(spot);
   }
 
@@ -231,7 +231,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     );
     setState(() => widget.template.spots.add(spot));
     await _persist();
-    _history.log('Added');
+    setState(() => _history.log('Added', spot.title));
     await _openEditor(spot);
   }
 
@@ -244,7 +244,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       if (_autoSortEv) _sortSpots();
     });
     await _persist();
-    if (generated.isNotEmpty) _history.log('Added');
+    if (generated.isNotEmpty) {
+      setState(() => _history.log('Added', '${generated.length} spots'));
+    }
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Generated ${generated.length} spots')));
   }
@@ -262,7 +264,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       if (_autoSortEv) _sortSpots();
     });
     await _persist();
-    _history.log('Added');
+    setState(() => _history.log('Added', '${missing.length} spots'));
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Added ${missing.length} spots')));
   }
@@ -293,7 +295,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         if (_autoSortEv) _sortSpots();
       });
       await _persist();
-      _history.log('Added');
+      setState(() => _history.log('Added', spot.title));
       WidgetsBinding.instance.addPostFrameCallback((_) => _focusSpot(spot.id));
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -370,7 +372,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       if (_autoSortEv) _sortSpots();
     });
     await _persist();
-    _history.log('Added');
+    setState(() => _history.log('Added', spot.title));
     WidgetsBinding.instance.addPostFrameCallback((_) => _focusSpot(spot.id));
   }
 
@@ -789,7 +791,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       _recordSnapshot();
       setState(() => widget.template.spots.clear());
       _persist();
-      _history.log('Deleted');
+      setState(() => _history.log('Deleted', 'all spots'));
     }
   }
 
@@ -1389,7 +1391,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         if (_autoSortEv) _sortSpots();
       });
       _persist();
-      _history.log('Deleted');
+      setState(() =>
+          _history.log('Deleted', '${_lastRemoved!.length} spots'));
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Removed ${_lastRemoved!.length} spot(s)'),
@@ -1433,7 +1436,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     );
     setState(() => widget.template.spots.insert(i + 1, copy));
     _persist();
-    _history.log('Added');
+    setState(() => _history.log('Added', copy.title));
   }
 
   Future<void> _renameTag() async {
@@ -2291,8 +2294,22 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   for (final e in _history.history.take(10))
                     ListTile(
                       dense: true,
-                      title: Text(e.action, style: const TextStyle(color: Colors.white)),
-                      trailing: Text(DateFormat.Hm().format(e.time), style: const TextStyle(color: Colors.white70)),
+                      leading: Icon(
+                        e.action == 'Added'
+                            ? Icons.add_circle
+                            : e.action == 'Deleted'
+                                ? Icons.remove_circle
+                                : Icons.edit,
+                        color: e.action == 'Added'
+                            ? Colors.green
+                            : e.action == 'Deleted'
+                                ? Colors.red
+                                : Colors.blue,
+                      ),
+                      title: Text('${e.action}: ${e.title}',
+                          style: const TextStyle(color: Colors.white)),
+                      trailing: Text(DateFormat.Hm().format(e.time),
+                          style: const TextStyle(color: Colors.white70)),
                     ),
               ],
             ),
@@ -2633,9 +2650,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                             ),
                                           );
                                           if (ok ?? false) {
+                                            final t = spot.title;
                                             setState(() => widget.template.spots.removeAt(index));
                                             _persist();
-                                            _history.log('Deleted');
+                                            setState(() => _history.log('Deleted', t));
                                           }
                                         },
                                       ),
@@ -2666,9 +2684,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                             _duplicateSpot(spot);
                           } else {
                             _lastRemoved = [spot];
+                            final t = spot.title;
                             setState(() => widget.template.spots.remove(spot));
                             _persist();
-                            _history.log('Deleted');
+                            setState(() => _history.log('Deleted', t));
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 content: const Text('Deleted'),

--- a/lib/services/template_undo_redo_service.dart
+++ b/lib/services/template_undo_redo_service.dart
@@ -2,8 +2,9 @@ import "../models/v2/training_pack_spot.dart";
 
 class ChangeEntry {
   final String action;
+  final String title;
   final DateTime time;
-  ChangeEntry(this.action) : time = DateTime.now();
+  ChangeEntry(this.action, this.title) : time = DateTime.now();
 }
 
 class UndoRedoService {
@@ -41,8 +42,8 @@ class UndoRedoService {
     _redo.clear();
   }
 
-  void log(String action) {
-    _events.add(ChangeEntry(action));
+  void log(String action, String title) {
+    _events.add(ChangeEntry(action, title));
     if (_events.length > 10) _events.removeAt(0);
   }
 


### PR DESCRIPTION
## Summary
- include spot titles in change log
- color-code recent change icons
- trigger UI update whenever logging changes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fc1c36b8832ab3d6b7d358034741