### PR TITLE
Add Start Over option in training screen

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -172,6 +172,36 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
         ),
         title: Text(widget.template.name),
         actions: [
+          PopupMenuButton<String>(
+            onSelected: (v) async {
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: const Text('Start over?'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, true),
+                      child: const Text('OK'),
+                    ),
+                  ],
+                ),
+              );
+              if (confirm == true) {
+                setState(() {
+                  _index = 0;
+                  _results.clear();
+                });
+                _save();
+              }
+            },
+            itemBuilder: (_) => const [
+              PopupMenuItem(value: 'start', child: Text('🔁 Start Over')),
+            ],
+          ),
           PopupMenuButton<PlayOrder>(
             initialValue: _order,
             onSelected: (v) {


### PR DESCRIPTION
## Summary
- add a Start Over menu in the training screen to reset progress

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d5b3b25c832a862d801ed616bb7a