### PR TITLE
Clarify ephemeral spot flag

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -11,6 +11,9 @@ class TrainingPackSpot {
   DateTime editedAt;
   bool pinned;
   bool dirty;
+
+  /// Ephemeral flag — used only in RAM to highlight freshly imported spots.
+  /// Never written to / read from JSON.
   bool isNew = false;
   EvaluationResult? evalResult;
 
@@ -67,6 +70,7 @@ class TrainingPackSpot {
             DateTime.tryParse(j['editedAt'] as String? ?? '') ?? DateTime.now(),
         pinned: j['pinned'] == true,
         dirty: j['dirty'] == true,
+        // `isNew` never restored from disk
         isNew: false,
         evalResult: j['evalResult'] != null
             ? EvaluationResult.fromJson(


### PR DESCRIPTION
## Summary
- add doc comments for the `isNew` flag in `TrainingPackSpot`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698b29a1a0832a92a48f4ff129454d