### PR TITLE
Update CI for dart and tweak snack title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: '3.22.2'
+      - uses: dart-lang/setup-dart@v1
       - name: Verify pubspec lock
         run: |
           set +e

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -7,7 +7,8 @@ import 'package:timeago/timeago.dart' as timeago;
 import '../models/v2/training_pack_template.dart';
 import '../services/template_storage_service.dart';
 import '../helpers/training_pack_storage.dart';
-import '../services/training_pack_author_service.dart';
+import '../services/training_pack_author_service.dart'
+    show TrainingPackAuthorService, PresetConfig;
 import 'v2/training_pack_template_editor_screen.dart';
 import 'v2/training_session_screen.dart';
 
@@ -113,8 +114,10 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
             TrainingPackTemplateEditorScreen(template: tpl, templates: templates),
       ),
     );
-    ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Pack "${tpl.name}" created (${tpl.heroBbStack} bb)')));
+    final suffix = tpl.name.split(' ').skip(1).join(' ');
+    final title = '${tpl.heroBbStack}bb $suffix';
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Pack "$title" created')));
   }
 
   void _showPresetSheet() {


### PR DESCRIPTION
## Summary
- set up Dart SDK in CI workflow
- refine import and pack SnackBar text

## Testing
- `flutter test --no-pub` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1674150832a849f1368dda06e87