### PR TITLE
Add continue session card

### DIFF
--- a/lib/models/v2/training_session.dart
+++ b/lib/models/v2/training_session.dart
@@ -9,6 +9,7 @@ class TrainingSession {
   int index;
   final Map<String, bool> results;
   final bool authorPreview;
+  bool get isCompleted => completedAt != null;
 
   TrainingSession({
     required this.id,

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -374,6 +374,59 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
           ? const Center(child: CircularProgressIndicator())
           : Column(
               children: [
+                Builder(
+                  builder: (context) {
+                    final session =
+                        context.read<TrainingSessionService>().currentSession;
+                    final template = context.read<TrainingSessionService>().template;
+                    if (session == null || session.isCompleted || template == null) {
+                      return const SizedBox.shrink();
+                    }
+                    final progress =
+                        (session.index / template.spots.length * 100).clamp(0, 100);
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                      child: Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(template.name,
+                                        style: const TextStyle(fontSize: 16)),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      '${session.index + 1} / ${template.spots.length}',
+                                      style: const TextStyle(color: Colors.white70),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    CombinedProgressBar(progress, progress),
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              ElevatedButton(
+                                onPressed: () {
+                                  Navigator.pushReplacement(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) =>
+                                          TrainingSessionScreen(session: session),
+                                    ),
+                                  );
+                                },
+                                child: const Text('Resume'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
                 Padding(
                   padding: const EdgeInsets.all(16),
                   child: Row(

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -32,6 +32,9 @@ class TrainingSessionService extends ChangeNotifier {
   Map<String, int> get handGoalTotal => Map.unmodifiable(_handGoalTotal);
   Map<String, int> get handGoalCount => Map.unmodifiable(_handGoalCount);
 
+  TrainingSession? get currentSession => _session;
+  bool get isCompleted => _session?.completedAt != null;
+
   void _startTicker() {
     _timer?.cancel();
     _timer =


### PR DESCRIPTION
## Summary
- expose `currentSession` and `isCompleted` on `TrainingSessionService`
- add `isCompleted` getter for `TrainingSession`
- show card to resume active session in `PacksLibraryScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec602bc9c832a8241c382bd501a9b