### PR TITLE
Add focus tags to training pack templates

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -11,6 +11,7 @@ class TrainingPackTemplate {
   GameType gameType;
   List<TrainingPackSpot> spots;
   List<String> tags;
+  List<String> focusTags;
   int heroBbStack;
   List<int> playerStacksBb;
   HeroPosition heroPos;
@@ -35,6 +36,7 @@ class TrainingPackTemplate {
     this.gameType = GameType.tournament,
     List<TrainingPackSpot>? spots,
     List<String>? tags,
+    List<String>? focusTags,
     this.heroBbStack = 10,
     List<int>? playerStacksBb,
     this.heroPos = HeroPosition.sb,
@@ -53,6 +55,7 @@ class TrainingPackTemplate {
     this.streetGoal = 0,
   })  : spots = spots ?? [],
         tags = tags ?? [],
+        focusTags = focusTags ?? [],
         playerStacksBb = playerStacksBb ?? const [10, 10],
         meta = meta ?? {},
         createdAt = createdAt ?? DateTime.now() {
@@ -66,6 +69,7 @@ class TrainingPackTemplate {
     GameType? gameType,
     List<TrainingPackSpot>? spots,
     List<String>? tags,
+    List<String>? focusTags,
     int? heroBbStack,
     List<int>? playerStacksBb,
     HeroPosition? heroPos,
@@ -90,6 +94,7 @@ class TrainingPackTemplate {
       gameType: gameType ?? this.gameType,
       spots: spots ?? List<TrainingPackSpot>.from(this.spots),
       tags: tags ?? List<String>.from(this.tags),
+      focusTags: focusTags ?? List<String>.from(this.focusTags),
       heroBbStack: heroBbStack ?? this.heroBbStack,
       playerStacksBb: playerStacksBb ?? List<int>.from(this.playerStacksBb),
       heroPos: heroPos ?? this.heroPos,
@@ -120,6 +125,7 @@ class TrainingPackTemplate {
           TrainingPackSpot.fromJson(Map<String, dynamic>.from(s))
       ],
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
+      focusTags: [for (final t in (json['focusTags'] as List? ?? [])) t as String],
       heroBbStack: json['heroBbStack'] as int? ?? 10,
       playerStacksBb: [
         for (final v in (json['playerStacksBb'] as List? ?? [10, 10]))
@@ -158,6 +164,7 @@ class TrainingPackTemplate {
         'gameType': gameType.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
         if (tags.isNotEmpty) 'tags': tags,
+        if (focusTags.isNotEmpty) 'focusTags': focusTags,
         if (heroRange != null) 'heroRange': heroRange,
         'heroBbStack': heroBbStack,
         'playerStacksBb': playerStacksBb,

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -305,6 +305,14 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
           children: [
             LinearProgressIndicator(value: progress),
             const SizedBox(height: 8),
+            if (widget.template.focusTags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  '🎯 Focus: ${widget.template.focusTags.join(', ')}',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ),
             Text('Spot ${_index + 1} of ${_spots.length}',
                 style: const TextStyle(color: Colors.white70)),
             const SizedBox(height: 8),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -68,6 +68,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   late final TextEditingController _descCtr;
   late final TextEditingController _evCtr;
   late final TextEditingController _anteCtr;
+  late final TextEditingController _focusCtr;
   late final FocusNode _descFocus;
   late String _templateName;
   String _query = '';
@@ -501,6 +502,13 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _persist();
   }
 
+  void _addFocusTag(String tag) {
+    if (tag.isEmpty) return;
+    setState(() => widget.template.focusTags.add(tag));
+    _focusCtr.clear();
+    _persist();
+  }
+
   void _saveDesc() {
     setState(() => widget.template.description = _descCtr.text.trim());
     _persist();
@@ -551,6 +559,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _evCtr = TextEditingController(
         text: widget.template.minEvForCorrect.toString());
     _anteCtr = TextEditingController(text: widget.template.anteBb.toString());
+    _focusCtr = TextEditingController();
     _descFocus = FocusNode();
     _descFocus.addListener(() {
       if (!_descFocus.hasFocus) _saveDesc();
@@ -623,6 +632,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _descCtr.dispose();
     _evCtr.dispose();
     _anteCtr.dispose();
+    _focusCtr.dispose();
     _searchCtrl.dispose();
     _tagSearchCtrl.dispose();
     _scrollCtrl.dispose();
@@ -2653,6 +2663,28 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               ],
             ),
             const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final tag in widget.template.focusTags)
+                  InputChip(
+                    label: Text(tag),
+                    onDeleted: () {
+                      setState(() => widget.template.focusTags.remove(tag));
+                      _persist();
+                    },
+                  ),
+                SizedBox(
+                  width: 120,
+                  child: TextField(
+                    controller: _focusCtr,
+                    decoration: const InputDecoration(hintText: 'Focus tag'),
+                    onSubmitted: (v) => _addFocusTag(v.trim()),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
             DropdownButtonFormField<GameType>(
               value: widget.template.gameType,
               decoration: const InputDecoration(labelText: 'Game Type'),
@@ -3313,6 +3345,11 @@ class _TemplatePreviewCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(template.description),
+              ),
+            if (template.focusTags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text('🎯 Focus: ${template.focusTags.join(', ')}'),
               ),
             Padding(
               padding: const EdgeInsets.only(top: 12),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -566,6 +566,12 @@ class _TrainingPackTemplateListScreenState
             style: const TextStyle(fontSize: 12, color: Colors.white70),
           ));
         }
+        if (t.focusTags.isNotEmpty) {
+          items.add(Text(
+            '🎯 Focus: ${t.focusTags.join(', ')}',
+            style: const TextStyle(fontSize: 12, color: Colors.white70),
+          ));
+        }
         if (t.lastGeneratedAt != null) {
           items.add(Text(
             'Last generated: ${timeago.format(t.lastGeneratedAt!)}',


### PR DESCRIPTION
## Summary
- support optional `focusTags` for `TrainingPackTemplate`
- allow editing focus tags in template editor
- show focus tags in template list, preview and play screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867203b2ff4832a80abad863a9967cb