### PR TITLE
feat: translate pack categories

### DIFF
--- a/lib/helpers/category_translations.dart
+++ b/lib/helpers/category_translations.dart
@@ -1,0 +1,10 @@
+const Map<String, String> kCategoryTranslations = {
+  'Push/Fold': 'Пуш/Фолд',
+  'Postflop': 'Постфлоп',
+  'ICM': 'ICM',
+};
+
+String translateCategory(String? category) {
+  if (category == null) return '';
+  return kCategoryTranslations[category] ?? category;
+}

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -32,6 +32,7 @@ import '../utils/template_coverage_utils.dart';
 import '../services/mistake_review_pack_service.dart';
 import 'package:intl/intl.dart';
 import 'training_stats_screen.dart';
+import '../helpers/category_translations.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -366,7 +367,8 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
         subtitle: FutureBuilder<TrainingPackStat?>(
           future: TrainingPackStatsService.getStats(t.id),
           builder: (context, snap) {
-            final main = '${t.category ?? 'Без категории'} • ${t.hands.length} рук • v$version';
+            final c = translateCategory(t.category);
+            final main = '${c.isEmpty ? 'Без категории' : c} • ${t.hands.length} рук • v$version';
             final stat = snap.data;
             if (stat == null) return Text(main);
             final date = DateFormat('dd MMM', Intl.getCurrentLocale()).format(stat.last);


### PR DESCRIPTION
## Summary
- translate category names in Template Library screen
- add helper for pack category translations

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d85b24b2c832a81b7231d660df5b2