### PR TITLE
Implement training streak tracking

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -145,7 +145,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
-        actions: [SyncStatusIcon.of(context), 
+        actions: [const StreakWidget(), SyncStatusIcon.of(context),
           PopupMenuButton<String>(
             onSelected: (value) {
               switch (value) {

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -13,6 +13,8 @@ import '../../widgets/spot_quiz_widget.dart';
 import '../../widgets/common/explanation_text.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_result_screen.dart';
+import 'package:provider/provider.dart';
+import '../../services/streak_service.dart';
 
 enum PlayOrder { sequential, random, mistakes }
 
@@ -289,6 +291,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     } else {
       _index = _spots.length - 1;
       _save();
+      await context.read<StreakService>().recordTraining();
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(

--- a/lib/widgets/streak_widget.dart
+++ b/lib/widgets/streak_widget.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/streak_service.dart';
+
+class StreakWidget extends StatelessWidget {
+  const StreakWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<StreakService>();
+    return ValueListenableBuilder<int>(
+      valueListenable: service.streak,
+      builder: (_, value, __) {
+        if (value <= 0) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: Row(
+            children: [
+              const Text('🔥', style: TextStyle(fontSize: 18)),
+              const SizedBox(width: 4),
+              Text('$value', style: const TextStyle(fontWeight: FontWeight.bold)),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- track training streak via `StreakService` with Firestore sync
- update streak when finishing a training pack
- show streak counter in main navigation bar

## Testing
- `dart` and `flutter` commands were unavailable; tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6867be164cf8832aa772d70b75301374