### PR TITLE
Add preview action in pack library

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -184,6 +184,27 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                         label: '${pct(icmDone).round()} % ICM',
                         color: col(pct(icmDone)),
                       ),
+                      PopupMenuButton<String>(
+                        onSelected: (v) {
+                          if (v == 'import') _import(t);
+                          if (v == 'preview') {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => TrainingPackTemplateEditorScreen(
+                                  template: t,
+                                  templates: [t],
+                                  readOnly: true,
+                                ),
+                              ),
+                            );
+                          }
+                        },
+                        itemBuilder: (_) => const [
+                          PopupMenuItem(value: 'import', child: Text('Import')),
+                          PopupMenuItem(value: 'preview', child: Text('Preview')),
+                        ],
+                      )
                     ],
                   ),
                   onTap: () => _import(t),


### PR DESCRIPTION
## Summary
- allow previewing packs without import
- support read-only mode in training pack editor

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4352e268832aa46902bbf0f0efb3