### PR TITLE
Implement Resume feature in pack library

### DIFF
--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -103,7 +103,9 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     setState(() {
       _packSpots = spots;
       _spots = [for (final s in _packSpots) _toSpot(s)];
-      _index = 0;
+      final idx = _packSpots.indexWhere(
+          (p) => p.heroEv == null || p.heroIcmEv == null);
+      _index = idx == -1 ? 0 : idx;
       _correct = 0;
     });
     _initialMistakes = {


### PR DESCRIPTION
## Summary
- show last trained time in the pack library tiles
- sort packs by recent training date
- add Resume button to continue a pack
- start sessions from the first unsolved spot

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5afb0c58832a89d7d65b76be60b2