### PR TITLE
Add Mistake autotagging

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -380,6 +380,12 @@ class EvaluationExecutorService implements EvaluationExecutor {
       evThreshold: settings.evThreshold,
       useIcm: settings.useIcm,
     );
+    final hadTag = spot.tags.contains('Mistake');
+    if (spot.evalResult != null && !spot.evalResult!.correct && !hadTag) {
+      spot.tags.add('Mistake');
+    } else if (spot.evalResult != null && spot.evalResult!.correct && hadTag) {
+      spot.tags.remove('Mistake');
+    }
     if (template != null) {
       TemplateCoverageUtils.recountAll(template);
       final changed = prev == null ||
@@ -387,7 +393,8 @@ class EvaluationExecutorService implements EvaluationExecutor {
             prev.toJson(),
             spot.evalResult!.toJson(),
           );
-      if (changed) {
+      final tagChanged = hadTag != spot.tags.contains('Mistake');
+      if (changed || tagChanged) {
         await TrainingPackStorage.save([template]);
       }
     }


### PR DESCRIPTION
## Summary
- autotag `Mistake` when evaluation is incorrect and remove when correct
- persist template when evaluation result or tags change

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2f04961c832aa43130fc6e69ae10