### PR TITLE
Add street progress indicator in template list

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -388,6 +388,22 @@ class _TrainingPackTemplateListScreenState
       onLongPress: () => _duplicate(t),
       title: Row(
         children: [
+          if (t.streetGoal > 0)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  value: (_streetProgress[t.id]?.clamp(0, t.streetGoal) ?? 0) /
+                      t.streetGoal,
+                  strokeWidth: 3,
+                  backgroundColor: Colors.white24,
+                  valueColor:
+                      const AlwaysStoppedAnimation(Colors.orangeAccent),
+                ),
+              ),
+            ),
           Expanded(child: Text(t.name)),
           if (isNew)
             const Padding(


### PR DESCRIPTION
## Summary
- display street goal progress as a circular indicator in each template tile

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686718627398832abe8fa1f5996b79e3