### PR TITLE
Add evaluation settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,7 @@ import 'services/remote_config_service.dart';
 import 'services/theme_service.dart';
 import 'services/ab_test_engine.dart';
 import 'services/asset_sync_service.dart';
+import 'services/evaluation_settings_service.dart';
 import 'widgets/sync_status_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
@@ -128,6 +129,7 @@ Future<void> main() async {
       (e, st) => ErrorLogger.instance.logError('Asset sync failed', e, st),
     ),
   );
+  await EvaluationSettingsService.instance.load();
   runApp(
     MultiProvider(
       providers: [

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -60,6 +60,7 @@ import '../../widgets/markdown_preview_dialog.dart';
 import '../../main.dart';
 import '../../services/preview_cache_service.dart';
 import '../../widgets/snapshot_list_dialog.dart';
+import '../../services/evaluation_settings_service.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
 enum SpotSort { original, evDesc, evAsc, icmDesc, icmAsc }
@@ -3376,6 +3377,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     String rangeMode = 'simple';
     final rangeCtr = TextEditingController(text: _rangeStr);
     bool rangeErr = false;
+    final eval = EvaluationSettingsService.instance;
+    final thresholdCtr =
+        TextEditingController(text: eval.evThreshold.toStringAsFixed(2));
+    bool icm = eval.useIcm;
     final formKey = GlobalKey<FormState>();
     final ok = await showModalBottomSheet<bool>(
       context: context,
@@ -3474,6 +3479,26 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   final n = int.tryParse(v ?? '') ?? -1;
                   return n < 0 || n > 5 ? '' : null;
                 },
+              ),
+              TextFormField(
+                controller: thresholdCtr,
+                decoration: const InputDecoration(labelText: 'EV Threshold'),
+                keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true, signed: true),
+                onChanged: (v) => set(() {
+                  final val = double.tryParse(v) ?? eval.evThreshold;
+                  eval.update(threshold: val);
+                  this.setState(() {});
+                }),
+              ),
+              SwitchListTile(
+                title: const Text('ICM mode'),
+                value: icm,
+                onChanged: (v) => set(() {
+                  icm = v;
+                  eval.update(icm: v);
+                  this.setState(() {});
+                }),
               ),
               Row(
                 children: [
@@ -3619,6 +3644,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     countCtr.dispose();
     anteCtr.dispose();
     rangeCtr.dispose();
+    thresholdCtr.dispose();
   }
 
   @override

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -22,6 +22,7 @@ import 'bulk_evaluator_service.dart';
 import '../utils/template_coverage_utils.dart';
 import '../helpers/training_pack_storage.dart';
 import '../services/evaluation_logic_service.dart';
+import 'evaluation_settings_service.dart';
 import '../models/evaluation_mode.dart';
 
 /// Interface for evaluation execution logic.
@@ -373,10 +374,11 @@ class EvaluationExecutorService implements EvaluationExecutor {
   }) async {
     await BulkEvaluatorService().generateMissing(spot, anteBb: anteBb);
     final prev = spot.evalResult;
+    final settings = EvaluationSettingsService.instance;
     spot.evalResult = EvaluationLogicService.evaluateDecision(
       spot,
-      evThreshold: -0.01,
-      useIcm: mode == EvaluationMode.icm,
+      evThreshold: settings.evThreshold,
+      useIcm: settings.useIcm,
     );
     if (template != null) {
       TemplateCoverageUtils.recountAll(template);

--- a/lib/services/evaluation_settings_service.dart
+++ b/lib/services/evaluation_settings_service.dart
@@ -1,0 +1,32 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class EvaluationSettingsService {
+  EvaluationSettingsService._();
+  static final EvaluationSettingsService _instance = EvaluationSettingsService._();
+  factory EvaluationSettingsService() => _instance;
+  static EvaluationSettingsService get instance => _instance;
+
+  static const _thresholdKey = 'evaluation_ev_threshold';
+  static const _icmKey = 'evaluation_use_icm';
+
+  double evThreshold = -0.01;
+  bool useIcm = false;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    evThreshold = prefs.getDouble(_thresholdKey) ?? -0.01;
+    useIcm = prefs.getBool(_icmKey) ?? false;
+  }
+
+  Future<void> update({double? threshold, bool? icm}) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (threshold != null) {
+      evThreshold = threshold;
+      await prefs.setDouble(_thresholdKey, threshold);
+    }
+    if (icm != null) {
+      useIcm = icm;
+      await prefs.setBool(_icmKey, icm);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add EvaluationSettingsService
- use EV threshold and ICM mode when evaluating spots
- expose global evaluation settings in template settings dialog
- load evaluation settings on startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2a9a6e34832ab8a64d3a66546665