### PR TITLE
Add preview PNG support

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -33,6 +33,7 @@ class TrainingPackTemplate {
   String? targetStreet;
   int streetGoal;
   bool isDraft;
+  String? png;
 
   TrainingPackTemplate({
     required this.id,
@@ -60,6 +61,7 @@ class TrainingPackTemplate {
     this.targetStreet,
     this.streetGoal = 0,
     this.isDraft = false,
+    this.png,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         focusTags = focusTags ?? [],
@@ -96,6 +98,7 @@ class TrainingPackTemplate {
     String? targetStreet,
     int? streetGoal,
     bool? isDraft,
+    String? png,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -123,6 +126,7 @@ class TrainingPackTemplate {
       targetStreet: targetStreet ?? this.targetStreet,
       streetGoal: streetGoal ?? this.streetGoal,
       isDraft: isDraft ?? this.isDraft,
+      png: png ?? this.png,
     );
   }
 
@@ -167,6 +171,7 @@ class TrainingPackTemplate {
       targetStreet: json['targetStreet'] as String?,
       streetGoal: json['streetGoal'] as int? ?? 0,
       isDraft: json['isDraft'] as bool? ?? false,
+      png: json['png'] as String?,
     );
     if (!tpl.meta.containsKey('evCovered') || !tpl.meta.containsKey('icmCovered')) {
       TemplateCoverageUtils.recountAll(tpl);
@@ -202,6 +207,7 @@ class TrainingPackTemplate {
         if (targetStreet != null) 'targetStreet': targetStreet,
         if (streetGoal > 0) 'streetGoal': streetGoal,
         if (isDraft) 'isDraft': true,
+        if (png != null) 'png': png,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/widgets/training_pack_template_card.dart
+++ b/lib/widgets/training_pack_template_card.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/preview_cache_service.dart';
+
+class TrainingPackTemplateCard extends StatefulWidget {
+  final TrainingPackTemplate template;
+  final VoidCallback? onTap;
+  const TrainingPackTemplateCard({super.key, required this.template, this.onTap});
+
+  @override
+  State<TrainingPackTemplateCard> createState() => _TrainingPackTemplateCardState();
+}
+
+class _TrainingPackTemplateCardState extends State<TrainingPackTemplateCard> {
+  String? previewPath;
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  void _load() async {
+    final png = widget.template.png;
+    if (png != null) {
+      final path = await PreviewCacheService.instance.getPreviewPath(png);
+      if (!mounted) return;
+      setState(() => previewPath = path);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(widget.template.name,
+          style: const TextStyle(fontWeight: FontWeight.bold)),
+    );
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          children: [
+            if (previewPath != null)
+              Positioned.fill(
+                child: Image.file(File(previewPath!), fit: BoxFit.cover),
+              ),
+            if (previewPath != null)
+              Positioned.fill(
+                child: Container(color: Colors.black45),
+              ),
+            content,
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `png` field to `TrainingPackTemplate` model
- load PNG previews in `_TemplatePreviewCard`
- show preview backgrounds in `TrainingPackTemplateEditorScreen`
- implement `TrainingPackTemplateCard` widget for card previews

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1d4c51d4832a9f1a29c9ba86a479