### PR TITLE
feat: select duplicate spots

### DIFF
--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -10,6 +10,8 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
   final ValueChanged<String>? onTagTap;
   final VoidCallback? onDuplicate;
   final VoidCallback? onNewTap;
+  final VoidCallback? onDupTap;
+  final bool showDuplicate;
   final Color? titleColor;
   final bool isMistake;
   const TrainingPackSpotPreviewCard({
@@ -19,8 +21,10 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
     this.onTagTap,
     this.onDuplicate,
     this.onNewTap,
+    this.onDupTap,
     this.titleColor,
     this.isMistake = false,
+    this.showDuplicate = false,
   });
 
   @override
@@ -150,6 +154,15 @@ class TrainingPackSpotPreviewCard extends StatelessWidget {
                             onTap: onNewTap,
                             child: const Icon(Icons.fiber_new,
                                 color: Colors.orangeAccent),
+                          ),
+                        ),
+                      if (showDuplicate)
+                        Tooltip(
+                          message: 'Duplicate',
+                          child: InkWell(
+                            onTap: onDupTap,
+                            child: const Icon(Icons.copy_all,
+                                color: Colors.redAccent),
                           ),
                         ),
                       if (spot.hand.playerCount > 2)

--- a/test/select_duplicates_test.dart
+++ b/test/select_duplicates_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('select duplicates', (tester) async {
+    final hand = HandData(
+      heroCards: 'Ah Kh',
+      position: HeroPosition.sb,
+    );
+    final dup1 = TrainingPackSpot(id: 'a', hand: hand);
+    final dup2 = TrainingPackSpot(id: 'b', hand: hand);
+    final unique = TrainingPackSpot(id: 'c', hand: HandData(heroCards: '2c 2d'));
+    final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [dup1, dup2, unique]);
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Duplicate').first);
+    await tester.pumpAndSettle();
+    expect(find.text('1 selected'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add ability to select all duplicate spots via toolbar and shortcut
- display duplicate icon in spot preview card
- add widget test for selecting duplicates

## Testing
- `flutter analyze` *(fails: 2223 issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_686993fe65bc832abccf7cea5d61bb50