### PR TITLE
Add summary stats to hand analysis history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Export Markdown summary from pack template preview.
 - Add Import Starter Packs button to Template Library.
 - Suggest next built-in pack from the same category when one is completed.
+- Add hand analysis history with EV/ICM stats and filters.

--- a/lib/screens/hand_analysis_history_screen.dart
+++ b/lib/screens/hand_analysis_history_screen.dart
@@ -99,6 +99,24 @@ class _HandAnalysisHistoryScreenState extends State<HandAnalysisHistoryScreen> {
         },
       );
 
+  Widget _summary(List<HandAnalysisRecord> data) {
+    if (data.isEmpty) return const SizedBox.shrink();
+    final ev = data.map((e) => e.ev).reduce((a, b) => a + b) / data.length;
+    final icm = data.map((e) => e.icm).reduce((a, b) => a + b) / data.length;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Средний EV ${ev.toStringAsFixed(2)} BB • ICM ${icm.toStringAsFixed(2)}',
+        style: const TextStyle(color: Colors.white70),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final records = context.watch<HandAnalysisHistoryService>().records;
@@ -138,6 +156,7 @@ class _HandAnalysisHistoryScreenState extends State<HandAnalysisHistoryScreen> {
                     ],
                   ),
                 ),
+                _summary(data),
                 Expanded(
                   child: data.isEmpty
                       ? const Center(child: Text('Нет результатов', style: TextStyle(color: Colors.white70)))


### PR DESCRIPTION
## Summary
- show average EV/ICM in history screen
- document hand analysis history feature

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef86734c0832a98495753d4be8948