### PR TITLE
Update theme colors

### DIFF
--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,10 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_colors.dart';
 
 class ThemeService extends ChangeNotifier {
   static const _key = 'theme_mode';
   ThemeMode _mode = ThemeMode.dark;
   ThemeMode get mode => _mode;
+
+  ThemeData get lightTheme => ThemeData(
+        brightness: Brightness.light,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.accent,
+          brightness: Brightness.light,
+        ),
+        scaffoldBackgroundColor: AppColors.background,
+        cardColor: AppColors.cardBackground,
+        textTheme: ThemeData.light().textTheme.apply(
+              fontFamily: 'Roboto',
+              bodyColor: Colors.black,
+              displayColor: Colors.black,
+            ),
+      );
+
+  ThemeData get darkTheme => ThemeData(
+        brightness: Brightness.dark,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.accent,
+          brightness: Brightness.dark,
+        ),
+        scaffoldBackgroundColor: AppColors.background,
+        cardColor: AppColors.cardBackground,
+        textTheme: ThemeData.dark().textTheme.apply(
+              fontFamily: 'Roboto',
+              bodyColor: Colors.white,
+              displayColor: Colors.white,
+            ),
+      );
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const background = Color(0xFF161616);
-  static const cardBackground = Color(0xFF24242A);
-  static const accent = Color(0xFFE8C35E);
+  static const background = Color(0xFF1A1A1C);
+  static const cardBackground = Color(0xFF242428);
+  static const button = Color(0xFFB73239);
+  static const accent = Color(0xFFD8B243);
   static final errorBg = Colors.red.withOpacity(.2);
   static const evPre = Color(0xFF009733);
   static const evPost = Color(0xFFC9A559);


### PR DESCRIPTION
## Summary
- add GGPoker-like colors for buttons and backgrounds
- expose light and dark themes via ThemeService

## Testing
- `flutter analyze` *(fails: Could not complete due to environment limitations)*
- `flutter test --run-skipped` *(fails: Could not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686fa559802c832a881bb5a5a7a5cfd0