### PR TITLE
Add Markdown preview dialog

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -1521,6 +1521,13 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     if (ok == true) await _exportPreviewMarkdown(md);
   }
 
+  void _showMarkdownPreview() {
+    showDialog(
+      context: context,
+      builder: (_) => MarkdownPreviewDialog(template: widget.template),
+    );
+  }
+
   Future<void> _exportPreviewCsv() async {
     final rows = <List<dynamic>>[
       ['Position', 'HeroCards', 'Board', 'EV', 'Tags']
@@ -4041,14 +4048,15 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                 setState(() => _previewMode = !_previewMode);
                 _storePreview();
               },
-            ),
           ),
-          IconButton(icon: const Icon(Icons.save), onPressed: _save),
-          IconButton(
-            icon: const Icon(Icons.picture_as_pdf),
-            onPressed: () async {
-              try {
-                final file =
+        ),
+        IconButton(icon: const Icon(Icons.save), onPressed: _save),
+        IconButton(icon: const Icon(Icons.description), onPressed: _showMarkdownPreview),
+        IconButton(
+          icon: const Icon(Icons.picture_as_pdf),
+          onPressed: () async {
+            try {
+              final file =
                     await PackExportService.exportToPdf(widget.template);
                 if (!mounted) return;
                 await FileSaverService.instance.sharePdf(file.path);

--- a/lib/services/pack_export_service.dart
+++ b/lib/services/pack_export_service.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:archive/archive.dart';
+import 'package:intl/intl.dart';
 
 import '../models/v2/training_pack_template.dart';
 
@@ -135,6 +136,23 @@ class PackExportService {
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
     return file;
+  }
+
+  static String toMarkdown(TrainingPackTemplate tpl) {
+    final spots = tpl.spots;
+    final total = spots.length;
+    final evCovered = spots.where((s) => s.heroEv != null && !s.dirty).length;
+    final icmCovered = spots.where((s) => s.heroIcmEv != null && !s.dirty).length;
+    final buffer = StringBuffer()
+      ..writeln('# ${tpl.name}')
+      ..writeln('- **ID:** ${tpl.id}')
+      ..writeln('- **Spots:** $total')
+      ..writeln('- **EV coverage:** ${total == 0 ? 0 : (evCovered / total * 100).toStringAsFixed(1)}%')
+      ..writeln('- **ICM coverage:** ${total == 0 ? 0 : (icmCovered / total * 100).toStringAsFixed(1)}%')
+      ..writeln('- **Created:** ${DateFormat('yyyy-MM-dd').format(tpl.createdAt)}');
+    final tags = tpl.tags.toSet().where((e) => e.isNotEmpty).toList();
+    if (tags.isNotEmpty) buffer.writeln('- **Tags:** ${tags.join(', ')}');
+    return buffer.toString().trimRight();
   }
 
   static String _toSnakeCase(String input) {

--- a/lib/widgets/markdown_preview_dialog.dart
+++ b/lib/widgets/markdown_preview_dialog.dart
@@ -1,24 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/pack_export_service.dart';
 
 class MarkdownPreviewDialog extends StatelessWidget {
-  final String markdown;
-  const MarkdownPreviewDialog({super.key, required this.markdown});
+  final String? markdown;
+  final TrainingPackTemplate? template;
+  const MarkdownPreviewDialog({super.key, this.markdown, this.template});
 
   @override
   Widget build(BuildContext context) {
+    final md = markdown ?? PackExportService.toMarkdown(template!);
     return AlertDialog(
       title: const Text('Markdown Preview'),
       content: SizedBox(
         width: double.maxFinite,
         child: SingleChildScrollView(
-          child: SelectableText(markdown, style: const TextStyle(color: Colors.white)),
+          child: SelectableText(md, style: const TextStyle(color: Colors.white)),
         ),
       ),
       actions: [
         TextButton(
           onPressed: () {
-            Clipboard.setData(ClipboardData(text: markdown));
+            Clipboard.setData(ClipboardData(text: md));
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Copied')),
             );


### PR DESCRIPTION
## Summary
- allow MarkdownPreviewDialog to accept a template and render Markdown via PackExportService
- implement PackExportService.toMarkdown for TrainingPackTemplate
- add preview button in TrainingPackTemplateEditorScreen app bar

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0aed4408832a98790a4e36294e21