### PR TITLE
Fix play screen exit

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -183,7 +183,10 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                 ],
               ),
             );
-            if (confirm == true) Navigator.pop(context);
+            if (confirm == true) {
+              _save();
+              Navigator.pop(context);
+            }
           },
         ),
         title: Text(widget.template.name),


### PR DESCRIPTION
## Summary
- save training state when exiting a training pack

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d797d468832aa8ade89dedbf7d60