### PR TITLE
Add MistakeCategorizationEngine

### DIFF
--- a/lib/models/mistake.dart
+++ b/lib/models/mistake.dart
@@ -1,0 +1,16 @@
+import '../widgets/poker_table_view.dart' show PlayerAction;
+import 'v2/training_pack_spot.dart';
+
+class Mistake {
+  final TrainingPackSpot spot;
+  final PlayerAction action;
+  final double handStrength;
+  String? category;
+
+  Mistake({
+    required this.spot,
+    required this.action,
+    required this.handStrength,
+    this.category,
+  });
+}

--- a/lib/services/mistake_categorization_engine.dart
+++ b/lib/services/mistake_categorization_engine.dart
@@ -1,0 +1,48 @@
+import '../helpers/hand_utils.dart';
+import '../models/mistake.dart';
+import '../models/v2/hero_position.dart';
+import 'pack_generator_service.dart';
+import '../widgets/poker_table_view.dart' show PlayerAction;
+
+class MistakeCategorizationEngine {
+  const MistakeCategorizationEngine();
+
+  double computeHandStrength(String cards) {
+    final code = handCode(cards);
+    if (code == null) return 0;
+    final idx = PackGeneratorService.handRanking.indexOf(code);
+    if (idx < 0) return 0;
+    return 1 - idx / (PackGeneratorService.handRanking.length - 1);
+  }
+
+  String categorize(Mistake mistake) {
+    final exp = mistake.spot.evalResult?.expectedAction.toLowerCase();
+    final pos = mistake.spot.hand.position;
+    final a = mistake.action;
+    final s = mistake.handStrength;
+    String r = 'Unclassified';
+    if (a == PlayerAction.fold && exp != 'fold') {
+      r = s > 0.6 ? 'Overfold' : 'Too Passive';
+    } else if (a == PlayerAction.call && exp == 'fold') {
+      r = 'Overcall';
+    } else if (a == PlayerAction.push && exp == 'call') {
+      r = 'Wrong Push';
+    } else if (a == PlayerAction.call && exp == 'push') {
+      r = 'Wrong Call';
+    } else if ((a == PlayerAction.check || a == PlayerAction.call) &&
+        (exp == 'raise' || exp == 'bet' || exp == 'push')) {
+      r = 'Missed Value';
+    } else if ((a == PlayerAction.check || a == PlayerAction.fold) && exp == 'call') {
+      r = 'Too Passive';
+    } else if ((a == PlayerAction.raise || a == PlayerAction.push) &&
+        (exp == 'check' || exp == 'call' || exp == 'fold')) {
+      if (exp == 'call' && (pos == HeroPosition.utg || pos == HeroPosition.mp)) {
+        r = 'Wrong Push';
+      } else {
+        r = 'Too Aggro';
+      }
+    }
+    mistake.category = r;
+    return r;
+  }
+}

--- a/test/mistake_categorization_engine_test.dart
+++ b/test/mistake_categorization_engine_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/mistake.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/services/mistake_categorization_engine.dart';
+import 'package:poker_analyzer/widgets/poker_table_view.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final engine = const MistakeCategorizationEngine();
+
+  TrainingPackSpot spot(String exp, {HeroPosition pos = HeroPosition.btn}) {
+    return TrainingPackSpot(
+      id: 's',
+      hand: HandData(heroCards: 'Ah Ad', position: pos),
+      evalResult: EvaluationResult(
+        correct: false,
+        expectedAction: exp,
+        userEquity: 0,
+        expectedEquity: 0,
+      ),
+    );
+  }
+
+  test('overfold', () {
+    final m = Mistake(
+      spot: spot('push'),
+      action: PlayerAction.fold,
+      handStrength: 0.8,
+    );
+    expect(engine.categorize(m), 'Overfold');
+    expect(m.category, 'Overfold');
+  });
+
+  test('overcall', () {
+    final m = Mistake(
+      spot: spot('fold'),
+      action: PlayerAction.call,
+      handStrength: 0.2,
+    );
+    expect(engine.categorize(m), 'Overcall');
+  });
+
+  test('wrong push', () {
+    final m = Mistake(
+      spot: spot('call', pos: HeroPosition.utg),
+      action: PlayerAction.push,
+      handStrength: 0.5,
+    );
+    expect(engine.categorize(m), 'Wrong Push');
+  });
+
+  test('wrong call', () {
+    final m = Mistake(
+      spot: spot('push'),
+      action: PlayerAction.call,
+      handStrength: 0.5,
+    );
+    expect(engine.categorize(m), 'Wrong Call');
+  });
+
+  test('missed value', () {
+    final m = Mistake(
+      spot: spot('raise'),
+      action: PlayerAction.check,
+      handStrength: 0.6,
+    );
+    expect(engine.categorize(m), 'Missed Value');
+  });
+
+  test('too passive', () {
+    final m = Mistake(
+      spot: spot('call'),
+      action: PlayerAction.check,
+      handStrength: 0.4,
+    );
+    expect(engine.categorize(m), 'Too Passive');
+  });
+
+  test('too aggro', () {
+    final m = Mistake(
+      spot: spot('check'),
+      action: PlayerAction.raise,
+      handStrength: 0.5,
+    );
+    expect(engine.categorize(m), 'Too Aggro');
+  });
+
+  test('unclassified', () {
+    final m = Mistake(
+      spot: spot('push'),
+      action: PlayerAction.push,
+      handStrength: 0.5,
+    );
+    expect(engine.categorize(m), 'Unclassified');
+  });
+}


### PR DESCRIPTION
## Summary
- create Mistake model
- add MistakeCategorizationEngine to classify mistakes
- provide unit tests for mistake categorization

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870644f4afc832a9cda808d37a10d6e