### PR TITLE
feat: overlay label in spot png export

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -42,6 +42,7 @@ import '../../theme/app_colors.dart';
 import '../../services/room_hand_history_importer.dart';
 import '../../services/push_fold_ev_service.dart';
 import '../../services/pack_export_service.dart';
+import '../../services/png_exporter.dart';
 import '../../widgets/range_matrix_picker.dart';
 import '../../services/evaluation_executor_service.dart';
 import '../../services/pack_generator_service.dart';
@@ -1015,12 +1016,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       await jsonFile.writeAsString(jsonEncode(widget.template.toJson()));
       for (int i = 0; i < widget.template.spots.length; i++) {
         final spot = widget.template.spots[i];
-        final key = _itemKeys[spot.id];
-        final boundary = key?.currentContext?.findRenderObject() as RenderRepaintBoundary?;
-        if (boundary == null) continue;
-        final image = await boundary.toImage(pixelRatio: 3);
-        final data = await image.toByteData(format: ui.ImageByteFormat.png);
-        final bytes = data?.buffer.asUint8List();
+        final preview = TrainingPackSpotPreviewCard(spot: spot);
+        final label = spot.title.isNotEmpty ? spot.title : 'Spot ${i + 1}';
+        final bytes = await PngExporter.exportSpot(context, preview, label: label);
         if (bytes == null) continue;
         final imgFile = File('${dir.path}/spot_$i.png');
         await imgFile.writeAsBytes(bytes);

--- a/lib/services/png_exporter.dart
+++ b/lib/services/png_exporter.dart
@@ -1,0 +1,55 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+
+class PngExporter {
+  static Future<Uint8List?> _capture(BuildContext context, Widget child) async {
+    final key = GlobalKey();
+    final entry = OverlayEntry(
+      builder: (_) => Center(
+        child: Opacity(
+          opacity: 0,
+          child: RepaintBoundary(key: key, child: child),
+        ),
+      ),
+    );
+    Overlay.of(context, rootOverlay: true).insert(entry);
+    await Future.delayed(const Duration(milliseconds: 50));
+    final boundary = key.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+    Uint8List? bytes;
+    if (boundary != null) {
+      final image = await boundary.toImage(pixelRatio: 3);
+      final data = await image.toByteData(format: ui.ImageByteFormat.png);
+      bytes = data?.buffer.asUint8List();
+    }
+    entry.remove();
+    return bytes;
+  }
+
+  static Future<Uint8List?> exportSpot(BuildContext context, Widget spot, {required String label}) {
+    return _capture(
+      context,
+      Stack(
+        children: [
+          spot,
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: Container(
+              color: Colors.black.withOpacity(0.5),
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+              alignment: Alignment.center,
+              child: Text(
+                label,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PngExporter for capturing widgets as PNG with footer text
- include spot preview label overlay in bundle export

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5dc93bcc832aac253d0e7c926822