### PR TITLE
Implement Resume flow improvements

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -177,6 +177,8 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                     t.spots.where((s) => s.heroEv != null && !s.dirty).length;
                 final icmDone =
                     t.spots.where((s) => s.heroIcmEv != null && !s.dirty).length;
+                final solvedAll = t.spots.every(
+                    (s) => s.heroEv != null && s.heroIcmEv != null);
                 double pct(int done) =>
                     total == 0 ? 0 : done * 100 / total;
                 Color col(double p) => p >= 80
@@ -226,7 +228,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                     children: [
                       if (t.lastTrainedAt != null)
                         Text(
-                          'Trained ${timeago.format(t.lastTrainedAt!)}',
+                          'Trained ${timeago.format(t.lastTrainedAt!, locale: 'en_short')}',
                           style: const TextStyle(
                               fontSize: 11, color: Colors.white54),
                         ),
@@ -248,15 +250,17 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                       ),
                       IconButton(
                         icon: const Icon(Icons.play_circle_fill),
-                        tooltip: 'Resume',
-                        onPressed: () async {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => TrainingSessionScreen(template: t),
-                            ),
-                          );
-                        },
+                        tooltip: solvedAll ? 'All solved' : 'Resume',
+                        onPressed: solvedAll
+                            ? null
+                            : () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => TrainingSessionScreen(template: t),
+                                  ),
+                                );
+                              },
                       ),
                       PopupMenuButton<String>(
                         onSelected: (v) {

--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -100,12 +100,37 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         return;
       }
     }
+    final firstUnsolved = spots.indexWhere(
+        (p) => p.heroEv == null || p.heroIcmEv == null);
+    if (firstUnsolved == -1) {
+      final review = await showDialog<bool>(
+        context: context,
+        builder: (_) => AlertDialog(
+          content: const Text('Everything in this pack is solved.\nReview mistakes instead?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Review Mistakes'),
+            )
+          ],
+        ),
+      );
+      if (review == true) {
+        _mistakesOnly = true;
+        await _start();
+      } else {
+        Navigator.pop(context);
+      }
+      return;
+    }
     setState(() {
       _packSpots = spots;
       _spots = [for (final s in _packSpots) _toSpot(s)];
-      final idx = _packSpots.indexWhere(
-          (p) => p.heroEv == null || p.heroIcmEv == null);
-      _index = idx == -1 ? 0 : idx;
+      _index = firstUnsolved;
       _correct = 0;
     });
     _initialMistakes = {

--- a/tests/widgets/resume_button_test.dart
+++ b/tests/widgets/resume_button_test.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/screens/packs_library_screen.dart';
+import 'package:poker_analyzer/screens/v2/training_session_screen.dart';
+
+class _FakeBundle extends CachingAssetBundle {
+  final Map<String, String> data;
+  _FakeBundle(this.data);
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => data[key]!;
+}
+
+void main() {
+  testWidgets('resume button opens session', (tester) async {
+    final tpl = TrainingPackTemplate(
+      id: 'p1',
+      name: 'Pack',
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      createdAt: DateTime.now(),
+    );
+    final bundle = _FakeBundle({
+      'AssetManifest.json': jsonEncode({'assets/packs/test.json': ['assets/packs/test.json']}),
+      'assets/packs/test.json': jsonEncode(tpl.toJson()),
+    });
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: bundle,
+      child: const MaterialApp(home: PacksLibraryScreen()),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.play_circle_fill));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- tweak PacksLibraryScreen resume button and subtitle
- update TrainingSessionScreen start logic
- add Resume button widget test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5bc46ee8832a85233ec26f2245e7