### PR TITLE
Add evaluated progress to editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3501,9 +3501,28 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        GestureDetector(
-                          onTap: _renameTemplate,
-                          child: Text(_templateName),
+                        Row(
+                          children: [
+                            GestureDetector(
+                              onTap: _renameTemplate,
+                              child: Text(_templateName),
+                            ),
+                            const SizedBox(width: 8),
+                            Builder(builder: (context) {
+                              final total = widget.template.spots.length;
+                              final done = widget.template.spots
+                                  .where((s) => s.heroEv != null || s.heroIcmEv != null)
+                                  .length;
+                              final pct = total == 0 ? 0 : (done * 100 / total).round();
+                              return Text(
+                                'EV: $pct%',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelSmall
+                                    ?.copyWith(color: Colors.white70),
+                              );
+                            }),
+                          ],
                         ),
                         Builder(builder: (context) {
                           final total = widget.template.spots.length;


### PR DESCRIPTION
## Summary
- show evaluated spot percent in template editor AppBar

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac5165a10832a896267eca2ac874a