### PR TITLE
Add GGPoker-like table theme

### DIFF
--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -20,7 +20,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
   late List<double> _bets;
   int _heroIndex = 0;
   double _pot = 0.0;
-  TableTheme _theme = TableTheme.green;
+  TableTheme _theme = TableTheme.dark;
   final _history = TableEditHistory();
 
   TableState get _state => TableState(

--- a/lib/widgets/poker_table_painter.dart
+++ b/lib/widgets/poker_table_painter.dart
@@ -44,6 +44,12 @@ class PokerTablePainter extends CustomPainter {
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         );
+      case TableTheme.dark:
+        return const LinearGradient(
+          colors: [Color(0xFF1A1A1A), Color(0xFF000000)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
     }
   }
 
@@ -55,6 +61,8 @@ class PokerTablePainter extends CustomPainter {
         return Colors.grey;
       case TableTheme.blue:
         return Colors.lightBlueAccent;
+      case TableTheme.dark:
+        return Colors.orangeAccent;
     }
   }
 

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -23,7 +23,7 @@ const playerActionColors = {
   PlayerAction.post: Colors.brown,
 };
 
-enum TableTheme { green, carbon, blue }
+enum TableTheme { green, carbon, blue, dark }
 
 class PokerTableView extends StatefulWidget {
   final int heroIndex;
@@ -62,7 +62,7 @@ class PokerTableView extends StatefulWidget {
     this.heroCards = const [],
     this.revealedCards = const [],
     this.scale = 1.0,
-    this.theme = TableTheme.green,
+    this.theme = TableTheme.dark,
     this.onThemeChanged,
   });
 


### PR DESCRIPTION
## Summary
- introduce `dark` table theme for GGPoker-like look
- make dark theme the default

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f82ad9d24832a8215c2f24e6b59f3