### PR TITLE
Add Recently Practised shelf

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,5 +4,6 @@
   "recommended": "Recommended",
   "starterPacks": "Starter Packs",
   "builtInPacks": "Built-in Packs",
-  "yourPacks": "Your Packs"
+  "yourPacks": "Your Packs",
+  "recentPacks": "Recently Practised"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -4,5 +4,6 @@
   "recommended": "Рекомендовано",
   "starterPacks": "Стартовые паки",
   "builtInPacks": "Встроенные паки",
-  "yourPacks": "Ваши паки"
+  "yourPacks": "Ваши паки",
+  "recentPacks": "Недавняя практика"
 }


### PR DESCRIPTION
## Summary
- add `recentlyPractisedTemplates` helper in stats service
- show recent packs in library
- toggle shelf visibility via filter chip
- update English and Russian localizations

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5d402a88832aa938264812086880