### PR TITLE
Implement cloud sync start-up

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -10,7 +10,9 @@ class AppBootstrap {
     await FavoritePackService.instance.init();
     if (cloud != null) {
       await cloud.init();
+      await cloud.syncUp();
       await cloud.syncDown();
+      await cloud.loadHands();
       cloud.watchChanges();
     }
   }

--- a/lib/services/cloud_sync_service.dart
+++ b/lib/services/cloud_sync_service.dart
@@ -239,12 +239,12 @@ class CloudSyncService {
 
   Future<List<SavedHand>> downloadHands() async {
     if (uid == null) return [];
-    final snap = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('saved_hands')
-        .doc('main')
-        .get();
+    final snap = await CloudRetryPolicy.execute(() =>
+        _db.collection('users')
+            .doc(uid)
+            .collection('saved_hands')
+            .doc('main')
+            .get());
     if (!snap.exists) return [];
     final data = snap.data();
     final list = data?['hands'];
@@ -275,12 +275,12 @@ class CloudSyncService {
           DateTime.fromMillisecondsSinceEpoch(0);
     }
     if (uid == null) return hands;
-    final snap = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('saved_hands')
-        .doc('main')
-        .get();
+    final snap = await CloudRetryPolicy.execute(() =>
+        _db.collection('users')
+            .doc(uid)
+            .collection('saved_hands')
+            .doc('main')
+            .get());
     if (snap.exists) {
       final remote = snap.data()!;
       final remoteAt = DateTime.tryParse(remote['updatedAt'] as String? ?? '') ??


### PR DESCRIPTION
## Summary
- trigger uploads and downloads during start-up
- fetch remote hands with retry logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e6d7134832aadbe11beafd8a1a0