### PR TITLE
Add EV lost indicator to TrainingScreen

### DIFF
--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -275,7 +275,20 @@ class _TrainingScreenState extends State<TrainingScreen> {
                   child: const Text('⬅️ Back'),
                 )
               : null,
-          title: const Text('Training'),
+          title: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Training'),
+              if (_drill)
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: Text(
+                    'EV Lost: ${evLoss.toStringAsFixed(2)} bb',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+            ],
+          ),
           centerTitle: true,
           actions: [SyncStatusIcon.of(context)],
         ),


### PR DESCRIPTION
## Summary
- display EV lost in TrainingScreen AppBar during drills

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662c7348dc832a90c2f71ab1088d9b