### PR TITLE
Fix repeat last session and history handling

### DIFF
--- a/lib/helpers/pack_spot_utils.dart
+++ b/lib/helpers/pack_spot_utils.dart
@@ -1,0 +1,65 @@
+import '../models/saved_hand.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/card_model.dart';
+import '../models/action_entry.dart';
+
+SavedHand handFromPackSpot(TrainingPackSpot spot) {
+  final parts = spot.hand.heroCards
+      .split(RegExp(r'\s+'))
+      .where((e) => e.isNotEmpty)
+      .toList();
+  final cards = [for (final p in parts) CardModel(rank: p[0], suit: p.substring(1))];
+  final playerCards = [for (int i = 0; i < spot.hand.playerCount; i++) <CardModel>[]];
+  if (cards.length >= 2 && spot.hand.heroIndex < playerCards.length) {
+    playerCards[spot.hand.heroIndex] = cards;
+  }
+  final board = [for (final c in spot.hand.board) CardModel(rank: c[0], suit: c.substring(1))];
+  final actions = <ActionEntry>[];
+  for (final list in spot.hand.actions.values) {
+    for (final a in list) {
+      actions.add(ActionEntry(a.street, a.playerIndex, a.action,
+          amount: a.amount,
+          generated: a.generated,
+          manualEvaluation: a.manualEvaluation,
+          customLabel: a.customLabel));
+    }
+  }
+  final stacks = {
+    for (int i = 0; i < spot.hand.playerCount; i++)
+      i: spot.hand.stacks['$i']?.round() ?? 0
+  };
+  final positions = {
+    for (int i = 0; i < spot.hand.playerCount; i++)
+      i: i == spot.hand.heroIndex ? spot.hand.position.label : ''
+  };
+  String? gto;
+  for (final a in spot.hand.actions[0] ?? []) {
+    if (a.playerIndex == spot.hand.heroIndex) {
+      gto = a.action.toUpperCase();
+      break;
+    }
+  }
+  int street = 0;
+  if (board.length >= 5) {
+    street = 3;
+  } else if (board.length == 4) {
+    street = 2;
+  } else if (board.length >= 3) {
+    street = 1;
+  }
+  return SavedHand(
+    name: spot.title,
+    spotId: spot.id,
+    heroIndex: spot.hand.heroIndex,
+    heroPosition: spot.hand.position.label,
+    numberOfPlayers: spot.hand.playerCount,
+    playerCards: playerCards,
+    boardCards: board,
+    boardStreet: street,
+    actions: actions,
+    stackSizes: stacks,
+    playerPositions: positions,
+    tags: List<String>.from(spot.tags),
+    gtoAction: gto,
+  );
+}

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -8,6 +8,8 @@ import '../helpers/date_utils.dart';
 import '../models/drill_result.dart';
 import '../services/training_pack_storage_service.dart';
 import '../models/saved_hand.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../helpers/pack_spot_utils.dart';
 import 'package:collection/collection.dart';
 import 'training_screen.dart';
 
@@ -155,7 +157,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
   Future<void> _repeatMistakes() async {
     final history = context.read<DrillHistoryService>().results;
     final ids = <String>{};
-    for (final r in history) ids.addAll(r.wrongSpotIds);
+    for (final r in history) ids.addAll(r.wrongSpotIds.where((e) => e.isNotEmpty));
     if (ids.isEmpty) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Ошибок не найдено')));
@@ -200,7 +202,9 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
       context,
       MaterialPageRoute(
         builder: (_) => TrainingScreen.drill(
-          hands: pack.hands,
+          hands: pack.hands.isNotEmpty
+              ? pack.hands
+              : [for (final s in pack.spots) handFromPackSpot(s as TrainingPackSpot)],
           templateId: pack.id,
           templateName: pack.name,
         ),

--- a/lib/screens/start_training_from_pack_screen.dart
+++ b/lib/screens/start_training_from_pack_screen.dart
@@ -4,10 +4,7 @@ import 'package:collection/collection.dart';
 import '../helpers/training_pack_storage.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
-import '../models/saved_hand.dart';
-import '../models/action_entry.dart';
-import '../models/card_model.dart';
-import '../models/player_model.dart';
+import '../helpers/pack_spot_utils.dart';
 import 'training_screen.dart';
 
 class StartTrainingFromPackScreen extends StatefulWidget {
@@ -41,59 +38,12 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
     });
   }
 
-  SavedHand _handFromSpot(TrainingPackSpot spot) {
-    final parts = spot.hand.heroCards.split(RegExp(r'\s+')).where((e) => e.isNotEmpty).toList();
-    final cards = [for (final p in parts) CardModel(rank: p[0], suit: p.substring(1))];
-    final playerCards = [for (int i = 0; i < spot.hand.playerCount; i++) <CardModel>[]];
-    if (cards.length >= 2 && spot.hand.heroIndex < playerCards.length) {
-      playerCards[spot.hand.heroIndex] = cards;
-    }
-    final board = [for (final c in spot.hand.board) CardModel(rank: c[0], suit: c.substring(1))];
-    final actions = <ActionEntry>[];
-    for (final list in spot.hand.actions.values) {
-      for (final a in list) {
-        actions.add(ActionEntry(a.street, a.playerIndex, a.action, amount: a.amount, generated: a.generated, manualEvaluation: a.manualEvaluation, customLabel: a.customLabel));
-      }
-    }
-    final stacks = {for (int i = 0; i < spot.hand.playerCount; i++) i: spot.hand.stacks['$i']?.round() ?? 0};
-    final positions = {for (int i = 0; i < spot.hand.playerCount; i++) i: i == spot.hand.heroIndex ? spot.hand.position.label : ''};
-    String? gto;
-    for (final a in spot.hand.actions[0] ?? []) {
-      if (a.playerIndex == spot.hand.heroIndex) {
-        gto = a.action.toUpperCase();
-        break;
-      }
-    }
-    int street = 0;
-    if (board.length >= 5) {
-      street = 3;
-    } else if (board.length == 4) {
-      street = 2;
-    } else if (board.length >= 3) {
-      street = 1;
-    }
-    return SavedHand(
-      name: spot.title,
-      spotId: spot.id,
-      heroIndex: spot.hand.heroIndex,
-      heroPosition: spot.hand.position.label,
-      numberOfPlayers: spot.hand.playerCount,
-      playerCards: playerCards,
-      boardCards: board,
-      boardStreet: street,
-      actions: actions,
-      stackSizes: stacks,
-      playerPositions: positions,
-      tags: List<String>.from(spot.tags),
-      gtoAction: gto,
-    );
-  }
 
   Future<void> _start(TrainingPackTemplate tpl) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_lastKey, tpl.name);
     setState(() => _last = tpl.name);
-    final hands = [for (final s in tpl.spots) _handFromSpot(s)];
+    final hands = [for (final s in tpl.spots) handFromPackSpot(s)];
     await Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -168,7 +168,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
       total: total,
       correct: correct,
       evLoss: evLoss,
-      wrongSpotIds: _wrongIds,
+      wrongSpotIds: [for (final id in _wrongIds) if (id.isNotEmpty) id],
     );
     await context.read<DrillHistoryService>().add(result);
     if (mounted) Navigator.pop(context);


### PR DESCRIPTION
## Summary
- create `handFromPackSpot` helper
- use `handFromPackSpot` in training pack start screen
- repair drill history repeat options
- keep only valid wrong spot ids when saving results

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e479a82c832aaffe840c8ca6edea