### PR TITLE
Improve adaptive training with EV/ICM stats

### DIFF
--- a/lib/screens/training_spot_detail_screen.dart
+++ b/lib/screens/training_spot_detail_screen.dart
@@ -40,22 +40,40 @@ class TrainingSpotDetailScreen extends StatelessWidget {
         children: [
           Text('Hero position: $pos',
               style: const TextStyle(color: Colors.white)),
-          if (heroCards.isNotEmpty)
-            Text('Hero cards: $heroCards',
-                style: const TextStyle(color: Colors.white)),
-          if (board.isNotEmpty)
-            Text('Board: $board', style: const TextStyle(color: Colors.white)),
-          const SizedBox(height: 16),
-          ActionHistoryWidget(actions: spot.actions, playerPositions: _posMap()),
-          if (user != null) ...[
-            const SizedBox(height: 16),
-            Text('Your action: $user',
-                style: const TextStyle(color: Colors.white)),
-          ],
-          if (spot.recommendedAction != null) ...[
-            const SizedBox(height: 8),
-            EvalResultView(spot: spot, action: user ?? ''),
-          ],
+      if (heroCards.isNotEmpty)
+        Text('Hero cards: $heroCards',
+            style: const TextStyle(color: Colors.white)),
+      if (board.isNotEmpty)
+        Text('Board: $board', style: const TextStyle(color: Colors.white)),
+      const SizedBox(height: 16),
+      ActionHistoryWidget(actions: spot.actions, playerPositions: _posMap()),
+      if (user != null) ...[
+        const SizedBox(height: 16),
+        Text('Your action: $user',
+            style: const TextStyle(color: Colors.white)),
+      ],
+      Builder(builder: (context) {
+        double? ev;
+        double? icm;
+        for (final a in spot.actions) {
+          if (a.playerIndex == spot.heroIndex && a.street == 0) {
+            ev ??= a.ev;
+            icm ??= a.icmEv;
+          }
+        }
+        if (ev == null && icm == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Text(
+            'EV ${ev?.toStringAsFixed(2) ?? '-'}  ICM ${icm?.toStringAsFixed(2) ?? '-'}',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        );
+      }),
+      if (spot.recommendedAction != null) ...[
+        const SizedBox(height: 8),
+        EvalResultView(spot: spot, action: user ?? ''),
+      ],
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/screens/training_template_detail_screen.dart
+++ b/lib/screens/training_template_detail_screen.dart
@@ -16,6 +16,8 @@ class TrainingTemplateDetailScreen extends StatelessWidget {
     final accuracy = (stat?.accuracy ?? 0) * 100;
     final ev = stat?.postEvPct ?? 0;
     final icm = stat?.postIcmPct ?? 0;
+    final dEv = ev - (stat?.preEvPct ?? 0);
+    final dIcm = icm - (stat?.preIcmPct ?? 0);
     final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
     final focus = template.handTypeSummary();
     final diff = template.difficultyLevel;
@@ -41,6 +43,11 @@ class TrainingTemplateDetailScreen extends StatelessWidget {
             Text('Difficulty: $diff', style: const TextStyle(color: Colors.white)),
             Text('EV ${ev.toStringAsFixed(1)}%  ICM ${icm.toStringAsFixed(1)}%',
                 style: const TextStyle(color: Colors.white)),
+            if (stat != null)
+              Text(
+                'ΔEV ${dEv >= 0 ? '+' : ''}${dEv.toStringAsFixed(1)}%  ΔICM ${dIcm >= 0 ? '+' : ''}${dIcm.toStringAsFixed(1)}%',
+                style: const TextStyle(color: Colors.white70),
+              ),
             if (focus.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.only(top: 8),

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -58,6 +58,10 @@ class AdaptiveTrainingService extends ChangeNotifier {
       var score = 1 - (stat?.accuracy ?? 0);
       score += 1 - (stat?.postEvPct ?? 0) / 100;
       score += 1 - (stat?.postIcmPct ?? 0) / 100;
+      final dEv = (stat?.postEvPct ?? 0) - (stat?.preEvPct ?? 0);
+      final dIcm = (stat?.postIcmPct ?? 0) - (stat?.preIcmPct ?? 0);
+      score -= dEv * .05;
+      score -= dIcm * .05;
       if (miss > 0) score += 2 + miss * .5;
       if (posMiss > 0) score += 1 + posMiss * .3;
       final diff = (t.difficultyLevel - level).abs();


### PR DESCRIPTION
## Summary
- adjust adaptive training score with EV/ICM progress
- show EV/ICM deltas in template detail view
- display EV and ICM for actions in spot detail

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f0f02a6d0832abc341f840b966e42