### PR TITLE
Add auto sync on reconnect

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -318,6 +318,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
   @override
   void dispose() {
     _sync.dispose();
+    context.read<CloudSyncService>().dispose();
     super.dispose();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   cloud_firestore: ^4.8.0
   firebase_auth: ^4.8.0
   google_sign_in: ^6.1.5
-  connectivity_plus: ^6.1.4
+  connectivity_plus: ^6.0.4
   url_launcher: ^6.1.11
 
 dependency_overrides:


### PR DESCRIPTION
## Summary
- downgrade `connectivity_plus` to 6.0.4
- monitor network changes in `CloudSyncService`
- dispose `CloudSyncService` on app exit

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867b2f72e9c832a9287fdf989fd320d