### PR TITLE
Implement Firestore sync for hands and sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ while returning `null` allows the export to proceed.
 
 ## Future plans
 
-Cloud sync for saved hands and sessions will be added later.
+The app now syncs saved hands and session data with Firestore.
 
 ## Branch naming
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,7 +158,9 @@ Future<void> main() async {
                 ..load(),
         ),
         ChangeNotifierProvider(
-          create: (_) => SavedHandStorageService()..load(),
+          create: (context) =>
+              SavedHandStorageService(cloud: context.read<CloudSyncService>())
+                ..load(),
         ),
         ChangeNotifierProvider(
           create: (context) => SavedHandManagerService(
@@ -176,8 +178,14 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (_) => MistakeStreakService()..load(),
         ),
-        ChangeNotifierProvider(create: (_) => SessionNoteService()..load()),
-        ChangeNotifierProvider(create: (_) => SessionPinService()..load()),
+        ChangeNotifierProvider(
+            create: (context) =>
+                SessionNoteService(cloud: context.read<CloudSyncService>())
+                  ..load()),
+        ChangeNotifierProvider(
+            create: (context) =>
+                SessionPinService(cloud: context.read<CloudSyncService>())
+                  ..load()),
         ChangeNotifierProvider<TrainingPackStorageService>.value(
           value: packStorage,
         ),
@@ -302,6 +310,7 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) => SessionLogService(
             sessions: context.read<TrainingSessionService>(),
+            cloud: context.read<CloudSyncService>(),
           )..load(),
         ),
         Provider(create: (_) => EvaluationExecutorService()),


### PR DESCRIPTION
## Summary
- add sync collections and Firestore upload/download helpers
- sync saved hands to cloud
- sync session notes, logs and pins
- wire cloud sync services in main
- document cloud sync capability

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f073b72b4832a93d4a80d0415b1e7