### PR TITLE
Add share pack bundle action

### DIFF
--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -267,6 +267,15 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
     if (mounted) _clearSelection();
   }
 
+  Future<void> _shareSelectedBundle() async {
+    final service = context.read<TrainingPackStorageService>();
+    final list = [for (final p in service.packs) if (_selectedIds.contains(p.id)) p];
+    for (final p in list) {
+      await _shareBundle(p);
+    }
+    if (mounted) _clearSelection();
+  }
+
   Future<void> _editSelected() async {
     final result = await showBulkEditDialog(context);
     if (result == null) return;
@@ -461,6 +470,7 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
                 ),
                 IconButton(onPressed: _exportSelected, icon: const Icon(Icons.upload_file)),
                 IconButton(onPressed: _shareSelected, icon: const Icon(Icons.share)),
+                IconButton(onPressed: _shareSelectedBundle, icon: const Icon(Icons.archive)),
                 IconButton(onPressed: _editSelected, icon: const Icon(Icons.edit)),
               ]
             : [


### PR DESCRIPTION
## Summary
- allow sharing multiple packs as `.pka` bundles
- include new toolbar button for selected packs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e6b5854832aa3d16b536c471f98