### PR TITLE
Add feedback banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,7 @@ import 'services/drill_suggestion_engine.dart';
 import 'services/weak_spot_recommendation_service.dart';
 import 'services/player_progress_service.dart';
 import 'services/personal_recommendation_service.dart';
+import 'services/feedback_service.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
 import 'services/hand_analysis_history_service.dart';
@@ -344,6 +345,13 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) =>
               PlayerProgressService(hands: context.read<SavedHandManagerService>()),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => FeedbackService(
+            achievements: context.read<AchievementEngine>(),
+            progress: context.read<PlayerProgressService>(),
+            next: context.read<NextStepEngine>(),
+          ),
         ),
         ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),
         ChangeNotifierProvider(

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/motivation_card.dart';
 import '../widgets/active_goals_card.dart';
 import '../widgets/next_step_card.dart';
 import '../widgets/suggested_drill_card.dart';
+import '../widgets/feedback_banner.dart';
 import '../widgets/today_progress_banner.dart';
 import '../widgets/streak_mini_card.dart';
 import '../widgets/streak_chart.dart';
@@ -138,6 +139,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
         ),
         const MotivationCard(),
         const ActiveGoalsCard(),
+        const FeedbackBanner(),
         const NextStepCard(),
         const SuggestedDrillCard(),
         const Expanded(child: AnalyzerTab()),

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'player_progress_service.dart';
+import 'achievement_engine.dart';
+import 'next_step_engine.dart';
+
+class FeedbackData {
+  final IconData icon;
+  final String text;
+  const FeedbackData({required this.icon, required this.text});
+}
+
+class FeedbackService extends ChangeNotifier {
+  final AchievementEngine achievements;
+  final PlayerProgressService progress;
+  final NextStepEngine next;
+  FeedbackData? _data;
+  FeedbackData? get data => _data;
+
+  FeedbackService({required this.achievements, required this.progress, required this.next}) {
+    achievements.addListener(_update);
+    progress.addListener(_update);
+    next.addListener(_update);
+    _update();
+  }
+
+  Achievement? _closestAchievement() {
+    Achievement? best;
+    var remain = 1 << 30;
+    for (final a in achievements.achievements) {
+      final r = a.nextTarget - a.progress;
+      if (r > 0 && r < remain) {
+        remain = r;
+        best = a;
+      }
+    }
+    return best;
+  }
+
+  HeroPosition? _weakPosition() {
+    HeroPosition? worst;
+    var acc = 101.0;
+    for (final e in progress.progress.entries) {
+      final pct = e.value.accuracy * 100;
+      if (e.value.hands >= 20 && pct < acc) {
+        acc = pct;
+        worst = e.key;
+      }
+    }
+    return worst;
+  }
+
+  void _update() {
+    final step = next.suggestion;
+    if (step != null) {
+      _set(FeedbackData(icon: step.icon, text: '${step.title}: ${step.message}'));
+      return;
+    }
+    final pos = _weakPosition();
+    if (pos != null) {
+      final a = progress.progress[pos]!.accuracy * 100;
+      _set(FeedbackData(icon: Icons.school, text: 'Низкая точность на ${pos.label} - ${a.toStringAsFixed(1)}%'));
+      return;
+    }
+    final ach = _closestAchievement();
+    if (ach != null) {
+      final left = ach.nextTarget - ach.progress;
+      _set(FeedbackData(icon: ach.icon, text: 'Еще $left до ${ach.title}'));
+      return;
+    }
+    _set(null);
+  }
+
+  void _set(FeedbackData? data) {
+    if (data == null && _data == null) return;
+    if (data != null && _data != null && data.text == _data!.text) return;
+    _data = data;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    achievements.removeListener(_update);
+    progress.removeListener(_update);
+    next.removeListener(_update);
+    super.dispose();
+  }
+}

--- a/lib/widgets/feedback_banner.dart
+++ b/lib/widgets/feedback_banner.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/feedback_service.dart';
+
+class FeedbackBanner extends StatelessWidget {
+  const FeedbackBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = context.watch<FeedbackService>().data;
+    if (data == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(data.icon, color: accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(data.text, style: const TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add feedback service for personalized hints
- show feedback banner on main screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f94b39054832aa887c006aad0504d