### PR TITLE
Add Review Mistakes card

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -25,6 +25,7 @@ import '../services/training_pack_template_service.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/bulk_evaluator_service.dart';
 import '../utils/template_coverage_utils.dart';
+import '../services/mistake_review_pack_service.dart';
 import 'package:intl/intl.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
@@ -380,6 +381,36 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               onPressed: _importStarterPacks,
               child: const Text('Import Starter Packs'),
             ),
+          ),
+          Builder(
+            builder: (context) {
+              final service = context.watch<MistakeReviewPackService>();
+              if (!service.hasMistakes()) return const SizedBox.shrink();
+              return Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Card(
+                  child: ListTile(
+                    leading:
+                        const Icon(Icons.error, color: Colors.orangeAccent),
+                    title: const Text('Review Mistakes'),
+                    onTap: () async {
+                      final tpl = await service.buildPack(context);
+                      if (tpl == null) return;
+                      await context
+                          .read<TrainingSessionService>()
+                          .startSession(tpl, persist: false);
+                      if (!context.mounted) return;
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const TrainingSessionScreen()),
+                      );
+                    },
+                  ),
+                ),
+              );
+            },
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/services/mistake_review_pack_service.dart
+++ b/lib/services/mistake_review_pack_service.dart
@@ -62,6 +62,11 @@ class MistakeReviewPackService extends ChangeNotifier {
   final List<MistakePack> _packs = [];
   List<MistakePack> get packs => List.unmodifiable(_packs);
 
+  bool hasMistakes() => _packs.isNotEmpty;
+
+  Future<TrainingPackTemplate?> buildPack(BuildContext context) =>
+      MistakeReviewPackService.latestTemplate(context);
+
   void _trim() {
     _packs.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     final seen = <String>{};


### PR DESCRIPTION
## Summary
- allow MistakeReviewPackService to build packs directly
- show a "Review Mistakes" card in TemplateLibraryScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d70c672ec832a90d12488bc7bea72