### PR TITLE
Implement training pack result improvements

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -11,7 +11,9 @@ enum PlayOrder { sequential, random, mistakes }
 
 class TrainingPackPlayScreen extends StatefulWidget {
   final TrainingPackTemplate template;
-  const TrainingPackPlayScreen({super.key, required this.template});
+  final TrainingPackTemplate original;
+  const TrainingPackPlayScreen({super.key, required this.template, TrainingPackTemplate? original})
+      : original = original ?? template;
 
   @override
   State<TrainingPackPlayScreen> createState() => _TrainingPackPlayScreenState();
@@ -109,6 +111,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
           builder: (_) => TrainingPackResultScreen(
             template: widget.template,
             results: _results,
+            original: widget.original,
           ),
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   open_filex: ^4.7.0
   file_picker: ^5.2.10
   desktop_drop: ^0.6.0
-  fl_chart: ^0.64.0
+  fl_chart: ^0.65.0
   pie_chart: ^5.4.0
   pdf: ^3.10.4
   printing: ^5.12.0


### PR DESCRIPTION
## Summary
- update `fl_chart` dependency
- reset progress when retrying mistakes
- preserve original template and improve navigation

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c63a4b30832aad1a1284991b5b5e