### PR TITLE
Add mistake progress bar

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3675,6 +3675,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     final totalSpots = shown.length;
     final mistakeCount =
         widget.template.spots.where((s) => s.tags.contains('Mistake')).length;
+    final mistakeFree =
+        shown.where((s) => !s.tags.contains('Mistake')).length;
+    final mistakePct = totalSpots == 0 ? 0 : mistakeFree / totalSpots;
     final evCovered = shown.where((s) => s.heroEv != null && !s.dirty).length;
     final icmCovered = shown.where((s) => s.heroIcmEv != null && !s.dirty).length;
     final evCoverage = totalSpots == 0 ? 0.0 : evCovered / totalSpots;
@@ -4623,6 +4626,12 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         minHeight: 4,
                       ),
                     ],
+                  ),
+                  LinearProgressIndicator(
+                    value: mistakePct,
+                    color: Colors.redAccent,
+                    backgroundColor: Colors.transparent,
+                    minHeight: 4,
                   ),
                   const SizedBox(height: 16),
             if (coverageWarningNeeded) ...[


### PR DESCRIPTION
## Summary
- compute `mistakePct` in template editor
- display red progress bar for Mistake tags

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c336810c0832abecea7f6f5592210