### PR TITLE
Add preset grouping and stack override

### DIFF
--- a/test/generate_from_preset_test.dart
+++ b/test/generate_from_preset_test.dart
@@ -4,7 +4,7 @@ import 'package:poker_analyzer/helpers/training_pack_validator.dart';
 
 void main() {
   group('generateFromPreset', () {
-    for (final id in TrainingPackAuthorService.presets.keys) {
+    for (final id in TrainingPackAuthorService.presetConfigs.keys) {
       test(id, () {
         final tpl = TrainingPackAuthorService.generateFromPreset(id);
         expect(tpl.spots, isNotEmpty);


### PR DESCRIPTION
## Summary
- add public preset configs and categories
- group presets by category in the pack library and show descriptions
- enable stack override by long-press with slider
- test preset generation

## Testing
- `dart test` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0960860832a9bab33652ef475f1