### PR TITLE
Add mistakes review CTA

### DIFF
--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -12,6 +12,7 @@ import '../../helpers/hand_type_utils.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_play_screen.dart';
 import 'training_pack_template_editor_screen.dart';
+import '../../services/mistake_review_pack_service.dart';
 
 class TrainingPackResultScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -71,6 +72,8 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
             ans != 'false' &&
             exp.toLowerCase() != ans.toLowerCase();
       }).toList();
+
+  List<String> get _mistakeIds => [for (final s in _mistakeSpots) s.id];
 
   @override
   void initState() {
@@ -214,6 +217,31 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
                   },
                 ),
               ),
+            ],
+            if (_mistakeIds.isNotEmpty) ...[
+              ElevatedButton(
+                onPressed: () async {
+                  final template = widget.template.copyWith(
+                    id: const Uuid().v4(),
+                    name: 'Review mistakes',
+                    spots: [for (final s in widget.template.spots) if (_mistakeIds.contains(s.id)) s],
+                  );
+                  MistakeReviewPackService.latestTemplate = template;
+                  await context.read<MistakeReviewPackService>().addPack(_mistakeIds);
+                  if (!mounted) return;
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => TrainingPackPlayScreen(
+                        template: MistakeReviewPackService.latestTemplate!,
+                        original: null,
+                      ),
+                    ),
+                  );
+                },
+                child: Text('🔥 Review ${_mistakeIds.length} mistakes'),
+              ),
+              const SizedBox(height: 8),
             ],
             ElevatedButton(
               onPressed: _mistakes == 0

--- a/lib/services/mistake_review_pack_service.dart
+++ b/lib/services/mistake_review_pack_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import '../models/mistake_pack.dart';
+import '../models/v2/training_pack_template.dart';
 import 'saved_hand_manager_service.dart';
 import 'mistake_pack_cloud_service.dart';
 
@@ -14,6 +15,8 @@ class MistakeReviewPackService extends ChangeNotifier {
   static const _progressKey = 'mistake_review_progress';
   static const _dateKey = 'mistake_review_date';
   static const _packsKey = 'mistake_packs';
+
+  static TrainingPackTemplate? latestTemplate;
 
   final SavedHandManagerService hands;
   final MistakePackCloudService? cloud;


### PR DESCRIPTION
## Summary
- add latestTemplate cache to MistakeReviewPackService
- add "🔥 Review mistakes" CTA in TrainingPackResultScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680924b290832a9187452deae5e517