### PR TITLE
Add clipboard HH detector and unit tests

### DIFF
--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -27,6 +27,20 @@ import '../widgets/snapshot_manager_dialog.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../services/room_hand_history_importer.dart';
 
+bool _containsPokerHistoryMarkers(String text) {
+  final lower = text.toLowerCase();
+  const markers = [
+    '*** hole cards ***',
+    'pokerstars',
+    'hand #',
+    'pokertracker',
+    'карманные карты',
+    'раздача #',
+    'рука #',
+  ];
+  return markers.any(lower.contains);
+}
+
 enum _SortOption { newest, oldest, position, tags, mistakes }
 
 enum _MistakeFilter { any, zero, oneTwo, threePlus }
@@ -188,17 +202,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
   Future<void> _checkClipboard() async {
     final data = await Clipboard.getData('text/plain');
     final txt = data?.text?.trim() ?? '';
-    final lower = txt.toLowerCase();
-    const markers = [
-      '*** hole cards ***',
-      'pokerstars',
-      'hand #',
-      'pokertracker',
-      'карманные карты',
-      'раздача #',
-      'рука #'
-    ];
-    final show = markers.any(lower.contains);
+    final show = _containsPokerHistoryMarkers(txt);
     if (show != _showPasteBubble) {
       setState(() => _showPasteBubble = show);
     }

--- a/test/clipboard_detection_test.dart
+++ b/test/clipboard_detection_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/screens/pack_editor_screen.dart';
+
+void main() {
+  group('Clipboard HH detection', () {
+    test('Detects English marker', () {
+      expect(_containsPokerHistoryMarkers('*** HOLE CARDS ***'), isTrue);
+    });
+
+    test('Detects PokerStars header', () {
+      expect(_containsPokerHistoryMarkers('PokerStars Hand #123456'), isTrue);
+    });
+
+    test('Detects Russian marker', () {
+      expect(_containsPokerHistoryMarkers('*** Карманные карты ***'), isTrue);
+    });
+
+    test('Ignores random text', () {
+      expect(_containsPokerHistoryMarkers('Hello world'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `_containsPokerHistoryMarkers` helper in `pack_editor_screen.dart`
- use it when checking clipboard
- add unit tests for clipboard detection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686967652710832a9c888d096b0e238e