### PR TITLE
Add session summary and review mistakes

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -4,7 +4,8 @@ import 'package:provider/provider.dart';
 import '../services/training_session_service.dart';
 import '../widgets/spot_quiz_widget.dart';
 import 'session_result_screen.dart';
-import 'training_summary_screen.dart';
+import 'training_session_summary_screen.dart';
+import 'package:uuid/uuid.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -157,13 +158,25 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       context,
       MaterialPageRoute(
         fullscreenDialog: true,
-        builder: (_) => TrainingSummaryScreen(
+        builder: (_) => TrainingSessionSummaryScreen(
           correct: service.correctCount,
           total: service.totalCount,
           elapsed: service.elapsedTime,
-          onRepeat: () {
+          onReview: () {
             Navigator.pop(context);
-            service.startSession(service.template!);
+            final ids = service.results.keys
+                .where((k) => service.results[k] == false)
+                .toSet();
+            final spots = service.spots
+                .where((s) => ids.contains(s.id))
+                .toList();
+            if (spots.isEmpty) return;
+            final tpl = service.template!.copyWith(
+              id: const Uuid().v4(),
+              name: 'Review mistakes',
+              spots: spots,
+            );
+            service.startSession(tpl, persist: false);
             setState(() {
               _selected = null;
               _correct = null;

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+
+class TrainingSessionSummaryScreen extends StatelessWidget {
+  final int correct;
+  final int total;
+  final Duration elapsed;
+  final VoidCallback onReview;
+  final VoidCallback onBack;
+  const TrainingSessionSummaryScreen({
+    super.key,
+    required this.correct,
+    required this.total,
+    required this.elapsed,
+    required this.onReview,
+    required this.onBack,
+  });
+
+  String _format(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rate = total == 0 ? 0 : correct * 100 / total;
+    final avg = total == 0 ? 0.0 : elapsed.inSeconds / total;
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('$correct/$total',
+                  style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 32,
+                      fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Text('Accuracy: ${rate.toStringAsFixed(1)}%',
+                  style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Text('Time: ${_format(elapsed)}',
+                  style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Text('Avg: ${avg.toStringAsFixed(1)} s/spot',
+                  style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 24),
+              ElevatedButton(onPressed: onReview, child: const Text('Review Mistakes')),
+              const SizedBox(height: 8),
+              OutlinedButton(onPressed: onBack, child: const Text('Done')),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingSessionSummaryScreen` with accuracy and time metrics
- show summary when a training session finishes
- offer to review only the mistaken spots

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6544e39c832aaf26d0c947aef07d