### PR TITLE
Improve adaptive training with mistake analysis

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -123,10 +123,17 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
   Future<void> _load() async {
     final service = context.read<AdaptiveTrainingService>();
     await service.refresh();
-    final list = service.recommended;
+    final list = service.recommended.toList();
+    final review = await MistakeReviewPackService.latestTemplate(context);
+    if (review != null) list.insert(0, review);
+    final stats = <String, TrainingPackStat?>{};
+    for (final t in list) {
+      stats[t.id] = service.statFor(t.id) ??
+          await TrainingPackStatsService.getStats(t.id);
+    }
     _stats
       ..clear()
-      ..addEntries(list.map((e) => MapEntry(e.id, service.statFor(e.id))));
+      ..addAll(stats);
     setState(() {
       _tpls = list;
       _loading = false;

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -1,79 +1,101 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/adaptive_training_service.dart';
-import '../services/training_session_service.dart';
 import '../services/mistake_review_pack_service.dart';
+import '../services/training_pack_stats_service.dart';
 import '../models/v2/training_pack_template.dart';
-import 'training_session_screen.dart';
 import 'training_template_detail_screen.dart';
 
-class TrainingRecommendationScreen extends StatelessWidget {
+class TrainingRecommendationScreen extends StatefulWidget {
   const TrainingRecommendationScreen({super.key});
 
   @override
+  State<TrainingRecommendationScreen> createState() => _TrainingRecommendationScreenState();
+}
+
+class _TrainingRecommendationScreenState extends State<TrainingRecommendationScreen> {
+  List<TrainingPackTemplate> _tpls = [];
+  final Map<String, TrainingPackStat?> _stats = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final service = context.read<AdaptiveTrainingService>();
+    await service.refresh();
+    final list = service.recommended.toList();
+    final review = await MistakeReviewPackService.latestTemplate(context);
+    if (review != null) list.insert(0, review);
+    final stats = <String, TrainingPackStat?>{};
+    for (final t in list) {
+      stats[t.id] = service.statFor(t.id) ?? await TrainingPackStatsService.getStats(t.id);
+    }
+    setState(() {
+      _tpls = list;
+      _stats
+        ..clear()
+        ..addAll(stats);
+      _loading = false;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final service = context.watch<AdaptiveTrainingService>();
-    final list = service.recommended;
     return Scaffold(
       appBar: AppBar(title: const Text('Рекомендации')),
-      body: list.isEmpty
-          ? const Center(child: Text('Нет рекомендаций'))
-          : ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: list.length,
-              itemBuilder: (context, index) {
-                final tpl = list[index];
-                final stat = service.statFor(tpl.id);
-                final acc = (stat?.accuracy ?? 0) * 100;
-                final ev = stat?.postEvPct ?? 0;
-                final icm = stat?.postIcmPct ?? 0;
-                final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
-                final focus = tpl.handTypeSummary();
-                final hasMistakes = context
-                    .read<MistakeReviewPackService>()
-                    .hasMistakes(tpl.id);
-                return Card(
-                  color: Colors.grey[850],
-                  margin: const EdgeInsets.only(bottom: 12),
-                  child: ListTile(
-                    title: Text(tpl.name,
-                        style: const TextStyle(color: Colors.white)),
-                    subtitle: Text(
-                      '${acc.toStringAsFixed(1)}% • EV ${ev.toStringAsFixed(1)}% • ICM ${icm.toStringAsFixed(1)}%' +
-                          (hasMistakes ? ' • ошибки' : '') +
-                          (focus.isNotEmpty ? ' • $focus' : ''),
-                      style: const TextStyle(color: Colors.white70),
-                    ),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Row(
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _tpls.isEmpty
+              ? const Center(child: Text('Нет рекомендаций'))
+              : ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: _tpls.length,
+                  itemBuilder: (context, index) {
+                    final tpl = _tpls[index];
+                    final stat = _stats[tpl.id];
+                    final acc = (stat?.accuracy ?? 0) * 100;
+                    final ev = stat?.postEvPct ?? 0;
+                    final icm = stat?.postIcmPct ?? 0;
+                    final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
+                    final focus = tpl.handTypeSummary();
+                    final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(tpl.id);
+                    return Card(
+                      color: Colors.grey[850],
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: ListTile(
+                        title: Text(tpl.name, style: const TextStyle(color: Colors.white)),
+                        subtitle: Text(
+                          '${acc.toStringAsFixed(1)}% • EV ${ev.toStringAsFixed(1)}% • ICM ${icm.toStringAsFixed(1)}%'
+                          '${hasMistakes ? ' • ошибки' : ''}${focus.isNotEmpty ? ' • $focus' : ''}',
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
                           children: [
-                            for (var i = 0; i < rating; i++)
-                              const Icon(Icons.star,
-                                  color: Colors.amber, size: 16)
+                            Row(children: [for (var i = 0; i < rating; i++) const Icon(Icons.star, color: Colors.amber, size: 16)]),
+                            const SizedBox(width: 8),
+                            const Icon(Icons.chevron_right, color: Colors.greenAccent),
                           ],
                         ),
-                        const SizedBox(width: 8),
-                        const Icon(Icons.chevron_right,
-                            color: Colors.greenAccent),
-                      ],
-                    ),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => TrainingTemplateDetailScreen(
-                            template: tpl,
-                            stat: stat,
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => TrainingTemplateDetailScreen(
+                                template: tpl,
+                                stat: stat,
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                ),
     );
   }
 }

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -37,10 +37,11 @@ class AdaptiveTrainingService extends ChangeNotifier {
       if (prefs.getBool('completed_tpl_${t.id}') ?? false) continue;
       final stat = await TrainingPackStatsService.getStats(t.id);
       stats[t.id] = stat;
+      final miss = mistakes.mistakeCount(t.id);
       var score = 1 - (stat?.accuracy ?? 0);
       score += 1 - (stat?.postEvPct ?? 0) / 100;
       score += 1 - (stat?.postIcmPct ?? 0) / 100;
-      if (mistakes.hasMistakes(t.id)) score += 1;
+      if (miss > 0) score += 1 + miss * .2;
       final diff = (t.difficultyLevel - level).abs();
       score += diff * 0.3;
       entries.add(MapEntry(t, score));

--- a/lib/services/mistake_review_pack_service.dart
+++ b/lib/services/mistake_review_pack_service.dart
@@ -185,6 +185,8 @@ class MistakeReviewPackService extends ChangeNotifier {
   bool hasMistakes(String templateId) =>
       _packSpots[templateId]?.isNotEmpty ?? false;
 
+  int mistakeCount(String templateId) => _packSpots[templateId]?.length ?? 0;
+
   Future<TrainingPackTemplate?> review(
       BuildContext context, String templateId) async {
     if (_busy) return null;


### PR DESCRIPTION
## Summary
- update adaptive recommendations using mistake counts
- show dynamic mistake review packs in home and recommendation screens
- expose mistakeCount in MistakeReviewPackService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0a534c30832aaae2b1a439e3e45c