### PR TITLE
Add dynamic progress adaptation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -204,8 +204,10 @@ Future<void> main() async {
           ),
         ),
         ChangeNotifierProvider(
-          create: (context) =>
-              ProgressForecastService(hands: context.read<SavedHandManagerService>()),
+          create: (context) => ProgressForecastService(
+            hands: context.read<SavedHandManagerService>(),
+            style: context.read<PlayerStyleService>(),
+          ),
         ),
         ChangeNotifierProvider(
           create: (context) => MistakeReviewPackService(

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -5,6 +5,7 @@ import '../services/training_session_service.dart';
 import '../widgets/spot_quiz_widget.dart';
 import '../widgets/style_hint_bar.dart';
 import '../widgets/stack_range_bar.dart';
+import '../widgets/dynamic_progress_row.dart';
 import 'session_result_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
@@ -324,6 +325,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                       const SizedBox(height: 8),
                       const StyleHintBar(),
                       const StackRangeBar(),
+                      const DynamicProgressRow(),
                       Expanded(child: SpotQuizWidget(spot: spot)),
                       if (service.focusHandTypes.isNotEmpty)
                         Padding(

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -21,6 +21,7 @@ import '../../models/v2/training_pack_spot.dart';
 import '../../models/v2/training_pack_variant.dart';
 import '../../widgets/spot_quiz_widget.dart';
 import '../../widgets/common/explanation_text.dart';
+import '../../widgets/dynamic_progress_row.dart';
 import '../../theme/app_colors.dart';
 import '../../services/streak_service.dart';
 import '../../services/notification_service.dart';
@@ -802,6 +803,8 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
               ),
             Text('Spot ${_index + 1} of ${_spots.length}',
                 style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+            SizedBox(height: 8 * scale),
+            const DynamicProgressRow(),
             SizedBox(height: 8 * scale),
             Expanded(
               child: GestureDetector(

--- a/lib/services/personal_recommendation_service.dart
+++ b/lib/services/personal_recommendation_service.dart
@@ -7,6 +7,7 @@ import 'achievement_engine.dart';
 import 'weak_spot_recommendation_service.dart';
 import 'player_style_service.dart';
 import 'player_style_forecast_service.dart';
+import 'progress_forecast_service.dart';
 
 class RecommendationTask {
   final String title;
@@ -21,18 +22,21 @@ class PersonalRecommendationService extends ChangeNotifier {
   final WeakSpotRecommendationService weak;
   final PlayerStyleService style;
   final PlayerStyleForecastService forecast;
+  final ProgressForecastService progress;
   PersonalRecommendationService({
     required this.achievements,
     required this.adaptive,
     required this.weak,
     required this.style,
     required this.forecast,
+    required this.progress,
   }) {
     achievements.addListener(() => unawaited(_update()));
     adaptive.recommendedNotifier.addListener(() => unawaited(_update()));
     weak.addListener(() => unawaited(_update()));
     style.addListener(() => unawaited(_update()));
     forecast.addListener(() => unawaited(_update()));
+    progress.addListener(() => unawaited(_update()));
     unawaited(_update());
   }
 
@@ -74,6 +78,30 @@ class PersonalRecommendationService extends ChangeNotifier {
         break;
       case PlayerStyle.neutral:
         break;
+    }
+    final prog = progress.forecast;
+    if (prog.accuracy < 0.7) {
+      _tasks.insert(
+        0,
+        const RecommendationTask(
+            title: 'Работайте над точностью',
+            icon: Icons.bar_chart,
+            remaining: 1),
+      );
+    }
+    if (prog.ev < 0) {
+      _tasks.insert(
+        0,
+        const RecommendationTask(
+            title: 'Улучшите EV', icon: Icons.show_chart, remaining: 1),
+      );
+    }
+    if (prog.icm < 0) {
+      _tasks.insert(
+        0,
+        const RecommendationTask(
+            title: 'Улучшите ICM', icon: Icons.pie_chart, remaining: 1),
+      );
     }
     notifyListeners();
   }

--- a/lib/widgets/dynamic_progress_row.dart
+++ b/lib/widgets/dynamic_progress_row.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/progress_forecast_service.dart';
+
+class DynamicProgressRow extends StatelessWidget {
+  const DynamicProgressRow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<ProgressForecastService>();
+    final hist = service.history;
+    final forecast = service.forecast;
+    double lastAcc = forecast.accuracy;
+    double prevAcc = lastAcc;
+    double lastEv = forecast.ev;
+    double prevEv = lastEv;
+    double lastIcm = forecast.icm;
+    double prevIcm = lastIcm;
+    if (hist.length >= 2) {
+      lastAcc = hist.last.accuracy;
+      prevAcc = hist[hist.length - 2].accuracy;
+      lastEv = hist.last.ev;
+      prevEv = hist[hist.length - 2].ev;
+      lastIcm = hist.last.icm;
+      prevIcm = hist[hist.length - 2].icm;
+    }
+    final accUp = lastAcc >= prevAcc;
+    final evUp = lastEv >= prevEv;
+    final icmUp = lastIcm >= prevIcm;
+    Widget item(String label, double value, bool up) {
+      final color = up ? Colors.greenAccent : Colors.redAccent;
+      final icon = up ? Icons.trending_up : Icons.trending_down;
+      return Expanded(
+        child: Column(
+          children: [
+            Text(label, style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, size: 14, color: color),
+                const SizedBox(width: 4),
+                Text(
+                  label == 'Acc'
+                      ? '${(value * 100).toStringAsFixed(1)}%'
+                      : value.toStringAsFixed(2),
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          item('Acc', forecast.accuracy, accUp),
+          item('EV', forecast.ev, evUp),
+          item('ICM', forecast.icm, icmUp),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- adjust progress forecast by player style
- add progress-based recommendations
- show dynamic progress in training screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdc55c0d8832ab7ee73eeeb938a0e