### PR TITLE
Add remote EV solver service

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -3929,6 +3929,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     final eval = EvaluationSettingsService.instance;
     final thresholdCtr =
         TextEditingController(text: eval.evThreshold.toStringAsFixed(2));
+    final endpointCtr = TextEditingController(text: eval.remoteEndpoint);
     bool icm = eval.useIcm;
     final formKey = GlobalKey<FormState>();
     final ok = await showModalBottomSheet<bool>(
@@ -4046,6 +4047,15 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                 onChanged: (v) => set(() {
                   icm = v;
                   eval.update(icm: v);
+                  this.setState(() {});
+                }),
+              ),
+              TextFormField(
+                controller: endpointCtr,
+                decoration:
+                    const InputDecoration(labelText: 'EV API Endpoint'),
+                onChanged: (v) => set(() {
+                  eval.update(endpoint: v);
                   this.setState(() {});
                 }),
               ),

--- a/lib/services/evaluation_settings_service.dart
+++ b/lib/services/evaluation_settings_service.dart
@@ -8,17 +8,20 @@ class EvaluationSettingsService {
 
   static const _thresholdKey = 'evaluation_ev_threshold';
   static const _icmKey = 'evaluation_use_icm';
+  static const _endpointKey = 'evaluation_api_endpoint';
 
   double evThreshold = -0.01;
   bool useIcm = false;
+  String remoteEndpoint = '';
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
     evThreshold = prefs.getDouble(_thresholdKey) ?? -0.01;
     useIcm = prefs.getBool(_icmKey) ?? false;
+    remoteEndpoint = prefs.getString(_endpointKey) ?? '';
   }
 
-  Future<void> update({double? threshold, bool? icm}) async {
+  Future<void> update({double? threshold, bool? icm, String? endpoint}) async {
     final prefs = await SharedPreferences.getInstance();
     if (threshold != null) {
       evThreshold = threshold;
@@ -27,6 +30,10 @@ class EvaluationSettingsService {
     if (icm != null) {
       useIcm = icm;
       await prefs.setBool(_icmKey, icm);
+    }
+    if (endpoint != null) {
+      remoteEndpoint = endpoint;
+      await prefs.setString(_endpointKey, endpoint);
     }
   }
 }

--- a/lib/services/offline_evaluator_service.dart
+++ b/lib/services/offline_evaluator_service.dart
@@ -2,11 +2,17 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'push_fold_ev_service.dart';
+import 'remote_ev_service.dart';
 
 class OfflineEvaluatorService {
-  OfflineEvaluatorService({this.remote = const PushFoldEvService()});
+  OfflineEvaluatorService({
+    PushFoldEvService? offline,
+    RemoteEvService? remote,
+  })  : offline = offline ?? const PushFoldEvService(),
+        remote = remote ?? RemoteEvService();
 
-  final PushFoldEvService remote;
+  final PushFoldEvService offline;
+  final RemoteEvService remote;
   static bool _offline = false;
   static bool get isOffline => _offline;
   static set isOffline(bool v) => _offline = v;
@@ -42,6 +48,7 @@ class OfflineEvaluatorService {
           }
         }
       }
+      await offline.evaluate(spot, anteBb: anteBb);
       return;
     }
     await remote.evaluate(spot, anteBb: anteBb);
@@ -69,6 +76,7 @@ class OfflineEvaluatorService {
           }
         }
       }
+      await offline.evaluateIcm(spot, anteBb: anteBb);
       return;
     }
     await remote.evaluateIcm(spot, anteBb: anteBb);

--- a/lib/services/remote_ev_service.dart
+++ b/lib/services/remote_ev_service.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/v2/training_pack_spot.dart';
+import 'evaluation_settings_service.dart';
+
+class RemoteEvService {
+  final String endpoint;
+  final http.Client client;
+  const RemoteEvService({String? endpoint, http.Client? client})
+      : endpoint = endpoint ?? EvaluationSettingsService.instance.remoteEndpoint,
+        client = client ?? const http.Client();
+
+  Future<void> evaluate(TrainingPackSpot spot, {int anteBb = 0}) async {
+    try {
+      final res = await client.post(
+        Uri.parse(endpoint),
+        headers: const {'Content-Type': 'application/json'},
+        body: jsonEncode({'hand': spot.hand.toJson(), 'anteBb': anteBb}),
+      );
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body) as Map<String, dynamic>;
+        final ev = (data['ev'] as num?)?.toDouble();
+        _apply(spot, ev: ev);
+      }
+    } catch (_) {}
+  }
+
+  Future<void> evaluateIcm(TrainingPackSpot spot, {int anteBb = 0}) async {
+    try {
+      final res = await client.post(
+        Uri.parse(endpoint),
+        headers: const {'Content-Type': 'application/json'},
+        body: jsonEncode({'hand': spot.hand.toJson(), 'anteBb': anteBb, 'icm': true}),
+      );
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body) as Map<String, dynamic>;
+        final ev = (data['ev'] as num?)?.toDouble();
+        final icm = (data['icm'] as num?)?.toDouble();
+        _apply(spot, ev: ev, icm: icm);
+      }
+    } catch (_) {}
+  }
+
+  void _apply(TrainingPackSpot spot, {double? ev, double? icm}) {
+    final hero = spot.hand.heroIndex;
+    final acts = spot.hand.actions[0] ?? [];
+    for (final a in acts) {
+      if (a.playerIndex == hero && a.action == 'push') {
+        if (ev != null) a.ev = ev;
+        if (icm != null) a.icmEv = icm;
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `RemoteEvService` to send hands to external solver
- cache endpoint in `EvaluationSettingsService`
- call remote solver from `OfflineEvaluatorService` when online
- allow editing endpoint in template settings

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686f0168de18832a9c023413f4324901