### PR TITLE
Implement dynamic progress adjustments

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,7 @@ Future<void> main() async {
             hands: context.read<SavedHandManagerService>(),
             progress: context.read<PlayerProgressService>(),
             forecast: context.read<PlayerStyleForecastService>(),
+            style: context.read<PlayerStyleService>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -312,6 +312,11 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                         ),
                         const SizedBox(height: 4),
                         Text(
+                          'EV ${service.evAverage.toStringAsFixed(2)} • ICM ${service.icmAverage.toStringAsFixed(2)}',
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
                           '${service.session!.index + 1} / ${service.template!.spots.length}',
                           style: const TextStyle(color: Colors.white70),
                         ),

--- a/lib/services/dynamic_pack_adjustment_service.dart
+++ b/lib/services/dynamic_pack_adjustment_service.dart
@@ -14,12 +14,14 @@ class DynamicPackAdjustmentService {
   final SavedHandManagerService hands;
   final PlayerProgressService progress;
   final PlayerStyleForecastService forecast;
+  final PlayerStyleService style;
   const DynamicPackAdjustmentService({
     required this.mistakes,
     required this.eval,
     required this.hands,
     required this.progress,
     required this.forecast,
+    required this.style,
   });
 
   Future<TrainingPackTemplate> adjust(TrainingPackTemplate tpl) async {
@@ -57,6 +59,22 @@ class DynamicPackAdjustmentService {
       return (stack - tpl.heroBbStack).abs() <= 2;
     }).length;
     if (posMist > 10) diff--;
+    if (pos != null) {
+      if (pos.ev > 0) diff++;
+      if (pos.ev < 0) diff--;
+      if (pos.icm > 0) diff++;
+      if (pos.icm < 0) diff--;
+    }
+    switch (style.style) {
+      case PlayerStyle.aggressive:
+        diff--;
+        break;
+      case PlayerStyle.passive:
+        diff++;
+        break;
+      case PlayerStyle.neutral:
+        break;
+    }
     switch (forecast.forecast) {
       case PlayerStyle.aggressive:
         diff--;

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -71,6 +71,33 @@ class TrainingSessionService extends ChangeNotifier {
   Map<String, bool> get results => _session?.results ?? {};
   int get correctCount => results.values.where((e) => e).length;
   int get totalCount => results.length;
+  double get evAverage {
+    double sum = 0;
+    int count = 0;
+    for (final id in results.keys) {
+      final s = _spots.firstWhere((e) => e.id == id, orElse: () => TrainingPackSpot(id: ''));
+      final ev = s.heroEv;
+      if (ev != null) {
+        sum += ev;
+        count++;
+      }
+    }
+    return count > 0 ? sum / count : 0;
+  }
+
+  double get icmAverage {
+    double sum = 0;
+    int count = 0;
+    for (final id in results.keys) {
+      final s = _spots.firstWhere((e) => e.id == id, orElse: () => TrainingPackSpot(id: ''));
+      final icm = s.heroIcmEv;
+      if (icm != null) {
+        sum += icm;
+        count++;
+      }
+    }
+    return count > 0 ? sum / count : 0;
+  }
   List<TrainingAction> get actionLog => List.unmodifiable(_actions);
   List<TrainingPackSpot> get spots => List.unmodifiable(_spots);
   TrainingPackTemplate? get template => _template;
@@ -363,6 +390,7 @@ class TrainingSessionService extends ChangeNotifier {
     }
     if (_box != null) await _box!.put(_session!.id, _session!.toJson());
     _saveActive();
+    notifyListeners();
   }
 
   TrainingPackSpot? nextSpot() {


### PR DESCRIPTION
## Summary
- adapt training packs using player style and EV/ICM progress
- expose average EV and ICM in training sessions
- display live EV and ICM metrics while training
- wire up new style dependency for dynamic pack adjustments

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd650b0b0832aad2e067843c912c2