### PR TITLE
Add hand analysis history

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
+import 'services/hand_analysis_history_service.dart';
 import 'services/training_pack_play_controller.dart';
 import 'services/notification_service.dart';
 import 'services/daily_target_service.dart';
@@ -278,6 +279,7 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (_) => MixedDrillHistoryService()..load(),
         ),
+        ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..load()),
         ChangeNotifierProvider(
           create: (_) => TrainingPackPlayController()..load(),
         ),

--- a/lib/models/hand_analysis_record.dart
+++ b/lib/models/hand_analysis_record.dart
@@ -1,0 +1,54 @@
+import 'card_model.dart';
+
+class HandAnalysisRecord {
+  final String card1;
+  final String card2;
+  final int stack;
+  final int playerCount;
+  final int heroIndex;
+  final double ev;
+  final double icm;
+  final String action;
+  final DateTime date;
+
+  HandAnalysisRecord({
+    required this.card1,
+    required this.card2,
+    required this.stack,
+    required this.playerCount,
+    required this.heroIndex,
+    required this.ev,
+    required this.icm,
+    required this.action,
+    DateTime? date,
+  }) : date = date ?? DateTime.now();
+
+  List<CardModel> get cards => [
+        CardModel(rank: card1[0], suit: card1.substring(1)),
+        CardModel(rank: card2[0], suit: card2.substring(1)),
+      ];
+
+  Map<String, dynamic> toJson() => {
+        'card1': card1,
+        'card2': card2,
+        'stack': stack,
+        'playerCount': playerCount,
+        'heroIndex': heroIndex,
+        'ev': ev,
+        'icm': icm,
+        'action': action,
+        'date': date.toIso8601String(),
+      };
+
+  factory HandAnalysisRecord.fromJson(Map<String, dynamic> j) => HandAnalysisRecord(
+        card1: j['card1'] as String? ?? '',
+        card2: j['card2'] as String? ?? '',
+        stack: j['stack'] as int? ?? 0,
+        playerCount: j['playerCount'] as int? ?? 0,
+        heroIndex: j['heroIndex'] as int? ?? 0,
+        ev: (j['ev'] as num?)?.toDouble() ?? 0,
+        icm: (j['icm'] as num?)?.toDouble() ?? 0,
+        action: j['action'] as String? ?? '',
+        date: DateTime.tryParse(j['date'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/screens/hand_analysis_history_screen.dart
+++ b/lib/screens/hand_analysis_history_screen.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/hand_analysis_history_service.dart';
+import '../models/hand_analysis_record.dart';
+import '../theme/app_colors.dart';
+import '../models/card_model.dart';
+import 'quick_hand_analysis_screen.dart';
+
+class HandAnalysisHistoryScreen extends StatefulWidget {
+  const HandAnalysisHistoryScreen({super.key});
+
+  @override
+  State<HandAnalysisHistoryScreen> createState() => _HandAnalysisHistoryScreenState();
+}
+
+class _HandAnalysisHistoryScreenState extends State<HandAnalysisHistoryScreen> {
+  String _period = 'Все';
+  String _result = 'Все';
+
+  List<HandAnalysisRecord> _filter(List<HandAnalysisRecord> all) {
+    Duration? d;
+    if (_period == '7 дней') {
+      d = const Duration(days: 7);
+    } else if (_period == '30 дней') {
+      d = const Duration(days: 30);
+    }
+    final now = DateTime.now();
+    return [
+      for (final r in all)
+        if ((d == null || r.date.isAfter(now.subtract(d))) &&
+            (_result == 'Все' || r.action == _result.toLowerCase()))
+          r
+    ];
+  }
+
+  Widget _card(CardModel c) {
+    final red = c.suit == '♥' || c.suit == '♦';
+    return Container(
+      width: 24,
+      height: 34,
+      margin: const EdgeInsets.only(right: 4),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '${c.rank}${c.suit}',
+        style: TextStyle(
+          color: red ? Colors.red : Colors.black,
+          fontWeight: FontWeight.bold,
+          fontSize: 14,
+        ),
+      ),
+    );
+  }
+
+  Widget _list(List<HandAnalysisRecord> data) => ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: data.length,
+        itemBuilder: (context, index) {
+          final r = data[index];
+          final d = r.date;
+          final label = '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}.${d.year}';
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            decoration: BoxDecoration(
+              color: AppColors.cardBackground,
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.3),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: ListTile(
+              leading: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [for (final c in r.cards) _card(c)],
+              ),
+              title: Text(
+                'EV ${r.ev.toStringAsFixed(2)} BB • ICM ${r.icm.toStringAsFixed(2)}',
+                style: const TextStyle(color: Colors.white),
+              ),
+              subtitle: Text(
+                '${r.action} • $label',
+                style: const TextStyle(color: Colors.white70),
+              ),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => QuickHandAnalysisScreen(record: r)),
+                );
+              },
+            ),
+          );
+        },
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final records = context.watch<HandAnalysisHistoryService>().records;
+    final data = _filter(records);
+    return Scaffold(
+      appBar: AppBar(title: const Text('История анализов'), centerTitle: true),
+      backgroundColor: AppColors.background,
+      body: records.isEmpty
+          ? const Center(child: Text('История пуста', style: TextStyle(color: Colors.white70)))
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                  child: Row(
+                    children: [
+                      DropdownButton<String>(
+                        value: _period,
+                        underline: const SizedBox(),
+                        dropdownColor: AppColors.cardBackground,
+                        style: const TextStyle(color: Colors.white),
+                        items: const ['Все', '7 дней', '30 дней']
+                            .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                            .toList(),
+                        onChanged: (v) => setState(() => _period = v ?? 'Все'),
+                      ),
+                      const SizedBox(width: 12),
+                      DropdownButton<String>(
+                        value: _result,
+                        underline: const SizedBox(),
+                        dropdownColor: AppColors.cardBackground,
+                        style: const TextStyle(color: Colors.white),
+                        items: const ['Все', 'Push', 'Fold']
+                            .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                            .toList(),
+                        onChanged: (v) => setState(() => _result = v ?? 'Все'),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: data.isEmpty
+                      ? const Center(child: Text('Нет результатов', style: TextStyle(color: Colors.white70)))
+                      : _list(data),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -39,6 +39,7 @@ import '../services/streak_service.dart';
 import 'goals_overview_screen.dart';
 import 'mistake_repeat_screen.dart';
 import 'quick_hand_analysis_screen.dart';
+import 'hand_analysis_history_screen.dart';
 import 'achievements_screen.dart';
 import '../services/goals_service.dart';
 import '../widgets/focus_of_the_week_card.dart';
@@ -584,6 +585,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('⚡ Быстрый анализ'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const HandAnalysisHistoryScreen()),
+                );
+              },
+              child: const Text('🕓 История анализов'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/services/hand_analysis_history_service.dart
+++ b/lib/services/hand_analysis_history_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/hand_analysis_record.dart';
+
+class HandAnalysisHistoryService extends ChangeNotifier {
+  static const _key = 'hand_analysis_history';
+  final List<HandAnalysisRecord> _records = [];
+
+  List<HandAnalysisRecord> get records => List.unmodifiable(_records);
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw != null) {
+      try {
+        final list = jsonDecode(raw);
+        if (list is List) {
+          _records
+            ..clear()
+            ..addAll(list.map((e) => HandAnalysisRecord.fromJson(Map<String, dynamic>.from(e as Map))));
+          _records.sort((a, b) => b.date.compareTo(a.date));
+        }
+      } catch (_) {}
+    }
+    notifyListeners();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode([for (final r in _records) r.toJson()]));
+  }
+
+  Future<void> add(HandAnalysisRecord r) async {
+    _records.insert(0, r);
+    if (_records.length > 50) _records.removeRange(50, _records.length);
+    await _save();
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- create `HandAnalysisHistoryService` with local persistence
- add `HandAnalysisRecord` model
- store quick analysis results in history
- show history list with filters and quick re-run
- expose history on the main menu

## Testing
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef68077d8832aba62ceb04c35c1b9