### PR TITLE
Add street goal input formatter

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -680,6 +680,7 @@ class _TrainingPackTemplateListScreenState
                   TextField(
                     controller: streetGoalCtrl,
                     keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     decoration: const InputDecoration(
                         labelText: 'Street Goal (optional)'),
                   ),


### PR DESCRIPTION
## Summary
- restrict street goal input to digits in the custom pack generator

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686700990fe4832a9eef517e2c481edd