### PR TITLE
Add dynamic progress analyzer

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'services/player_style_service.dart';
 import 'services/player_style_forecast_service.dart';
 import 'services/real_time_stack_range_service.dart';
 import 'services/progress_forecast_service.dart';
+import 'services/dynamic_progress_service.dart';
 import 'services/personal_recommendation_service.dart';
 import 'services/feedback_service.dart';
 import 'services/drill_history_service.dart';
@@ -201,6 +202,12 @@ Future<void> main() async {
         ChangeNotifierProvider(
           create: (context) => RealTimeStackRangeService(
             forecast: context.read<PlayerStyleForecastService>(),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => DynamicProgressService(
+            hands: context.read<SavedHandManagerService>(),
+            stack: context.read<RealTimeStackRangeService>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/quick_continue_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
+import '../widgets/dynamic_progress_card.dart';
 import '../widgets/player_style_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
@@ -88,6 +89,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const ProgressSummaryBox(),
           const PositionProgressCard(),
           const ProgressForecastCard(),
+          const DynamicProgressCard(),
           const PlayerStyleCard(),
           const StreakChart(),
           const DailyProgressRing(),

--- a/lib/services/dynamic_progress_service.dart
+++ b/lib/services/dynamic_progress_service.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import '../models/saved_hand.dart';
+import 'saved_hand_manager_service.dart';
+import 'real_time_stack_range_service.dart';
+
+class DynamicProgressData {
+  final double accuracy;
+  final double ev;
+  final double icm;
+  const DynamicProgressData({this.accuracy = 0, this.ev = 0, this.icm = 0});
+}
+
+class DynamicProgressService extends ChangeNotifier {
+  final SavedHandManagerService hands;
+  final RealTimeStackRangeService stack;
+  DynamicProgressData _current = const DynamicProgressData();
+  DynamicProgressData _delta = const DynamicProgressData();
+  DynamicProgressData get current => _current;
+  DynamicProgressData get delta => _delta;
+
+  DynamicProgressService({required this.hands, required this.stack}) {
+    _update();
+    hands.addListener(_update);
+    stack.addListener(_update);
+  }
+
+  void _update() {
+    final target = stack.stack;
+    final filtered = hands.hands.reversed.where((h) {
+      final s = h.stackSizes[h.heroIndex] ?? 0;
+      return (s - target).abs() <= 2;
+    }).toList();
+    final recent = filtered.take(20).toList();
+    final prev = filtered.skip(20).take(20).toList();
+    _current = _calc(recent);
+    final p = _calc(prev);
+    _delta = DynamicProgressData(
+      accuracy: _current.accuracy - p.accuracy,
+      ev: _current.ev - p.ev,
+      icm: _current.icm - p.icm,
+    );
+    notifyListeners();
+  }
+
+  DynamicProgressData _calc(List<SavedHand> list) {
+    if (list.isEmpty) return const DynamicProgressData();
+    var handsCount = 0;
+    var correct = 0;
+    var ev = 0.0;
+    var icm = 0.0;
+    var evc = 0;
+    for (final h in list) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp != null && gto != null) {
+        handsCount++;
+        if (exp == gto) correct++;
+      }
+      final hev = h.heroEv;
+      if (hev != null) {
+        ev += hev;
+        icm += h.heroIcmEv ?? 0;
+        evc++;
+      }
+    }
+    return DynamicProgressData(
+      accuracy: handsCount > 0 ? correct / handsCount : 0,
+      ev: evc > 0 ? ev / evc : 0,
+      icm: evc > 0 ? icm / evc : 0,
+    );
+  }
+
+  @override
+  void dispose() {
+    hands.removeListener(_update);
+    stack.removeListener(_update);
+    super.dispose();
+  }
+}

--- a/lib/widgets/dynamic_progress_card.dart
+++ b/lib/widgets/dynamic_progress_card.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/dynamic_progress_service.dart';
+
+class DynamicProgressCard extends StatelessWidget {
+  const DynamicProgressCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final current = context.watch<DynamicProgressService>().current;
+    final delta = context.watch<DynamicProgressService>().delta;
+    Widget item(String title, double value, double diff) {
+      final color = diff > 0
+          ? Colors.greenAccent
+          : diff < 0
+              ? Colors.redAccent
+              : Colors.white70;
+      final sign = diff > 0 ? '+' : '';
+      return Expanded(
+        child: Column(
+          children: [
+            Text(title, style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 4),
+            Text(value.toStringAsFixed(title == 'Acc' ? 2 : 2),
+                style: const TextStyle(color: Colors.white)),
+            Text('$sign${diff.toStringAsFixed(title == 'Acc' ? 2 : 2)}',
+                style: TextStyle(color: color, fontSize: 12)),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Динамика последних раздач',
+              style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              item('Acc', current.accuracy * 100, delta.accuracy * 100),
+              item('EV', current.ev, delta.ev),
+              item('ICM', current.icm, delta.icm),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `DynamicProgressService` to track recent hand accuracy and EV trends
- display `DynamicProgressCard` on training home screen
- wire up service in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd04bc4e4832a88449ec73aa8ec3a