### PR TITLE
Implement coverage percent overlay

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -4636,27 +4636,33 @@ class _CoverageProgress extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final percent = (value * 100).round();
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: LinearProgressIndicator(
-            value: value,
-            backgroundColor: Colors.white24,
-            valueColor: AlwaysStoppedAnimation(color),
-            minHeight: 6,
+    final percent = '${(value * 100).toStringAsFixed(0)}%';
+    return Tooltip(
+      message:
+          'This shows how many spots have calculated EV/ICM. Aim for 100% before training or publishing.',
+      child: Row(
+        children: [
+          Text(label, style: const TextStyle(color: Colors.white70)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: value,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation(color),
+                    minHeight: 6,
+                  ),
+                ),
+                Text(percent, style: const TextStyle(color: Colors.white)),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(height: 4),
-        Tooltip(
-          message:
-              'This shows how many spots have calculated EV/ICM. Aim for 100% before training or publishing.',
-          child: Text('$label $percent%',
-              style: const TextStyle(color: Colors.white70)),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- show EV and ICM coverage percentages directly on their progress bars in `TrainingPackTemplateEditorScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5be87804832abc50af3d07122e12