### PR TITLE
Add progress overview screen

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -37,6 +37,7 @@ import 'training_history_screen.dart';
 import 'session_stats_screen.dart';
 import 'training_stats_screen.dart';
 import 'progress_screen.dart';
+import 'progress_overview_screen.dart';
 import 'drill_history_screen.dart';
 import '../services/streak_service.dart';
 import 'goals_overview_screen.dart';
@@ -529,6 +530,16 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => const ProgressScreen()),
+          );
+        },
+      ),
+      _MenuItem(
+        icon: Icons.show_chart,
+        label: 'Прогресс',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const ProgressOverviewScreen()),
           );
         },
       ),

--- a/lib/screens/progress_overview_screen.dart
+++ b/lib/screens/progress_overview_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/progress_forecast_service.dart';
+import '../models/training_result.dart';
+import '../widgets/daily_ev_icm_chart.dart';
+import '../widgets/common/accuracy_chart.dart';
+import '../widgets/common/average_accuracy_chart.dart';
+import '../widgets/sync_status_widget.dart';
+import '../theme/app_colors.dart';
+
+class ProgressOverviewScreen extends StatelessWidget {
+  static const route = '/progress_overview';
+  const ProgressOverviewScreen({super.key});
+
+  List<TrainingResult> _sessions(List<ProgressEntry> history) {
+    return [
+      for (final e in history)
+        TrainingResult(
+          date: e.date,
+          total: 0,
+          correct: 0,
+          accuracy: e.accuracy * 100,
+        )
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final history = context.watch<ProgressForecastService>().history;
+    final sessions = _sessions(history);
+    final hasData = sessions.length >= 2;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Progress Overview'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const DailyEvIcmChart(),
+          const SizedBox(height: 16),
+          if (hasData) AccuracyChart(sessions: sessions) else _placeholder(),
+          if (hasData) AverageAccuracyChart(sessions: sessions),
+        ],
+      ),
+    );
+  }
+
+  Widget _placeholder() {
+    return Container(
+      height: 200,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: const Text('Недостаточно данных',
+          style: TextStyle(color: Colors.white70)),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create progress_overview_screen with EV/ICM and accuracy charts
- link progress overview from the main menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc274e5c832a8702ec03f5ae58cf