### PR TITLE
Enable auto evaluation on manual hand save

### DIFF
--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -94,6 +94,15 @@ class SavedHandManagerService extends ChangeNotifier {
     }
   }
 
+  Future<void> save(SavedHand hand) async {
+    final index = hands.indexWhere((h) => h.savedAt == hand.savedAt);
+    if (index >= 0) {
+      await update(index, hand);
+    } else {
+      await add(hand);
+    }
+  }
+
   Future<void> removeAt(int index) async {
     await _storage.removeAt(index);
     await _sync();


### PR DESCRIPTION
## Summary
- add `save` helper to `SavedHandManagerService`
- evaluate and store hands directly from `SavedHandEditorScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687195997ffc832a9fcc5ef48035f327