### PR TITLE
Add training onboarding

### DIFF
--- a/lib/helpers/training_onboarding.dart
+++ b/lib/helpers/training_onboarding.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../screens/template_library_screen.dart';
+import '../screens/training_onboarding_screen.dart';
+
+Future<void> openTrainingTemplates(BuildContext context) async {
+  final prefs = await SharedPreferences.getInstance();
+  final seen = prefs.getBool('seen_training_onboarding') ?? false;
+  await Navigator.push(
+    context,
+    MaterialPageRoute(
+      builder: (_) => seen
+          ? const TemplateLibraryScreen()
+          : const TrainingOnboardingScreen(),
+    ),
+  );
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -16,10 +16,10 @@ import 'daily_hand_screen.dart';
 import 'spot_of_the_day_screen.dart';
 import 'create_pack_screen.dart';
 import 'edit_pack_screen.dart';
-import 'template_library_screen.dart';
 import 'my_training_packs_screen.dart';
 import 'training_screen.dart';
 import 'start_training_from_pack_screen.dart';
+import '../helpers/training_onboarding.dart';
 import 'package:provider/provider.dart';
 import '../services/hand_history_file_service.dart';
 import '../services/saved_hand_manager_service.dart';
@@ -641,14 +641,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             ),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const TemplateLibraryScreen(),
-                  ),
-                );
-              },
+              onPressed: () => openTrainingTemplates(context),
               child: const Text('📑 Шаблоны'),
             ),
             const SizedBox(height: 16),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -12,7 +12,7 @@ import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import 'training_progress_analytics_screen.dart';
-import 'template_library_screen.dart';
+import '../helpers/training_onboarding.dart';
 import '../widgets/sync_status_widget.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
@@ -60,12 +60,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => const TemplateLibraryScreen()),
-          );
-        },
+        onPressed: () => openTrainingTemplates(context),
         child: const Icon(Icons.auto_awesome_motion),
       ),
       bottomNavigationBar: SafeArea(

--- a/lib/screens/training_onboarding_screen.dart
+++ b/lib/screens/training_onboarding_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_colors.dart';
+import 'template_library_screen.dart';
+
+class TrainingOnboardingScreen extends StatefulWidget {
+  const TrainingOnboardingScreen({super.key});
+
+  @override
+  State<TrainingOnboardingScreen> createState() => _TrainingOnboardingScreenState();
+}
+
+class _TrainingOnboardingScreenState extends State<TrainingOnboardingScreen> {
+  final _controller = PageController();
+  int _index = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _finish() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('seen_training_onboarding', true);
+    if (!mounted) return;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const TemplateLibraryScreen()),
+    );
+  }
+
+  Widget _page(String title, String text) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            text,
+            style: const TextStyle(color: Colors.white70, fontSize: 16),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = [
+      _page('Тренировочный пак', 'Карточка со спотом, варианты действий и EV каждой опции'),
+      _page('Ошибки', 'Неверные ответы сохраняются в «Повторы»'),
+      _page('Прогресс и стрик', 'Проходи споты без ошибок, чтобы растить стрик'),
+      _page('Статистика', 'Смотри результаты во вкладке «📊 Insights»'),
+    ];
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView(
+              controller: _controller,
+              onPageChanged: (v) => setState(() => _index = v),
+              children: pages,
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              for (int i = 0; i < pages.length; i++)
+                Container(
+                  width: 8,
+                  height: 8,
+                  margin: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: i == _index ? Colors.orange : Colors.white24,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _index == pages.length - 1
+                  ? _finish
+                  : () => _controller.nextPage(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeInOut,
+                      ),
+              child: Text(_index == pages.length - 1 ? 'Понял!' : 'Далее'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -11,8 +11,8 @@ import '../widgets/info_tooltip.dart';
 import '../theme/app_colors.dart';
 import "../widgets/progress_chip.dart";
 import '../widgets/color_picker_dialog.dart';
-import 'template_library_screen.dart';
 import 'training_pack_screen.dart';
+import '../helpers/training_onboarding.dart';
 import 'training_pack_comparison_screen.dart';
 import 'create_pack_screen.dart';
 import '../widgets/sync_status_widget.dart';
@@ -207,12 +207,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
               const Icon(Icons.auto_awesome, size: 96, color: Colors.white30),
               const SizedBox(height: 24),
               ElevatedButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const TemplateLibraryScreen()),
-                  );
-                },
+                onPressed: () => openTrainingTemplates(context),
                 child: const Text('Создать из шаблона'),
               ),
               const SizedBox(height: 12),
@@ -352,14 +347,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
                 ),
                 const SizedBox(width: 12),
                 ElevatedButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const TemplateLibraryScreen(),
-                      ),
-                    );
-                  },
+                onPressed: () => openTrainingTemplates(context),
                   child: const Text('📑 Шаблоны'),
                 ),
               ],


### PR DESCRIPTION
## Summary
- add TrainingOnboardingScreen with swipeable pages and finish button
- check onboarding before opening template library
- route template library buttons through onboarding screen

## Testing
- `dart analyze` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d74c99218832ab1bb2fccc7c551ef