### PR TITLE
Enable cloud syncing of evaluation queue

### DIFF
--- a/lib/services/cloud_sync_service.dart
+++ b/lib/services/cloud_sync_service.dart
@@ -23,6 +23,7 @@ class CloudSyncService {
     'session_notes',
     'session_logs',
     'pinned_sessions',
+    'evaluation_queue',
   ];
 
   final FirebaseFirestore _db = FirebaseFirestore.instance;
@@ -334,5 +335,25 @@ class CloudSyncService {
     final list = data?['ids'];
     if (list is List) return {for (final i in list) (i as num).toInt()};
     return {};
+  }
+
+  Future<void> uploadQueue(Map<String, dynamic> queue) async {
+    await queueMutation('evaluation_queue', 'main', {
+      ...queue,
+      'updatedAt': DateTime.now().toIso8601String(),
+    });
+    await syncUp();
+  }
+
+  Future<Map<String, dynamic>?> downloadQueue() async {
+    if (uid == null) return null;
+    final snap = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('evaluation_queue')
+        .doc('main')
+        .get();
+    if (!snap.exists) return null;
+    return snap.data();
   }
 }


### PR DESCRIPTION
## Summary
- add evaluation_queue to cloud sync collections
- sync evaluation queue state via CloudSyncService
- call sync methods when loading and saving the queue

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f10474d50832a8c8cf25c55d94045