### PR TITLE
Add Start Training from template editor

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3170,24 +3170,15 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     );
   }
 
-  Future<void> _startTraining() async {
-    final spot = widget.template.spots
-        .firstWhereOrNull((s) => s.heroEv == null || s.heroIcmEv == null);
-    if (spot == null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('All spots solved')));
-      return;
-    }
-    final evalSpot = _toSpot(spot);
+
+  Future<void> _startTrainingSession() async {
+    await context
+        .read<TrainingSessionService>()
+        .startSession(widget.template, persist: false);
+    if (!mounted) return;
     await Navigator.push(
       context,
-      MaterialPageRoute(
-        builder: (_) => SpotSolveScreen(
-          spot: evalSpot,
-          packSpot: spot,
-          template: widget.template,
-        ),
-      ),
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
     );
   }
 
@@ -4504,7 +4495,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
         actions: widget.readOnly
             ? [
                 IconButton(
-                    onPressed: _startTraining,
+                    onPressed: _startTrainingSession,
                     icon: const Text('Start Training')),
                 TextButton(onPressed: () => Navigator.pop(context), child: const Text('Close'))
               ]
@@ -4811,7 +4802,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             },
           ),
           IconButton(
-              onPressed: _startTraining,
+              onPressed: _startTrainingSession,
               icon: const Text('Start Training'))
         ],
         bottom: PreferredSize(


### PR DESCRIPTION
## Summary
- enable launching a training session from TrainingPackTemplateEditorScreen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d464655cc832abc89908df6715afa