### PR TITLE
Implement dynamic pack adaptation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -186,6 +186,8 @@ Future<void> main() async {
         Provider(
           create: (context) => DynamicPackAdjustmentService(
             mistakes: context.read<MistakeReviewPackService>(),
+            eval: EvaluationExecutorService(),
+            hands: context.read<SavedHandManagerService>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -305,6 +305,11 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                         _progressBar(service),
                         const SizedBox(height: 4),
                         Text(
+                          'Accuracy ${(service.results.isEmpty ? 0 : service.results.values.where((e) => e).length * 100 / service.results.length).toStringAsFixed(0)}%',
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
                           '${service.session!.index + 1} / ${service.template!.spots.length}',
                           style: const TextStyle(color: Colors.white70),
                         ),

--- a/lib/services/dynamic_pack_adjustment_service.dart
+++ b/lib/services/dynamic_pack_adjustment_service.dart
@@ -2,10 +2,18 @@ import '../models/v2/training_pack_template.dart';
 import 'training_pack_stats_service.dart';
 import 'mistake_review_pack_service.dart';
 import 'pack_generator_service.dart';
+import 'evaluation_executor_service.dart';
+import 'saved_hand_manager_service.dart';
 
 class DynamicPackAdjustmentService {
   final MistakeReviewPackService mistakes;
-  const DynamicPackAdjustmentService({required this.mistakes});
+  final EvaluationExecutorService eval;
+  final SavedHandManagerService hands;
+  const DynamicPackAdjustmentService({
+    required this.mistakes,
+    required this.eval,
+    required this.hands,
+  });
 
   Future<TrainingPackTemplate> adjust(TrainingPackTemplate tpl) async {
     final stat = await TrainingPackStatsService.getStats(tpl.id);
@@ -14,8 +22,21 @@ class DynamicPackAdjustmentService {
       if (stat.accuracy > 0.85 && stat.postEvPct >= stat.preEvPct) diff++;
       if (stat.accuracy < 0.6 || stat.postEvPct < stat.preEvPct) diff--;
     }
+    final acc = eval.accuracy;
+    if (acc > 0.8) diff++;
+    if (acc < 0.5) diff--;
     final mc = mistakes.mistakeCount(tpl.id);
     if (mc > 5) diff--;
+    final posMist = hands.hands.where((h) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp == null || gto == null || exp == gto) return false;
+      final pos = h.heroPosition.toLowerCase();
+      if (pos != tpl.heroPos.name) return false;
+      final stack = h.stackSizes[h.heroIndex] ?? 0;
+      return (stack - tpl.heroBbStack).abs() <= 2;
+    }).length;
+    if (posMist > 10) diff--;
     var stack = (tpl.heroBbStack + diff).clamp(5, 40);
     final base = tpl.heroRange ?? PackGeneratorService.topNHands(25).toList();
     var pct = (base.length * 100 / 169).round() + diff * 5;


### PR DESCRIPTION
## Summary
- adjust packs using overall accuracy and mistakes
- show updated stack/range info for recommended packs
- include dynamic adjustments in home/recommendation lists
- display session accuracy during training

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e2becfc832aa810730f67936c05