### PR TITLE
Add initial template import

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ flutter:
     - assets/spots/spots.json
     - assets/training_packs/
     - assets/training_templates/
+    - assets/templates/initial/
     - assets/ranges/
     - assets/packs/
 


### PR DESCRIPTION
## Summary
- load initial templates from assets into the library
- expose import button in template library screen
- register new assets directory in pubspec

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2424043c832aa364b516c53155d9