### PR TITLE
Add training pack result screen

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../widgets/spot_quiz_widget.dart';
+import 'training_pack_result_screen.dart';
 
 enum PlayOrder { sequential, random, mistakes }
 
@@ -102,11 +103,13 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     } else {
       _index = _spots.length - 1;
       _save();
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          content: const Text('Session complete'),
-          actions: [TextButton(onPressed: () => Navigator.pop(context), child: const Text('OK'))],
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TrainingPackResultScreen(
+            template: widget.template,
+            results: _results,
+          ),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- show a new result screen when finishing a training pack
- include per-spot EV chart and session stats

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c43a6d20832ab442a1afcc090459