### PR TITLE
Add auto-preview after clipboard import

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -494,6 +494,14 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
         ),
       );
     }
+    if (parsed.length > 0 && parsed.length <= 3) {
+      final hand = parsed.first;
+      if (widget.pack.isBuiltIn) {
+        await _previewHand(hand);
+      } else {
+        await _editHand(hand);
+      }
+    }
     setState(() => _showPasteBubble = false);
   }
 


### PR DESCRIPTION
## Summary
- trigger hand viewer/editor automatically after importing 1-3 hands from clipboard

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696122b88c832aa24078111674281e