### PR TITLE
Implement localized section titles

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: app_ru.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,8 @@
+{
+  "@@locale": "en",
+  "favorites": "Favorites",
+  "recommended": "Recommended",
+  "starterPacks": "Starter Packs",
+  "builtInPacks": "Built-in Packs",
+  "yourPacks": "Your Packs"
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,0 +1,8 @@
+{
+  "@@locale": "ru",
+  "favorites": "Избранное",
+  "recommended": "Рекомендовано",
+  "starterPacks": "Стартовые паки",
+  "builtInPacks": "Встроенные паки",
+  "yourPacks": "Ваши паки"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,6 +63,8 @@ import 'services/ab_test_engine.dart';
 import 'services/asset_sync_service.dart';
 import 'services/evaluation_settings_service.dart';
 import 'widgets/sync_status_widget.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
 import 'helpers/training_pack_storage.dart';
@@ -399,6 +401,23 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
                 displayColor: Colors.white,
               ),
             ),
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [
+              Locale('en'),
+              Locale('ru'),
+            ],
+            localeResolutionCallback: (locale, supportedLocales) {
+              if (locale == null) return const Locale('ru');
+              for (final l in supportedLocales) {
+                if (l.languageCode == locale.languageCode) return l;
+              }
+              return const Locale('ru');
+            },
             home: const MainNavigationScreen(),
           );
         },

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -35,6 +35,7 @@ import '../services/mistake_review_pack_service.dart';
 import 'package:intl/intl.dart';
 import 'training_stats_screen.dart';
 import '../helpers/category_translations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -637,6 +638,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
     final templates = context.watch<TemplateStorageService>().templates;
     final tagList = <String>{for (final t in templates) ...t.tags}.toList()..sort();
     final visible = _applyFilters(templates);
@@ -732,7 +734,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       body: Column(
         children: [
           SwitchListTile(
-            title: const Text('Избранное'),
+            title: Text(l.favorites),
             value: _favoritesOnly,
             onChanged: _setFavoritesOnly,
             activeColor: Colors.orange,
@@ -855,7 +857,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               ? ListView(
                   children: [
                     if (sortedFav.isNotEmpty) ...[
-                      const ListTile(title: Text('★ Favorites')),
+                      ListTile(title: Text('★ ${l.favorites}')),
                       for (final t in sortedFav) _item(t),
                       if (builtInStarter.isNotEmpty || builtInOther.isNotEmpty || user.isNotEmpty) const Divider(),
                     ]
@@ -864,7 +866,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                       if (builtInStarter.isNotEmpty || builtInOther.isNotEmpty || user.isNotEmpty) const Divider(),
                     ],
                     if (featured.isNotEmpty) ...[
-                      const ListTile(title: Text('Рекомендовано')),
+                      ListTile(title: Text(l.recommended)),
                       for (final t in featured) _item(t),
                       if (builtInStarter.isNotEmpty ||
                           builtInOther.isNotEmpty ||
@@ -879,7 +881,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                         const Divider(),
                     ],
                     if (builtInStarter.isNotEmpty) ...[
-                      const ListTile(title: Text('Стартовые паки')),
+                      ListTile(title: Text(l.starterPacks)),
                       for (final t in builtInStarter) _item(t),
                       if (builtInOther.isNotEmpty || user.isNotEmpty) const Divider(),
                     ]
@@ -888,7 +890,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                       if (builtInOther.isNotEmpty || user.isNotEmpty) const Divider(),
                     ],
                     if (builtInOther.isNotEmpty) ...[
-                      const ListTile(title: Text('Встроенные паки')),
+                      ListTile(title: Text(l.builtInPacks)),
                       for (final t in builtInOther) _item(t),
                       if (user.isNotEmpty) const Divider(),
                     ]
@@ -900,7 +902,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                         child:
-                            Text('Your Packs', style: Theme.of(context).textTheme.titleMedium),
+                            Text(l.yourPacks, style: Theme.of(context).textTheme.titleMedium),
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   intl: ^0.20.2
   freezed_annotation: ^2.2.0
   json_annotation: ^4.8.1
+  flutter_localizations:
+    sdk: flutter
   sticky_headers: ^0.3.0+2
   archive: ^4.0.0
   share_plus: ^7.0.0
@@ -70,6 +72,8 @@ dev_dependencies:
   yaml: ^3.1.1
 
 flutter:
+
+  generate: true
 
   uses-material-design: true
 


### PR DESCRIPTION
## Summary
- enable localization generation and add English/Russian translations
- wire up localization delegates in the main app
- localize template library section headers

## Testing
- `flutter analyze`
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_686e50f54eec832a9544332b88382db4