### PR TITLE
Implement keyboard shortcut tweaks

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -514,20 +514,18 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
 
   bool _onKey(FocusNode _, RawKeyEvent e) {
     if (e is! RawKeyDownEvent) return false;
+    if (FocusManager.instance.primaryFocus?.context?.widget is EditableText) {
+      return false;
+    }
     final isCmd = e.isControlPressed || e.isMetaPressed;
-    switch (e.logicalKey.keyLabel.toLowerCase()) {
-      case 'a':
-        if (isCmd) {
-          _toggleSelectAll();
-          return true;
-        }
-        break;
-      case 'i':
-        if (isCmd) {
-          _invertSelection();
-          return true;
-        }
-        break;
+    if (!isCmd) return false;
+    if (e.logicalKey == LogicalKeyboardKey.keyA) {
+      _toggleSelectAll();
+      return true;
+    }
+    if (e.logicalKey == LogicalKeyboardKey.keyI) {
+      _invertSelection();
+      return true;
     }
     return false;
   }
@@ -2311,7 +2309,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                     },
                     itemBuilder: (_) => const [
                       PopupMenuItem(value: 'rename', child: Text('Rename…')),
-                      PopupMenuItem(value: 'all', child: Text('Select All')),
+                      PopupMenuItem(value: 'all', child: Text('Select All (Ctrl + A)')),
                       PopupMenuItem(value: 'none', child: Text('Select None')),
                     ],
                   ),

--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -165,24 +165,23 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
         ..clear()
         ..addAll(newSel);
     });
+    _reconcileSelection(visible);
   }
 
   bool _onKey(FocusNode _, RawKeyEvent e, Set<String> visible) {
     if (e is! RawKeyDownEvent) return false;
+    if (FocusManager.instance.primaryFocus?.context?.widget is EditableText) {
+      return false;
+    }
     final isCmd = e.isControlPressed || e.isMetaPressed;
-    switch (e.logicalKey.keyLabel.toLowerCase()) {
-      case 'a':
-        if (isCmd) {
-          _toggleSelectAll(visible);
-          return true;
-        }
-        break;
-      case 'i':
-        if (isCmd) {
-          _invertSelection(visible);
-          return true;
-        }
-        break;
+    if (!isCmd) return false;
+    if (e.logicalKey == LogicalKeyboardKey.keyA) {
+      _toggleSelectAll(visible);
+      return true;
+    }
+    if (e.logicalKey == LogicalKeyboardKey.keyI) {
+      _invertSelection(visible);
+      return true;
     }
     return false;
   }
@@ -383,12 +382,13 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
         actions: _selectionMode
             ? [
                 IconButton(
+                  tooltip: 'Select All (Ctrl + A)',
                   icon: Icon(_selectedIds.length == packs.length ? Icons.clear_all : Icons.select_all),
                   onPressed: () => _toggleSelectAll({for (final p in packs) p.id}),
                 ),
                 if (packs.isNotEmpty)
                   IconButton(
-                    tooltip: 'Invert selection',
+                    tooltip: 'Invert Selection (Ctrl + I)',
                     icon: const Icon(Icons.sync_alt),
                     onPressed: () => _invertSelection({for (final p in packs) p.id}),
                   ),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1773,20 +1773,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   bool _onKey(FocusNode _, RawKeyEvent e) {
     if (e is! RawKeyDownEvent) return false;
+    if (FocusManager.instance.primaryFocus?.context?.widget is EditableText) {
+      return false;
+    }
     final isCmd = e.isControlPressed || e.isMetaPressed;
-    switch (e.logicalKey.keyLabel.toLowerCase()) {
-      case 'a':
-        if (isCmd) {
-          _toggleSelectAll();
-          return true;
-        }
-        break;
-      case 'i':
-        if (isCmd) {
-          _invertSelection();
-          return true;
-        }
-        break;
+    if (!isCmd) return false;
+    if (e.logicalKey == LogicalKeyboardKey.keyA) {
+      _toggleSelectAll();
+      return true;
+    }
+    if (e.logicalKey == LogicalKeyboardKey.keyI) {
+      _invertSelection();
+      return true;
     }
     return false;
   }
@@ -2643,14 +2641,20 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
           ? BottomAppBar(
               child: Row(
                 children: [
-                  TextButton(
-                    onPressed: _toggleSelectAll,
-                    child: const Text('Select All'),
+                  Tooltip(
+                    message: 'Select All (Ctrl + A)',
+                    child: TextButton(
+                      onPressed: _toggleSelectAll,
+                      child: const Text('Select All'),
+                    ),
                   ),
                   const SizedBox(width: 12),
-                  TextButton(
-                    onPressed: _invertSelection,
-                    child: const Text('Invert Selection'),
+                  Tooltip(
+                    message: 'Invert Selection (Ctrl + I)',
+                    child: TextButton(
+                      onPressed: _invertSelection,
+                      child: const Text('Invert Selection'),
+                    ),
                   ),
                   const SizedBox(width: 12),
                   TextButton(


### PR DESCRIPTION
## Summary
- handle selection shortcuts with constants
- ignore shortcuts while editing text
- show keyboard hints in tooltips
- keep selection reconciled after invert

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686826ac4860832a95014497a009ce90