### PR TITLE
Add resume training card

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
+import 'services/training_pack_play_controller.dart';
 import 'services/notification_service.dart';
 import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
@@ -102,8 +103,10 @@ Future<void> main() async {
   final packCloud = TrainingPackCloudSyncService();
   final mistakeCloud = MistakePackCloudService();
   final goalCloud = GoalProgressCloudService();
-  final templateStorage =
-      TrainingPackTemplateStorageService(cloud: packCloud, goals: goalCloud);
+  final templateStorage = TrainingPackTemplateStorageService(
+    cloud: packCloud,
+    goals: goalCloud,
+  );
   await templateStorage.load();
   await packCloud.syncDown(packStorage);
   await packCloud.syncDownTemplates(templateStorage);
@@ -115,15 +118,18 @@ Future<void> main() async {
         Provider<CloudSyncService>.value(value: cloud),
         Provider(create: (_) => CloudTrainingHistoryService()),
         ChangeNotifierProvider(
-          create: (context) =>
-              TrainingSpotStorageService(cloud: context.read<CloudSyncService>()),
+          create: (context) => TrainingSpotStorageService(
+            cloud: context.read<CloudSyncService>(),
+          ),
         ),
         ChangeNotifierProvider(
           create: (context) =>
               TrainingStatsService(cloud: context.read<CloudSyncService>())
                 ..load(),
         ),
-        ChangeNotifierProvider(create: (_) => SavedHandStorageService()..load()),
+        ChangeNotifierProvider(
+          create: (_) => SavedHandStorageService()..load(),
+        ),
         ChangeNotifierProvider(
           create: (context) => SavedHandManagerService(
             storage: context.read<SavedHandStorageService>(),
@@ -137,17 +143,17 @@ Future<void> main() async {
             cloud: mistakeCloud,
           )..load(),
         ),
-        ChangeNotifierProvider(
-          create: (_) => SessionNoteService()..load(),
+        ChangeNotifierProvider(create: (_) => SessionNoteService()..load()),
+        ChangeNotifierProvider(create: (_) => SessionPinService()..load()),
+        ChangeNotifierProvider<TrainingPackStorageService>.value(
+          value: packStorage,
         ),
-        ChangeNotifierProvider(
-          create: (_) => SessionPinService()..load(),
-        ),
-        ChangeNotifierProvider<TrainingPackStorageService>.value(value: packStorage),
         Provider<TrainingPackCloudSyncService>.value(value: packCloud),
         Provider<MistakePackCloudService>.value(value: mistakeCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
-        ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(value: templateStorage),
+        ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(
+          value: templateStorage,
+        ),
         ChangeNotifierProvider(
           create: (context) => CategoryUsageService(
             templates: context.read<TemplateStorageService>(),
@@ -177,34 +183,34 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
         ChangeNotifierProvider(
           create: (context) => ActionSyncService(
-              foldedPlayers: context.read<FoldedPlayersService>(),
-              allInPlayers: context.read<AllInPlayersService>()),
+            foldedPlayers: context.read<FoldedPlayersService>(),
+            allInPlayers: context.read<AllInPlayersService>(),
+          ),
         ),
         ChangeNotifierProvider(
           create: (context) {
-            final service =
-                UserPreferencesService(cloud: context.read<CloudSyncService>());
+            final service = UserPreferencesService(
+              cloud: context.read<CloudSyncService>(),
+            );
             UserPreferences.init(service);
             service.load();
             return service;
           },
         ),
-        ChangeNotifierProvider(
-          create: (_) => TagService()..load(),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => IgnoredMistakeService()..load(),
-        ),
+        ChangeNotifierProvider(create: (_) => TagService()..load()),
+        ChangeNotifierProvider(create: (_) => IgnoredMistakeService()..load()),
         ChangeNotifierProvider(create: (_) => GoalsService()..load()),
         ChangeNotifierProvider(
-            create: (context) =>
-                StreakService(cloud: context.read<CloudSyncService>())..load()),
+          create: (context) =>
+              StreakService(cloud: context.read<CloudSyncService>())..load(),
+        ),
         ChangeNotifierProvider(
           create: (context) =>
               AchievementEngine(stats: context.read<TrainingStatsService>()),
         ),
         ChangeNotifierProvider(
-          create: (context) => GoalEngine(stats: context.read<TrainingStatsService>()),
+          create: (context) =>
+              GoalEngine(stats: context.read<TrainingStatsService>()),
         ),
         ChangeNotifierProvider(
           create: (context) => ReminderService(
@@ -234,12 +240,17 @@ Future<void> main() async {
           ),
         ),
         ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),
-        ChangeNotifierProvider(create: (_) => MixedDrillHistoryService()..load()),
+        ChangeNotifierProvider(
+          create: (_) => MixedDrillHistoryService()..load(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => TrainingPackPlayController()..load(),
+        ),
         ChangeNotifierProvider(create: (_) => TrainingSessionService()..load()),
         ChangeNotifierProvider(
-          create: (context) =>
-              SessionLogService(sessions: context.read<TrainingSessionService>())
-                ..load(),
+          create: (context) => SessionLogService(
+            sessions: context.read<TrainingSessionService>(),
+          )..load(),
         ),
         Provider(create: (_) => EvaluationExecutorService()),
         ChangeNotifierProvider(create: (_) => UserActionLogger()..load()),
@@ -275,8 +286,10 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     }
     if (id == null || ts == 0) return;
     if (DateTime.now()
-        .difference(DateTime.fromMillisecondsSinceEpoch(ts))
-        .inHours > 12) return;
+            .difference(DateTime.fromMillisecondsSinceEpoch(ts))
+            .inHours >
+        12)
+      return;
     final templates = await TrainingPackStorage.load();
     final tpl = templates.firstWhereOrNull((t) => t.id == id);
     if (tpl == null) return;
@@ -340,10 +353,10 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.greenAccent),
           scaffoldBackgroundColor: Colors.black,
           textTheme: ThemeData.dark().textTheme.apply(
-                fontFamily: 'Roboto',
-                bodyColor: Colors.white,
-                displayColor: Colors.white,
-              ),
+            fontFamily: 'Roboto',
+            bodyColor: Colors.white,
+            displayColor: Colors.white,
+          ),
         ),
         home: const MainNavigationScreen(),
       ),

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -20,6 +20,8 @@ import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/streak_widget.dart';
+import '../services/training_pack_play_controller.dart';
+import '../widgets/resume_training_card.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'package:provider/provider.dart';
@@ -60,7 +62,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       builder: (context) {
         return AlertDialog(
           backgroundColor: AppColors.cardBackground,
-          title: const Text('Daily Goal', style: TextStyle(color: Colors.white)),
+          title: const Text(
+            'Daily Goal',
+            style: TextStyle(color: Colors.white),
+          ),
           content: TextField(
             controller: controller,
             keyboardType: TextInputType.number,
@@ -97,8 +102,15 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   }
 
   Widget _home() {
+    final ctrl = context.read<TrainingPackPlayController>();
     return Column(
       children: [
+        ValueListenableBuilder<bool>(
+          valueListenable: ctrl.hasIncompleteSession,
+          builder: (_, has, __) => has
+              ? ResumeTrainingCard(controller: ctrl)
+              : const SizedBox.shrink(),
+        ),
         const SpotOfTheDayCard(),
         const StreakChart(),
         const TodayProgressBanner(),
@@ -146,20 +158,26 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Poker AI Analyzer'),
-        actions: [StreakWidget(), SyncStatusIcon.of(context),
+        actions: [
+          StreakWidget(),
+          SyncStatusIcon.of(context),
           PopupMenuButton<String>(
             onSelected: (value) {
               switch (value) {
                 case 'settings':
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (_) => const SettingsPlaceholderScreen()),
+                    MaterialPageRoute(
+                      builder: (_) => const SettingsPlaceholderScreen(),
+                    ),
                   );
                   break;
                 case 'plugins':
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (_) => const PluginManagerScreen()),
+                    MaterialPageRoute(
+                      builder: (_) => const PluginManagerScreen(),
+                    ),
                   );
                   break;
                 case 'about':
@@ -200,10 +218,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                 icon: Icon(Icons.history),
                 label: 'История',
               ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.flag),
-                label: 'Goal',
-              ),
+              BottomNavigationBarItem(icon: Icon(Icons.flag), label: 'Goal'),
               BottomNavigationBarItem(
                 icon: Icon(Icons.backpack),
                 label: 'My Packs',

--- a/lib/services/training_pack_play_controller.dart
+++ b/lib/services/training_pack_play_controller.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/training_pack_storage.dart';
+import '../models/v2/training_pack_template.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class TrainingPackPlayController extends ChangeNotifier {
+  final ValueNotifier<bool> hasIncompleteSession = ValueNotifier(false);
+  TrainingPackTemplate? _template;
+  int _progress = 0;
+
+  TrainingPackTemplate? get template => _template;
+  int get progress => _progress;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    String? id;
+    int ts = 0;
+    for (final k in prefs.getKeys()) {
+      if (k.startsWith('tpl_prog_')) {
+        final pack = k.substring(9);
+        final t = prefs.getInt('tpl_ts_$pack') ?? 0;
+        if (t > ts) {
+          ts = t;
+          id = pack;
+        }
+      }
+    }
+    if (id == null || ts == 0) {
+      hasIncompleteSession.value = false;
+      _template = null;
+      _progress = 0;
+      return;
+    }
+    final templates = await TrainingPackStorage.load();
+    final tpl = templates.firstWhere(
+      (t) => t.id == id,
+      orElse: () => TrainingPackTemplate(id: '', name: ''),
+    );
+    if (tpl.id.isEmpty) {
+      hasIncompleteSession.value = false;
+      _template = null;
+      _progress = 0;
+      return;
+    }
+    final idx = prefs.getInt('tpl_prog_$id') ?? 0;
+    if (idx >= tpl.spots.length - 1) {
+      hasIncompleteSession.value = false;
+      _template = null;
+      _progress = 0;
+      return;
+    }
+    _template = tpl;
+    _progress = (((idx + 1) / tpl.spots.length) * 100).round();
+    hasIncompleteSession.value = true;
+  }
+
+  Future<void> resume(BuildContext context) async {
+    final tpl = _template;
+    if (tpl == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackPlayScreen(template: tpl, original: tpl),
+      ),
+    );
+    await load();
+  }
+}

--- a/lib/widgets/resume_training_card.dart
+++ b/lib/widgets/resume_training_card.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../services/training_pack_play_controller.dart';
+
+class ResumeTrainingCard extends StatelessWidget {
+  final TrainingPackPlayController controller;
+  const ResumeTrainingCard({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final tpl = controller.template;
+    if (tpl == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return GestureDetector(
+      onTap: () => controller.resume(context),
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          '🔥 Continue training: ${tpl.name} · ${controller.progress}%',
+          style: TextStyle(color: accent, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- insert ResumeTrainingCard at the top of home screen
- add TrainingPackPlayController to load/resume incomplete training sessions
- expose controller via provider in main

## Testing
- `flutter analyze` *(fails: 2388 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686806af4ef4832ab057a184e8a3b9f8