### PR TITLE
Implement RemoteConfigService and integrate reminders

### DIFF
--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -15,13 +15,14 @@ class _NotificationSettingsScreenState extends State<NotificationSettingsScreen>
   @override
   void initState() {
     super.initState();
-    NotificationService.getReminderTime().then((t) => setState(() => _time = t));
+    NotificationService.getReminderTime(context)
+        .then((t) => setState(() => _time = t));
   }
 
   Future<void> _pick() async {
     final picked = await showTimePicker(context: context, initialTime: _time);
     if (picked != null) {
-      await NotificationService.updateReminderTime(picked);
+      await NotificationService.updateReminderTime(context, picked);
       if (mounted) setState(() => _time = picked);
     }
   }

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -295,7 +295,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
       await NotificationService.cancel(101);
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('last_training_day', DateTime.now().toIso8601String().split('T').first);
-      await NotificationService.scheduleDailyReminder();
+      await NotificationService.scheduleDailyReminder(context);
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:provider/provider.dart';
+import 'remote_config_service.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -17,27 +19,30 @@ class NotificationService {
 
   static Future<void> cancel(int id) => _plugin.cancel(id);
 
-  static Future<int> _loadTime() async {
+  static Future<int> _loadTime(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getInt(_timeKey) ?? 20 * 60;
+    final def = context
+        .read<RemoteConfigService>()
+        .get<int>('dailyReminderDefaultMinutes', 20 * 60);
+    return prefs.getInt(_timeKey) ?? def;
   }
 
-  static Future<TimeOfDay> getReminderTime() async {
-    final m = await _loadTime();
+  static Future<TimeOfDay> getReminderTime(BuildContext context) async {
+    final m = await _loadTime(context);
     return TimeOfDay(hour: m ~/ 60, minute: m % 60);
   }
 
-  static Future<void> updateReminderTime(TimeOfDay t) async {
+  static Future<void> updateReminderTime(BuildContext context, TimeOfDay t) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_timeKey, t.hour * 60 + t.minute);
     await cancel(101);
-    await scheduleDailyReminder();
+    await scheduleDailyReminder(context);
   }
 
-  static Future<void> scheduleDailyReminder() async {
+  static Future<void> scheduleDailyReminder(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
     final last = prefs.getString('last_training_day');
-    final time = await _loadTime();
+    final time = await _loadTime(context);
     final now = DateTime.now();
     var day = DateTime(now.year, now.month, now.day);
     final today = _fmt(day);

--- a/lib/services/remote_config_service.dart
+++ b/lib/services/remote_config_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'cloud_retry_policy.dart';
+
+class RemoteConfigService extends ChangeNotifier {
+  final ValueNotifier<Map<String, dynamic>> data = ValueNotifier({});
+  Map<String, dynamic> _data = {};
+  DateTime? _lastFetch;
+
+  T get<T>(String key, T def) {
+    final v = _data[key];
+    if (v is T) return v;
+    return def;
+  }
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString('remote_config_json');
+    final ts = prefs.getInt('remote_config_ts');
+    if (json != null) {
+      _data = jsonDecode(json) as Map<String, dynamic>;
+    }
+    if (ts != null) _lastFetch = DateTime.fromMillisecondsSinceEpoch(ts);
+    data.value = Map.from(_data);
+    final now = DateTime.now();
+    if (_lastFetch == null || now.difference(_lastFetch!).inHours >= 12) {
+      try {
+        final doc = await CloudRetryPolicy.execute(() => FirebaseFirestore.instance.collection('config').doc('public').get());
+        if (doc.exists) {
+          _data = doc.data() ?? {};
+          data.value = Map.from(_data);
+          await prefs.setString('remote_config_json', jsonEncode(_data));
+          await prefs.setInt('remote_config_ts', now.millisecondsSinceEpoch);
+          _lastFetch = now;
+          notifyListeners();
+        }
+      } catch (_) {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `RemoteConfigService` for reading shared remote parameters
- fetch remote config on startup and provide via `ChangeNotifierProvider`
- update `NotificationService` to use remote config for default reminder time
- adapt notification settings and training pack play screen
- schedule daily reminder from app state

## Testing
- `dart format` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6868110d718c832ab6b0f6cab29186c4