### PR TITLE
Implement Mistake Repeat feature

### DIFF
--- a/lib/models/drill_result.dart
+++ b/lib/models/drill_result.dart
@@ -7,6 +7,7 @@ class DrillResult {
   final int total;
   final int correct;
   final double evLoss;
+  final List<String> wrongSpotIds;
   DrillResult({
     required this.templateId,
     required this.templateName,
@@ -14,7 +15,8 @@ class DrillResult {
     required this.total,
     required this.correct,
     required this.evLoss,
-  });
+    List<String>? wrongSpotIds,
+  }) : wrongSpotIds = wrongSpotIds ?? [];
 
   Map<String, dynamic> toJson() => {
         'templateId': templateId,
@@ -23,6 +25,7 @@ class DrillResult {
         'total': total,
         'correct': correct,
         'evLoss': evLoss,
+        if (wrongSpotIds.isNotEmpty) 'wrongSpotIds': wrongSpotIds,
       };
 
   factory DrillResult.fromJson(Map<String, dynamic> j) => DrillResult(
@@ -32,5 +35,6 @@ class DrillResult {
         total: j['total'] as int? ?? 0,
         correct: j['correct'] as int? ?? 0,
         evLoss: (j['evLoss'] as num?)?.toDouble() ?? 0.0,
+        wrongSpotIds: [for (final id in (j['wrongSpotIds'] as List? ?? [])) id as String],
       );
 }

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -5,6 +5,7 @@ import 'action_evaluation_request.dart';
 
 class SavedHand {
   final String name;
+  final String? spotId;
   final int heroIndex;
   final String heroPosition;
   final int numberOfPlayers;
@@ -82,6 +83,7 @@ class SavedHand {
 
   SavedHand({
     required this.name,
+    this.spotId,
     required this.heroIndex,
     required this.heroPosition,
     required this.numberOfPlayers,
@@ -143,6 +145,7 @@ class SavedHand {
 
   SavedHand copyWith({
     String? name,
+    String? spotId,
     int? heroIndex,
     String? heroPosition,
     int? numberOfPlayers,
@@ -198,6 +201,7 @@ class SavedHand {
   }) {
     return SavedHand(
       name: name ?? this.name,
+      spotId: spotId ?? this.spotId,
       heroIndex: heroIndex ?? this.heroIndex,
       heroPosition: heroPosition ?? this.heroPosition,
       numberOfPlayers: numberOfPlayers ?? this.numberOfPlayers,
@@ -296,6 +300,7 @@ class SavedHand {
 
   Map<String, dynamic> toJson() => {
         'name': name,
+        if (spotId != null) 'spotId': spotId,
         'heroIndex': heroIndex,
         'heroPosition': heroPosition,
         'numberOfPlayers': numberOfPlayers,
@@ -405,6 +410,7 @@ class SavedHand {
         ]
     ];
     final boardStreet = json['boardStreet'] as int? ?? 0;
+    final spotId = json['spotId'] as String?;
     final oppIndex = json['opponentIndex'] as int?;
     final activeIndex = json['activePlayerIndex'] as int?;
     final acts = [
@@ -546,6 +552,7 @@ class SavedHand {
     }
     return SavedHand(
       name: json['name'] as String? ?? '',
+      spotId: spotId,
       heroIndex: json['heroIndex'] as int? ?? 0,
       heroPosition: json['heroPosition'] as String? ?? 'BTN',
       numberOfPlayers: json['numberOfPlayers'] as int? ?? 6,

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -6,6 +6,9 @@ import '../services/drill_history_service.dart';
 import '../theme/app_colors.dart';
 import '../helpers/date_utils.dart';
 import '../models/drill_result.dart';
+import '../services/training_pack_storage_service.dart';
+import '../models/saved_hand.dart';
+import 'training_screen.dart';
 
 class DrillHistoryScreen extends StatefulWidget {
   const DrillHistoryScreen({super.key});
@@ -148,6 +151,35 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
     );
   }
 
+  Future<void> _repeatMistakes() async {
+    final history = context.read<DrillHistoryService>().results;
+    final ids = <String>{};
+    for (final r in history) ids.addAll(r.wrongSpotIds);
+    if (ids.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Ошибок не найдено')));
+      return;
+    }
+    final packs = context.read<TrainingPackStorageService>().packs;
+    final hands = <SavedHand>[];
+    for (final p in packs) {
+      for (final h in p.hands) {
+        if (ids.contains(h.spotId)) hands.add(h);
+      }
+    }
+    if (hands.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Ошибок не найдено')));
+      return;
+    }
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingScreen.drill(hands: hands, templateName: 'Mistakes'),
+      ),
+    );
+  }
+
   Widget _empty() => const Center(
         child: Text('История пока пуста',
             style: TextStyle(color: Colors.white70)),
@@ -235,7 +267,12 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
             icon: const Text('📈', style: TextStyle(fontSize: 20)),
             label: const Text('Показать график'),
             style: TextButton.styleFrom(foregroundColor: Colors.white),
-          )
+          ),
+          IconButton(
+            onPressed: _repeatMistakes,
+            icon: const Text('🔁', style: TextStyle(fontSize: 20)),
+            tooltip: 'Повтор ошибок',
+          ),
         ],
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(56),

--- a/lib/screens/start_training_from_pack_screen.dart
+++ b/lib/screens/start_training_from_pack_screen.dart
@@ -74,6 +74,7 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
     }
     return SavedHand(
       name: spot.title,
+      spotId: spot.id,
       heroIndex: spot.hand.heroIndex,
       heroPosition: spot.hand.position.label,
       numberOfPlayers: spot.hand.playerCount,

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -39,6 +39,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
   int total = 0;
   int correct = 0;
   double evLoss = 0;
+  final List<String> _wrongIds = [];
 
   @override
   void initState() {
@@ -71,8 +72,11 @@ class _TrainingScreenState extends State<TrainingScreen> {
       _wasCorrect = isCorrect;
       if (isCorrect) {
         correct++;
-      } else if (hero?.ev != null) {
-        evLoss += -hero!.ev!;
+      } else {
+        _wrongIds.add(hand.spotId ?? '');
+        if (hero?.ev != null) {
+          evLoss += -hero!.ev!;
+        }
       }
     });
     ScaffoldMessenger.of(context).clearSnackBars();
@@ -164,6 +168,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
       total: total,
       correct: correct,
       evLoss: evLoss,
+      wrongSpotIds: _wrongIds,
     );
     await context.read<DrillHistoryService>().add(result);
     if (mounted) Navigator.pop(context);


### PR DESCRIPTION
## Summary
- track wrong spot ids in drill results
- store spotId in generated training hands
- collect mistakes in history and allow repeating them

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: package not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dfec2688832aa23efcf787bba509