### PR TITLE
Add weekly accuracy achievement

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -345,8 +345,10 @@ Future<void> main() async {
           ),
         ),
         ChangeNotifierProvider(
-          create: (context) =>
-              AchievementEngine(stats: context.read<TrainingStatsService>()),
+          create: (context) => AchievementEngine(
+            stats: context.read<TrainingStatsService>(),
+            goals: context.read<GoalsService>(),
+          ),
         ),
         ChangeNotifierProvider(
           create: (context) =>


### PR DESCRIPTION
## Summary
- unlock a new achievement when weekly accuracy reaches 80%
- include GoalsService in AchievementEngine constructor

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706383f30c832aa85bbfe790b2af25