### PR TITLE
Add repeat incorrect drill card

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -20,6 +20,7 @@ import '../services/stack_manager_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/action_history_service.dart';
 import '../services/training_import_export_service.dart';
+import '../widgets/repeat_last_incorrect_card.dart';
 
 class AnalyzerTab extends StatelessWidget {
   const AnalyzerTab({super.key});
@@ -101,25 +102,35 @@ class AnalyzerTab extends StatelessWidget {
                 ),
               ),
             ],
-            child: PokerAnalyzerScreen(
-              actionSync: context.read<ActionSyncService>(),
-              foldedPlayersService: context.read<FoldedPlayersService>(),
-              allInPlayersService: context.read<AllInPlayersService>(),
-              handContext: CurrentHandContextService(),
-              playbackManager: context.read<PlaybackManagerService>(),
-              stackService: context.read<PlaybackManagerService>().stackService,
-              potSyncService: context.read<PlaybackManagerService>().potSync,
-              boardManager: context.read<BoardManagerService>(),
-              boardSync: context.read<BoardSyncService>(),
-              boardEditing: context.read<BoardEditingService>(),
-              playerEditing: context.read<PlayerEditingService>(),
-              playerManager: context.read<PlayerManagerService>(),
-              playerProfile: context.read<PlayerProfileService>(),
-              actionTagService: context.read<PlayerProfileService>().actionTagService,
-              boardReveal: boardReveal,
-              lockService: lockService,
-              actionHistory: context.read<ActionHistoryService>(),
-              demoMode: false,
+            child: Column(
+              children: [
+                const RepeatLastIncorrectCard(),
+                Expanded(
+                  child: PokerAnalyzerScreen(
+                    actionSync: context.read<ActionSyncService>(),
+                    foldedPlayersService: context.read<FoldedPlayersService>(),
+                    allInPlayersService: context.read<AllInPlayersService>(),
+                    handContext: CurrentHandContextService(),
+                    playbackManager: context.read<PlaybackManagerService>(),
+                    stackService:
+                        context.read<PlaybackManagerService>().stackService,
+                    potSyncService:
+                        context.read<PlaybackManagerService>().potSync,
+                    boardManager: context.read<BoardManagerService>(),
+                    boardSync: context.read<BoardSyncService>(),
+                    boardEditing: context.read<BoardEditingService>(),
+                    playerEditing: context.read<PlayerEditingService>(),
+                    playerManager: context.read<PlayerManagerService>(),
+                    playerProfile: context.read<PlayerProfileService>(),
+                    actionTagService:
+                        context.read<PlayerProfileService>().actionTagService,
+                    boardReveal: boardReveal,
+                    lockService: lockService,
+                    actionHistory: context.read<ActionHistoryService>(),
+                    demoMode: false,
+                  ),
+                ),
+              ],
             ),
           );
         },

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -122,4 +122,21 @@ class TrainingPackService {
       spots: [spot],
     );
   }
+
+  static Future<TrainingPackTemplate?> createRepeatForIncorrect(BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final hand = hands.reversed.firstWhereOrNull((h) {
+      final ev = h.evLoss ?? 0.0;
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      return ev.abs() >= 1.0 && !h.corrected && exp != null && gto != null && exp != gto;
+    });
+    if (hand == null) return null;
+    final spot = _spotFromHand(hand);
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Repeat Incorrect',
+      spots: [spot],
+    );
+  }
 }

--- a/lib/widgets/repeat_last_incorrect_card.dart
+++ b/lib/widgets/repeat_last_incorrect_card.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class RepeatLastIncorrectCard extends StatelessWidget {
+  const RepeatLastIncorrectCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final hand = hands.reversed.firstWhereOrNull((h) {
+      final ev = h.evLoss ?? 0.0;
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      return ev.abs() >= 1.0 && !h.corrected && exp != null && gto != null && exp != gto;
+    });
+    if (hand == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final cat = hand.category ?? 'Без категории';
+    final ev = hand.evLoss?.abs() ?? 0.0;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.replay, color: accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Повторить раздачу',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(cat, style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 4),
+                Text('-${ev.toStringAsFixed(1)} EV',
+                    style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl = await TrainingPackService.createRepeatForIncorrect(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Тренировать'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show RepeatLastIncorrectCard in AnalyzerTab
- create repeat pack for incorrect hands
- new widget for quick drill after analysis

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719a19fcd0832ab5cce02d0413c89e