### PR TITLE
Add daily progress notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -494,6 +494,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     _sync = ConnectivitySyncController(cloud: context.read<CloudSyncService>());
     context.read<UserActionLogger>().log('opened_app');
     unawaited(NotificationService.scheduleDailyReminder(context));
+    unawaited(NotificationService.scheduleDailyProgress(context));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeResumeTraining();
       _maybeShowIntroOverlay();

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -453,10 +453,12 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
       _save();
       await context.read<StreakService>().onFinish();
       await NotificationService.cancel(101);
+      await NotificationService.cancel(102);
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('last_training_day',
           DateTime.now().toIso8601String().split('T').first);
       await NotificationService.scheduleDailyReminder(context);
+      await NotificationService.scheduleDailyProgress(context);
       final ids = _wrongIds();
       if (ids.isNotEmpty) {
         final template = widget.template.copyWith(

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -3,17 +3,35 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
 import 'remote_config_service.dart';
+import 'training_stats_service.dart';
+import 'personal_recommendation_service.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+import '../screens/training_home_screen.dart';
+import '../main.dart';
 
 class NotificationService {
   static final _plugin = FlutterLocalNotificationsPlugin();
   static const _timeKey = 'daily_reminder_time';
+  static const _progressId = 102;
 
   static Future<void> init() async {
     const android = AndroidInitializationSettings('@mipmap/ic_launcher');
     const ios = DarwinInitializationSettings();
-    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    await _plugin.initialize(
+      const InitializationSettings(android: android, iOS: ios),
+      onDidReceiveNotificationResponse: (r) {
+        if (r.payload == 'progress') {
+          final ctx = navigatorKey.currentState?.context;
+          if (ctx != null) {
+            Navigator.push(
+              ctx,
+              MaterialPageRoute(builder: (_) => const TrainingHomeScreen()),
+            );
+          }
+        }
+      },
+    );
     tz.initializeTimeZones();
   }
 
@@ -63,6 +81,41 @@ class NotificationService {
         android: AndroidNotificationDetails('daily_push', 'Daily Push'),
         iOS: DarwinNotificationDetails(),
       ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  static Future<void> scheduleDailyProgress(BuildContext context) async {
+    final stats = context.read<TrainingStatsService>();
+    final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+    final sessions = stats.sessionsDaily(1);
+    if (sessions.isNotEmpty && sessions.first.value > 0) return;
+    final rec = context.read<PersonalRecommendationService>();
+    final tpl = rec.packs.isNotEmpty ? rec.packs.first : null;
+    final prefs = await SharedPreferences.getInstance();
+    var focus = tpl?.heroPos.label ?? 'training';
+    var remaining = 0;
+    if (tpl != null) {
+      final idx = prefs.getInt('tpl_prog_${tpl.id}') ?? 0;
+      remaining = tpl.spots.length - idx - 1;
+      if (remaining < 0) remaining = 0;
+    }
+    var when = tz.TZDateTime.local(today.year, today.month, today.day, 18);
+    if (when.isBefore(tz.TZDateTime.now(tz.local))) {
+      when = when.add(const Duration(days: 1));
+    }
+    await _plugin.zonedSchedule(
+      _progressId,
+      'Poker Analyzer',
+      '⚡ Готов улучшить $focus? У тебя есть $remaining незавершённых спотов — продолжим тренировку?',
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('daily_progress', 'Daily Progress'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      payload: 'progress',
       androidAllowWhileIdle: true,
       uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,

--- a/lib/services/reminder_service.dart
+++ b/lib/services/reminder_service.dart
@@ -159,6 +159,7 @@ class ReminderService extends ChangeNotifier {
     }
     if (!needSpot && activeGoal == null) return;
     await NotificationService.scheduleDailyReminder(context);
+    await NotificationService.scheduleDailyProgress(context);
   }
 }
 


### PR DESCRIPTION
## Summary
- trigger a new daily progress notification showing pending spots and focus
- handle notification tap to open `TrainingHomeScreen`
- reschedule daily progress push on app start, training finish and reminders

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff49eb3bc832a9f10d134f9ed7f1f