### PR TITLE
Add push_to_cloud tool

### DIFF
--- a/lib/services/pack_cloud_service.dart
+++ b/lib/services/pack_cloud_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/v2/training_pack_template.dart';
+import 'cloud_retry_policy.dart';
+
+class PackCloudService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  Future<bool> uploadBundle(File file) async {
+    final bytes = await file.readAsBytes();
+    final archive = ZipDecoder().decodeBytes(bytes);
+    final tplFile = archive.files.firstWhere((e) => e.name == 'template.json');
+    final map =
+        jsonDecode(utf8.decode(tplFile.content)) as Map<String, dynamic>;
+    final tpl = TrainingPackTemplate.fromJson(map);
+    final doc = _db.collection('bundles').doc(tpl.id);
+    final exists = await doc.get().then((d) => d.exists);
+    if (exists) return false;
+    await CloudRetryPolicy.execute(() => doc.set({
+          'name': tpl.name,
+          'description': tpl.description,
+          'spots': tpl.spots.length,
+          'evCovered': tpl.evCovered,
+          'icmCovered': tpl.icmCovered,
+          'createdAt': tpl.createdAt.toIso8601String(),
+          if (tpl.lastGeneratedAt != null)
+            'lastGenerated': tpl.lastGeneratedAt!.toIso8601String(),
+          'bundle': bytes,
+        }));
+    return true;
+  }
+}

--- a/tool/push_to_cloud.dart
+++ b/tool/push_to_cloud.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/services/pack_cloud_service.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stderr.writeln('Usage: dart run tool/push_to_cloud.dart <bundlesDir>');
+    exit(1);
+  }
+  final dir = Directory(args.first);
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: ${args.first}');
+    exit(1);
+  }
+  final service = PackCloudService();
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.toLowerCase().endsWith('.pka'))
+      .toList();
+  stdout.writeln('Uploading ${files.length} bundles…');
+  for (var i = 0; i < files.length; i++) {
+    final file = files[i];
+    try {
+      final uploaded = await service.uploadBundle(file);
+      final status = uploaded ? '[OK]' : 'SKIP';
+      stdout.writeln('[${i + 1}/${files.length}] ${p.basename(file.path)}  –  $status');
+    } catch (_) {
+      stdout.writeln('[${i + 1}/${files.length}] ${p.basename(file.path)}  –  [ERROR]');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `PackCloudService` for uploading pack bundles to Firestore
- add CLI `tool/push_to_cloud.dart` to upload all `.pka` bundles from a directory

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0eaa77e4832a83c111cdb68432cd