### PR TITLE
Add Daily Challenge feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
 import 'services/weekly_challenge_service.dart';
+import 'services/daily_challenge_service.dart';
 import 'services/session_log_service.dart';
 import 'services/category_usage_service.dart';
 import 'user_preferences.dart';
@@ -218,6 +219,13 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
         ChangeNotifierProvider(create: (_) => XPTrackerService(cloud: xpCloud)..load()),
+        ChangeNotifierProvider(
+          create: (context) => DailyChallengeService(
+            adaptive: context.read<AdaptiveTrainingService>(),
+            templates: context.read<TemplateStorageService>(),
+            xp: context.read<XPTrackerService>(),
+          )..load(),
+        ),
         ChangeNotifierProvider(
           create: (context) => WeeklyChallengeService(
             stats: context.read<TrainingStatsService>(),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/streak_chart.dart';
 import '../widgets/daily_progress_ring.dart';
 import '../widgets/repeat_mistakes_card.dart';
 import '../widgets/weekly_challenge_card.dart';
+import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
@@ -79,6 +80,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const ProgressSummaryBox(),
           const StreakChart(),
           const DailyProgressRing(),
+          const DailyChallengeCard(),
           const WeeklyChallengeCard(),
           const XPProgressBar(),
           const RepeatMistakesCard(),

--- a/lib/services/daily_challenge_service.dart
+++ b/lib/services/daily_challenge_service.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template.dart';
+import 'adaptive_training_service.dart';
+import 'template_storage_service.dart';
+import 'xp_tracker_service.dart';
+
+class DailyChallengeService extends ChangeNotifier {
+  static const _idKey = 'daily_challenge_id';
+  static const _dateKey = 'daily_challenge_date';
+  static const _rewardKey = 'daily_challenge_rewarded';
+  static const _rewardXp = 20;
+
+  final AdaptiveTrainingService adaptive;
+  final TemplateStorageService templates;
+  final XPTrackerService xp;
+
+  TrainingPackTemplate? _template;
+  DateTime? _date;
+  bool _rewarded = false;
+  Timer? _timer;
+
+  DailyChallengeService({
+    required this.adaptive,
+    required this.templates,
+    required this.xp,
+  });
+
+  TrainingPackTemplate? get template => _template;
+  bool get rewarded => _rewarded;
+  DateTime? get date => _date;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final id = prefs.getString(_idKey);
+    final dateStr = prefs.getString(_dateKey);
+    _rewarded = prefs.getBool(_rewardKey) ?? false;
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    _template = id != null
+        ? templates.templates.firstWhere(
+            (t) => t.id == id,
+            orElse: () => TrainingPackTemplate(id: id, name: id),
+          )
+        : null;
+    await ensureToday();
+    xp.addListener(_check);
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<void> ensureToday() async {
+    final now = DateTime.now();
+    if (_date != null && _template != null && _isSameDay(_date!, now)) {
+      _schedule();
+      await _check();
+      return;
+    }
+    await adaptive.refresh();
+    final list = adaptive.recommended;
+    if (list.isEmpty) return;
+    final tpl = list.first;
+    _template = tpl;
+    _date = DateTime(now.year, now.month, now.day);
+    _rewarded = false;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_idKey, tpl.id);
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+    await prefs.setBool(_rewardKey, false);
+    _schedule();
+    notifyListeners();
+    await _check();
+  }
+
+  Future<void> _check() async {
+    final tpl = _template;
+    if (tpl == null || _rewarded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final done = prefs.getBool('completed_tpl_${tpl.id}') ?? false;
+    if (!done) return;
+    _rewarded = true;
+    await prefs.setBool(_rewardKey, true);
+    await xp.add(xp: _rewardXp, source: 'daily_challenge');
+    notifyListeners();
+  }
+
+  void _schedule() {
+    _timer?.cancel();
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day + 1);
+    _timer = Timer(next.difference(now), ensureToday);
+  }
+
+  @override
+  void dispose() {
+    xp.removeListener(_check);
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/widgets/daily_challenge_card.dart
+++ b/lib/widgets/daily_challenge_card.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/daily_challenge_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class DailyChallengeCard extends StatelessWidget {
+  const DailyChallengeCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DailyChallengeService>();
+    final tpl = service.template;
+    if (tpl == null) return const SizedBox.shrink();
+    final completed = service.rewarded;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.flash_on, color: Colors.amberAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Daily Challenge',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(tpl.name,
+                    style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (completed)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+              decoration: BoxDecoration(
+                color: Colors.green,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text('Completed ✅',
+                  style: TextStyle(color: Colors.white)),
+            )
+          else
+            ElevatedButton(
+              onPressed: () async {
+                await context
+                    .read<TrainingSessionService>()
+                    .startSession(tpl);
+                if (context.mounted) {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const TrainingSessionScreen()),
+                  );
+                }
+              },
+              child: const Text('Start'),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `DailyChallengeService` to pick a recommended template daily
- show the daily challenge on the home screen
- reward bonus XP when the challenge is completed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f14267fd0832a820388e03c857648