### PR TITLE
Add EV and ICM chart to session analysis

### DIFF
--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
 
 import '../models/saved_hand.dart';
 import '../models/action_entry.dart';
@@ -67,6 +68,108 @@ class SessionAnalysisScreen extends StatelessWidget {
     return icm;
   }
 
+  Widget _buildChart() {
+    final data = [...hands]..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+    if (data.length < 2) return const SizedBox(height: 200);
+    final evs = <double>[];
+    final icms = <double>[];
+    for (final h in data) {
+      final ev = _ev(h) ?? 0;
+      evs.add(ev);
+      icms.add(_icm(h, ev) ?? 0);
+    }
+    final spotsEv = <FlSpot>[];
+    final spotsIcm = <FlSpot>[];
+    double maxAbs = 0;
+    for (var i = 0; i < evs.length; i++) {
+      final ev = evs[i];
+      final icm = icms[i];
+      if (ev.abs() > maxAbs) maxAbs = ev.abs();
+      if (icm.abs() > maxAbs) maxAbs = icm.abs();
+      spotsEv.add(FlSpot(i.toDouble(), ev));
+      spotsIcm.add(FlSpot(i.toDouble(), icm));
+    }
+    if (maxAbs < 0.1) maxAbs = 0.1;
+    final interval = (maxAbs / 5).ceilToDouble();
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: -maxAbs,
+          maxY: maxAbs,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: interval,
+            getDrawingHorizontalLine: (value) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: interval,
+                reservedSize: 40,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toStringAsFixed(1),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  return Text(
+                    '${i + 1}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spotsEv,
+              color: AppColors.evPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+            LineChartBarData(
+              spots: spotsIcm,
+              color: AppColors.icmPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final list = [...hands]..sort((a, b) => b.savedAt.compareTo(a.savedAt));
@@ -112,6 +215,8 @@ class SessionAnalysisScreen extends StatelessWidget {
               ],
             ),
           ),
+          const SizedBox(height: 16),
+          _buildChart(),
           const SizedBox(height: 16),
           for (final h in list) ...[
             Container(


### PR DESCRIPTION
## Summary
- compute EV and ICM values for each hand
- show line chart for EV and ICM

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c18d3a0832a9e41a180733470f5