### PR TITLE
Add Weakness overview access

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -8,6 +8,7 @@ import 'settings_placeholder_screen.dart';
 import 'insights_screen.dart';
 import 'goal_overview_screen.dart';
 import 'pack_overview_screen.dart';
+import 'weakness_overview_screen.dart';
 import '../widgets/streak_banner.dart';
 import '../widgets/motivation_card.dart';
 import '../widgets/active_goals_card.dart';
@@ -163,6 +164,26 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
         const FeedbackBanner(),
         const NextStepCard(),
         const SuggestedDrillCard(),
+        Container(
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: ListTile(
+            leading: const Icon(Icons.insights, color: Colors.white),
+            trailing: const Icon(Icons.chevron_right),
+            title: const Text('Анализ слабых мест',
+                style: TextStyle(color: Colors.white)),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const WeaknessOverviewScreen()),
+              );
+            },
+          ),
+        ),
         const Expanded(child: AnalyzerTab()),
       ],
     );

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -19,6 +19,7 @@ import '../services/session_note_service.dart';
 import '../widgets/sync_status_widget.dart';
 import 'notification_settings_screen.dart';
 import 'goal_overview_screen.dart';
+import 'weakness_overview_screen.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -191,6 +192,19 @@ class SettingsPlaceholderScreen extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const GoalOverviewScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.insights, color: Colors.white),
+            title: const Text('Анализ слабых мест',
+                style: TextStyle(color: Colors.white)),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const WeaknessOverviewScreen()),
               );
             },
           ),


### PR DESCRIPTION
## Summary
- link WeaknessOverviewScreen from the home page
- expose WeaknessOverviewScreen in the More menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fa1f7290832a80c364f228db18ae