### PR TITLE
feat: translate category names

### DIFF
--- a/lib/helpers/category_translations.dart
+++ b/lib/helpers/category_translations.dart
@@ -2,6 +2,7 @@ const Map<String, String> kCategoryTranslations = {
   'Push/Fold': 'Пуш/Фолд',
   'Postflop': 'Постфлоп',
   'ICM': 'ICM',
+  '3bet': '3-бет',
 };
 
 String translateCategory(String? category) {

--- a/lib/screens/template_preview_dialog.dart
+++ b/lib/screens/template_preview_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/training_pack_template.dart';
 import '../helpers/color_utils.dart';
+import '../helpers/category_translations.dart';
 
 class TemplatePreviewDialog extends StatelessWidget {
   final TrainingPackTemplate template;
@@ -32,7 +33,7 @@ class TemplatePreviewDialog extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 8),
-              Text(template.category ?? 'Без категории'),
+              Text(translateCategory(template.category) ?? 'Без категории'),
             ],
           ),
           const SizedBox(height: 8),

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -6,6 +6,7 @@ import '../theme/app_colors.dart';
 import 'training_activity_by_weekday_screen.dart';
 import 'top_mistakes_overview_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../helpers/category_translations.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -20,7 +21,8 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
         .toList();
     final Map<String, _CategoryStats> map = {};
     for (final p in packs) {
-      final c = p.category.isNotEmpty ? p.category : 'Без категории';
+      final raw = p.category.isNotEmpty ? p.category : 'Без категории';
+      final c = translateCategory(raw);
       map.putIfAbsent(c, () => _CategoryStats()).add(p);
     }
     final stats = map.entries


### PR DESCRIPTION
## Summary
- translate pack categories like `3bet`
- show translated category in template preview dialog
- show translated categories in progress analytics

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd2913150832aa7347ee4d51f6ba0