### PR TITLE
Add multi-select for packs

### DIFF
--- a/lib/widgets/selectable_list_item.dart
+++ b/lib/widgets/selectable_list_item.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class SelectableListItem extends StatelessWidget {
+  final Widget child;
+  final bool selectionMode;
+  final bool selected;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  const SelectableListItem({
+    super.key,
+    required this.child,
+    required this.selectionMode,
+    required this.selected,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = selected ? Colors.blueGrey.shade700 : null;
+    return InkWell(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Container(
+        color: color,
+        padding: selectionMode ? const EdgeInsets.only(left: 8) : null,
+        child: Row(
+          children: [
+            if (selectionMode)
+              Checkbox(
+                value: selected,
+                onChanged: (_) => onTap?.call(),
+              ),
+            Expanded(child: child),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- enable multi-selection in My Packs
- add reusable `SelectableListItem` widget

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686817410cb8832aaec6ab172a0cf875