### PR TITLE
Extend template cloud sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,6 +122,7 @@ Future<void> main() async {
   final packStorage = TrainingPackStorageService(cloud: cloud);
   await packStorage.load();
   final packCloud = TrainingPackCloudSyncService();
+  await packCloud.init();
   final mistakeCloud = MistakePackCloudService();
   final goalCloud = GoalProgressCloudService();
   final xpCloud = XPTrackerCloudService();
@@ -132,6 +133,7 @@ Future<void> main() async {
   await templateStorage.load();
   await packCloud.syncDown(packStorage);
   await packCloud.syncDownTemplates(templateStorage);
+  await packCloud.syncDownStats();
   await packCloud.syncUpTemplates(templateStorage);
   unawaited(
     AssetSyncService.instance.syncIfNeeded().catchError(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import 'achievements_screen.dart';
 import 'package:provider/provider.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/auth_service.dart';
+import '../services/training_pack_cloud_sync_service.dart';
 import '../widgets/sync_status_widget.dart';
 import 'evaluation_settings_screen.dart';
 
@@ -189,6 +190,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       final ok = await auth.signInWithGoogle();
                       if (ok) {
                         await context.read<CloudSyncService>().syncDown();
+                        await context
+                            .read<TrainingPackCloudSyncService>()
+                            .syncDownStats();
                       }
                     } else {
                       await auth.signOut();

--- a/lib/screens/training_progress_overview_screen.dart
+++ b/lib/screens/training_progress_overview_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/training_pack_storage_service.dart';
+import '../services/training_pack_cloud_sync_service.dart';
+import '../helpers/date_utils.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -23,11 +25,31 @@ class TrainingProgressOverviewScreen extends StatelessWidget {
         centerTitle: true,
         actions: [SyncStatusIcon.of(context)],
       ),
-      body: ListView.separated(
-        padding: const EdgeInsets.all(16),
-        itemCount: packs.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 12),
-        itemBuilder: (context, index) {
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: ValueListenableBuilder<DateTime?>(
+              valueListenable:
+                  context.read<TrainingPackCloudSyncService>().lastSync,
+              builder: (context, value, child) {
+                final text = value == null
+                    ? 'Последняя синхр.: -'
+                    : 'Последняя синхр.: ${formatDateTime(value.toLocal())}';
+                return Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(text,
+                      style: const TextStyle(color: Colors.white70)),
+                );
+              },
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: packs.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
           final p = packs[index];
           final progress = p.pctComplete;
           final color = progress < 0.5
@@ -43,8 +65,8 @@ class TrainingProgressOverviewScreen extends StatelessWidget {
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(p.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                children: [
+                  Text(p.name, style: const TextStyle(fontWeight: FontWeight.bold)),
                 const SizedBox(height: 4),
                 Row(
                   children: [
@@ -69,7 +91,10 @@ class TrainingProgressOverviewScreen extends StatelessWidget {
           );
         },
       ),
-    );
+    ),
+          ],
+        ),
+      );
   }
 }
 


### PR DESCRIPTION
## Summary
- support statistics in `TrainingPackCloudSyncService`
- store last template sync time
- sync stats on sign in
- show last sync time on training progress overview

## Testing
- `dart format`: command not found
- `flutter format`: command not found

------
https://chatgpt.com/codex/tasks/task_e_686f142c10e4832a87b4c58188f06a16