### PR TITLE
Fix auto-advance review flow

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -538,7 +538,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
 
       if (!mounted) return;
     }
-    await _next();
+    if (!_autoAdvance) await _next();
   }
 
   @override
@@ -583,6 +583,8 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
             onPressed: _saveCurrentSpot,
           ),
           IconButton(
+            tooltip:
+                _autoAdvance ? 'Авто-переход включён' : 'Авто-переход выключён',
             icon: Icon(_autoAdvance ? Icons.pause : Icons.play_arrow),
             onPressed: () => setState(() => _autoAdvance = !_autoAdvance),
           ),


### PR DESCRIPTION
## Summary
- show tooltip for auto-advance toggle
- prevent skipping on incorrect answers when auto-advance enabled

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baefbb4e8832a960b570884121df6