### PR TITLE
Implement autofocus for new template name field

### DIFF
--- a/lib/screens/create_template_screen.dart
+++ b/lib/screens/create_template_screen.dart
@@ -54,9 +54,12 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Название'),
+            Focus(
+              autofocus: true,
+              child: TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Название'),
+              ),
             ),
             const SizedBox(height: 16),
             TextField(


### PR DESCRIPTION
## Summary
- focus `CreateTemplateScreen` name input automatically for faster template creation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686981f83528832a9f69b693f74e4c9c