### PR TITLE
Implement automatic mistake categorization

### DIFF
--- a/lib/services/mistake_review_service.dart
+++ b/lib/services/mistake_review_service.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/mistake.dart';
+import 'mistake_categorization_engine.dart';
+
+class MistakeReviewService extends ChangeNotifier {
+  final List<Mistake> _mistakes = [];
+  List<Mistake> get mistakes => List.unmodifiable(_mistakes);
+
+  void addMistake(Mistake mistake) {
+    final engine = const MistakeCategorizationEngine();
+    final result = engine.categorize(mistake);
+    mistake.category = result.isNotEmpty ? result : 'Unclassified';
+    _mistakes.add(mistake);
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- add MistakeReviewService for storing mistakes
- classify mistake when adding using MistakeCategorizationEngine

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707357ebf0832aad6ad7a980df8ad8