### PR TITLE
Add persistent sort options

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -634,7 +634,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               ],
             ),
             PopupMenuButton<String>(
-              onSelected: (v) => setState(() => _sort = v),
+              onSelected: _setSort,
               initialValue: _sort,
               itemBuilder: (_) => const [
                 PopupMenuItem(value: 'edited', child: Text('Newest')),


### PR DESCRIPTION
## Summary
- make sort menu persist selection

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e49b9a0e0832ab40314b63eeff5a4