### PR TITLE
Add goal progress bar

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -23,6 +23,8 @@ class TrainingPackTemplate {
   DateTime? lastGeneratedAt;
   Map<String, dynamic> meta;
   bool goalAchieved;
+  int goalTarget;
+  int goalProgress;
 
   TrainingPackTemplate({
     required this.id,
@@ -43,6 +45,8 @@ class TrainingPackTemplate {
     this.lastGeneratedAt,
     Map<String, dynamic>? meta,
     this.goalAchieved = false,
+    this.goalTarget = 0,
+    this.goalProgress = 0,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         playerStacksBb = playerStacksBb ?? const [10, 10],
@@ -70,6 +74,8 @@ class TrainingPackTemplate {
     DateTime? lastGeneratedAt,
     Map<String, dynamic>? meta,
     bool? goalAchieved,
+    int? goalTarget,
+    int? goalProgress,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -90,6 +96,8 @@ class TrainingPackTemplate {
       lastGeneratedAt: lastGeneratedAt ?? this.lastGeneratedAt,
       meta: meta ?? Map<String, dynamic>.from(this.meta),
       goalAchieved: goalAchieved ?? this.goalAchieved,
+      goalTarget: goalTarget ?? this.goalTarget,
+      goalProgress: goalProgress ?? this.goalProgress,
     );
   }
 
@@ -124,6 +132,8 @@ class TrainingPackTemplate {
           DateTime.tryParse(json['lastGeneratedAt'] as String? ?? ''),
       meta: json['meta'] != null ? Map<String, dynamic>.from(json['meta']) : {},
       goalAchieved: json['goalAchieved'] as bool? ?? false,
+      goalTarget: json['goalTarget'] as int? ?? 0,
+      goalProgress: json['goalProgress'] as int? ?? 0,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
       tpl.recountCoverage();
@@ -151,6 +161,8 @@ class TrainingPackTemplate {
           'lastGeneratedAt': lastGeneratedAt!.toIso8601String(),
         if (meta.isNotEmpty) 'meta': meta,
         if (goalAchieved) 'goalAchieved': true,
+        if (goalTarget > 0) 'goalTarget': goalTarget,
+        if (goalProgress > 0) 'goalProgress': goalProgress,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1428,6 +1428,19 @@ class _TrainingPackTemplateListScreenState
                         ),
                         subtitle: (() {
                           final items = <Widget>[];
+                          final ratio = t.goalTarget > 0
+                              ? (t.goalProgress / t.goalTarget).clamp(0.0, 1.0)
+                              : 0.0;
+                          if (t.goalTarget > 0) {
+                            items.add(Row(
+                              children: [
+                                Expanded(child: LinearProgressIndicator(value: ratio)),
+                                const SizedBox(width: 8),
+                                Text('${(ratio * 100).round()}%',
+                                    style: const TextStyle(fontSize: 12)),
+                              ],
+                            ));
+                          }
                           final prog = _progress[t.id];
                           if (prog != null) {
                             items.add(Text(


### PR DESCRIPTION
## Summary
- track goalTarget and goalProgress in training pack template
- render progress bar for each pack tile

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ed3f7c14832aa923479e8dba9977