### PR TITLE
Implement retrospective error review for training packs

### DIFF
--- a/lib/models/mistake_pack.dart
+++ b/lib/models/mistake_pack.dart
@@ -2,12 +2,14 @@ import 'package:uuid/uuid.dart';
 
 class MistakePack {
   final String id;
+  final String templateId;
   final List<String> spotIds;
   final DateTime createdAt;
   final String note;
 
   MistakePack({
     String? id,
+    required this.templateId,
     List<String>? spotIds,
     DateTime? createdAt,
     this.note = '',
@@ -16,6 +18,7 @@ class MistakePack {
         createdAt = createdAt ?? DateTime.now();
 
   Map<String, dynamic> toJson() => {
+        'templateId': templateId,
         'spotIds': spotIds,
         'createdAt': createdAt.toIso8601String(),
         if (note.isNotEmpty) 'note': note,
@@ -23,6 +26,7 @@ class MistakePack {
 
   factory MistakePack.fromJson(Map<String, dynamic> j) => MistakePack(
         id: j['id'] as String?,
+        templateId: j['templateId'] as String? ?? '',
         spotIds: [for (final s in (j['spotIds'] as List? ?? [])) s as String],
         createdAt:
             DateTime.tryParse(j['createdAt'] as String? ?? '') ?? DateTime.now(),

--- a/lib/screens/session_analysis_import_screen.dart
+++ b/lib/screens/session_analysis_import_screen.dart
@@ -158,7 +158,9 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     final template = TrainingPackTemplate(id: const Uuid().v4(), name: 'Review Imported', spots: spots);
     context.read<TemplateStorageService>().addTemplate(template);
     MistakeReviewPackService.setLatestTemplate(template);
-    await context.read<MistakeReviewPackService>().addPack([for (final s in spots) s.id]);
+    await context
+        .read<MistakeReviewPackService>()
+        .addPack([for (final s in spots) s.id], templateId: template.id);
     if (!mounted) return;
     Navigator.push(
       context,

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
+import '../widgets/review_past_mistakes_card.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -84,6 +85,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const DailyChallengeCard(),
           const WeeklyChallengeCard(),
           const XPProgressBar(),
+          const ReviewPastMistakesCard(),
           const RepeatMistakesCard(),
         ],
       ),

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -236,10 +236,11 @@ class _TrainingScreenState extends State<TrainingScreen> {
       wrongSpotIds: [for (final id in _wrongIds) if (id.isNotEmpty) id],
     );
     await context.read<DrillHistoryService>().add(result);
-    if (_wrongIds.isNotEmpty) {
+    if (_wrongIds.isNotEmpty && widget.templateId != null) {
       await context
           .read<MistakeReviewPackService>()
-          .addPack([for (final id in _wrongIds) if (id.isNotEmpty) id]);
+          .addPack([for (final id in _wrongIds) if (id.isNotEmpty) id],
+              templateId: widget.templateId!);
     }
     if (!mounted) return;
     if (repeat == true && widget.templateId != null) {

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -465,7 +465,9 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
           spots: [for (final s in widget.template.spots) if (ids.contains(s.id)) s],
         );
         MistakeReviewPackService.setLatestTemplate(template);
-        await context.read<MistakeReviewPackService>().addPack(ids);
+        await context
+            .read<MistakeReviewPackService>()
+            .addPack(ids, templateId: widget.original.id);
         final start = await showDialog<bool>(
           context: context,
           builder: (_) => AlertDialog(

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -384,7 +384,9 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
                     spots: [for (final s in widget.template.spots) if (_mistakeIds.contains(s.id)) s],
                   );
                   MistakeReviewPackService.setLatestTemplate(template);
-                  await context.read<MistakeReviewPackService>().addPack(_mistakeIds);
+                  await context
+                      .read<MistakeReviewPackService>()
+                      .addPack(_mistakeIds, templateId: widget.template.id);
                   if (!mounted) return;
                   Navigator.push(
                     context,

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -312,7 +312,9 @@ class TrainingSessionService extends ChangeNotifier {
         spots: [for (final s in _template!.spots) if (ids.contains(s.id)) s],
       );
       MistakeReviewPackService.setLatestTemplate(tpl);
-      await context.read<MistakeReviewPackService>().addPack(ids);
+      await context
+          .read<MistakeReviewPackService>()
+          .addPack(ids, templateId: _template!.id);
     }
     Navigator.pushReplacement(
       context,

--- a/lib/widgets/review_past_mistakes_card.dart
+++ b/lib/widgets/review_past_mistakes_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+import '../services/mistake_review_pack_service.dart';
+import '../services/template_storage_service.dart';
+import '../models/v2/training_pack_template.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class ReviewPastMistakesCard extends StatelessWidget {
+  const ReviewPastMistakesCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final mistakes = context.watch<MistakeReviewPackService>().templateMistakes;
+    final templates = context.watch<TemplateStorageService>().templates;
+    final list = <MapEntry<TrainingPackTemplate, int>>[];
+    mistakes.forEach((id, spots) {
+      final tpl = templates.firstWhereOrNull((t) => t.id == id);
+      if (tpl != null && spots.isNotEmpty) {
+        list.add(MapEntry(tpl, spots.length));
+      }
+    });
+    if (list.isEmpty) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Review Past Mistakes',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: [
+              for (final e in list)
+                ElevatedButton(
+                  onPressed: () async {
+                    final tpl = await context
+                        .read<MistakeReviewPackService>()
+                        .review(context, e.key.id);
+                    if (tpl != null && context.mounted) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => TrainingPackPlayScreen(
+                            template: tpl,
+                            original: tpl,
+                          ),
+                        ),
+                      );
+                    }
+                  },
+                  child: Text('${e.key.name} (${e.value})'),
+                ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add templateId to `MistakePack` for mapping mistakes to packs
- persist mistakes per template and rebuild on load
- track past mistakes when completing sessions
- start mistake review from play and result screens
- list past mistakes on Training Home

## Testing
- `dart format` *(fails: `dart` not found)*
- `flutter analyze` *(fails: `flutter` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f83b40874832a92cf676e0c16483c