### PR TITLE
Add configurable daily push reminder time

### DIFF
--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../services/notification_service.dart';
+
+class NotificationSettingsScreen extends StatefulWidget {
+  const NotificationSettingsScreen({super.key});
+
+  @override
+  State<NotificationSettingsScreen> createState() => _NotificationSettingsScreenState();
+}
+
+class _NotificationSettingsScreenState extends State<NotificationSettingsScreen> {
+  TimeOfDay _time = const TimeOfDay(hour: 20, minute: 0);
+
+  @override
+  void initState() {
+    super.initState();
+    NotificationService.getReminderTime().then((t) => setState(() => _time = t));
+  }
+
+  Future<void> _pick() async {
+    final picked = await showTimePicker(context: context, initialTime: _time);
+    if (picked != null) {
+      await NotificationService.updateReminderTime(picked);
+      if (mounted) setState(() => _time = picked);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timeText = _time.format(context);
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Notification Settings'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Reminder Time', style: TextStyle(color: Colors.white)),
+            subtitle: Text(timeText, style: const TextStyle(color: Colors.white70)),
+            onTap: _pick,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -13,6 +13,7 @@ import '../services/daily_reminder_service.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/sync_status_widget.dart';
+import 'notification_settings_screen.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -109,6 +110,16 @@ class SettingsPlaceholderScreen extends StatelessWidget {
               if (picked != null) {
                 dailyReminder.setHour(picked.hour);
               }
+            },
+          ),
+          ListTile(
+            title: const Text('Push Reminder', style: TextStyle(color: Colors.white)),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const NotificationSettingsScreen()),
+              );
             },
           ),
           const Padding(


### PR DESCRIPTION
## Summary
- store daily reminder time in `NotificationService`
- allow changing reminder time via `NotificationSettingsScreen`
- link notification settings from settings placeholder screen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68681005674c832aa92af6ffbbbd7275