### PR TITLE
Add share button in achievements screen

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   table_calendar: ^3.0.9
   flutter_local_notifications: ^17.0.0
   timezone: ^0.9.2
+  image: ^4.1.3
   firebase_core: ^2.14.0
   cloud_firestore: ^4.8.0
   firebase_auth: ^4.8.0


### PR DESCRIPTION
## Summary
- add share button to AchievementsScreen
- capture widget tree to image and share
- include `image` package

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f141d0e14832a8902f18014e77af3