### PR TITLE
Add markdown preview dialog

### DIFF
--- a/lib/widgets/markdown_preview_dialog.dart
+++ b/lib/widgets/markdown_preview_dialog.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class MarkdownPreviewDialog extends StatelessWidget {
+  final String markdown;
+  const MarkdownPreviewDialog({super.key, required this.markdown});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Markdown Preview'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: SelectableText(markdown, style: const TextStyle(color: Colors.white)),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Clipboard.setData(ClipboardData(text: markdown));
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Copied to clipboard')),
+            );
+          },
+          child: const Text('Copy'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Save'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<bool?> showMarkdownPreviewDialog(BuildContext context, String markdown) {
+  return showDialog<bool>(
+    context: context,
+    builder: (_) => MarkdownPreviewDialog(markdown: markdown),
+  );
+}


### PR DESCRIPTION
## Summary
- implement MarkdownPreviewDialog with selectable text and copy button
- refactor TrainingPackTemplateEditorScreen to preview markdown before export

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7ca67b48832abcc917ba5fcef2d7