### PR TITLE
Implement mistake retry flow

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -212,6 +212,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         }
       }
     }
+    await service.complete(context);
   }
 
   void _showEndlessSummary() {


### PR DESCRIPTION
## Summary
- add startFromMistakes and complete methods
- auto-redirect to retry mistakes after session summary

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edd89ba88832a8ba363bb04d7e770