### PR TITLE
Add mistake save notification

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -405,7 +405,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
         .addSpot(widget.original, _spots[_index]);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Saved to Mistake Review')),
+        const SnackBar(content: Text('Сохранено в Повторы ошибок')),
       );
     }
   }
@@ -463,13 +463,17 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
         HapticFeedback.mediumImpact();
       }
       _showDiff(evDiff, icmDiff);
-      if ((evDiff != null && evDiff < 0) || (icmDiff != null && icmDiff < 0)) {
+      final incorrect =
+          (evDiff != null && evDiff < 0) ||
+          (icmDiff != null && icmDiff < 0) ||
+          !evaluation.correct;
+      if (incorrect && first) {
         await context
             .read<MistakeReviewPackService>()
             .addSpot(widget.original, spot);
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Saved to Mistake Review')),
+            const SnackBar(content: Text('Сохранено в Повторы ошибок')),
           );
         }
       }


### PR DESCRIPTION
## Summary
- save current spot with Russian snackbar message
- notify on first incorrect answer by adding spot to Mistake Review

## Testing
- `flutter pub get` *(fails: file_picker plugin messages)*
- `flutter test --no-pub` *(fails: numerous compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bab0a47ec832aa5045c4ae98e00c5