### PR TITLE
Implement realtime stack/range feedback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,7 @@ Future<void> main() async {
             hands: context.read<SavedHandManagerService>(),
             progress: context.read<PlayerProgressService>(),
             forecast: context.read<PlayerStyleForecastService>(),
+            realtime: context.read<RealTimeStackRangeService>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -30,6 +30,7 @@ import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
 import '../widgets/player_style_card.dart';
+import '../widgets/stack_range_bar.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import 'training_progress_analytics_screen.dart';
@@ -89,6 +90,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const PositionProgressCard(),
           const ProgressForecastCard(),
           const PlayerStyleCard(),
+          const StackRangeBar(),
           const StreakChart(),
           const DailyProgressRing(),
           const DailyGoalsCard(),

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -12,6 +12,7 @@ import 'training_template_detail_screen.dart';
 import 'training_session_screen.dart';
 import '../widgets/progress_forecast_card.dart';
 import '../widgets/player_style_card.dart';
+import '../widgets/stack_range_bar.dart';
 
 class TrainingRecommendationScreen extends StatefulWidget {
   const TrainingRecommendationScreen({super.key});
@@ -108,6 +109,7 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
               children: [
                 const ProgressForecastCard(),
                 const PlayerStyleCard(),
+                const StackRangeBar(),
                 if (_tpls.isEmpty && _tasks.isEmpty)
                   const Center(child: Text('Нет рекомендаций'))
                 else ...[

--- a/lib/services/dynamic_pack_adjustment_service.dart
+++ b/lib/services/dynamic_pack_adjustment_service.dart
@@ -7,6 +7,7 @@ import 'saved_hand_manager_service.dart';
 import 'player_progress_service.dart';
 import 'player_style_forecast_service.dart';
 import 'player_style_service.dart';
+import 'real_time_stack_range_service.dart';
 
 class DynamicPackAdjustmentService {
   final MistakeReviewPackService mistakes;
@@ -14,12 +15,14 @@ class DynamicPackAdjustmentService {
   final SavedHandManagerService hands;
   final PlayerProgressService progress;
   final PlayerStyleForecastService forecast;
+  final RealTimeStackRangeService realtime;
   const DynamicPackAdjustmentService({
     required this.mistakes,
     required this.eval,
     required this.hands,
     required this.progress,
     required this.forecast,
+    required this.realtime,
   });
 
   Future<TrainingPackTemplate> adjust(TrainingPackTemplate tpl) async {
@@ -67,9 +70,8 @@ class DynamicPackAdjustmentService {
       case PlayerStyle.neutral:
         break;
     }
-    var stack = (tpl.heroBbStack + diff).clamp(5, 40);
-    final base = tpl.heroRange ?? PackGeneratorService.topNHands(25).toList();
-    var pct = (base.length * 100 / 169).round() + diff * 5;
+    var stack = (realtime.stack + diff).clamp(5, 40);
+    var pct = (realtime.range.length * 100 / 169).round() + diff * 5;
     pct = pct.clamp(5, 100);
     final range = PackGeneratorService.topNHands(pct).toList();
     return tpl.copyWith(heroBbStack: stack, heroRange: range);


### PR DESCRIPTION
## Summary
- integrate RealTimeStackRangeService into dynamic pack adjustment
- propagate realtime stack & range to recommendations
- show current stack/range on training home and recommendation screens

## Testing
- `flutter format lib/services/dynamic_pack_adjustment_service.dart lib/main.dart lib/screens/training_home_screen.dart lib/screens/training_recommendation_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbe3bfe18832abafaded622791ae3