### PR TITLE
Add monthly analytics

### DIFF
--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -1,171 +1,130 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../services/training_pack_storage_service.dart';
+import '../services/training_stats_service.dart';
+import '../services/achievement_engine.dart';
 import '../theme/app_colors.dart';
-import 'training_activity_by_weekday_screen.dart';
-import 'top_mistakes_overview_screen.dart';
 import '../widgets/sync_status_widget.dart';
-import '../helpers/category_translations.dart';
 
-class TrainingProgressAnalyticsScreen extends StatefulWidget {
+class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
   const TrainingProgressAnalyticsScreen({super.key});
 
-  @override
-  State<TrainingProgressAnalyticsScreen> createState() => _TrainingProgressAnalyticsScreenState();
-}
-
-class _TrainingProgressAnalyticsScreenState extends State<TrainingProgressAnalyticsScreen> {
-  String _selected = 'Все категории';
+  Widget _chart(List<MapEntry<DateTime, int>> data, Color color) {
+    if (data.length < 2) return const SizedBox(height: 200);
+    final spots = <FlSpot>[];
+    for (var i = 0; i < data.length; i++) {
+      spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
+    }
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: 0,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 1,
+            getDrawingHorizontalLine: (v) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval:
+                    data.map((e) => e.value).reduce((a, b) => a > b ? a : b) / 4,
+                reservedSize: 30,
+                getTitlesWidget: (v, meta) => Text(
+                  v.toInt().toString(),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[i].key;
+                  return Text(
+                    '${d.month.toString().padLeft(2, '0')}.${(d.year % 100).toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: false,
+              color: color,
+              barWidth: 2,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    final packs = context
-        .watch<TrainingPackStorageService>()
-        .packs
-        .where((p) => !p.isBuiltIn)
-        .toList();
-    final Map<String, _CategoryStats> map = {};
-    for (final p in packs) {
-      final raw = p.category.isNotEmpty ? p.category : 'Без категории';
-      final c = translateCategory(raw);
-      map.putIfAbsent(c, () => _CategoryStats()).add(p);
-    }
-    const priority = {
-      'Пуш/Фолд': 1,
-      'ICM': 2,
-      'Постфлоп': 3,
-      '3-бет': 4,
-    };
-    final stats = map.entries
-        .where((e) => e.value.attempts > 0)
-        .toList()
-      ..sort((a, b) {
-        final pa = priority[a.key];
-        final pb = priority[b.key];
-        if (pa != null && pb != null) return pa.compareTo(pb);
-        if (pa != null) return -1;
-        if (pb != null) return 1;
-        return a.key.compareTo(b.key);
-      });
-    final categories = ['Все категории', ...stats.map((e) => e.key)];
-    final filtered = _selected == 'Все категории'
-        ? stats
-        : stats.where((e) => e.key == _selected).toList();
+    final stats = context.watch<TrainingStatsService>();
+    final achievements = context.watch<AchievementEngine>().achievements;
+    final accent = Theme.of(context).colorScheme.secondary;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Аналитика по категориям'),
+        title: const Text('Training Analytics'),
         centerTitle: true,
-        actions: [SyncStatusIcon.of(context), 
-          TextButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (_) => const TrainingActivityByWeekdayScreen()),
-              );
-            },
-            child: const Text(
-              'Дни недели',
-              style: TextStyle(color: Colors.white),
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (_) => const TopMistakesOverviewScreen()),
-              );
-            },
-            child: const Text(
-              'Ошибки',
-              style: TextStyle(color: Colors.white),
-            ),
-          ),
-        ],
+        actions: [SyncStatusIcon.of(context)],
       ),
-      body: Column(
+      body: ListView(
+        padding: const EdgeInsets.all(16),
         children: [
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: DropdownButton<String>(
-              value: _selected,
-              dropdownColor: AppColors.cardBackground,
-              underline: const SizedBox.shrink(),
-              style: const TextStyle(color: Colors.white),
-              items: [
-                for (final c in categories)
-                  DropdownMenuItem(value: c, child: Text(c))
-              ],
-              onChanged: (v) => setState(() => _selected = v ?? 'Все категории'),
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              for (final a in achievements)
+                Column(
+                  children: [
+                    Icon(a.icon, color: accent),
+                    const SizedBox(height: 4),
+                    Text('${a.progress}/${a.target}')
+                  ],
+                )
+            ],
           ),
-          Expanded(
-            child: ListView.separated(
-              padding: const EdgeInsets.all(16),
-              itemCount: filtered.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 12),
-              itemBuilder: (context, index) {
-                final e = filtered[index];
-                final s = e.value;
-                final progress = s.avgProgress;
-                final color = progress < 0.5
-                    ? Colors.redAccent
-                    : progress < 0.8
-                        ? AppColors.accent
-                        : Colors.greenAccent;
-                return Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: AppColors.cardBackground,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(e.key,
-                          style: const TextStyle(fontWeight: FontWeight.bold)),
-                      const SizedBox(height: 4),
-                      Text('Попыток: ${s.attempts} • Решено: ${s.solved}'),
-                      const SizedBox(height: 4),
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: LinearProgressIndicator(
-                          value: progress,
-                          backgroundColor: Colors.white24,
-                          valueColor: AlwaysStoppedAnimation<Color>(color),
-                          minHeight: 6,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                          'Средний прогресс: ${(progress * 100).toStringAsFixed(0)}%'),
-                    ],
-                  ),
-                );
-              },
-            ),
-          ),
+          const SizedBox(height: 12),
+          _chart(stats.handsMonthly(12), accent),
+          const SizedBox(height: 12),
+          _chart(stats.sessionsMonthly(12), Colors.greenAccent),
+          const SizedBox(height: 12),
+          _chart(stats.mistakesMonthly(12), Colors.redAccent),
         ],
       ),
     );
   }
-}
-
-class _CategoryStats {
-  int packs = 0;
-  int attempts = 0;
-  int solved = 0;
-  double progress = 0.0;
-
-  void add(TrainingPack p) {
-    packs += 1;
-    attempts += p.lastAttempted;
-    solved += p.solved;
-    progress += p.pctComplete;
-  }
-
-  double get avgProgress => packs == 0 ? 0 : progress / packs;
 }

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -116,6 +116,47 @@ class TrainingStatsService extends ChangeNotifier {
     return _groupWeekly(daily);
   }
 
+  List<MapEntry<DateTime, int>> _groupMonthly(
+      List<MapEntry<DateTime, int>> daily) {
+    final Map<DateTime, int> grouped = {};
+    for (final e in daily) {
+      final m = DateTime(e.key.year, e.key.month);
+      grouped.update(m, (v) => v + e.value, ifAbsent: () => e.value);
+    }
+    final list = grouped.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+    return list;
+  }
+
+  List<MapEntry<DateTime, int>> handsMonthly([int months = 12]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month - months + 1);
+    final daily = [
+      for (final e in _entries(_handsPerDay))
+        if (!e.key.isBefore(start)) e
+    ];
+    return _groupMonthly(daily);
+  }
+
+  List<MapEntry<DateTime, int>> sessionsMonthly([int months = 12]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month - months + 1);
+    final daily = [
+      for (final e in _entries(_sessionsPerDay))
+        if (!e.key.isBefore(start)) e
+    ];
+    return _groupMonthly(daily);
+  }
+
+  List<MapEntry<DateTime, int>> mistakesMonthly([int months = 12]) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month - months + 1);
+    final daily = [
+      for (final e in _entries(_mistakesPerDay))
+        if (!e.key.isBefore(start)) e
+    ];
+    return _groupMonthly(daily);
+  }
+
   Map<String, int> _loadMap(SharedPreferences prefs, String key) {
     final raw = prefs.getString(key);
     if (raw == null) return {};


### PR DESCRIPTION
## Summary
- support monthly chart data in TrainingStatsService
- replace analytics screen to display monthly charts

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1e375af0832a85261d6fa9e2ab40