### PR TITLE
Implement training summary screen

### DIFF
--- a/lib/screens/v2/training_summary_screen.dart
+++ b/lib/screens/v2/training_summary_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import '../../theme/app_colors.dart';
+
+class TrainingSummaryScreen extends StatelessWidget {
+  final int correct;
+  final int total;
+  final int fixedCount;
+  final int remainingMistakeCount;
+  const TrainingSummaryScreen({
+    super.key,
+    required this.correct,
+    required this.total,
+    required this.fixedCount,
+    required this.remainingMistakeCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rate = total == 0 ? 0 : correct * 100 / total;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Summary')),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text('Correct $correct / $total',
+                style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Text('Accuracy: ${rate.toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 16),
+            Text('Fixed Mistakes: $fixedCount',
+                style: const TextStyle(color: Colors.white70)),
+            Text('Remaining Mistakes: $remainingMistakeCount',
+                style: const TextStyle(color: Colors.white70)),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Review Mistakes'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Exit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TrainingSummaryScreen to show results of a training session
- show summary at the end of training_session_screen flow
- allow restarting with mistakes only from summary screen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c58dd9030832a81e703ce59b6d62e