### PR TITLE
Add weakness report export option

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -70,4 +70,5 @@
   ,"accuracyLabel": "Accuracy: {value}%"
   ,"evBb": "EV: {value} BB"
   ,"icmLabel": "ICM: {value}"
+  ,"exportWeaknessReport": "Export Weakness Report"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -70,4 +70,5 @@
   ,"accuracyLabel": "Accuracy: {value}%"
   ,"evBb": "EV: {value} BB"
   ,"icmLabel": "ICM: {value}"
+  ,"exportWeaknessReport": "Export Weakness Report"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -70,4 +70,5 @@
   ,"accuracyLabel": "Accuracy: {value}%"
   ,"evBb": "EV: {value} BB"
   ,"icmLabel": "ICM: {value}"
+  ,"exportWeaknessReport": "Export Weakness Report"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -70,4 +70,5 @@
   ,"accuracyLabel": "Accuracy: {value}%"
   ,"evBb": "EV: {value} BB"
   ,"icmLabel": "ICM: {value}"
+  ,"exportWeaknessReport": "Экспортировать отчёт о слабых местах"
 }

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -27,6 +27,7 @@ import '../services/next_step_engine.dart';
 import 'mistake_repeat_screen.dart';
 import 'goals_overview_screen.dart';
 import 'spot_of_the_day_screen.dart';
+import 'weakness_overview_screen.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -348,6 +349,18 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
                   ),
                 ),
               ],
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const WeaknessOverviewScreen(autoExport: true),
+                  ),
+                );
+              },
+              child: Text(l.exportWeaknessReport),
             ),
           ],
         ),

--- a/lib/screens/weakness_overview_screen.dart
+++ b/lib/screens/weakness_overview_screen.dart
@@ -11,9 +11,26 @@ import '../services/training_session_service.dart';
 import '../helpers/category_translations.dart';
 import 'training_session_screen.dart';
 
-class WeaknessOverviewScreen extends StatelessWidget {
+class WeaknessOverviewScreen extends StatefulWidget {
   static const route = '/weakness_overview';
-  const WeaknessOverviewScreen({super.key});
+  final bool autoExport;
+  const WeaknessOverviewScreen({super.key, this.autoExport = false});
+
+  @override
+  State<WeaknessOverviewScreen> createState() => _WeaknessOverviewScreenState();
+}
+
+class _WeaknessOverviewScreenState extends State<WeaknessOverviewScreen> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.autoExport) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await _exportPdf(context);
+        if (mounted) Navigator.pop(context);
+      });
+    }
+  }
 
   List<MapEntry<String, _CatStat>> _entries(BuildContext context) {
     final hands = context.read<SavedHandManagerService>().hands;


### PR DESCRIPTION
## Summary
- add exportWeaknessReport localization key
- support autoExport in WeaknessOverviewScreen
- allow exporting weakness report from TrainingSessionSummaryScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687128d10204832a88608bbc8654b312