### PR TITLE
Add achievement progress screen

### DIFF
--- a/lib/screens/achievement_progress_screen.dart
+++ b/lib/screens/achievement_progress_screen.dart
@@ -1,0 +1,173 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/achievement_engine.dart';
+import '../services/training_stats_service.dart';
+import '../theme/app_colors.dart';
+import '../widgets/sync_status_widget.dart';
+
+class AchievementProgressScreen extends StatelessWidget {
+  const AchievementProgressScreen({super.key});
+
+  Widget _chart(List<MapEntry<DateTime, int>> data, Color color) {
+    if (data.length < 2) return const SizedBox(height: 200);
+    final spots = <FlSpot>[];
+    for (var i = 0; i < data.length; i++) {
+      spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
+    }
+    final step = (data.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: 0,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 1,
+            getDrawingHorizontalLine: (v) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval:
+                    data.map((e) => e.value).reduce((a, b) => a > b ? a : b) / 4,
+                reservedSize: 30,
+                getTitlesWidget: (v, meta) => Text(
+                  v.toInt().toString(),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= data.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[i].key;
+                  return Text(
+                    '${d.month.toString().padLeft(2, '0')}.${(d.year % 100).toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: false,
+              color: color,
+              barWidth: 2,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>();
+    final achievements =
+        context.watch<AchievementEngine>().achievements.where((a) => a.completed).toList();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Прогресс достижений'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _chart(stats.handsMonthly(12), accent),
+          const SizedBox(height: 12),
+          _chart(stats.sessionsMonthly(12), Colors.greenAccent),
+          const SizedBox(height: 12),
+          _chart(stats.mistakesMonthly(12), Colors.redAccent),
+          const SizedBox(height: 12),
+          if (achievements.isEmpty)
+            const Center(child: Text('Достижения еще не получены'))
+          else
+            GridView.builder(
+              padding: EdgeInsets.zero,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: achievements.length,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
+                childAspectRatio: 1.2,
+              ),
+              itemBuilder: (context, index) {
+                final a = achievements[index];
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[850],
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(a.icon, size: 40, color: accent),
+                      const SizedBox(height: 8),
+                      Text(
+                        a.title,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const Spacer(),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(4),
+                              child: LinearProgressIndicator(
+                                value: 1.0,
+                                backgroundColor: Colors.white24,
+                                valueColor: AlwaysStoppedAnimation<Color>(accent),
+                                minHeight: 6,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text('${a.target}/${a.target}')
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      const Icon(Icons.check_circle, color: Colors.green),
+                    ],
+                  ),
+                );
+              },
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -43,6 +43,7 @@ import 'mistake_repeat_screen.dart';
 import 'quick_hand_analysis_screen.dart';
 import 'hand_analysis_history_screen.dart';
 import 'achievements_screen.dart';
+import 'achievement_progress_screen.dart';
 import '../services/goals_service.dart';
 import '../widgets/focus_of_the_week_card.dart';
 import '../widgets/sync_status_widget.dart';
@@ -570,6 +571,15 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 );
               },
               child: const Text('🏆 Достижения'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AchievementProgressScreen()),
+                );
+              },
+              child: const Text('📈 Прогресс достижений'),
             ),
             ElevatedButton(
               onPressed: () {


### PR DESCRIPTION
## Summary
- create `AchievementProgressScreen`
- link from main menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f89930c20832aaa2103145df4ecf3