### PR TITLE
Add repeat last corrected drill

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/feedback_banner.dart';
 import '../widgets/recent_unlocks_banner.dart';
 import '../widgets/today_progress_banner.dart';
 import '../widgets/ev_goal_banner.dart';
+import '../widgets/repeat_last_corrected_card.dart';
 import '../widgets/streak_mini_card.dart';
 import '../widgets/streak_chart.dart';
 import '../widgets/spot_of_the_day_card.dart';
@@ -164,6 +165,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
         const MotivationCard(),
         const ActiveGoalsCard(),
         const EVGoalBanner(),
+        const RepeatLastCorrectedCard(),
         const FeedbackBanner(),
         const RecentUnlocksBanner(),
         const NextStepCard(),

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
+import 'package:collection/collection.dart';
 
 import '../models/saved_hand.dart';
 import '../models/v2/training_pack_template.dart';
@@ -108,6 +109,17 @@ class TrainingPackService {
       id: const Uuid().v4(),
       name: 'Комбо Drill: топ ошибки',
       spots: spots,
+    );
+  }
+  static Future<TrainingPackTemplate?> createRepeatForCorrected(BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final hand = hands.reversed.firstWhereOrNull((h) => h.corrected);
+    if (hand == null) return null;
+    final spot = _spotFromHand(hand);
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Repeat Corrected',
+      spots: [spot],
     );
   }
 }

--- a/lib/widgets/repeat_last_corrected_card.dart
+++ b/lib/widgets/repeat_last_corrected_card.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class RepeatLastCorrectedCard extends StatelessWidget {
+  const RepeatLastCorrectedCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final hand = hands.reversed.firstWhereOrNull((h) => h.corrected);
+    if (hand == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final cat = hand.category ?? 'Без категории';
+    final ev = hand.evLossRecovered ?? 0.0;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.repeat, color: accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(cat,
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(
+                  '+${ev.toStringAsFixed(1)} EV восстановлено',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl =
+                  await TrainingPackService.createRepeatForCorrected(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Повторить'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `RepeatLastCorrectedCard` to quickly retry the last corrected hand
- generate a drill from the most recent corrected hand with `createRepeatForCorrected`
- show the card on the main screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687193a0c0dc832a99dcb18f0cb87433