### PR TITLE
Auto-evaluate generated example spot

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -481,6 +481,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       setState(() => widget.template.spots.add(spot));
       await _persist();
       setState(() => _log('Added', spot));
+      try {
+        await context
+            .read<EvaluationExecutorService>()
+            .evaluateSingle(spot, widget.template);
+        await _persist();
+        if (mounted) setState(() {});
+      } catch (_) {
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Evaluation failed')));
+        }
+      }
       await _openEditor(spot);
     } catch (e) {
       if (mounted) {

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -16,6 +16,9 @@ import '../models/player_model.dart';
 import '../models/mistake_severity.dart';
 import 'goals_service.dart';
 import 'training_stats_service.dart';
+import '../models/v2/training_pack_template.dart';
+import 'bulk_evaluator_service.dart';
+import '../utils/template_coverage_utils.dart';
 
 /// Interface for evaluation execution logic.
 abstract class EvaluationExecutor {
@@ -356,6 +359,15 @@ class EvaluationExecutorService implements EvaluationExecutor {
     }
     final action = heroAct?.action ?? '-';
     return evaluateSpot(ctx, spotData, action);
+  }
+
+  Future<void> evaluateSingle(
+    TrainingPackSpot spot,
+    TrainingPackTemplate template,
+  ) async {
+    await BulkEvaluatorService()
+        .generateMissing(spot, anteBb: template.anteBb);
+    TemplateCoverageUtils.recountAll(template);
   }
 
   /// Classifies [mistakeCount] into a [MistakeSeverity] level.


### PR DESCRIPTION
## Summary
- add evaluateSingle helper to EvaluationExecutorService
- auto-evaluate spot after generating an example in training pack template editor

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd82bad40832a88fce4317becc643