### PR TITLE
Add per-category progress stats

### DIFF
--- a/lib/models/category_progress.dart
+++ b/lib/models/category_progress.dart
@@ -1,0 +1,24 @@
+class CategoryProgress {
+  int played;
+  int correct;
+  double evLost;
+  double evSaved;
+  CategoryProgress({
+    this.played = 0,
+    this.correct = 0,
+    this.evLost = 0,
+    this.evSaved = 0,
+  });
+  Map<String, dynamic> toJson() => {
+        'played': played,
+        'correct': correct,
+        if (evLost != 0) 'evLost': evLost,
+        if (evSaved != 0) 'evSaved': evSaved,
+      };
+  factory CategoryProgress.fromJson(Map<String, dynamic> j) => CategoryProgress(
+        played: (j['played'] as num?)?.toInt() ?? 0,
+        correct: (j['correct'] as num?)?.toInt() ?? 0,
+        evLost: (j['evLost'] as num?)?.toDouble() ?? 0,
+        evSaved: (j['evSaved'] as num?)?.toDouble() ?? 0,
+      );
+}


### PR DESCRIPTION
## Summary
- track category progress when submitting training results
- save/restore category stats with active session
- expose category stats API

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711b1dcfcc832aa80245d73c0374a3