### PR TITLE
feat: sort analytics categories by priority

### DIFF
--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -25,10 +25,23 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
       final c = translateCategory(raw);
       map.putIfAbsent(c, () => _CategoryStats()).add(p);
     }
+    const priority = {
+      'Пуш/Фолд': 1,
+      'ICM': 2,
+      'Постфлоп': 3,
+      '3-бет': 4,
+    };
     final stats = map.entries
         .where((e) => e.value.attempts > 0)
         .toList()
-      ..sort((a, b) => b.value.attempts.compareTo(a.value.attempts));
+      ..sort((a, b) {
+        final pa = priority[a.key];
+        final pb = priority[b.key];
+        if (pa != null && pb != null) return pa.compareTo(pb);
+        if (pa != null) return -1;
+        if (pb != null) return 1;
+        return a.key.compareTo(b.key);
+      });
     return Scaffold(
       appBar: AppBar(
         title: const Text('Аналитика по категориям'),


### PR DESCRIPTION
## Summary
- sort TrainingProgressAnalyticsScreen by predefined priority

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/screens/training_progress_analytics_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd3bd4b30832a8cc001c2524c4a8f