### PR TITLE
Add combo drill from top categories

### DIFF
--- a/lib/screens/weakness_overview_screen.dart
+++ b/lib/screens/weakness_overview_screen.dart
@@ -34,8 +34,32 @@ class WeaknessOverviewScreen extends StatelessWidget {
       ),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),
-        itemCount: entries.length,
+        itemCount: entries.length + (entries.length >= 3 ? 1 : 0),
         itemBuilder: (context, index) {
+          if (index == entries.length && entries.length >= 3) {
+            return Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: ElevatedButton(
+                onPressed: () async {
+                  final tpl =
+                      await TrainingPackService.createDrillFromTopCategories(
+                          context);
+                  if (tpl == null) return;
+                  await context
+                      .read<TrainingSessionService>()
+                      .startSession(tpl);
+                  if (context.mounted) {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const TrainingSessionScreen()),
+                    );
+                  }
+                },
+                child: const Text('Создать Drill из топ-3 категорий'),
+              ),
+            );
+          }
           final e = entries[index];
           final name = translateCategory(e.key);
           return Container(


### PR DESCRIPTION
## Summary
- build combo drill generation from top three categories
- show bottom button in WeaknessOverviewScreen to start combo drill

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710c337d78832ab2df6fa44efe6673