### PR TITLE
Fix selection menu and hint text

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -2299,7 +2299,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                   ),
                   PopupMenuButton<String>(
                     onSelected: (v) {
-                      if (v == 'all') {
+                      if (v == 'all' || v == 'all_shortcut') {
                         _toggleSelectAll();
                       } else if (v == 'rename') {
                         _showRenameDialog();
@@ -2309,7 +2309,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                     },
                     itemBuilder: (_) => const [
                       PopupMenuItem(value: 'rename', child: Text('Rename…')),
-                      PopupMenuItem(value: 'all', child: Text('Select All (Ctrl + A)')),
+                      PopupMenuItem(value: 'all_shortcut', child: Text('Select All (Ctrl + A)')),
                       PopupMenuItem(value: 'none', child: Text('Select None')),
                     ],
                   ),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2645,7 +2645,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     message: 'Select All (Ctrl + A)',
                     child: TextButton(
                       onPressed: _toggleSelectAll,
-                      child: const Text('Select All'),
+                      child: const Text('Select All (Ctrl + A)'),
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -2653,7 +2653,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     message: 'Invert Selection (Ctrl + I)',
                     child: TextButton(
                       onPressed: _invertSelection,
-                      child: const Text('Invert Selection'),
+                      child: const Text('Invert (Ctrl + I)'),
                     ),
                   ),
                   const SizedBox(width: 12),


### PR DESCRIPTION
## Summary
- adjust popup menu `value` to avoid duplicate keys in `PackEditorScreen`
- show shortcut hints in bottom bar buttons of training pack template editor

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682a5fd258832a81181b13b721f2a6