### PR TITLE
Implement TemplateCoverageUtils.recountAll

### DIFF
--- a/lib/helpers/template_coverage_utils.dart
+++ b/lib/helpers/template_coverage_utils.dart
@@ -1,0 +1,16 @@
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class TemplateCoverageUtils {
+  static void recountAll(TrainingPackTemplate template) {
+    final List<TrainingPackSpot> list = template.spots;
+    int ev = 0;
+    int icm = 0;
+    for (final s in list) {
+      if (!s.dirty && s.heroEv != null) ev++;
+      if (!s.dirty && s.heroIcmEv != null) icm++;
+    }
+    template.meta['evCovered'] = ev;
+    template.meta['icmCovered'] = icm;
+  }
+}

--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../data/seed_packs.dart';
+import 'template_coverage_utils.dart';
 
 class TrainingPackStorage {
   static const _key = 'training_pack_templates';
@@ -19,7 +20,7 @@ class TrainingPackStorage {
     bool changed = false;
     for (final t in templates) {
       if (!t.meta.containsKey('evCovered') || !t.meta.containsKey('icmCovered')) {
-        t.recountCoverage();
+        TemplateCoverageUtils.recountAll(t);
         changed = true;
       }
     }
@@ -29,7 +30,7 @@ class TrainingPackStorage {
 
   static Future<void> save(List<TrainingPackTemplate> t) async {
     for (final tpl in t) {
-      tpl.recountCoverage();
+      TemplateCoverageUtils.recountAll(tpl);
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, jsonEncode([for (final x in t) x.toJson()]));

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -5,6 +5,7 @@ import '../game_type.dart';
 import '../training_pack.dart' show parseGameType;
 import '../../services/pack_generator_service.dart';
 import '../../helpers/poker_position_helper.dart';
+import '../../helpers/template_coverage_utils.dart';
 
 class TrainingPackTemplate {
   final String id;
@@ -66,7 +67,7 @@ class TrainingPackTemplate {
         playerStacksBb = playerStacksBb ?? const [10, 10],
         meta = meta ?? {},
         createdAt = createdAt ?? DateTime.now() {
-    recountCoverage();
+    TemplateCoverageUtils.recountAll(this);
   }
 
   TrainingPackTemplate copyWith({
@@ -168,7 +169,7 @@ class TrainingPackTemplate {
       isDraft: json['isDraft'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
-      tpl.recountCoverage();
+      TemplateCoverageUtils.recountAll(tpl);
     }
     return tpl;
   }
@@ -240,15 +241,14 @@ class TrainingPackTemplate {
   }
 
   void recountCoverage([List<TrainingPackSpot>? all]) {
-    final list = all ?? spots;
-    int ev = 0;
-    int icm = 0;
-    for (final s in list) {
-      if (!s.dirty && s.heroEv != null) ev++;
-      if (!s.dirty && s.heroIcmEv != null) icm++;
+    if (all != null) {
+      final tmp = copyWith(spots: all);
+      TemplateCoverageUtils.recountAll(tmp);
+      meta['evCovered'] = tmp.evCovered;
+      meta['icmCovered'] = tmp.icmCovered;
+    } else {
+      TemplateCoverageUtils.recountAll(this);
     }
-    meta['evCovered'] = ev;
-    meta['icmCovered'] = icm;
   }
 
   Future<List<TrainingPackSpot>> generateSpots() async {
@@ -264,7 +264,10 @@ class TrainingPackTemplate {
       anteBb: anteBb,
     );
     final spots = tpl.spots.take(spotCount).toList();
-    recountCoverage([...this.spots, ...spots]);
+    final tmp = copyWith(spots: [...this.spots, ...spots]);
+    TemplateCoverageUtils.recountAll(tmp);
+    meta['evCovered'] = tmp.evCovered;
+    meta['icmCovered'] = tmp.icmCovered;
     return spots;
   }
 

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -22,6 +22,7 @@ import '../../services/template_undo_redo_service.dart';
 import 'package:collection/collection.dart';
 import '../../models/game_type.dart';
 import '../../helpers/training_pack_storage.dart';
+import '../../helpers/template_coverage_utils.dart';
 import '../../helpers/title_utils.dart';
 import '../../models/v2/hand_data.dart';
 import '../../models/v2/hero_position.dart';
@@ -393,7 +394,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   Future<void> _persist() async {
     widget.template.isDraft = true;
-    widget.template.recountCoverage();
+    TemplateCoverageUtils.recountAll(widget.template);
     await TrainingPackStorage.save(widget.templates);
   }
 
@@ -1034,7 +1035,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     }
     final ready = validateTrainingPackTemplate(widget.template).isEmpty;
     widget.template.isDraft = !ready;
-    widget.template.recountCoverage();
+    TemplateCoverageUtils.recountAll(widget.template);
     TrainingPackStorage.save(widget.templates);
     unawaited(
       BulkEvaluatorService()

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -18,6 +18,7 @@ import '../../helpers/training_pack_storage.dart';
 import '../../services/pack_generator_service.dart';
 import '../../services/training_spot_storage_service.dart';
 import '../../services/saved_hand_manager_service.dart';
+import '../../helpers/template_coverage_utils.dart';
 import '../../services/training_pack_template_ui_service.dart';
 import '../../models/saved_hand.dart';
 import '../../models/action_entry.dart';
@@ -612,7 +613,7 @@ class _TrainingPackTemplateListScreenState
             .generateMissingForTemplate(t)
             .catchError((_) => 0);
         if (!mounted) return;
-        t.recountCoverage();
+        TemplateCoverageUtils.recountAll(t);
         refreshed += n;
         setState(() {});
       }
@@ -2229,7 +2230,7 @@ class _TrainingPackTemplateListScreenState
                       if (mounted) setDialog(() {});
                     },
                   );
-                  tpl.recountCoverage();
+                  TemplateCoverageUtils.recountAll(tpl);
                   if (mounted) setState(() {});
                 }
                 await TrainingPackStorage.save(_templates);

--- a/lib/services/bulk_evaluator_service.dart
+++ b/lib/services/bulk_evaluator_service.dart
@@ -2,6 +2,7 @@ import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'push_fold_ev_service.dart';
 import 'offline_evaluator_service.dart';
+import '../helpers/template_coverage_utils.dart';
 
 class BulkEvaluatorService {
   BulkEvaluatorService({OfflineEvaluatorService? evaluator})
@@ -47,7 +48,7 @@ class BulkEvaluatorService {
         }
       }
       if (next <= 1) onProgress?.call(1.0);
-      template.recountCoverage();
+      TemplateCoverageUtils.recountAll(template);
       return updated;
     } else if (target is TrainingPackSpot) {
       final spot = target;

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -135,7 +135,7 @@ class PackGeneratorService {
       anteBb: p.anteBb,
       range: p.heroRange,
     );
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: p.id,
       name: p.name,
       description: p.description,
@@ -150,7 +150,9 @@ class PackGeneratorService {
       heroRange: p.heroRange,
       createdAt: p.createdAt,
       lastGeneratedAt: DateTime.now(),
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 
   static TrainingPackTemplate generatePushFoldPackSync({
@@ -218,13 +220,15 @@ class PackGeneratorService {
         ),
       );
     }
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: id,
       name: name,
       gameType: GameType.tournament,
       spots: spots,
       createdAt: createdAt,
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 
   static String _firstCombo(String hand) {
@@ -301,12 +305,14 @@ class PackGeneratorService {
       );
     }
 
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: 'final_table_co',
       name: 'Final Table ICM',
       gameType: GameType.tournament,
       spots: spots,
       createdAt: createdAt,
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 }

--- a/lib/services/training_pack_template_ui_service.dart
+++ b/lib/services/training_pack_template_ui_service.dart
@@ -7,6 +7,7 @@ import '../models/action_entry.dart';
 import '../helpers/hand_utils.dart';
 import 'pack_generator_service.dart';
 import 'push_fold_ev_service.dart';
+import '../helpers/template_coverage_utils.dart';
 
 class TrainingPackTemplateUiService {
   const TrainingPackTemplateUiService();
@@ -111,7 +112,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    template.recountCoverage([...template.spots, ...generated]);
+    TemplateCoverageUtils.recountAll(template);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }
@@ -223,7 +224,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    template.recountCoverage([...template.spots, ...generated]);
+    TemplateCoverageUtils.recountAll(template);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }

--- a/test/template_ev_cache_test.dart
+++ b/test/template_ev_cache_test.dart
@@ -7,6 +7,7 @@ import 'package:poker_analyzer/models/v2/hero_position.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/services/pack_generator_service.dart';
 import 'package:poker_analyzer/services/training_pack_template_ui_service.dart';
+import 'package:poker_analyzer/helpers/template_coverage_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -51,7 +52,7 @@ void main() {
     final service = TrainingPackTemplateUiService();
     final generated = await service.generateMissingSpotsWithProgress(ctx, tpl);
     tpl.spots.addAll(generated);
-    tpl.recountCoverage();
+    TemplateCoverageUtils.recountAll(tpl);
     expect(tpl.evCovered, 4 + generated.length);
   });
 }


### PR DESCRIPTION
## Summary
- centralize training pack template coverage counters in `TemplateCoverageUtils`
- update templates and services to use the new recount method
- update coverage handling in storage, screens and generators
- adjust unit test for coverage update

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af326b050832ab4f5157cb25060e6