### PR TITLE
Add tooltip explanation to progress bar

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -4640,7 +4640,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     ],
                   ),
                   Tooltip(
-                    message: 'Mistake-free = количество раздач без ошибок',
+                    message: 'Mistake-free = number of spots without mistakes',
                     child: LinearProgressIndicator(
                       value: mistakePct,
                       color: Colors.redAccent,


### PR DESCRIPTION
## Summary
- clarify the mistake-free progress bar with a tooltip

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c37067964832aa22e1c425410d543