### PR TITLE
Add quick start from pack library

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -7,10 +7,11 @@ import 'package:timeago/timeago.dart' as timeago;
 import '../models/v2/training_pack_template.dart';
 import '../services/template_storage_service.dart';
 import '../helpers/training_pack_storage.dart';
+import '../helpers/training_pack_validator.dart';
 import '../services/training_pack_author_service.dart' show TrainingPackAuthorService, PresetConfig;
 import '../models/v2/hero_position.dart';
 import 'v2/training_pack_template_editor_screen.dart';
-import 'v2/training_session_screen.dart';
+import 'training_session_screen.dart';
 
 class PacksLibraryScreen extends StatefulWidget {
   const PacksLibraryScreen({super.key});
@@ -347,6 +348,26 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                         label: '${pct(icmDone).round()} % ICM',
                         color: col(pct(icmDone)),
                       ),
+                      if (validateTrainingPackTemplate(t).isEmpty &&
+                          !context.read<TemplateStorageService>().templates.any((e) => e.name == t.name))
+                        Padding(
+                          padding: const EdgeInsets.only(left: 4),
+                          child: ElevatedButton(
+                            onPressed: () async {
+                              final newSession = await context
+                                  .read<TrainingSessionService>()
+                                  .startFromTemplate(t);
+                              if (!context.mounted) return;
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => TrainingSessionScreen(session: newSession),
+                                ),
+                              );
+                            },
+                            child: const Text('Start'),
+                          ),
+                        ),
                       IconButton(
                         icon: const Icon(Icons.play_circle_fill),
                         tooltip: solvedAll ? 'All solved' : 'Resume',

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -9,6 +9,7 @@ import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
+import '../models/v2/training_session.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -32,9 +33,11 @@ class _EndlessStats {
   }
 }
 
+
 class TrainingSessionScreen extends StatefulWidget {
   final VoidCallback? onSessionEnd;
-  const TrainingSessionScreen({super.key, this.onSessionEnd});
+  final TrainingSession? session;
+  const TrainingSessionScreen({super.key, this.onSessionEnd, this.session});
 
   @override
   State<TrainingSessionScreen> createState() => _TrainingSessionScreenState();

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -241,6 +241,11 @@ class TrainingSessionService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<TrainingSession> startFromTemplate(TrainingPackTemplate template) async {
+    await startSession(template, persist: false);
+    return _session!;
+  }
+
   Future<void> submitResult(
     String spotId,
     String action,


### PR DESCRIPTION
## Summary
- enable starting a training session directly from pack library
- expose `startFromTemplate` in training session service
- support passing session object to `TrainingSessionScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb45dfc50832ab9874e3fa67e046c