### PR TITLE
feat: show training pack progress in library

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -632,11 +632,20 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               children: [
                 Text(main),
                 const SizedBox(height: 4),
-                LinearProgressIndicator(
-                  value: stat.accuracy,
-                  backgroundColor: Colors.white12,
-                  color: color,
-                  minHeight: 4,
+                Row(
+                  children: [
+                    Expanded(
+                      child: LinearProgressIndicator(
+                        value: stat.accuracy,
+                        backgroundColor: Colors.white12,
+                        color: color,
+                        minHeight: 4,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text('${(stat.accuracy * 100).round()}%',
+                        style: const TextStyle(fontSize: 12)),
+                  ],
                 ),
                 const SizedBox(height: 2),
                 Text('${l.lastTrained}: $date',


### PR DESCRIPTION
## Summary
- display progress percentage and last training info in TemplateLibraryScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7c0e5a1c832a8b011d43182f8b65