### PR TITLE
Add TopCategoriesDrillCard

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -22,6 +22,7 @@ import '../services/action_history_service.dart';
 import '../services/training_import_export_service.dart';
 import '../widgets/repeat_last_incorrect_card.dart';
 import '../widgets/top_mistake_drill_card.dart';
+import '../widgets/top_categories_drill_card.dart';
 import '../widgets/category_drill_card.dart';
 import '../widgets/last_mistake_drill_card.dart';
 
@@ -109,6 +110,7 @@ class AnalyzerTab extends StatelessWidget {
               children: [
                 const RepeatLastIncorrectCard(),
                 const TopMistakeDrillCard(),
+                const TopCategoriesDrillCard(),
                 const CategoryDrillCard(),
                 const LastMistakeDrillCard(),
                 Expanded(

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -1292,6 +1292,22 @@ class SavedHandManagerService extends ChangeNotifier {
     return result;
   }
 
+  List<MapEntry<String, double>> getTopMistakeCategories({int limit = 3}) {
+    final map = <String, double>{};
+    for (final h in hands) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      map[cat] = (map[cat] ?? 0) + (h.evLoss ?? 0);
+    }
+    final list = map.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return list.take(limit).toList();
+  }
+
   TrainingPackTemplate createPack(String name, List<SavedHand> selected) {
     HeroPosition _pos(String s) => parseHeroPosition(s);
 

--- a/lib/widgets/top_categories_drill_card.dart
+++ b/lib/widgets/top_categories_drill_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../helpers/category_translations.dart';
+import '../screens/training_session_screen.dart';
+
+class TopCategoriesDrillCard extends StatelessWidget {
+  const TopCategoriesDrillCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final list =
+        context.watch<SavedHandManagerService>().getTopMistakeCategories(limit: 3);
+    if (list.isEmpty) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.leaderboard, color: accent),
+              const SizedBox(width: 8),
+              const Text(
+                'Топ слабые категории',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final e in list)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${translateCategory(e.key)} • -${e.value.toStringAsFixed(1)} EV',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: () async {
+                      final tpl = await TrainingPackService.createDrillFromCategory(
+                          context, e.key);
+                      if (tpl == null) return;
+                      await context.read<TrainingSessionService>().startSession(tpl);
+                      if (context.mounted) {
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const TrainingSessionScreen()),
+                        );
+                      }
+                    },
+                    child: const Text('Тренировать'),
+                  ),
+                ],
+              ),
+            )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- list top 3 weak categories in `AnalyzerTab`
- show EV loss and offer drills for each
- expose helper `getTopMistakeCategories` in `SavedHandManagerService`

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722643c22c832ab4ba12cd79b8f0b5