### PR TITLE
Add last mistake drill card

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -23,6 +23,7 @@ import '../services/training_import_export_service.dart';
 import '../widgets/repeat_last_incorrect_card.dart';
 import '../widgets/top_mistake_drill_card.dart';
 import '../widgets/category_drill_card.dart';
+import '../widgets/last_mistake_drill_card.dart';
 
 class AnalyzerTab extends StatelessWidget {
   const AnalyzerTab({super.key});
@@ -109,6 +110,7 @@ class AnalyzerTab extends StatelessWidget {
                 const RepeatLastIncorrectCard(),
                 const TopMistakeDrillCard(),
                 const CategoryDrillCard(),
+                const LastMistakeDrillCard(),
                 Expanded(
                   child: PokerAnalyzerScreen(
                     actionSync: context.read<ActionSyncService>(),

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -149,4 +149,13 @@ class TrainingPackService {
       spots: [spot],
     );
   }
+
+  static TrainingPackTemplate createDrillFromHand(SavedHand hand) {
+    final spot = _spotFromHand(hand);
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Drill: ${hand.name}',
+      spots: [spot],
+    );
+  }
 }

--- a/lib/widgets/last_mistake_drill_card.dart
+++ b/lib/widgets/last_mistake_drill_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class LastMistakeDrillCard extends StatefulWidget {
+  const LastMistakeDrillCard({super.key});
+
+  @override
+  State<LastMistakeDrillCard> createState() => _LastMistakeDrillCardState();
+}
+
+class _LastMistakeDrillCardState extends State<LastMistakeDrillCard> {
+  static const _key = 'last_mistake_drill_ts';
+  int? _ts;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((p) {
+      if (mounted) setState(() => _ts = p.getInt(_key));
+    });
+  }
+
+  Future<void> _mark(int ts) async {
+    final p = await SharedPreferences.getInstance();
+    await p.setInt(_key, ts);
+    if (mounted) setState(() => _ts = ts);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final hand = hands.reversed.firstWhereOrNull((h) {
+      final ev = h.evLoss ?? 0.0;
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      return ev.abs() >= 1.0 && !h.corrected && exp != null && gto != null && exp != gto;
+    });
+    if (hand == null) return const SizedBox.shrink();
+    final ts = hand.savedAt.millisecondsSinceEpoch;
+    if (_ts == ts) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final cat = hand.category ?? 'Без категории';
+    final ev = hand.evLoss?.abs() ?? 0.0;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.bug_report, color: accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Последняя ошибка',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(cat, style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 4),
+                Text('-${ev.toStringAsFixed(1)} EV',
+                    style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () async {
+              final tpl = TrainingPackService.createDrillFromHand(hand);
+              await context.read<TrainingSessionService>().startSession(tpl);
+              await _mark(ts);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+            child: const Text('Тренировать'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- build new `createDrillFromHand` helper
- surface last mistake drill card in analyzer tab

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a2e1cb9c832aace61504b9491779