### PR TITLE
Add community plugin screen

### DIFF
--- a/lib/screens/community_plugin_screen.dart
+++ b/lib/screens/community_plugin_screen.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import '../plugins/plugin_loader.dart';
+
+class CommunityPlugin {
+  final String name;
+  final String url;
+  final String? checksum;
+  final String? description;
+  const CommunityPlugin({
+    required this.name,
+    required this.url,
+    this.checksum,
+    this.description,
+  });
+  factory CommunityPlugin.fromJson(Map<String, dynamic> json) {
+    return CommunityPlugin(
+      name: json['name'] as String,
+      url: json['url'] as String,
+      checksum: json['checksum'] as String?,
+      description: json['description'] as String?,
+    );
+  }
+}
+
+class CommunityPluginScreen extends StatefulWidget {
+  const CommunityPluginScreen({super.key});
+  @override
+  State<CommunityPluginScreen> createState() => _CommunityPluginScreenState();
+}
+
+class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
+  static const _url = 'https://pokeranalyzer.app/plugins.json';
+  List<CommunityPlugin> _plugins = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final res = await http.get(Uri.parse(_url));
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body);
+        if (data is List) {
+          _plugins = [for (final e in data) CommunityPlugin.fromJson(e as Map<String, dynamic>)];
+        }
+      }
+    } catch (_) {}
+    if (mounted) setState(() => _loading = false);
+  }
+
+  Future<void> _install(CommunityPlugin p) async {
+    try {
+      await PluginLoader().downloadFromUrl(p.url, checksum: p.checksum);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Plugin installed')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Install failed: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Community Plugins'),
+        centerTitle: true,
+        actions: [IconButton(icon: const Icon(Icons.sync), onPressed: _load)],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _plugins.isEmpty
+              ? const Center(child: Text('No plugins'))
+              : ListView.separated(
+                  itemCount: _plugins.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final p = _plugins[index];
+                    return ListTile(
+                      title: Text(p.name),
+                      subtitle: p.description == null ? null : Text(p.description!),
+                      trailing: TextButton(
+                        onPressed: () => _install(p),
+                        child: const Text('Install'),
+                      ),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -27,6 +27,7 @@ import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
+import 'community_plugin_screen.dart';
 import 'onboarding_screen.dart';
 import 'ev_icm_analytics_screen.dart';
 import 'progress_dashboard_screen.dart';
@@ -191,6 +192,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                     ),
                   );
                   break;
+                case 'community_plugins':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const CommunityPluginScreen(),
+                    ),
+                  );
+                  break;
                 case 'onboarding':
                   Navigator.push(
                     context,
@@ -221,6 +230,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             itemBuilder: (context) => const [
               PopupMenuItem(value: 'settings', child: Text('⚙️ Settings')),
               PopupMenuItem(value: 'plugins', child: Text('🧩 Plugins')),
+              PopupMenuItem(value: 'community_plugins', child: Text('🌐 Community')),
               PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
               PopupMenuItem(value: 'evicm', child: Text('EV/ICM')),
               PopupMenuItem(value: 'dashboard', child: Text('📈 Dashboard')),


### PR DESCRIPTION
## Summary
- list community plugins from a JSON endpoint
- download/install plugins with `PluginLoader.downloadFromUrl`
- open community plugin list from the main menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa558c190832a9ff67be9d0212033