### PR TITLE
Add quick new pack tile

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -828,6 +828,16 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                         child:
                             Text('Your Packs', style: Theme.of(context).textTheme.titleMedium),
                       ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        child: Card(
+                          child: ListTile(
+                            leading: const Icon(Icons.add),
+                            title: const Text('Создать новый пак'),
+                            onTap: _createTemplate,
+                          ),
+                        ),
+                      ),
                       for (final t in user) _item(t),
                     ]
                     else if (filteringActive) ...[


### PR DESCRIPTION
## Summary
- add quick 'Создать новый пак' tile in library

## Testing
- `flutter analyze` *(fails: 2622 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3f0503b8832aa4acaeed2dd127bf