### PR TITLE
Add EV/ICM bulk generation

### DIFF
--- a/lib/services/bulk_evaluator_service.dart
+++ b/lib/services/bulk_evaluator_service.dart
@@ -45,4 +45,12 @@ class BulkEvaluatorService {
     template.recountCoverage();
     return updated;
   }
+
+  Future<int> generateMissingForTemplate(
+    TrainingPackTemplate template,
+    void Function(double progress)? onProgress,
+  ) async {
+    final res = await generateMissing(template, onProgress: onProgress);
+    return res.length;
+  }
 }


### PR DESCRIPTION
## Summary
- support generating missing EV/ICM for a training pack template
- allow generating EV/ICM for all templates via the pack list screen

## Testing
- `flutter format lib/services/bulk_evaluator_service.dart lib/screens/v2/training_pack_template_list_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa2565be0832a9c395127aa191bbd