### PR TITLE
Implement snooze for next training pack dialog

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -185,6 +185,15 @@ class _PackCard extends StatelessWidget {
         .sortedByPriority()
         .firstOrNull;
     if (next == null) return;
+    final snoozeKey = 'snooze_tpl_${next.id}';
+    final snooze = prefs.getString(snoozeKey);
+    if (snooze != null) {
+      final savedAt = DateTime.tryParse(snooze);
+      if (savedAt != null &&
+          DateTime.now().difference(savedAt) < const Duration(hours: 12)) {
+        return;
+      }
+    }
     final start = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -215,6 +224,11 @@ class _PackCard extends StatelessWidget {
         );
       }
       onDone();
+    } else if (start == false) {
+      await prefs.setString(
+        snoozeKey,
+        DateTime.now().toIso8601String(),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid repeating next pack suggestions for 12h after rejection

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de6a28480832a85101a13c862f863