### PR TITLE
Add starter pack recommendations

### DIFF
--- a/lib/utils/template_priority.dart
+++ b/lib/utils/template_priority.dart
@@ -1,0 +1,17 @@
+import '../models/v2/training_pack_template.dart';
+
+const kTplPriority = ['Push/Fold', 'ICM', 'Postflop', '3-бет'];
+
+extension SortedByPriority on Iterable<TrainingPackTemplate> {
+  List<TrainingPackTemplate> sortedByPriority() {
+    final map = {
+      for (var i = 0; i < kTplPriority.length; i++) kTplPriority[i]: i
+    };
+    return toList()
+      ..sort((a, b) {
+        final pa = map[a.category] ?? 999;
+        final pb = map[b.category] ?? 999;
+        return pa != pb ? pa - pb : a.name.compareTo(b.name);
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- show starter pack recommendations carousel
- track starter completion status in preferences
- hide completed starter packs
- mark pack as completed when finishing a session

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686dd9ab3608832ab6198defaf6cc6d0