### PR TITLE
feat: parse room histories

### DIFF
--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -543,6 +543,21 @@ class _RoomHandHistoryImportScreenState
                                       children: [
                                         Text('${h.heroPosition} • ${h.numberOfPlayers}p',
                                             style: const TextStyle(color: Colors.white70)),
+                                        Builder(builder: (_) {
+                                          final hero = h.playerCards.length > h.heroIndex
+                                              ? h.playerCards[h.heroIndex]
+                                                  .map((c) => c.toString())
+                                                  .join(' ')
+                                              : '';
+                                          final board = h.boardCards.map((c) => c.toString()).join(' ');
+                                          if (hero.isEmpty && board.isEmpty) return const SizedBox.shrink();
+                                          final text = hero.isEmpty ? board : '$hero  $board';
+                                          return Padding(
+                                            padding: const EdgeInsets.only(top: 2),
+                                            child: Text(text,
+                                                style: const TextStyle(color: Colors.white70)),
+                                          );
+                                        }),
                                         if (h.tags.isNotEmpty)
                                           Padding(
                                             padding: const EdgeInsets.only(top: 4),


### PR DESCRIPTION
## Summary
- detect poker room formats and parse hands
- render parsed hero and board cards in import screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0167a2ec832ab9cf4a9540107118