### PR TITLE
Add outdated spot flag

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -10,6 +10,7 @@ class TrainingPackSpot {
   List<String> tags;
   DateTime editedAt;
   bool pinned;
+  bool dirty;
   EvaluationResult? evalResult;
 
   TrainingPackSpot({
@@ -20,6 +21,7 @@ class TrainingPackSpot {
     List<String>? tags,
     DateTime? editedAt,
     this.pinned = false,
+    this.dirty = false,
     this.evalResult,
   })  : hand = hand ?? HandData(),
         tags = tags ?? [],
@@ -33,6 +35,7 @@ class TrainingPackSpot {
     List<String>? tags,
     DateTime? editedAt,
     bool? pinned,
+    bool? dirty,
     EvaluationResult? evalResult,
   }) =>
       TrainingPackSpot(
@@ -43,6 +46,7 @@ class TrainingPackSpot {
         tags: tags ?? List<String>.from(this.tags),
         editedAt: editedAt ?? this.editedAt,
         pinned: pinned ?? this.pinned,
+        dirty: dirty ?? this.dirty,
         evalResult: evalResult ?? this.evalResult,
       );
 
@@ -57,6 +61,7 @@ class TrainingPackSpot {
         editedAt:
             DateTime.tryParse(j['editedAt'] as String? ?? '') ?? DateTime.now(),
         pinned: j['pinned'] == true,
+        dirty: j['dirty'] == true,
         evalResult: j['evalResult'] != null
             ? EvaluationResult.fromJson(
                 Map<String, dynamic>.from(j['evalResult']))
@@ -71,6 +76,7 @@ class TrainingPackSpot {
         if (tags.isNotEmpty) 'tags': tags,
         'editedAt': editedAt.toIso8601String(),
         if (pinned) 'pinned': true,
+        if (dirty) 'dirty': true,
         if (evalResult != null) 'evalResult': evalResult!.toJson(),
       };
 
@@ -101,10 +107,11 @@ class TrainingPackSpot {
           hand == other.hand &&
           const ListEquality().equals(tags, other.tags) &&
           pinned == other.pinned &&
+          dirty == other.dirty &&
           evalResult == other.evalResult;
 
   @override
   int get hashCode =>
       Object.hash(id, title, note, hand, const ListEquality().hash(tags), pinned,
-          evalResult);
+          dirty, evalResult);
 }

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -155,8 +155,8 @@ class TrainingPackTemplate {
     int ev = 0;
     int icm = 0;
     for (final s in list) {
-      if (s.heroEv != null) ev++;
-      if (s.heroIcmEv != null) icm++;
+      if (!s.dirty && s.heroEv != null) ev++;
+      if (!s.dirty && s.heroIcmEv != null) icm++;
     }
     meta['evCovered'] = ev;
     meta['icmCovered'] = icm;

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -213,6 +213,12 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   void _recordSnapshot() => _history.record(widget.template.spots);
 
+  void _markAllDirty() {
+    for (final s in widget.template.spots) {
+      s.dirty = true;
+    }
+  }
+
   void _log(String action, TrainingPackSpot spot) {
     _history.log(action, spot.title, spot.id);
     final key = _itemKeys[spot.id];
@@ -1140,6 +1146,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               icmEv: icm,
               hint: r?.hint,
             );
+            spot.dirty = false;
             break;
           }
         }
@@ -2161,6 +2168,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         widget.template.heroRange =
             parsedSet.isEmpty ? null : parsedSet.toList();
       });
+      _markAllDirty();
       await _persist();
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -2604,6 +2612,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               onChanged: (v) {
                 final val = double.tryParse(v) ?? 0.01;
                 setState(() => widget.template.minEvForCorrect = val);
+                _markAllDirty();
                 _persist();
               },
             ),
@@ -2622,6 +2631,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                       TextPosition(offset: _anteCtr.text.length));
                 }
                 setState(() => widget.template.anteBb = val);
+                _markAllDirty();
                 _persist();
               },
             ),

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -86,6 +86,17 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
       ),
       child: Row(
         children: [
+          if (spot.dirty)
+            Container(
+              width: 4,
+              decoration: const BoxDecoration(
+                color: Colors.amber,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(8),
+                  bottomLeft: Radius.circular(8),
+                ),
+              ),
+            ),
           if (isMistake)
             Container(
               width: 4,
@@ -311,6 +322,26 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                   '📌 Pinned',
                   style: TextStyle(
                     color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          if (spot.dirty)
+            Positioned(
+              top: 4,
+              left: 4,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.amber,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: const Text(
+                  '⚠️ Outdated',
+                  style: TextStyle(
+                    color: Colors.black,
                     fontSize: 12,
                     fontWeight: FontWeight.bold,
                   ),


### PR DESCRIPTION
## Summary
- track outdated status of each `TrainingPackSpot`
- exclude outdated spots from coverage stats
- highlight outdated spots in the list
- mark all spots outdated when template settings change
- clear outdated flags after re-evaluating all

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686665f95d70832a986e6d79ba121152