### PR TITLE
Add dashboard sharing

### DIFF
--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -1,15 +1,38 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/rendering.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../services/training_stats_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/daily_target_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
+import '../services/png_exporter.dart';
 
-class ProgressDashboardScreen extends StatelessWidget {
+class ProgressDashboardScreen extends StatefulWidget {
   const ProgressDashboardScreen({super.key});
+
+  @override
+  State<ProgressDashboardScreen> createState() => _ProgressDashboardScreenState();
+}
+
+class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
+  final _boundaryKey = GlobalKey();
+
+  Future<void> _share() async {
+    final boundary = _boundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null) return;
+    final bytes = await PngExporter.captureBoundary(boundary);
+    if (bytes == null) return;
+    final dir = await getTemporaryDirectory();
+    final file = File('${dir.path}/dashboard_${DateTime.now().millisecondsSinceEpoch}.png');
+    await file.writeAsBytes(bytes, flush: true);
+    await Share.shareXFiles([XFile(file.path)]);
+  }
 
   Widget _chart(List<MapEntry<DateTime, double>> data, Color color) {
     if (data.length < 2) return const SizedBox(height: 200);
@@ -117,11 +140,16 @@ class ProgressDashboardScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Progress Dashboard'),
         centerTitle: true,
-        actions: [SyncStatusIcon.of(context)],
+        actions: [
+          IconButton(onPressed: _share, icon: const Icon(Icons.share)),
+          SyncStatusIcon.of(context)
+        ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
+      body: RepaintBoundary(
+        key: _boundaryKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
           GridView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
@@ -158,6 +186,7 @@ class ProgressDashboardScreen extends StatelessWidget {
           const SizedBox(height: 16),
           _chart(icm, AppColors.icmPre),
         ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enable sharing the progress dashboard as an image

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f97216004832a8be12fd6b35e73c4