### PR TITLE
Add Pack Library screen

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/v2/training_pack_template.dart';
+import '../services/template_storage_service.dart';
+import '../helpers/training_pack_storage.dart';
+import 'v2/training_pack_template_editor_screen.dart';
+
+class PacksLibraryScreen extends StatefulWidget {
+  const PacksLibraryScreen({super.key});
+
+  @override
+  State<PacksLibraryScreen> createState() => _PacksLibraryScreenState();
+}
+
+class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
+  final List<TrainingPackTemplate> _packs = [];
+  bool _loaded = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_loaded) {
+      _loaded = true;
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final bundle = DefaultAssetBundle.of(context);
+    final manifest =
+        jsonDecode(await bundle.loadString('AssetManifest.json')) as Map;
+    final paths = manifest.keys
+        .where((e) => e.startsWith('assets/packs/') && e.endsWith('.json'));
+    final list = <TrainingPackTemplate>[];
+    for (final p in paths) {
+      final data = jsonDecode(await bundle.loadString(p));
+      if (data is Map<String, dynamic>) {
+        list.add(TrainingPackTemplate.fromJson(data));
+      }
+    }
+    list.sort((a, b) => a.name.compareTo(b.name));
+    if (mounted) setState(() => _packs.addAll(list));
+  }
+
+  Future<void> _import(TrainingPackTemplate tpl) async {
+    final templates = await TrainingPackStorage.load();
+    final newTpl = tpl.copyWith(id: const Uuid().v4(), createdAt: DateTime.now());
+    templates.add(newTpl);
+    await TrainingPackStorage.save(templates);
+    context.read<TemplateStorageService>().addTemplate(newTpl);
+    if (!mounted) return;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) =>
+            TrainingPackTemplateEditorScreen(template: newTpl, templates: templates),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pack Library')),
+      body: _packs.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: _packs.length,
+              itemBuilder: (_, i) {
+                final t = _packs[i];
+                return ListTile(
+                  title: Text(t.name),
+                  subtitle: Text(t.description),
+                  onTap: () => _import(t),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ flutter:
     - assets/training_packs/
     - assets/training_templates/
     - assets/ranges/
+    - assets/packs/
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo


### PR DESCRIPTION
## Summary
- implement `PacksLibraryScreen` for importing pack templates
- register new assets folder

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c39252f30832ab1c11b7b8132c270