### PR TITLE
Add evaluation settings screen

### DIFF
--- a/lib/screens/evaluation_settings_screen.dart
+++ b/lib/screens/evaluation_settings_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../services/offline_evaluator_service.dart';
+import '../services/evaluation_settings_service.dart';
+
+class EvaluationSettingsScreen extends StatefulWidget {
+  const EvaluationSettingsScreen({super.key});
+
+  @override
+  State<EvaluationSettingsScreen> createState() => _EvaluationSettingsScreenState();
+}
+
+class _EvaluationSettingsScreenState extends State<EvaluationSettingsScreen> {
+  late bool _offline;
+  late TextEditingController _endpoint;
+
+  @override
+  void initState() {
+    super.initState();
+    final s = EvaluationSettingsService.instance;
+    _offline = s.offline;
+    _endpoint = TextEditingController(text: s.remoteEndpoint);
+  }
+
+  Future<void> _setOffline(bool v) async {
+    setState(() => _offline = v);
+    await EvaluationSettingsService.instance.update(offline: v);
+    OfflineEvaluatorService.isOffline = v;
+  }
+
+  Future<void> _setEndpoint(String v) async {
+    await EvaluationSettingsService.instance.update(endpoint: v);
+  }
+
+  @override
+  void dispose() {
+    _endpoint.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Evaluation Settings'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SwitchListTile(
+            value: _offline,
+            title: const Text('Offline Mode'),
+            activeColor: Colors.orange,
+            onChanged: _setOffline,
+          ),
+          TextField(
+            controller: _endpoint,
+            decoration: const InputDecoration(labelText: 'EV API Endpoint'),
+            onChanged: _setEndpoint,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/auth_service.dart';
 import '../widgets/sync_status_widget.dart';
+import 'evaluation_settings_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -163,6 +164,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               title: const Text('Режим тренера (Coach Mode)'),
               onChanged: _toggleCoachMode,
               activeColor: Colors.orange,
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EvaluationSettingsScreen(),
+                  ),
+                );
+              },
+              child: const Text('Evaluation Settings'),
             ),
             Consumer<AuthService>(
               builder: (context, auth, child) {

--- a/lib/services/evaluation_settings_service.dart
+++ b/lib/services/evaluation_settings_service.dart
@@ -9,19 +9,22 @@ class EvaluationSettingsService {
   static const _thresholdKey = 'evaluation_ev_threshold';
   static const _icmKey = 'evaluation_use_icm';
   static const _endpointKey = 'evaluation_api_endpoint';
+  static const _offlineKey = 'evaluation_offline_mode';
 
   double evThreshold = -0.01;
   bool useIcm = false;
   String remoteEndpoint = '';
+  bool offline = false;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
     evThreshold = prefs.getDouble(_thresholdKey) ?? -0.01;
     useIcm = prefs.getBool(_icmKey) ?? false;
     remoteEndpoint = prefs.getString(_endpointKey) ?? '';
+    offline = prefs.getBool(_offlineKey) ?? false;
   }
 
-  Future<void> update({double? threshold, bool? icm, String? endpoint}) async {
+  Future<void> update({double? threshold, bool? icm, String? endpoint, bool? offline}) async {
     final prefs = await SharedPreferences.getInstance();
     if (threshold != null) {
       evThreshold = threshold;
@@ -34,6 +37,10 @@ class EvaluationSettingsService {
     if (endpoint != null) {
       remoteEndpoint = endpoint;
       await prefs.setString(_endpointKey, endpoint);
+    }
+    if (offline != null) {
+      this.offline = offline;
+      await prefs.setBool(_offlineKey, offline);
     }
   }
 }

--- a/lib/services/offline_evaluator_service.dart
+++ b/lib/services/offline_evaluator_service.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'push_fold_ev_service.dart';
 import 'remote_ev_service.dart';
+import 'evaluation_settings_service.dart';
 
 class OfflineEvaluatorService {
   OfflineEvaluatorService({
@@ -13,9 +14,9 @@ class OfflineEvaluatorService {
 
   final PushFoldEvService offline;
   final RemoteEvService remote;
-  static bool _offline = false;
-  static bool get isOffline => _offline;
-  static set isOffline(bool v) => _offline = v;
+  static bool get isOffline => EvaluationSettingsService.instance.offline;
+  static set isOffline(bool v) =>
+      EvaluationSettingsService.instance.update(offline: v);
   Box<dynamic>? _box;
 
   Future<void> _open() async {


### PR DESCRIPTION
## Summary
- add offline and endpoint prefs in `EvaluationSettingsService`
- sync `OfflineEvaluatorService` with evaluation prefs
- create `EvaluationSettingsScreen`
- link evaluation settings from the main settings page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f073d4b48832abbabed80025f0b58