### PR TITLE
Add top progress indicator

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -562,14 +562,13 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
             ],
           ),
         ],
+        bottom: PreferredSize(preferredSize: const Size.fromHeight(4), child: LinearProgressIndicator(value: progress)),
       ),
       backgroundColor: const Color(0xFF1B1C1E),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            LinearProgressIndicator(value: progress),
-            const SizedBox(height: 8),
             if (widget.template.focusTags.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.only(bottom: 8),


### PR DESCRIPTION
## Summary
- show linear progress bar under TrainingPackPlayScreen app bar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa9c89e5c832a907283a57198dfda