### PR TITLE
Add corrected mistake history

### DIFF
--- a/lib/screens/corrected_mistake_history_screen.dart
+++ b/lib/screens/corrected_mistake_history_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/saved_hand_manager_service.dart';
+import 'mistake_detail_screen.dart';
+
+class CorrectedMistakeHistoryScreen extends StatelessWidget {
+  const CorrectedMistakeHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final corrected = [for (final h in hands) if (h.corrected) h]
+      ..sort((a, b) => b.savedAt.compareTo(a.savedAt));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Исправленные ошибки'),
+        centerTitle: true,
+      ),
+      body: corrected.isEmpty
+          ? const Center(
+              child: Text('Нет данных',
+                  style: TextStyle(color: Colors.white70)),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: corrected.length,
+              itemBuilder: (context, index) {
+                final h = corrected[index];
+                return GestureDetector(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => MistakeDetailScreen(hand: h),
+                      ),
+                    );
+                  },
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 8),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[850],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(h.heroPosition,
+                                  style: const TextStyle(color: Colors.white)),
+                              if (h.evLossRecovered != null)
+                                Text(
+                                  '+${h.evLossRecovered!.toStringAsFixed(2)} EV',
+                                  style: const TextStyle(
+                                      color: Colors.greenAccent, fontSize: 12),
+                                ),
+                              if (h.tags.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4),
+                                  child: Wrap(
+                                    spacing: 4,
+                                    children: [
+                                      for (final t in h.tags)
+                                        Chip(
+                                          label: Text(t),
+                                          backgroundColor:
+                                              const Color(0xFF3A3B3E),
+                                          labelStyle:
+                                              const TextStyle(color: Colors.white),
+                                          visualDensity: VisualDensity.compact,
+                                        ),
+                                    ],
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                        const Icon(Icons.chevron_right, color: Colors.white),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/weakness_overview_screen.dart
+++ b/lib/screens/weakness_overview_screen.dart
@@ -12,6 +12,7 @@ import '../helpers/category_translations.dart';
 import 'training_session_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_detail_screen.dart';
+import 'corrected_mistake_history_screen.dart';
 
 class WeaknessOverviewScreen extends StatefulWidget {
   static const route = '/weakness_overview';
@@ -232,6 +233,17 @@ class _WeaknessOverviewScreenState extends State<WeaknessOverviewScreen> {
               ),
             ),
           ),
+        TextButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const CorrectedMistakeHistoryScreen(),
+              ),
+            );
+          },
+          child: const Text('Показать всё'),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- list all corrected hands in new `CorrectedMistakeHistoryScreen`
- link from WeaknessOverview to full history

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687151096efc832abf4a007ac47cbc1f