### PR TITLE
Add session analysis shortcut

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -850,6 +850,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             ),
             const SizedBox(height: 16),
             ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SessionAnalysisImportScreen()),
+                );
+              },
+              child: const Text('Анализ сессии EV/ICM'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
               onPressed: () async {
                 final manager = Provider.of<SavedHandManagerService>(context,
                     listen: false);


### PR DESCRIPTION
## Summary
- add EV/ICM session import entry on the main menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1f6cdf4c832aa84e63ffab2251eb