### PR TITLE
Add hand type summary for templates

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -250,4 +250,36 @@ class TrainingPackTemplate {
     return spots;
   }
 
+  String handTypeSummary() {
+    final ranks = '23456789TJQKA';
+    final List<String> hands = heroRange ??
+        [
+          for (final s in spots)
+            s.hand.heroCards.length >= 4
+                ? '${s.hand.heroCards[0]}${s.hand.heroCards[2]}'
+                : ''
+        ].where((e) => e.isNotEmpty).toList();
+    final set = <String>{};
+    for (final h in hands) {
+      if (h.length < 2) continue;
+      if (h.length == 2 && h[0] == h[1]) {
+        final v = ranks.indexOf(h[0]) + 2;
+        if (v <= 6) {
+          set.add('small pairs');
+        } else if (v <= 10) {
+          set.add('mid pairs');
+        } else {
+          set.add('big pairs');
+        }
+      } else if (h.length == 3 && h[2] == 's') {
+        if (h[0] == 'A') set.add('AXs');
+        if (h[0] == 'K') set.add('KXs');
+        if (h[0] == 'Q') set.add('QXs');
+      }
+    }
+    final list = set.toList();
+    list.sort();
+    return list.join(', ');
+  }
+
 }

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -313,6 +313,14 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                   style: const TextStyle(color: Colors.white70),
                 ),
               ),
+            if (widget.template.heroRange != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  widget.template.handTypeSummary(),
+                  style: const TextStyle(color: Colors.white54),
+                ),
+              ),
             Text('Spot ${_index + 1} of ${_spots.length}',
                 style: const TextStyle(color: Colors.white70)),
             const SizedBox(height: 8),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3351,6 +3351,12 @@ class _TemplatePreviewCard extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 8),
                 child: Text('🎯 Focus: ${template.focusTags.join(', ')}'),
               ),
+            if (template.heroRange != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(template.handTypeSummary(),
+                    style: const TextStyle(color: Colors.white70)),
+              ),
             Padding(
               padding: const EdgeInsets.only(top: 12),
               child: Text('Spots: ${template.spots.length}'),


### PR DESCRIPTION
## Summary
- compute hand type summary from hero cards
- show hand type summary in template preview card
- show hand type summary while playing a training pack

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686724642d7c832aa8e24ec45b069a00