### PR TITLE
Add caching to PackRuntimeBuilder

### DIFF
--- a/lib/services/pack_runtime_builder.dart
+++ b/lib/services/pack_runtime_builder.dart
@@ -10,6 +10,20 @@ import 'range_library_service.dart';
 class PackRuntimeBuilder {
   const PackRuntimeBuilder();
 
+  static final _cache = <String, List<TrainingPackSpot>>{};
+
+  Future<List<TrainingPackSpot>> buildIfNeeded(
+    TrainingPackTemplate tpl,
+    TrainingPackVariant variant,
+  ) async {
+    final key = '${tpl.id}_${variant.rangeId}';
+    final cached = _cache[key];
+    if (cached != null) return cached;
+    final spots = await generateFromVariant(tpl, variant);
+    _cache[key] = spots;
+    return spots;
+  }
+
   Future<List<TrainingPackSpot>> generateFromVariant(
     TrainingPackTemplate tpl,
     TrainingPackVariant variant,


### PR DESCRIPTION
## Summary
- cache generated training pack spots in `PackRuntimeBuilder`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b274e07fc832aaaffe3b183ba15a2