### PR TITLE
Implement session reset feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
 import 'services/session_note_service.dart';
 import 'services/session_pin_service.dart';
+import 'services/session_manager.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -277,6 +278,13 @@ Future<void> main() async {
           create: (_) => TrainingPackPlayController()..load(),
         ),
         ChangeNotifierProvider(create: (_) => TrainingSessionService()..load()),
+        Provider(
+          create: (context) => SessionManager(
+            hands: context.read<SavedHandManagerService>(),
+            notes: context.read<SessionNoteService>(),
+            sessions: context.read<TrainingSessionService>(),
+          ),
+        ),
         ChangeNotifierProvider(
           create: (context) => SessionLogService(
             sessions: context.read<TrainingSessionService>(),

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/session_label_overlay.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/session_note_service.dart';
+import '../services/session_manager.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../helpers/date_utils.dart';
 import '../theme/app_colors.dart';
@@ -298,6 +299,18 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
                         child: ElevatedButton(
                           onPressed: () => _exportPdf(context),
                           child: const Text('Экспорт в PDF'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () async {
+                            await context
+                                .read<SessionManager>()
+                                .reset(widget.sessionId);
+                            if (context.mounted) Navigator.pop(context);
+                          },
+                          child: const Text('Reset Session'),
                         ),
                       ),
                     ],

--- a/lib/services/session_manager.dart
+++ b/lib/services/session_manager.dart
@@ -1,0 +1,21 @@
+import 'saved_hand_manager_service.dart';
+import 'session_note_service.dart';
+import 'training_session_service.dart';
+
+class SessionManager {
+  final SavedHandManagerService hands;
+  final SessionNoteService notes;
+  final TrainingSessionService sessions;
+
+  SessionManager({
+    required this.hands,
+    required this.notes,
+    required this.sessions,
+  });
+
+  Future<void> reset(int sessionId) async {
+    await hands.removeSession(sessionId);
+    await notes.setNote(sessionId, '');
+    await sessions.reset();
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -158,6 +158,19 @@ class TrainingSessionService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> reset() async {
+    _timer?.cancel();
+    _session = null;
+    _template = null;
+    _spots.clear();
+    _actions.clear();
+    _focusHandTypes.clear();
+    _handGoalTotal.clear();
+    _handGoalCount.clear();
+    if (_activeBox != null) await _activeBox!.delete('session');
+    notifyListeners();
+  }
+
   void _saveActive() {
     if (_session == null || _activeBox == null || _session!.authorPreview) return;
     if (_session!.completedAt != null) {


### PR DESCRIPTION
## Summary
- add SessionManager service with reset logic
- expose SessionManager via provider
- extend TrainingSessionService with reset method
- add reset session button on SessionHandsScreen

## Testing
- `flutter --version` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e98976dc8832abe1aa5c9cfc7dbb4