### PR TITLE
Add quick continue

### DIFF
--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -120,12 +120,14 @@ class TrainingSessionService extends ChangeNotifier {
             for (final e in (spots as List? ?? []))
               TrainingPackSpot.fromJson(Map<String, dynamic>.from(e))
           ];
-          _focusHandTypes
-            ..clear()
-            ..addAll([
-              for (final t in (data['focusHandTypes'] as List? ?? []))
-                FocusGoal.fromJson(t)
-            ]);
+      _focusHandTypes
+        ..clear()
+        ..addAll([
+          for (final t in (data['focusHandTypes'] as List? ?? []))
+            FocusGoal.fromJson(t)
+        ]);
+          _preEvPct = (data['preEvPct'] as num?)?.toDouble() ?? 0;
+          _preIcmPct = (data['preIcmPct'] as num?)?.toDouble() ?? 0;
           final totalRaw = data['handGoalTotal'];
           if (totalRaw is Map) {
             _handGoalTotal
@@ -198,7 +200,9 @@ class TrainingSessionService extends ChangeNotifier {
         if (_focusHandTypes.isNotEmpty)
           'focusHandTypes': [for (final g in _focusHandTypes) g.toString()],
         if (_handGoalTotal.isNotEmpty) 'handGoalTotal': _handGoalTotal,
-        if (_handGoalCount.isNotEmpty) 'handGoalProgress': _handGoalCount
+        if (_handGoalCount.isNotEmpty) 'handGoalProgress': _handGoalCount,
+        'preEvPct': _preEvPct,
+        'preIcmPct': _preIcmPct
       });
     }
   }

--- a/lib/widgets/quick_continue_card.dart
+++ b/lib/widgets/quick_continue_card.dart
@@ -1,174 +1,78 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import '../services/spot_of_the_day_service.dart';
-import '../services/mistake_review_pack_service.dart';
-import '../services/weekly_challenge_service.dart';
-import '../services/training_pack_storage_service.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import '../screens/training_pack_review_screen.dart';
-import '../screens/training_pack_screen.dart';
-import '../screens/training_screen.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
 
-class QuickContinueCard extends StatefulWidget {
+class QuickContinueCard extends StatelessWidget {
   const QuickContinueCard({super.key});
 
   @override
-  State<QuickContinueCard> createState() => _QuickContinueCardState();
-}
-
-class _ContinueItem {
-  final String title;
-  final int progress;
-  final int total;
-  final DateTime date;
-  final WidgetBuilder builder;
-  const _ContinueItem({
-    required this.title,
-    required this.progress,
-    required this.total,
-    required this.date,
-    required this.builder,
-  });
-}
-
-class _QuickContinueCardState extends State<QuickContinueCard> {
-  _ContinueItem? _item;
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final spot = context.read<SpotOfTheDayService>().currentSpot;
-    final spotResult = context.read<SpotOfTheDayService>().result;
-    final mistake = context.read<MistakeReviewPackService>();
-    final challenge = context.read<WeeklyChallengeService>();
-    final packs = context.read<TrainingPackStorageService>().packs;
-    final prefs = await SharedPreferences.getInstance();
-    final l = AppLocalizations.of(context)!;
-    final items = <_ContinueItem>[];
-    if (spot != null && spotResult == null) {
-      items.add(
-        _ContinueItem(
-          title: 'Spot of the Day',
-          progress: 0,
-          total: 1,
-          date: DateTime.now(),
-          builder: (_) => TrainingScreen(spot: spot),
-        ),
-      );
-    }
-    final mPack = mistake.pack;
-    if (mPack != null && mistake.progress < mPack.hands.length) {
-      items.add(
-        _ContinueItem(
-          title: l.repeatMistakes,
-          progress: mistake.progress,
-          total: mPack.hands.length,
-          date: DateTime.now(),
-          builder: (_) => TrainingPackReviewScreen(
-            pack: mPack,
-            mistakenNames: {for (final h in mPack.hands) h.name},
+  Widget build(BuildContext context) {
+    return Consumer<TrainingSessionService>(
+      builder: (context, service, _) {
+        final session = service.session;
+        final template = service.template;
+        if (session == null || template == null || session.isCompleted) {
+          return const SizedBox.shrink();
+        }
+        final focus =
+            service.focusHandTypes.map((e) => e.label).join(', ');
+        final total = template.spots.length;
+        final progress = '${session.index}/${total}';
+        final evPct = total == 0 ? 0.0 : template.evCovered * 100 / total;
+        final icmPct = total == 0 ? 0.0 : template.icmCovered * 100 / total;
+        final deltaEv = evPct - service.preEvPct;
+        final deltaIcm = icmPct - service.preIcmPct;
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
           ),
-        ),
-      );
-    }
-    final c = challenge.current;
-    final cProgress = challenge.progressValue;
-    if (cProgress > 0 && cProgress < c.target) {
-      items.add(
-        _ContinueItem(
-          title: c.title,
-          progress: cProgress,
-          total: c.target,
-          date: DateTime.now(),
-          builder: (_) => TrainingPackReviewScreen(pack: challenge.currentPack),
-        ),
-      );
-    }
-    for (final p in packs) {
-      final idx = prefs.getInt('training_progress_${p.name}') ?? 0;
-      if (idx > 0 && idx < p.hands.length) {
-        final date = p.history.isNotEmpty
-            ? p.history.last.date
-            : DateTime.now();
-        items.add(
-          _ContinueItem(
-            title: p.name,
-            progress: idx,
-            total: p.hands.length,
-            date: date,
-            builder: (_) => TrainingPackScreen(pack: p),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(template.name,
+                  style:
+                      const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              if (focus.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(focus,
+                      style: const TextStyle(color: Colors.white70)),
+                ),
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text('Вы завершили $progress рук',
+                    style: const TextStyle(color: Colors.white70)),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  'EV ${deltaEv >= 0 ? '+' : ''}${deltaEv.toStringAsFixed(2)}% · ICM ${deltaIcm >= 0 ? '+' : ''}${deltaIcm.toStringAsFixed(2)}%',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const TrainingSessionScreen()),
+                    );
+                  },
+                  child: const Text('Продолжить'),
+                ),
+              ),
+            ],
           ),
         );
-      }
-    }
-    items.sort((a, b) => b.date.compareTo(a.date));
-    setState(() {
-      _item = items.isNotEmpty ? items.first : null;
-      _loading = false;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_loading) return const SizedBox.shrink();
-    final item = _item;
-    if (item == null) return const SizedBox.shrink();
-    final accent = Theme.of(context).colorScheme.secondary;
-    final value = (item.progress / item.total).clamp(0.0, 1.0);
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.grey[850],
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        children: [
-          const Icon(Icons.play_arrow, color: Colors.lightBlueAccent),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(item.title,
-                    style: const TextStyle(
-                        fontSize: 16, fontWeight: FontWeight.bold)),
-                const SizedBox(height: 4),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    value: value,
-                    backgroundColor: Colors.white24,
-                    valueColor: AlwaysStoppedAnimation(accent),
-                    minHeight: 6,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text('${item.progress}/${item.total}',
-                    style:
-                        const TextStyle(color: Colors.white70, fontSize: 12)),
-              ],
-            ),
-          ),
-          const SizedBox(width: 8),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: item.builder),
-              ).then((_) => _load());
-            },
-            child: const Text('Continue'),
-          ),
-        ],
-      ),
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- store pre-session EV/ICM metrics
- show QuickContinue card for active training session

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fee8ff890832aab37619b339af66b