### PR TITLE
Enable PNG export without overlay

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1018,7 +1018,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         final spot = widget.template.spots[i];
         final preview = TrainingPackSpotPreviewCard(spot: spot);
         final label = spot.title.isNotEmpty ? spot.title : 'Spot ${i + 1}';
-        final bytes = await PngExporter.exportSpot(context, preview, label: label);
+        final bytes = await PngExporter.exportSpot(preview, label: label);
         if (bytes == null) continue;
         final imgFile = File('${dir.path}/spot_$i.png');
         await imgFile.writeAsBytes(bytes);


### PR DESCRIPTION
## Summary
- render widgets offscreen for PNG export so overlay is unnecessary
- adjust bundle export to call new exporter API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a68d91350832a9f4e973167068aed