### PR TITLE
feat: add training pack play service

### DIFF
--- a/lib/services/pack_runtime_builder.dart
+++ b/lib/services/pack_runtime_builder.dart
@@ -28,6 +28,16 @@ class PackRuntimeBuilder {
     return future.whenComplete(() => _pending.remove(key));
   }
 
+  void clearCache(
+    TrainingPackTemplate tpl,
+    TrainingPackVariant variant,
+  ) {
+    final key =
+        '${tpl.id}_${variant.gameType.name}_${variant.position.name}_${variant.rangeId ?? 'default'}';
+    _cache.remove(key);
+    _pending.remove(key);
+  }
+
   Future<List<TrainingPackSpot>> _generateSafe(
     TrainingPackTemplate tpl,
     TrainingPackVariant variant,

--- a/lib/services/training_pack_play_service.dart
+++ b/lib/services/training_pack_play_service.dart
@@ -1,0 +1,39 @@
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_variant.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'pack_runtime_builder.dart';
+
+class TrainingPackPlayService {
+  TrainingPackPlayService({PackRuntimeBuilder? builder})
+      : _builder = builder ?? const PackRuntimeBuilder();
+
+  final PackRuntimeBuilder _builder;
+  String? _lastKey;
+  TrainingPackTemplate? _tpl;
+  TrainingPackVariant? _variant;
+  List<TrainingPackSpot>? _spots;
+
+  Future<List<TrainingPackSpot>> loadSpots(
+    TrainingPackTemplate tpl,
+    TrainingPackVariant variant, {
+    bool forceReload = false,
+  }) async {
+    final key = '${tpl.id}_${variant.gameType.name}_${variant.position.name}_${variant.rangeId ?? 'default'}';
+    if (forceReload && _lastKey != null) {
+      _builder.clearCache(tpl, variant);
+    }
+    _tpl = tpl;
+    _variant = variant;
+    if (!forceReload && key == _lastKey && _spots != null) {
+      return _spots!;
+    }
+    _lastKey = key;
+    _spots = await _builder.buildIfNeeded(tpl, variant);
+    return _spots!;
+  }
+
+  Future<List<TrainingPackSpot>> reload({bool forceReload = false}) async {
+    if (_tpl == null || _variant == null) return [];
+    return loadSpots(_tpl!, _variant!, forceReload: forceReload);
+  }
+}

--- a/test/services/training_pack_play_service_test.dart
+++ b/test/services/training_pack_play_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/training_pack_variant.dart';
+import 'package:poker_analyzer/services/training_pack_play_service.dart';
+
+void main() {
+  test('loadSpots caches result and reloads on force', () async {
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 'Test',
+      heroBbStack: 10,
+      playerStacksBb: const [10, 10],
+      heroPos: HeroPosition.sb,
+      spotCount: 2,
+      heroRange: const ['AA', 'KK'],
+    );
+    const variant = TrainingPackVariant(
+      position: HeroPosition.sb,
+      gameType: GameType.tournament,
+    );
+    final service = TrainingPackPlayService();
+    final list1 = await service.loadSpots(tpl, variant);
+    final list2 = await service.loadSpots(tpl, variant);
+    expect(identical(list1, list2), isTrue);
+    final list3 = await service.loadSpots(tpl, variant, forceReload: true);
+    expect(identical(list2, list3), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- support clearing runtime builder cache
- implement TrainingPackPlayService with reload capability
- cover TrainingPackPlayService with a test

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_686b29ab55b0832aa6402e0a5ce58034