### PR TITLE
Add adaptive pack generation

### DIFF
--- a/lib/screens/quick_hand_analysis_screen.dart
+++ b/lib/screens/quick_hand_analysis_screen.dart
@@ -8,6 +8,10 @@ import '../services/hand_analysis_history_service.dart';
 import '../models/hand_analysis_record.dart';
 import '../services/hand_analyzer_service.dart';
 import '../services/xp_tracker_service.dart';
+import '../services/adaptive_training_service.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
+import '../models/v2/training_pack_template.dart';
 import '../theme/app_colors.dart';
 import '../helpers/hand_utils.dart';
 
@@ -171,6 +175,32 @@ class _QuickHandAnalysisScreenState extends State<QuickHandAnalysisScreen> {
                   Text('ICM: ${_icm!.toStringAsFixed(2)}', style: const TextStyle(color: Colors.white)),
                   Text('Решение: $_action', style: const TextStyle(color: Colors.white)),
                   if (_hint != null) Text(_hint!, style: const TextStyle(color: Colors.white70)),
+                  ValueListenableBuilder<List<TrainingPackTemplate>>( 
+                    valueListenable: context.read<AdaptiveTrainingService>().recommendedNotifier,
+                    builder: (_, list, __) {
+                      if (list.isEmpty) return const SizedBox.shrink();
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const SizedBox(height: 16),
+                          const Text('Рекомендуемые паки:', style: TextStyle(color: Colors.white)),
+                          for (final t in list.take(3))
+                            TextButton(
+                              onPressed: () async {
+                                await context.read<TrainingSessionService>().startSession(t);
+                                if (context.mounted) {
+                                  await Navigator.push(
+                                    context,
+                                    MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                                  );
+                                }
+                              },
+                              child: Text(t.name),
+                            ),
+                        ],
+                      );
+                    },
+                  ),
                 ],
               ),
           ],

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -3,8 +3,10 @@ import 'package:provider/provider.dart';
 import '../services/adaptive_training_service.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../services/training_pack_stats_service.dart';
+import '../services/training_session_service.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_template_detail_screen.dart';
+import 'training_session_screen.dart';
 
 class TrainingRecommendationScreen extends StatefulWidget {
   const TrainingRecommendationScreen({super.key});
@@ -59,6 +61,19 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Рекомендации')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final tpl = await _service.buildAdaptivePack();
+          await context.read<TrainingSessionService>().startSession(tpl);
+          if (context.mounted) {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+            );
+          }
+        },
+        child: const Icon(Icons.auto_mode),
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _tpls.isEmpty


### PR DESCRIPTION
## Summary
- implement adaptive pack generator in `AdaptiveTrainingService`
- add FAB on recommendation screen to launch adaptive pack
- show recommended packs in quick hand analysis screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f13f76bec832aaa7511138f1055eb