### PR TITLE
Add snackbar and error handling for preview JSON export

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1220,10 +1220,23 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   }
 
   Future<void> _exportPreviewJson() async {
-    final safe = widget.template.name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    final safe =
+        widget.template.name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
     final name = 'preview_$safe';
-    await FileSaverService.instance
-        .saveJson(name, widget.template.toJson());
+    try {
+      await FileSaverService.instance.saveJson(name, widget.template.toJson());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Preview saved')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _import() async {


### PR DESCRIPTION
## Summary
- show success/fail snackbars when exporting preview JSON

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a40d92660832a99d2050c39f52589