### PR TITLE
Add Weekly Reward Chest

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,7 @@ import 'services/notification_service.dart';
 import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
+import 'services/reward_service.dart';
 import 'services/weekly_challenge_service.dart';
 import 'services/daily_challenge_service.dart';
 import 'services/daily_goals_service.dart';
@@ -267,6 +268,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
         ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
         ChangeNotifierProvider(create: (_) => XPTrackerService(cloud: xpCloud)..load()),
+        ChangeNotifierProvider(create: (_) => RewardService()..load()),
         ChangeNotifierProvider(
           create: (context) => DailyChallengeService(
             adaptive: context.read<AdaptiveTrainingService>(),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/daily_goals_card.dart';
 import '../widgets/daily_progress_ring.dart';
 import '../widgets/repeat_mistakes_card.dart';
 import '../widgets/weekly_challenge_card.dart';
+import '../widgets/weekly_chest_card.dart';
 import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
@@ -94,6 +95,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const DailyGoalsCard(),
           const DailyChallengeCard(),
           const WeeklyChallengeCard(),
+          const WeeklyChestCard(),
           const XPProgressBar(),
           const WeakSpotCard(),
           const ReviewPastMistakesCard(),

--- a/lib/services/reward_service.dart
+++ b/lib/services/reward_service.dart
@@ -1,0 +1,46 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RewardService extends ChangeNotifier {
+  static const _rewardKey = 'weekly_reward_pending';
+  String? _reward;
+
+  String? get reward => _reward;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _reward = prefs.getString(_rewardKey);
+  }
+
+  Future<void> _save(String? value) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (value == null) {
+      await prefs.remove(_rewardKey);
+    } else {
+      await prefs.setString(_rewardKey, value);
+    }
+  }
+
+  Future<void> setReward(String value) async {
+    _reward = value;
+    await _save(value);
+    notifyListeners();
+  }
+
+  Future<void> clear() async {
+    _reward = null;
+    await _save(null);
+    notifyListeners();
+  }
+
+  String randomReward() {
+    const rewards = [
+      'XP Boost',
+      'Training Pack',
+      'Extra Mistake Slot',
+      'Card Skin'
+    ];
+    return rewards[Random().nextInt(rewards.length)];
+  }
+}

--- a/lib/widgets/weekly_chest_card.dart
+++ b/lib/widgets/weekly_chest_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/streak_service.dart';
+import '../services/reward_service.dart';
+
+class WeeklyChestCard extends StatelessWidget {
+  const WeeklyChestCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final streak = context.watch<StreakService>();
+    final days = streak.weeklyActiveDays;
+    final progress = (days / 5).clamp(0.0, 1.0);
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.card_giftcard, color: Colors.orangeAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Weekly Chest',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation(accent),
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text('$days / 5 days',
+                    style: const TextStyle(color: Colors.white70, fontSize: 12)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (streak.weeklyChestClaimed)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+              decoration: BoxDecoration(
+                color: Colors.green,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text('Received ✅',
+                  style: TextStyle(color: Colors.white)),
+            )
+          else if (streak.weeklyChestAvailable)
+            ElevatedButton(
+              onPressed: () async {
+                final reward = await context
+                    .read<StreakService>()
+                    .claimWeeklyChest(context.read<RewardService>());
+                if (!context.mounted || reward == null) return;
+                showDialog(
+                  context: context,
+                  builder: (_) => AlertDialog(
+                    title: const Text('Congratulations!'),
+                    content: Text('You got $reward'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('OK'),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            )
+          else
+            const SizedBox.shrink(),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement reward tracking service
- extend streak service for weekly reward logic
- expose new weekly chest card on home screen
- wire reward service into app providers

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687000c245c8832a8b04a19c991e4237