### PR TITLE
Add ante field to training pack templates

### DIFF
--- a/lib/services/push_fold_ev_service.dart
+++ b/lib/services/push_fold_ev_service.dart
@@ -29,7 +29,7 @@ double computePushEV({
 class PushFoldEvService {
   const PushFoldEvService();
 
-  Future<void> evaluate(TrainingPackSpot spot) async {
+  Future<void> evaluate(TrainingPackSpot spot, {int anteBb = 0}) async {
     final hero = spot.hand.heroIndex;
     final hand = handCode(spot.hand.heroCards);
     final stack = spot.hand.stacks['$hero']?.round();
@@ -41,14 +41,14 @@ class PushFoldEvService {
           heroBbStack: stack,
           bbCount: spot.hand.playerCount - 1,
           heroHand: hand,
-          anteBb: 0,
+          anteBb: anteBb,
         );
         break;
       }
     }
   }
 
-  Future<void> evaluateIcm(TrainingPackSpot spot) async {
+  Future<void> evaluateIcm(TrainingPackSpot spot, {int anteBb = 0}) async {
     final hero = spot.hand.heroIndex;
     final hand = handCode(spot.hand.heroCards);
     final stack = spot.hand.stacks['$hero']?.round();
@@ -64,7 +64,7 @@ class PushFoldEvService {
           heroBbStack: stack,
           bbCount: spot.hand.playerCount - 1,
           heroHand: hand,
-          anteBb: 0,
+          anteBb: anteBb,
         );
         a.icmEv = computeIcmPushEV(
           chipStacksBb: stacks,


### PR DESCRIPTION
## Summary
- support custom ante in template editor via new input field
- clamp ante to 0-5 in settings
- propagate ante value to EV calculations

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663e0eb70c832aafce4d0fdc05e6b2