### PR TITLE
Fix hand type label utils

### DIFF
--- a/lib/helpers/hand_type_utils.dart
+++ b/lib/helpers/hand_type_utils.dart
@@ -22,7 +22,6 @@ String? handTypeLabelError(String label) {
   return 'Invalid hand type (e.g. JXs, 76s+, suited connectors)';
 }
 
-bool isValidHandTypeLabel(String label) => handTypeLabelError(label) == null;
 
 bool matchHandTypeLabel(String label, String handCode) {
   final l = label.trim().toUpperCase();
@@ -71,7 +70,7 @@ bool matchHandTypeLabel(String label, String handCode) {
     final h = m2.group(1)!;
     final lw = m2.group(2)!;
     final s = m2.group(3);
-    final plus = m2.group(4) != null;
+    final plus = s?.contains('+') == true;
     final hiIdx = _ranks.indexOf(hi);
     final loIdx = _ranks.indexOf(lo);
     final hIdx = _ranks.indexOf(h);


### PR DESCRIPTION
## Summary
- remove unused `isValidHandTypeLabel` line
- fix connector regex group index

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676fb14af4832a8f4764a2ab7c320b