### PR TITLE
Implement player progress tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'services/daily_reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/weak_spot_recommendation_service.dart';
+import 'services/player_progress_service.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
 import 'services/hand_analysis_history_service.dart';
@@ -189,6 +190,7 @@ Future<void> main() async {
             mistakes: context.read<MistakeReviewPackService>(),
             eval: EvaluationExecutorService(),
             hands: context.read<SavedHandManagerService>(),
+            progress: context.read<PlayerProgressService>(),
           ),
         ),
         ChangeNotifierProvider(
@@ -322,6 +324,10 @@ Future<void> main() async {
             hands: context.read<SavedHandManagerService>(),
             eval: EvaluationExecutorService(),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) =>
+              PlayerProgressService(hands: context.read<SavedHandManagerService>()),
         ),
         ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),
         ChangeNotifierProvider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
+import '../widgets/position_progress_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import 'training_progress_analytics_screen.dart';
@@ -81,6 +82,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const QuickContinueCard(),
           const SpotOfTheDayCard(),
           const ProgressSummaryBox(),
+          const PositionProgressCard(),
           const StreakChart(),
           const DailyProgressRing(),
           const DailyChallengeCard(),

--- a/lib/services/dynamic_pack_adjustment_service.dart
+++ b/lib/services/dynamic_pack_adjustment_service.dart
@@ -4,15 +4,18 @@ import 'mistake_review_pack_service.dart';
 import 'pack_generator_service.dart';
 import 'evaluation_executor_service.dart';
 import 'saved_hand_manager_service.dart';
+import 'player_progress_service.dart';
 
 class DynamicPackAdjustmentService {
   final MistakeReviewPackService mistakes;
   final EvaluationExecutorService eval;
   final SavedHandManagerService hands;
+  final PlayerProgressService progress;
   const DynamicPackAdjustmentService({
     required this.mistakes,
     required this.eval,
     required this.hands,
+    required this.progress,
   });
 
   Future<TrainingPackTemplate> adjust(TrainingPackTemplate tpl) async {
@@ -35,6 +38,11 @@ class DynamicPackAdjustmentService {
     if (acc < 0.5) diff--;
     final mc = mistakes.mistakeCount(tpl.id);
     if (mc > 5) diff--;
+    final pos = progress.progress[tpl.heroPos];
+    if (pos != null) {
+      if (pos.accuracy > 0.85) diff++;
+      if (pos.accuracy < 0.6) diff--;
+    }
     final posMist = hands.hands.where((h) {
       final exp = h.expectedAction?.trim().toLowerCase();
       final gto = h.gtoAction?.trim().toLowerCase();

--- a/lib/services/player_progress_service.dart
+++ b/lib/services/player_progress_service.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/foundation.dart';
+import '../models/v2/hero_position.dart';
+import 'saved_hand_manager_service.dart';
+
+class PositionProgress {
+  final int hands;
+  final int correct;
+  final double ev;
+  final double icm;
+  const PositionProgress({this.hands = 0, this.correct = 0, this.ev = 0, this.icm = 0});
+  double get accuracy => hands > 0 ? correct / hands : 0;
+}
+
+class PlayerProgressService extends ChangeNotifier {
+  final SavedHandManagerService hands;
+  Map<HeroPosition, PositionProgress> _progress = {};
+  Map<HeroPosition, PositionProgress> get progress => _progress;
+  PlayerProgressService({required this.hands}) {
+    _update();
+    hands.addListener(_update);
+  }
+
+  void _update() {
+    final map = <HeroPosition, List<PositionProgress>>{};
+    for (final h in hands.hands) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp == null || gto == null) continue;
+      final pos = parseHeroPosition(h.heroPosition);
+      final list = map.putIfAbsent(pos, () => []);
+      final ev = h.heroEv ?? 0;
+      final icm = h.heroIcmEv ?? 0;
+      final correct = exp == gto ? 1 : 0;
+      list.add(PositionProgress(hands: 1, correct: correct, ev: ev, icm: icm));
+    }
+    final result = <HeroPosition, PositionProgress>{};
+    for (final e in map.entries) {
+      final hands = e.value.length;
+      final correct = e.value.fold(0, (p, v) => p + v.correct);
+      final ev = e.value.fold(0.0, (p, v) => p + v.ev) / hands;
+      final icm = e.value.fold(0.0, (p, v) => p + v.icm) / hands;
+      result[e.key] = PositionProgress(hands: hands, correct: correct, ev: ev, icm: icm);
+    }
+    _progress = result;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    hands.removeListener(_update);
+    super.dispose();
+  }
+}

--- a/lib/widgets/position_progress_card.dart
+++ b/lib/widgets/position_progress_card.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/v2/hero_position.dart';
+import '../services/player_progress_service.dart';
+
+class PositionProgressCard extends StatelessWidget {
+  const PositionProgressCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = context.watch<PlayerProgressService>().progress;
+    if (progress.isEmpty) return const SizedBox.shrink();
+    final rows = <TableRow>[];
+    rows.add(const TableRow(children: [
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 2),
+        child: Text('Pos', style: TextStyle(color: Colors.white70)),
+      ),
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 2),
+        child: Text('Acc', style: TextStyle(color: Colors.white70)),
+      ),
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 2),
+        child: Text('EV', style: TextStyle(color: Colors.white70)),
+      ),
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 2),
+        child: Text('ICM', style: TextStyle(color: Colors.white70)),
+      ),
+    ]));
+    for (final p in kPositionOrder) {
+      final stat = progress[p];
+      if (stat == null) continue;
+      rows.add(TableRow(children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child: Text(p.label, style: const TextStyle(color: Colors.white)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child: Text('${(stat.accuracy * 100).round()}%',
+              style: const TextStyle(color: Colors.white)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child:
+              Text(stat.ev.toStringAsFixed(1), style: const TextStyle(color: Colors.white)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child:
+              Text(stat.icm.toStringAsFixed(1), style: const TextStyle(color: Colors.white)),
+        ),
+      ]));
+    }
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Table(columnWidths: const {
+        0: FixedColumnWidth(40),
+        1: FixedColumnWidth(40),
+        2: FixedColumnWidth(50),
+        3: FixedColumnWidth(50),
+      }, children: rows),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PlayerProgressService to compute accuracy, EV and ICM per position
- adapt DynamicPackAdjustmentService with progress metrics
- expose position progress in home screen via PositionProgressCard
- register new service in main

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f89781920832ab7bc9144396e08f6