### PR TITLE
Improve hand type utils and UI

### DIFF
--- a/lib/helpers/hand_type_utils.dart
+++ b/lib/helpers/hand_type_utils.dart
@@ -1,9 +1,9 @@
 
 const _ranks = '23456789TJQKA';
 
-bool isValidHandTypeLabel(String label) {
+String? handTypeLabelError(String label) {
   final l = label.trim().toUpperCase();
-  if (l.isEmpty) return false;
+  if (l.isEmpty) return 'Empty label';
   if ({
         'PAIRS',
         'SMALL PAIRS',
@@ -16,11 +16,13 @@ bool isValidHandTypeLabel(String label) {
         'CONNECTORS',
         'SUITED AX',
         'OFFSUIT AX'
-      }.contains(l)) return true;
-  if (RegExp(r'^[2-9TJQKA]X[so]?$').hasMatch(l)) return true;
-  if (RegExp(r'^[2-9TJQKA]{2}[so]?\+?$').hasMatch(l)) return true;
-  return false;
+      }.contains(l)) return null;
+  if (RegExp(r'^[2-9TJQKA]X[so]?$').hasMatch(l)) return null;
+  if (RegExp(r'^[2-9TJQKA]{2}(?:[so](?:\+)?|\+)?$').hasMatch(l)) return null;
+  return 'Invalid hand type (e.g. JXs, 76s+, suited connectors)';
 }
+
+bool isValidHandTypeLabel(String label) => handTypeLabelError(label) == null;
 
 bool matchHandTypeLabel(String label, String handCode) {
   final l = label.trim().toUpperCase();
@@ -64,7 +66,7 @@ bool matchHandTypeLabel(String label, String handCode) {
     if (s == 'O' && suited) return false;
     return true;
   }
-  final m2 = RegExp(r'^([2-9TJQKA])([2-9TJQKA])([so])?(\+)?$').firstMatch(l);
+  final m2 = RegExp(r'^([2-9TJQKA])([2-9TJQKA])([so](?:\+)?|\+)?$').firstMatch(l);
   if (m2 != null) {
     final h = m2.group(1)!;
     final lw = m2.group(2)!;

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -512,9 +512,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   }
 
   void _addHandType(String val) {
-    if (!isValidHandTypeLabel(val)) {
+    final err = handTypeLabelError(val);
+    if (err != null) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Invalid hand type')));
+          .showSnackBar(SnackBar(content: Text(err)));
       return;
     }
     setState(() => widget.template.focusHandTypes.add(val));

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -578,6 +578,12 @@ class _TrainingPackTemplateListScreenState
             style: const TextStyle(fontSize: 12, color: Colors.white70),
           ));
         }
+        if (t.focusHandTypes.isNotEmpty) {
+          items.add(Text(
+            '🃏 Hand Goal: ${t.focusHandTypes.join(', ')}',
+            style: const TextStyle(fontSize: 12, color: Colors.white70),
+          ));
+        }
         if (t.lastGeneratedAt != null) {
           items.add(Text(
             'Last generated: ${timeago.format(t.lastGeneratedAt!)}',


### PR DESCRIPTION
## Summary
- add `handTypeLabelError` with better validation messages
- support `o+` labels in hand type utils
- show focus hand types in template list

## Testing
- `flutter analyze --no-pub` *(fails: many analysis issues)*

------
https://chatgpt.com/codex/tasks/task_e_68676c34d030832abf2db2940ccf0b38