### PR TITLE
Add GGPoker converter plugin

### DIFF
--- a/lib/plugins/gg_poker_converter_plugin.dart
+++ b/lib/plugins/gg_poker_converter_plugin.dart
@@ -1,0 +1,13 @@
+import 'package:poker_analyzer/plugins/converters/ggpoker_hand_history_converter.dart';
+import 'package:poker_analyzer/plugins/plugin.dart';
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+
+class GGPokerConverterPlugin extends GGPokerHandHistoryConverter implements Plugin {
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
+    registry.get<ConverterRegistry>().register(this);
+  }
+}
+

--- a/lib/plugins/plugin_loader.dart
+++ b/lib/plugins/plugin_loader.dart
@@ -23,6 +23,7 @@ import 'converters/winamax_hand_history_converter.dart';
 import 'converters/partypoker_hand_history_converter.dart';
 import 'converters/wpn_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
+import 'gg_poker_converter_plugin.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -112,6 +113,8 @@ class PluginLoader {
         ]);
       case 'PokerStarsConverterPlugin':
         return PokerStarsConverterPlugin();
+      case 'GGPokerConverterPlugin':
+        return GGPokerConverterPlugin();
     }
     return null;
   }

--- a/plugins/GGPokerConverterPlugin.dart
+++ b/plugins/GGPokerConverterPlugin.dart
@@ -1,0 +1,6 @@
+import 'dart:isolate';
+import 'package:poker_analyzer/plugins/gg_poker_converter_plugin.dart';
+
+void main(List<String> args, SendPort sendPort) {
+  sendPort.send(GGPokerConverterPlugin());
+}


### PR DESCRIPTION
## Summary
- implement `GGPokerConverterPlugin`
- register new plugin in loader
- add entrypoint for dynamic plugin loading

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc25f174832aabae49fd24e7f017