### PR TITLE
Enable drag reorder in pack template editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -5379,6 +5379,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                             ),
                           ),
                           ReorderableListView.builder(
+                            key: const PageStorageKey('spots'),
                             shrinkWrap: true,
                             physics: const NeverScrollableScrollPhysics(),
                             itemCount: spots.length,
@@ -5413,17 +5414,18 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                               child: Row(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  if (_isMultiSelect)
-                                    Checkbox(
-                                      value: selected,
-                                      onChanged: (_) => setState(() {
-                                        if (selected) {
-                                          _selectedSpotIds.remove(spot.id);
-                                        } else {
-                                          _selectedSpotIds.add(spot.id);
-                                        }
-                                      }),
-                                    ),
+                                  _isMultiSelect
+                                      ? Checkbox(
+                                          value: selected,
+                                          onChanged: (_) => setState(() {
+                                            if (selected) {
+                                              _selectedSpotIds.remove(spot.id);
+                                            } else {
+                                              _selectedSpotIds.add(spot.id);
+                                            }
+                                          }),
+                                        )
+                                      : const Icon(Icons.drag_handle),
                                   Expanded(
                                   child: TrainingPackSpotPreviewCard(
                                     spot: spot,


### PR DESCRIPTION
## Summary
- add `ReorderableListView` key and drag-handle icon for spot list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c66bf4bf8832ab1612dd5edaeef4e