### PR TITLE
Add PartyPoker and WPN converters

### DIFF
--- a/lib/plugins/converters/partypoker_hand_history_converter.dart
+++ b/lib/plugins/converters/partypoker_hand_history_converter.dart
@@ -1,0 +1,144 @@
+import '../converter_format_capabilities.dart';
+import '../converter_plugin.dart';
+import 'package:poker_analyzer/models/saved_hand.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+
+class PartyPokerHandHistoryConverter extends ConverterPlugin {
+  PartyPokerHandHistoryConverter()
+      : super(
+          formatId: 'partypoker_hand_history',
+          description: 'PartyPoker hand history format',
+          capabilities: const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: false,
+          ),
+        );
+
+  CardModel? _parseCard(String token) {
+    if (token.length < 2) return null;
+    final rank = token.substring(0, token.length - 1).toUpperCase();
+    final suitChar = token[token.length - 1].toLowerCase();
+    switch (suitChar) {
+      case 'h':
+        return CardModel(rank: rank, suit: '♥');
+      case 'd':
+        return CardModel(rank: rank, suit: '♦');
+      case 'c':
+        return CardModel(rank: rank, suit: '♣');
+      case 's':
+        return CardModel(rank: rank, suit: '♠');
+    }
+    return null;
+  }
+
+  double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
+
+  @override
+  SavedHand? convertFrom(String externalData) {
+    final lines = externalData.split(RegExp(r'\r?\n'));
+    if (lines.isEmpty || !lines.first.toLowerCase().contains('partypoker')) {
+      return null;
+    }
+    final seatRegex =
+        RegExp(r'^Seat (\d+):\s*(.+?) \(([^)]+)\)', caseSensitive: false);
+    final seatEntries = <Map<String, dynamic>>[];
+    for (final line in lines) {
+      final m = seatRegex.firstMatch(line.trim());
+      if (m != null) {
+        seatEntries.add({
+          'seat': int.parse(m.group(1)!),
+          'name': m.group(2)!.trim(),
+          'stack': _amount(m.group(3)!),
+        });
+      }
+    }
+    if (seatEntries.isEmpty) return null;
+    seatEntries.sort((a, b) => (a['seat'] as int).compareTo(b['seat'] as int));
+    final playerCount = seatEntries.length;
+
+    String? heroName;
+    List<CardModel> heroCards = [];
+    for (final line in lines) {
+      final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
+      if (m != null) {
+        heroName = m.group(1)!.trim();
+        final c1 = _parseCard(m.group(2)!);
+        final c2 = _parseCard(m.group(3)!);
+        if (c1 != null && c2 != null) heroCards = [c1, c2];
+        break;
+      }
+    }
+    final nameToIndex = <String, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      nameToIndex[seatEntries[i]['name'].toString().toLowerCase()] = i;
+    }
+    int heroIndex = 0;
+    if (heroName != null) {
+      heroIndex = nameToIndex[heroName.toLowerCase()] ?? 0;
+    }
+    final playerCards = List.generate(playerCount, (_) => <CardModel>[]);
+    if (heroCards.isNotEmpty) playerCards[heroIndex] = heroCards;
+    final stackSizes = <int, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      stackSizes[i] = (seatEntries[i]['stack'] as double).round();
+    }
+    final actions = <ActionEntry>[];
+    bool preflop = false;
+    for (final line in lines) {
+      final t = line.trim();
+      if (t.startsWith('*** HOLE CARDS')) preflop = true;
+      if (t.startsWith('*** FLOP')) preflop = false;
+      if (!preflop) continue;
+      Match? m;
+      m = RegExp(r'^(.+?): folds').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'fold'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): checks').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'check'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): calls ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'call', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): bets ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'bet', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): raises .* to ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'raise', amount: _amount(m.group(2)!)));
+        continue;
+      }
+    }
+    final positions = {for (int i = 0; i < playerCount; i++) i: ''};
+    return SavedHand(
+      name: '',
+      heroIndex: heroIndex,
+      heroPosition: positions[heroIndex] ?? '',
+      numberOfPlayers: playerCount,
+      playerCards: playerCards,
+      boardCards: const [],
+      boardStreet: 0,
+      actions: actions,
+      stackSizes: stackSizes,
+      playerPositions: positions,
+      comment: '',
+      playerTypes: {for (int i = 0; i < playerCount; i++) i: PlayerType.unknown},
+    );
+  }
+}

--- a/lib/plugins/converters/wpn_hand_history_converter.dart
+++ b/lib/plugins/converters/wpn_hand_history_converter.dart
@@ -1,0 +1,144 @@
+import '../converter_format_capabilities.dart';
+import '../converter_plugin.dart';
+import 'package:poker_analyzer/models/saved_hand.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+
+class WpnHandHistoryConverter extends ConverterPlugin {
+  WpnHandHistoryConverter()
+      : super(
+          formatId: 'wpn_hand_history',
+          description: 'Winning Poker Network hand history format',
+          capabilities: const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: false,
+          ),
+        );
+
+  CardModel? _parseCard(String token) {
+    if (token.length < 2) return null;
+    final rank = token.substring(0, token.length - 1).toUpperCase();
+    final suitChar = token[token.length - 1].toLowerCase();
+    switch (suitChar) {
+      case 'h':
+        return CardModel(rank: rank, suit: '♥');
+      case 'd':
+        return CardModel(rank: rank, suit: '♦');
+      case 'c':
+        return CardModel(rank: rank, suit: '♣');
+      case 's':
+        return CardModel(rank: rank, suit: '♠');
+    }
+    return null;
+  }
+
+  double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
+
+  @override
+  SavedHand? convertFrom(String externalData) {
+    final lines = externalData.split(RegExp(r'\r?\n'));
+    if (lines.isEmpty || !lines.first.toLowerCase().contains('winning poker')) {
+      return null;
+    }
+    final seatRegex =
+        RegExp(r'^Seat (\d+):\s*(.+?) \(([^)]+)\)', caseSensitive: false);
+    final seatEntries = <Map<String, dynamic>>[];
+    for (final line in lines) {
+      final m = seatRegex.firstMatch(line.trim());
+      if (m != null) {
+        seatEntries.add({
+          'seat': int.parse(m.group(1)!),
+          'name': m.group(2)!.trim(),
+          'stack': _amount(m.group(3)!),
+        });
+      }
+    }
+    if (seatEntries.isEmpty) return null;
+    seatEntries.sort((a, b) => (a['seat'] as int).compareTo(b['seat'] as int));
+    final playerCount = seatEntries.length;
+
+    String? heroName;
+    List<CardModel> heroCards = [];
+    for (final line in lines) {
+      final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
+      if (m != null) {
+        heroName = m.group(1)!.trim();
+        final c1 = _parseCard(m.group(2)!);
+        final c2 = _parseCard(m.group(3)!);
+        if (c1 != null && c2 != null) heroCards = [c1, c2];
+        break;
+      }
+    }
+    final nameToIndex = <String, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      nameToIndex[seatEntries[i]['name'].toString().toLowerCase()] = i;
+    }
+    int heroIndex = 0;
+    if (heroName != null) {
+      heroIndex = nameToIndex[heroName.toLowerCase()] ?? 0;
+    }
+    final playerCards = List.generate(playerCount, (_) => <CardModel>[]);
+    if (heroCards.isNotEmpty) playerCards[heroIndex] = heroCards;
+    final stackSizes = <int, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      stackSizes[i] = (seatEntries[i]['stack'] as double).round();
+    }
+    final actions = <ActionEntry>[];
+    bool preflop = false;
+    for (final line in lines) {
+      final t = line.trim();
+      if (t.startsWith('*** HOLE CARDS')) preflop = true;
+      if (t.startsWith('*** FLOP')) preflop = false;
+      if (!preflop) continue;
+      Match? m;
+      m = RegExp(r'^(.+?): folds').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'fold'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): checks').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'check'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): calls ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'call', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): bets ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'bet', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): raises .* to ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'raise', amount: _amount(m.group(2)!)));
+        continue;
+      }
+    }
+    final positions = {for (int i = 0; i < playerCount; i++) i: ''};
+    return SavedHand(
+      name: '',
+      heroIndex: heroIndex,
+      heroPosition: positions[heroIndex] ?? '',
+      numberOfPlayers: playerCount,
+      playerCards: playerCards,
+      boardCards: const [],
+      boardStreet: 0,
+      actions: actions,
+      stackSizes: stackSizes,
+      playerPositions: positions,
+      comment: '',
+      playerTypes: {for (int i = 0; i < playerCount; i++) i: PlayerType.unknown},
+    );
+  }
+}

--- a/lib/plugins/plugin_loader.dart
+++ b/lib/plugins/plugin_loader.dart
@@ -19,6 +19,8 @@ import 'converters/simple_hand_history_converter.dart';
 import 'converters/pokerstars_hand_history_converter.dart';
 import 'converters/ggpoker_hand_history_converter.dart';
 import 'converters/winamax_hand_history_converter.dart';
+import 'converters/partypoker_hand_history_converter.dart';
+import 'converters/wpn_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 
 /// Prototype loader for built-in plug-ins.
@@ -82,6 +84,8 @@ class PluginLoader {
       PokerStarsHandHistoryConverter(),
       GGPokerHandHistoryConverter(),
       WinamaxHandHistoryConverter(),
+      PartyPokerHandHistoryConverter(),
+      WpnHandHistoryConverter(),
     ];
     return <Plugin>[
       SampleLoggingPlugin(),
@@ -100,6 +104,8 @@ class PluginLoader {
           PokerStarsHandHistoryConverter(),
           GGPokerHandHistoryConverter(),
           WinamaxHandHistoryConverter(),
+          PartyPokerHandHistoryConverter(),
+          WpnHandHistoryConverter(),
         ]);
       case 'PokerStarsConverterPlugin':
         return PokerStarsConverterPlugin();

--- a/tests/architecture/new_converters_test.dart
+++ b/tests/architecture/new_converters_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/plugins/plugin_loader.dart';
+import 'package:poker_analyzer/plugins/plugin_manager.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+
+void main() {
+  group('PartyPoker and WPN converters', () {
+    test('import and export pipeline', () {
+      final loader = PluginLoader();
+      final manager = PluginManager();
+      final registry = ServiceRegistry();
+      for (final plugin in loader.loadBuiltInPlugins()) {
+        manager.load(plugin);
+      }
+      manager.initializeAll(registry);
+      final converterRegistry = registry.get<ConverterRegistry>();
+      final party = converterRegistry.findByFormatId('partypoker_hand_history');
+      final wpn = converterRegistry.findByFormatId('wpn_hand_history');
+      expect(party, isNotNull);
+      expect(wpn, isNotNull);
+      final partySample = [
+        'PartyPoker Hand #1',
+        'Seat 1: Hero (1)',
+        'Seat 2: Villain (1)',
+        '*** HOLE CARDS ***',
+        'Dealt to Hero [Ah Kh]',
+        'Hero raises 2 to 2',
+        'Villain folds',
+      ].join('\n');
+      final wpnSample = [
+        'Winning Poker Network Hand #1',
+        'Seat 1: Hero (1)',
+        'Seat 2: Villain (1)',
+        '*** HOLE CARDS ***',
+        'Dealt to Hero [Ah Kh]',
+        'Hero raises to 2',
+        'Villain folds',
+      ].join('\n');
+      final partyHand = party!.convertFrom(partySample);
+      final wpnHand = wpn!.convertFrom(wpnSample);
+      expect(partyHand, isNotNull);
+      expect(wpnHand, isNotNull);
+      expect(converterRegistry.tryExport('partypoker_hand_history', partyHand!), isNull);
+      expect(converterRegistry.tryExport('wpn_hand_history', wpnHand!), isNull);
+    });
+  });
+}

--- a/tests/converter_validation_test.dart
+++ b/tests/converter_validation_test.dart
@@ -48,6 +48,36 @@ void main() {
               'Seat 2: Player2 (\$1 in chips)',
             ].join('\n');
             break;
+          case 'ggpoker_hand_history':
+            sample = [
+              'Hand #1 - Holdem NL (0.01/0.02)',
+              "Table 'Alpha' 6-max",
+              'Seat 1: P1 (1)',
+              'Seat 2: P2 (1)',
+            ].join('\n');
+            break;
+          case 'partypoker_hand_history':
+            sample = [
+              'PartyPoker Hand #1',
+              'Seat 1: Hero (1)',
+              'Seat 2: Villain (1)',
+              '*** HOLE CARDS ***',
+              'Dealt to Hero [Ah Kh]',
+              'Hero raises 2 to 2',
+              'Villain folds',
+            ].join('\n');
+            break;
+          case 'wpn_hand_history':
+            sample = [
+              'Winning Poker Network Hand #1',
+              'Seat 1: Hero (1)',
+              'Seat 2: Villain (1)',
+              '*** HOLE CARDS ***',
+              'Dealt to Hero [Ah Kh]',
+              'Hero raises to 2',
+              'Villain folds',
+            ].join('\n');
+            break;
           case 'winamax_hand_history':
             sample = [
               'Winamax Poker - Tournament',


### PR DESCRIPTION
## Summary
- support PartyPoker and WPN hand histories
- register new converters in the plugin loader
- validate new formats in unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f99c676e8832a9eff022c0ca75fda