### PR TITLE
Add CSV export for session stats

### DIFF
--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -659,6 +659,19 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     }
   }
 
+  Future<void> _exportCsv(BuildContext context) async {
+    final manager = context.read<SavedHandManagerService>();
+    final notes = context.read<SessionNoteService>().notes;
+    final path = await manager.exportAllSessionsCsv(notes);
+    if (path == null) return;
+    await Share.shareXFiles([XFile(path)], text: 'training_summary.csv');
+    if (context.mounted) {
+      final name = path.split(Platform.pathSeparator).last;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+    }
+  }
+
   Future<void> _showExportOptions() async {
     final result = await showModalBottomSheet<String>(
       context: context,
@@ -670,6 +683,11 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
               leading: const Icon(Icons.description),
               title: const Text('Markdown'),
               onTap: () => Navigator.pop(ctx, 'md'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.table_chart),
+              title: const Text('CSV'),
+              onTap: () => Navigator.pop(ctx, 'csv'),
             ),
             ListTile(
               leading: const Icon(Icons.picture_as_pdf),
@@ -685,6 +703,8 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
       await _exportMarkdown(context);
     } else if (result == 'pdf') {
       await _exportPdf(context);
+    } else if (result == 'csv') {
+      await _exportCsv(context);
     }
   }
 

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -81,6 +81,18 @@ class SettingsPlaceholderScreen extends StatelessWidget {
         .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
   }
 
+  Future<void> _exportSummaryCsv(BuildContext context) async {
+    final manager = context.read<SavedHandManagerService>();
+    final notes = context.read<SessionNoteService>().notes;
+    final path = await manager.exportAllSessionsCsv(notes);
+    if (path == null) return;
+    await Share.shareXFiles([XFile(path)], text: 'training_summary.csv');
+    if (!context.mounted) return;
+    final name = path.split(Platform.pathSeparator).last;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+  }
+
   @override
   Widget build(BuildContext context) {
     final reminder = context.watch<ReminderService>();
@@ -196,6 +208,13 @@ class SettingsPlaceholderScreen extends StatelessWidget {
             child: ElevatedButton(
               onPressed: () => _exportSummary(context),
               child: const Text('Export Training Summary'),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: ElevatedButton(
+              onPressed: () => _exportSummaryCsv(context),
+              child: const Text('Export Summary CSV'),
             ),
           ),
           Padding(


### PR DESCRIPTION
## Summary
- enable CSV export of session statistics via SavedHandManagerService
- allow exporting session CSV from the session stats screen
- allow exporting training summary CSV from settings

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f141779f4832aab3f4b32e99d4f65