### PR TITLE
Implement clipboard paste in template editor

### DIFF
--- a/tests/widgets/clipboard_detector_template_test.dart
+++ b/tests/widgets/clipboard_detector_template_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/models/v2/hand_data.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('clipboard paste bubble appears', (tester) async {
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 'Test',
+      spots: [TrainingPackSpot(id: 's', hand: HandData())],
+      createdAt: DateTime.now(),
+    );
+    SharedPreferences.setMockInitialValues({});
+    await Clipboard.setData(const ClipboardData(text: 'GGPoker Hand #1'));
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    final state = tester.state(find.byType(TrainingPackTemplateEditorScreen)) as dynamic;
+    await state._checkClipboard();
+    await tester.pump();
+    expect(find.text('Paste Hands'), findsOneWidget);
+    await Clipboard.setData(const ClipboardData(text: 'foo'));
+    await state._checkClipboard();
+    await tester.pump();
+    expect(find.text('Paste Hands'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add clipboard HH import to template editor
- display paste bubble and import indicator
- support tagging and moving newly added spots
- add keyboard shortcut
- test clipboard detection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869692aa7c4832ab02ad87dbfba897c