### PR TITLE
Add category drill suggestion

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -22,6 +22,7 @@ import '../services/action_history_service.dart';
 import '../services/training_import_export_service.dart';
 import '../widgets/repeat_last_incorrect_card.dart';
 import '../widgets/top_mistake_drill_card.dart';
+import '../widgets/category_drill_card.dart';
 
 class AnalyzerTab extends StatelessWidget {
   const AnalyzerTab({super.key});
@@ -107,6 +108,7 @@ class AnalyzerTab extends StatelessWidget {
               children: [
                 const RepeatLastIncorrectCard(),
                 const TopMistakeDrillCard(),
+                const CategoryDrillCard(),
                 Expanded(
                   child: PokerAnalyzerScreen(
                     actionSync: context.read<ActionSyncService>(),

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -78,6 +78,11 @@ class TrainingPackService {
     );
   }
 
+  static Future<TrainingPackTemplate?> createDrillForCategory(
+      BuildContext context, String category) {
+    return createDrillFromCategory(context, category);
+  }
+
   static Future<TrainingPackTemplate?> createDrillFromTopCategories(
       BuildContext context) async {
     final hands = context.read<SavedHandManagerService>().hands;

--- a/lib/widgets/category_drill_card.dart
+++ b/lib/widgets/category_drill_card.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../helpers/category_translations.dart';
+import '../screens/training_session_screen.dart';
+
+class CategoryDrillCard extends StatefulWidget {
+  const CategoryDrillCard({super.key});
+
+  @override
+  State<CategoryDrillCard> createState() => _CategoryDrillCardState();
+}
+
+class _CategoryDrillCardState extends State<CategoryDrillCard> {
+  static const _key = 'top_mistake_drill_done';
+  bool _done = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((p) {
+      if (mounted) setState(() => _done = p.getBool(_key) ?? false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_done) return const SizedBox.shrink();
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final map = <String, int>{};
+    for (final h in hands.reversed.take(20)) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      map[cat] = (map[cat] ?? 0) + 1;
+    }
+    if (map.isEmpty) return const SizedBox.shrink();
+    final entry = map.entries.reduce((a, b) => a.value >= b.value ? a : b);
+    if (entry.value < 3) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final name = translateCategory(entry.key).isEmpty
+        ? 'Без категории'
+        : translateCategory(entry.key);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.flag, color: accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Проработка категории',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(name, style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl = await TrainingPackService.createDrillFromCategory(
+                  context, entry.key);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Тренировать'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a new drill suggestion after TopMistakeDrillCard
- add alias `createDrillForCategory`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719e0529f0832a8c88866c3d020ae0