### PR TITLE
Add exit confirmation to TrainingPack play screen

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -145,6 +145,28 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     final actions = _heroActions(spot);
     return Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () async {
+            final confirm = await showDialog<bool>(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text('Exit training? Your progress will be saved.'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    child: const Text('Cancel'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    child: const Text('Exit'),
+                  ),
+                ],
+              ),
+            );
+            if (confirm == true) Navigator.pop(context);
+          },
+        ),
         title: Text(widget.template.name),
         actions: [
           PopupMenuButton<PlayOrder>(


### PR DESCRIPTION
## Summary
- add exit confirmation dialog with back button in TrainingPackPlayScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cfc73f40832a9801424f31f5d834