### PR TITLE
Improve responsive layouts

### DIFF
--- a/lib/screens/achievements_catalog_screen.dart
+++ b/lib/screens/achievements_catalog_screen.dart
@@ -6,6 +6,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../services/streak_service.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class AchievementsCatalogScreen extends StatelessWidget {
   const AchievementsCatalogScreen({super.key});
@@ -36,16 +37,19 @@ class AchievementsCatalogScreen extends StatelessWidget {
 
           final data = goals.achievements;
 
-          return GridView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: data.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              crossAxisSpacing: 12,
-              mainAxisSpacing: 12,
-              childAspectRatio: 1.2,
-            ),
-            itemBuilder: (context, index) {
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxWidth < 360;
+              return GridView.builder(
+                padding: responsiveAll(context, 16),
+                itemCount: data.length,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: compact ? 1 : 2,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                  childAspectRatio: 1.2,
+                ),
+                itemBuilder: (context, index) {
               final item = data[index];
               final completed = item.completed;
               final color = completed ? Colors.white : Colors.white54;
@@ -61,7 +65,7 @@ class AchievementsCatalogScreen extends StatelessWidget {
                 );
               }
               Widget card = Container(
-                padding: const EdgeInsets.all(12),
+                padding: responsiveAll(context, 12),
                 decoration: BoxDecoration(
                   color: Colors.grey[850],
                   borderRadius: BorderRadius.circular(8),

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -11,6 +11,7 @@ import 'player_zone_demo_screen.dart';
 import 'poker_table_demo_screen.dart';
 import 'hand_editor_screen.dart';
 import 'settings_screen.dart';
+import '../utils/responsive.dart';
 import 'remote_sessions_screen.dart';
 import 'global_evaluation_screen.dart';
 import 'daily_hand_screen.dart';
@@ -176,8 +177,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       clipBehavior: Clip.none,
       children: [
         Container(
-          margin: const EdgeInsets.only(bottom: 24),
-          padding: const EdgeInsets.all(12),
+          margin: EdgeInsets.only(bottom: responsiveSize(context, 24)),
+          padding: responsiveAll(context, 12),
           decoration: BoxDecoration(
             color: highlight ? Colors.orange[700] : Colors.grey[850],
             borderRadius: BorderRadius.circular(8),
@@ -266,8 +267,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     final spot = _spotOfDay;
     if (spot == null) return const SizedBox.shrink();
     return Container(
-      margin: const EdgeInsets.only(bottom: 24),
-      padding: const EdgeInsets.all(12),
+      margin: EdgeInsets.only(bottom: responsiveSize(context, 24)),
+      padding: responsiveAll(context, 12),
       decoration: BoxDecoration(
         color: Colors.grey[850],
         borderRadius: BorderRadius.circular(8),
@@ -391,8 +392,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),
-      margin: const EdgeInsets.only(bottom: 24),
-      padding: const EdgeInsets.all(12),
+      margin: EdgeInsets.only(bottom: responsiveSize(context, 24)),
+      padding: responsiveAll(context, 12),
       decoration: BoxDecoration(
         color: cardColor,
         borderRadius: BorderRadius.circular(8),
@@ -448,8 +449,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           ),
         );
     return Container(
-      margin: const EdgeInsets.only(bottom: 24),
-      padding: const EdgeInsets.all(12),
+      margin: EdgeInsets.only(bottom: responsiveSize(context, 24)),
+      padding: responsiveAll(context, 12),
       decoration: BoxDecoration(
         color: Colors.grey[850],
         borderRadius: BorderRadius.circular(8),
@@ -556,35 +557,40 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
 
   Widget _buildMenuGrid(BuildContext context) {
     final items = _buildMenuItems(context);
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 2,
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
-        childAspectRatio: 1.2,
-      ),
-      itemCount: items.length,
-      itemBuilder: (context, index) {
-        final item = items[index];
-        return GestureDetector(
-          key: item.key,
-          onTap: item.onTap,
-          child: Card(
-            color: Colors.grey[850],
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(item.icon, size: 48, color: Colors.orange),
-                const SizedBox(height: 8),
-                Text(item.label),
-              ],
-            ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 360;
+        return GridView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: compact ? 1 : 2,
+            mainAxisSpacing: 12,
+            crossAxisSpacing: 12,
+            childAspectRatio: 1.2,
           ),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final item = items[index];
+            return GestureDetector(
+              key: item.key,
+              onTap: item.onTap,
+              child: Card(
+                color: Colors.grey[850],
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(item.icon, size: 48, color: Colors.orange),
+                    const SizedBox(height: 8),
+                    Text(item.label),
+                  ],
+                ),
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/screens/my_achievements_screen.dart
+++ b/lib/screens/my_achievements_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../utils/responsive.dart';
 
 import '../services/goals_service.dart';
 import '../widgets/sync_status_widget.dart';
@@ -28,57 +29,62 @@ class MyAchievementsScreen extends StatelessWidget {
             return const Center(child: Text('Достижения еще не получены'));
           }
 
-          return GridView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: completed.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              crossAxisSpacing: 12,
-              mainAxisSpacing: 12,
-              childAspectRatio: 1.2,
-            ),
-            itemBuilder: (context, index) {
-              final item = completed[index];
-              return Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Colors.grey[850],
-                  borderRadius: BorderRadius.circular(8),
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxWidth < 360;
+              return GridView.builder(
+                padding: responsiveAll(context, 16),
+                itemCount: completed.length,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: compact ? 1 : 2,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                  childAspectRatio: 1.2,
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Icon(item.icon, size: 40, color: accent),
-                    const SizedBox(height: 8),
-                    Text(
-                      item.title,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
+                itemBuilder: (context, index) {
+                  final item = completed[index];
+                  return Container(
+                    padding: responsiveAll(context, 12),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[850],
+                      borderRadius: BorderRadius.circular(8),
                     ),
-                    const Spacer(),
-                    Row(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Expanded(
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
-                              value: 1.0,
-                              backgroundColor: Colors.white24,
-                              valueColor:
-                                  AlwaysStoppedAnimation<Color>(accent),
-                              minHeight: 6,
-                            ),
+                        Icon(item.icon, size: 40, color: accent),
+                        const SizedBox(height: 8),
+                        Text(
+                          item.title,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
-                        const SizedBox(width: 8),
-                        Text('${item.target}/${item.target}'),
+                        const Spacer(),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(4),
+                                child: LinearProgressIndicator(
+                                  value: 1.0,
+                                  backgroundColor: Colors.white24,
+                                  valueColor:
+                                      AlwaysStoppedAnimation<Color>(accent),
+                                  minHeight: 6,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text('${item.target}/${item.target}'),
+                          ],
+                        ),
+                        const SizedBox(height: 4),
+                        const Icon(Icons.check_circle, color: Colors.green),
                       ],
                     ),
-                    const SizedBox(height: 4),
-                    const Icon(Icons.check_circle, color: Colors.green),
-                  ],
-                ),
+                  );
+                },
               );
             },
           );

--- a/lib/utils/responsive.dart
+++ b/lib/utils/responsive.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+bool isCompactWidth(BuildContext context) => MediaQuery.of(context).size.width < 360;
+
+double responsiveSize(BuildContext context, double value) => isCompactWidth(context) ? value / 2 : value;
+
+EdgeInsets responsiveAll(BuildContext context, double value) => EdgeInsets.all(responsiveSize(context, value));


### PR DESCRIPTION
## Summary
- add responsive utility for compact screens
- adjust achievements and menu screens to use LayoutBuilder and dynamic padding

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f99d31b64832ab43404dabfeb5794