### PR TITLE
Add flexible focus hand types

### DIFF
--- a/lib/helpers/hand_type_utils.dart
+++ b/lib/helpers/hand_type_utils.dart
@@ -1,0 +1,87 @@
+
+const _ranks = '23456789TJQKA';
+
+bool isValidHandTypeLabel(String label) {
+  final l = label.trim().toUpperCase();
+  if (l.isEmpty) return false;
+  if ({
+        'PAIRS',
+        'SMALL PAIRS',
+        'MID PAIRS',
+        'BIG PAIRS',
+        'LOW PAIRS',
+        'HIGH PAIRS',
+        'SUITED CONNECTORS',
+        'OFFSUIT CONNECTORS',
+        'CONNECTORS',
+        'SUITED AX',
+        'OFFSUIT AX'
+      }.contains(l)) return true;
+  if (RegExp(r'^[2-9TJQKA]X[so]?$').hasMatch(l)) return true;
+  if (RegExp(r'^[2-9TJQKA]{2}[so]?\+?$').hasMatch(l)) return true;
+  return false;
+}
+
+bool matchHandTypeLabel(String label, String handCode) {
+  final l = label.trim().toUpperCase();
+  final code = handCode.toUpperCase();
+  final hi = code[0];
+  final lo = code.length > 1 ? code[1] : '';
+  final suited = code.endsWith('S');
+  if (l == 'PAIRS') return code.length == 2;
+  if (l == 'SMALL PAIRS' || l == 'LOW PAIRS') {
+    return code.length == 2 && _ranks.indexOf(hi) <= _ranks.indexOf('6');
+  }
+  if (l == 'MID PAIRS') {
+    return code.length == 2 &&
+        _ranks.indexOf(hi) > _ranks.indexOf('6') &&
+        _ranks.indexOf(hi) <= _ranks.indexOf('T');
+  }
+  if (l == 'BIG PAIRS' || l == 'HIGH PAIRS') {
+    return code.length == 2 && _ranks.indexOf(hi) > _ranks.indexOf('T');
+  }
+  if (l == 'SUITED CONNECTORS') {
+    return suited && _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  }
+  if (l == 'OFFSUIT CONNECTORS') {
+    return !suited && _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  }
+  if (l == 'CONNECTORS') {
+    return _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  }
+  if (l == 'SUITED AX') {
+    return code.startsWith('A') && suited && code.length == 3 && hi != lo;
+  }
+  if (l == 'OFFSUIT AX') {
+    return code.startsWith('A') && !suited && code.length == 3 && hi != lo;
+  }
+  final m1 = RegExp(r'^([2-9TJQKA])X([so])?$').firstMatch(l);
+  if (m1 != null) {
+    final r = m1.group(1)!;
+    final s = m1.group(2);
+    if (code.length != 3 || code[0] != r || hi == lo) return false;
+    if (s == 'S' && !suited) return false;
+    if (s == 'O' && suited) return false;
+    return true;
+  }
+  final m2 = RegExp(r'^([2-9TJQKA])([2-9TJQKA])([so])?(\+)?$').firstMatch(l);
+  if (m2 != null) {
+    final h = m2.group(1)!;
+    final lw = m2.group(2)!;
+    final s = m2.group(3);
+    final plus = m2.group(4) != null;
+    final hiIdx = _ranks.indexOf(hi);
+    final loIdx = _ranks.indexOf(lo);
+    final hIdx = _ranks.indexOf(h);
+    final lwIdx = _ranks.indexOf(lw);
+    final diff = hiIdx - loIdx;
+    final baseDiff = hIdx - lwIdx;
+    if (s == 'S' && !suited) return false;
+    if (s == 'O' && suited) return false;
+    if (plus) {
+      return diff == baseDiff && hiIdx >= hIdx && loIdx >= lwIdx;
+    }
+    return code.startsWith('$h$lw') && diff == baseDiff && (s == null || (s == 'S' ? suited : !suited));
+  }
+  return false;
+}

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -4,6 +4,9 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../helpers/hand_utils.dart';
+import '../../helpers/hand_type_utils.dart';
+
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../widgets/spot_quiz_widget.dart';
@@ -153,36 +156,10 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
 
   bool _matchHandType(TrainingPackSpot spot) {
     if (widget.template.focusHandTypes.isEmpty) return false;
-    final cards = spot.hand.heroCards.split(RegExp(r'\s+'));
-    if (cards.length < 2) return false;
-    final r1 = cards[0][0];
-    final r2 = cards[1][0];
-    final suited = cards[0][1] == cards[1][1];
-    final ranks = '23456789TJQKA';
+    final code = handCode(spot.hand.heroCards);
+    if (code == null) return false;
     for (final t in widget.template.focusHandTypes) {
-      switch (t) {
-        case 'AXs':
-          if (suited && (r1 == 'A' || r2 == 'A')) return true;
-          break;
-        case 'KXs':
-          if (suited && (r1 == 'K' || r2 == 'K')) return true;
-          break;
-        case 'QXs':
-          if (suited && (r1 == 'Q' || r2 == 'Q')) return true;
-          break;
-        case 'pairs':
-          if (r1 == r2) return true;
-          break;
-        case 'small pairs':
-          if (r1 == r2 && ranks.indexOf(r1) + 2 <= 6) return true;
-          break;
-        case 'mid pairs':
-          if (r1 == r2 && ranks.indexOf(r1) + 2 > 6 && ranks.indexOf(r1) + 2 <= 10) return true;
-          break;
-        case 'big pairs':
-          if (r1 == r2 && ranks.indexOf(r1) + 2 > 10) return true;
-          break;
-      }
+      if (matchHandTypeLabel(t, code)) return true;
     }
     return false;
   }

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -42,6 +42,7 @@ import '../../services/evaluation_executor_service.dart';
 import '../../services/pack_generator_service.dart';
 import '../../services/training_pack_template_ui_service.dart';
 import '../../helpers/hand_utils.dart';
+import '../../helpers/hand_type_utils.dart';
 import '../../services/training_pack_template_storage_service.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
@@ -69,6 +70,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   late final TextEditingController _evCtr;
   late final TextEditingController _anteCtr;
   late final TextEditingController _focusCtr;
+  late final TextEditingController _handTypeCtr;
   late final FocusNode _descFocus;
   late String _templateName;
   String _query = '';
@@ -509,6 +511,17 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _persist();
   }
 
+  void _addHandType(String val) {
+    if (!isValidHandTypeLabel(val)) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Invalid hand type')));
+      return;
+    }
+    setState(() => widget.template.focusHandTypes.add(val));
+    _handTypeCtr.clear();
+    _persist();
+  }
+
   void _saveDesc() {
     setState(() => widget.template.description = _descCtr.text.trim());
     _persist();
@@ -560,6 +573,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         text: widget.template.minEvForCorrect.toString());
     _anteCtr = TextEditingController(text: widget.template.anteBb.toString());
     _focusCtr = TextEditingController();
+    _handTypeCtr = TextEditingController();
     _descFocus = FocusNode();
     _descFocus.addListener(() {
       if (!_descFocus.hasFocus) _saveDesc();
@@ -633,6 +647,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     _evCtr.dispose();
     _anteCtr.dispose();
     _focusCtr.dispose();
+    _handTypeCtr.dispose();
     _searchCtrl.dispose();
     _tagSearchCtrl.dispose();
     _scrollCtrl.dispose();
@@ -2685,6 +2700,33 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               ],
             ),
             const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final t in widget.template.focusHandTypes)
+                  InputChip(
+                    label: Text(t),
+                    onDeleted: () {
+                      setState(() => widget.template.focusHandTypes.remove(t));
+                      _persist();
+                    },
+                  ),
+                SizedBox(
+                  width: 120,
+                  child: TextField(
+                    controller: _handTypeCtr,
+                    decoration: const InputDecoration(hintText: 'Hand type'),
+                    onSubmitted: (v) => _addHandType(v.trim()),
+                  ),
+                ),
+              ],
+            ),
+            const Padding(
+              padding: EdgeInsets.only(top: 4),
+              child: Text('e.g. JXs, 76s+, suited connectors',
+                  style: TextStyle(color: Colors.white70)),
+            ),
+            const SizedBox(height: 16),
             DropdownButtonFormField<GameType>(
               value: widget.template.gameType,
               decoration: const InputDecoration(labelText: 'Game Type'),
@@ -3350,6 +3392,11 @@ class _TemplatePreviewCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text('🎯 Focus: ${template.focusTags.join(', ')}'),
+              ),
+            if (template.focusHandTypes.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text('🎯 Hand Goal: ${template.focusHandTypes.join(', ')}'),
               ),
             if (template.heroRange != null)
               Padding(


### PR DESCRIPTION
## Summary
- add `hand_type_utils` to parse labels like `JXs` or `76s+`
- simplify play hand type matching with new parser
- allow editing focus hand types with validation in template editor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676a466f5c832a91c61c4f1e4abd15