### PR TITLE
Add tag suggestion for hand goals

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -534,6 +534,46 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     setState(() => widget.template.focusHandTypes.add(val));
     _handTypeCtr.clear();
     _persist();
+    final tag = _tagForHandType(val);
+    if (tag != null && !widget.template.tags.contains(tag)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              Expanded(child: Text("Add tag '$tag' for this hand goal?")),
+              TextButton(
+                onPressed: () {
+                  setState(() => widget.template.tags.add(tag));
+                  _persist();
+                  ScaffoldMessenger.of(context).removeCurrentSnackBar();
+                },
+                child: const Text('Add'),
+              ),
+              TextButton(
+                onPressed: () =>
+                    ScaffoldMessenger.of(context).removeCurrentSnackBar(),
+                child: const Text('Dismiss'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+  }
+
+  String? _tagForHandType(String label) {
+    final l = label.trim().toUpperCase();
+    if (l == 'SUITED CONNECTORS') return 'SC';
+    if (l == 'OFFSUIT CONNECTORS') return 'OC';
+    final m = RegExp(r'^([2-9TJQKA])X([SO])?$').firstMatch(l);
+    if (m != null) {
+      final r = m.group(1)!;
+      final s = m.group(2);
+      if (s == 'S') return '${r}xs';
+      if (s == 'O') return '${r}xo';
+      return '${r}x';
+    }
+    return null;
   }
 
   void _saveDesc() {


### PR DESCRIPTION
## Summary
- auto-suggest tag when adding a hand goal in template editor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677d5e7468832aa19e553de9af61df