### PR TITLE
Update GGPoker color palette

### DIFF
--- a/lib/models/mistake_severity.dart
+++ b/lib/models/mistake_severity.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 enum MistakeSeverity { high, medium, low }
 
@@ -8,7 +9,7 @@ extension MistakeSeverityColor on MistakeSeverity {
       case MistakeSeverity.high:
         return Colors.redAccent;
       case MistakeSeverity.medium:
-        return Colors.orangeAccent;
+        return AppColors.accent;
       case MistakeSeverity.low:
       default:
         return Colors.greenAccent;

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -124,7 +124,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
             LineChartBarData(
               spots: spots,
               isCurved: true,
-              color: Colors.orangeAccent,
+              color: AppColors.accent,
               barWidth: 2,
               dotData: FlDotData(show: false),
             ),

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -30,7 +30,7 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
 
   Color _color(int count, int target) {
     if (count >= target) return Colors.greenAccent;
-    if (count > 0) return Colors.orangeAccent;
+    if (count > 0) return AppColors.accent;
     return Colors.white24;
   }
 
@@ -224,7 +224,7 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                         const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
                     decoration: BoxDecoration(
                       gradient: const LinearGradient(
-                        colors: [Colors.orangeAccent, Colors.redAccent],
+                        colors: [AppColors.accent, Colors.redAccent],
                       ),
                       borderRadius: BorderRadius.circular(8),
                     ),

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -98,7 +98,7 @@ class _InsightsScreenState extends State<InsightsScreen> {
             LineChartBarData(
               spots: spots,
               isCurved: false,
-              color: Colors.orangeAccent,
+              color: AppColors.accent,
               barWidth: 2,
               dotData: FlDotData(show: false),
             )

--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -3250,7 +3250,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                               message: 'New',
                               child: InkWell(
                                 onTap: _selectAllNew,
-                                child: const Icon(Icons.fiber_new, color: Colors.orangeAccent),
+                                child: const Icon(Icons.fiber_new, color: AppColors.accent),
                               ),
                             ),
                           PopupMenuButton<String>(
@@ -3362,7 +3362,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (hand.isDuplicate)
-                            const Icon(Icons.warning, color: Colors.orangeAccent),
+                            const Icon(Icons.warning, color: AppColors.accent),
                           IconButton(
                             icon: const Text('✏️'),
                             onPressed: () => _editComment(hand),

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1818,7 +1818,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         overlay,
         payouts,
         0,
-        Colors.orangeAccent,
+        AppColors.accent,
         highlight: true,
         fadeStart: 0.5,
       );
@@ -1845,7 +1845,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       payouts[_winnerIndex!] = _potSync.pots[currentStreet];
     }
     if (payouts.isNotEmpty) {
-      _distributeChips(payouts, color: Colors.orangeAccent, fadeStart: 0.5);
+      _distributeChips(payouts, color: AppColors.accent, fadeStart: 0.5);
     }
     _demoAnimations.showWinnerGlow(
       context: context,
@@ -2057,7 +2057,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   /// Animate chips from the pot to one or more players.
   void _distributeChips(
     Map<int, int> targets, {
-    Color color = Colors.orangeAccent,
+    Color color = AppColors.accent,
     double scale = 1.0,
     double fadeStart = 0.3,
   }) {
@@ -2498,7 +2498,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         overlay,
         wins,
         delay,
-        Colors.orangeAccent,
+        AppColors.accent,
         highlight: true,
         fadeStart: 0.6,
       );
@@ -2508,7 +2508,7 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         overlay,
         {_winnerIndex!: _potSync.pots[currentStreet]},
         delay,
-        Colors.orangeAccent,
+        AppColors.accent,
         highlight: true,
         fadeStart: 0.6,
       );
@@ -5944,10 +5944,10 @@ class _PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     pow(centerY - (centerY + dy + bias + 12), 2)),
                 height: 1,
                 decoration: BoxDecoration(
-                  color: Colors.orangeAccent.withOpacity(0.9),
+                  color: AppColors.accent.withOpacity(0.9),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.orangeAccent.withOpacity(0.6),
+                      color: AppColors.accent.withOpacity(0.6),
                       blurRadius: 4,
                     )
                   ],
@@ -8305,7 +8305,7 @@ class _TotalPotTracker extends StatelessWidget {
       child: Text(
         'Total Pot: ${ActionFormattingHelper.formatAmount(totalPot)}',
         style: const TextStyle(
-          color: Colors.orangeAccent,
+          color: AppColors.accent,
           fontWeight: FontWeight.bold,
           fontSize: 16,
         ),

--- a/lib/screens/streak_calendar_screen.dart
+++ b/lib/screens/streak_calendar_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
 import '../widgets/sync_status_widget.dart';
+import '../theme/app_colors.dart';
 
 class StreakCalendarScreen extends StatelessWidget {
   const StreakCalendarScreen({super.key});
@@ -77,7 +78,7 @@ class StreakCalendarScreen extends StatelessWidget {
           final borderColor = currentStreak.contains(key)
               ? Colors.greenAccent
               : longestStreak.contains(key)
-                  ? Colors.orangeAccent
+                  ? AppColors.accent
                   : Colors.transparent;
           return Container(
             alignment: Alignment.center,

--- a/lib/screens/streak_history_screen.dart
+++ b/lib/screens/streak_history_screen.dart
@@ -123,7 +123,7 @@ class StreakHistoryScreen extends StatelessWidget {
               extraLinesData: ExtraLinesData(horizontalLines: [
                 HorizontalLine(
                   y: target.toDouble(),
-                  color: Colors.orangeAccent,
+                  color: AppColors.accent,
                   strokeWidth: 2,
                   dashArray: [4, 4],
                 ),

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -11,6 +11,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../asset_manifest.dart';
+import '../theme/app_colors.dart';
 
 import '../helpers/color_utils.dart';
 import '../services/template_storage_service.dart';
@@ -1079,7 +1080,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 child: Card(
                   child: ListTile(
                     leading:
-                        const Icon(Icons.error, color: Colors.orangeAccent),
+                        const Icon(Icons.error, color: AppColors.accent),
                     title: Text(l.reviewMistakes),
                     onTap: () async {
                       final tpl = await service.buildPack(context);

--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -85,7 +85,7 @@ class _PackDataSource extends DataTableSource {
     final progressColor = progress < 0.5
         ? Colors.redAccent
         : progress < 0.8
-            ? Colors.orangeAccent
+            ? AppColors.accent
             : Colors.greenAccent;
     final selectedRow = selected.contains(s.pack);
     return DataRow(

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -114,7 +114,7 @@ class _TrainingProgressAnalyticsScreenState extends State<TrainingProgressAnalyt
                 final color = progress < 0.5
                     ? Colors.redAccent
                     : progress < 0.8
-                        ? Colors.orangeAccent
+                        ? AppColors.accent
                         : Colors.greenAccent;
                 return Container(
                   padding: const EdgeInsets.all(12),

--- a/lib/screens/training_progress_overview_screen.dart
+++ b/lib/screens/training_progress_overview_screen.dart
@@ -33,7 +33,7 @@ class TrainingProgressOverviewScreen extends StatelessWidget {
           final color = progress < 0.5
               ? Colors.redAccent
               : progress < 0.8
-                  ? Colors.orangeAccent
+                  ? AppColors.accent
                   : Colors.greenAccent;
           return Container(
             padding: const EdgeInsets.all(12),

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -5126,7 +5126,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                         child: Container(
                           padding: const EdgeInsets.all(12),
                           decoration: BoxDecoration(
-                            color: Colors.orangeAccent.withOpacity(.2),
+                            color: AppColors.accent.withOpacity(.2),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: const Text(
@@ -5217,7 +5217,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                 child: Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Colors.orangeAccent.withOpacity(.2),
+                    color: AppColors.accent.withOpacity(.2),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: const Text(

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -8,6 +8,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:csv/csv.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
+import '../../theme/app_colors.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../services/pack_import_service.dart';
 import '../../models/v2/training_pack_template.dart';
@@ -512,7 +513,7 @@ class _TrainingPackTemplateListScreenState
                   strokeWidth: 8,
                   backgroundColor: Colors.white24,
                   valueColor:
-                      const AlwaysStoppedAnimation(Colors.orangeAccent),
+                      const AlwaysStoppedAnimation(AppColors.accent),
                 ),
                 Text('${(value * 100).round()}%',
                     style: const TextStyle(
@@ -802,7 +803,7 @@ class _TrainingPackTemplateListScreenState
                   strokeWidth: 3,
                   backgroundColor: Colors.white24,
                   valueColor:
-                      const AlwaysStoppedAnimation(Colors.orangeAccent),
+                      const AlwaysStoppedAnimation(AppColors.accent),
                 ),
               ),
             ),
@@ -2824,7 +2825,7 @@ class _TrainingPackTemplateListScreenState
                     ),
                     child: Row(
                       children: [
-                        const Icon(Icons.insights, color: Colors.orangeAccent),
+                        const Icon(Icons.insights, color: AppColors.accent),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Column(

--- a/lib/services/pot_animation_service.dart
+++ b/lib/services/pot_animation_service.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../theme/app_colors.dart';
 
 import '../helpers/table_geometry_helper.dart';
 import '../models/player_model.dart';
@@ -87,7 +88,7 @@ class PotAnimationService {
         end: end,
         amount: amount,
         playerIndex: player,
-        color: Colors.orangeAccent,
+        color: AppColors.accent,
         scale: scale,
       ));
       registerResetAnimation();
@@ -171,7 +172,7 @@ class PotAnimationService {
             end: end,
             amount: amount,
             playerIndex: player,
-            color: Colors.orangeAccent,
+            color: AppColors.accent,
             scale: scale,
           ));
           registerResetAnimation();

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const background = Color(0xFF1B1C1E);
-  static const cardBackground = Color(0xFF2A2B2E);
-  static const accent = Colors.orangeAccent;
+  static const background = Color(0xFF161616);
+  static const cardBackground = Color(0xFF24242A);
+  static const accent = Color(0xFFE8C35E);
   static final errorBg = Colors.red.withOpacity(.2);
-  static const evPre = Colors.orangeAccent;
-  static const evPost = Colors.deepOrangeAccent;
-  static const icmPre = Colors.lightBlueAccent;
-  static const icmPost = Colors.blueAccent;
+  static const evPre = Color(0xFF009733);
+  static const evPost = Color(0xFFC9A559);
+  static const icmPre = Color(0xFF404B1E);
+  static const icmPost = Color(0xFF675729);
 }

--- a/lib/widgets/achievement_unlocked_overlay.dart
+++ b/lib/widgets/achievement_unlocked_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 class AchievementUnlockedOverlay extends StatefulWidget {
   final IconData icon;
@@ -71,7 +72,7 @@ class _AchievementUnlockedOverlayState extends State<AchievementUnlockedOverlay>
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(widget.icon, color: Colors.orangeAccent),
+                    Icon(widget.icon, color: AppColors.accent),
                     const SizedBox(width: 8),
                     Column(
                       mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/badge_icon.dart
+++ b/lib/widgets/badge_icon.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 class BadgeIcon extends StatelessWidget {
   final IconData icon;
@@ -10,7 +11,7 @@ class BadgeIcon extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(boxShadow: [
         BoxShadow(
-          color: Colors.orangeAccent.withOpacity(0.6),
+          color: AppColors.accent.withOpacity(0.6),
           blurRadius: 12,
           spreadRadius: 2,
         )

--- a/lib/widgets/central_pot_stack.dart
+++ b/lib/widgets/central_pot_stack.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_widget.dart';
 
 /// Animated chip stack visualization of the central pot.
@@ -28,7 +29,7 @@ class CentralPotStack extends StatelessWidget {
         key: ValueKey(amount),
         amount: amount,
         scale: scale,
-        color: Colors.orangeAccent,
+        color: AppColors.accent,
       ),
     );
   }

--- a/lib/widgets/central_pot_widget.dart
+++ b/lib/widgets/central_pot_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_trail.dart';
 
 /// Pot display widget positioned in the middle of the table.
@@ -39,13 +40,13 @@ class CentralPotWidget extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (showChip) ...[
-              MiniChip(color: Colors.orangeAccent, size: 14 * scale),
+              MiniChip(color: AppColors.accent, size: 14 * scale),
               SizedBox(width: 6 * scale),
             ],
             Text(
               text,
               style: TextStyle(
-                color: Colors.orangeAccent,
+                color: AppColors.accent,
                 fontWeight: FontWeight.bold,
                 fontSize: 16 * scale,
               ),

--- a/lib/widgets/central_spr_widget.dart
+++ b/lib/widgets/central_spr_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 /// Displays the Stack-to-Pot Ratio (SPR) in the center of the table.
 class CentralSprWidget extends StatelessWidget {
@@ -35,7 +36,7 @@ class CentralSprWidget extends StatelessWidget {
         child: Text(
           text,
           style: TextStyle(
-            color: Colors.orangeAccent,
+            color: AppColors.accent,
             fontWeight: FontWeight.bold,
             fontSize: 14 * scale,
           ),

--- a/lib/widgets/chip_reward_animation.dart
+++ b/lib/widgets/chip_reward_animation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animation of the pot chips rewarding the winning player.
@@ -41,7 +42,7 @@ class ChipRewardAnimation extends StatelessWidget {
       start: start,
       end: end,
       amount: amount,
-      color: Colors.orangeAccent,
+      color: AppColors.accent,
       scale: scale,
       control: control,
       fadeStart: fadeStart,

--- a/lib/widgets/common/accuracy_trend_chart.dart
+++ b/lib/widgets/common/accuracy_trend_chart.dart
@@ -39,7 +39,7 @@ class AccuracyTrendChart extends StatelessWidget {
     final line = LineChartBarData(
       spots: spots,
       isCurved: true,
-      color: Colors.orangeAccent,
+      color: AppColors.accent,
       barWidth: 2,
       dotData: FlDotData(show: false),
     );

--- a/lib/widgets/common/session_volume_accuracy_chart.dart
+++ b/lib/widgets/common/session_volume_accuracy_chart.dart
@@ -47,7 +47,7 @@ class SessionVolumeAccuracyChart extends StatelessWidget {
     final accuracyLine = LineChartBarData(
       spots: accuracySpots,
       isCurved: true,
-      color: Colors.orangeAccent,
+      color: AppColors.accent,
       barWidth: 2,
       dotData: FlDotData(show: false),
     );

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -1975,7 +1975,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
             constraints: const BoxConstraints(),
             icon: Icon(
               i <= spot.rating ? Icons.star : Icons.star_border,
-              color: highlight ? Colors.orangeAccent : Colors.amber,
+              color: highlight ? AppColors.accent : Colors.amber,
               size: 20,
             ),
             onPressed: () => _updateRating(spot, i),

--- a/lib/widgets/hero_range_grid_widget.dart
+++ b/lib/widgets/hero_range_grid_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 /// Displays the hero's strategy range in a 13x13 hand grid.
 class HeroRangeGridWidget extends StatelessWidget {
@@ -33,7 +34,7 @@ class HeroRangeGridWidget extends StatelessWidget {
   Color _cellColor(double freq) {
     final clamped = freq.clamp(0.0, 1.0);
     if (clamped >= 0.5) {
-      return Colors.orangeAccent;
+      return AppColors.accent;
     }
     if (clamped >= 0.2) {
       return Colors.red.shade900;

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../theme/app_colors.dart';
 import 'package:intl/intl.dart';
 import '../models/card_model.dart';
 import 'action_timer_ring.dart';
@@ -100,7 +101,7 @@ class PlayerInfoWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     const stackStyle = TextStyle(color: Colors.white70, fontSize: 12);
     final borderColor = isActive
-        ? Colors.orangeAccent
+        ? AppColors.accent
         : isHero
             ? Colors.purpleAccent
             : null;
@@ -306,13 +307,13 @@ class PlayerInfoWidget extends StatelessWidget {
                   Icon(
                     Icons.circle,
                     size: 12,
-                    color: Colors.orangeAccent.withOpacity(0.8),
+                    color: AppColors.accent.withOpacity(0.8),
                   ),
                   const SizedBox(width: 2),
                   Text(
                     '$streetInvestment',
                     style: TextStyle(
-                      color: Colors.orangeAccent.withOpacity(0.8),
+                      color: AppColors.accent.withOpacity(0.8),
                       fontSize: 12,
                     ),
                   ),

--- a/lib/widgets/player_stack_chips.dart
+++ b/lib/widgets/player_stack_chips.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 /// Displays a small pile of chips representing the player's remaining stack.
 class PlayerStackChips extends StatelessWidget {
@@ -20,7 +21,7 @@ class PlayerStackChips extends StatelessWidget {
 
   Color _colorForStack() {
     if (stack >= 50) return Colors.redAccent;
-    if (stack >= 10) return Colors.orangeAccent;
+    if (stack >= 10) return AppColors.accent;
     return Colors.blueAccent;
   }
 

--- a/lib/widgets/player_stack_value.dart
+++ b/lib/widgets/player_stack_value.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 /// Displays the current remaining stack with a chip icon.
 class PlayerStackValue extends StatefulWidget {
@@ -84,7 +85,7 @@ class _PlayerStackValueState extends State<PlayerStackValue>
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.casino, size: iconSize, color: Colors.orangeAccent),
+              Icon(Icons.casino, size: iconSize, color: AppColors.accent),
               SizedBox(width: 4 * widget.scale),
               Text(
                 _formatStack(widget.stack),

--- a/lib/widgets/player_zone_widget.dart
+++ b/lib/widgets/player_zone_widget.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import '../theme/app_colors.dart';
 import '../helpers/table_geometry_helper.dart';
 import '../models/card_model.dart';
 import '../models/player_model.dart';
@@ -1700,11 +1701,11 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                       padding: EdgeInsets.symmetric(
                           horizontal: 4 * widget.scale, vertical: 2 * widget.scale),
                       decoration: BoxDecoration(
-                        color: Colors.orangeAccent,
+                        color: AppColors.accent,
                         borderRadius: BorderRadius.circular(6 * widget.scale),
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.orangeAccent.withOpacity(0.6),
+                            color: AppColors.accent.withOpacity(0.6),
                             blurRadius: 4 * widget.scale,
                           ),
                         ],
@@ -2122,7 +2123,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                             vertical: 2 * widget.scale,
                           ),
                           decoration: BoxDecoration(
-                            color: Colors.orangeAccent,
+                            color: AppColors.accent,
                             borderRadius:
                                 BorderRadius.circular(8 * widget.scale),
                             boxShadow: const [
@@ -2156,7 +2157,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                           vertical: 2 * widget.scale,
                         ),
                         decoration: BoxDecoration(
-                          color: Colors.orangeAccent,
+                          color: AppColors.accent,
                           borderRadius: BorderRadius.circular(8 * widget.scale),
                           boxShadow: const [
                             BoxShadow(
@@ -2334,11 +2335,11 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                   padding: EdgeInsets.symmetric(
                       horizontal: 6 * widget.scale, vertical: 2 * widget.scale),
                   decoration: BoxDecoration(
-                    color: Colors.orangeAccent,
+                    color: AppColors.accent,
                     borderRadius: BorderRadius.circular(8 * widget.scale),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.orangeAccent.withOpacity(0.6),
+                        color: AppColors.accent.withOpacity(0.6),
                         blurRadius: 6 * widget.scale,
                       ),
                     ],
@@ -2453,10 +2454,10 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
       result = Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(14 * widget.scale),
-          border: Border.all(color: Colors.orangeAccent, width: 2 * widget.scale),
+          border: Border.all(color: AppColors.accent, width: 2 * widget.scale),
           boxShadow: [
             BoxShadow(
-              color: Colors.orangeAccent.withOpacity(0.7),
+              color: AppColors.accent.withOpacity(0.7),
               blurRadius: 12 * widget.scale,
               spreadRadius: 2 * widget.scale,
             ),
@@ -3007,7 +3008,7 @@ class _FoldChipOverlay extends StatelessWidget {
                       height: 24,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.orangeAccent,
+                        color: AppColors.accent,
                         boxShadow: [
                           BoxShadow(
                             color: Colors.black.withOpacity(0.5),
@@ -3596,7 +3597,7 @@ class _ChipWinOverlay extends StatelessWidget {
                       height: 24,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.orangeAccent,
+                        color: AppColors.accent,
                         boxShadow: [
                           BoxShadow(
                             color: Colors.black.withOpacity(0.5),

--- a/lib/widgets/pot_animation_widget.dart
+++ b/lib/widgets/pot_animation_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_widget.dart';
 import 'chip_trail.dart';
 
@@ -63,7 +64,7 @@ class _PotAnimationWidgetState extends State<PotAnimationWidget>
         count,
         (index) => Padding(
           padding: EdgeInsets.symmetric(horizontal: 1 * scale),
-          child: MiniChip(color: Colors.orangeAccent, size: 10 * scale),
+          child: MiniChip(color: AppColors.accent, size: 10 * scale),
         ),
       ),
     );

--- a/lib/widgets/pot_chip_animation.dart
+++ b/lib/widgets/pot_chip_animation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animation of chips flying from a player to the pot stack.
@@ -37,7 +38,7 @@ class PotChipAnimation extends StatelessWidget {
       start: start,
       end: end,
       amount: amount,
-      color: Colors.orangeAccent,
+      color: AppColors.accent,
       scale: scale,
       control: control,
       fadeStart: 0.6,

--- a/lib/widgets/pot_collection_chips.dart
+++ b/lib/widgets/pot_collection_chips.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animated stack of chips flying from the pot to a player's stack.
@@ -41,7 +42,7 @@ class PotCollectionChips extends StatelessWidget {
       start: start,
       end: end,
       amount: amount,
-      color: Colors.orangeAccent,
+      color: AppColors.accent,
       scale: scale,
       control: control,
       fadeStart: fadeStart,

--- a/lib/widgets/pot_win_animation.dart
+++ b/lib/widgets/pot_win_animation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animation of chips flying from the pot to a player's stack
@@ -33,7 +34,7 @@ class PotWinAnimation extends StatefulWidget {
     required this.start,
     required this.end,
     required this.amount,
-    this.color = Colors.orangeAccent,
+    this.color = AppColors.accent,
     this.scale = 1.0,
     this.control,
     this.fadeStart = 0.6,

--- a/lib/widgets/stack_bar_widget.dart
+++ b/lib/widgets/stack_bar_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 /// Displays player's remaining stack as a thin progress bar.
 class StackBarWidget extends StatelessWidget {
@@ -56,7 +57,7 @@ class StackBarWidget extends StatelessWidget {
                 ? BoxDecoration(
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.orangeAccent.withOpacity(glow),
+                        color: AppColors.accent.withOpacity(glow),
                         blurRadius: 8 * glow * scale,
                         spreadRadius: 2 * glow * scale,
                       ),

--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_widget.dart';
 
 /// Displays pot size for a specific street in the history panel.
@@ -42,7 +43,7 @@ class StreetPotWidget extends StatelessWidget {
                   ChipStackWidget(
                     amount: value,
                     scale: 0.6,
-                    color: Colors.orangeAccent,
+                    color: AppColors.accent,
                   ),
                   const SizedBox(width: 8),
                   Text(
@@ -70,7 +71,7 @@ class StreetPotWidget extends StatelessWidget {
                 child: LinearProgressIndicator(
                   value: factor,
                   backgroundColor: Colors.white10,
-                  color: Colors.orangeAccent,
+                  color: AppColors.accent,
                   minHeight: 4,
                 ),
               ),

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -7,6 +7,7 @@ import '../../models/v2/hero_position.dart';
 import '../../models/action_entry.dart';
 import '../../screens/v2/hand_editor_screen.dart';
 import '../../services/evaluation_executor_service.dart';
+import '../../theme/app_colors.dart';
 
 /// ***Only the new Stateful implementation below is kept.
 ///   The former Stateless version has been removed to avoid a duplicate-class error.***
@@ -261,7 +262,7 @@ class _TrainingPackSpotPreviewCardState
                           child: InkWell(
                             onTap: widget.onNewTap,
                             child: const Icon(Icons.fiber_new,
-                                color: Colors.orangeAccent),
+                                color: AppColors.accent),
                           ),
                         ),
                       if (widget.showDuplicate)

--- a/lib/widgets/win_chips_animation.dart
+++ b/lib/widgets/win_chips_animation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animation of chips flying from the pot to a player's stack.
@@ -36,7 +37,7 @@ class WinChipsAnimation extends StatelessWidget {
     this.control,
     this.onCompleted,
     this.fadeStart = 0.7,
-    this.color = Colors.orangeAccent,
+    this.color = AppColors.accent,
   }) : super(key: key);
 
   @override

--- a/lib/widgets/winner_flying_chip.dart
+++ b/lib/widgets/winner_flying_chip.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 class WinnerFlyingChip extends StatefulWidget {
   final Offset start;
@@ -91,7 +92,7 @@ class _WinnerFlyingChipState extends State<WinnerFlyingChip>
         height: 24,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: Colors.orangeAccent,
+          color: AppColors.accent,
           boxShadow: [
             BoxShadow(
               color: Colors.black.withOpacity(0.5),


### PR DESCRIPTION
## Summary
- refresh theme colors to deeper greens and golds
- reference `AppColors` throughout widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c2127dc832a86be75d9f3c1d679