### PR TITLE
Add snapshot save feature

### DIFF
--- a/lib/models/template_snapshot.dart
+++ b/lib/models/template_snapshot.dart
@@ -1,0 +1,34 @@
+import 'package:uuid/uuid.dart';
+import 'v2/training_pack_spot.dart';
+
+class TemplateSnapshot {
+  final String id;
+  final String comment;
+  final DateTime timestamp;
+  final List<TrainingPackSpot> spots;
+
+  TemplateSnapshot({
+    String? id,
+    required this.comment,
+    DateTime? timestamp,
+    required this.spots,
+  })  : id = id ?? const Uuid().v4(),
+        timestamp = timestamp ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'comment': comment,
+        'timestamp': timestamp.toIso8601String(),
+        'spots': [for (final s in spots) s.toJson()],
+      };
+
+  factory TemplateSnapshot.fromJson(Map<String, dynamic> json) => TemplateSnapshot(
+        id: json['id'] as String?,
+        comment: json['comment'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+        spots: [
+          for (final s in (json['spots'] as List? ?? []))
+            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s as Map))
+        ],
+      );
+}

--- a/lib/services/template_undo_redo_service.dart
+++ b/lib/services/template_undo_redo_service.dart
@@ -1,4 +1,5 @@
 import "../models/v2/training_pack_spot.dart";
+import '../models/template_snapshot.dart';
 
 class ChangeEntry {
   final String action;
@@ -14,6 +15,7 @@ class UndoRedoService {
   final List<List<TrainingPackSpot>> _undo = [];
   final List<List<TrainingPackSpot>> _redo = [];
   final List<ChangeEntry> _events = [];
+  final List<TemplateSnapshot> _snapshots = [];
   UndoRedoService({this.limit = 30, this.eventsLimit = 50});
 
   bool get canUndo => _undo.isNotEmpty;
@@ -50,6 +52,14 @@ class UndoRedoService {
   }
 
   List<ChangeEntry> get history => List.unmodifiable(_events.reversed);
+
+  List<TemplateSnapshot> get snapshots => List.unmodifiable(_snapshots);
+
+  TemplateSnapshot saveSnapshot(List<TrainingPackSpot> spots, String comment) {
+    final snap = TemplateSnapshot(comment: comment, spots: _clone(spots));
+    _snapshots.add(snap);
+    return snap;
+  }
 
   List<TrainingPackSpot> _clone(List<TrainingPackSpot> src) =>
       [for (final s in src) TrainingPackSpot.fromJson(s.toJson())];


### PR DESCRIPTION
## Summary
- create `TemplateSnapshot` model for saving training pack template snapshots
- extend `UndoRedoService` with snapshot support
- allow template editor to save snapshots from the app bar

## Testing
- `dart` and `flutter` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_686c1a64eb64832a920075f301266ecb