### PR TITLE
Implement New indicator for template spots

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -12,6 +12,7 @@ class TrainingPackSpot {
   bool pinned;
   bool dirty;
   EvaluationResult? evalResult;
+  bool isNew;
 
   TrainingPackSpot({
     required this.id,
@@ -23,6 +24,7 @@ class TrainingPackSpot {
     this.pinned = false,
     this.dirty = false,
     this.evalResult,
+    this.isNew = false,
   })  : hand = hand ?? HandData(),
         tags = tags ?? [],
         editedAt = editedAt ?? DateTime.now();
@@ -37,6 +39,7 @@ class TrainingPackSpot {
     bool? pinned,
     bool? dirty,
     EvaluationResult? evalResult,
+    bool? isNew,
   }) =>
       TrainingPackSpot(
         id: id ?? this.id,
@@ -48,6 +51,7 @@ class TrainingPackSpot {
         pinned: pinned ?? this.pinned,
         dirty: dirty ?? this.dirty,
         evalResult: evalResult ?? this.evalResult,
+        isNew: isNew ?? this.isNew,
       );
 
   factory TrainingPackSpot.fromJson(Map<String, dynamic> j) => TrainingPackSpot(
@@ -66,6 +70,7 @@ class TrainingPackSpot {
             ? EvaluationResult.fromJson(
                 Map<String, dynamic>.from(j['evalResult']))
             : null,
+        isNew: false,
       );
 
   Map<String, dynamic> toJson() => {

--- a/tests/widgets/new_spots_indicator_test.dart
+++ b/tests/widgets/new_spots_indicator_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_ai_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_ai_analyzer/models/v2/hand_data.dart';
+import 'package:poker_ai_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('import marks new spots and bulk selects on tap', (tester) async {
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 'Test',
+      spots: [],
+      createdAt: DateTime.now(),
+    );
+    SharedPreferences.setMockInitialValues({});
+    final text = [
+      "PokerStars Hand #1: Hold'em No Limit (\$0.01/\$0.02 USD) - 2023/01/01 00:00:00 ET",
+      "Table 'Alpha' 6-max Seat #1 is the button",
+      'Seat 1: Player1 (\$1 in chips)',
+      'Seat 2: Player2 (\$1 in chips)',
+      '*** HOLE CARDS ***',
+      'Dealt to Player1 [Ah Kh]',
+      'Player1: raises 2 to 2',
+      'Player2: folds',
+      '*** SUMMARY ***',
+      '',
+      "PokerStars Hand #2: Hold'em No Limit (\$0.01/\$0.02 USD) - 2023/01/01 00:01:00 ET",
+      "Table 'Beta' 6-max Seat #1 is the button",
+      'Seat 1: Hero (\$1 in chips)',
+      'Seat 2: Villain (\$1 in chips)',
+      '*** HOLE CARDS ***',
+      'Dealt to Hero [Qs Qd]',
+      'Hero: raises 4 to 4',
+      'Villain: folds',
+      '*** SUMMARY ***',
+    ].join('\n');
+    await Clipboard.setData(ClipboardData(text: text));
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    final state = tester.state(find.byType(TrainingPackTemplateEditorScreen)) as dynamic;
+    await state._importFromClipboardSpots();
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.fiber_new), findsNWidgets(2));
+    await tester.tap(find.byIcon(Icons.fiber_new).first);
+    await tester.pumpAndSettle();
+    expect(find.byType(Checkbox), findsNWidgets(2));
+    for (final cb in tester.widgetList<Checkbox>(find.byType(Checkbox))) {
+      expect(cb.value, isTrue);
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `isNew` flag to `TrainingPackSpot`
- mark new spots on import, reset after 30 seconds
- bulk operations clear `isNew`
- UI icon for new spots with bulk-select tap
- keyboard shortcut Ctrl/⌘+N to select all new
- widget test for new spot selection

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696be05dd0832a8f3646e79d927303