### PR TITLE
Implement basic achievement tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'services/hand_analyzer_service.dart';
 import 'services/achievement_engine.dart';
 import 'services/goal_engine.dart';
 import 'services/streak_service.dart';
+import 'services/achievement_service.dart';
 import 'services/reminder_service.dart';
 import 'services/daily_reminder_service.dart';
 import 'services/next_step_engine.dart';
@@ -321,6 +322,14 @@ Future<void> main() async {
             cloud: context.read<CloudSyncService>(),
             xp: context.read<XPTrackerService>(),
           )..load(),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => AchievementService(
+            stats: context.read<TrainingStatsService>(),
+            hands: context.read<SavedHandManagerService>(),
+            streak: context.read<StreakService>(),
+            xp: context.read<XPTrackerService>(),
+          ),
         ),
         ChangeNotifierProvider(
           create: (context) =>

--- a/lib/models/simple_achievement.dart
+++ b/lib/models/simple_achievement.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class SimpleAchievement {
+  final String id;
+  final String title;
+  final IconData icon;
+  final bool unlocked;
+  final DateTime? date;
+
+  const SimpleAchievement({
+    required this.id,
+    required this.title,
+    required this.icon,
+    this.unlocked = false,
+    this.date,
+  });
+
+  SimpleAchievement copyWith({bool? unlocked, DateTime? date}) => SimpleAchievement(
+        id: id,
+        title: title,
+        icon: icon,
+        unlocked: unlocked ?? this.unlocked,
+        date: date ?? this.date,
+      );
+}

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -32,6 +32,7 @@ import '../widgets/progress_forecast_card.dart';
 import '../widgets/player_style_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
+import '../widgets/achievements_card.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -95,6 +96,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const DailyChallengeCard(),
           const WeeklyChallengeCard(),
           const XPProgressBar(),
+          const AchievementsCard(),
           const WeakSpotCard(),
           const ReviewPastMistakesCard(),
           const RepeatMistakesCard(),

--- a/lib/services/achievement_service.dart
+++ b/lib/services/achievement_service.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/simple_achievement.dart';
+import '../widgets/achievement_unlocked_overlay.dart';
+import '../services/training_stats_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/streak_service.dart';
+import '../services/xp_tracker_service.dart';
+import '../main.dart';
+
+class AchievementService extends ChangeNotifier {
+  AchievementService({
+    required this.stats,
+    required this.hands,
+    required this.streak,
+    required this.xp,
+  }) {
+    _init();
+  }
+
+  final TrainingStatsService stats;
+  final SavedHandManagerService hands;
+  final StreakService streak;
+  final XPTrackerService xp;
+
+  static const _key = 'simple_ach_';
+
+  final List<SimpleAchievement> _achievements = [];
+
+  List<SimpleAchievement> get achievements => List.unmodifiable(_achievements);
+
+  DateTime? _parse(String? s) => s != null ? DateTime.tryParse(s) : null;
+
+  Future<void> _init() async {
+    final prefs = await SharedPreferences.getInstance();
+    _achievements.addAll([
+      SimpleAchievement(
+        id: 'first_pack',
+        title: 'Первый пак завершён',
+        icon: Icons.flag,
+        unlocked: prefs.getBool('${_key}first_pack') ?? false,
+        date: _parse(prefs.getString('${_key}first_pack_date')),
+      ),
+      SimpleAchievement(
+        id: 'streak_7',
+        title: '7 дней подряд',
+        icon: Icons.local_fire_department,
+        unlocked: prefs.getBool('${_key}streak_7') ?? false,
+        date: _parse(prefs.getString('${_key}streak_7_date')),
+      ),
+      SimpleAchievement(
+        id: 'hands_100',
+        title: '100 рук сыграно',
+        icon: Icons.pan_tool_alt,
+        unlocked: prefs.getBool('${_key}hands_100') ?? false,
+        date: _parse(prefs.getString('${_key}hands_100_date')),
+      ),
+      SimpleAchievement(
+        id: 'ev_015',
+        title: 'EV-мастер',
+        icon: Icons.trending_up,
+        unlocked: prefs.getBool('${_key}ev_015') ?? false,
+        date: _parse(prefs.getString('${_key}ev_015_date')),
+      ),
+      SimpleAchievement(
+        id: 'error_free_3',
+        title: 'Без ошибок 3 дня',
+        icon: Icons.check_circle,
+        unlocked: prefs.getBool('${_key}error_free_3') ?? false,
+        date: _parse(prefs.getString('${_key}error_free_3_date')),
+      ),
+    ]);
+    stats.sessionsStream.listen((_) => _check());
+    stats.handsStream.listen((_) => _check());
+    streak.addListener(_check);
+    _check();
+  }
+
+  Future<void> _save(SimpleAchievement a) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('$_key${a.id}', a.unlocked);
+    if (a.date != null) {
+      await prefs.setString('$_key${a.id}_date', a.date!.toIso8601String());
+    }
+  }
+
+  Future<void> _unlock(String id) async {
+    final i = _achievements.indexWhere((a) => a.id == id);
+    if (i == -1) return;
+    final a = _achievements[i];
+    if (a.unlocked) return;
+    final updated = a.copyWith(unlocked: true, date: DateTime.now());
+    _achievements[i] = updated;
+    await _save(updated);
+    await xp.add(xp: XPTrackerService.achievementXp, source: 'achievement');
+    final ctx = navigatorKey.currentState?.context;
+    if (ctx != null) {
+      showAchievementUnlockedOverlay(ctx, a.icon, a.title);
+    }
+    notifyListeners();
+  }
+
+  void _check() {
+    if (stats.sessionsCompleted > 0) _unlock('first_pack');
+    if (streak.streak.value >= 7) _unlock('streak_7');
+    if (stats.handsReviewed >= 100) _unlock('hands_100');
+    if (streak.errorFreeStreak >= 3) _unlock('error_free_3');
+    _checkEv();
+  }
+
+  void _checkEv() {
+    final ach = _achievements.firstWhere((a) => a.id == 'ev_015');
+    if (ach.unlocked) return;
+    if (hands.hands.isEmpty) return;
+    final id = hands.hands.last.sessionId;
+    final evs = <double>[];
+    for (final h in hands.hands.where((e) => e.sessionId == id)) {
+      final v = h.heroEv;
+      if (v != null) evs.add(v);
+    }
+    if (evs.isEmpty) return;
+    final avg = evs.reduce((a, b) => a + b) / evs.length;
+    if (avg > 0.15) _unlock('ev_015');
+  }
+}

--- a/lib/widgets/achievements_card.dart
+++ b/lib/widgets/achievements_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/achievement_service.dart';
+import '../screens/achievements_catalog_screen.dart';
+
+class AchievementsCard extends StatelessWidget {
+  const AchievementsCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<AchievementService>();
+    final unlocked = service.achievements.where((a) => a.unlocked).length;
+    final total = service.achievements.length;
+    final accent = Theme.of(context).colorScheme.secondary;
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AchievementsCatalogScreen()),
+        );
+      },
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.emoji_events, color: accent),
+            const SizedBox(width: 8),
+            const Expanded(
+              child: Text(
+                'Achievements',
+                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+            ),
+            Text('$unlocked/$total',
+                style: const TextStyle(color: Colors.white70)),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add AchievementService for event-based unlocks
- show Achievements card on training home screen
- wire new service into main provider tree

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687006d68760832a8bfd820e947f9bc5