### PR TITLE
Add delete shortcut

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -527,6 +527,10 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
       _invertSelection();
       return true;
     }
+    if (e.logicalKey == LogicalKeyboardKey.backspace) {
+      _deleteSelected();
+      return true;
+    }
     return false;
   }
 
@@ -2272,6 +2276,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
           actions: _selectionMode
               ? [
                   IconButton(
+                    tooltip: 'Delete (Ctrl + Backspace)',
                     onPressed: _deleteSelected,
                     icon: const Icon(Icons.delete),
                   ),

--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -183,6 +183,10 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
       _invertSelection(visible);
       return true;
     }
+    if (e.logicalKey == LogicalKeyboardKey.backspace) {
+      _deleteSelected();
+      return true;
+    }
     return false;
   }
 
@@ -392,7 +396,11 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
                     icon: const Icon(Icons.sync_alt),
                     onPressed: () => _invertSelection({for (final p in packs) p.id}),
                   ),
-                IconButton(onPressed: _deleteSelected, icon: const Icon(Icons.delete)),
+                IconButton(
+                  tooltip: 'Delete (Ctrl + Backspace)',
+                  onPressed: _deleteSelected,
+                  icon: const Icon(Icons.delete),
+                ),
                 IconButton(onPressed: _exportSelected, icon: const Icon(Icons.upload_file)),
                 IconButton(onPressed: _shareSelected, icon: const Icon(Icons.share)),
                 IconButton(onPressed: _editSelected, icon: const Icon(Icons.edit)),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1786,6 +1786,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       _invertSelection();
       return true;
     }
+    if (e.logicalKey == LogicalKeyboardKey.backspace) {
+      _bulkDelete();
+      return true;
+    }
     return false;
   }
 
@@ -2482,7 +2486,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
           if (_isMultiSelect)
             IconButton(
               icon: const Icon(Icons.delete, color: Colors.red),
-              tooltip: 'Delete Selected',
+              tooltip: 'Delete (Ctrl + Backspace)',
               onPressed: _bulkDelete,
             ),
           PopupMenuButton<SortBy>(
@@ -2689,7 +2693,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   const SizedBox(width: 12),
                   TextButton.icon(
                     icon: const Icon(Icons.delete, color: Colors.red),
-                    label: const Text('Delete'),
+                    label: const Text('Delete (Ctrl + Backspace)'),
                     onPressed: _bulkDelete,
                   ),
                 ],


### PR DESCRIPTION
## Summary
- add Ctrl+Backspace shortcut for bulk delete actions
- show shortcut tooltips on delete buttons

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682d0f4b3c832aa53483a4e91d4883