### PR TITLE
Add level display to achievements

### DIFF
--- a/lib/models/level_stage.dart
+++ b/lib/models/level_stage.dart
@@ -1,0 +1,22 @@
+import "package:flutter/material.dart";
+enum LevelStage { bronze, silver, gold, platinum, diamond }
+
+extension LevelStageX on LevelStage {
+  String get label =>
+      ['Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond'][index];
+  Color get color => const [
+        Color(0xffcd7f32),
+        Color(0xffc0c0c0),
+        Color(0xffffd700),
+        Color(0xffe5e4e2),
+        Color(0xffb9f2ff)
+      ][index];
+}
+
+LevelStage stageForLevel(int level) {
+  if (level >= 21) return LevelStage.diamond;
+  if (level >= 16) return LevelStage.platinum;
+  if (level >= 11) return LevelStage.gold;
+  if (level >= 6) return LevelStage.silver;
+  return LevelStage.bronze;
+}

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -9,6 +9,8 @@ import 'package:share_plus/share_plus.dart';
 
 import '../services/achievement_engine.dart';
 import '../services/user_action_logger.dart';
+import '../services/xp_tracker_service.dart';
+import '../models/level_stage.dart';
 import '../widgets/sync_status_widget.dart';
 
 class AchievementsScreen extends StatefulWidget {
@@ -51,6 +53,8 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
   @override
   Widget build(BuildContext context) {
     final engine = context.watch<AchievementEngine>();
+    final xp = context.watch<XPTrackerService>();
+    final stage = stageForLevel(xp.level);
     final accent = Theme.of(context).colorScheme.secondary;
     return RepaintBoundary(
       key: _boundaryKey,
@@ -65,9 +69,45 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
         ),
         body: ListView.builder(
           padding: const EdgeInsets.all(16),
-          itemCount: engine.achievements.length,
+          itemCount: engine.achievements.length + 1,
           itemBuilder: (context, index) {
-          final a = engine.achievements[index];
+          if (index == 0) {
+            return Container(
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${stage.label} Level ${xp.level}',
+                    style: TextStyle(
+                      color: stage.color,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text('${xp.xp} / ${xp.nextLevelXp} XP',
+                      style: const TextStyle(color: Colors.white)),
+                  const SizedBox(height: 8),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: xp.progress.clamp(0.0, 1.0),
+                      backgroundColor: Colors.white24,
+                      valueColor:
+                          AlwaysStoppedAnimation<Color>(stage.color),
+                      minHeight: 6,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+          final a = engine.achievements[index - 1];
           final done = a.completed;
           return Container(
             margin: const EdgeInsets.only(bottom: 12),


### PR DESCRIPTION
## Summary
- map user levels to Bronze, Silver, Gold, Platinum and Diamond
- show current level and progress in achievements screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8e8b0b98832ab71e7ca46c845c91