### PR TITLE
Implement pack sync

### DIFF
--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -68,6 +68,7 @@ import '../services/cloud_training_history_service.dart';
 import '../helpers/color_utils.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
+import '../services/training_pack_cloud_sync_service.dart';
 
 
 class _SessionSummary {
@@ -1526,6 +1527,18 @@ body { font-family: sans-serif; padding: 16px; }
                       ? Colors.amber
                       : Colors.red,
               minHeight: 6,
+            ),
+            const SizedBox(height: 4),
+            ValueListenableBuilder<DateTime?>(
+              valueListenable:
+                  context.read<TrainingPackCloudSyncService>().lastSync,
+              builder: (context, value, child) {
+                final t = value == null
+                    ? '-'
+                    : formatDateTime(value.toLocal());
+                return Text('Синхр.: $t',
+                    style: const TextStyle(fontSize: 12, color: Colors.white70));
+              },
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- allow uploading custom packs via `TrainingPackCloudSyncService.syncUp`
- update `syncDown` to track last sync time
- show pack sync status in `TrainingPackScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f899a1334832aa9e4d1ea8af5dab5