### PR TITLE
Fix drill history dialog text formatting

### DIFF
--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -62,7 +62,10 @@ class DrillHistoryScreen extends StatelessWidget {
                         builder: (_) => AlertDialog(
                           title: Text(r.templateName),
                           content: Text(
-                              '${formatDate(r.date)}\nВерно: ${r.correct}/${r.total} ($pct%)\nПотеря EV: ${r.evLoss.toStringAsFixed(2)} bb'),
+                            '${formatDate(r.date)}\n'
+                            'Верно: ${r.correct}/${r.total} ($pct%)\n'
+                            'Потеря EV: ${r.evLoss.toStringAsFixed(2)} bb',
+                          ),
                           actions: [
                             TextButton(
                               onPressed: () => Navigator.pop(context),


### PR DESCRIPTION
## Summary
- improve formatting of the detailed drill history dialog

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5374940832ab6e853c354c3dbc5