### PR TITLE
Update firebase_core for firebase_auth_mocks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   flutter_local_notifications: ^17.0.0
   timezone: ^0.9.2
   image: ^4.1.3
-  firebase_core: ^2.14.0
+  firebase_core: ^3.0.0
   cloud_firestore: ^4.8.0
   firebase_auth: ^4.8.0
   firebase_storage: ^11.2.0
@@ -76,7 +76,7 @@ dev_dependencies:
   crypto: ^3.0.2
   pedantic: ^1.11.1
   fake_cloud_firestore: ^3.1.0
-  firebase_auth_mocks: ^0.14.2
+  firebase_auth_mocks: ^0.14.0
 
 flutter:
 


### PR DESCRIPTION
## Summary
- update firebase_core to ^3.0.0
- use firebase_auth_mocks ^0.14.0

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686faa84acac832ab72a36c45bf55402