### PR TITLE
Add pack difficulty badge

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -16,6 +16,7 @@ class TrainingPackTemplate {
   List<String> tags;
   List<String> focusTags;
   List<FocusGoal> focusHandTypes;
+  String? difficulty;
   int heroBbStack;
   List<int> playerStacksBb;
   HeroPosition heroPos;
@@ -44,6 +45,7 @@ class TrainingPackTemplate {
     List<String>? tags,
     List<String>? focusTags,
     List<FocusGoal>? focusHandTypes,
+    this.difficulty,
     this.heroBbStack = 10,
     List<int>? playerStacksBb,
     this.heroPos = HeroPosition.sb,
@@ -81,6 +83,7 @@ class TrainingPackTemplate {
     List<String>? tags,
     List<String>? focusTags,
     List<FocusGoal>? focusHandTypes,
+    String? difficulty,
     int? heroBbStack,
     List<int>? playerStacksBb,
     HeroPosition? heroPos,
@@ -110,6 +113,7 @@ class TrainingPackTemplate {
       focusTags: focusTags ?? List<String>.from(this.focusTags),
       focusHandTypes:
           focusHandTypes ?? List<FocusGoal>.from(this.focusHandTypes),
+      difficulty: difficulty ?? this.difficulty,
       heroBbStack: heroBbStack ?? this.heroBbStack,
       playerStacksBb: playerStacksBb ?? List<int>.from(this.playerStacksBb),
       heroPos: heroPos ?? this.heroPos,
@@ -149,6 +153,7 @@ class TrainingPackTemplate {
         for (final t in (json['focusHandTypes'] as List? ?? []))
           FocusGoal.fromJson(t)
       ],
+      difficulty: json['difficulty'] as String?,
       heroBbStack: json['heroBbStack'] as int? ?? 10,
       playerStacksBb: [
         for (final v in (json['playerStacksBb'] as List? ?? [10, 10]))
@@ -194,6 +199,7 @@ class TrainingPackTemplate {
         if (focusHandTypes.isNotEmpty)
           'focusHandTypes': [for (final g in focusHandTypes) g.toString()],
         if (heroRange != null) 'heroRange': heroRange,
+        if (difficulty != null) 'difficulty': difficulty,
         'heroBbStack': heroBbStack,
         'playerStacksBb': playerStacksBb,
         'heroPos': heroPos.name,

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -113,7 +113,30 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                         ? Colors.orange
                         : Colors.red;
                 return ListTile(
-                  title: Text(t.name),
+                  title: Row(
+                    children: [
+                      Expanded(child: Text(t.name)),
+                      if (t.difficulty != null)
+                        Container(
+                          margin: const EdgeInsets.only(left: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: t.difficulty == 'Beginner'
+                                ? Colors.green
+                                : t.difficulty == 'Intermediate'
+                                    ? Colors.orange
+                                    : t.difficulty == 'Advanced'
+                                        ? Colors.red
+                                        : Colors.grey,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            t.difficulty!,
+                            style: const TextStyle(fontSize: 10, color: Colors.white),
+                          ),
+                        ),
+                    ],
+                  ),
                   subtitle: Text(t.description),
                   leading: CircleAvatar(child: Text(total.toString())),
                   trailing: Row(


### PR DESCRIPTION
## Summary
- include `difficulty` field in `TrainingPackTemplate`
- show colored difficulty badge in Pack Library

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c402efdd0832a9057953127bb3afb