### PR TITLE
Update Markdown copy toast

### DIFF
--- a/lib/widgets/markdown_preview_dialog.dart
+++ b/lib/widgets/markdown_preview_dialog.dart
@@ -19,9 +19,8 @@ class MarkdownPreviewDialog extends StatelessWidget {
         TextButton(
           onPressed: () {
             Clipboard.setData(ClipboardData(text: markdown));
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Copied to clipboard')),
-            );
+            ScaffoldMessenger.of(context)
+                .showSnackBar(const SnackBar(content: Text('Copied')));
           },
           child: const Text('Copy'),
         ),


### PR DESCRIPTION
## Summary
- tweak toast text for copy action in markdown dialog

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a7e1ee460832a9f9aacf2d12516a6