### PR TITLE
Show template position coverage

### DIFF
--- a/lib/models/v2/hero_position.dart
+++ b/lib/models/v2/hero_position.dart
@@ -20,3 +20,23 @@ extension HeroPositionLabel on HeroPosition {
     }
   }
 }
+
+HeroPosition parseHeroPosition(String s) {
+  final p = s.toUpperCase();
+  if (p.startsWith('SB')) return HeroPosition.sb;
+  if (p.startsWith('BB')) return HeroPosition.bb;
+  if (p.startsWith('BTN')) return HeroPosition.btn;
+  if (p.startsWith('CO')) return HeroPosition.co;
+  if (p.startsWith('MP') || p.startsWith('HJ')) return HeroPosition.mp;
+  if (p.startsWith('UTG')) return HeroPosition.utg;
+  return HeroPosition.unknown;
+}
+
+const kPositionOrder = [
+  HeroPosition.utg,
+  HeroPosition.mp,
+  HeroPosition.co,
+  HeroPosition.btn,
+  HeroPosition.sb,
+  HeroPosition.bb,
+];

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -512,6 +512,12 @@ class _TrainingPackTemplateListScreenState
       ),
       subtitle: (() {
         final items = <Widget>[];
+        final pos = t.posRangeLabel();
+        if (pos.isNotEmpty) {
+          items.add(Text(pos,
+              style: const TextStyle(fontSize: 12, color: Colors.white70)));
+          items.add(const SizedBox(height: 4));
+        }
         final progVal =
             total > 0 ? (_progress[t.id]?.clamp(0, total) ?? 0) / total : 0.0;
         final progColor = t.goalAchieved ? Colors.green : Colors.orange;


### PR DESCRIPTION
## Summary
- support parsing hero position strings
- compute hero+villain position coverage label
- show coverage label on template list screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686722eff384832a99af93c8b2b69912