### PR TITLE
Add onboarding tutorial

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,7 @@ import 'services/favorite_pack_service.dart';
 import 'services/evaluation_settings_service.dart';
 import 'widgets/sync_status_widget.dart';
 import 'widgets/first_launch_overlay.dart';
+import 'screens/onboarding_screen.dart';
 import 'app_bootstrap.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -346,6 +347,17 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     });
   }
 
+  Future<void> _maybeShowOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool('has_seen_onboarding') == true) return;
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return;
+    await Navigator.push(
+      ctx,
+      MaterialPageRoute(builder: (_) => const OnboardingScreen()),
+    );
+  }
+
   Future<void> _maybeResumeTraining() async {
     final prefs = await SharedPreferences.getInstance();
     String? id;
@@ -410,6 +422,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeResumeTraining();
       _maybeShowIntroOverlay();
+      _maybeShowOnboarding();
     });
   }
 

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
+import 'onboarding_screen.dart';
 import 'package:provider/provider.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -184,6 +185,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                     ),
                   );
                   break;
+                case 'onboarding':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const OnboardingScreen()),
+                  );
+                  break;
                 case 'about':
                   showAboutDialog(context: context);
                   break;
@@ -192,6 +199,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             itemBuilder: (context) => const [
               PopupMenuItem(value: 'settings', child: Text('⚙️ Settings')),
               PopupMenuItem(value: 'plugins', child: Text('🧩 Plugins')),
+              PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
               PopupMenuItem(value: 'about', child: Text('About')),
             ],
           ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_colors.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final _controller = PageController();
+  int _index = 0;
+
+  Future<void> _finish() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('has_seen_onboarding', true);
+    if (mounted) Navigator.pop(context);
+  }
+
+  Widget _page(String title, String text) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            text,
+            style: const TextStyle(color: Colors.white70, fontSize: 16),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = [
+      _page('Создание паков', 'Формируйте собственные наборы рук для тренировки'),
+      _page('Импорт сессий', 'Загружайте файлы раздач и анализируйте каждую руку'),
+      _page('Повтор ошибок', 'Возвращайтесь к ошибкам и улучшайте результаты'),
+    ];
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        actions: [
+          TextButton(
+            onPressed: _finish,
+            child: const Text('Пропустить'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView(
+              controller: _controller,
+              onPageChanged: (v) => setState(() => _index = v),
+              children: pages,
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              for (int i = 0; i < pages.length; i++)
+                Container(
+                  width: 8,
+                  height: 8,
+                  margin: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: i == _index ? Colors.orange : Colors.white24,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _index == pages.length - 1
+                  ? _finish
+                  : () => _controller.nextPage(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeInOut,
+                      ),
+              child: Text(_index == pages.length - 1 ? 'Готово' : 'Далее'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce OnboardingScreen
- hook onboarding into app startup and menu

## Testing
- `flutter analyze` *(fails: issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686f142f85f0832a8bc71fa8a74f6158