### PR TITLE
Display EV loss info in mistake review

### DIFF
--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -163,6 +163,7 @@ class _RetryTrainingScreenState extends State<RetryTrainingScreen> {
                     selectedAction: _selectedAction ?? '',
                     correctAction: error.correctAction,
                     explanation: error.aiExplanation,
+                    evLoss: null,
                   ),
                 ],
               ],

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -619,6 +619,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                 correctAction: expected,
                 explanation: explanation,
                 category: category,
+                evLoss: evDiff != null && evDiff < 0 ? -evDiff : null,
               ),
               SizedBox(height: 16 * scale),
               ElevatedButton(

--- a/lib/widgets/common/explanation_text.dart
+++ b/lib/widgets/common/explanation_text.dart
@@ -5,6 +5,7 @@ class ExplanationText extends StatelessWidget {
   final String correctAction;
   final String explanation;
   final String? category;
+  final double? evLoss;
 
   const ExplanationText({
     super.key,
@@ -12,6 +13,7 @@ class ExplanationText extends StatelessWidget {
     required this.correctAction,
     required this.explanation,
     this.category,
+    this.evLoss,
   });
 
   @override
@@ -28,6 +30,15 @@ class ExplanationText extends StatelessWidget {
           const SizedBox(height: 8),
           Text('Категория: $category',
               style: const TextStyle(fontSize: 12, color: Colors.grey)),
+          if (evLoss != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                'Утечка EV: -${evLoss!.toStringAsFixed(2)}',
+                style:
+                    const TextStyle(fontSize: 12, color: Colors.redAccent),
+              ),
+            ),
         ],
         const SizedBox(height: 4),
         Text(


### PR DESCRIPTION
## Summary
- extend `ExplanationText` to show EV loss
- pass EV loss from `TrainingPackPlayScreen`
- adapt `RetryTrainingScreen` to new API

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e25ecea4832a88c77f3e210f817c