### PR TITLE
Fix PNG export overlay

### DIFF
--- a/lib/services/png_exporter.dart
+++ b/lib/services/png_exporter.dart
@@ -7,13 +7,14 @@ class PngExporter {
     final key = GlobalKey();
     final entry = OverlayEntry(
       builder: (_) => Center(
-        child: Opacity(
-          opacity: 0,
+        child: Offstage(
+          offstage: true,
           child: RepaintBoundary(key: key, child: child),
         ),
       ),
     );
     Overlay.of(context, rootOverlay: true).insert(entry);
+    await Future.delayed(Duration.zero);
     await Future.delayed(const Duration(milliseconds: 50));
     final boundary = key.currentContext?.findRenderObject() as RenderRepaintBoundary?;
     Uint8List? bytes;


### PR DESCRIPTION
## Summary
- use `Offstage` in `PngExporter` overlay so captured images aren't transparent
- yield a frame before capture

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a61a07d18832a8c92ca970dbce1b2