### PR TITLE
Add default training packs

### DIFF
--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -42,6 +42,9 @@ class TemplateStorageService extends ChangeNotifier {
   }
 
   void addTemplate(TrainingPackTemplate template) {
+    final exists = _templates.any(
+        (t) => t.id == template.id || t.name.trim() == template.name.trim());
+    if (exists) return;
     _templates.add(template);
     _resort();
     notifyListeners();


### PR DESCRIPTION
## Summary
- generate default packs from presets when storage is empty
- avoid duplicate templates

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d11a13958832a89516de7ef0c2989