### PR TITLE
Add EV threshold setting for training packs

### DIFF
--- a/lib/helpers/pack_spot_utils.dart
+++ b/lib/helpers/pack_spot_utils.dart
@@ -21,7 +21,9 @@ SavedHand handFromPackSpot(TrainingPackSpot spot) {
           amount: a.amount,
           generated: a.generated,
           manualEvaluation: a.manualEvaluation,
-          customLabel: a.customLabel));
+          customLabel: a.customLabel,
+          ev: a.ev,
+          icmEv: a.icmEv));
     }
   }
   final stacks = {

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -17,6 +17,7 @@ class TrainingPackTemplate {
   int spotCount;
   int bbCallPct;
   int anteBb;
+  double minEvForCorrect;
   List<String>? heroRange;
   final DateTime createdAt;
   DateTime? lastGeneratedAt;
@@ -35,6 +36,7 @@ class TrainingPackTemplate {
     this.spotCount = 20,
     this.bbCallPct = 20,
     this.anteBb = 0,
+    this.minEvForCorrect = 0.01,
     this.heroRange,
     DateTime? createdAt,
     this.lastGeneratedAt,
@@ -60,6 +62,7 @@ class TrainingPackTemplate {
     int? spotCount,
     int? bbCallPct,
     int? anteBb,
+    double? minEvForCorrect,
     List<String>? heroRange,
     DateTime? createdAt,
     DateTime? lastGeneratedAt,
@@ -78,6 +81,7 @@ class TrainingPackTemplate {
       spotCount: spotCount ?? this.spotCount,
       bbCallPct: bbCallPct ?? this.bbCallPct,
       anteBb: anteBb ?? this.anteBb,
+      minEvForCorrect: minEvForCorrect ?? this.minEvForCorrect,
       heroRange: heroRange ?? this.heroRange,
       createdAt: createdAt ?? this.createdAt,
       lastGeneratedAt: lastGeneratedAt ?? this.lastGeneratedAt,
@@ -108,6 +112,7 @@ class TrainingPackTemplate {
       spotCount: json['spotCount'] as int? ?? 20,
       bbCallPct: json['bbCallPct'] as int? ?? 20,
       anteBb: json['anteBb'] as int? ?? 0,
+      minEvForCorrect: (json['minEvForCorrect'] as num?)?.toDouble() ?? 0.01,
       heroRange: (json['heroRange'] as List?)?.map((e) => e as String).toList(),
       createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
           DateTime.now(),
@@ -135,6 +140,7 @@ class TrainingPackTemplate {
         'spotCount': spotCount,
         'bbCallPct': bbCallPct,
         'anteBb': anteBb,
+        'minEvForCorrect': minEvForCorrect,
         'createdAt': createdAt.toIso8601String(),
         if (lastGeneratedAt != null)
           'lastGeneratedAt': lastGeneratedAt!.toIso8601String(),

--- a/lib/screens/start_training_from_pack_screen.dart
+++ b/lib/screens/start_training_from_pack_screen.dart
@@ -51,6 +51,7 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
                 hands: hands,
                 templateId: tpl.id,
                 templateName: tpl.name,
+                minEvForCorrect: tpl.minEvForCorrect,
               )),
     );
   }

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -18,14 +18,21 @@ class TrainingScreen extends StatefulWidget {
   final bool drillMode;
   final String? templateId;
   final String? templateName;
+  final double minEvForCorrect;
 
   const TrainingScreen({super.key, required TrainingSpot trainingSpot})
       : spot = trainingSpot,
         hands = null,
-        drillMode = false;
+        drillMode = false,
+        minEvForCorrect = 0.01;
 
-  const TrainingScreen.drill({super.key, required this.hands, this.templateId, this.templateName})
-      : spot = null,
+  const TrainingScreen.drill({
+    super.key,
+    required this.hands,
+    this.templateId,
+    this.templateName,
+    this.minEvForCorrect = 0.01,
+  })  : spot = null,
         drillMode = true;
 
   @override
@@ -59,13 +66,17 @@ class _TrainingScreenState extends State<TrainingScreen> {
     if (_selected != null) return;
     final hand = widget.hands![_index];
     final expected = hand.gtoAction?.trim().toUpperCase() ?? '';
-    final isCorrect = action.toUpperCase() == expected;
+    bool isCorrect = action.toUpperCase() == expected;
     ActionEntry? hero;
     for (final a in hand.actions) {
       if (a.street == 0 && a.playerIndex == hand.heroIndex) {
         hero = a;
         break;
       }
+    }
+    if (!isCorrect && hero?.ev != null &&
+        hero!.ev!.abs() < widget.minEvForCorrect) {
+      isCorrect = true;
     }
     setState(() {
       _selected = action;
@@ -74,9 +85,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
         correct++;
       } else {
         _wrongIds.add(hand.spotId ?? '');
-        if (hero?.ev != null) {
-          evLoss += -hero!.ev!;
-        }
+        if (hero?.ev != null) evLoss += -hero!.ev!;
       }
     });
     ScaffoldMessenger.of(context).clearSnackBars();

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -64,6 +64,7 @@ class TrainingPackTemplateEditorScreen extends StatefulWidget {
 
 class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateEditorScreen> {
   late final TextEditingController _descCtr;
+  late final TextEditingController _evCtr;
   late final FocusNode _descFocus;
   late String _templateName;
   String _query = '';
@@ -533,6 +534,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     super.initState();
     _templateName = widget.template.name;
     _descCtr = TextEditingController(text: widget.template.description);
+    _evCtr = TextEditingController(
+        text: widget.template.minEvForCorrect.toString());
     _descFocus = FocusNode();
     _descFocus.addListener(() {
       if (!_descFocus.hasFocus) _saveDesc();
@@ -603,6 +606,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _storeScroll();
     _descFocus.dispose();
     _descCtr.dispose();
+    _evCtr.dispose();
     _searchCtrl.dispose();
     _tagSearchCtrl.dispose();
     _scrollCtrl.dispose();
@@ -2452,6 +2456,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               decoration: const InputDecoration(labelText: 'Description'),
               maxLines: 4,
               onEditingComplete: _saveDesc,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _evCtr,
+              decoration:
+                  const InputDecoration(labelText: 'Min EV to be correct (bb)'),
+              keyboardType: TextInputType.number,
+              onChanged: (v) {
+                final val = double.tryParse(v) ?? 0.01;
+                setState(() => widget.template.minEvForCorrect = val);
+                _persist();
+              },
             ),
             const SizedBox(height: 16),
             Wrap(


### PR DESCRIPTION
## Summary
- support configurable EV threshold in `TrainingPackTemplate`
- expose threshold field in template editor
- keep EV data when converting spots to hands
- use threshold during training answer evaluation
- pass threshold when starting training from pack

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662d5387c8832ab0614db975e20bdb