### PR TITLE
Enable quick Mixed Drill rerun

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -2559,18 +2559,24 @@ class _TrainingPackTemplateListScreenState
             label: const Text('Top 10 Mistakes'),
           ),
           const SizedBox(height: 12),
-          FloatingActionButton.extended(
-            heroTag: 'mixedDrillFab',
-            icon: const Icon(Icons.shuffle),
-            label: const Text('Mixed Drill'),
-            onPressed: _startMixedDrill,
+          GestureDetector(
+            onLongPress: _runMixedDrill,
+            child: FloatingActionButton.extended(
+              heroTag: 'mixedDrillFab',
+              icon: const Icon(Icons.shuffle),
+              label: const Text('Mixed Drill'),
+              onPressed: _startMixedDrill,
+            ),
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4),
-            child: Text.rich(
-              TextSpan(text: _mixedSummary()),
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 12, color: Colors.white70),
+            child: InkWell(
+              onTap: _runMixedDrill,
+              child: Text.rich(
+                TextSpan(text: _mixedSummary()),
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 12, color: Colors.white70),
+              ),
             ),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- allow starting Mixed Drill again via long-press on button
- tap mixed summary to rerun immediately

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678a15589c832aa1cb087dd4567c6f