### PR TITLE
Implement playable variants

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -298,4 +298,28 @@ class TrainingPackTemplate {
     return list.join(', ');
   }
 
+  List<TrainingPackVariant> playableVariants({bool groupByPosition = false}) {
+    final list = <TrainingPackVariant>[];
+    final raw = meta['variants'];
+    if (raw is List) {
+      for (final v in raw) {
+        final variant = v is TrainingPackVariant
+            ? v
+            : TrainingPackVariant.fromJson(Map<String, dynamic>.from(v));
+        if (variant.rangeId != null) list.add(variant);
+      }
+    }
+    if (groupByPosition && list.length > 1) {
+      final items = list.asMap().entries.toList();
+      items.sort((a, b) {
+        final pa = kPositionOrder.indexOf(a.value.position);
+        final pb = kPositionOrder.indexOf(b.value.position);
+        if (pa == pb) return a.key.compareTo(b.key);
+        return pa.compareTo(pb);
+      });
+      return [for (final e in items) e.value];
+    }
+    return list;
+  }
+
 }

--- a/lib/models/v2/training_pack_variant.dart
+++ b/lib/models/v2/training_pack_variant.dart
@@ -1,0 +1,34 @@
+import 'hero_position.dart';
+import '../game_type.dart';
+import '../training_pack.dart' show parseGameType;
+
+class TrainingPackVariant {
+  final HeroPosition position;
+  final GameType gameType;
+  final String? tag;
+  final String? rangeId;
+
+  const TrainingPackVariant({
+    required this.position,
+    required this.gameType,
+    this.tag,
+    this.rangeId,
+  });
+
+  factory TrainingPackVariant.fromJson(Map<String, dynamic> j) => TrainingPackVariant(
+        position: HeroPosition.values.firstWhere(
+          (e) => e.name == j['position'],
+          orElse: () => HeroPosition.unknown,
+        ),
+        gameType: parseGameType(j['gameType']),
+        tag: j['tag'] as String?,
+        rangeId: j['rangeId'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'position': position.name,
+        'gameType': gameType.name,
+        if (tag != null) 'tag': tag,
+        if (rangeId != null) 'rangeId': rangeId,
+      };
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackVariant` model
- compute playable variants from template meta

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b203ca944832a87449087cc81e5d1