### PR TITLE
Add variant play option

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -16,6 +16,7 @@ import '../../helpers/hand_type_utils.dart';
 
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
+import '../../models/v2/training_pack_variant.dart';
 import '../../widgets/spot_quiz_widget.dart';
 import '../../widgets/common/explanation_text.dart';
 import '../../theme/app_colors.dart';
@@ -29,8 +30,15 @@ enum PlayOrder { sequential, random, mistakes }
 class TrainingPackPlayScreen extends StatefulWidget {
   final TrainingPackTemplate template;
   final TrainingPackTemplate original;
-  const TrainingPackPlayScreen({super.key, required this.template, TrainingPackTemplate? original})
-      : original = original ?? template;
+  final TrainingPackVariant? variant;
+  final List<TrainingPackSpot>? spots;
+  const TrainingPackPlayScreen({
+    super.key,
+    required this.template,
+    this.variant,
+    this.spots,
+    TrainingPackTemplate? original,
+  }) : original = original ?? template;
 
   @override
   State<TrainingPackPlayScreen> createState() => _TrainingPackPlayScreenState();
@@ -71,7 +79,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     final streetKey = 'tpl_street_${widget.template.id}';
     final handKey = 'tpl_hand_${widget.template.id}';
     final seq = prefs.getStringList(seqKey);
-    var spots = List<TrainingPackSpot>.from(widget.template.spots);
+    var spots = List<TrainingPackSpot>.from(widget.spots ?? widget.template.spots);
     if (seq != null && seq.length == spots.length) {
       final map = {for (final s in spots) s.id: s};
       final ordered = <TrainingPackSpot>[];
@@ -166,7 +174,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   }
 
   Future<void> _startNew() async {
-    var spots = List<TrainingPackSpot>.from(widget.template.spots);
+    var spots = List<TrainingPackSpot>.from(widget.spots ?? widget.template.spots);
     if (_order == PlayOrder.random) {
       spots.shuffle();
     } else if (_order == PlayOrder.mistakes) {
@@ -178,7 +186,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
             ans != 'false' &&
             exp.toLowerCase() != ans.toLowerCase();
       }).toList();
-      if (spots.isEmpty) spots = List<TrainingPackSpot>.from(widget.template.spots);
+      if (spots.isEmpty) spots = List<TrainingPackSpot>.from(widget.spots ?? widget.template.spots);
     }
     setState(() {
       _spots = spots;

--- a/lib/services/pack_runtime_builder.dart
+++ b/lib/services/pack_runtime_builder.dart
@@ -13,12 +13,14 @@ class PackRuntimeBuilder {
   static final _cache = <String, List<TrainingPackSpot>>{};
   static final _pending = <String, Future<List<TrainingPackSpot>>>{};
 
+  static String _key(TrainingPackTemplate tpl, TrainingPackVariant v) =>
+      '${tpl.id}_${v.gameType.name}_${v.position.name}_${v.rangeId ?? 'default'}';
+
   Future<List<TrainingPackSpot>> buildIfNeeded(
     TrainingPackTemplate tpl,
     TrainingPackVariant variant,
   ) async {
-    final key =
-        '${tpl.id}_${variant.gameType.name}_${variant.position.name}_${variant.rangeId ?? 'default'}';
+    final key = _key(tpl, variant);
     final cached = _cache[key];
     if (cached != null) return cached;
     final pending = _pending[key];
@@ -32,10 +34,14 @@ class PackRuntimeBuilder {
     TrainingPackTemplate tpl,
     TrainingPackVariant variant,
   ) {
-    final key =
-        '${tpl.id}_${variant.gameType.name}_${variant.position.name}_${variant.rangeId ?? 'default'}';
+    final key = _key(tpl, variant);
     _cache.remove(key);
     _pending.remove(key);
+  }
+
+  bool isPending(TrainingPackTemplate tpl, TrainingPackVariant variant) {
+    final key = _key(tpl, variant);
+    return _pending.containsKey(key);
   }
 
   Future<List<TrainingPackSpot>> _generateSafe(

--- a/tests/widgets/template_play_button_test.dart
+++ b/tests/widgets/template_play_button_test.dart
@@ -1,23 +1,39 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_variant.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/training_pack_template.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
 import 'package:poker_analyzer/services/training_session_service.dart';
 import 'package:poker_analyzer/screens/v2/training_pack_template_list_screen.dart';
-import 'package:poker_analyzer/screens/training_session_screen.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_play_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('play button opens training session', (tester) async {
+  testWidgets('play button opens variant chooser', (tester) async {
+    final variant1 = const TrainingPackVariant(
+      position: HeroPosition.btn,
+      gameType: GameType.tournament,
+      rangeId: 'test',
+    );
+    final variant2 = const TrainingPackVariant(
+      position: HeroPosition.sb,
+      gameType: GameType.tournament,
+      rangeId: 'test',
+    );
     final template = TrainingPackTemplate(
       id: 't1',
       name: 'Test',
-      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spots: const [],
+      meta: {
+        'variants': [variant1.toJson(), variant2.toJson()]
+      },
       createdAt: DateTime.now(),
     );
     SharedPreferences.setMockInitialValues({
@@ -32,6 +48,9 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byIcon(Icons.play_arrow));
     await tester.pumpAndSettle();
-    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+    expect(find.text('BTN'), findsOneWidget);
+    await tester.tap(find.text('BTN'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingPackPlayScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement spot generation caching in `PackRuntimeBuilder`
- launch training by selecting variants from list screen
- support external spot lists in `TrainingPackPlayScreen`
- update play button widget test for variant chooser

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b2aa4ffa0832ab4b723e05f71f35d