### PR TITLE
Improve adaptive training recommendations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,11 +194,13 @@ Future<void> main() async {
         Provider<MistakePackCloudService>.value(value: mistakeCloud),
         Provider<XPTrackerCloudService>.value(value: xpCloud),
         ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
+        ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..load()),
         ChangeNotifierProvider(
           create: (context) => AdaptiveTrainingService(
             templates: context.read<TemplateStorageService>(),
             mistakes: context.read<MistakeReviewPackService>(),
             hands: context.read<SavedHandManagerService>(),
+            history: context.read<HandAnalysisHistoryService>(),
             xp: context.read<XPTrackerService>(),
           ),
         ),
@@ -297,7 +299,6 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (_) => MixedDrillHistoryService()..load(),
         ),
-        ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..load()),
         Provider(create: (_) => const HandAnalyzerService()),
         ChangeNotifierProvider(
           create: (_) => TrainingPackPlayController()..load(),

--- a/lib/services/mistake_review_pack_service.dart
+++ b/lib/services/mistake_review_pack_service.dart
@@ -122,16 +122,16 @@ class MistakeReviewPackService extends ChangeNotifier {
   }
 
   List<SavedHand> _mistakes() {
-    final list = <SavedHand>[];
-    for (final h in hands.hands.reversed) {
-      final exp = h.expectedAction?.trim().toLowerCase();
-      final gto = h.gtoAction?.trim().toLowerCase();
-      if (exp != null && gto != null && exp.isNotEmpty && gto.isNotEmpty && exp != gto) {
-        list.add(h);
-        if (list.length >= 10) break;
-      }
-    }
-    return list.reversed.toList();
+    final list = [
+      for (final h in hands.hands)
+        if (h.expectedAction != null &&
+            h.gtoAction != null &&
+            h.expectedAction!.trim().toLowerCase() !=
+                h.gtoAction!.trim().toLowerCase())
+          h
+    ];
+    list.sort((a, b) => (b.evLoss ?? 0).compareTo(a.evLoss ?? 0));
+    return list.take(10).toList();
   }
 
   void _generate() {


### PR DESCRIPTION
## Summary
- integrate hand analysis history into adaptive training
- sort mistake review pack by EV loss
- inject analysis history into provider setup

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f12604d44832abdabdf5305e2c45e