### PR TITLE
Fix TrainingPackResultScreen layout

### DIFF
--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -102,19 +102,27 @@ class TrainingPackResultScreen extends StatelessWidget {
                         title: Text(
                           board.isEmpty ? '(Preflop)' : board,
                           style: const TextStyle(color: Colors.white),
+                          softWrap: false,
+                          overflow: TextOverflow.ellipsis,
                         ),
                         subtitle: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text('Hero: $hero',
                                 style:
-                                    const TextStyle(color: Colors.white70)),
+                                    const TextStyle(color: Colors.white70),
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis),
                             Text('Expected: $exp',
                                 style:
-                                    const TextStyle(color: Colors.greenAccent)),
+                                    const TextStyle(color: Colors.greenAccent),
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis),
                             Text('Your: $ans',
                                 style:
-                                    const TextStyle(color: Colors.redAccent)),
+                                    const TextStyle(color: Colors.redAccent),
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis),
                           ],
                         ),
                       ),
@@ -123,7 +131,6 @@ class TrainingPackResultScreen extends StatelessWidget {
                 ),
               ),
             ],
-            const Spacer(),
             ElevatedButton(
               onPressed: _mistakes == 0
                   ? null


### PR DESCRIPTION
## Summary
- ensure mistake list texts truncate instead of overflowing
- remove leftover spacer after mistake list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cefd9580832a877c3b3c41ad52d5