### PR TITLE
Add category filter to analytics

### DIFF
--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -8,9 +8,16 @@ import 'top_mistakes_overview_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../helpers/category_translations.dart';
 
-class TrainingProgressAnalyticsScreen extends StatelessWidget {
+class TrainingProgressAnalyticsScreen extends StatefulWidget {
   static const route = '/training/analytics';
   const TrainingProgressAnalyticsScreen({super.key});
+
+  @override
+  State<TrainingProgressAnalyticsScreen> createState() => _TrainingProgressAnalyticsScreenState();
+}
+
+class _TrainingProgressAnalyticsScreenState extends State<TrainingProgressAnalyticsScreen> {
+  String _selected = 'Все категории';
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +49,10 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
         if (pb != null) return 1;
         return a.key.compareTo(b.key);
       });
+    final categories = ['Все категории', ...stats.map((e) => e.key)];
+    final filtered = _selected == 'Все категории'
+        ? stats
+        : stats.where((e) => e.key == _selected).toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('Аналитика по категориям'),
@@ -75,47 +86,69 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: ListView.separated(
-        padding: const EdgeInsets.all(16),
-        itemCount: stats.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 12),
-        itemBuilder: (context, index) {
-          final e = stats[index];
-          final s = e.value;
-          final progress = s.avgProgress;
-          final color = progress < 0.5
-              ? Colors.redAccent
-              : progress < 0.8
-                  ? Colors.orangeAccent
-                  : Colors.greenAccent;
-          return Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: AppColors.cardBackground,
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(e.key, style: const TextStyle(fontWeight: FontWeight.bold)),
-                const SizedBox(height: 4),
-                Text('Попыток: ${s.attempts} • Решено: ${s.solved}'),
-                const SizedBox(height: 4),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    value: progress,
-                    backgroundColor: Colors.white24,
-                    valueColor: AlwaysStoppedAnimation<Color>(color),
-                    minHeight: 6,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text('Средний прогресс: ${(progress * 100).toStringAsFixed(0)}%'),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: DropdownButton<String>(
+              value: _selected,
+              dropdownColor: AppColors.cardBackground,
+              underline: const SizedBox.shrink(),
+              style: const TextStyle(color: Colors.white),
+              items: [
+                for (final c in categories)
+                  DropdownMenuItem(value: c, child: Text(c))
               ],
+              onChanged: (v) => setState(() => _selected = v ?? 'Все категории'),
             ),
-          );
-        },
+          ),
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: filtered.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final e = filtered[index];
+                final s = e.value;
+                final progress = s.avgProgress;
+                final color = progress < 0.5
+                    ? Colors.redAccent
+                    : progress < 0.8
+                        ? Colors.orangeAccent
+                        : Colors.greenAccent;
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.cardBackground,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(e.key,
+                          style: const TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 4),
+                      Text('Попыток: ${s.attempts} • Решено: ${s.solved}'),
+                      const SizedBox(height: 4),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: progress,
+                          backgroundColor: Colors.white24,
+                          valueColor: AlwaysStoppedAnimation<Color>(color),
+                          minHeight: 6,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                          'Средний прогресс: ${(progress * 100).toStringAsFixed(0)}%'),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow filtering by category in TrainingProgressAnalyticsScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd50855c4832abc50d7dbcbe929b2