### PR TITLE
Remove visibleCount local variable

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2881,8 +2881,6 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               ? KeyEventResult.handled
               : KeyEventResult.ignored,
           child: Scaffold(
-      // вычисляем число видимых спотов один раз
-      final int visibleCount = _visibleSpots().length;
 
       appBar: AppBar(
         leading: _isMultiSelect
@@ -2901,7 +2899,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   ),
                   const Spacer(),
                   Text(
-                    '$visibleCount spots',
+                    '${_visibleSpots().length} spots',
                     style: Theme.of(context)
                         .textTheme
                         .labelMedium


### PR DESCRIPTION
## Summary
- call `_visibleSpots().length` directly in `TrainingPackTemplateEditorScreen`

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869a384e720832a95f086246716ef07