### PR TITLE
Highlight recent packs in library list

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -539,6 +539,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                   const Icon(Icons.shield, size: 18, color: Colors.grey),
                   const SizedBox(width: 4),
                 ],
+                if (_recent.any((e) => e.id == t.id)) ...[
+                  const Icon(Icons.schedule, size: 16, color: Colors.grey),
+                  const SizedBox(width: 4),
+                ],
                 Expanded(
                   child: Text(
                     t.name,


### PR DESCRIPTION
## Summary
- show schedule icon for recently practiced packs in template library

## Testing
- `flutter analyze` *(fails: many issues, but command ran)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f3ce6a8832a91bdfc795fa1d063