### PR TITLE
Implement duplicate spot detection in template editor

### DIFF
--- a/test/duplicate_spot_detection_test.dart
+++ b/test/duplicate_spot_detection_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+
+HandData _hand(String pos, String hero, String board) {
+  final b = <String>[];
+  for (var i = 0; i + 1 < board.length; i += 2) {
+    b.add(board.substring(i, i + 2));
+  }
+  final hc = hero.length == 4 ? '${hero.substring(0, 2)} ${hero.substring(2)}' : hero;
+  return HandData(position: parseHeroPosition(pos), heroCards: hc, board: b);
+}
+
+void main() {
+  test('detect duplicate spots', () {
+    final s1 = TrainingPackSpot(id: 'a', hand: _hand('BTN', 'AhKh', 'KdQsJs'));
+    final s2 = TrainingPackSpot(id: 'b', hand: _hand('BTN', 'AhKh', 'KdQsJs'));
+    final s3 = TrainingPackSpot(id: 'c', hand: _hand('SB', 'AhKh', 'KdQsJs'));
+    final list = [s1, s2, s3];
+    final groups = duplicateSpotGroupsStatic(list);
+    expect(groups.length, 1);
+    expect(groups.first, containsAll(<int>[0, 1]));
+  });
+}


### PR DESCRIPTION
## Summary
- enable duplicate spot detection in template editor
- merge/delete duplicate spots with undo
- add keyboard shortcut and toolbar button
- provide unit test for detection logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698d6bd2ac832a80009a4c48ccd2bf