### PR TITLE
Add Packs button

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -18,6 +18,7 @@ import 'edit_pack_screen.dart';
 import 'template_library_screen.dart';
 import 'my_training_packs_screen.dart';
 import 'training_screen.dart';
+import 'start_training_from_pack_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/hand_history_file_service.dart';
 import '../services/saved_hand_manager_service.dart';
@@ -660,6 +661,17 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🗂️ Мои паки'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const StartTrainingFromPackScreen()),
+                );
+              },
+              child: const Text('📦 Packs'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- show packs training start button in the main menu

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68659a881e30832a9f4baa6366cb5fc9