### PR TITLE
Add PokerStars converter plugin

### DIFF
--- a/lib/plugins/plugin_loader.dart
+++ b/lib/plugins/plugin_loader.dart
@@ -19,6 +19,7 @@ import 'converters/simple_hand_history_converter.dart';
 import 'converters/pokerstars_hand_history_converter.dart';
 import 'converters/ggpoker_hand_history_converter.dart';
 import 'converters/winamax_hand_history_converter.dart';
+import 'poker_stars_converter_plugin.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -100,6 +101,8 @@ class PluginLoader {
           GGPokerHandHistoryConverter(),
           WinamaxHandHistoryConverter(),
         ]);
+      case 'PokerStarsConverterPlugin':
+        return PokerStarsConverterPlugin();
     }
     return null;
   }
@@ -165,10 +168,18 @@ class PluginLoader {
   }) async {
     final builtIn = loadBuiltInPlugins();
     final support = await getApplicationSupportDirectory();
-    final dir = Directory(p.join(support.path, 'plugins'));
+    final supportDir = Directory(p.join(support.path, 'plugins'));
     final files = <File>[];
-    if (await dir.exists()) {
-      await for (final entity in dir.list()) {
+    if (await supportDir.exists()) {
+      await for (final entity in supportDir.list()) {
+        if (entity is File && entity.path.endsWith(_suffix)) {
+          files.add(entity);
+        }
+      }
+    }
+    final rootDir = Directory('plugins');
+    if (await rootDir.exists()) {
+      await for (final entity in rootDir.list()) {
         if (entity is File && entity.path.endsWith(_suffix)) {
           files.add(entity);
         }

--- a/lib/plugins/poker_stars_converter_plugin.dart
+++ b/lib/plugins/poker_stars_converter_plugin.dart
@@ -1,0 +1,12 @@
+import 'package:poker_analyzer/plugins/converters/pokerstars_hand_history_converter.dart';
+import 'package:poker_analyzer/plugins/plugin.dart';
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+
+class PokerStarsConverterPlugin extends PokerStarsHandHistoryConverter implements Plugin {
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
+    registry.get<ConverterRegistry>().register(this);
+  }
+}

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -39,6 +39,14 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
         }
       }
     }
+    final rootDir = Directory('plugins');
+    if (await rootDir.exists()) {
+      await for (final entity in rootDir.list()) {
+        if (entity is File && entity.path.endsWith('.dart')) {
+          files.add(p.basename(entity.path));
+        }
+      }
+    }
     setState(() {
       _config = Map<String, bool>.from(config);
       _files = files;

--- a/plugins/PokerStarsConverterPlugin.dart
+++ b/plugins/PokerStarsConverterPlugin.dart
@@ -1,0 +1,6 @@
+import 'dart:isolate';
+import 'package:poker_analyzer/plugins/poker_stars_converter_plugin.dart';
+
+void main(List<String> args, SendPort sendPort) {
+  sendPort.send(PokerStarsConverterPlugin());
+}


### PR DESCRIPTION
## Summary
- implement PokerStars converter plugin
- allow plugin loader to instantiate plugin
- search app and root directories for plugin files

## Testing
- `dart` and `flutter` were unavailable, so tests could not run

------
https://chatgpt.com/codex/tasks/task_e_686f8997eb94832a8f955b7e631099bc