### PR TITLE
Suggest top mistakes drill

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -21,6 +21,7 @@ import '../services/transition_lock_service.dart';
 import '../services/action_history_service.dart';
 import '../services/training_import_export_service.dart';
 import '../widgets/repeat_last_incorrect_card.dart';
+import '../widgets/top_mistake_drill_card.dart';
 
 class AnalyzerTab extends StatelessWidget {
   const AnalyzerTab({super.key});
@@ -105,6 +106,7 @@ class AnalyzerTab extends StatelessWidget {
             child: Column(
               children: [
                 const RepeatLastIncorrectCard(),
+                const TopMistakeDrillCard(),
                 Expanded(
                   child: PokerAnalyzerScreen(
                     actionSync: context.read<ActionSyncService>(),

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -111,6 +111,11 @@ class TrainingPackService {
       spots: spots,
     );
   }
+
+  static Future<TrainingPackTemplate?> createTopMistakeDrill(
+      BuildContext context) async {
+    return createDrillFromTopCategories(context);
+  }
   static Future<TrainingPackTemplate?> createRepeatForCorrected(BuildContext context) async {
     final hands = context.read<SavedHandManagerService>().hands;
     final hand = hands.reversed.firstWhereOrNull((h) => h.corrected);

--- a/lib/widgets/top_mistake_drill_card.dart
+++ b/lib/widgets/top_mistake_drill_card.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class TopMistakeDrillCard extends StatefulWidget {
+  const TopMistakeDrillCard({super.key});
+
+  @override
+  State<TopMistakeDrillCard> createState() => _TopMistakeDrillCardState();
+}
+
+class _TopMistakeDrillCardState extends State<TopMistakeDrillCard> {
+  static const _key = 'top_mistake_drill_done';
+  bool _done = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((p) {
+      if (mounted) setState(() => _done = p.getBool(_key) ?? false);
+    });
+  }
+
+  Future<void> _mark() async {
+    final p = await SharedPreferences.getInstance();
+    await p.setBool(_key, true);
+    if (mounted) setState(() => _done = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final map = <String, double>{};
+    for (final h in hands) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      map[cat] = (map[cat] ?? 0) + (h.evLoss ?? 0);
+    }
+    if (_done || map.length < 3) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.bolt, color: accent),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Топ ошибки',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                SizedBox(height: 4),
+                Text('Восстановите EV',
+                    style: TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl = await TrainingPackService.createTopMistakeDrill(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              await _mark();
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Начать'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TopMistakeDrillCard for top categories drill
- call TopMistakeDrillCard from AnalyzerTab
- expose TrainingPackService.createTopMistakeDrill

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719ba0936c832a9682e64ae35f8fbe