### PR TITLE
Add EV/ICM analytics screen

### DIFF
--- a/lib/screens/ev_icm_analytics_screen.dart
+++ b/lib/screens/ev_icm_analytics_screen.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../services/training_stats_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
+
+class EvIcmAnalyticsScreen extends StatelessWidget {
+  static const route = '/ev_icm_analytics';
+  const EvIcmAnalyticsScreen({super.key});
+
+  Widget _chart(List<MapEntry<DateTime, double>> data, Color color) {
+    if (data.length < 2) return const SizedBox(height: 200);
+    final spots = <FlSpot>[];
+    double minY = data.first.value;
+    double maxY = data.first.value;
+    for (var i = 0; i < data.length; i++) {
+      final v = data[i].value;
+      if (v < minY) minY = v;
+      if (v > maxY) maxY = v;
+      spots.add(FlSpot(i.toDouble(), v));
+    }
+    if (minY == maxY) {
+      minY -= 1;
+      maxY += 1;
+    }
+    final interval = (maxY - minY) / 4;
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: minY,
+          maxY: maxY,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: interval,
+            getDrawingHorizontalLine: (v) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: interval,
+                reservedSize: 40,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toStringAsFixed(1),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[i].key;
+                  return Text(
+                    '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              color: color,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>();
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final ev = stats.evWeekly(hands, 8);
+    final icm = stats.icmWeekly(hands, 8);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('EV & ICM Analytics'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _chart(ev, AppColors.evPre),
+          const SizedBox(height: 16),
+          _chart(icm, AppColors.icmPre),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -27,6 +27,7 @@ import '../services/ab_test_engine.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'onboarding_screen.dart';
+import 'ev_icm_analytics_screen.dart';
 import 'package:provider/provider.dart';
 import '../widgets/sync_status_widget.dart';
 
@@ -193,6 +194,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                     MaterialPageRoute(builder: (_) => const OnboardingScreen()),
                   );
                   break;
+                case 'evicm':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const EvIcmAnalyticsScreen(),
+                    ),
+                  );
+                  break;
                 case 'about':
                   showAboutDialog(context: context);
                   break;
@@ -202,6 +211,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               PopupMenuItem(value: 'settings', child: Text('⚙️ Settings')),
               PopupMenuItem(value: 'plugins', child: Text('🧩 Plugins')),
               PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
+              PopupMenuItem(value: 'evicm', child: Text('EV/ICM')),
               PopupMenuItem(value: 'about', child: Text('About')),
             ],
           ),


### PR DESCRIPTION
## Summary
- aggregate EV and ICM metrics in `TrainingStatsService`
- show EV/ICM analytics with `fl_chart`
- link new analytics screen from main menu

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8426edfc832a8dc35a63438175e8