### PR TITLE
Implement bundle preview & install

### DIFF
--- a/lib/screens/pack_bundle_viewer_screen.dart
+++ b/lib/screens/pack_bundle_viewer_screen.dart
@@ -4,7 +4,11 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
 import '../models/v2/training_pack_template.dart';
+import '../helpers/training_pack_storage.dart';
+import '../helpers/training_pack_validator.dart';
+import 'v2/training_pack_template_list_screen.dart';
 
 class PackBundleInfo {
   final String path;
@@ -54,6 +58,131 @@ class _PackBundleViewerScreenState extends State<PackBundleViewerScreen> {
     });
   }
 
+  Future<void> _install(PackBundleInfo info) async {
+    final listState =
+        TrainingPackTemplateListScreen.maybeOf(context);
+    final messenger =
+        ScaffoldMessenger.maybeOf(listState?.context ?? context);
+    List<TrainingPackTemplate> templates = await TrainingPackStorage.load();
+    final idx = templates.indexWhere((t) => t.id == info.template.id);
+    final identical =
+        idx != -1 && templates[idx].createdAt == info.template.createdAt;
+    if (identical) return;
+    if (idx != -1) {
+      final confirm = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Перезаписать существующий пак?'),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('No')),
+            TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Yes')),
+          ],
+        ),
+      );
+      if (confirm != true) return;
+      templates.removeAt(idx);
+    }
+    final issues = validateTrainingPackTemplate(info.template);
+    if (issues.isNotEmpty) {
+      messenger?.showSnackBar(
+        SnackBar(content: Text('Ошибка: ${issues.join(', ')}')),
+      );
+      return;
+    }
+    templates.add(info.template);
+    await TrainingPackStorage.save(templates);
+    messenger?.showSnackBar(const SnackBar(content: Text('Пак установлен')));
+    Navigator.pop(context); // sheet
+    Navigator.pop(context); // screen
+    listState?.refreshFromStorage();
+  }
+
+  void _showBundleInfo(PackBundleInfo info) async {
+    final templates = await TrainingPackStorage.load();
+    final existing =
+        templates.firstWhereOrNull((e) => e.id == info.template.id);
+    final identical = existing != null &&
+        existing.createdAt == info.template.createdAt;
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.grey[900],
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) {
+        final t = info.template;
+        final total = t.spots.length;
+        final evPct =
+            total == 0 ? 0 : (t.evCovered * 100 / total).round();
+        final icmPct =
+            total == 0 ? 0 : (t.icmCovered * 100 / total).round();
+        Color color(int v) =>
+            v < 70 ? Colors.red : v < 90 ? Colors.yellow[700]! : Colors.green;
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(t.name,
+                  style: const TextStyle(fontSize: 18, color: Colors.white)),
+              if (t.description.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(t.description,
+                      style: const TextStyle(color: Colors.white70)),
+                ),
+              const SizedBox(height: 8),
+              Text('Спотов: $total',
+                  style: const TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  Chip(
+                    label: Text('EV $evPct%'),
+                    backgroundColor: color(evPct),
+                  ),
+                  const SizedBox(width: 8),
+                  Chip(
+                    label: Text('ICM $icmPct%'),
+                    backgroundColor: color(icmPct),
+                  ),
+                ],
+              ),
+              if (t.lastGeneratedAt != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    'Сгенерирован: ${t.lastGeneratedAt!.toLocal().toString().split('.').first}',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Отмена'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: identical ? null : () => _install(info),
+                    child: const Text('Установить'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -78,6 +207,7 @@ class _PackBundleViewerScreenState extends State<PackBundleViewerScreen> {
                     if (date != null) date.toLocal().toString().split('.').first,
                     '${coverage.round()}%'
                   ].join(' · ')),
+                  onTap: () => _showBundleInfo(b),
                 );
               },
             ),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -47,6 +47,9 @@ import 'package:timeago/timeago.dart' as timeago;
 class TrainingPackTemplateListScreen extends StatefulWidget {
   const TrainingPackTemplateListScreen({super.key});
 
+  static _TrainingPackTemplateListScreenState? maybeOf(BuildContext context) =>
+      context.findAncestorStateOfType<_TrainingPackTemplateListScreenState>();
+
   @override
   State<TrainingPackTemplateListScreen> createState() =>
       _TrainingPackTemplateListScreenState();
@@ -97,6 +100,17 @@ class _TrainingPackTemplateListScreenState
   bool _autoEvalRunning = false;
   Timer? _autoEvalTimer;
   bool _autoEvalQueued = false;
+
+  Future<void> refreshFromStorage() async {
+    final list = await TrainingPackStorage.load();
+    if (!mounted) return;
+    setState(() {
+      _templates
+        ..clear()
+        ..addAll(list);
+      _sortTemplates();
+    });
+  }
 
   List<GeneratedPackInfo> _dedupHistory() {
     final map = <String, GeneratedPackInfo>{};


### PR DESCRIPTION
## Summary
- allow installing .pka bundles from viewer
- bottom sheet preview with EV/ICM info
- update template list after install

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b07a43b94832aa7b6a450260e3566