### PR TITLE
Auto categorize mistakes in evaluateSingle

### DIFF
--- a/lib/screens/saved_hand_editor_screen.dart
+++ b/lib/screens/saved_hand_editor_screen.dart
@@ -94,7 +94,7 @@ class _SavedHandEditorScreenState extends State<SavedHandEditorScreen> {
       final spot = _spotFromHand(hand);
       await context
           .read<EvaluationExecutorService>()
-          .evaluateSingle(spot, anteBb: hand.anteBb);
+          .evaluateSingle(context, spot, hand: hand, anteBb: hand.anteBb);
       final evalActs = <ActionEntry>[];
       for (final l in spot.hand.actions.values) {
         evalActs.addAll(l);

--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -57,7 +57,7 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
     for (final h in data) {
       final spot = _spotFromHand(h);
       try {
-        await executor.evaluateSingle(spot, anteBb: h.anteBb);
+        await executor.evaluateSingle(context, spot, hand: h, anteBb: h.anteBb);
       } catch (_) {}
       evs.add(spot.heroEv ?? 0);
       icms.add(spot.heroIcmEv ?? 0);

--- a/lib/screens/v2/spot_list_section.dart
+++ b/lib/screens/v2/spot_list_section.dart
@@ -189,6 +189,7 @@ part of 'training_pack_template_editor_screen.dart';
       await context
           .read<EvaluationExecutorService>()
           .evaluateSingle(
+            context,
             spot,
             template: widget.template,
             anteBb: widget.template.anteBb,
@@ -458,6 +459,7 @@ part of 'training_pack_template_editor_screen.dart';
       hand: HandData.fromSimpleInput(cards, pos, stack),
     );
     await context.read<EvaluationExecutorService>().evaluateSingle(
+      context,
       spot,
       template: widget.template,
       anteBb: widget.template.anteBb,
@@ -513,6 +515,7 @@ part of 'training_pack_template_editor_screen.dart';
         await context
             .read<EvaluationExecutorService>()
             .evaluateSingle(
+              context,
               spot,
               template: widget.template,
               anteBb: widget.template.anteBb,

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -4766,6 +4766,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                               try {
                                                 spot.dirty = false;
                                                 await context.read<EvaluationExecutorService>().evaluateSingle(
+                                                      context,
                                                       spot,
                                                       template: widget.template,
                                                       anteBb: widget.template.anteBb,
@@ -9990,6 +9991,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                                               try {
                                                 spot.dirty = false;
                                                 await context.read<EvaluationExecutorService>().evaluateSingle(
+                                                      context,
                                                       spot,
                                                       template: widget.template,
                                                       anteBb: widget.template.anteBb,

--- a/lib/services/mistake_categorizer.dart
+++ b/lib/services/mistake_categorizer.dart
@@ -1,0 +1,64 @@
+import '../models/saved_hand.dart';
+import '../models/mistake.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hand_data.dart';
+import '../models/v2/hero_position.dart';
+import '../models/evaluation_result.dart';
+import '../widgets/poker_table_view.dart' show PlayerAction;
+import '../helpers/hand_utils.dart';
+import '../helpers/poker_position_helper.dart';
+import 'mistake_categorization_engine.dart';
+
+class MistakeCategorizer {
+  const MistakeCategorizer();
+
+  String classify(SavedHand hand) {
+    final act = heroAction(hand)?.action;
+    final gto = hand.gtoAction;
+    if (act == null || gto == null) return 'Unclassified';
+    final cards = hand.playerCards[hand.heroIndex]
+        .map((c) => '${c.rank}${c.suit}')
+        .join(' ');
+    final spot = TrainingPackSpot(
+      id: hand.spotId ?? '',
+      hand: HandData(
+        heroCards: cards,
+        position: parseHeroPosition(hand.heroPosition),
+        heroIndex: hand.heroIndex,
+        playerCount: hand.numberOfPlayers,
+        anteBb: hand.anteBb,
+      ),
+      evalResult: EvaluationResult(
+        correct: act.trim().toLowerCase() == gto.trim().toLowerCase(),
+        expectedAction: gto,
+        userEquity: 0,
+        expectedEquity: 0,
+      ),
+    );
+    final strength =
+        const MistakeCategorizationEngine().computeHandStrength(cards);
+    final m = Mistake(
+      spot: spot,
+      action: _parseAction(act),
+      handStrength: strength,
+    );
+    return const MistakeCategorizationEngine().categorize(m);
+  }
+
+  PlayerAction _parseAction(String a) {
+    switch (a.toLowerCase()) {
+      case 'fold':
+        return PlayerAction.fold;
+      case 'call':
+        return PlayerAction.call;
+      case 'push':
+        return PlayerAction.push;
+      case 'raise':
+      case 'bet':
+        return PlayerAction.raise;
+      case 'post':
+        return PlayerAction.post;
+    }
+    return PlayerAction.none;
+  }
+}

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -453,7 +453,7 @@ class _TrainingPackSpotPreviewCardState
                               setState(() => spot.tags.add('Mistake'));
                               await context
                                   .read<EvaluationExecutorService>()
-                                  .evaluateSingle(spot);
+                                  .evaluateSingle(context, spot);
                               widget.onPersist?.call();
                             }
                           }
@@ -516,7 +516,7 @@ class _TrainingPackSpotPreviewCardState
                         onPressed: () async {
                           await context
                               .read<EvaluationExecutorService>()
-                              .evaluateSingle(widget.spot);
+                              .evaluateSingle(context, widget.spot);
                           if (mounted) setState(() {});
                         },
                       ),


### PR DESCRIPTION
## Summary
- add MistakeCategorizer service
- auto-classify mistakes and update hand after evaluation
- pass context and hand to evaluateSingle in relevant calls

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a4f4f1d4832abc1927200c2f2ac1