### PR TITLE
Add progress export features

### DIFF
--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -17,6 +17,7 @@ import '../helpers/color_utils.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:printing/printing.dart';
+import '../services/progress_export_service.dart';
 
 import '../theme/app_colors.dart';
 import '../widgets/common/accuracy_chart.dart';
@@ -704,6 +705,30 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Файл сохранён: $fileName')),
+      );
+    }
+  }
+
+  Future<void> _exportProgressCsv({bool weekly = false}) async {
+    final service = ProgressExportService(
+        stats: context.read<TrainingStatsService>());
+    final file = await service.exportCsv(weekly: weekly);
+    _lastCsvPath = file.path;
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
+      );
+    }
+  }
+
+  Future<void> _exportProgressPdf({bool weekly = false}) async {
+    final service = ProgressExportService(
+        stats: context.read<TrainingStatsService>());
+    final file = await service.exportPdf(weekly: weekly);
+    _lastPdfPath = file.path;
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
       );
     }
   }
@@ -3088,20 +3113,36 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                       child: const Text('Экспорт CSV'),
                     ),
                     const SizedBox(width: 8),
-                    ElevatedButton(
-                      onPressed: _getFilteredHistory().isEmpty
-                          ? null
-                          : _exportVisiblePdf,
-                      child: const Text('Экспорт PDF'),
-                    ),
-                  ],
-                ),
+                  ElevatedButton(
+                    onPressed: _getFilteredHistory().isEmpty
+                        ? null
+                        : _exportVisiblePdf,
+                    child: const Text('Экспорт PDF'),
+                  ),
+                ],
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  ElevatedButton(
+                    onPressed: () => _exportProgressCsv(weekly: false),
+                    child: const Text('Прогресс CSV'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: () => _exportProgressPdf(weekly: false),
+                    child: const Text('Прогресс PDF'),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
                     ElevatedButton(
                       onPressed: _openLatestExport,
                       child: const Text('Открыть'),

--- a/lib/services/progress_export_service.dart
+++ b/lib/services/progress_export_service.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+import 'training_stats_service.dart';
+
+class ProgressExportService {
+  final TrainingStatsService stats;
+  ProgressExportService({required this.stats});
+
+  Future<File> exportCsv({bool weekly = false}) async {
+    final rows = stats.progressRows(weekly: weekly);
+    final csvStr = const ListToCsvConverter().convert(rows, eol: '\r\n');
+    final dir = await getTemporaryDirectory();
+    final mode = weekly ? 'weekly' : 'daily';
+    final file = File('${dir.path}/progress_\${mode}_\${DateTime.now().millisecondsSinceEpoch}.csv');
+    await file.writeAsString(csvStr, encoding: utf8);
+    return file;
+  }
+
+  Future<File> exportPdf({bool weekly = false}) async {
+    final rows = stats.progressRows(weekly: weekly);
+    final header = rows.first.cast<String>();
+    final data = rows.skip(1).toList();
+    final pdf = pw.Document();
+    pdf.addPage(
+      pw.Page(
+        pageFormat: PdfPageFormat.a4,
+        build: (context) {
+          return pw.Table.fromTextArray(headers: header, data: data);
+        },
+      ),
+    );
+    final bytes = await pdf.save();
+    final dir = await getTemporaryDirectory();
+    final mode = weekly ? 'weekly' : 'daily';
+    final file = File('${dir.path}/progress_\${mode}_\${DateTime.now().millisecondsSinceEpoch}.pdf');
+    await file.writeAsBytes(bytes);
+    return file;
+  }
+}

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -239,6 +239,29 @@ class TrainingStatsService extends ChangeNotifier {
     return _groupMonthly(daily);
   }
 
+  List<List<dynamic>> progressRows({bool weekly = false, int count = 30}) {
+    final sessions = weekly ? sessionsWeekly(count) : sessionsDaily(count);
+    final hands = weekly ? handsWeekly(count) : handsDaily(count);
+    final mistakes = weekly ? mistakesWeekly(count) : mistakesDaily(count);
+    final sMap = {for (final e in sessions) e.key: e.value};
+    final hMap = {for (final e in hands) e.key: e.value};
+    final mMap = {for (final e in mistakes) e.key: e.value};
+    final dates = {
+      ...sMap.keys,
+      ...hMap.keys,
+      ...mMap.keys,
+    }.toList()
+      ..sort();
+    final rows = <List<dynamic>>[
+      ['Date', 'Sessions', 'Hands', 'Mistakes']
+    ];
+    for (final d in dates) {
+      final key = d.toIso8601String().split('T').first;
+      rows.add([key, sMap[d] ?? 0, hMap[d] ?? 0, mMap[d] ?? 0]);
+    }
+    return rows;
+  }
+
   Map<String, int> _loadMap(SharedPreferences prefs, String key) {
     final raw = prefs.getString(key);
     if (raw == null) return {};


### PR DESCRIPTION
## Summary
- generate progress rows in TrainingStatsService
- add ProgressExportService for CSV/PDF
- export progress from TrainingHistoryScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc25b03c832aa7806df1e064f2e1