### PR TITLE
Fix preview zip export loop

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1276,10 +1276,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     archive.addFile(ArchiveFile('template.json', jsonData.length, jsonData));
     final dir = await TrainingPackStorage.previewImageDir(widget.template);
     if (await dir.exists()) {
-      for (final file in dir
-          .listSync()
-          .whereType<File>()
-          .where((f) => f.path.toLowerCase().endsWith('.png'))) {
+      for (final file in dir.listSync().whereType<File>().where((f) => f.path.toLowerCase().endsWith('.png'))) {
         final bytes = await file.readAsBytes();
         final name = file.path.split(Platform.pathSeparator).last;
         archive.addFile(ArchiveFile(name, bytes.length, bytes));


### PR DESCRIPTION
## Summary
- clean up preview zip export to use one PNG-filtered loop

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d1ec420832a9ae672afbd515958