### PR TITLE
Add player style recommendations

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
+import '../widgets/player_style_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import 'training_progress_analytics_screen.dart';
@@ -87,6 +88,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const ProgressSummaryBox(),
           const PositionProgressCard(),
           const ProgressForecastCard(),
+          const PlayerStyleCard(),
           const StreakChart(),
           const DailyProgressRing(),
           const DailyGoalsCard(),

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -11,6 +11,7 @@ import '../models/v2/training_pack_template.dart';
 import 'training_template_detail_screen.dart';
 import 'training_session_screen.dart';
 import '../widgets/progress_forecast_card.dart';
+import '../widgets/player_style_card.dart';
 
 class TrainingRecommendationScreen extends StatefulWidget {
   const TrainingRecommendationScreen({super.key});
@@ -106,6 +107,7 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
               padding: const EdgeInsets.all(16),
               children: [
                 const ProgressForecastCard(),
+                const PlayerStyleCard(),
                 if (_tpls.isEmpty && _tasks.isEmpty)
                   const Center(child: Text('Нет рекомендаций'))
                 else ...[

--- a/lib/widgets/player_style_card.dart
+++ b/lib/widgets/player_style_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/player_style_service.dart';
+
+class PlayerStyleCard extends StatelessWidget {
+  const PlayerStyleCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.watch<PlayerStyleService>().style;
+    String label;
+    String hint;
+    IconData icon;
+    switch (style) {
+      case PlayerStyle.aggressive:
+        label = 'Агрессивный';
+        hint = 'Сбавьте агрессию ранних улиц';
+        icon = Icons.trending_down;
+        break;
+      case PlayerStyle.passive:
+        label = 'Пассивный';
+        hint = 'Проявите больше агрессии';
+        icon = Icons.trending_up;
+        break;
+      case PlayerStyle.neutral:
+        label = 'Нейтральный';
+        hint = 'Сохраняйте баланс игры';
+        icon = Icons.balance;
+        break;
+    }
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: Colors.greenAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Стиль: $label',
+                    style: const TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(hint, style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show the player's style with hints in recommendations
- add style card on home screen
- integrate style card into recommendation screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb16e24b8832abbf3f4f456f9ff86