### PR TITLE
Show count of visible spots in app bar

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2890,9 +2890,21 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             : null,
         title: _isMultiSelect
             ? Text('${_selectedSpotIds.length} selected')
-            : GestureDetector(
-                onTap: _renameTemplate,
-                child: Text(_templateName),
+            : Row(
+                children: [
+                  GestureDetector(
+                    onTap: _renameTemplate,
+                    child: Text(_templateName),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '$totalSpots spots',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelMedium
+                        ?.copyWith(color: Colors.white70),
+                  ),
+                ],
               ),
         actions: [
           DropdownButton<GameType>(


### PR DESCRIPTION
## Summary
- show number of filtered spots in the template editor app bar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a1bc3e6c832abe3b4a9f161b2cb6