### PR TITLE
Add feedback modal for training spots

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../widgets/spot_quiz_widget.dart';
+import '../../widgets/common/explanation_text.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_result_screen.dart';
 
@@ -132,9 +133,45 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     return context.mounted && res == true;
   }
 
-  void _choose(String act) {
+  Future<void> _choose(String act) async {
     final spot = _spots[_index];
     _results[spot.id] = act.toLowerCase();
+
+    final expected = spot.evalResult?.expectedAction ?? _expected(spot) ?? '-';
+    final explanation = spot.note.trim().isNotEmpty
+        ? spot.note.trim()
+        : (spot.evalResult?.hint ?? '');
+
+    await showModalBottomSheet(
+      context: context,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: Colors.grey[900],
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ExplanationText(
+              selectedAction: act,
+              correctAction: expected,
+              explanation: explanation,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (!mounted) return;
     if (_index + 1 < _spots.length) {
       setState(() => _index++);
       _save();


### PR DESCRIPTION
## Summary
- show per-spot answer in TrainingPackPlayScreen
- wait for user to continue before going on

## Testing
- `dart analyze`
- `flutter --version` *(fails: pub upgrade error)*

------
https://chatgpt.com/codex/tasks/task_e_6866d83cecb8832ab04313398bae6503