### PR TITLE
Add daily goals and reminder integration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,6 +60,7 @@ import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
 import 'services/weekly_challenge_service.dart';
 import 'services/daily_challenge_service.dart';
+import 'services/daily_goals_service.dart';
 import 'services/session_log_service.dart';
 import 'services/category_usage_service.dart';
 import 'user_preferences.dart';
@@ -257,6 +258,12 @@ Future<void> main() async {
           ),
         ),
         ChangeNotifierProvider(create: (_) => SpotOfTheDayService()..load()),
+        ChangeNotifierProvider(
+          create: (context) => DailyGoalsService(
+            stats: context.read<TrainingStatsService>(),
+            hands: context.read<SavedHandManagerService>(),
+          )..load(),
+        ),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
         ChangeNotifierProvider(
@@ -305,6 +312,7 @@ Future<void> main() async {
             spot: context.read<SpotOfTheDayService>(),
             target: context.read<DailyTargetService>(),
             stats: context.read<TrainingStatsService>(),
+            goals: context.read<DailyGoalsService>(),
           )..load(),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -18,6 +18,7 @@ import 'training_session_screen.dart';
 import '../services/spot_of_the_day_service.dart';
 import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/streak_chart.dart';
+import '../widgets/daily_goals_card.dart';
 import '../widgets/daily_progress_ring.dart';
 import '../widgets/repeat_mistakes_card.dart';
 import '../widgets/weekly_challenge_card.dart';
@@ -85,6 +86,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const PositionProgressCard(),
           const StreakChart(),
           const DailyProgressRing(),
+          const DailyGoalsCard(),
           const DailyChallengeCard(),
           const WeeklyChallengeCard(),
           const XPProgressBar(),

--- a/lib/services/daily_goals_service.dart
+++ b/lib/services/daily_goals_service.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/saved_hand.dart';
+import 'training_stats_service.dart';
+import 'saved_hand_manager_service.dart';
+
+class DailyGoalsService extends ChangeNotifier {
+  static const _dateKey = 'daily_goals_date';
+  static const _targetsKey = 'daily_goals_targets';
+  static const _baseSessionsKey = 'daily_goals_base_sessions';
+
+  final TrainingStatsService stats;
+  final SavedHandManagerService hands;
+
+  DateTime? _date;
+  int _baseSessions = 0;
+  double targetSessions = 0;
+  double targetAccuracy = 0;
+  double targetEv = 0;
+  double targetIcm = 0;
+
+  Timer? _timer;
+
+  DailyGoalsService({required this.stats, required this.hands});
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dateStr = prefs.getString(_dateKey);
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    final raw = prefs.getString(_targetsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw) as Map<String, dynamic>;
+        targetSessions = (data['sessions'] as num?)?.toDouble() ?? 0;
+        targetAccuracy = (data['accuracy'] as num?)?.toDouble() ?? 0;
+        targetEv = (data['ev'] as num?)?.toDouble() ?? 0;
+        targetIcm = (data['icm'] as num?)?.toDouble() ?? 0;
+      } catch (_) {}
+    }
+    _baseSessions = prefs.getInt(_baseSessionsKey) ?? stats.sessionsCompleted;
+    await _ensureToday();
+    stats.sessionsStream.listen((_) => notifyListeners());
+    hands.addListener(notifyListeners);
+    _schedule();
+    notifyListeners();
+  }
+
+  List<SavedHand> _handsSince(DateTime start) {
+    final end = start.add(const Duration(days: 1));
+    return [
+      for (final h in hands.hands)
+        if (!h.date.isBefore(start) && h.date.isBefore(end)) h
+    ];
+  }
+
+  List<SavedHand> _recentHands(int days) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(Duration(days: days));
+    return [for (final h in hands.hands) if (!h.date.isBefore(start)) h];
+  }
+
+  double _calcAccuracy(List<SavedHand> list) {
+    int total = 0;
+    int correct = 0;
+    for (final h in list) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp == null || gto == null) continue;
+      total++;
+      if (exp == gto) correct++;
+    }
+    return total > 0 ? correct / total * 100 : 0;
+  }
+
+  double _calcEv(List<SavedHand> list) {
+    final vals = [for (final h in list) if (h.heroEv != null) h.heroEv!];
+    if (vals.isEmpty) return 0;
+    return vals.reduce((a, b) => a + b) / vals.length;
+  }
+
+  double _calcIcm(List<SavedHand> list) {
+    final vals = [for (final h in list) if (h.heroIcmEv != null) h.heroIcmEv!];
+    if (vals.isEmpty) return 0;
+    return vals.reduce((a, b) => a + b) / vals.length;
+  }
+
+  Future<void> _ensureToday() async {
+    final now = DateTime.now();
+    if (_date != null &&
+        _date!.year == now.year &&
+        _date!.month == now.month &&
+        _date!.day == now.day) {
+      return;
+    }
+    final recent = _recentHands(7);
+    final sessions = stats.sessionsDaily(7);
+    final avgSessions = sessions.isNotEmpty
+        ? sessions.map((e) => e.value).reduce((a, b) => a + b) / sessions.length
+        : 0;
+    targetSessions = (avgSessions + 1).roundToDouble();
+    targetAccuracy = (_calcAccuracy(recent) + 5).clamp(50, 100);
+    targetEv = _calcEv(recent) + 0.1;
+    targetIcm = _calcIcm(recent) + 0.1;
+    _baseSessions = stats.sessionsCompleted;
+    _date = DateTime(now.year, now.month, now.day);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+    await prefs.setInt(_baseSessionsKey, _baseSessions);
+    await prefs.setString(
+      _targetsKey,
+      jsonEncode({
+        'sessions': targetSessions,
+        'accuracy': targetAccuracy,
+        'ev': targetEv,
+        'icm': targetIcm,
+      }),
+    );
+  }
+
+  void _schedule() {
+    _timer?.cancel();
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day + 1);
+    _timer = Timer(next.difference(now), () async {
+      await _ensureToday();
+      _schedule();
+      notifyListeners();
+    });
+  }
+
+  int get progressSessions => stats.sessionsCompleted - _baseSessions;
+  double get progressAccuracy => _calcAccuracy(_handsSince(DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)));
+  double get progressEv => _calcEv(_handsSince(DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)));
+  double get progressIcm => _calcIcm(_handsSince(DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)));
+
+  bool get anyIncomplete =>
+      progressSessions < targetSessions ||
+      progressAccuracy < targetAccuracy ||
+      progressEv < targetEv ||
+      progressIcm < targetIcm;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    hands.removeListener(notifyListeners);
+    super.dispose();
+  }
+}
+

--- a/lib/widgets/daily_goals_card.dart
+++ b/lib/widgets/daily_goals_card.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/daily_goals_service.dart';
+
+class DailyGoalsCard extends StatelessWidget {
+  const DailyGoalsCard({super.key});
+
+  Widget _bar(BuildContext context, String title, double progress, double target, {int decimals = 0}) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final value = target > 0 ? (progress / target).clamp(0.0, 1.0) : 0.0;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: value,
+              backgroundColor: Colors.white24,
+              valueColor: AlwaysStoppedAnimation(accent),
+              minHeight: 6,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Text(
+              '${progress.toStringAsFixed(decimals)}/${target.toStringAsFixed(decimals)}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DailyGoalsService>();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Daily Goals',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          _bar(context, 'Sessions', service.progressSessions.toDouble(), service.targetSessions.toDouble()),
+          _bar(context, 'Accuracy %', service.progressAccuracy, service.targetAccuracy),
+          _bar(context, 'EV', service.progressEv, service.targetEv, decimals: 1),
+          _bar(context, 'ICM', service.progressIcm, service.targetIcm, decimals: 2),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `DailyGoalsService` for adaptive daily objectives
- display progress in new `DailyGoalsCard`
- update `DailyReminderService` to account for daily goals
- register `DailyGoalsService` and pass to reminder service
- show daily goals on training home screen

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8be86ff0832aa77b271f8597f115