### PR TITLE
Add recovery history button

### DIFF
--- a/lib/screens/weakness_overview_screen.dart
+++ b/lib/screens/weakness_overview_screen.dart
@@ -14,6 +14,7 @@ import 'training_session_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_detail_screen.dart';
 import 'corrected_mistake_history_screen.dart';
+import 'category_recovery_screen.dart';
 
 class WeaknessOverviewScreen extends StatefulWidget {
   static const route = '/weakness_overview';
@@ -249,6 +250,23 @@ class _WeaknessOverviewScreenState extends State<WeaknessOverviewScreen> {
     );
   }
 
+  Widget _historyButton(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: TextButton.icon(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (_) => const CategoryRecoveryScreen()),
+          );
+        },
+        icon: const Icon(Icons.category),
+        label: const Text('История устранённых слабостей'),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final hands = context.watch<SavedHandManagerService>().hands;
@@ -462,9 +480,12 @@ class _WeaknessOverviewScreenState extends State<WeaknessOverviewScreen> {
             Expanded(
               child: ListView.builder(
                 controller: _ctrl,
-                itemCount: entries.length + 1,
+                itemCount: entries.length + 2,
                 itemBuilder: (context, index) {
                   if (index == entries.length) {
+                    return _historyButton(context);
+                  }
+                  if (index == entries.length + 1) {
                     return _recentFixes(context);
                   }
                   final e = entries[index];


### PR DESCRIPTION
## Summary
- add navigation to CategoryRecoveryScreen from WeaknessOverviewScreen

## Testing
- `flutter analyze` *(fails: 5894 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68718b0ff1bc832a9c4c1edacef67bdc