### PR TITLE
Add tag autocomplete

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -375,7 +375,12 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   Future<void> _openEditor(TrainingPackSpot spot) async {
     await Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => TrainingPackSpotEditorScreen(spot: spot)),
+      MaterialPageRoute(
+        builder: (_) => TrainingPackSpotEditorScreen(
+          spot: spot,
+          templateTags: widget.template.tags,
+        ),
+      ),
     );
     setState(() {
       if (_autoSortEv) _sortSpots();
@@ -704,7 +709,11 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       );
     }
     if (spots.length <= 3) {
-      await showSpotViewerDialog(context, spots.first);
+      await showSpotViewerDialog(
+        context,
+        spots.first,
+        templateTags: widget.template.tags,
+      );
     }
   }
 
@@ -2064,7 +2073,11 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   }
 
   Future<void> _bulkAddTag([List<String>? ids]) async {
-    final allTags = widget.templates.expand((t) => t.tags).toSet().toList();
+    final service = context.read<TemplateStorageService>();
+    final allTags = {
+      ...service.templates.expand((t) => t.tags),
+      ...widget.template.tags,
+    }.toList();
     final c = TextEditingController();
     final tag = await showDialog<String>(
       context: context,
@@ -4579,7 +4592,11 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         index: index,
                         child: InkWell(
                           onTap: () async {
-                            await showSpotViewerDialog(context, spot);
+                            await showSpotViewerDialog(
+                              context,
+                              spot,
+                              templateTags: widget.template.tags,
+                            );
                             if (_autoSortEv) setState(() => _sortSpots());
                             _focusSpot(spot.id);
                           },

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -13,10 +13,12 @@ import '../screens/v2/training_pack_spot_editor_screen.dart';
 class SpotViewerDialog extends StatefulWidget {
   final TrainingPackSpot spot;
   final BuildContext parentContext;
+  final List<String> templateTags;
   const SpotViewerDialog({
     super.key,
     required this.spot,
     required this.parentContext,
+    this.templateTags = const [],
   });
 
   @override
@@ -258,7 +260,10 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
             Navigator.pop(context);
             await Navigator.of(widget.parentContext).push(
               MaterialPageRoute(
-                builder: (_) => TrainingPackSpotEditorScreen(spot: spot),
+                builder: (_) => TrainingPackSpotEditorScreen(
+                  spot: spot,
+                  templateTags: widget.templateTags,
+                ),
               ),
             );
           },
@@ -277,9 +282,17 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
   }
 }
 
-Future<void> showSpotViewerDialog(BuildContext context, TrainingPackSpot spot) {
+Future<void> showSpotViewerDialog(
+  BuildContext context,
+  TrainingPackSpot spot, {
+  List<String> templateTags = const [],
+}) {
   return showDialog(
     context: context,
-    builder: (_) => SpotViewerDialog(spot: spot, parentContext: context),
+    builder: (_) => SpotViewerDialog(
+      spot: spot,
+      parentContext: context,
+      templateTags: templateTags,
+    ),
   );
 }


### PR DESCRIPTION
## Summary
- autocomplete for single-spot tag input
- tag suggestions for bulk tagging
- pass template tags through spot viewer dialog

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abd112408832a9b1bec588e3bd703