### PR TITLE
Add favorites toggle to template list

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -671,6 +671,12 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       ),
       body: Column(
         children: [
+          SwitchListTile(
+            title: const Text('Избранное'),
+            value: _favoritesOnly,
+            onChanged: _setFavoritesOnly,
+            activeColor: Colors.orange,
+          ),
           FutureBuilder<TrainingPackTemplate?>(
             future: _loadLastPack(context),
             builder: (context, snap) {


### PR DESCRIPTION
## Summary
- add a visible favorites switch in `TemplateLibraryScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4ce71e20832ab08481299cfda02d