### PR TITLE
Update CategoryDrillCard

### DIFF
--- a/lib/widgets/category_drill_card.dart
+++ b/lib/widgets/category_drill_card.dart
@@ -16,13 +16,21 @@ class CategoryDrillCard extends StatefulWidget {
 
 class _CategoryDrillCardState extends State<CategoryDrillCard> {
   static const _key = 'top_mistake_drill_done';
+  static const _tsKey = 'category_drill_last_time';
   bool _done = false;
 
   @override
   void initState() {
     super.initState();
     SharedPreferences.getInstance().then((p) {
-      if (mounted) setState(() => _done = p.getBool(_key) ?? false);
+      final done = p.getBool(_key) ?? false;
+      final ts = p.getInt(_tsKey);
+      final hide = ts != null &&
+          DateTime.now()
+                  .difference(DateTime.fromMillisecondsSinceEpoch(ts))
+                  .inDays <
+              7;
+      if (mounted) setState(() => _done = done && !hide);
     });
   }
 
@@ -76,6 +84,10 @@ class _CategoryDrillCardState extends State<CategoryDrillCard> {
                   context, entry.key);
               if (tpl == null) return;
               await context.read<TrainingSessionService>().startSession(tpl);
+              final p = await SharedPreferences.getInstance();
+              await p.setInt(
+                  _tsKey, DateTime.now().millisecondsSinceEpoch);
+              if (mounted) setState(() => _done = false);
               if (context.mounted) {
                 await Navigator.push(
                   context,


### PR DESCRIPTION
## Summary
- store the last drill timestamp in SharedPreferences
- hide the category drill for a week after use

## Testing
- `flutter analyze` *(fails: 15218 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68719fc38684832aaf973e832d9b3896