### PR TITLE
Fix completed filter for templates

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1034,10 +1034,13 @@ class _TrainingPackTemplateListScreenState
     final filtered = _selectedTag == null
         ? byType
         : [for (final t in byType) if (t.tags.contains(_selectedTag)) t];
+    final completed = _completedOnly
+        ? [for (final t in filtered) if (t.goalAchieved) t]
+        : filtered;
     final shown = _query.isEmpty
-        ? filtered
+        ? completed
         : [
-            for (final t in filtered)
+            for (final t in completed)
               if (t.name.toLowerCase().contains(_query) ||
                   t.description.toLowerCase().contains(_query))
                 t


### PR DESCRIPTION
## Summary
- fix completed filter logic in TrainingPackTemplateListScreen

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*
- `apt-get install -y flutter` *(fails: `Unable to locate package flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_6866ea918050832ab0ac57d95031d598