### PR TITLE
Display street goal in template list

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -184,6 +184,21 @@ class _TrainingPackTemplateListScreenState
     }
   }
 
+  String _streetName(String street) {
+    switch (street) {
+      case 'preflop':
+        return 'Preflop';
+      case 'flop':
+        return 'Flop';
+      case 'turn':
+        return 'Turn';
+      case 'river':
+        return 'River';
+      default:
+        return street;
+    }
+  }
+
   Widget _buildTemplateTile(TrainingPackTemplate t, bool narrow,
       {int? index}) {
     final total = t.spots.length;
@@ -293,6 +308,16 @@ class _TrainingPackTemplateListScreenState
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (t.targetStreet != null)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(
+                t.streetGoal > 0
+                    ? '${_streetName(t.targetStreet!)} Goal: ${t.streetGoal}%'
+                    : '${_streetName(t.targetStreet!)} Focus',
+                style: const TextStyle(fontSize: 12, color: Colors.white70),
+              ),
+            ),
           IconButton(
             icon: const Icon(Icons.play_arrow),
             tooltip: 'Start training',


### PR DESCRIPTION
## Summary
- show street goal label for each training pack template

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670691c800832a999afc40a24ece25