### PR TITLE
Implement dirty spot check before example spot

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -531,6 +531,26 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   Future<void> _generateExampleSpot() async {
     final variants = widget.template.playableVariants();
     if (variants.length != 1) return;
+    if (widget.template.spots.any((s) => s.dirty)) {
+      final ok = await showDialog<bool>(
+        context: context,
+        builder: (_) => AlertDialog(
+          content: const Text(
+              'Discard unsaved changes and generate new spot?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      if (ok != true) return;
+    }
     setState(() => _generatingExample = true);
     try {
       final spot =


### PR DESCRIPTION
## Summary
- confirm discard when generating example spot with dirty spots

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d839e28832a9428cde6c114e599