### PR TITLE
Add CSV preview export

### DIFF
--- a/lib/services/file_saver_service.dart
+++ b/lib/services/file_saver_service.dart
@@ -16,4 +16,14 @@ class FileSaverService {
       mimeType: MimeType.other,
     );
   }
+
+  Future<void> saveCsv(String name, String data) async {
+    final bytes = Uint8List.fromList(utf8.encode(data));
+    await FileSaver.instance.saveAs(
+      name: name,
+      bytes: bytes,
+      ext: 'csv',
+      mimeType: MimeType.csv,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- allow saving CSV files via `FileSaverService`
- export preview CSV in `TrainingPackTemplateEditorScreen`

## Testing
- `dart format lib/services/file_saver_service.dart lib/screens/v2/training_pack_template_editor_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a43acb850832a8acb0f7b176db6ae