### PR TITLE
Add weak spot recommendations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ import 'services/reminder_service.dart';
 import 'services/daily_reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
+import 'services/weak_spot_recommendation_service.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
 import 'services/hand_analysis_history_service.dart';
@@ -314,6 +315,12 @@ Future<void> main() async {
           create: (context) => DrillSuggestionEngine(
             hands: context.read<SavedHandManagerService>(),
             packs: context.read<TrainingPackStorageService>(),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => WeakSpotRecommendationService(
+            hands: context.read<SavedHandManagerService>(),
+            eval: EvaluationExecutorService(),
           ),
         ),
         ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -26,6 +26,7 @@ import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/review_past_mistakes_card.dart';
+import '../widgets/weak_spot_card.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -85,6 +86,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const DailyChallengeCard(),
           const WeeklyChallengeCard(),
           const XPProgressBar(),
+          const WeakSpotCard(),
           const ReviewPastMistakesCard(),
           const RepeatMistakesCard(),
         ],

--- a/lib/services/weak_spot_recommendation_service.dart
+++ b/lib/services/weak_spot_recommendation_service.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+import '../models/v2/hero_position.dart';
+import 'evaluation_executor_service.dart';
+import 'pack_generator_service.dart';
+import 'saved_hand_manager_service.dart';
+import '../models/v2/training_pack_template.dart';
+
+class WeakSpotRecommendation {
+  final String position;
+  final int mistakes;
+  WeakSpotRecommendation({required this.position, required this.mistakes});
+}
+
+class WeakSpotRecommendationService extends ChangeNotifier {
+  final SavedHandManagerService hands;
+  final EvaluationExecutorService eval;
+  WeakSpotRecommendation? _rec;
+  WeakSpotRecommendation? get recommendation => _rec;
+  WeakSpotRecommendationService({required this.hands, required this.eval}) {
+    _update();
+    hands.addListener(_update);
+  }
+
+  void _update() {
+    final summary = eval.summarizeHands(hands.hands);
+    if (summary.positionMistakeFrequencies.isEmpty) {
+      _rec = null;
+    } else {
+      final entry = summary.positionMistakeFrequencies.entries
+          .reduce((a, b) => a.value >= b.value ? a : b);
+      _rec = WeakSpotRecommendation(position: entry.key, mistakes: entry.value);
+    }
+    notifyListeners();
+  }
+
+  Future<TrainingPackTemplate?> buildPack() async {
+    final pos = _rec?.position;
+    if (pos == null) return null;
+    final heroPos = parseHeroPosition(pos);
+    return PackGeneratorService.generatePushFoldPack(
+      id: 'weak_${DateTime.now().millisecondsSinceEpoch}',
+      name: 'Focus $pos',
+      heroBbStack: 15,
+      playerStacksBb: const [15, 15],
+      heroPos: heroPos,
+      heroRange: PackGeneratorService.topNHands(25).toList(),
+    );
+  }
+}

--- a/lib/widgets/weak_spot_card.dart
+++ b/lib/widgets/weak_spot_card.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/weak_spot_recommendation_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class WeakSpotCard extends StatelessWidget {
+  const WeakSpotCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final rec = context.watch<WeakSpotRecommendationService>().recommendation;
+    if (rec == null) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.school, color: Colors.orange),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Рекомендация',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text('${rec.position} — ${rec.mistakes} ошибок',
+                    style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl = await context
+                  .read<WeakSpotRecommendationService>()
+                  .buildPack();
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Тренировать'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- analyze saved hands to detect weak positions
- generate training packs for the weakest spot
- show personalized training card on training home

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f878262a0832a9b89ad3756829d9b