### PR TITLE
Add session analysis export

### DIFF
--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -9,12 +9,15 @@ import '../helpers/hand_utils.dart';
 import '../services/evaluation_executor_service.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../services/training_session_service.dart';
+import '../services/pack_export_service.dart';
+import '../services/file_saver_service.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:share_plus/share_plus.dart';
 import 'training_session_screen.dart';
 
 class SessionAnalysisScreen extends StatefulWidget {
@@ -38,7 +41,8 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
 
   Future<void> _compute() async {
     final executor = context.read<EvaluationExecutorService>();
-    final data = [...widget.hands]..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+    final data = [...widget.hands]
+      ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
     final evs = <double>[];
     final icms = <double>[];
     for (final h in data) {
@@ -73,10 +77,15 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
   }
 
   TrainingPackSpot _spotFromHand(SavedHand h) {
-    final heroCards = h.playerCards[h.heroIndex].map((c) => '${c.rank}${c.suit}').join(' ');
-    final actions = <ActionEntry>[for (final a in h.actions) if (a.street == 0) a];
+    final heroCards =
+        h.playerCards[h.heroIndex].map((c) => '${c.rank}${c.suit}').join(' ');
+    final actions = <ActionEntry>[
+      for (final a in h.actions)
+        if (a.street == 0) a
+    ];
     final stacks = <String, double>{
-      for (int i = 0; i < h.numberOfPlayers; i++) '$i': (h.stackSizes[i] ?? 0).toDouble()
+      for (int i = 0; i < h.numberOfPlayers; i++)
+        '$i': (h.stackSizes[i] ?? 0).toDouble()
     };
     return TrainingPackSpot(
       id: const Uuid().v4(),
@@ -186,10 +195,44 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
     );
   }
 
+  Future<void> _exportCsv() async {
+    try {
+      final list = [...widget.hands]
+        ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+      final file = await PackExportService.exportSessionCsv(list, _evs, _icms);
+      if (!mounted) return;
+      await Share.shareXFiles([XFile(file.path)]);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('CSV exported')));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Export failed: $e')));
+      }
+    }
+  }
+
+  Future<void> _exportPdf() async {
+    try {
+      final list = [...widget.hands]
+        ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+      final file = await PackExportService.exportSessionPdf(list, _evs, _icms);
+      if (!mounted) return;
+      await FileSaverService.instance.sharePdf(file.path);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('PDF exported')));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Export failed: $e')));
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final list = [...widget.hands]..sort((a, b) => a.savedAt.compareTo(b.savedAt));
+    final list = [...widget.hands]
+      ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
     int correct = 0;
     int mistakes = 0;
     for (final h in list) {
@@ -203,9 +246,8 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
         }
       }
     }
-    final accuracy = correct + mistakes > 0
-        ? correct * 100 / (correct + mistakes)
-        : 0.0;
+    final accuracy =
+        correct + mistakes > 0 ? correct * 100 / (correct + mistakes) : 0.0;
     final preEv = _evs.isNotEmpty ? _evs.first : 0.0;
     final postEv = _evs.isNotEmpty ? _evs.last : 0.0;
     final preIcm = _icms.isNotEmpty ? _icms.first : 0.0;
@@ -218,71 +260,95 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
           : ListView(
               padding: const EdgeInsets.all(16),
               children: [
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: AppColors.cardBackground,
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Hands: ${list.length}',
-                    style: const TextStyle(color: Colors.white)),
-                const SizedBox(height: 4),
-                Text('Accuracy: ${accuracy.toStringAsFixed(1)}%',
-                    style: const TextStyle(color: Colors.white)),
-                const SizedBox(height: 4),
-                Text('Mistakes: $mistakes',
-                    style: const TextStyle(color: Colors.white)),
-                const SizedBox(height: 4),
-                Text('EV: ${preEv.toStringAsFixed(2)} ➜ ${postEv.toStringAsFixed(2)}',
-                    style: const TextStyle(color: Colors.white)),
-                const SizedBox(height: 4),
-                Text('ICM: ${preIcm.toStringAsFixed(2)} ➜ ${postIcm.toStringAsFixed(2)}',
-                    style: const TextStyle(color: Colors.white)),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.cardBackground,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Hands: ${list.length}',
+                          style: const TextStyle(color: Colors.white)),
+                      const SizedBox(height: 4),
+                      Text('Accuracy: ${accuracy.toStringAsFixed(1)}%',
+                          style: const TextStyle(color: Colors.white)),
+                      const SizedBox(height: 4),
+                      Text('Mistakes: $mistakes',
+                          style: const TextStyle(color: Colors.white)),
+                      const SizedBox(height: 4),
+                      Text(
+                          'EV: ${preEv.toStringAsFixed(2)} ➜ ${postEv.toStringAsFixed(2)}',
+                          style: const TextStyle(color: Colors.white)),
+                      const SizedBox(height: 4),
+                      Text(
+                          'ICM: ${preIcm.toStringAsFixed(2)} ➜ ${postIcm.toStringAsFixed(2)}',
+                          style: const TextStyle(color: Colors.white)),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _buildChart(),
+                const SizedBox(height: 16),
+                Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () async {
+                      final tpl = await MistakeReviewPackService.latestTemplate(
+                          context);
+                      if (tpl == null) return;
+                      await context
+                          .read<TrainingSessionService>()
+                          .startSession(tpl, persist: false);
+                      if (!context.mounted) return;
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const TrainingSessionScreen()),
+                      );
+                    },
+                    child: const Text('Review Mistakes'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: _exportPdf,
+                        child: const Text('Экспорт PDF'),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: _exportCsv,
+                        child: const Text('Экспорт CSV'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                for (var i = 0; i < list.length; i++) ...[
+                  Container(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    decoration: BoxDecoration(
+                      color: AppColors.cardBackground,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: ListTile(
+                      title: Text(list[i].name,
+                          style: const TextStyle(color: Colors.white)),
+                      subtitle: Text(
+                        'EV: ${_evs[i].toStringAsFixed(2)} • ICM: ${_icms[i].toStringAsFixed(2)}',
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                      onTap: () => showSavedHandViewerDialog(context, list[i]),
+                    ),
+                  ),
+                ],
               ],
             ),
-          ),
-          const SizedBox(height: 16),
-          _buildChart(),
-          const SizedBox(height: 16),
-          Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () async {
-                final tpl = await MistakeReviewPackService.latestTemplate(context);
-                if (tpl == null) return;
-                await context.read<TrainingSessionService>().startSession(tpl, persist: false);
-                if (!context.mounted) return;
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
-                );
-              },
-              child: const Text('Review Mistakes'),
-            ),
-          ),
-          const SizedBox(height: 16),
-          for (var i = 0; i < list.length; i++) ...[
-            Container(
-              margin: const EdgeInsets.symmetric(vertical: 4),
-              decoration: BoxDecoration(
-                color: AppColors.cardBackground,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: ListTile(
-                title:
-                    Text(list[i].name, style: const TextStyle(color: Colors.white)),
-                subtitle: Text(
-                  'EV: ${_evs[i].toStringAsFixed(2)} • ICM: ${_icms[i].toStringAsFixed(2)}',
-                  style: const TextStyle(color: Colors.white70),
-                ),
-                onTap: () => showSavedHandViewerDialog(context, list[i]),
-              ),
-            ),
-          ],
-        ],
-      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- enable exporting session analysis to CSV and PDF
- generate session report from saved hands
- add export buttons on session analysis screen

## Testing
- `flutter analyze` *(fails: 3135 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686f8982d704832aabc72ef686eb4e4b