### PR TITLE
Add tiered achievements with progress bars

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -1,26 +1,48 @@
 import 'package:flutter/material.dart';
+import 'level_stage.dart';
+
 class Achievement {
   final String title;
   final String description;
   final IconData icon;
   final int progress;
-  final int target;
+  final List<int> thresholds;
 
   const Achievement({
     required this.title,
     required this.description,
     required this.icon,
     required this.progress,
-    required this.target,
+    required this.thresholds,
   });
 
-  bool get completed => progress >= target;
+  int get levelIndex {
+    var idx = 0;
+    for (final t in thresholds) {
+      if (progress >= t) idx++; else break;
+    }
+    return idx;
+  }
+
+  LevelStage get level => LevelStage.values[levelIndex.clamp(0, thresholds.length - 1)];
+
+  bool get completed => levelIndex >= thresholds.length;
+
+  int get nextTarget =>
+      levelIndex < thresholds.length ? thresholds[levelIndex] : thresholds.last;
+
+  double get pct {
+    if (completed) return 1.0;
+    final prev = levelIndex == 0 ? 0 : thresholds[levelIndex - 1];
+    final next = thresholds[levelIndex];
+    return ((progress - prev) / (next - prev)).clamp(0.0, 1.0);
+  }
 
   Achievement copyWith({int? progress}) => Achievement(
         title: title,
         description: description,
         icon: icon,
         progress: progress ?? this.progress,
-        target: target,
+        thresholds: thresholds,
       );
 }

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -109,6 +109,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
           }
           final a = engine.achievements[index - 1];
           final done = a.completed;
+          final stage = a.level;
           return Container(
             margin: const EdgeInsets.only(bottom: 12),
             padding: const EdgeInsets.all(12),
@@ -132,9 +133,10 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                       ClipRRect(
                         borderRadius: BorderRadius.circular(4),
                         child: LinearProgressIndicator(
-                          value: (a.progress / a.target).clamp(0.0, 1.0),
+                          value: a.pct,
                           backgroundColor: Colors.white24,
-                          valueColor: AlwaysStoppedAnimation<Color>(accent),
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(stage.color),
                           minHeight: 6,
                         ),
                       ),
@@ -144,9 +146,9 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                 const SizedBox(width: 12),
                 Column(
                   children: [
-                    Text(done ? '✅' : '⏳'),
+                    Text(stage.label, style: TextStyle(color: stage.color)),
                     const SizedBox(height: 4),
-                    Text('${a.progress}/${a.target}')
+                    Text('${a.progress}/${a.nextTarget}')
                   ],
                 )
               ],

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -110,9 +110,9 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
               for (final a in achievements)
                 Column(
                   children: [
-                    Icon(a.icon, color: accent),
+                    Icon(a.icon, color: a.level.color),
                     const SizedBox(height: 4),
-                    Text('${a.progress}/${a.target}')
+                    Text('${a.progress}/${a.nextTarget}')
                   ],
                 )
             ],

--- a/lib/widgets/motivation_card.dart
+++ b/lib/widgets/motivation_card.dart
@@ -27,7 +27,7 @@ class MotivationCard extends StatelessWidget {
     Achievement? bestAch;
     int achRemain = 1 << 30;
     for (final a in achievements) {
-      final remain = a.target - a.progress;
+      final remain = a.nextTarget - a.progress;
       if (remain > 0 && remain < achRemain) {
         bestAch = a;
         achRemain = remain;
@@ -42,8 +42,8 @@ class MotivationCard extends StatelessWidget {
     final title = showGoal ? bestGoal.title : bestAch!.title;
     final icon = showGoal ? Icons.flag : bestAch!.icon;
     final progress = showGoal ? engine.progress(bestGoal) : bestAch!.progress;
-    final target = showGoal ? bestGoal.target : bestAch!.target;
-    final accent = Theme.of(context).colorScheme.secondary;
+    final target = showGoal ? bestGoal.target : bestAch!.nextTarget;
+    final accent = showGoal ? Theme.of(context).colorScheme.secondary : bestAch!.level.color;
 
     return GestureDetector(
       onTap: () {


### PR DESCRIPTION
## Summary
- model multi-level achievements
- track unlocked levels in `AchievementEngine`
- visualize achievement stage and progress

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f91675d30832a8bb9d9628fb3ca8f