### PR TITLE
Add zip preview export

### DIFF
--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../data/seed_packs.dart';
@@ -31,5 +33,10 @@ class TrainingPackStorage {
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, jsonEncode([for (final x in t) x.toJson()]));
+  }
+
+  static Future<Directory> previewImageDir(TrainingPackTemplate t) async {
+    final dir = await getApplicationDocumentsDirectory();
+    return Directory('${dir.path}/template_previews/${t.id}');
   }
 }

--- a/lib/services/file_saver_service.dart
+++ b/lib/services/file_saver_service.dart
@@ -26,4 +26,13 @@ class FileSaverService {
       mimeType: MimeType.csv,
     );
   }
+
+  Future<void> saveZip(String name, Uint8List data) async {
+    await FileSaver.instance.saveAs(
+      name: name,
+      bytes: data,
+      ext: 'zip',
+      mimeType: MimeType.other,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- enable preview image directory access
- allow saving zip files via FileSaverService
- add ZIP export button in preview mode

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4ac89410832aa3cd7e83d474b942