### PR TITLE
Improve share zip flow

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1313,11 +1313,13 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         archive.addFile(ArchiveFile(name, bytes.length, bytes));
       }
     }
+    await Future.delayed(Duration.zero);
     final bytes = ZipEncoder().encode(archive);
     if (bytes == null) return;
     final tmp = await getTemporaryDirectory();
     final safe = widget.template.name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
-    final file = File('${tmp.path}/preview_$safe.zip');
+    final file = File(
+        '${tmp.path}/preview_${safe}_${DateTime.now().millisecondsSinceEpoch}.zip');
     await file.writeAsBytes(bytes, flush: true);
     try {
       await Share.shareXFiles([XFile(file.path)]);


### PR DESCRIPTION
## Summary
- avoid UI freeze when generating zip
- name share preview zip with timestamp

## Testing
- `flutter analyze` *(fails: 2389 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686a527ddb38832ab057d6ebfb3cf23f