### PR TITLE
Add EV recovery snackbar

### DIFF
--- a/lib/models/saved_hand.dart
+++ b/lib/models/saved_hand.dart
@@ -651,5 +651,12 @@ class SavedHand {
     }
     return null;
   }
+
+  SavedHand markAsCorrected() {
+    return copyWith(
+      corrected: true,
+      evLossRecovered: evLoss ?? 0,
+    );
+  }
 }
 

--- a/lib/screens/mistake_detail_screen.dart
+++ b/lib/screens/mistake_detail_screen.dart
@@ -4,6 +4,9 @@ import '../models/training_spot.dart';
 import '../widgets/replay_spot_widget.dart';
 import '../widgets/action_history_widget.dart';
 import '../models/action_entry.dart';
+import '../services/saved_hand_manager_service.dart';
+import 'ev_recovery_history_screen.dart';
+import 'package:provider/provider.dart';
 
 class MistakeDetailScreen extends StatelessWidget {
   final SavedHand hand;
@@ -38,6 +41,37 @@ class MistakeDetailScreen extends StatelessWidget {
           ActionHistoryWidget(actions: _actions(), playerPositions: _posMap()),
         ],
       ),
+      floatingActionButton: hand.corrected
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: () async {
+                final manager = context.read<SavedHandManagerService>();
+                final index = manager.hands.indexOf(hand);
+                if (index < 0) return;
+                final updated = hand.markAsCorrected();
+                await manager.update(index, updated);
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      '+${updated.evLossRecovered!.toStringAsFixed(1)} EV восстановлено',
+                    ),
+                    action: SnackBarAction(
+                      label: 'История',
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const EVRecoveryHistoryScreen()),
+                        );
+                      },
+                    ),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.check),
+              label: const Text('Исправлено'),
+            ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add SavedHand.markAsCorrected helper
- notify about EV recovery when marking a mistake fixed

## Testing
- `flutter format lib/models/saved_hand.dart lib/screens/mistake_detail_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718610fd90832a806114b0c9b61958