### PR TITLE
Add FAB for quick new spot

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -503,6 +503,19 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     await _openEditor(spot);
   }
 
+  Future<void> _newSpot() async {
+    _recordSnapshot();
+    final spot = TrainingPackSpot(
+      id: const Uuid().v4(),
+      createdAt: DateTime.now(),
+    );
+    setState(() => widget.template.spots.insert(0, spot));
+    await _persist();
+    setState(() => _log('Added', spot));
+    await _openEditor(spot);
+    if (mounted) setState(() {});
+  }
+
   Future<void> _generateSpot() async {
     _recordSnapshot();
     final spot = TrainingPackSpot(
@@ -4160,6 +4173,13 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   heroTag: 'addSpotFab',
                   onPressed: _addSpot,
                   child: const Icon(Icons.add),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton.extended(
+                  heroTag: 'newSpotFab',
+                  onPressed: _newSpot,
+                  icon: const Icon(Icons.add),
+                  label: const Text('+ New Spot'),
                 ),
                 const SizedBox(height: 12),
                 FloatingActionButton(


### PR DESCRIPTION
## Summary
- create `_newSpot()` helper to insert a blank spot at index 0
- add `+ New Spot` extended FAB in template editor

## Testing
- `flutter test --no-pub` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c086b489c832a8cc1a7594ee9169c