### PR TITLE
Implement mistake review pack flow

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -13,6 +13,7 @@ import '../helpers/poker_street_helper.dart';
 import '../widgets/spot_viewer_dialog.dart';
 import '../theme/app_colors.dart';
 import 'training_session_screen.dart';
+import 'v2/training_pack_play_screen.dart';
 
 class TrainingSessionSummaryScreen extends StatelessWidget {
   final TrainingSession session;
@@ -145,6 +146,23 @@ class TrainingSessionSummaryScreen extends StatelessWidget {
                       child: Text('No mistakes',
                           style: TextStyle(color: Colors.white70)))),
             const SizedBox(height: 16),
+            if (mistakes.isNotEmpty) ...[
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => TrainingPackPlayScreen(
+                        template: MistakeReviewPackService.cachedTemplate!,
+                        original: null,
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Review Mistakes'),
+              ),
+              const SizedBox(height: 8),
+            ],
             Row(
               children: [
                 Expanded(

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -86,6 +86,11 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
   @override
   void initState() {
     super.initState();
+    if (widget.template.id == MistakeReviewPackService.cachedTemplate?.id) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        context.read<MistakeReviewPackService>().setProgress(0);
+      });
+    }
     final achieved = _correct == _total;
     SharedPreferences.getInstance()
         .then((p) => p.setBool('tpl_goal_${widget.original.id}', achieved));

--- a/lib/screens/v2/training_pack_result_screen_v2.dart
+++ b/lib/screens/v2/training_pack_result_screen_v2.dart
@@ -2,10 +2,12 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:provider/provider.dart';
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_play_screen.dart';
+import '../../services/mistake_review_pack_service.dart';
 
 class TrainingPackResultScreenV2 extends StatelessWidget {
   final TrainingPackTemplate template;
@@ -78,6 +80,11 @@ class TrainingPackResultScreenV2 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (template.id == MistakeReviewPackService.cachedTemplate?.id) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        context.read<MistakeReviewPackService>().setProgress(0);
+      });
+    }
     final spots = template.spots;
     if (spots.isEmpty) return _emptyResultState();
     int correct = 0;

--- a/lib/widgets/repeat_mistakes_card.dart
+++ b/lib/widgets/repeat_mistakes_card.dart
@@ -59,7 +59,7 @@ class RepeatMistakesCard extends StatelessWidget {
                     mistakenNames: {for (final h in pack.hands) h.name},
                   ),
                 ),
-              ).then((_) => service.setProgress(total));
+              ).then((_) => service.setProgress(0));
             },
             child: const Text('Start'),
           ),


### PR DESCRIPTION
## Summary
- integrate MistakeReviewPackService when training session ends
- provide Review Mistakes option on session summary
- reset mistake review progress on pack completion
- refresh Repeat Mistakes card behavior

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f14187d98832aaf5011e6f6eaa25b