### PR TITLE
Fix manifest error caching and unawaited cloud sync

### DIFF
--- a/lib/asset_manifest.dart
+++ b/lib/asset_manifest.dart
@@ -7,5 +7,8 @@ class AssetManifest {
       rootBundle
           .loadString('AssetManifest.json')
           .then<Map<String, dynamic>>(jsonDecode)
-          .catchError((_) => <String, dynamic>{});
+          .catchError((e) {
+        debugPrint('🛑 AssetManifest load failed: $e');
+        return <String, dynamic>{};
+      });
 }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -334,7 +334,8 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       }
     }
     await prefs.setBool('imported_initial_templates', true);
-    context.read<CloudSyncService>().save('imported_initial_templates', '1');
+    unawaited(
+        context.read<CloudSyncService>().save('imported_initial_templates', '1'));
     if (!mounted) return;
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Добавлено $added паков')));


### PR DESCRIPTION
## Summary
- improve asset manifest error handling
- sync imported initial templates in the background

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e29ab13d0832a9f3849716a4f1610