### PR TITLE
Add cloud sync tests

### DIFF
--- a/lib/services/cloud_sync_service.dart
+++ b/lib/services/cloud_sync_service.dart
@@ -13,7 +13,9 @@ import '../models/saved_hand.dart';
 import '../models/session_log.dart';
 
 class CloudSyncService {
-  CloudSyncService();
+  CloudSyncService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _db = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
 
   static const _cols = [
     'training_spots',
@@ -26,7 +28,8 @@ class CloudSyncService {
     'evaluation_queue',
   ];
 
-  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final FirebaseFirestore _db;
+  final FirebaseAuth _auth;
   late SharedPreferences _prefs;
   Box? _box;
   static bool get isLocal => kIsWeb ||
@@ -34,7 +37,7 @@ class CloudSyncService {
           defaultTargetPlatform == TargetPlatform.linux ||
           defaultTargetPlatform == TargetPlatform.macOS));
   bool get _local => CloudSyncService.isLocal;
-  String? get uid => FirebaseAuth.instance.currentUser?.uid;
+  String? get uid => _auth.currentUser?.uid;
   final List<Map<String, dynamic>> _pending = [];
   final ValueNotifier<DateTime?> lastSync = ValueNotifier(null);
   final ValueNotifier<double> progress = ValueNotifier(0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,8 @@ dev_dependencies:
   yaml: ^3.1.1
   crypto: ^3.0.2
   pedantic: ^1.11.1
+  fake_cloud_firestore: ^3.1.0
+  firebase_auth_mocks: ^0.14.2
 
 flutter:
 

--- a/test/services/cloud_sync_service_test.dart
+++ b/test/services/cloud_sync_service_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/cloud_sync_service.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/models/action_evaluation_request.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeFirebaseFirestore firestore;
+  late MockFirebaseAuth auth;
+  late CloudSyncService service;
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u'));
+    SharedPreferences.setMockInitialValues({});
+    service = CloudSyncService(firestore: firestore, auth: auth);
+    await service.init();
+  });
+
+  test('upload and download session logs', () async {
+    final logs = [
+      SessionLog(
+        sessionId: 's',
+        templateId: 't',
+        startedAt: DateTime.utc(2024),
+        completedAt: DateTime.utc(2024, 1, 1),
+        correctCount: 1,
+        mistakeCount: 0,
+      )
+    ];
+    await service.uploadSessionLogs(logs);
+    final snap = await firestore
+        .collection('users')
+        .doc('u')
+        .collection('session_logs')
+        .doc('main')
+        .get();
+    expect(snap.exists, true);
+    expect((snap.data()?['logs'] as List).length, 1);
+    final loaded = await service.downloadSessionLogs();
+    expect(loaded.length, 1);
+    expect(loaded.first.sessionId, 's');
+  });
+
+  test('upload and download session notes', () async {
+    final notes = {1: 'n'};
+    await service.uploadSessionNotes(notes);
+    final snap = await firestore
+        .collection('users')
+        .doc('u')
+        .collection('session_notes')
+        .doc('main')
+        .get();
+    expect(snap.exists, true);
+    expect((snap.data()?['notes'] as Map).length, 1);
+    final loaded = await service.downloadSessionNotes();
+    expect(loaded[1], 'n');
+  });
+
+  test('upload and download evaluation queue', () async {
+    final request = ActionEvaluationRequest(
+      street: 0,
+      playerIndex: 0,
+      action: 'fold',
+    );
+    final queue = {
+      'pending': [request.toJson()],
+      'failed': <dynamic>[],
+      'completed': <dynamic>[]
+    };
+    await service.uploadQueue(queue);
+    final snap = await firestore
+        .collection('users')
+        .doc('u')
+        .collection('evaluation_queue')
+        .doc('main')
+        .get();
+    expect(snap.exists, true);
+    expect((snap.data()?['pending'] as List).length, 1);
+    final loaded = await service.downloadQueue();
+    expect((loaded?['pending'] as List).length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- support injecting Firebase instances into CloudSyncService
- add fake firestore & auth test dependencies
- test upload and download of logs, notes and queue

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa55a8950832a9cc6165b1a15f9d7