### PR TITLE
Add Mistakes Only quick filter

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3778,6 +3778,17 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             },
           ),
           IconButton(
+            icon: Icon(Icons.error_outline,
+                color: _quickFilter == 'Mistake spots' ? AppColors.accent : null),
+            tooltip: 'Mistakes Only',
+            onPressed: () {
+              setState(() => _quickFilter = _quickFilter == 'Mistake spots'
+                  ? null
+                  : 'Mistake spots');
+              _storeQuickFilter();
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.copy_all),
             tooltip: "Find Duplicates",
             onPressed: _findDuplicateSpots,

--- a/test/mistakes_only_quick_filter_test.dart
+++ b/test/mistakes_only_quick_filter_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_analyzer/widgets/v2/training_pack_spot_preview_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('toggle mistakes-only quick filter', (tester) async {
+    final ok = TrainingPackSpot(
+      id: 'a',
+      hand: HandData(),
+      evalResult: EvaluationResult(correct: true, expectedAction: '-', userEquity: 0, expectedEquity: 0),
+    );
+    final err = TrainingPackSpot(
+      id: 'b',
+      hand: HandData(),
+      evalResult: EvaluationResult(correct: false, expectedAction: '-', userEquity: 0, expectedEquity: 0),
+    );
+    final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [ok, err]);
+    await tester.pumpWidget(MaterialApp(
+      home: TrainingPackTemplateEditorScreen(template: tpl, templates: [tpl]),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(2));
+    await tester.tap(find.byTooltip('Mistakes Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsOneWidget);
+    await tester.tap(find.byTooltip('Mistakes Only'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackSpotPreviewCard), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add Mistakes Only icon toggle in template editor
- persist quick filter state in prefs
- test quick filter toggle

## Testing
- `flutter test` *(fails: /flutter/flutter/bin/internal/shared.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686afcb8c348832aa4f25e183e2ecd44