### PR TITLE
Add preset generation option

### DIFF
--- a/lib/services/training_pack_template_service.dart
+++ b/lib/services/training_pack_template_service.dart
@@ -1,0 +1,10 @@
+import '../models/v2/training_pack_preset.dart';
+import '../models/v2/training_pack_template.dart';
+import 'pack_generator_service.dart';
+
+class TrainingPackTemplateService {
+  static Future<TrainingPackTemplate> generateFromPreset(
+      TrainingPackPreset preset) {
+    return PackGeneratorService.generatePackFromPreset(preset);
+  }
+}


### PR DESCRIPTION
## Summary
- let the admin generate pack templates from presets
- hook it up to TemplateLibraryScreen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ddeeb80832aa458f4cad663ebe9