### PR TITLE
Improve bulk edit shortcuts

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -2299,7 +2299,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                   ),
                   PopupMenuButton<String>(
                     onSelected: (v) {
-                      if (v == 'all' || v == 'all_shortcut') {
+                      if (v == 'all') {
                         _toggleSelectAll();
                       } else if (v == 'rename') {
                         _showRenameDialog();
@@ -2309,7 +2309,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                     },
                     itemBuilder: (_) => const [
                       PopupMenuItem(value: 'rename', child: Text('Rename…')),
-                      PopupMenuItem(value: 'all_shortcut', child: Text('Select All (Ctrl + A)')),
+                      PopupMenuItem(value: 'all', child: Text('Select All (Ctrl + A)')),
                       PopupMenuItem(value: 'none', child: Text('Select None')),
                     ],
                   ),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2653,7 +2653,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     message: 'Invert Selection (Ctrl + I)',
                     child: TextButton(
                       onPressed: _invertSelection,
-                      child: const Text('Invert (Ctrl + I)'),
+                      child: const Text('Invert Selection (Ctrl + I)'),
                     ),
                   ),
                   const SizedBox(width: 12),


### PR DESCRIPTION
## Summary
- clean up duplicate select-all entry in `PackEditorScreen`
- update multi-select label in `TrainingPackTemplateEditorScreen`

## Testing
- `flutter test --no-pub` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682c27a0d4832a89cd09fe08939185