### PR TITLE
Add ante support in drills

### DIFF
--- a/lib/helpers/pack_spot_utils.dart
+++ b/lib/helpers/pack_spot_utils.dart
@@ -3,7 +3,7 @@ import '../models/v2/training_pack_spot.dart';
 import '../models/card_model.dart';
 import '../models/action_entry.dart';
 
-SavedHand handFromPackSpot(TrainingPackSpot spot) {
+SavedHand handFromPackSpot(TrainingPackSpot spot, {int anteBb = 0}) {
   final parts = spot.hand.heroCards
       .split(RegExp(r'\s+'))
       .where((e) => e.isNotEmpty)
@@ -61,6 +61,7 @@ SavedHand handFromPackSpot(TrainingPackSpot spot) {
     actions: actions,
     stackSizes: stacks,
     playerPositions: positions,
+    anteBb: anteBb,
     tags: List<String>.from(spot.tags),
     gtoAction: gto,
   );

--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -39,6 +39,7 @@ class SavedHand {
   final int? totalPot;
   /// Rake taken from the pot in chips or big blinds.
   final int? rake;
+  final int anteBb;
   final Map<int, String> playerPositions;
   final Map<int, PlayerType>? playerTypes;
   final String? comment;
@@ -100,6 +101,7 @@ class SavedHand {
     this.winnings,
     this.totalPot,
     this.rake,
+    this.anteBb = 0,
     this.tournamentId,
     this.buyIn,
     this.totalPrizePool,
@@ -162,6 +164,7 @@ class SavedHand {
     Map<int, int>? winnings,
     int? totalPot,
     int? rake,
+    int? anteBb,
     String? tournamentId,
     int? buyIn,
     int? totalPrizePool,
@@ -225,6 +228,7 @@ class SavedHand {
           (this.winnings == null ? null : Map<int, int>.from(this.winnings!)),
       totalPot: totalPot ?? this.totalPot,
       rake: rake ?? this.rake,
+      anteBb: anteBb ?? this.anteBb,
       tournamentId: tournamentId ?? this.tournamentId,
       buyIn: buyIn ?? this.buyIn,
       totalPrizePool: totalPrizePool ?? this.totalPrizePool,
@@ -340,6 +344,7 @@ class SavedHand {
           'winnings': winnings!.map((k, v) => MapEntry(k.toString(), v)),
         if (totalPot != null) 'totalPot': totalPot,
         if (rake != null) 'rake': rake,
+        'anteBb': anteBb,
         if (tournamentId != null) 'tournamentId': tournamentId,
         if (buyIn != null) 'buyIn': buyIn,
         if (totalPrizePool != null) 'totalPrizePool': totalPrizePool,
@@ -454,6 +459,7 @@ class SavedHand {
     }
     final totalPot = json['totalPot'] as int?;
     final rake = json['rake'] as int?;
+    final anteBb = json['anteBb'] as int? ?? 0;
     final tournamentId = json['tournamentId'] as String?;
     final buyIn = json['buyIn'] as int?;
     final totalPrizePool = json['totalPrizePool'] as int?;
@@ -569,6 +575,7 @@ class SavedHand {
       winnings: wins,
       totalPot: totalPot,
       rake: rake,
+      anteBb: anteBb,
       tournamentId: tournamentId,
       buyIn: buyIn,
       totalPrizePool: totalPrizePool,

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -12,6 +12,7 @@ class TrainingSpot {
   final List<PlayerType> playerTypes;
   final List<String> positions;
   final List<int> stacks;
+  final int anteBb;
 
   /// Optional strategy advice for each player indexed by player position.
   final List<String>? strategyAdvice;
@@ -45,6 +46,7 @@ class TrainingSpot {
     required this.playerTypes,
     required this.positions,
     required this.stacks,
+    this.anteBb = 0,
     this.strategyAdvice,
     this.equities,
     this.rangeMatrix,
@@ -85,6 +87,7 @@ class TrainingSpot {
       stacks: [
         for (int i = 0; i < hand.numberOfPlayers; i++) hand.stackSizes[i] ?? 0
       ],
+      anteBb: hand.anteBb,
       rangeMatrix: null,
       equities: null,
       tournamentId: hand.tournamentId,
@@ -129,6 +132,7 @@ class TrainingSpot {
         'playerTypes': [for (final t in playerTypes) t.name],
         'positions': positions,
         'stacks': stacks,
+        'anteBb': anteBb,
         if (equities != null) 'equities': equities,
         if (rangeMatrix != null) 'rangeMatrix': rangeMatrix,
         if (tournamentId != null) 'tournamentId': tournamentId,
@@ -211,6 +215,7 @@ class TrainingSpot {
     for (int i = 0; i < numberOfPlayers; i++) {
       stacks.add(i < stackData.length ? stackData[i].toInt() : 0);
     }
+    final anteBb = json['anteBb'] as int? ?? 0;
 
     final adviceData = (json['strategyAdvice'] as List?)?.cast<String>();
     final equityData = (json['equities'] as List?)?.cast<num>();
@@ -239,6 +244,7 @@ class TrainingSpot {
       playerTypes: types,
       positions: positions,
       stacks: stacks,
+      anteBb: anteBb,
       strategyAdvice: adviceData,
       equities: equities,
       rangeMatrix: rangeMatrix,
@@ -273,6 +279,7 @@ class TrainingSpot {
     List<double>? equities,
     List<List<double>>? rangeMatrix,
     DateTime? createdAt,
+    int? anteBb,
   }) {
     return TrainingSpot(
       playerCards: [for (final list in playerCards) List<CardModel>.from(list)],
@@ -283,6 +290,7 @@ class TrainingSpot {
       playerTypes: List<PlayerType>.from(playerTypes),
       positions: List<String>.from(positions),
       stacks: List<int>.from(stacks),
+      anteBb: anteBb ?? this.anteBb,
       strategyAdvice: strategyAdvice ?? this.strategyAdvice,
       equities: equities ?? this.equities,
       rangeMatrix: rangeMatrix ?? this.rangeMatrix,

--- a/lib/screens/start_training_from_pack_screen.dart
+++ b/lib/screens/start_training_from_pack_screen.dart
@@ -43,7 +43,7 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_lastKey, tpl.name);
     setState(() => _last = tpl.name);
-    final hands = [for (final s in tpl.spots) handFromPackSpot(s)];
+    final hands = [for (final s in tpl.spots) handFromPackSpot(s, anteBb: tpl.anteBb)];
     await Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -239,7 +239,8 @@ class _TrainingScreenState extends State<TrainingScreen> {
       if (tpl != null) {
         final hands = [
           for (final s in tpl.spots)
-            if (_wrongIds.contains(s.id)) handFromPackSpot(s)
+            if (_wrongIds.contains(s.id))
+              handFromPackSpot(s, anteBb: tpl.anteBb)
         ];
         if (hands.isNotEmpty) {
           unawaited(Navigator.pushReplacement(
@@ -345,6 +346,14 @@ class _TrainingScreenState extends State<TrainingScreen> {
                 Text(
                   'Раздача ${_index + 1} / ${widget.hands!.length}',
                   style: const TextStyle(color: Colors.white70),
+                ),
+              if (_drill && spot.anteBb > 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    'Ante: ${spot.anteBb} BB',
+                    style: const TextStyle(color: Colors.white),
+                  ),
                 ),
               if (_drill) const SizedBox(height: 8),
               TrainingSpotDiagram(


### PR DESCRIPTION
## Summary
- keep ante info in SavedHand and TrainingSpot
- include template ante when creating training hands
- show ante value at the top of drills

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686637e3d0b4832a8f0c846ef87cbd36