### PR TITLE
Add CategoryRecoveryScreen

### DIFF
--- a/lib/screens/category_recovery_screen.dart
+++ b/lib/screens/category_recovery_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../helpers/category_translations.dart';
+import 'corrected_mistake_history_screen.dart';
+
+class CategoryRecoveryScreen extends StatelessWidget {
+  const CategoryRecoveryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final Map<String, double> map = {};
+    for (final h in hands) {
+      if (!h.corrected) continue;
+      final r = h.evLossRecovered;
+      if (r == null) continue;
+      final cat = h.category ?? '';
+      map[cat] = (map[cat] ?? 0) + r;
+    }
+    final entries = map.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История устранённых слабостей'),
+        centerTitle: true,
+      ),
+      body: entries.isEmpty
+          ? const Center(
+              child: Text('Нет данных', style: TextStyle(color: Colors.white70)),
+            )
+          : ListView.separated(
+              itemCount: entries.length,
+              separatorBuilder: (_, __) => const Divider(),
+              itemBuilder: (context, index) {
+                final e = entries[index];
+                final name = translateCategory(e.key).isEmpty
+                    ? 'Без категории'
+                    : translateCategory(e.key);
+                return ListTile(
+                  title: Text(name, style: const TextStyle(color: Colors.white)),
+                  subtitle: Text(
+                    '+${e.value.toStringAsFixed(2)} EV',
+                    style: const TextStyle(color: Colors.greenAccent),
+                  ),
+                  trailing: const Icon(Icons.chevron_right, color: Colors.white),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            CorrectedMistakeHistoryScreen(category: e.key),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/corrected_mistake_history_screen.dart
+++ b/lib/screens/corrected_mistake_history_screen.dart
@@ -4,9 +4,11 @@ import 'package:provider/provider.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'mistake_detail_screen.dart';
+import '../helpers/category_translations.dart';
 
 class CorrectedMistakeHistoryScreen extends StatefulWidget {
-  const CorrectedMistakeHistoryScreen({super.key});
+  final String? category;
+  const CorrectedMistakeHistoryScreen({super.key, this.category});
 
   @override
   State<CorrectedMistakeHistoryScreen> createState() =>
@@ -22,7 +24,7 @@ class _CorrectedMistakeHistoryScreenState
     final hands = context.watch<SavedHandManagerService>().hands;
     final all = [
       for (final h in hands)
-        if (h.corrected) h
+        if (h.corrected && (widget.category == null || h.category == widget.category)) h
     ]..sort((a, b) => b.savedAt.compareTo(a.savedAt));
     final filtered = _evOnly
         ? [
@@ -30,9 +32,15 @@ class _CorrectedMistakeHistoryScreenState
               if (h.evLossRecovered != null && h.evLossRecovered! > 0) h
           ]
         : all;
+    final title = widget.category == null
+        ? 'Исправленные ошибки'
+        : 'Исправленные ошибки: ' +
+            (translateCategory(widget.category).isEmpty
+                ? 'Без категории'
+                : translateCategory(widget.category));
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Исправленные ошибки'),
+        title: Text(title),
         centerTitle: true,
       ),
       body: all.isEmpty


### PR DESCRIPTION
## Summary
- add CategoryRecoveryScreen for viewing recovered EV by category
- allow CorrectedMistakeHistoryScreen to filter by category

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687188f4b224832aae7f68b825d6e079