### PR TITLE
Implement training streak

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -193,7 +193,9 @@ Future<void> main() async {
           create: (_) => IgnoredMistakeService()..load(),
         ),
         ChangeNotifierProvider(create: (_) => GoalsService()..load()),
-        ChangeNotifierProvider(create: (_) => StreakService()..load()),
+        ChangeNotifierProvider(
+            create: (context) =>
+                StreakService(cloud: context.read<CloudSyncService>())..load()),
         ChangeNotifierProvider(
           create: (context) =>
               AchievementEngine(stats: context.read<TrainingStatsService>()),

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/spot_of_the_day_card.dart';
 import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
+import '../widgets/streak_widget.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'package:provider/provider.dart';
@@ -145,7 +146,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
-        actions: [SyncStatusIcon.of(context), 
+        actions: [const StreakWidget(), SyncStatusIcon.of(context),
           PopupMenuButton<String>(
             onSelected: (value) {
               switch (value) {

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -13,6 +13,7 @@ import '../../widgets/spot_quiz_widget.dart';
 import '../../widgets/common/explanation_text.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_result_screen.dart';
+import '../../services/streak_service.dart';
 
 enum PlayOrder { sequential, random, mistakes }
 
@@ -289,6 +290,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     } else {
       _index = _spots.length - 1;
       _save();
+      await context.read<StreakService>().onFinish();
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(

--- a/lib/widgets/streak_widget.dart
+++ b/lib/widgets/streak_widget.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/streak_service.dart';
+
+class StreakWidget extends StatelessWidget {
+  const StreakWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<StreakService>();
+    return ValueListenableBuilder<int>(
+      valueListenable: service.streak,
+      builder: (context, value, _) {
+        if (value <= 0) return const SizedBox.shrink();
+        final accent = Theme.of(context).colorScheme.secondary;
+        return Row(
+          children: [
+            Text('🔥', style: TextStyle(color: accent)),
+            const SizedBox(width: 4),
+            Text('$value', style: const TextStyle(fontWeight: FontWeight.bold)),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- track training streak in `StreakService`
- sync training streak with Firestore
- show streak in `MainNavigationScreen` app bar via `StreakWidget`
- update streak when a training pack finishes

## Testing
- `dart` and `flutter` commands were unavailable in the environment so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6867c0699ecc832a9ffeac7931e9e26d