### PR TITLE
Implement Daily Focus Recap

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'services/daily_reminder_service.dart';
 import 'services/next_step_engine.dart';
 import 'services/drill_suggestion_engine.dart';
 import 'services/weak_spot_recommendation_service.dart';
+import 'services/daily_focus_recap_service.dart';
 import 'services/player_progress_service.dart';
 import 'services/player_style_service.dart';
 import 'services/player_style_forecast_service.dart';
@@ -373,6 +374,12 @@ Future<void> main() async {
             hands: context.read<SavedHandManagerService>(),
             progress: context.read<PlayerProgressService>(),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => DailyFocusRecapService(
+            hands: context.read<SavedHandManagerService>(),
+            weak: context.read<WeakSpotRecommendationService>(),
+          )..load(),
         ),
         ChangeNotifierProvider(
           create: (context) => FeedbackService(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -26,6 +26,7 @@ import '../widgets/weekly_challenge_card.dart';
 import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
+import '../widgets/daily_focus_recap_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
@@ -84,6 +85,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
         children: [
           const _RecommendedCarousel(),
           const QuickContinueCard(),
+          const DailyFocusRecapCard(),
           const SpotOfTheDayCard(),
           const ProgressSummaryBox(),
           const PositionProgressCard(),

--- a/lib/services/daily_focus_recap_service.dart
+++ b/lib/services/daily_focus_recap_service.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/v2/hero_position.dart';
+import '../models/saved_hand.dart';
+import '../models/v2/training_pack_template.dart';
+import 'saved_hand_manager_service.dart';
+import 'weak_spot_recommendation_service.dart';
+
+class _PosStats {
+  final int hands;
+  final int correct;
+  final double ev;
+  final double icm;
+  const _PosStats({this.hands = 0, this.correct = 0, this.ev = 0, this.icm = 0});
+  double get accuracy => hands > 0 ? correct / hands : 0;
+}
+
+class DailyFocusRecapService extends ChangeNotifier {
+  static const _dateKey = 'focus_recap_date';
+  static const _summaryKey = 'focus_recap_summary';
+  static const _focusKey = 'focus_recap_focus';
+  static const _shownKey = 'focus_recap_shown';
+
+  final SavedHandManagerService hands;
+  final WeakSpotRecommendationService weak;
+
+  DateTime? _date;
+  String _summary = '';
+  HeroPosition? _focus;
+  bool _shown = false;
+
+  DailyFocusRecapService({required this.hands, required this.weak});
+
+  String get summary => _summary;
+  HeroPosition? get focus => _focus;
+  bool get show => !_shown && _summary.isNotEmpty;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dateStr = prefs.getString(_dateKey);
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    final focusStr = prefs.getString(_focusKey);
+    _focus = focusStr != null
+        ? HeroPosition.values
+            .firstWhere((e) => e.name == focusStr, orElse: () => HeroPosition.unknown)
+        : null;
+    _summary = prefs.getString(_summaryKey) ?? '';
+    _shown = prefs.getString(_shownKey) == dateStr && dateStr != null;
+    await _ensureToday();
+    hands.addListener(_ensureToday);
+  }
+
+  Future<void> markShown() async {
+    _shown = true;
+    await _save();
+    notifyListeners();
+  }
+
+  Future<TrainingPackTemplate?> recommendedPack() =>
+      focus == null ? Future.value(null) : weak.buildPack(focus!);
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (_date != null) await prefs.setString(_dateKey, _date!.toIso8601String());
+    if (_focus != null) await prefs.setString(_focusKey, _focus!.name);
+    await prefs.setString(_summaryKey, _summary);
+    if (_shown && _date != null) {
+      await prefs.setString(_shownKey, _date!.toIso8601String());
+    }
+  }
+
+  Future<void> _ensureToday() async {
+    final now = DateTime.now();
+    if (_date != null &&
+        _date!.year == now.year &&
+        _date!.month == now.month &&
+        _date!.day == now.day) return;
+    _compute();
+    _date = DateTime(now.year, now.month, now.day);
+    _shown = false;
+    await _save();
+    notifyListeners();
+  }
+
+  Map<HeroPosition, _PosStats> _calc(List<SavedHand> list) {
+    final map = <HeroPosition, _PosStats>{};
+    for (final h in list) {
+      final pos = parseHeroPosition(h.heroPosition);
+      final prev = map[pos] ?? const _PosStats();
+      final correct =
+          h.expectedAction?.trim().toLowerCase() == h.gtoAction?.trim().toLowerCase();
+      map[pos] = _PosStats(
+        hands: prev.hands + 1,
+        correct: prev.correct + (correct ? 1 : 0),
+        ev: prev.ev + (h.heroEv ?? 0),
+        icm: prev.icm + (h.heroIcmEv ?? 0),
+      );
+    }
+    final res = <HeroPosition, _PosStats>{};
+    for (final e in map.entries) {
+      res[e.key] = _PosStats(
+        hands: e.value.hands,
+        correct: e.value.correct,
+        ev: e.value.hands > 0 ? e.value.ev / e.value.hands : 0,
+        icm: e.value.hands > 0 ? e.value.icm / e.value.hands : 0,
+      );
+    }
+    return res;
+  }
+
+  void _compute() {
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    final start = DateTime(yesterday.year, yesterday.month, yesterday.day);
+    final end = start.add(const Duration(days: 1));
+    final yHands = [
+      for (final h in hands.hands)
+        if (!h.date.isBefore(start) && h.date.isBefore(end)) h
+    ];
+    if (yHands.isEmpty) {
+      _summary = '';
+      _focus = null;
+      return;
+    }
+    final prevStart = start.subtract(const Duration(days: 1));
+    final prevEnd = start;
+    final prevHands = [
+      for (final h in hands.hands)
+        if (!h.date.isBefore(prevStart) && h.date.isBefore(prevEnd)) h
+    ];
+    final currMap = _calc(yHands);
+    final prevMap = _calc(prevHands);
+    HeroPosition? bestPos;
+    double bestDiff = 0;
+    HeroPosition? worstPos;
+    double worstDiff = 0;
+    for (final pos in currMap.keys) {
+      final curr = currMap[pos]!;
+      final prev = prevMap[pos];
+      final delta = curr.accuracy - (prev?.accuracy ?? curr.accuracy);
+      if (delta > bestDiff) {
+        bestDiff = delta;
+        bestPos = pos;
+      }
+      if (delta < worstDiff) {
+        worstDiff = delta;
+        worstPos = pos;
+      }
+    }
+    _focus = worstPos;
+    final parts = <String>[];
+    if (bestDiff > 0 && bestPos != null) {
+      parts.add('${bestPos.label} +${(bestDiff * 100).toStringAsFixed(1)}%');
+    }
+    if (worstDiff < 0 && worstPos != null) {
+      parts.add('${worstPos.label} ${(worstDiff * 100).toStringAsFixed(1)}%');
+    }
+    _summary = parts.isEmpty ? '' : 'Сегодня: ${parts.join(', ')}';
+  }
+}

--- a/lib/widgets/daily_focus_recap_card.dart
+++ b/lib/widgets/daily_focus_recap_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/daily_focus_recap_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class DailyFocusRecapCard extends StatelessWidget {
+  const DailyFocusRecapCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DailyFocusRecapService>();
+    if (!service.show) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(service.summary,
+              style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              OutlinedButton(
+                onPressed: () => service.markShown(),
+                child: const Text('Позже'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: () async {
+                  final tpl = await service.recommendedPack();
+                  await service.markShown();
+                  if (tpl == null || !context.mounted) return;
+                  await context
+                      .read<TrainingSessionService>()
+                      .startSession(tpl);
+                  if (context.mounted) {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const TrainingSessionScreen()),
+                    );
+                  }
+                },
+                child: const Text('Тренировать'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add daily focus recap service
- show recap card on training home screen
- provide recommended pack based on weak spots

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe87ff29c832aa7c3cae644c5b408