### PR TITLE
Highlight mistakes in template editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2999,6 +2999,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                   Expanded(
                                   child: TrainingPackSpotPreviewCard(
                                       spot: spot,
+                                      isMistake: spot.evalResult?.correct == false,
                                       titleColor: spot.evalResult == null
                                           ? Colors.yellow
                                           : (spot.evalResult!.correct ? null : Colors.red),

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -10,6 +10,7 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
   final ValueChanged<String>? onTagTap;
   final VoidCallback? onDuplicate;
   final Color? titleColor;
+  final bool isMistake;
   const TrainingPackSpotPreviewCard({
     super.key,
     required this.spot,
@@ -17,6 +18,7 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
     this.onTagTap,
     this.onDuplicate,
     this.titleColor,
+    this.isMistake = false,
   });
 
   @override
@@ -84,6 +86,17 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
       ),
       child: Row(
         children: [
+          if (isMistake)
+            Container(
+              width: 4,
+              decoration: const BoxDecoration(
+                color: Colors.red,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(8),
+                  bottomLeft: Radius.circular(8),
+                ),
+              ),
+            ),
           if (barColor != null)
             Container(
               width: 4,


### PR DESCRIPTION
## Summary
- add `isMistake` flag to `TrainingPackSpotPreviewCard`
- draw a red bar on spots with mistakes
- mark mistakes when listing spots in the template editor

## Testing
- `dart format lib/widgets/v2/training_pack_spot_preview_card.dart lib/screens/v2/training_pack_template_editor_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665cb9cbf4832aa1d5143050b2b5a8