### PR TITLE
Implement dynamic icon for select all toggle

### DIFF
--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -335,7 +335,7 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
                       }
                     });
                   },
-                  icon: const Icon(Icons.select_all),
+                  icon: Icon(_selectedIds.length == packs.length ? Icons.clear_all : Icons.select_all),
                 ),
                 IconButton(onPressed: _deleteSelected, icon: const Icon(Icons.delete)),
                 IconButton(onPressed: _exportSelected, icon: const Icon(Icons.upload_file)),


### PR DESCRIPTION
## Summary
- switch between `select_all` and `clear_all` icons in pack selection toolbar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681bc028b8832ab319e7debec287b1