### PR TITLE
Implement draft templates

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -31,6 +31,7 @@ class TrainingPackTemplate {
   int goalProgress;
   String? targetStreet;
   int streetGoal;
+  bool isDraft;
 
   TrainingPackTemplate({
     required this.id,
@@ -57,6 +58,7 @@ class TrainingPackTemplate {
     this.goalProgress = 0,
     this.targetStreet,
     this.streetGoal = 0,
+    this.isDraft = false,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         focusTags = focusTags ?? [],
@@ -92,6 +94,7 @@ class TrainingPackTemplate {
     int? goalProgress,
     String? targetStreet,
     int? streetGoal,
+    bool? isDraft,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -118,6 +121,7 @@ class TrainingPackTemplate {
       goalProgress: goalProgress ?? this.goalProgress,
       targetStreet: targetStreet ?? this.targetStreet,
       streetGoal: streetGoal ?? this.streetGoal,
+      isDraft: isDraft ?? this.isDraft,
     );
   }
 
@@ -161,6 +165,7 @@ class TrainingPackTemplate {
       goalProgress: json['goalProgress'] as int? ?? 0,
       targetStreet: json['targetStreet'] as String?,
       streetGoal: json['streetGoal'] as int? ?? 0,
+      isDraft: json['isDraft'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
       tpl.recountCoverage();
@@ -195,6 +200,7 @@ class TrainingPackTemplate {
         if (goalProgress > 0) 'goalProgress': goalProgress,
         if (targetStreet != null) 'targetStreet': targetStreet,
         if (streetGoal > 0) 'streetGoal': streetGoal,
+        if (isDraft) 'isDraft': true,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -364,6 +364,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   }
 
   Future<void> _persist() async {
+    widget.template.isDraft = true;
     widget.template.recountCoverage();
     await TrainingPackStorage.save(widget.templates);
   }
@@ -991,7 +992,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Name is required')));
       return;
     }
-    _persist();
+    final ready = validateTrainingPackTemplate(widget.template).isEmpty;
+    widget.template.isDraft = !ready;
+    widget.template.recountCoverage();
+    TrainingPackStorage.save(widget.templates);
     Navigator.pop(context);
   }
 

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -606,6 +606,16 @@ class _TrainingPackTemplateListScreenState
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
             ),
+          if (t.isDraft)
+            const Padding(
+              padding: EdgeInsets.only(left: 4),
+              child: Chip(
+                label: Text('DRAFT', style: TextStyle(fontSize: 12)),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                backgroundColor: Colors.grey,
+              ),
+            ),
           if (allIcm)
             const Padding(
               padding: EdgeInsets.only(left: 4),
@@ -1746,7 +1756,10 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _export() async {
-    final json = jsonEncode([for (final t in _templates) t.toJson()]);
+    final json = jsonEncode([
+      for (final t in _templates)
+        if (!t.isDraft) t.toJson()
+    ]);
     await Clipboard.setData(ClipboardData(text: json));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Templates copied to clipboard')),


### PR DESCRIPTION
## Summary
- add `isDraft` flag to `TrainingPackTemplate`
- mark templates as draft during autosave
- allow marking ready via explicit save
- show draft chip in template list
- skip drafts when exporting pack templates

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a811cb4cc832a809f439aacbea2b7