### PR TITLE
Implement starter pack import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Remove unused spot storage field from app state.
 - Add "Select All" toggle in the My Packs selection toolbar.
 - Export Markdown summary from pack template preview.
+- Add Import Starter Packs button to Template Library.

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -191,6 +191,24 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     );
   }
 
+  Future<void> _importStarterPacks() async {
+    final presets = await TrainingPackPresetRepository.getAll();
+    if (!mounted) return;
+    final service = context.read<TemplateStorageService>();
+    var added = 0;
+    for (final p in presets) {
+      final exists = service.templates.any((t) => t.id == p.id || t.name == p.name);
+      if (exists) continue;
+      final tpl = await TrainingPackTemplateService.generateFromPreset(p);
+      tpl.isBuiltIn = true;
+      service.addTemplate(tpl);
+      added++;
+    }
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Added $added packs')));
+  }
+
   Future<TrainingPackTemplate?> _loadLastPack(BuildContext context) async {
     final service = context.read<TemplateStorageService>();
     final list = [for (final t in service.templates) if (!t.isBuiltIn) t];
@@ -302,6 +320,13 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 ),
               );
             },
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _importStarterPacks,
+              child: const Text('Import Starter Packs'),
+            ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),


### PR DESCRIPTION
## Summary
- add import starter packs button in TemplateLibraryScreen
- implement pack generation from presets
- document starter pack import in changelog

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d68da3d18832a89c918c524a0ba11