### PR TITLE
Implement direct sharing after export

### DIFF
--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -141,9 +141,7 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
 
   Future<void> _shareBundle(TrainingPack pack) async {
     final tpl = _templateFromPack(pack);
-    final file = await PackExportService.exportBundle(tpl);
-    if (!mounted) return;
-    await Share.shareXFiles([XFile(file.path)]);
+    await PackExportService.exportBundle(tpl);
   }
 
   Future<void> _exportPack(TrainingPack pack) async {

--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -199,9 +199,8 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
     try {
       final list = [...widget.hands]
         ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
-      final file = await PackExportService.exportSessionCsv(list, _evs, _icms);
       if (!mounted) return;
-      await Share.shareXFiles([XFile(file.path)]);
+      await PackExportService.exportSessionCsv(list, _evs, _icms);
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('CSV exported')));
     } catch (e) {
@@ -216,9 +215,8 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
     try {
       final list = [...widget.hands]
         ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
-      final file = await PackExportService.exportSessionPdf(list, _evs, _icms);
       if (!mounted) return;
-      await FileSaverService.instance.sharePdf(file.path);
+      await PackExportService.exportSessionPdf(list, _evs, _icms);
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('PDF exported')));
     } catch (e) {

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -73,9 +73,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
     final manager = context.read<SavedHandManagerService>();
     final notes = context.read<SessionNoteService>().notes;
     final path = await manager.exportAllSessionsPdf(notes);
-    if (path == null) return;
-    await Share.shareXFiles([XFile(path)], text: 'training_summary.pdf');
-    if (!context.mounted) return;
+    if (path == null || !context.mounted) return;
     final name = path.split(Platform.pathSeparator).last;
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -544,18 +544,10 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
   }
 
   Future<void> _shareBundle() async {
-    final path = await _exportBundle(notify: false);
-    if (path == null || !mounted) return;
-    try {
-      await Share.shareXFiles([XFile(path)]);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Bundle shared')),
-      );
-    } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Не удалось поделиться пакетом')),
-      );
-    }
+    if (!mounted) return;
+    await PackExportService.exportBundle(widget.template);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Bundle shared')));
   }
 
   Future<void> _exportPackBundle() async {
@@ -579,9 +571,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
 
   Future<void> _exportCsv() async {
     try {
-      final file = await PackExportService.exportToCsv(widget.template);
       if (!mounted) return;
-      await Share.shareXFiles([XFile(file.path)]);
+      await PackExportService.exportToCsv(widget.template);
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('CSV exported')));
     } catch (e) {
@@ -3772,10 +3763,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
             icon: const Icon(Icons.picture_as_pdf),
             onPressed: () async {
               try {
-                final file =
-                    await PackExportService.exportToPdf(widget.template);
                 if (!mounted) return;
-                await FileSaverService.instance.sharePdf(file.path);
+                await PackExportService.exportToPdf(widget.template);
                 ScaffoldMessenger.of(context)
                     .showSnackBar(const SnackBar(content: Text('PDF exported')));
               } catch (e) {

--- a/lib/services/pack_export_service.dart
+++ b/lib/services/pack_export_service.dart
@@ -7,6 +7,8 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:archive/archive.dart';
 import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../models/saved_hand.dart';
@@ -64,6 +66,7 @@ class PackExportService {
     }
     final file = File(path);
     await file.writeAsString(csvStr);
+    await _shareFile(file);
     return file;
   }
 
@@ -119,6 +122,7 @@ class PackExportService {
     }
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
+    await _shareFile(file);
     return file;
   }
 
@@ -138,6 +142,7 @@ class PackExportService {
     }
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
+    await _shareFile(file);
     return file;
   }
 
@@ -168,6 +173,7 @@ class PackExportService {
     }
     final file = File(path);
     await file.writeAsString(csvStr);
+    await _shareFile(file);
     return file;
   }
 
@@ -244,6 +250,7 @@ class PackExportService {
     }
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
+    await _shareFile(file);
     return file;
   }
 
@@ -277,6 +284,13 @@ class PackExportService {
       }
     }
     return buffer.toString().trimRight();
+  }
+
+  static Future<void> _shareFile(File file) async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      await Permission.storage.request();
+    }
+    await Share.shareXFiles([XFile(file.path)]);
   }
 
   static String _toSnakeCase(String input) {

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -8,6 +8,8 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:csv/csv.dart';
 import 'package:uuid/uuid.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:share_plus/share_plus.dart';
 import '../helpers/date_utils.dart';
 
 import '../models/saved_hand.dart';
@@ -194,6 +196,7 @@ class SavedHandManagerService extends ChangeNotifier {
     final dir = await getApplicationDocumentsDirectory();
     final file = File('${dir.path}/all_saved_hands.pdf');
     await file.writeAsBytes(bytes);
+    await _shareFile(file);
     return file.path;
   }
 
@@ -386,6 +389,7 @@ class SavedHandManagerService extends ChangeNotifier {
     final dir = await getApplicationDocumentsDirectory();
     final file = File('${dir.path}/training_summary.pdf');
     await file.writeAsBytes(bytes);
+    await _shareFile(file);
     return file.path;
   }
 
@@ -1294,5 +1298,12 @@ class SavedHandManagerService extends ChangeNotifier {
       createdAt: DateTime.now(),
     );
     return tpl;
+  }
+
+  Future<void> _shareFile(File file) async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      await Permission.storage.request();
+    }
+    await Share.shareXFiles([XFile(file.path)]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   csv: ^6.0.0
   timeago: ^3.6.0
   file_saver: ^0.2.14
+  permission_handler: ^11.3.0
   confetti: ^0.7.0
   poker_solver: ^1.0.0
   hive: ^2.2.3

--- a/test/services/pack_export_service_test.dart
+++ b/test/services/pack_export_service_test.dart
@@ -4,6 +4,16 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:poker_analyzer/services/pack_export_service.dart';
 import 'package:poker_analyzer/services/pack_generator_service.dart';
 import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+
+class _FakeSharePlatform extends SharePlatform {
+  bool shared = false;
+  @override
+  Future<void> shareXFiles(List<XFile> files,
+      {String? text, String? subject, ShareOptions? sharePositionOrigin}) async {
+    shared = true;
+  }
+}
 
 class _FakePathProvider extends PathProviderPlatform {
   _FakePathProvider(this.path);
@@ -18,6 +28,8 @@ void main() {
   test('exportToCsv returns file with rows and columns', () async {
     final dir = await Directory.systemTemp.createTemp();
     PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    final share = _FakeSharePlatform();
+    SharePlatform.instance = share;
     final tpl = PackGeneratorService.generatePushFoldPackSync(
       id: 't',
       name: 'Test Pack',
@@ -31,5 +43,6 @@ void main() {
     expect(lines.length, 4);
     expect(lines.first.split(',').length, 10);
     await dir.delete(recursive: true);
+    expect(share.shared, true);
   });
 }


### PR DESCRIPTION
## Summary
- automatically share PDF exports from SavedHandManagerService
- automatically share exports from PackExportService
- request storage permission before sharing
- adjust widgets to avoid duplicate sharing
- update tests for new sharing behavior
- add permission_handler dependency

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f99d04500832a85704c4dc306fe82