### PR TITLE
Add skill progress tracker

### DIFF
--- a/import_export/training_generator.dart
+++ b/import_export/training_generator.dart
@@ -33,6 +33,7 @@ class TrainingGenerator {
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
       anteBb: hand.anteBb,
+      category: hand.category,
       tags: List<String>.from(hand.tags),
       actionHistory: null,
       difficulty: 3,

--- a/lib/models/skill_stat.dart
+++ b/lib/models/skill_stat.dart
@@ -1,0 +1,29 @@
+class SkillStat {
+  final String category;
+  final int handsPlayed;
+  final double evAvg;
+  final int mistakes;
+  final DateTime lastUpdated;
+  const SkillStat({
+    required this.category,
+    required this.handsPlayed,
+    required this.evAvg,
+    required this.mistakes,
+    required this.lastUpdated,
+  });
+  Map<String, dynamic> toJson() => {
+        'category': category,
+        'hands': handsPlayed,
+        'ev': evAvg,
+        'mistakes': mistakes,
+        'updated': lastUpdated.toIso8601String(),
+      };
+  factory SkillStat.fromJson(Map<String, dynamic> json) => SkillStat(
+        category: json['category'] as String? ?? '',
+        handsPlayed: json['hands'] as int? ?? 0,
+        evAvg: (json['ev'] as num?)?.toDouble() ?? 0,
+        mistakes: json['mistakes'] as int? ?? 0,
+        lastUpdated:
+            DateTime.tryParse(json['updated'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -27,6 +27,7 @@ class TrainingSpot {
   final int? numberOfEntrants;
   final String? gameType;
   final int anteBb;
+  final String? category;
   final List<String> tags;
   final int difficulty;
   final int rating;
@@ -55,6 +56,7 @@ class TrainingSpot {
     this.numberOfEntrants,
     this.gameType,
     this.anteBb = 0,
+    this.category,
     List<String>? tags,
     this.userAction,
     this.userComment,
@@ -95,6 +97,7 @@ class TrainingSpot {
       numberOfEntrants: hand.numberOfEntrants,
       gameType: hand.gameType,
       anteBb: hand.anteBb,
+      category: hand.category,
       tags: List<String>.from(hand.tags),
       userAction: null,
       userComment: hand.comment,
@@ -140,6 +143,7 @@ class TrainingSpot {
         if (numberOfEntrants != null) 'numberOfEntrants': numberOfEntrants,
         if (gameType != null) 'gameType': gameType,
         'anteBb': anteBb,
+        if (category != null) 'category': category,
         if (tags.isNotEmpty) 'tags': tags,
         if (strategyAdvice != null) 'strategyAdvice': strategyAdvice,
         'difficulty': difficulty,
@@ -252,6 +256,7 @@ class TrainingSpot {
       numberOfEntrants: (json['numberOfEntrants'] as num?)?.toInt(),
       gameType: json['gameType'] as String?,
       anteBb: json['anteBb'] as int? ?? 0,
+      category: json['category'] as String?,
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
       rating: (json['rating'] as num?)?.toInt() ?? 0,
@@ -269,6 +274,7 @@ class TrainingSpot {
     int? difficulty,
     int? rating,
     List<String>? tags,
+    String? category,
     String? userAction,
     String? userComment,
     String? actionHistory,
@@ -298,6 +304,7 @@ class TrainingSpot {
       numberOfEntrants: numberOfEntrants,
       gameType: gameType,
       anteBb: anteBb ?? this.anteBb,
+      category: category ?? this.category,
       tags: tags ?? List<String>.from(this.tags),
       difficulty: difficulty ?? this.difficulty,
       rating: rating ?? this.rating,

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -32,6 +32,7 @@ import '../widgets/progress_summary_box.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
 import '../widgets/player_style_card.dart';
+import '../widgets/skill_progress_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import '../widgets/achievements_card.dart';
@@ -91,6 +92,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const SpotOfTheDayCard(),
           const ProgressSummaryBox(),
           const PositionProgressCard(),
+          const SkillProgressCard(),
           const ProgressForecastCard(),
           const PlayerStyleCard(),
           const StreakChart(),

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -61,6 +61,12 @@ class SavedHandManagerService extends ChangeNotifier {
     await _storage.add(withSession);
     await _sync();
     _stats?.incrementHands();
+    final cat = withSession.category;
+    final ev = withSession.heroEv;
+    final exp = withSession.expectedAction?.trim().toLowerCase();
+    final gto = withSession.gtoAction?.trim().toLowerCase();
+    final miss = exp != null && gto != null && exp != gto;
+    _stats?.updateSkill(cat, ev, miss);
     if (sessionId != last?.sessionId) {
       _stats?.incrementSessions();
     }

--- a/lib/services/training_import_export_service.dart
+++ b/lib/services/training_import_export_service.dart
@@ -64,6 +64,7 @@ class TrainingImportExportService {
       totalPrizePool: totalPrizePool,
       numberOfEntrants: numberOfEntrants,
       gameType: gameType,
+      category: null,
       tags: const [],
       difficulty: 3,
       createdAt: DateTime.now(),

--- a/lib/widgets/skill_progress_card.dart
+++ b/lib/widgets/skill_progress_card.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/skill_stat.dart';
+import '../services/training_stats_service.dart';
+
+class SkillProgressCard extends StatelessWidget {
+  const SkillProgressCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<TrainingStatsService>().skillStats.values.toList();
+    if (stats.isEmpty) return const SizedBox.shrink();
+    stats.sort((a, b) => b.evAvg.compareTo(a.evAvg));
+    final top = stats.take(3).toList();
+    stats.sort((a, b) => a.evAvg.compareTo(b.evAvg));
+    final weak = stats.take(3).toList();
+    Widget row(SkillStat s) {
+      final v = ((s.evAvg + 5) / 10).clamp(0.0, 1.0);
+      final color = v >= 0.5 ? Colors.green : Colors.red;
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.category, style: const TextStyle(color: Colors.white)),
+            const SizedBox(height: 2),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: v,
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(color),
+                minHeight: 6,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              'EV ${s.evAvg.toStringAsFixed(2)} • ${s.mistakes}/${s.handsPlayed}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(Icons.assessment, color: Colors.lightBlueAccent),
+              SizedBox(width: 8),
+              Text('Skill Progress',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final s in top) row(s),
+          if (weak.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            const Text('Weakest',
+                style: TextStyle(color: Colors.white70, fontSize: 14)),
+            const SizedBox(height: 4),
+            for (final s in weak) row(s),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- model skill stats with category EV and mistakes
- track skills while saving hands
- extend TrainingSpot with category
- show top and weak skills on training home

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870607e3b08832aab4e51f07a08d217