### PR TITLE
Implement ephemeral spot flag

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -11,7 +11,7 @@ class TrainingPackSpot {
   DateTime editedAt;
   bool pinned;
   bool dirty;
-  bool isNew;
+  bool isNew = false;
   EvaluationResult? evalResult;
 
   TrainingPackSpot({
@@ -23,9 +23,10 @@ class TrainingPackSpot {
     DateTime? editedAt,
     this.pinned = false,
     this.dirty = false,
-    this.isNew = false,
+    bool? isNew,
     this.evalResult,
-  })  : hand = hand ?? HandData(),
+  })  : isNew = isNew ?? false,
+        hand = hand ?? HandData(),
         tags = tags ?? [],
         editedAt = editedAt ?? DateTime.now();
 


### PR DESCRIPTION
## Summary
- mark `isNew` at field level and default to `false`
- handle optional `isNew` parameter in spot constructor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686989c9f49c832aad79af41aa33ebf8