### PR TITLE
Add session note editor

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -1,6 +1,7 @@
 import 'services/training_pack_asset_loader.dart';
 import 'services/favorite_pack_service.dart';
 import 'services/cloud_sync_service.dart';
+import 'services/session_note_service.dart';
 
 class AppBootstrap {
   const AppBootstrap._();
@@ -15,5 +16,6 @@ class AppBootstrap {
       await cloud.loadHands();
       cloud.watchChanges();
     }
+    await SessionNoteService(cloud: cloud).load();
   }
 }


### PR DESCRIPTION
## Summary
- allow editing session notes from the analysis screen
- load session notes in app startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa556b3dc832ab42557a8e14d7adf