### PR TITLE
Implement post-session summary screen

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -4,11 +4,9 @@ import 'package:provider/provider.dart';
 import '../services/training_session_service.dart';
 import '../widgets/spot_quiz_widget.dart';
 import 'session_result_screen.dart';
-import 'training_session_summary_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:uuid/uuid.dart';
 import '../models/v2/training_session.dart';
 
 class _EndlessStats {
@@ -162,41 +160,6 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
   }
 
   Future<void> _showSummary(TrainingSessionService service) async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute(
-        fullscreenDialog: true,
-        builder: (_) => TrainingSessionSummaryScreen(
-          correct: service.correctCount,
-          total: service.totalCount,
-          elapsed: service.elapsedTime,
-          onReview: () {
-            Navigator.pop(context);
-            final ids = service.results.keys
-                .where((k) => service.results[k] == false)
-                .toSet();
-            final spots =
-                service.spots.where((s) => ids.contains(s.id)).toList();
-            if (spots.isEmpty) return;
-            final tpl = service.template!.copyWith(
-              id: const Uuid().v4(),
-              name: 'Review mistakes',
-              spots: spots,
-            );
-            service.startSession(tpl, persist: false);
-            setState(() {
-              _selected = null;
-              _correct = null;
-              _summaryShown = false;
-            });
-          },
-          onBack: () {
-            Navigator.pop(context);
-            Navigator.pop(context);
-          },
-        ),
-      ),
-    );
     final tpl = service.template;
     if (tpl != null) {
       final correct = service.correctCount;

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -1,62 +1,121 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../widgets/combined_progress_bar.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_session.dart';
+import '../services/training_session_service.dart';
+import '../widgets/spot_viewer_dialog.dart';
 import '../theme/app_colors.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'training_session_screen.dart';
 
 class TrainingSessionSummaryScreen extends StatelessWidget {
-  final int correct;
-  final int total;
-  final Duration elapsed;
-  final VoidCallback onReview;
-  final VoidCallback onBack;
+  final TrainingSession session;
+  final TrainingPackTemplate template;
+  final double preEvPct;
+  final double preIcmPct;
   const TrainingSessionSummaryScreen({
     super.key,
-    required this.correct,
-    required this.total,
-    required this.elapsed,
-    required this.onReview,
-    required this.onBack,
+    required this.session,
+    required this.template,
+    required this.preEvPct,
+    required this.preIcmPct,
   });
-
-  String _format(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
-    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
-    return h > 0 ? '$h:$m:$s' : '$m:$s';
-  }
 
   @override
   Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context)!;
-    final rate = total == 0 ? 0 : correct * 100 / total;
-    final avg = total == 0 ? 0.0 : elapsed.inSeconds / total;
+    final total = session.results.length;
+    final correct = session.results.values.where((e) => e).length;
+    final accuracy = total == 0 ? 0.0 : correct * 100 / total;
+    final tTotal = template.spots.length;
+    final evPct = tTotal == 0 ? 0.0 : template.evCovered * 100 / tTotal;
+    final icmPct = tTotal == 0 ? 0.0 : template.icmCovered * 100 / tTotal;
+    final mistakes = [
+      for (final id in session.results.keys)
+        if (session.results[id] == false)
+          template.spots.firstWhere(
+            (s) => s.id == id,
+            orElse: () => TrainingPackSpot(id: ''),
+          )
+    ].where((s) => s.id.isNotEmpty).toList();
     return Scaffold(
+      appBar: AppBar(title: const Text('Training Summary')),
       backgroundColor: AppColors.background,
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text('$correct/$total',
-                  style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold)),
-              const SizedBox(height: 8),
-              Text('Accuracy: ${rate.toStringAsFixed(1)}%',
-                  style: const TextStyle(color: Colors.white70)),
-              const SizedBox(height: 8),
-              Text('Time: ${_format(elapsed)}',
-                  style: const TextStyle(color: Colors.white70)),
-              const SizedBox(height: 8),
-              Text('Avg: ${avg.toStringAsFixed(1)} s/spot',
-                  style: const TextStyle(color: Colors.white70)),
-              const SizedBox(height: 24),
-              ElevatedButton(onPressed: onReview, child: Text(l.reviewMistakes)),
-              const SizedBox(height: 8),
-              OutlinedButton(onPressed: onBack, child: const Text('Done')),
-            ],
-          ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                '${accuracy.toStringAsFixed(1)}%',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 48,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            CombinedProgressBar(preEvPct, preIcmPct),
+            const SizedBox(height: 4),
+            CombinedProgressBar(evPct, icmPct),
+            const SizedBox(height: 16),
+            if (mistakes.isNotEmpty)
+              Expanded(
+                child: ListView.builder(
+                  itemCount: mistakes.length,
+                  itemBuilder: (context, index) {
+                    final s = mistakes[index];
+                    return ListTile(
+                      title: Text(s.title,
+                          style: const TextStyle(color: Colors.white)),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.replay, color: Colors.orange),
+                        onPressed: () => showSpotViewerDialog(context, s),
+                      ),
+                    );
+                  },
+                ),
+              )
+            else
+              const Expanded(
+                  child: Center(
+                      child: Text('No mistakes',
+                          style: TextStyle(color: Colors.white70)))),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      final service =
+                          context.read<TrainingSessionService>();
+                      final newSession = await service.startFromMistakes();
+                      if (!context.mounted) return;
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => TrainingSessionScreen(
+                            session: newSession,
+                          ),
+                        ),
+                      );
+                    },
+                    child: const Text('Repeat Mistakes'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () =>
+                        Navigator.of(context).popUntil((r) => r.isFirst),
+                    child: const Text('Back to Library'),
+                  ),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- update training session service to capture EV/ICM coverage before session and navigate to new summary screen when finished
- add detailed TrainingSessionSummaryScreen with progress bars and mistake list
- show summary via service from TrainingSessionScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee36cc94c832a9f8c0231bb0f240a