### PR TITLE
Add training progress forecasting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,7 @@ import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/weak_spot_recommendation_service.dart';
 import 'services/player_progress_service.dart';
+import 'services/progress_forecast_service.dart';
 import 'services/personal_recommendation_service.dart';
 import 'services/feedback_service.dart';
 import 'services/drill_history_service.dart';
@@ -340,6 +341,10 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) =>
               PlayerProgressService(hands: context.read<SavedHandManagerService>()),
+        ),
+        ChangeNotifierProvider(
+          create: (context) =>
+              ProgressForecastService(hands: context.read<SavedHandManagerService>()),
         ),
         ChangeNotifierProvider(
           create: (context) => WeakSpotRecommendationService(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
+import '../widgets/progress_forecast_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import 'training_progress_analytics_screen.dart';
@@ -85,6 +86,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const SpotOfTheDayCard(),
           const ProgressSummaryBox(),
           const PositionProgressCard(),
+          const ProgressForecastCard(),
           const StreakChart(),
           const DailyProgressRing(),
           const DailyGoalsCard(),

--- a/lib/services/progress_forecast_service.dart
+++ b/lib/services/progress_forecast_service.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart';
+import '../models/saved_hand.dart';
+import 'saved_hand_manager_service.dart';
+
+class ProgressEntry {
+  final DateTime date;
+  final double accuracy;
+  final double ev;
+  final double icm;
+  const ProgressEntry({
+    required this.date,
+    required this.accuracy,
+    required this.ev,
+    required this.icm,
+  });
+}
+
+class ProgressForecast {
+  final double accuracy;
+  final double ev;
+  final double icm;
+  const ProgressForecast({
+    required this.accuracy,
+    required this.ev,
+    required this.icm,
+  });
+}
+
+class ProgressForecastService extends ChangeNotifier {
+  final SavedHandManagerService hands;
+  List<ProgressEntry> _history = const [];
+  ProgressForecast _forecast = const ProgressForecast(accuracy: 0, ev: 0, icm: 0);
+
+  List<ProgressEntry> get history => List.unmodifiable(_history);
+  ProgressForecast get forecast => _forecast;
+
+  ProgressForecastService({required this.hands}) {
+    _update();
+    hands.addListener(_update);
+  }
+
+  void _update() {
+    final map = <DateTime, List<SavedHand>>{};
+    for (final h in hands.hands) {
+      final day = DateTime(h.date.year, h.date.month, h.date.day);
+      map.putIfAbsent(day, () => []).add(h);
+    }
+    final entries = map.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+    final hist = <ProgressEntry>[];
+    for (final e in entries) {
+      int correct = 0;
+      int total = 0;
+      double ev = 0;
+      double icm = 0;
+      int evCount = 0;
+      for (final h in e.value) {
+        final exp = h.expectedAction?.trim().toLowerCase();
+        final gto = h.gtoAction?.trim().toLowerCase();
+        if (exp != null && gto != null) {
+          total++;
+          if (exp == gto) correct++;
+        }
+        final hev = h.heroEv;
+        if (hev != null) {
+          ev += hev;
+          evCount++;
+        }
+        final hicm = h.heroIcmEv;
+        if (hicm != null) icm += hicm;
+      }
+      final acc = total > 0 ? correct / total : 0;
+      final avgEv = evCount > 0 ? ev / evCount : 0;
+      final avgIcm = evCount > 0 ? icm / evCount : 0;
+      hist.add(ProgressEntry(date: e.key, accuracy: acc, ev: avgEv, icm: avgIcm));
+    }
+    _history = hist;
+    _forecast = _calcForecast(hist);
+    notifyListeners();
+  }
+
+  ProgressForecast _calcForecast(List<ProgressEntry> data) {
+    if (data.isEmpty) return const ProgressForecast(accuracy: 0, ev: 0, icm: 0);
+    if (data.length == 1) return ProgressForecast(
+        accuracy: data.last.accuracy,
+        ev: data.last.ev,
+        icm: data.last.icm);
+    final n = data.length;
+    final xs = [for (var i = 0; i < n; i++) i + 1];
+    final sumX = xs.reduce((a, b) => a + b);
+    final sumX2 = xs.map((e) => e * e).reduce((a, b) => a + b);
+    double sumAcc = 0, sumEv = 0, sumIcm = 0;
+    double sumXAcc = 0, sumXEv = 0, sumXIcm = 0;
+    for (var i = 0; i < n; i++) {
+      final x = xs[i].toDouble();
+      final d = data[i];
+      sumAcc += d.accuracy;
+      sumEv += d.ev;
+      sumIcm += d.icm;
+      sumXAcc += x * d.accuracy;
+      sumXEv += x * d.ev;
+      sumXIcm += x * d.icm;
+    }
+    final denom = n * sumX2 - sumX * sumX;
+    double slopeAcc = 0, slopeEv = 0, slopeIcm = 0;
+    if (denom != 0) {
+      slopeAcc = (n * sumXAcc - sumX * sumAcc) / denom;
+      slopeEv = (n * sumXEv - sumX * sumEv) / denom;
+      slopeIcm = (n * sumXIcm - sumX * sumIcm) / denom;
+    }
+    return ProgressForecast(
+      accuracy: (data.last.accuracy + slopeAcc).clamp(0.0, 1.0),
+      ev: data.last.ev + slopeEv,
+      icm: data.last.icm + slopeIcm,
+    );
+  }
+
+  @override
+  void dispose() {
+    hands.removeListener(_update);
+    super.dispose();
+  }
+}

--- a/lib/widgets/progress_forecast_card.dart
+++ b/lib/widgets/progress_forecast_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/progress_forecast_service.dart';
+
+class ProgressForecastCard extends StatelessWidget {
+  const ProgressForecastCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final forecast = context.watch<ProgressForecastService>().forecast;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Прогноз следующей сессии',
+              style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  children: [
+                    const Text('Acc', style: TextStyle(color: Colors.white70)),
+                    const SizedBox(height: 4),
+                    Text('${(forecast.accuracy * 100).toStringAsFixed(1)}%',
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  children: [
+                    const Text('EV', style: TextStyle(color: Colors.white70)),
+                    const SizedBox(height: 4),
+                    Text(forecast.ev.toStringAsFixed(2),
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  children: [
+                    const Text('ICM', style: TextStyle(color: Colors.white70)),
+                    const SizedBox(height: 4),
+                    Text(forecast.icm.toStringAsFixed(2),
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ProgressForecastService` with linear trend analysis
- display upcoming session forecast on training home screen
- register new service in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa0494ecc832aba7156da0cc4bcfb