### PR TITLE
Implement clipboard check in template editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -584,7 +584,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   Future<void> _checkClipboard() async {
     final data = await Clipboard.getData('text/plain');
-    final show = containsPokerHistoryMarkers(data?.text ?? '');
+    final txt = data?.text?.trim() ?? '';
+    final show = containsPokerHistoryMarkers(txt);
     if (show != _showPasteBubble) setState(() => _showPasteBubble = show);
   }
 


### PR DESCRIPTION
## Summary
- refine `_checkClipboard` in `TrainingPackTemplateEditorScreen` to trim clipboard text before matching

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698662f44c832a8dfcd7245b0d5e89