### PR TITLE
Implement leveled achievements with stages

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -1,18 +1,33 @@
 import "package:flutter/material.dart";
+import "level_stage.dart";
+
 class Achievement {
   final String title;
   final String description;
   final IconData icon;
   final int progress;
-  final int target;
+  final List<int> thresholds;
 
   const Achievement({
     required this.title,
     required this.description,
     required this.icon,
     required this.progress,
-    required this.target,
+    required this.thresholds,
   });
+
+  int get level {
+    var l = 0;
+    for (final t in thresholds) {
+      if (progress >= t) l += 1;
+    }
+    return l.clamp(0, thresholds.length);
+  }
+
+  LevelStage get stage => LevelStage.values[(level.clamp(1, 5)) - 1];
+
+  int get target =>
+      level < thresholds.length ? thresholds[level] : thresholds.last;
 
   bool get completed => progress >= target;
 
@@ -21,6 +36,6 @@ class Achievement {
         description: description,
         icon: icon,
         progress: progress ?? this.progress,
-        target: target,
+        thresholds: thresholds,
       );
 }

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -55,7 +55,6 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
     final engine = context.watch<AchievementEngine>();
     final xp = context.watch<XPTrackerService>();
     final stage = stageForLevel(xp.level);
-    final accent = Theme.of(context).colorScheme.secondary;
     return RepaintBoundary(
       key: _boundaryKey,
       child: Scaffold(
@@ -119,7 +118,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(a.icon, color: accent),
+                Icon(a.icon, color: a.stage.color),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Column(
@@ -128,13 +127,15 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                       Text(a.title, style: const TextStyle(fontWeight: FontWeight.bold)),
                       const SizedBox(height: 4),
                       Text(a.description, style: const TextStyle(color: Colors.white70)),
+                      const SizedBox(height: 4),
+                      Text(a.stage.label, style: TextStyle(color: a.stage.color)),
                       const SizedBox(height: 8),
                       ClipRRect(
                         borderRadius: BorderRadius.circular(4),
                         child: LinearProgressIndicator(
                           value: (a.progress / a.target).clamp(0.0, 1.0),
                           backgroundColor: Colors.white24,
-                          valueColor: AlwaysStoppedAnimation<Color>(accent),
+                          valueColor: AlwaysStoppedAnimation<Color>(a.stage.color),
                           minHeight: 6,
                         ),
                       ),
@@ -145,6 +146,8 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                 Column(
                   children: [
                     Text(done ? '✅' : '⏳'),
+                    const SizedBox(height: 4),
+                    Text(a.stage.label, style: TextStyle(color: a.stage.color)),
                     const SizedBox(height: 4),
                     Text('${a.progress}/${a.target}')
                   ],


### PR DESCRIPTION
## Summary
- expand `Achievement` model to support level thresholds
- add stage-aware visuals on achievements screen
- track achievement levels and trigger notifications when level increases

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f90066b8c832a8d6305ef6d1d6cf2