### PR TITLE
Add daily training reminder

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
+import 'services/notification_service.dart';
 import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
@@ -82,6 +83,8 @@ Future<void> main() async {
   final auth = AuthService();
   if (!CloudSyncService.isLocal) {
     await Firebase.initializeApp();
+    await NotificationService.init();
+    await NotificationService.scheduleDailyReminder();
     if (!auth.isSignedIn) {
       final uid = await auth.signInAnonymously();
       if (uid != null) {

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -14,6 +14,7 @@ import '../../widgets/common/explanation_text.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_result_screen.dart';
 import '../../services/streak_service.dart';
+import '../../services/notification_service.dart';
 
 enum PlayOrder { sequential, random, mistakes }
 
@@ -291,6 +292,10 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
       _index = _spots.length - 1;
       _save();
       await context.read<StreakService>().onFinish();
+      await NotificationService.cancel(101);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('last_training_day', DateTime.now().toIso8601String().split('T').first);
+      await NotificationService.scheduleDailyReminder();
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  static final _plugin = FlutterLocalNotificationsPlugin();
+
+  static Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+  }
+
+  static Future<void> cancel(int id) => _plugin.cancel(id);
+
+  static Future<void> scheduleDailyReminder() async {
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getString('last_training_day');
+    final now = DateTime.now();
+    var day = DateTime(now.year, now.month, now.day);
+    final today = _fmt(day);
+    if (last == today) day = day.add(const Duration(days: 1));
+    final when = tz.TZDateTime.local(day.year, day.month, day.day, 20);
+    await _plugin.zonedSchedule(
+      101,
+      'Poker Analyzer',
+      'Time to train!',
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('daily_push', 'Daily Push'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  static String _fmt(DateTime d) => '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}


### PR DESCRIPTION
## Summary
- add NotificationService for scheduling daily training reminders
- initialize notifications and schedule reminders on app start
- reschedule reminder after completing a training session

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c4757474832a8593013517c5de58