### PR TITLE
Add SavedHand viewer dialog with editor link

### DIFF
--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -8,6 +8,7 @@ import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 
 class CreatePackFromTemplateScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -97,84 +98,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
   }
 
   Future<void> _previewHand(SavedHand hand) async {
-    await showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: Colors.grey[900],
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (context) => StatefulBuilder(
-        builder: (context, setStateSheet) {
-          var showAll = false;
-          Widget actionText(a) => Text(
-                'S${a.street}: P${a.playerIndex} ${a.action}${a.amount != null ? ' • ${a.amount}' : ''}',
-                style: const TextStyle(color: Colors.white70),
-              );
-          return Padding(
-            padding: const EdgeInsets.all(16),
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    hand.name.isEmpty ? 'Без названия' : hand.name,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 18,
-                        color: Colors.white),
-                  ),
-                  const SizedBox(height: 8),
-                  Text('Позиция: ${hand.heroPosition}',
-                      style: const TextStyle(color: Colors.white70)),
-                  if (hand.tags.isNotEmpty) ...[
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 4,
-                      children: [
-                        for (final t in hand.tags)
-                          Chip(
-                            label: Text(t),
-                            backgroundColor: const Color(0xFF3A3B3E),
-                            labelStyle: const TextStyle(color: Colors.white),
-                          ),
-                      ],
-                    ),
-                  ],
-                  if (hand.actions.isNotEmpty) ...[
-                    const SizedBox(height: 12),
-                    const Text('Действия:',
-                        style: TextStyle(color: Colors.white)),
-                    const SizedBox(height: 4),
-                    if (showAll)
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [for (final a in hand.actions) actionText(a)],
-                      )
-                    else ...[
-                      actionText(hand.actions.first),
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: TextButton(
-                          onPressed: () => setStateSheet(() => showAll = true),
-                          child: const Text('Показать всё'),
-                        ),
-                      ),
-                    ],
-                  ],
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () => Navigator.pop(context),
-                    child: const Text('Закрыть'),
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
-      ),
-    );
+    await showSavedHandViewerDialog(context, hand);
   }
 
   Future<void> _editSelected() async {

--- a/lib/screens/daily_hand_screen.dart
+++ b/lib/screens/daily_hand_screen.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/daily_hand_service.dart';
 import '../widgets/saved_hand_tile.dart';
-import '../widgets/saved_hand_detail_sheet.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../helpers/date_utils.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -41,20 +41,7 @@ class DailyHandScreen extends StatelessWidget {
             : SavedHandTile(
                 hand: hand,
                 onTap: () {
-                  showModalBottomSheet(
-                    context: context,
-                    isScrollControlled: true,
-                    backgroundColor: Colors.grey[900],
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                    ),
-                    builder: (_) => SavedHandDetailSheet(
-                      hand: hand,
-                      onDelete: () {},
-                      onExportJson: () async {},
-                      onExportCsv: () async {},
-                    ),
-                  );
+                  showSavedHandViewerDialog(context, hand);
                 },
               ),
       ),

--- a/lib/screens/error_free_streak_screen.dart
+++ b/lib/screens/error_free_streak_screen.dart
@@ -5,7 +5,7 @@ import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import 'streak_history_screen.dart';
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 
 /// Displays hands from the current error-free streak.
@@ -41,12 +41,7 @@ class ErrorFreeStreakScreen extends StatelessWidget {
         initialAccuracy: 'correct',
         showAccuracyToggle: false,
         onTap: (hand) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => HandHistoryReviewScreen(hand: hand),
-            ),
-          );
+          showSavedHandViewerDialog(context, hand);
         },
       ),
     );

--- a/lib/screens/mistake_repeat_screen.dart
+++ b/lib/screens/mistake_repeat_screen.dart
@@ -9,7 +9,7 @@ import 'package:open_filex/open_filex.dart';
 
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -232,13 +232,7 @@ class MistakeRepeatScreen extends StatelessWidget {
                         SavedHandTile(
                           hand: hand,
                           onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) =>
-                                    HandHistoryReviewScreen(hand: hand),
-                              ),
-                            );
+                            showSavedHandViewerDialog(context, hand);
                           },
                           onFavoriteToggle: () {
                             final manager =

--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/sync_status_widget.dart';
 import '../widgets/view_manager_dialog.dart';
 import '../models/pack_editor_snapshot.dart';
 import '../widgets/snapshot_manager_dialog.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 
 enum _SortOption { newest, oldest, position, tags, mistakes }
 
@@ -373,39 +374,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
   }
 
   Future<void> _previewHand(SavedHand hand) async {
-    await showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.grey[900],
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (_) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              hand.name.isEmpty ? 'Без названия' : hand.name,
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '${hand.heroPosition} • ${hand.numberOfPlayers}p',
-              style: const TextStyle(color: Colors.white70),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Actions: ${hand.actions.length}',
-              style: const TextStyle(color: Colors.white70),
-            ),
-          ],
-        ),
-      ),
-    );
+    await showSavedHandViewerDialog(context, hand);
   }
 
   Future<void> _editHand(SavedHand hand) async {

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -18,7 +18,7 @@ import '../services/ignored_mistake_service.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 
 /// Displays a list of hero positions sorted by mistake count.
@@ -308,12 +308,7 @@ class _PositionMistakeHandsScreen extends StatelessWidget {
         filterKey: position,
         title: 'Ошибки: $position',
         onTap: (hand) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => HandHistoryReviewScreen(hand: hand),
-            ),
-          );
+          showSavedHandViewerDialog(context, hand);
         },
       ),
     );

--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -9,6 +9,7 @@ import '../services/room_hand_history_importer.dart';
 import '../services/training_pack_storage_service.dart';
 import '../theme/app_colors.dart';
 import 'room_hand_history_editor_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 
 enum _Filter { all, newOnly, dup }
 
@@ -114,31 +115,7 @@ class _RoomHandHistoryImportScreenState
   }
 
   Future<void> _preview(SavedHand hand) async {
-    await showModalBottomSheet(
-      context: context,
-      backgroundColor: AppColors.cardBackground,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (_) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(hand.name,
-                style: const TextStyle(
-                    color: Colors.white, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 8),
-            Text('${hand.heroPosition} • ${hand.numberOfPlayers}p',
-                style: const TextStyle(color: Colors.white70)),
-            const SizedBox(height: 8),
-            Text('Actions: ${hand.actions.length}',
-                style: const TextStyle(color: Colors.white70)),
-          ],
-        ),
-      ),
-    );
+    await showSavedHandViewerDialog(context, hand);
   }
 
   void _replaceHand(SavedHand oldHand, SavedHand newHand) {

--- a/lib/screens/saved_hand_history_screen.dart
+++ b/lib/screens/saved_hand_history_screen.dart
@@ -6,7 +6,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
 import '../theme/constants.dart';
 import '../widgets/saved_hand_list_view.dart';
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 
 class SavedHandHistoryScreen extends StatefulWidget {
@@ -48,12 +48,7 @@ class _SavedHandHistoryScreenState extends State<SavedHandHistoryScreen>
   }
 
   void _openHand(SavedHand hand) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => HandHistoryReviewScreen(hand: hand),
-      ),
-    );
+    showSavedHandViewerDialog(context, hand);
   }
 
   void _toggleFavorite(SavedHand hand, SavedHandManagerService manager) {

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -8,7 +8,7 @@ import '../services/saved_hand_import_export_service.dart';
 import 'package:share_plus/share_plus.dart';
 import '../theme/constants.dart';
 import '../widgets/saved_hand_list_view.dart';
-import '../screens/hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../helpers/poker_street_helper.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -194,12 +194,7 @@ class _SavedHandsScreenState extends State<SavedHandsScreen> {
                       : null,
               showAccuracyToggle: false,
               onTap: (hand) {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => HandHistoryReviewScreen(hand: hand),
-                  ),
-                );
+                showSavedHandViewerDialog(context, hand);
               },
               onFavoriteToggle: (hand) {
                 final originalIndex = allHands.indexOf(hand);

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -11,7 +11,7 @@ import '../widgets/saved_hand_tile.dart';
 import '../helpers/date_utils.dart';
 import '../theme/app_colors.dart';
 import '../theme/constants.dart';
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 
 class SessionHandsScreen extends StatefulWidget {
@@ -245,12 +245,7 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
                     manager.update(originalIndex, updated);
                   },
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => HandHistoryReviewScreen(hand: hand),
-                      ),
-                    );
+                    showSavedHandViewerDialog(context, hand);
                   },
                 ),
             ]

--- a/lib/screens/snapshot_diff_screen.dart
+++ b/lib/screens/snapshot_diff_screen.dart
@@ -6,6 +6,7 @@ import '../models/pack_snapshot.dart';
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 
 class SnapshotDiffScreen extends StatefulWidget {
   final TrainingPack pack;
@@ -77,39 +78,7 @@ class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
   }
 
   Future<void> _previewHand(SavedHand hand) async {
-    await showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.grey[900],
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (_) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              hand.name.isEmpty ? 'Untitled' : hand.name,
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '${hand.heroPosition} • ${hand.numberOfPlayers}p',
-              style: const TextStyle(color: Colors.white70),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Actions: ${hand.actions.length}',
-              style: const TextStyle(color: Colors.white70),
-            ),
-          ],
-        ),
-      ),
-    );
+    await showSavedHandViewerDialog(context, hand);
   }
 
   Future<void> _apply() async {

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -27,7 +27,7 @@ import '../widgets/mistake_empty_state.dart';
 import '../widgets/common/mistake_trend_chart.dart';
 
 enum _ChartMode { daily, weekly }
-import 'hand_history_review_screen.dart';
+import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -1068,12 +1068,7 @@ class _TagMistakeHandsScreen extends StatelessWidget {
         filterKey: tag,
         title: 'Ошибки: $tag',
         onTap: (hand) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => HandHistoryReviewScreen(hand: hand),
-            ),
-          );
+          showSavedHandViewerDialog(context, hand);
         },
       ),
     );
@@ -1198,12 +1193,7 @@ class _DailySeverityHandsScreen extends StatelessWidget {
                     return SavedHandTile(
                       hand: hand,
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => HandHistoryReviewScreen(hand: hand),
-                          ),
-                        );
+                        showSavedHandViewerDialog(context, hand);
                       },
                     );
                   },

--- a/lib/widgets/saved_hand_viewer_dialog.dart
+++ b/lib/widgets/saved_hand_viewer_dialog.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/saved_hand.dart';
+import '../models/training_spot.dart';
+import '../models/action_entry.dart';
+import '../widgets/replay_spot_widget.dart';
+import '../widgets/action_history_widget.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../screens/saved_hand_editor_screen.dart';
+
+class SavedHandViewerDialog extends StatelessWidget {
+  final SavedHand hand;
+  final BuildContext parentContext;
+  const SavedHandViewerDialog({super.key, required this.hand, required this.parentContext});
+
+  Map<int, String> _posMap() => {
+        for (int i = 0; i < hand.numberOfPlayers; i++)
+          i: hand.playerPositions[i] ?? 'P${i + 1}'
+      };
+
+  List<ActionEntry> _actions() => List<ActionEntry>.from(hand.actions);
+
+  Future<void> _edit(BuildContext context) async {
+    Navigator.pop(context);
+    final result = await Navigator.of(parentContext).push<SavedHand>(
+      MaterialPageRoute(builder: (_) => SavedHandEditorScreen(hand: hand)),
+    );
+    if (result != null) {
+      final manager = parentContext.read<SavedHandManagerService>();
+      final index = manager.hands.indexOf(hand);
+      if (index >= 0) await manager.update(index, result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final spot = TrainingSpot.fromSavedHand(hand);
+    return AlertDialog(
+      title: Row(
+        children: [
+          Expanded(child: Text(hand.name.isEmpty ? 'Hand' : hand.name)),
+          IconButton(onPressed: () => _edit(context), icon: const Icon(Icons.edit)),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ReplaySpotWidget(
+              spot: spot,
+              expectedAction: hand.expectedAction,
+              gtoAction: hand.gtoAction,
+              evLoss: hand.evLoss,
+              feedbackText: hand.feedbackText,
+            ),
+            const SizedBox(height: 8),
+            ActionHistoryWidget(actions: _actions(), playerPositions: _posMap()),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showSavedHandViewerDialog(BuildContext context, SavedHand hand) {
+  return showDialog(
+    context: context,
+    builder: (_) => SavedHandViewerDialog(hand: hand, parentContext: context),
+  );
+}


### PR DESCRIPTION
## Summary
- implement `SavedHandViewerDialog` for previewing and editing a saved hand
- integrate viewer into saved-hand lists and preview flows

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659262a9a4832aa1e96a731dc5e9fe