### PR TITLE
Fix coverage after spot generation

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -174,7 +174,9 @@ class TrainingPackTemplate {
       bbCallPct: bbCallPct,
       anteBb: anteBb,
     );
-    return tpl.spots.take(spotCount).toList();
+    final spots = tpl.spots.take(spotCount).toList();
+    recountCoverage([...this.spots, ...spots]);
+    return spots;
   }
 
 }

--- a/lib/services/training_pack_template_ui_service.dart
+++ b/lib/services/training_pack_template_ui_service.dart
@@ -111,6 +111,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
+    template.recountCoverage([...template.spots, ...generated]);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }
@@ -222,6 +223,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
+    template.recountCoverage([...template.spots, ...generated]);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }


### PR DESCRIPTION
## Summary
- update meta counters when generating spots

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665bc8f8cc832ab1108a5153a1ee2d