### PR TITLE
Improve adaptive training suggestions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -188,6 +188,7 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) => AdaptiveTrainingService(
             templates: context.read<TemplateStorageService>(),
+            mistakes: context.read<MistakeReviewPackService>(),
           ),
         ),
         ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -10,6 +10,7 @@ import '../services/training_session_service.dart';
 import '../services/template_storage_service.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/adaptive_training_service.dart';
+import '../services/mistake_review_pack_service.dart';
 import '../utils/template_priority.dart';
 import 'training_session_screen.dart';
 
@@ -23,6 +24,7 @@ import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import 'training_progress_analytics_screen.dart';
+import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -54,6 +56,16 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
                 context,
                 MaterialPageRoute(
                     builder: (_) => const TrainingProgressAnalyticsScreen()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.star),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const TrainingRecommendationScreen()),
               );
             },
           ),
@@ -236,6 +248,11 @@ class _PackCard extends StatelessWidget {
             ? 'Продолжить'
             : 'Начать';
     final color = completed ? Colors.green : Colors.orange;
+    final hasMistakes =
+        context.read<MistakeReviewPackService>().hasMistakes(template.id);
+    final ev = stat?.postEvPct ?? 0;
+    final icm = stat?.postIcmPct ?? 0;
+    final focus = template.handTypeSummary();
     return Container(
       width: 120,
       height: 120,
@@ -247,13 +264,19 @@ class _PackCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.shield, color: color),
+          Icon(hasMistakes ? Icons.error : Icons.shield, color: color),
           const Spacer(),
           Text(
             template.name,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
+          if (focus.isNotEmpty)
+            Text(focus,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style:
+                    const TextStyle(fontSize: 12, color: Colors.white70)),
           const SizedBox(height: 4),
           TweenAnimationBuilder<double>(
             curve: Curves.easeOutCubic,
@@ -270,6 +293,9 @@ class _PackCard extends StatelessWidget {
               ),
             ),
           ),
+          const SizedBox(height: 2),
+          Text('EV ${ev.toStringAsFixed(0)}%  ICM ${icm.toStringAsFixed(0)}%',
+              style: const TextStyle(fontSize: 10, color: Colors.white70)),
           const SizedBox(height: 4),
           ElevatedButton.icon(
             onPressed: completed

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/adaptive_training_service.dart';
+import '../services/training_session_service.dart';
+import '../services/mistake_review_pack_service.dart';
+import '../models/v2/training_pack_template.dart';
+import 'training_session_screen.dart';
+
+class TrainingRecommendationScreen extends StatelessWidget {
+  const TrainingRecommendationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<AdaptiveTrainingService>();
+    final list = service.recommended;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Рекомендации')),
+      body: list.isEmpty
+          ? const Center(child: Text('Нет рекомендаций'))
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: list.length,
+              itemBuilder: (context, index) {
+                final tpl = list[index];
+                final stat = service.statFor(tpl.id);
+                final acc = (stat?.accuracy ?? 0) * 100;
+                final ev = stat?.postEvPct ?? 0;
+                final icm = stat?.postIcmPct ?? 0;
+                final hasMistakes = context
+                    .read<MistakeReviewPackService>()
+                    .hasMistakes(tpl.id);
+                return Card(
+                  color: Colors.grey[850],
+                  margin: const EdgeInsets.only(bottom: 12),
+                  child: ListTile(
+                    title: Text(tpl.name,
+                        style: const TextStyle(color: Colors.white)),
+                    subtitle: Text(
+                      '${acc.toStringAsFixed(1)}% • EV ${ev.toStringAsFixed(1)}% • ICM ${icm.toStringAsFixed(1)}%' +
+                          (hasMistakes ? ' • ошибки' : ''),
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                    trailing:
+                        const Icon(Icons.play_arrow, color: Colors.greenAccent),
+                    onTap: () async {
+                      await context
+                          .read<TrainingSessionService>()
+                          .startSession(tpl);
+                      if (context.mounted) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const TrainingSessionScreen()),
+                        );
+                      }
+                    },
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -3,12 +3,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_pack_template.dart';
 import 'template_storage_service.dart';
 import 'training_pack_stats_service.dart';
+import 'mistake_review_pack_service.dart';
 
 class AdaptiveTrainingService extends ChangeNotifier {
   final TemplateStorageService templates;
-  AdaptiveTrainingService({required this.templates}) {
+  final MistakeReviewPackService mistakes;
+  AdaptiveTrainingService({required this.templates, required this.mistakes}) {
     refresh();
     templates.addListener(refresh);
+    mistakes.addListener(refresh);
   }
 
   List<TrainingPackTemplate> _recommended = [];
@@ -26,10 +29,14 @@ class AdaptiveTrainingService extends ChangeNotifier {
       if (prefs.getBool('completed_tpl_${t.id}') ?? false) continue;
       final stat = await TrainingPackStatsService.getStats(t.id);
       stats[t.id] = stat;
-      entries.add(MapEntry(t, stat?.accuracy ?? 0));
+      var score = 1 - (stat?.accuracy ?? 0);
+      score += 1 - (stat?.postEvPct ?? 0) / 100;
+      score += 1 - (stat?.postIcmPct ?? 0) / 100;
+      if (mistakes.hasMistakes(t.id)) score += 1;
+      entries.add(MapEntry(t, score));
     }
-    entries.sort((a, b) => a.value.compareTo(b.value));
-    _recommended = [for (final e in entries.take(3)) e.key];
+    entries.sort((a, b) => b.value.compareTo(a.value));
+    _recommended = [for (final e in entries.take(5)) e.key];
     _stats = stats;
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- enhance AdaptiveTrainingService to use EV/ICM and mistakes
- add provider wiring for mistake tracking
- show recommended packs with more info
- implement a dedicated recommendation screen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0392cc48832aa9125394c996bc40