### PR TITLE
Integrate EV/ICM analytics into hands

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -189,6 +189,7 @@ Future<void> main() async {
           create: (context) => AdaptiveTrainingService(
             templates: context.read<TemplateStorageService>(),
             mistakes: context.read<MistakeReviewPackService>(),
+            xp: context.read<XPTrackerService>(),
           ),
         ),
         ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(

--- a/lib/models/hand_analysis_record.dart
+++ b/lib/models/hand_analysis_record.dart
@@ -9,6 +9,7 @@ class HandAnalysisRecord {
   final double ev;
   final double icm;
   final String action;
+  final String hint;
   final DateTime date;
 
   HandAnalysisRecord({
@@ -20,6 +21,7 @@ class HandAnalysisRecord {
     required this.ev,
     required this.icm,
     required this.action,
+    required this.hint,
     DateTime? date,
   }) : date = date ?? DateTime.now();
 
@@ -37,6 +39,7 @@ class HandAnalysisRecord {
         'ev': ev,
         'icm': icm,
         'action': action,
+        'hint': hint,
         'date': date.toIso8601String(),
       };
 
@@ -49,6 +52,7 @@ class HandAnalysisRecord {
         ev: (j['ev'] as num?)?.toDouble() ?? 0,
         icm: (j['icm'] as num?)?.toDouble() ?? 0,
         action: j['action'] as String? ?? '',
+        hint: j['hint'] as String? ?? '',
         date: DateTime.tryParse(j['date'] as String? ?? '') ?? DateTime.now(),
       );
 }

--- a/lib/screens/hand_analysis_history_screen.dart
+++ b/lib/screens/hand_analysis_history_screen.dart
@@ -128,7 +128,7 @@ class _HandAnalysisHistoryScreenState extends State<HandAnalysisHistoryScreen> {
                 style: const TextStyle(color: Colors.white),
               ),
               subtitle: Text(
-                '${r.action} • $label',
+                '${r.action} • $label\n${r.hint}',
                 style: const TextStyle(color: Colors.white70),
               ),
               onTap: () {

--- a/lib/screens/quick_hand_analysis_screen.dart
+++ b/lib/screens/quick_hand_analysis_screen.dart
@@ -7,6 +7,7 @@ import '../services/push_fold_ev_service.dart';
 import '../services/hand_analysis_history_service.dart';
 import '../models/hand_analysis_record.dart';
 import '../services/hand_analyzer_service.dart';
+import '../services/xp_tracker_service.dart';
 import '../theme/app_colors.dart';
 import '../helpers/hand_utils.dart';
 
@@ -27,6 +28,7 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
   double? _ev;
   double? _icm;
   String? _action;
+  String? _hint;
   Timer? _debounce;
 
   @override
@@ -41,6 +43,7 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
       _ev = r.ev;
       _icm = r.icm;
       _action = r.action;
+      _hint = r.hint;
     }
     WidgetsBinding.instance.addPostFrameCallback((_) => _analyze());
   }
@@ -54,17 +57,20 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
 
   Future<void> _analyze() async {
     final stack = int.tryParse(_stackController.text) ?? 10;
+    final level = context.read<XPTrackerService>().level;
     final record = context.read<HandAnalyzerService>().analyzePush(
       cards: _cards,
       stack: stack,
       playerCount: _playerCount,
       heroIndex: _heroIndex,
+      level: level,
     );
     if (record == null) return;
     setState(() {
       _ev = record.ev;
       _icm = record.icm;
       _action = record.action;
+      _hint = record.hint;
     });
   }
 
@@ -75,11 +81,13 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
 
   Future<void> _save() async {
     final stack = int.tryParse(_stackController.text) ?? 10;
+    final level = context.read<XPTrackerService>().level;
     final record = context.read<HandAnalyzerService>().analyzePush(
       cards: _cards,
       stack: stack,
       playerCount: _playerCount,
       heroIndex: _heroIndex,
+      level: level,
     );
     if (record == null) return;
     context.read<HandAnalysisHistoryService>().add(record);
@@ -87,6 +95,7 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
       _ev = record.ev;
       _icm = record.icm;
       _action = record.action;
+      _hint = record.hint;
     });
   }
 
@@ -161,6 +170,7 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
                   Text('EV: ${_ev!.toStringAsFixed(2)} BB', style: const TextStyle(color: Colors.white)),
                   Text('ICM: ${_icm!.toStringAsFixed(2)}', style: const TextStyle(color: Colors.white)),
                   Text('Решение: $_action', style: const TextStyle(color: Colors.white)),
+                  if (_hint != null) Text(_hint!, style: const TextStyle(color: Colors.white70)),
                 ],
               ),
           ],

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -322,6 +322,27 @@ class _PackCard extends StatelessWidget {
             ),
             label: Text(label),
           ),
+          if (hasMistakes)
+            OutlinedButton(
+              onPressed: () async {
+                final review = await context
+                    .read<MistakeReviewPackService>()
+                    .review(context, template.id);
+                if (review != null && context.mounted) {
+                  await context
+                      .read<TrainingSessionService>()
+                      .startSession(review);
+                  if (context.mounted) {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const TrainingSessionScreen()),
+                    );
+                  }
+                }
+              },
+              child: const Text('Ошибки', style: TextStyle(fontSize: 12)),
+            ),
         ],
       ),
     );

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -4,14 +4,21 @@ import '../models/v2/training_pack_template.dart';
 import 'template_storage_service.dart';
 import 'training_pack_stats_service.dart';
 import 'mistake_review_pack_service.dart';
+import 'xp_tracker_service.dart';
 
 class AdaptiveTrainingService extends ChangeNotifier {
   final TemplateStorageService templates;
   final MistakeReviewPackService mistakes;
-  AdaptiveTrainingService({required this.templates, required this.mistakes}) {
+  final XPTrackerService xp;
+  AdaptiveTrainingService({
+    required this.templates,
+    required this.mistakes,
+    required this.xp,
+  }) {
     refresh();
     templates.addListener(refresh);
     mistakes.addListener(refresh);
+    xp.addListener(refresh);
   }
 
   List<TrainingPackTemplate> _recommended = [];
@@ -22,7 +29,7 @@ class AdaptiveTrainingService extends ChangeNotifier {
 
   Future<void> refresh() async {
     final prefs = await SharedPreferences.getInstance();
-    final level = ((prefs.getInt('xp_total') ?? 0) ~/ 100) + 1;
+    final level = xp.level;
     final entries = <MapEntry<TrainingPackTemplate, double>>[];
     final stats = <String, TrainingPackStat?>{};
     for (final t in templates.templates) {

--- a/lib/services/hand_analyzer_service.dart
+++ b/lib/services/hand_analyzer_service.dart
@@ -11,6 +11,7 @@ class HandAnalyzerService {
     required int stack,
     required int playerCount,
     required int heroIndex,
+    required int level,
     int anteBb = 0,
   }) {
     if (cards.length < 2) return null;
@@ -19,7 +20,10 @@ class HandAnalyzerService {
     final ev = computePushEV(heroBbStack: stack, bbCount: playerCount - 1, heroHand: code, anteBb: anteBb);
     final stacks = List<int>.filled(playerCount, stack);
     final icm = computeIcmPushEV(chipStacksBb: stacks, heroIndex: heroIndex, heroHand: code, chipPushEv: ev);
-    final action = ev >= 0 ? 'push' : 'fold';
+    final threshold = -0.5 + level * 0.1;
+    final action = ev >= threshold ? 'push' : 'fold';
+    final hint =
+        'EV ${ev.toStringAsFixed(2)} BB • ICM ${icm.toStringAsFixed(2)} • Threshold ${threshold.toStringAsFixed(2)}';
     return HandAnalysisRecord(
       card1: '${cards[0].rank}${cards[0].suit}',
       card2: '${cards[1].rank}${cards[1].suit}',
@@ -29,6 +33,7 @@ class HandAnalyzerService {
       ev: ev,
       icm: icm,
       action: action,
+      hint: hint,
     );
   }
 }


### PR DESCRIPTION
## Summary
- extend hand analysis records with hints
- compute level-aware EV/ICM hints
- refresh adaptive training when XP changes
- show hints in quick analysis and history
- add mistake review shortcut on training cards

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f08b12950832a8d779767a1391165