### PR TITLE
Add EV/ICM progress tracking

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -165,7 +165,19 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       final correct = service.correctCount;
       final total = service.totalCount;
       final acc = total == 0 ? 0.0 : correct / total;
-      unawaited(TrainingPackStatsService.recordSession(tpl.id, correct, total));
+      final totalSpots = tpl.spots.length;
+      final evAfter = totalSpots == 0 ? 0.0 : tpl.evCovered * 100 / totalSpots;
+      final icmAfter =
+          totalSpots == 0 ? 0.0 : tpl.icmCovered * 100 / totalSpots;
+      unawaited(TrainingPackStatsService.recordSession(
+        tpl.id,
+        correct,
+        total,
+        preEvPct: service.preEvPct,
+        preIcmPct: service.preIcmPct,
+        postEvPct: evAfter,
+        postIcmPct: icmAfter,
+      ));
       if (acc >= 0.8) {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setBool('completed_tpl_${tpl.id}', true);


### PR DESCRIPTION
## Summary
- extend `TrainingPackStat` model with EV/ICM fields
- update stats recording and retrieval
- preserve EV/ICM data when saving last index
- log EV/ICM progress at the end of a training session

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee502a5c8832a95d0bad14033ee51