### PR TITLE
Improve adaptive training

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -252,6 +252,7 @@ class _PackCard extends StatelessWidget {
         context.read<MistakeReviewPackService>().hasMistakes(template.id);
     final ev = stat?.postEvPct ?? 0;
     final icm = stat?.postIcmPct ?? 0;
+    final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
     final focus = template.handTypeSummary();
     return Container(
       width: 120,
@@ -277,6 +278,7 @@ class _PackCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 style:
                     const TextStyle(fontSize: 12, color: Colors.white70)),
+          Row(children:[for(var i=0;i<rating;i++)const Icon(Icons.star,color:Colors.amber,size:12)]),
           const SizedBox(height: 4),
           TweenAnimationBuilder<double>(
             curve: Curves.easeOutCubic,

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -5,6 +5,7 @@ import '../services/training_session_service.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
+import 'training_template_detail_screen.dart';
 
 class TrainingRecommendationScreen extends StatelessWidget {
   const TrainingRecommendationScreen({super.key});
@@ -26,6 +27,8 @@ class TrainingRecommendationScreen extends StatelessWidget {
                 final acc = (stat?.accuracy ?? 0) * 100;
                 final ev = stat?.postEvPct ?? 0;
                 final icm = stat?.postIcmPct ?? 0;
+                final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
+                final focus = tpl.handTypeSummary();
                 final hasMistakes = context
                     .read<MistakeReviewPackService>()
                     .hasMistakes(tpl.id);
@@ -37,22 +40,35 @@ class TrainingRecommendationScreen extends StatelessWidget {
                         style: const TextStyle(color: Colors.white)),
                     subtitle: Text(
                       '${acc.toStringAsFixed(1)}% • EV ${ev.toStringAsFixed(1)}% • ICM ${icm.toStringAsFixed(1)}%' +
-                          (hasMistakes ? ' • ошибки' : ''),
+                          (hasMistakes ? ' • ошибки' : '') +
+                          (focus.isNotEmpty ? ' • $focus' : ''),
                       style: const TextStyle(color: Colors.white70),
                     ),
-                    trailing:
-                        const Icon(Icons.play_arrow, color: Colors.greenAccent),
-                    onTap: () async {
-                      await context
-                          .read<TrainingSessionService>()
-                          .startSession(tpl);
-                      if (context.mounted) {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (_) => const TrainingSessionScreen()),
-                        );
-                      }
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Row(
+                          children: [
+                            for (var i = 0; i < rating; i++)
+                              const Icon(Icons.star,
+                                  color: Colors.amber, size: 16)
+                          ],
+                        ),
+                        const SizedBox(width: 8),
+                        const Icon(Icons.chevron_right,
+                            color: Colors.greenAccent),
+                      ],
+                    ),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => TrainingTemplateDetailScreen(
+                            template: tpl,
+                            stat: stat,
+                          ),
+                        ),
+                      );
                     },
                   ),
                 );

--- a/lib/screens/training_template_detail_screen.dart
+++ b/lib/screens/training_template_detail_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/training_session_service.dart';
+import '../services/mistake_review_pack_service.dart';
+import '../services/adaptive_training_service.dart';
+import 'training_session_screen.dart';
+
+class TrainingTemplateDetailScreen extends StatelessWidget {
+  final TrainingPackTemplate template;
+  final TrainingPackStat? stat;
+  const TrainingTemplateDetailScreen({super.key, required this.template, this.stat});
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = (stat?.accuracy ?? 0) * 100;
+    final ev = stat?.postEvPct ?? 0;
+    final icm = stat?.postIcmPct ?? 0;
+    final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
+    final focus = template.handTypeSummary();
+    final diff = template.difficultyLevel;
+    final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(template.id);
+    return Scaffold(
+      appBar: AppBar(title: Text(template.name)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (template.description.isNotEmpty)
+              Text(template.description, style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 8),
+            Row(children:[for(var i=0;i<rating;i++)const Icon(Icons.star,color:Colors.amber)],),
+            if (accuracy > 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text('Accuracy ${accuracy.toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white70)),
+              ),
+            const SizedBox(height: 8),
+            Text('Difficulty: $diff', style: const TextStyle(color: Colors.white)),
+            Text('EV ${ev.toStringAsFixed(1)}%  ICM ${icm.toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white)),
+            if (focus.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(focus, style: const TextStyle(color: Colors.white70)),
+              ),
+            if (hasMistakes)
+              const Padding(
+                padding: EdgeInsets.only(top: 8),
+                child: Text('Есть ошибки', style: TextStyle(color: Colors.orange)),
+              ),
+            const Spacer(),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      await context.read<TrainingSessionService>().startSession(template);
+                      if (context.mounted) {
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                        );
+                      }
+                    },
+                    child: const Text('Начать'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: hasMistakes
+                        ? () async {
+                            final review = await context.read<MistakeReviewPackService>().review(context, template.id);
+                            if (review != null && context.mounted) {
+                              await context.read<TrainingSessionService>().startSession(review);
+                              if (context.mounted) {
+                                await Navigator.push(
+                                  context,
+                                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                                );
+                              }
+                            }
+                          }
+                        : null,
+                    child: const Text('Ошибки'),
+                  ),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -22,6 +22,7 @@ class AdaptiveTrainingService extends ChangeNotifier {
 
   Future<void> refresh() async {
     final prefs = await SharedPreferences.getInstance();
+    final level = ((prefs.getInt('xp_total') ?? 0) ~/ 100) + 1;
     final entries = <MapEntry<TrainingPackTemplate, double>>[];
     final stats = <String, TrainingPackStat?>{};
     for (final t in templates.templates) {
@@ -33,6 +34,8 @@ class AdaptiveTrainingService extends ChangeNotifier {
       score += 1 - (stat?.postEvPct ?? 0) / 100;
       score += 1 - (stat?.postIcmPct ?? 0) / 100;
       if (mistakes.hasMistakes(t.id)) score += 1;
+      final diff = (t.difficultyLevel - level).abs();
+      score += diff * 0.3;
       entries.add(MapEntry(t, score));
     }
     entries.sort((a, b) => b.value.compareTo(a.value));


### PR DESCRIPTION
## Summary
- update scoring in `AdaptiveTrainingService` to account for user level
- enhance recommendation list with rating display and pack details
- show rating in home carousel
- add new `TrainingTemplateDetailScreen`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f066ebd18832a870cb6b4ede29672