### PR TITLE
Implement hand history file import

### DIFF
--- a/lib/services/hand_history_file_service.dart
+++ b/lib/services/hand_history_file_service.dart
@@ -3,28 +3,65 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
+import 'package:poker_analyzer/plugins/plugin_loader.dart';
+import 'package:poker_analyzer/plugins/plugin_manager.dart';
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+import 'package:poker_analyzer/models/saved_hand.dart';
+
 import 'saved_hand_manager_service.dart';
 
 /// Handles importing external hand history files using available converters.
 class HandHistoryFileService {
-  HandHistoryFileService._(this._handManager);
+  HandHistoryFileService._(this._handManager, this._converters);
 
   static Future<HandHistoryFileService> create(
       SavedHandManagerService manager) async {
-    return HandHistoryFileService._(manager);
+    final registry = ServiceRegistry();
+    final loader = PluginLoader();
+    final managerPlugin = PluginManager();
+    await loader.loadAll(registry, managerPlugin);
+    final converters = registry.get<ConverterRegistry>();
+    return HandHistoryFileService._(manager, converters);
   }
 
   final SavedHandManagerService _handManager;
+  final ConverterRegistry _converters;
 
   /// Prompts the user to select hand history files and imports them.
   Future<int> importFromFiles(BuildContext context) async {
     final result = await FilePicker.platform.pickFiles(allowMultiple: true);
     if (result == null || result.files.isEmpty) return 0;
+    final imported = <SavedHand>[];
+    final formats = _converters.dumpFormatIds();
+    for (final f in result.files) {
+      final path = f.path;
+      if (path == null) continue;
+      try {
+        final data = await File(path).readAsString();
+        for (final id in formats) {
+          final hand = _converters.tryConvert(id, data);
+          if (hand != null) {
+            imported.add(hand);
+            break;
+          }
+        }
+      } catch (_) {}
+    }
+    if (imported.isEmpty) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Не удалось импортировать файлы')),
+        );
+      }
+      return 0;
+    }
+    await _handManager.addHands(imported);
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Не удалось импортировать файлы")),
+        SnackBar(content: Text('Импортировано ${imported.length} раздач')),
       );
     }
-    return 0;
+    return imported.length;
   }
 }

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -50,6 +50,15 @@ class SavedHandManagerService extends ChangeNotifier {
     }
   }
 
+  Future<void> addHands(List<SavedHand> hands) async {
+    if (hands.isEmpty) return;
+    final sorted = List<SavedHand>.from(hands)
+      ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+    for (final hand in sorted) {
+      await add(hand);
+    }
+  }
+
   Future<void> update(int index, SavedHand hand) async {
     final old = _storage.hands[index];
     await _storage.update(index, hand);


### PR DESCRIPTION
## Summary
- hook up plugin loader for file-based hand history imports
- parse files with available converter plugins
- bulk-add imported hands to storage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c160740832a801380a9fe06c892