### PR TITLE
Show EV in viewer

### DIFF
--- a/lib/models/evaluation_result.dart
+++ b/lib/models/evaluation_result.dart
@@ -9,11 +9,17 @@ class EvaluationResult {
   /// Equity of the hand if the optimal action was taken.
   final double expectedEquity;
 
+  final double? ev;
+
+  final double? icmEv;
+
   EvaluationResult({
     required this.correct,
     required this.expectedAction,
     required this.userEquity,
     required this.expectedEquity,
+    this.ev,
+    this.icmEv,
     this.hint,
   });
 
@@ -22,6 +28,8 @@ class EvaluationResult {
         'expectedAction': expectedAction,
         'userEquity': userEquity,
         'expectedEquity': expectedEquity,
+        if (ev != null) 'ev': ev,
+        if (icmEv != null) 'icmEv': icmEv,
         if (hint != null) 'hint': hint,
       };
 
@@ -30,6 +38,8 @@ class EvaluationResult {
         expectedAction: json['expectedAction'] as String? ?? '',
         userEquity: (json['userEquity'] as num?)?.toDouble() ?? 0.0,
         expectedEquity: (json['expectedEquity'] as num?)?.toDouble() ?? 0.0,
+        ev: (json['ev'] as num?)?.toDouble(),
+        icmEv: (json['icmEv'] as num?)?.toDouble(),
         hint: json['hint'] as String?,
       );
 }

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -176,6 +176,36 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
     );
   }
 
+  Widget _evCard() {
+    final res = spot.evalResult;
+    if (res == null) return const SizedBox.shrink();
+    final ev = res.ev;
+    final icm = res.icmEv;
+    if (ev == null && icm == null) return const SizedBox.shrink();
+    final rows = <Widget>[];
+    if (ev != null) {
+      rows.add(Text(
+        'EV: ${ev >= 0 ? '+' : ''}${ev.toStringAsFixed(1)} BB',
+        style: const TextStyle(color: Colors.white),
+      ));
+    }
+    if (icm != null) {
+      rows.add(Text(
+        'ICM EV: ${icm >= 0 ? '+' : ''}${icm.toStringAsFixed(3)}',
+        style: const TextStyle(color: Colors.white70),
+      ));
+    }
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade800,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: rows),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -210,6 +240,7 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
             ],
             const SizedBox(height: 8),
             ActionHistoryWidget(actions: _actions(), playerPositions: _posMap()),
+            _evCard(),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- extend `EvaluationResult` with optional `ev` and `icmEv`
- display hero EV and ICM EV in `SpotViewerDialog`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665dc6618c832a80175030e1c8d224