### PR TITLE
Add AbTestEngine for UX experiments

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ import 'user_preferences.dart';
 import 'services/user_action_logger.dart';
 import 'services/mistake_review_pack_service.dart';
 import 'services/remote_config_service.dart';
+import 'services/ab_test_engine.dart';
 import 'widgets/sync_status_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
@@ -97,6 +98,8 @@ Future<void> main() async {
       }
     }
   }
+  final ab = AbTestEngine(remote: rc);
+  await ab.init();
   final cloud = CloudSyncService();
   await cloud.init();
   await cloud.syncDown();
@@ -119,6 +122,7 @@ Future<void> main() async {
       providers: [
         ChangeNotifierProvider<AuthService>.value(value: auth),
         ChangeNotifierProvider<RemoteConfigService>.value(value: rc),
+        ChangeNotifierProvider<AbTestEngine>.value(value: ab),
         Provider<CloudSyncService>.value(value: cloud),
         Provider(create: (_) => CloudTrainingHistoryService()),
         ChangeNotifierProvider(

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -22,6 +22,7 @@ import '../services/daily_target_service.dart';
 import '../widgets/streak_widget.dart';
 import '../services/training_pack_play_controller.dart';
 import '../widgets/resume_training_card.dart';
+import '../services/ab_test_engine.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'package:provider/provider.dart';
@@ -103,14 +104,17 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
 
   Widget _home() {
     final ctrl = context.read<TrainingPackPlayController>();
+    final ab = context.watch<AbTestEngine>();
     return Column(
       children: [
-        ValueListenableBuilder<bool>(
-          valueListenable: ctrl.hasIncompleteSession,
-          builder: (_, has, __) => has
-              ? ResumeTrainingCard(controller: ctrl)
-              : const SizedBox.shrink(),
-        ),
+        ab.isVariant('resume_card', 'B')
+            ? ValueListenableBuilder<bool>(
+                valueListenable: ctrl.hasIncompleteSession,
+                builder: (_, has, __) => has
+                    ? ResumeTrainingCard(controller: ctrl)
+                    : const SizedBox.shrink(),
+              )
+            : const SizedBox.shrink(),
         const SpotOfTheDayCard(),
         const StreakChart(),
         const TodayProgressBanner(),

--- a/lib/services/ab_test_engine.dart
+++ b/lib/services/ab_test_engine.dart
@@ -1,0 +1,37 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'remote_config_service.dart';
+
+class AbTestEngine extends ChangeNotifier {
+  final RemoteConfigService remote;
+  AbTestEngine({required this.remote});
+
+  late final SharedPreferences _prefs;
+  final Map<String, String> _cache = {};
+  final Random _rand = Random();
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    final overrides = remote.get<Map<String, dynamic>>('experiments', {});
+    for (final entry in overrides.entries) {
+      final v = entry.value.toString();
+      _cache[entry.key] = v;
+      await _prefs.setString('abtest_${entry.key}', v);
+    }
+  }
+
+  String variantFor(String id) {
+    final cached = _cache[id];
+    if (cached != null) return cached;
+    var v = _prefs.getString('abtest_$id');
+    if (v == null) {
+      v = _rand.nextBool() ? 'A' : 'B';
+      _prefs.setString('abtest_$id', v);
+    }
+    _cache[id] = v;
+    return v;
+  }
+
+  bool isVariant(String id, String v) => variantFor(id) == v;
+}


### PR DESCRIPTION
## Summary
- introduce `AbTestEngine` service for A/B testing
- register the service in app startup
- display resume training card only for variant B

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6868125627b4832a8f39526cba083054