### PR TITLE
Implement new hand indicator

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -52,6 +52,7 @@ class SavedHand {
   final int? tagsCursor;
   final bool isFavorite;
   final bool isDuplicate;
+  bool isNew;
   final int sessionId;
   final DateTime savedAt;
   final DateTime date;
@@ -117,6 +118,7 @@ class SavedHand {
     this.tagsCursor,
     this.isFavorite = false,
     this.isDuplicate = false,
+    this.isNew = false,
     this.sessionId = 0,
     DateTime? savedAt,
     DateTime? date,
@@ -180,6 +182,7 @@ class SavedHand {
     int? tagsCursor,
     bool? isFavorite,
     bool? isDuplicate,
+    bool? isNew,
     DateTime? savedAt,
     DateTime? date,
     String? expectedAction,
@@ -244,6 +247,7 @@ class SavedHand {
       tagsCursor: tagsCursor ?? this.tagsCursor,
       isFavorite: isFavorite ?? this.isFavorite,
       isDuplicate: isDuplicate ?? this.isDuplicate,
+      isNew: isNew ?? this.isNew,
       sessionId: sessionId ?? this.sessionId,
       savedAt: savedAt ?? this.savedAt,
       date: date ?? this.date,
@@ -591,6 +595,7 @@ class SavedHand {
       tagsCursor: tagsCursor,
       isFavorite: isFavorite,
       isDuplicate: isDuplicate,
+      isNew: false,
       savedAt: savedAt,
       date: date,
       expectedAction: json['expectedAction'] as String?,

--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -413,6 +413,19 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
     if (confirm != true) return;
     final before = _hands.length;
     await _addHands(parsed);
+    for (final h in _hands.skip(before)) h.isNew = true;
+    setState(() {});
+    Future.delayed(const Duration(seconds: 30), () {
+      if (!mounted) return;
+      bool changed = false;
+      for (final hand in _hands) {
+        if (hand.isNew) {
+          hand.isNew = false;
+          changed = true;
+        }
+      }
+      if (changed) setState(() {});
+    });
     if (!mounted) return;
     final added = _hands.length - before;
     final addedIds = [for (final h in _hands.skip(before)) h.name];
@@ -661,6 +674,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
           _hands[idx] = h.copyWith(tags: set.toList());
           _modified = true;
         }
+        h.isNew = false;
       }
       _rebuildStats();
     });
@@ -677,6 +691,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
             _modified = true;
           }
         }
+        h.isNew = false;
       }
       _rebuildStats();
     });
@@ -876,6 +891,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
           _modified = true;
         }
       }
+      for (final h in list) h.isNew = false;
       if (ids == null) _selected.clear();
       _rebuildStats();
     });
@@ -1022,6 +1038,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
         }
         _modified = true;
       }
+      for (final h in selected) h.isNew = false;
       if (ids == null) _selected.clear();
     });
     service.applyDiff(pack, added: toAdd);
@@ -3117,6 +3134,11 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                       title: Row(
                         children: [
                           Expanded(child: Text(title)),
+                          if (hand.isNew)
+                            const Tooltip(
+                              message: 'New',
+                              child: Icon(Icons.fiber_new, color: Colors.orangeAccent),
+                            ),
                           PopupMenuButton<String>(
                             padding: EdgeInsets.zero,
                             onSelected: (p) async {


### PR DESCRIPTION
## Summary
- mark newly imported hands with a temporary `isNew` flag
- display a `fiber_new` icon for new hands
- clear the flag on tag or transfer actions and after 30 seconds

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e6e5ac68832ab39060770f4e28e2