### PR TITLE
Implement Mistake Pack cloud sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'services/session_note_service.dart';
 import 'services/session_pin_service.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
+import 'services/mistake_pack_cloud_service.dart';
 import 'services/template_storage_service.dart';
 import 'services/training_pack_template_storage_service.dart';
 import 'services/goal_progress_cloud_service.dart';
@@ -96,6 +97,7 @@ Future<void> main() async {
   final packStorage = TrainingPackStorageService(cloud: cloud);
   await packStorage.load();
   final packCloud = TrainingPackCloudSyncService();
+  final mistakeCloud = MistakePackCloudService();
   final goalCloud = GoalProgressCloudService();
   final templateStorage =
       TrainingPackTemplateStorageService(cloud: packCloud, goals: goalCloud);
@@ -129,6 +131,7 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) => MistakeReviewPackService(
             hands: context.read<SavedHandManagerService>(),
+            cloud: mistakeCloud,
           )..load(),
         ),
         ChangeNotifierProvider(
@@ -139,6 +142,7 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider<TrainingPackStorageService>.value(value: packStorage),
         Provider<TrainingPackCloudSyncService>.value(value: packCloud),
+        Provider<MistakePackCloudService>.value(value: mistakeCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
         ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(value: templateStorage),
         ChangeNotifierProvider(

--- a/lib/models/mistake_pack.dart
+++ b/lib/models/mistake_pack.dart
@@ -1,0 +1,31 @@
+import 'package:uuid/uuid.dart';
+
+class MistakePack {
+  final String id;
+  final List<String> spotIds;
+  final DateTime createdAt;
+  final String note;
+
+  MistakePack({
+    String? id,
+    List<String>? spotIds,
+    DateTime? createdAt,
+    this.note = '',
+  })  : id = id ?? const Uuid().v4(),
+        spotIds = spotIds ?? [],
+        createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'spotIds': spotIds,
+        'createdAt': createdAt.toIso8601String(),
+        if (note.isNotEmpty) 'note': note,
+      };
+
+  factory MistakePack.fromJson(Map<String, dynamic> j) => MistakePack(
+        id: j['id'] as String?,
+        spotIds: [for (final s in (j['spotIds'] as List? ?? [])) s as String],
+        createdAt:
+            DateTime.tryParse(j['createdAt'] as String? ?? '') ?? DateTime.now(),
+        note: j['note'] as String? ?? '',
+      );
+}

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -6,6 +6,7 @@ import '../models/saved_hand.dart';
 import '../models/action_entry.dart';
 import '../models/drill_result.dart';
 import '../services/drill_history_service.dart';
+import '../services/mistake_review_pack_service.dart';
 import 'package:provider/provider.dart';
 import '../widgets/training_spot_diagram.dart';
 import '../widgets/training_spot_preview.dart';
@@ -235,6 +236,11 @@ class _TrainingScreenState extends State<TrainingScreen> {
       wrongSpotIds: [for (final id in _wrongIds) if (id.isNotEmpty) id],
     );
     await context.read<DrillHistoryService>().add(result);
+    if (_wrongIds.isNotEmpty) {
+      await context
+          .read<MistakeReviewPackService>()
+          .addPack([for (final id in _wrongIds) if (id.isNotEmpty) id]);
+    }
     if (!mounted) return;
     if (repeat == true && widget.templateId != null) {
       final templates = await TrainingPackStorage.load();

--- a/lib/services/mistake_pack_cloud_service.dart
+++ b/lib/services/mistake_pack_cloud_service.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/mistake_pack.dart';
+
+class MistakePackCloudService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  String? get _uid => FirebaseAuth.instance.currentUser?.uid;
+
+  Future<List<MistakePack>> loadPacks() async {
+    if (_uid == null) return [];
+    final snap = await _db
+        .collection('mistakes')
+        .doc(_uid)
+        .collection('packs')
+        .get();
+    return [
+      for (final d in snap.docs)
+        MistakePack.fromJson({...d.data(), 'id': d.id})
+    ];
+  }
+
+  Future<void> savePack(MistakePack pack) async {
+    if (_uid == null) return;
+    await _db
+        .collection('mistakes')
+        .doc(_uid)
+        .collection('packs')
+        .doc(pack.id)
+        .set(pack.toJson());
+  }
+}

--- a/lib/services/mistake_review_pack_service.dart
+++ b/lib/services/mistake_review_pack_service.dart
@@ -1,15 +1,24 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
+import '../models/mistake_pack.dart';
 import 'saved_hand_manager_service.dart';
+import 'mistake_pack_cloud_service.dart';
 
 class MistakeReviewPackService extends ChangeNotifier {
   static const _progressKey = 'mistake_review_progress';
   static const _dateKey = 'mistake_review_date';
+  static const _packsKey = 'mistake_packs';
 
   final SavedHandManagerService hands;
+  final MistakePackCloudService? cloud;
+
+  final List<MistakePack> _packs = [];
+  List<MistakePack> get packs => List.unmodifiable(_packs);
 
   TrainingPack? _pack;
   int _progress = 0;
@@ -19,7 +28,7 @@ class MistakeReviewPackService extends ChangeNotifier {
   TrainingPack? get pack => _pack;
   int get progress => _progress;
 
-  MistakeReviewPackService({required this.hands});
+  MistakeReviewPackService({required this.hands, this.cloud});
 
   bool _sameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
@@ -29,8 +38,14 @@ class MistakeReviewPackService extends ChangeNotifier {
     _progress = prefs.getInt(_progressKey) ?? 0;
     final str = prefs.getString(_dateKey);
     _date = str != null ? DateTime.tryParse(str) : null;
+    final list = prefs.getStringList(_packsKey) ?? [];
+    _packs
+      ..clear()
+      ..addAll(list.map((e) =>
+          MistakePack.fromJson(jsonDecode(e) as Map<String, dynamic>)));
     _generate();
     _schedule();
+    unawaited(syncDown());
   }
 
   List<SavedHand> _mistakes() {
@@ -69,12 +84,40 @@ class MistakeReviewPackService extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_progressKey, _progress);
     await prefs.setString(_dateKey, _date!.toIso8601String());
+    await prefs.setStringList(
+      _packsKey,
+      [for (final p in _packs) jsonEncode(p.toJson())],
+    );
   }
 
   Future<void> setProgress(int value) async {
     _progress = value.clamp(0, _pack?.hands.length ?? 0);
     await _save();
     notifyListeners();
+  }
+
+  Future<void> addPack(List<String> spotIds, {String note = ''}) async {
+    _packs.add(MistakePack(spotIds: spotIds, note: note));
+    await _save();
+    await syncUp();
+    _generate();
+  }
+
+  Future<void> syncDown() async {
+    if (cloud == null) return;
+    final remote = await cloud!.loadPacks();
+    _packs
+      ..clear()
+      ..addAll(remote);
+    await _save();
+    _generate();
+  }
+
+  Future<void> syncUp() async {
+    if (cloud == null) return;
+    for (final p in _packs) {
+      await cloud!.savePack(p);
+    }
   }
 
   void _schedule() {


### PR DESCRIPTION
## Summary
- implement `MistakePack` model
- implement `MistakePackCloudService`
- extend `MistakeReviewPackService` with cloud sync and local storage
- record mistakes after training sessions
- wire up cloud sync service in app

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867aba6dfd4832aa74d4b32b96eb30b