### PR TITLE
Fix import race guard

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -329,7 +329,8 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
 
   Future<void> _importInitialTemplates([SharedPreferences? prefs]) async {
     if (_importing) return;
-    setState(() => _importing = true);
+    _importing = true;
+    setState(() {});
     prefs ??= await SharedPreferences.getInstance();
     if (prefs.getBool('imported_initial_templates') == true) {
       setState(() => _importing = false);


### PR DESCRIPTION
## Summary
- prevent race during import of initial templates

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e2eb4b9b4832aa00cc9e2dfd8949d