### PR TITLE
Implement new-only filter for Template Editor

### DIFF
--- a/test/new_only_filter_test.dart
+++ b/test/new_only_filter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_analyzer/widgets/v2/training_pack_spot_preview_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('toggle new-only filter', (tester) async {
+    final oldSpot = TrainingPackSpot(id: 'a');
+    final newSpot = TrainingPackSpot(id: 'b', isNew: true);
+    final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [oldSpot, newSpot]);
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(2));
+    await tester.tap(find.byTooltip('New Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsOneWidget);
+    await tester.tap(find.byTooltip('New Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add `_newOnly` flag with persistence and toggle
- filter visible spots by new-only option
- allow Alt+N shortcut to toggle new-only
- auto disable when new spots disappear or after bulk actions
- add widget test for new-only filter

## Testing
- `flutter analyze` *(fails: 2226 issues)*
- `flutter test test/new_only_filter_test.dart` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_68699c0f2234832aa8074579bd922d1e