### PR TITLE
Implement XP history cloud sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'services/mistake_pack_cloud_service.dart';
 import 'services/template_storage_service.dart';
 import 'services/training_pack_template_storage_service.dart';
 import 'services/goal_progress_cloud_service.dart';
+import 'services/xp_tracker_cloud_service.dart';
 import 'services/daily_hand_service.dart';
 import 'services/spot_of_the_day_service.dart';
 import 'services/action_sync_service.dart';
@@ -109,6 +110,7 @@ Future<void> main() async {
   final packCloud = TrainingPackCloudSyncService();
   final mistakeCloud = MistakePackCloudService();
   final goalCloud = GoalProgressCloudService();
+  final xpCloud = XPTrackerCloudService();
   final templateStorage = TrainingPackTemplateStorageService(
     cloud: packCloud,
     goals: goalCloud,
@@ -158,6 +160,7 @@ Future<void> main() async {
         ),
         Provider<TrainingPackCloudSyncService>.value(value: packCloud),
         Provider<MistakePackCloudService>.value(value: mistakeCloud),
+        Provider<XPTrackerCloudService>.value(value: xpCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
         ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(
           value: templateStorage,
@@ -171,7 +174,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => DailyHandService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
-        ChangeNotifierProvider(create: (_) => XPTrackerService()..load()),
+        ChangeNotifierProvider(create: (_) => XPTrackerService(cloud: xpCloud)..load()),
         ChangeNotifierProvider(
           create: (context) => WeeklyChallengeService(
             stats: context.read<TrainingStatsService>(),

--- a/lib/models/xp_entry.dart
+++ b/lib/models/xp_entry.dart
@@ -1,17 +1,22 @@
+import 'package:uuid/uuid.dart';
+
 class XPEntry {
+  final String id;
   final DateTime date;
   final int xp;
   final String source;
   final int streak;
 
   XPEntry({
+    String? id,
     required this.date,
     required this.xp,
     required this.source,
     required this.streak,
-  });
+  }) : id = id ?? const Uuid().v4();
 
   Map<String, dynamic> toJson() => {
+        'id': id,
         'date': date.toIso8601String(),
         'xp': xp,
         'source': source,
@@ -19,6 +24,7 @@ class XPEntry {
       };
 
   factory XPEntry.fromJson(Map<String, dynamic> json) => XPEntry(
+        id: json['id'] as String?,
         date: DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now(),
         xp: json['xp'] as int? ?? 0,
         source: json['source'] as String? ?? '',

--- a/lib/services/xp_tracker_cloud_service.dart
+++ b/lib/services/xp_tracker_cloud_service.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/xp_entry.dart';
+import 'cloud_retry_policy.dart';
+
+class XPTrackerCloudService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  String? get _uid => FirebaseAuth.instance.currentUser?.uid;
+
+  Future<List<XPEntry>> loadEntries() async {
+    if (_uid == null) return [];
+    final snap = await CloudRetryPolicy.execute(() => _db
+        .collection('users')
+        .doc(_uid)
+        .collection('xp')
+        .orderBy('date', descending: true)
+        .limit(100)
+        .get());
+    return [for (final d in snap.docs) XPEntry.fromJson({...d.data(), 'id': d.id})];
+  }
+
+  Future<void> saveEntry(XPEntry e) async {
+    if (_uid == null) return;
+    await CloudRetryPolicy.execute(() => _db
+        .collection('users')
+        .doc(_uid)
+        .collection('xp')
+        .doc(e.id)
+        .set(e.toJson()));
+  }
+}


### PR DESCRIPTION
## Summary
- sync XP progress across devices via Firestore
- add XPTrackerCloudService for loading and saving XP entries
- extend XPEntry with persistent IDs
- integrate cloud sync in XPTrackerService and trim history
- wire XPTrackerCloudService in the app

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686813254e28832aa194568ab7619db3