### PR TITLE
Add drill button from mistake review

### DIFF
--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -621,6 +621,27 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                 category: category,
                 evLoss: evDiff != null && evDiff < 0 ? -evDiff : null,
               ),
+              if (category != null) ...[
+                SizedBox(height: 12 * scale),
+                ElevatedButton(
+                  onPressed: () async {
+                    final tpl = await TrainingPackService.createDrillFromCategory(
+                        context, category!);
+                    if (tpl == null) return;
+                    await context.read<TrainingSessionService>().startSession(tpl);
+                    if (context.mounted) {
+                      Navigator.pop(ctx);
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const TrainingSessionScreen()),
+                      );
+                    }
+                  },
+                  child: Text('Тренироваться на похожих',
+                      style: TextStyle(fontSize: 14 * scale)),
+                ),
+              ],
               SizedBox(height: 16 * scale),
               ElevatedButton(
                 onPressed: () => Navigator.pop(ctx),

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -72,7 +72,7 @@ class TrainingPackService {
     final spots = [for (final h in selected) _spotFromHand(h)];
     return TrainingPackTemplate(
       id: const Uuid().v4(),
-      name: category,
+      name: 'Авто Drill: $category',
       spots: spots,
     );
   }


### PR DESCRIPTION
## Summary
- enable push-to-drill from mistakes
- use localized auto drill names

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712a079278832a870389ed879e4882