### PR TITLE
Improve clipboard HH detection

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -185,7 +185,17 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
   Future<void> _checkClipboard() async {
     final data = await Clipboard.getData('text/plain');
     final txt = data?.text?.trim() ?? '';
-    final show = txt.length > 100;
+    final lower = txt.toLowerCase();
+    const markers = [
+      '*** hole cards ***',
+      'pokerstars',
+      'hand #',
+      'pokertracker',
+      'карманные карты',
+      'раздача #',
+      'рука #'
+    ];
+    final show = markers.any(lower.contains);
     if (show != _showPasteBubble) {
       setState(() => _showPasteBubble = show);
     }


### PR DESCRIPTION
## Summary
- detect poker hand history markers in clipboard before showing paste button

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868eabf271c832a8c2aeefc6b985085