### PR TITLE
Fix loader dispose race and repeated start

### DIFF
--- a/lib/screens/v2/training_pack_loader.dart
+++ b/lib/screens/v2/training_pack_loader.dart
@@ -20,10 +20,18 @@ class TrainingPackLoader extends StatefulWidget {
 }
 
 class _TrainingPackLoaderState extends State<TrainingPackLoader> {
+  bool _canceled = false;
+
   @override
   void initState() {
     super.initState();
     _load();
+  }
+
+  @override
+  void dispose() {
+    _canceled = true;
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -33,20 +41,21 @@ class _TrainingPackLoaderState extends State<TrainingPackLoader> {
       widget.variant,
       forceReload: widget.forceReload,
     );
-    if (!mounted) return;
+    if (_canceled || !mounted) return;
+    final rootCtx = context;
     if (spots.isEmpty) {
-      Navigator.pop(context);
-      ScaffoldMessenger.of(context).showSnackBar(
+      Navigator.pop(rootCtx);
+      ScaffoldMessenger.of(rootCtx).showSnackBar(
         const SnackBar(content: Text('Не удалось сгенерировать споты')),
       );
       return;
     }
-    widget.template.spots = spots;
+    final playTpl = widget.template.copyWith(spots: spots);
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(
         builder: (_) => TrainingPackPlayScreen(
-          template: widget.template,
+          template: playTpl,
           original: widget.template,
           variant: widget.variant,
           spots: spots,

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -412,7 +412,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   Future<void> _showCompletion() async {
     if (_summaryShown) return;
     _summaryShown = true;
-    final spots = widget.template.spots;
+    final spots = widget.spots ?? widget.template.spots;
     int correct = 0;
     for (final s in spots) {
       final exp = _expected(s);

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -700,6 +700,7 @@ class _TrainingPackTemplateListScreenState
 
   Future<void> _startVariant(TrainingPackTemplate tpl, TrainingPackVariant v,
       {bool force = false}) async {
+    if (const PackRuntimeBuilder().isPending(tpl, v)) return;
     await Navigator.push(
       context,
       MaterialPageRoute(


### PR DESCRIPTION
## Summary
- fix dispose race in `TrainingPackLoader`
- prevent duplicate `TrainingPackLoader` pushes
- allow `TrainingPackPlayScreen` to handle missing template spots

## Testing
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba5193990832a93fca20ca4754a33