### PR TITLE
Implement pack goal tracking

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -22,6 +22,7 @@ class TrainingPackTemplate {
   final DateTime createdAt;
   DateTime? lastGeneratedAt;
   Map<String, dynamic> meta;
+  bool goalAchieved;
 
   TrainingPackTemplate({
     required this.id,
@@ -41,6 +42,7 @@ class TrainingPackTemplate {
     DateTime? createdAt,
     this.lastGeneratedAt,
     Map<String, dynamic>? meta,
+    this.goalAchieved = false,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         playerStacksBb = playerStacksBb ?? const [10, 10],
@@ -67,6 +69,7 @@ class TrainingPackTemplate {
     DateTime? createdAt,
     DateTime? lastGeneratedAt,
     Map<String, dynamic>? meta,
+    bool? goalAchieved,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -86,6 +89,7 @@ class TrainingPackTemplate {
       createdAt: createdAt ?? this.createdAt,
       lastGeneratedAt: lastGeneratedAt ?? this.lastGeneratedAt,
       meta: meta ?? Map<String, dynamic>.from(this.meta),
+      goalAchieved: goalAchieved ?? this.goalAchieved,
     );
   }
 
@@ -119,6 +123,7 @@ class TrainingPackTemplate {
       lastGeneratedAt:
           DateTime.tryParse(json['lastGeneratedAt'] as String? ?? ''),
       meta: json['meta'] != null ? Map<String, dynamic>.from(json['meta']) : {},
+      goalAchieved: json['goalAchieved'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
       tpl.recountCoverage();
@@ -145,6 +150,7 @@ class TrainingPackTemplate {
         if (lastGeneratedAt != null)
           'lastGeneratedAt': lastGeneratedAt!.toIso8601String(),
         if (meta.isNotEmpty) 'meta': meta,
+        if (goalAchieved) 'goalAchieved': true,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -72,6 +72,9 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
   @override
   void initState() {
     super.initState();
+    final achieved = _correct == _total;
+    SharedPreferences.getInstance()
+        .then((p) => p.setBool('tpl_goal_${widget.original.id}', achieved));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final ctx = _firstKey.currentContext;
       if (ctx != null) {

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -119,6 +119,14 @@ class _TrainingPackTemplateListScreenState
     if (mounted) setState(() => _progress..clear()..addAll(map));
   }
 
+  Future<void> _loadGoals() async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final t in _templates) {
+      t.goalAchieved = prefs.getBool('tpl_goal_${t.id}') ?? false;
+    }
+    if (mounted) setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
@@ -132,6 +140,7 @@ class _TrainingPackTemplateListScreenState
         _loading = false;
       });
       _loadProgress();
+      _loadGoals();
     });
     GeneratedPackHistoryService.load().then((list) {
       if (!mounted) return;
@@ -1241,7 +1250,10 @@ class _TrainingPackTemplateListScreenState
                                       template: tpl, original: tpl),
                                 ),
                               );
-                              if (mounted) _loadProgress();
+                              if (mounted) {
+                                _loadProgress();
+                                _loadGoals();
+                              }
                             },
                           ),
                           onTap: () {
@@ -1368,6 +1380,11 @@ class _TrainingPackTemplateListScreenState
                                 child:
                                     Text('📈', style: TextStyle(fontSize: 16)),
                               ),
+                            if (t.goalAchieved)
+                              const Padding(
+                                padding: EdgeInsets.only(left: 4),
+                                child: Text('🏆', style: TextStyle(fontSize: 16)),
+                              ),
                           ],
                         ),
                         subtitle: (() {
@@ -1412,7 +1429,10 @@ class _TrainingPackTemplateListScreenState
                                         template: t, original: t),
                                   ),
                                 );
-                                if (mounted) _loadProgress();
+                                if (mounted) {
+                                  _loadProgress();
+                                  _loadGoals();
+                                }
                               },
                             ),
                             IconButton(


### PR DESCRIPTION
## Summary
- add `goalAchieved` field to `TrainingPackTemplate`
- persist goal state after finishing training packs
- load goals in template list and show trophy badge

## Testing
- `flutter analyze` *(fails: 9953 issues)*
- `flutter test` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6866e56ab2e4832a80b9189f60ab6c66