### PR TITLE
Implement Review Mistakes quick mode

### DIFF
--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -226,14 +226,15 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
                     name: 'Review mistakes',
                     spots: [for (final s in widget.template.spots) if (_mistakeIds.contains(s.id)) s],
                   );
-                  MistakeReviewPackService.latestTemplate = template;
+                  MistakeReviewPackService.setLatestTemplate(template);
                   await context.read<MistakeReviewPackService>().addPack(_mistakeIds);
                   if (!mounted) return;
                   Navigator.push(
                     context,
                     MaterialPageRoute(
                       builder: (_) => TrainingPackPlayScreen(
-                        template: MistakeReviewPackService.latestTemplate!,
+                        template:
+                            MistakeReviewPackService.cachedTemplate!,
                         original: null,
                       ),
                     ),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -33,6 +33,7 @@ import '../../helpers/hand_utils.dart';
 import '../../helpers/hand_type_utils.dart';
 import 'training_pack_play_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../services/mistake_review_pack_service.dart';
 import '../../services/mixed_drill_history_service.dart';
 import '../../models/mixed_drill_stat.dart';
 
@@ -2940,6 +2941,30 @@ class _TrainingPackTemplateListScreenState
             onPressed: _generateTopMistakes,
             tooltip: 'Generate Top Mistakes Pack',
             label: const Text('Top 10 Mistakes'),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'reviewMistakesTplFab',
+            icon: const Icon(Icons.error),
+            label: const Text('Review Mistakes'),
+            onPressed: () async {
+              final tpl =
+                  await MistakeReviewPackService.latestTemplate(context);
+              if (!mounted) return;
+              if (tpl != null && tpl.spots.isNotEmpty) {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        TrainingPackPlayScreen(template: tpl, original: tpl),
+                  ),
+                );
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('No mistakes to review')),
+                );
+              }
+            },
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(


### PR DESCRIPTION
## Summary
- introduce a getter to build the latest mistake review template on demand
- insert a "Review Mistakes" FAB in the template list
- adapt training result screen to use the new API

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa71e0310832a97b7852ebbb83483