### PR TITLE
Implement share link functionality

### DIFF
--- a/lib/services/pack_export_service.dart
+++ b/lib/services/pack_export_service.dart
@@ -146,6 +146,11 @@ class PackExportService {
     return file;
   }
 
+  static String exportShareLink(TrainingPackTemplate tpl) {
+    final jsonStr = jsonEncode(tpl.toJson());
+    return base64Url.encode(utf8.encode(jsonStr));
+  }
+
   static Future<File> exportSessionCsv(
       List<SavedHand> hands, List<double> evs, List<double> icms) async {
     final rows = <List<dynamic>>[

--- a/lib/services/pack_import_service.dart
+++ b/lib/services/pack_import_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:csv/csv.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
@@ -97,6 +98,12 @@ class PackImportService {
       spots: spots,
       createdAt: DateTime.now(),
     );
+  }
+
+  static TrainingPackTemplate importFromShareLink(String data) {
+    final jsonStr = utf8.decode(base64Url.decode(data.trim()));
+    final map = jsonDecode(jsonStr) as Map<String, dynamic>;
+    return TrainingPackTemplate.fromJson(map);
   }
 
   static String _cell(List row, int? i) {


### PR DESCRIPTION
## Summary
- export pack templates as base64 share links
- parse share links when importing packs
- add copy share link option to pack overview actions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc2a6c74832aa7efd91f64e58897