### PR TITLE
Add cloud sync for favorites

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -86,11 +86,9 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     if (remote != null) {
       try {
         final list = List<String>.from(jsonDecode(remote));
-        final merged = {..._favorites, ...list};
-        if (merged.length != _favorites.length) {
-          _favorites
-            ..clear()
-            ..addAll(merged);
+        final before = _favorites.length;
+        _favorites.addAll(list);
+        if (_favorites.length != before) {
           await prefs.setStringList(_favKey, _favorites.toList());
         }
       } catch (_) {}


### PR DESCRIPTION
## Summary
- merge remote favorites locally on library load
- keep favorites up to date in the cloud

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ee0db74832aac6473996ee0377a