### PR TITLE
Add active goals dashboard card

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -10,6 +10,7 @@ import 'goal_overview_screen.dart';
 import 'pack_overview_screen.dart';
 import '../widgets/streak_banner.dart';
 import '../widgets/motivation_card.dart';
+import '../widgets/active_goals_card.dart';
 import '../widgets/next_step_card.dart';
 import '../widgets/suggested_drill_card.dart';
 import '../widgets/today_progress_banner.dart';
@@ -133,6 +134,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
           child: const Text('View History'),
         ),
         const MotivationCard(),
+        const ActiveGoalsCard(),
         const NextStepCard(),
         const SuggestedDrillCard(),
         const Expanded(child: AnalyzerTab()),

--- a/lib/services/goal_engine.dart
+++ b/lib/services/goal_engine.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/user_goal.dart';
 import '../widgets/confetti_overlay.dart';
 import '../main.dart';
 import 'training_stats_service.dart';
+import 'xp_tracker_service.dart';
 
 class GoalEngine extends ChangeNotifier {
   static const _prefsKey = 'user_goals';
@@ -63,6 +66,12 @@ class GoalEngine extends ChangeNotifier {
           showConfettiOverlay(ctx);
           ScaffoldMessenger.of(ctx).showSnackBar(
             SnackBar(content: Text('Goal completed: ${g.title}')),
+          );
+          unawaited(
+            ctx.read<XPTrackerService>().add(
+                  xp: XPTrackerService.achievementXp,
+                  source: 'goal',
+                ),
           );
         }
       }

--- a/lib/widgets/active_goals_card.dart
+++ b/lib/widgets/active_goals_card.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/goal_engine.dart';
+import '../screens/goals_history_screen.dart';
+
+class ActiveGoalsCard extends StatelessWidget {
+  const ActiveGoalsCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final engine = context.watch<GoalEngine>();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final goals = engine.goals.where((g) => !g.completed).toList();
+    if (goals.isEmpty) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text('Active Goals',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const GoalsHistoryScreen(),
+                    ),
+                  );
+                },
+                child: const Text('History'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (var i = 0; i < goals.length; i++) ...[
+            Text(goals[i].title,
+                style: const TextStyle(color: Colors.white)),
+            const SizedBox(height: 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: (engine.progress(goals[i]) / goals[i].target)
+                    .clamp(0.0, 1.0),
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(accent),
+                minHeight: 4,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                '${engine.progress(goals[i])}/${goals[i].target}',
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ),
+            if (i != goals.length - 1) const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show active goals on dashboard
- award XP and confetti when goals complete

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1430f008832a9f6519821cbf1b85