### PR TITLE
Add mixed drill clear option

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -347,6 +347,17 @@ class _TrainingPackTemplateListScreenState
     await prefs.setBool(_prefsMixedHandKey, _mixedHandGoalOnly);
   }
 
+  Future<void> _clearMixedPrefs() async {
+    setState(() {
+      _mixedCount = 20;
+      _mixedStreet = 'any';
+      _mixedAutoOnly = false;
+      _mixedHandGoalOnly = false;
+      _endlessDrill = false;
+    });
+    await _saveMixedPrefs();
+  }
+
   String _streetLabel(String? street) {
     switch (street) {
       case 'preflop':
@@ -2575,17 +2586,27 @@ class _TrainingPackTemplateListScreenState
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4),
-            child: InkWell(
-              onTap: _runMixedDrill,
-              behavior: HitTestBehavior.opaque,
-              child: Padding(
-                padding: const EdgeInsets.all(4),
-                child: Text.rich(
-                  TextSpan(text: _mixedSummary()),
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(fontSize: 12, color: Colors.white70),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                InkWell(
+                  onTap: _runMixedDrill,
+                  behavior: HitTestBehavior.opaque,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Text.rich(
+                      TextSpan(text: _mixedSummary()),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 12, color: Colors.white70),
+                    ),
+                  ),
                 ),
-              ),
+                IconButton(
+                  icon: const Icon(Icons.clear),
+                  tooltip: 'Clear',
+                  onPressed: _clearMixedPrefs,
+                ),
+              ],
             ),
           ),
           if (_mixedLastRun != null)


### PR DESCRIPTION
## Summary
- add `_clearMixedPrefs` to reset mixed drill settings and persist changes
- show a Clear icon button near mixed drill summary

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6867a0183ef4832abe16716494b083fd