### PR TITLE
Add Mistake Review button

### DIFF
--- a/lib/screens/mistake_review_screen.dart
+++ b/lib/screens/mistake_review_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../services/mistake_review_pack_service.dart';
+import 'v2/training_pack_play_screen.dart';
+
+class MistakeReviewScreen extends StatelessWidget {
+  const MistakeReviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final tpl = MistakeReviewPackService.cachedTemplate;
+    if (tpl == null) {
+      return const Scaffold(body: SizedBox.shrink());
+    }
+    return TrainingPackPlayScreen(template: tpl, original: tpl);
+  }
+}


### PR DESCRIPTION
## Summary
- add per-pack mistake tracking in `MistakeReviewPackService`
- show "Разобрать ошибки" button in template pack sheet when mistakes exist
- open `MistakeReviewScreen` to review mistakes

## Testing
- `flutter analyze` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e81ef55bc832a9863c9168a990e67