### PR TITLE
Add Retry Mistakes push

### DIFF
--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -162,7 +162,7 @@ class TrainingPackResultScreen extends StatelessWidget {
                             exp.toLowerCase() != ans.toLowerCase();
                       }).toList();
                       final retry = template.copyWith(id: const Uuid().v4(), name: 'Retry mistakes', spots: spots);
-                      Navigator.pushReplacement(
+                      Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (_) => TrainingPackPlayScreen(template: retry, original: original),


### PR DESCRIPTION
## Summary
- push the play screen instead of replacing when retrying mistakes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dbdc3834832a820935f47a1f05f2