### PR TITLE
Implement Mixed Drill last run reminder

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -76,6 +76,7 @@ class _TrainingPackTemplateListScreenState
   bool _endlessDrill = false;
   String _mixedStreet = 'any';
   bool _mixedHandGoalOnly = false;
+  DateTime? _mixedLastRun;
   String? _lastOpenedId;
   final Map<String, int> _progress = {};
   final Map<String, int> _streetProgress = {};
@@ -305,6 +306,10 @@ class _TrainingPackTemplateListScreenState
         _mixedStreet = prefs.getString(_prefsMixedStreetKey) ?? 'any';
         _mixedAutoOnly = prefs.getBool(_prefsMixedAutoKey) ?? false;
         _endlessDrill = prefs.getBool(_prefsEndlessKey) ?? false;
+        final ts = prefs.getInt('tpl_mixed_last_run');
+        _mixedLastRun = ts == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(ts);
       });
     }
   }
@@ -1994,6 +1999,10 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _runMixedDrill() async {
+    final now = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('tpl_mixed_last_run', now.millisecondsSinceEpoch);
+    setState(() => _mixedLastRun = now);
     final count = _mixedCount;
     final autoOnly = _mixedAutoOnly;
     final byType = _selectedType == null
@@ -2579,6 +2588,15 @@ class _TrainingPackTemplateListScreenState
               ),
             ),
           ),
+          if (_mixedLastRun != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                'Last run: ${timeago.format(_mixedLastRun!)}',
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 12, color: Colors.white54),
+              ),
+            ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(
             heroTag: 'pasteRangeTplFab',


### PR DESCRIPTION
## Summary
- save Mixed Drill last run timestamp in prefs
- show formatted last run time on template list screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678bd4bde4832a9e0ccf6e68c4c73f