### PR TITLE
Add goal progress bar

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -1428,6 +1428,16 @@ class _TrainingPackTemplateListScreenState
                         ),
                         subtitle: (() {
                           final items = <Widget>[];
+                          final progVal = total > 0
+                              ? (_progress[t.id]?.clamp(0, total) ?? 0) / total
+                              : 0.0;
+                          final progColor =
+                              t.goalAchieved ? Colors.green : Colors.orange;
+                          items.add(LinearProgressIndicator(
+                            value: progVal,
+                            color: progColor,
+                            backgroundColor: progColor.withOpacity(0.3),
+                          ));
                           final ratio = t.goalTarget > 0
                               ? (t.goalProgress / t.goalTarget).clamp(0.0, 1.0)
                               : 0.0;


### PR DESCRIPTION
## Summary
- show progress bar under template names

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ef97aa88832aa0b174db2ede810f