### PR TITLE
Update coverage recount logic

### DIFF
--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../data/seed_packs.dart';
+import '../utils/template_coverage_utils.dart';
 
 class TrainingPackStorage {
   static const _key = 'training_pack_templates';
@@ -19,7 +20,7 @@ class TrainingPackStorage {
     bool changed = false;
     for (final t in templates) {
       if (!t.meta.containsKey('evCovered') || !t.meta.containsKey('icmCovered')) {
-        t.recountCoverage();
+        TemplateCoverageUtils.recountAll(t);
         changed = true;
       }
     }
@@ -29,7 +30,7 @@ class TrainingPackStorage {
 
   static Future<void> save(List<TrainingPackTemplate> t) async {
     for (final tpl in t) {
-      tpl.recountCoverage();
+      TemplateCoverageUtils.recountAll(tpl);
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, jsonEncode([for (final x in t) x.toJson()]));

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -5,6 +5,7 @@ import '../game_type.dart';
 import '../training_pack.dart' show parseGameType;
 import '../../services/pack_generator_service.dart';
 import '../../helpers/poker_position_helper.dart';
+import '../../utils/template_coverage_utils.dart';
 
 class TrainingPackTemplate {
   final String id;
@@ -66,7 +67,7 @@ class TrainingPackTemplate {
         playerStacksBb = playerStacksBb ?? const [10, 10],
         meta = meta ?? {},
         createdAt = createdAt ?? DateTime.now() {
-    recountCoverage();
+    TemplateCoverageUtils.recountAll(this);
   }
 
   TrainingPackTemplate copyWith({
@@ -168,7 +169,7 @@ class TrainingPackTemplate {
       isDraft: json['isDraft'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
-      tpl.recountCoverage();
+      TemplateCoverageUtils.recountAll(tpl);
     }
     return tpl;
   }
@@ -240,15 +241,7 @@ class TrainingPackTemplate {
   }
 
   void recountCoverage([List<TrainingPackSpot>? all]) {
-    final list = all ?? spots;
-    int ev = 0;
-    int icm = 0;
-    for (final s in list) {
-      if (!s.dirty && s.heroEv != null) ev++;
-      if (!s.dirty && s.heroIcmEv != null) icm++;
-    }
-    meta['evCovered'] = ev;
-    meta['icmCovered'] = icm;
+    TemplateCoverageUtils.recountAll(this);
   }
 
   Future<List<TrainingPackSpot>> generateSpots() async {
@@ -264,7 +257,6 @@ class TrainingPackTemplate {
       anteBb: anteBb,
     );
     final spots = tpl.spots.take(spotCount).toList();
-    recountCoverage([...this.spots, ...spots]);
     return spots;
   }
 

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -34,6 +34,7 @@ import '../../widgets/spot_viewer_dialog.dart';
 import '../../services/training_session_service.dart';
 import '../training_session_screen.dart';
 import '../../helpers/training_pack_validator.dart';
+import '../../utils/template_coverage_utils.dart';
 import '../../widgets/common/ev_distribution_chart.dart';
 import '../../widgets/ev_summary_card.dart';
 import '../../theme/app_colors.dart';
@@ -393,7 +394,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   Future<void> _persist() async {
     widget.template.isDraft = true;
-    widget.template.recountCoverage();
+    TemplateCoverageUtils.recountAll(widget.template);
     await TrainingPackStorage.save(widget.templates);
   }
 
@@ -1034,7 +1035,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     }
     final ready = validateTrainingPackTemplate(widget.template).isEmpty;
     widget.template.isDraft = !ready;
-    widget.template.recountCoverage();
+    TemplateCoverageUtils.recountAll(widget.template);
     TrainingPackStorage.save(widget.templates);
     unawaited(
       BulkEvaluatorService()
@@ -1913,8 +1914,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroEv == null) {
                       await const PushFoldEvService()
                           .evaluate(s, anteBb: widget.template.anteBb);
-                      widget.template.meta['evCovered'] =
-                          (widget.template.meta['evCovered'] ?? 0) + 1;
+                      TemplateCoverageUtils.recountAll(widget.template);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();
@@ -1981,8 +1981,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroIcmEv == null) {
                       await const PushFoldEvService()
                           .evaluateIcm(s, anteBb: widget.template.anteBb);
-                      widget.template.meta['icmCovered'] =
-                          (widget.template.meta['icmCovered'] ?? 0) + 1;
+                      TemplateCoverageUtils.recountAll(widget.template);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -18,6 +18,7 @@ import '../../helpers/training_pack_storage.dart';
 import '../../services/pack_generator_service.dart';
 import '../../services/training_spot_storage_service.dart';
 import '../../services/saved_hand_manager_service.dart';
+import '../../utils/template_coverage_utils.dart';
 import '../../services/training_pack_template_ui_service.dart';
 import '../../models/saved_hand.dart';
 import '../../models/action_entry.dart';
@@ -612,7 +613,7 @@ class _TrainingPackTemplateListScreenState
             .generateMissingForTemplate(t, onProgress: null)
             .catchError((_) => 0);
         if (!mounted) return;
-        t.recountCoverage();
+        TemplateCoverageUtils.recountAll(t);
         refreshed += n;
       }
       if (refreshed > 0) {
@@ -2228,7 +2229,7 @@ class _TrainingPackTemplateListScreenState
                       if (mounted) setDialog(() {});
                     },
                   );
-                  tpl.recountCoverage();
+                  TemplateCoverageUtils.recountAll(tpl);
                 }
                 await TrainingPackStorage.save(_templates);
                 if (Navigator.canPop(ctx)) Navigator.pop(ctx);

--- a/lib/services/bulk_evaluator_service.dart
+++ b/lib/services/bulk_evaluator_service.dart
@@ -2,6 +2,7 @@ import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'push_fold_ev_service.dart';
 import 'offline_evaluator_service.dart';
+import '../utils/template_coverage_utils.dart';
 
 class BulkEvaluatorService {
   BulkEvaluatorService({OfflineEvaluatorService? evaluator})
@@ -47,7 +48,7 @@ class BulkEvaluatorService {
         }
       }
       if (next <= 1) onProgress?.call(1.0);
-      template.recountCoverage();
+      TemplateCoverageUtils.recountAll(template);
       return updated;
     } else if (target is TrainingPackSpot) {
       final spot = target;

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -7,6 +7,7 @@ import '../models/action_entry.dart';
 import '../models/game_type.dart';
 import 'push_fold_ev_service.dart';
 import 'icm_push_ev_service.dart';
+import '../utils/template_coverage_utils.dart';
 
 class PackGeneratorService {
   static const _ranks = [
@@ -135,7 +136,7 @@ class PackGeneratorService {
       anteBb: p.anteBb,
       range: p.heroRange,
     );
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: p.id,
       name: p.name,
       description: p.description,
@@ -150,7 +151,9 @@ class PackGeneratorService {
       heroRange: p.heroRange,
       createdAt: p.createdAt,
       lastGeneratedAt: DateTime.now(),
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 
   static TrainingPackTemplate generatePushFoldPackSync({
@@ -218,13 +221,15 @@ class PackGeneratorService {
         ),
       );
     }
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: id,
       name: name,
       gameType: GameType.tournament,
       spots: spots,
       createdAt: createdAt,
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 
   static String _firstCombo(String hand) {
@@ -301,12 +306,14 @@ class PackGeneratorService {
       );
     }
 
-    return TrainingPackTemplate(
+    final tpl = TrainingPackTemplate(
       id: 'final_table_co',
       name: 'Final Table ICM',
       gameType: GameType.tournament,
       spots: spots,
       createdAt: createdAt,
-    )..recountCoverage();
+    );
+    TemplateCoverageUtils.recountAll(tpl);
+    return tpl;
   }
 }

--- a/lib/services/training_pack_template_ui_service.dart
+++ b/lib/services/training_pack_template_ui_service.dart
@@ -7,6 +7,7 @@ import '../models/action_entry.dart';
 import '../helpers/hand_utils.dart';
 import 'pack_generator_service.dart';
 import 'push_fold_ev_service.dart';
+import '../utils/template_coverage_utils.dart';
 
 class TrainingPackTemplateUiService {
   const TrainingPackTemplateUiService();
@@ -111,7 +112,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    template.recountCoverage([...template.spots, ...generated]);
+    TemplateCoverageUtils.recountAll(template);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }
@@ -223,7 +224,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    template.recountCoverage([...template.spots, ...generated]);
+    TemplateCoverageUtils.recountAll(template);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }

--- a/lib/utils/template_coverage_utils.dart
+++ b/lib/utils/template_coverage_utils.dart
@@ -1,0 +1,16 @@
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class TemplateCoverageUtils {
+  static void recountAll(TrainingPackTemplate template) {
+    final List<TrainingPackSpot> list = template.spots;
+    int ev = 0;
+    int icm = 0;
+    for (final s in list) {
+      if (!s.dirty && s.heroEv != null) ev++;
+      if (!s.dirty && s.heroIcmEv != null) icm++;
+    }
+    template.meta['evCovered'] = ev;
+    template.meta['icmCovered'] = icm;
+  }
+}

--- a/test/template_ev_cache_test.dart
+++ b/test/template_ev_cache_test.dart
@@ -7,6 +7,7 @@ import 'package:poker_analyzer/models/v2/hero_position.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/services/pack_generator_service.dart';
 import 'package:poker_analyzer/services/training_pack_template_ui_service.dart';
+import 'package:poker_analyzer/utils/template_coverage_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -51,7 +52,7 @@ void main() {
     final service = TrainingPackTemplateUiService();
     final generated = await service.generateMissingSpotsWithProgress(ctx, tpl);
     tpl.spots.addAll(generated);
-    tpl.recountCoverage();
+    TemplateCoverageUtils.recountAll(tpl);
     expect(tpl.evCovered, 4 + generated.length);
   });
 }


### PR DESCRIPTION
## Summary
- create TemplateCoverageUtils with recountAll
- refresh coverage on template updates, evaluation, and save
- use recountAll across services and screens
- adjust tests for new helper

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af561f768832a8898f63e80e27b7a