### PR TITLE
Disable tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Run unit tests
-        run: flutter test
+        # - name: Run unit tests
+        #   run: flutter test
 


### PR DESCRIPTION
## Summary
- comment out test run in GitHub Actions

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68698067f550832a8389ee039af9bac9