### PR TITLE
Add duplicates only filter

### DIFF
--- a/test/duplicates_only_filter_test.dart
+++ b/test/duplicates_only_filter_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_analyzer/widgets/v2/training_pack_spot_preview_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('toggle duplicates only filter', (tester) async {
+    final hand = HandData(heroCards: 'Ah Kh', position: HeroPosition.sb);
+    final dup1 = TrainingPackSpot(id: 'a', hand: hand);
+    final dup2 = TrainingPackSpot(id: 'b', hand: hand);
+    final unique = TrainingPackSpot(id: 'c', hand: HandData(heroCards: '2c 2d'));
+    final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [dup1, dup2, unique]);
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(3));
+    await tester.tap(find.byTooltip('Duplicates Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsOneWidget);
+    await tester.tap(find.byTooltip('Duplicates Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(3));
+  });
+}


### PR DESCRIPTION
## Summary
- filter spots by duplicates only option
- persist duplicates only flag via prefs
- toggle duplicates-only display from app bar or Alt+D
- reset filter after removing or merging duplicates
- test toggle for duplicates only filter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686997b37e34832a92738bdbc4f489f4