### PR TITLE
Add offline EV/ICM cache

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -2056,7 +2056,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             if (!started) {
               started = true;
               Future.microtask(() async {
-                final res = await const BulkEvaluatorService().generateMissing(
+                final res = await BulkEvaluatorService().generateMissing(
                   widget.template,
                   onProgress: (p) {
                     _calcProgress = p;
@@ -2345,7 +2345,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
               Future.microtask(() async {
                 var done = 0;
                 for (final spot in spots) {
-                  await const BulkEvaluatorService().generateMissing(
+                  await BulkEvaluatorService().generateMissing(
                     spot,
                     anteBb: widget.template.anteBb,
                   );

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -2133,7 +2133,7 @@ class _TrainingPackTemplateListScreenState
               started = true;
               Future.microtask(() async {
                 for (var i = 0; i < list.length; i++) {
-                  await const BulkEvaluatorService().generateMissingForTemplate(
+                  await BulkEvaluatorService().generateMissingForTemplate(
                     list[i],
                     (p) {
                       progress = (i + p) / list.length;

--- a/lib/services/bulk_evaluator_service.dart
+++ b/lib/services/bulk_evaluator_service.dart
@@ -1,11 +1,13 @@
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'push_fold_ev_service.dart';
+import 'offline_evaluator_service.dart';
 
 class BulkEvaluatorService {
-  const BulkEvaluatorService({this.evaluator = const PushFoldEvService()});
+  BulkEvaluatorService({OfflineEvaluatorService? evaluator})
+      : evaluator = evaluator ?? OfflineEvaluatorService();
 
-  final PushFoldEvService evaluator;
+  final OfflineEvaluatorService evaluator;
 
   Future<List<TrainingPackSpot>> generateMissing(
     dynamic target, {

--- a/lib/services/offline_evaluator_service.dart
+++ b/lib/services/offline_evaluator_service.dart
@@ -1,0 +1,76 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'push_fold_ev_service.dart';
+
+class OfflineEvaluatorService {
+  OfflineEvaluatorService({this.remote = const PushFoldEvService()});
+
+  final PushFoldEvService remote;
+  bool isOffline = false;
+  Box<dynamic>? _box;
+
+  Future<void> _open() async {
+    if (!Hive.isBoxOpen('ev_cache')) {
+      await Hive.initFlutter();
+      _box = await Hive.openBox('ev_cache');
+    } else {
+      _box = Hive.box('ev_cache');
+    }
+  }
+
+  Future<bool> _online() async {
+    if (isOffline) return false;
+    final r = await Connectivity().checkConnectivity();
+    return r != ConnectivityResult.none;
+  }
+
+  Future<void> evaluate(TrainingPackSpot spot, {int anteBb = 0}) async {
+    await _open();
+    final key = '${spot.id}|$anteBb';
+    final cached = (_box!.get(key) as Map?)?.cast<String, dynamic>();
+    if (!await _online() && cached != null && cached['ev'] != null) {
+      final hero = spot.hand.heroIndex;
+      final acts = spot.hand.actions[0] ?? [];
+      for (final a in acts) {
+        if (a.playerIndex == hero && a.action == 'push') {
+          a.ev = (cached['ev'] as num).toDouble();
+          return;
+        }
+      }
+    }
+    await remote.evaluate(spot, anteBb: anteBb);
+    final ev = spot.heroEv;
+    if (ev != null) {
+      final map = cached ?? <String, dynamic>{};
+      map['ev'] = ev;
+      await _box!.put(key, map);
+    }
+  }
+
+  Future<void> evaluateIcm(TrainingPackSpot spot, {int anteBb = 0}) async {
+    await _open();
+    final key = '${spot.id}|$anteBb';
+    final cached = (_box!.get(key) as Map?)?.cast<String, dynamic>();
+    if (!await _online() && cached != null && cached['icm'] != null) {
+      final hero = spot.hand.heroIndex;
+      final acts = spot.hand.actions[0] ?? [];
+      for (final a in acts) {
+        if (a.playerIndex == hero && a.action == 'push') {
+          a.icmEv = (cached['icm'] as num).toDouble();
+          if (cached['ev'] != null) a.ev ??= (cached['ev'] as num).toDouble();
+          return;
+        }
+      }
+    }
+    await remote.evaluateIcm(spot, anteBb: anteBb);
+    final ev = spot.heroEv;
+    final icm = spot.heroIcmEv;
+    if (ev != null || icm != null) {
+      final map = cached ?? <String, dynamic>{};
+      if (ev != null) map['ev'] = ev;
+      if (icm != null) map['icm'] = icm;
+      await _box!.put(key, map);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `OfflineEvaluatorService` using Hive for caching push/fold EV and ICM
- integrate `OfflineEvaluatorService` into `BulkEvaluatorService`
- update screens to use the new evaluator service

## Testing
- `flutter format lib/services/offline_evaluator_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac610a594832abe2820bb57f9d2bb