### PR TITLE
Add template firestore sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,7 +95,11 @@ Future<void> main() async {
   final packStorage = TrainingPackStorageService(cloud: cloud);
   await packStorage.load();
   final packCloud = TrainingPackCloudSyncService();
+  final templateStorage = TrainingPackTemplateStorageService(cloud: packCloud);
+  await templateStorage.load();
   await packCloud.syncDown(packStorage);
+  await packCloud.syncDownTemplates(templateStorage);
+  await packCloud.syncUpTemplates(templateStorage);
   runApp(
     MultiProvider(
       providers: [
@@ -133,7 +137,7 @@ Future<void> main() async {
         ChangeNotifierProvider<TrainingPackStorageService>.value(value: packStorage),
         Provider<TrainingPackCloudSyncService>.value(value: packCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
-        ChangeNotifierProvider(create: (_) => TrainingPackTemplateStorageService()..load()),
+        ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(value: templateStorage),
         ChangeNotifierProvider(
           create: (context) => CategoryUsageService(
             templates: context.read<TemplateStorageService>(),

--- a/lib/services/training_pack_template_storage_service.dart
+++ b/lib/services/training_pack_template_storage_service.dart
@@ -4,9 +4,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/training_pack_template_model.dart';
 import '../repositories/training_pack_template_repository.dart';
+import 'training_pack_cloud_sync_service.dart';
 
 class TrainingPackTemplateStorageService extends ChangeNotifier {
   static const _key = 'training_pack_templates';
+
+  TrainingPackTemplateStorageService({this.cloud});
+
+  final TrainingPackCloudSyncService? cloud;
 
   final List<TrainingPackTemplateModel> _templates = [];
   List<TrainingPackTemplateModel> get templates => List.unmodifiable(_templates);
@@ -36,6 +41,7 @@ class TrainingPackTemplateStorageService extends ChangeNotifier {
   Future<void> add(TrainingPackTemplateModel model) async {
     _templates.add(model);
     await _persist();
+    await cloud?.saveTemplate(model);
     notifyListeners();
   }
 
@@ -44,12 +50,14 @@ class TrainingPackTemplateStorageService extends ChangeNotifier {
     if (index == -1) return;
     _templates[index] = model;
     await _persist();
+    await cloud?.saveTemplate(model);
     notifyListeners();
   }
 
   Future<void> remove(TrainingPackTemplateModel model) async {
     _templates.removeWhere((t) => t.id == model.id);
     await _persist();
+    await cloud?.deleteTemplate(model.id);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- extend `TrainingPackCloudSyncService` with Firestore support for templates
- push template changes to Firestore via `TrainingPackTemplateStorageService`
- sync templates on app start

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a6a45478832aad696e67786c2214