### PR TITLE
Add template markdown export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Fix training resume dialog to load packs before showing confirmation.
 - Remove unused spot storage field from app state.
 - Add "Select All" toggle in the My Packs selection toolbar.
+- Export Markdown summary from pack template preview.

--- a/lib/services/file_saver_service.dart
+++ b/lib/services/file_saver_service.dart
@@ -44,4 +44,14 @@ class FileSaverService {
       mimeType: MimeType.other,
     );
   }
+
+  Future<void> saveMd(String name, String data) async {
+    final bytes = Uint8List.fromList(utf8.encode(data));
+    await FileSaver.instance.saveAs(
+      name: name,
+      bytes: bytes,
+      ext: 'md',
+      mimeType: MimeType.other,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- support saving Markdown with FileSaverService
- export Markdown summary from training pack template editor
- update exports with a new button
- document change in changelog

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7a73812c832abb89f80ef67221f5