### PR TITLE
Add Apple sign-in

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -264,26 +264,44 @@ class _ProfileScreenState extends State<ProfileScreen> {
           const SizedBox(height: 16),
           Consumer<AuthService>(
             builder: (context, auth, child) {
-              final email = auth.email;
-              final text = email != null
-                  ? 'Sign Out ($email)'
-                  : 'Sign In with Google';
-              return ElevatedButton(
-                onPressed: () async {
-                  if (!auth.isSignedIn) {
-                    final ok = await auth.signInWithGoogle();
-                    if (ok) {
-                      final cloud = context.read<CloudSyncService>();
-                      await cloud.syncDown();
-                      await context
-                          .read<TrainingPackCloudSyncService>()
-                          .syncDownStats();
-                    }
-                  } else {
-                    await auth.signOut();
-                  }
-                },
-                child: Text(text),
+              if (auth.isSignedIn) {
+                final email = auth.email;
+                return ElevatedButton(
+                  onPressed: auth.signOut,
+                  child: Text('Sign Out ($email)'),
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ElevatedButton(
+                    onPressed: () async {
+                      final ok = await auth.signInWithGoogle();
+                      if (ok) {
+                        final cloud = context.read<CloudSyncService>();
+                        await cloud.syncDown();
+                        await context
+                            .read<TrainingPackCloudSyncService>()
+                            .syncDownStats();
+                      }
+                    },
+                    child: const Text('Sign In with Google'),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: () async {
+                      final ok = await auth.signInWithApple();
+                      if (ok) {
+                        final cloud = context.read<CloudSyncService>();
+                        await cloud.syncDown();
+                        await context
+                            .read<TrainingPackCloudSyncService>()
+                            .syncDownStats();
+                      }
+                    },
+                    child: const Text('Sign In with Apple'),
+                  ),
+                ],
               );
             },
           ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -201,25 +201,42 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             Consumer<AuthService>(
               builder: (context, auth, child) {
-                final email = auth.email;
-                final text = email != null
-                    ? 'Sign Out ($email)'
-                    : 'Sign In with Google';
-                return ElevatedButton(
-                  onPressed: () async {
-                    if (auth.currentUser == null) {
-                      final ok = await auth.signInWithGoogle();
-                      if (ok) {
-                        await context.read<CloudSyncService>().syncDown();
-                        await context
-                            .read<TrainingPackCloudSyncService>()
-                            .syncDownStats();
-                      }
-                    } else {
-                      await auth.signOut();
-                    }
-                  },
-                  child: Text(text),
+                if (auth.currentUser != null) {
+                  final email = auth.email;
+                  return ElevatedButton(
+                    onPressed: auth.signOut,
+                    child: Text('Sign Out ($email)'),
+                  );
+                }
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () async {
+                        final ok = await auth.signInWithGoogle();
+                        if (ok) {
+                          await context.read<CloudSyncService>().syncDown();
+                          await context
+                              .read<TrainingPackCloudSyncService>()
+                              .syncDownStats();
+                        }
+                      },
+                      child: const Text('Sign In with Google'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () async {
+                        final ok = await auth.signInWithApple();
+                        if (ok) {
+                          await context.read<CloudSyncService>().syncDown();
+                          await context
+                              .read<TrainingPackCloudSyncService>()
+                              .syncDownStats();
+                        }
+                      },
+                      child: const Text('Sign In with Apple'),
+                    ),
+                  ],
                 );
               },
             ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class AuthService extends ChangeNotifier {
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -37,6 +38,26 @@ class AuthService extends ChangeNotifier {
         idToken: auth.idToken,
       );
       await _auth.signInWithCredential(cred);
+      notifyListeners();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> signInWithApple() async {
+    try {
+      final credential = await SignInWithApple.getAppleIDCredential(
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+      );
+      final oauthCred = OAuthProvider('apple.com').credential(
+        idToken: credential.identityToken,
+        accessToken: credential.authorizationCode,
+      );
+      await _auth.signInWithCredential(oauthCred);
       notifyListeners();
       return true;
     } catch (_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   firebase_auth: ^5.0.0
   firebase_storage: ^12.4.9
   google_sign_in: ^6.1.5
+  sign_in_with_apple: ^7.0.1
   connectivity_plus: ^6.0.4
   url_launcher: ^6.1.11
 


### PR DESCRIPTION
## Summary
- add sign_in_with_apple dependency
- implement AuthService.signInWithApple()
- show Apple login button alongside Google in auth views

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb6ce67bc832aa9ef745f0f3b735c