### PR TITLE
Add tooltip explanation for mistake-free bar

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -4639,11 +4639,14 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                       ),
                     ],
                   ),
-                  LinearProgressIndicator(
-                    value: mistakePct,
-                    color: Colors.redAccent,
-                    backgroundColor: Colors.transparent,
-                    minHeight: 4,
+                  Tooltip(
+                    message: 'Mistake-free = количество раздач без ошибок',
+                    child: LinearProgressIndicator(
+                      value: mistakePct,
+                      color: Colors.redAccent,
+                      backgroundColor: Colors.transparent,
+                      minHeight: 4,
+                    ),
                   ),
                   const SizedBox(height: 16),
             if (coverageWarningNeeded) ...[


### PR DESCRIPTION
## Summary
- explain red mistake-free progress bar via tooltip

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c35d43df8832a910e2f77ba52ebec