### PR TITLE
Add PNG option for preview JSON export

### DIFF
--- a/lib/services/file_saver_service.dart
+++ b/lib/services/file_saver_service.dart
@@ -35,4 +35,13 @@ class FileSaverService {
       mimeType: MimeType.other,
     );
   }
+
+  Future<void> savePng(String name, Uint8List data) async {
+    await FileSaver.instance.saveAs(
+      name: name,
+      bytes: data,
+      ext: 'png',
+      mimeType: MimeType.other,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- support saving PNG files via FileSaverService
- allow exporting PNG alongside preview JSON
- remember PNG setting in template prefs and add toggle in settings

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a712bf800832aa5732d756a18d244