### PR TITLE
Add Popular Packs shelf

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,5 +5,6 @@
   "starterPacks": "Starter Packs",
   "builtInPacks": "Built-in Packs",
   "yourPacks": "Your Packs",
-  "recentPacks": "Recently Practised"
+  "recentPacks": "Recently Practised",
+  "popularPacks": "\ud83d\udd25 Popular"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -5,5 +5,6 @@
   "starterPacks": "Стартовые паки",
   "builtInPacks": "Встроенные паки",
   "yourPacks": "Ваши паки",
-  "recentPacks": "Недавняя практика"
+  "recentPacks": "Недавняя практика",
+  "popularPacks": "\ud83d\udd25 \u041f\u043e\u043f\u0443\u043b\u044f\u0440\u043d\u043e\u0435"
 }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -72,6 +72,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   bool _importing = false;
 
   List<TrainingPackTemplate> _recent = [];
+  List<TrainingPackTemplate> _popular = [];
 
   @override
   void initState() {
@@ -90,6 +91,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     await _load(prefs);
     await _autoImport(prefs);
     await _updateRecent();
+    await _updatePopular();
   }
 
   @override
@@ -216,6 +218,14 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     );
     if (!mounted) return;
     setState(() => _recent = recent);
+  }
+
+  Future<void> _updatePopular() async {
+    final templates = context.read<TemplateStorageService>().templates;
+    final popular =
+        await TrainingPackStatsService.mostPlayedTemplates(templates, 5);
+    if (!mounted) return;
+    setState(() => _popular = popular);
   }
 
 
@@ -943,6 +953,14 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     ]
                     else if (filteringActive) ...[
                       _emptyTile,
+                      if (builtInStarter.isNotEmpty ||
+                          builtInOther.isNotEmpty ||
+                          user.isNotEmpty)
+                        const Divider(),
+                    ],
+                    if (_popular.isNotEmpty) ...[
+                      ListTile(title: Text(l.popularPacks)),
+                      for (final t in _popular) _item(t),
                       if (builtInStarter.isNotEmpty ||
                           builtInOther.isNotEmpty ||
                           user.isNotEmpty)


### PR DESCRIPTION
## Summary
- add most played templates calculation
- track popular packs in template library
- add "Popular" localization strings

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e62d1db70832a91fd43298844b26a