### PR TITLE
Add primary weakness drill to analyzer tab

### DIFF
--- a/lib/screens/analyzer_tab.dart
+++ b/lib/screens/analyzer_tab.dart
@@ -20,6 +20,7 @@ import '../services/stack_manager_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/action_history_service.dart';
 import '../services/training_import_export_service.dart';
+import '../widgets/primary_weakness_drill_card.dart';
 import '../widgets/repeat_last_incorrect_card.dart';
 import '../widgets/top_mistake_drill_card.dart';
 import '../widgets/top_categories_drill_card.dart';
@@ -34,8 +35,9 @@ class AnalyzerTab extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PlayerProfileService()),
-        ChangeNotifierProvider(create: (context) =>
-            PlayerManagerService(context.read<PlayerProfileService>())),
+        ChangeNotifierProvider(
+            create: (context) =>
+                PlayerManagerService(context.read<PlayerProfileService>())),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
         ChangeNotifierProvider(
@@ -49,7 +51,8 @@ class AnalyzerTab extends StatelessWidget {
             final history = PotHistoryService();
             final potSync = PotSyncService(historyService: history);
             final stackService = StackManagerService(
-              Map<int, int>.from(context.read<PlayerManagerService>().initialStacks),
+              Map<int, int>.from(
+                  context.read<PlayerManagerService>().initialStacks),
               potSync: potSync,
             );
             return PlaybackManagerService(
@@ -100,7 +103,8 @@ class AnalyzerTab extends StatelessWidget {
               Provider(
                 create: (_) => PlayerEditingService(
                   playerManager: context.read<PlayerManagerService>(),
-                  stackService: context.read<PlaybackManagerService>().stackService,
+                  stackService:
+                      context.read<PlaybackManagerService>().stackService,
                   playbackManager: context.read<PlaybackManagerService>(),
                   profile: context.read<PlayerProfileService>(),
                 ),
@@ -108,6 +112,7 @@ class AnalyzerTab extends StatelessWidget {
             ],
             child: Column(
               children: [
+                const PrimaryWeaknessDrillCard(),
                 const RepeatLastIncorrectCard(),
                 const TopMistakeDrillCard(),
                 const TopCategoriesDrillCard(),

--- a/lib/widgets/primary_weakness_drill_card.dart
+++ b/lib/widgets/primary_weakness_drill_card.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/category_translations.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class PrimaryWeaknessDrillCard extends StatelessWidget {
+  const PrimaryWeaknessDrillCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final list = context
+        .watch<SavedHandManagerService>()
+        .getTopMistakeCategories(limit: 1);
+    if (list.isEmpty) return const SizedBox.shrink();
+    final entry = list.first;
+    final accent = Theme.of(context).colorScheme.secondary;
+    final name = translateCategory(entry.key).isEmpty
+        ? 'Без категории'
+        : translateCategory(entry.key);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning, color: accent),
+              const SizedBox(width: 8),
+              const Text(
+                'Главная слабость',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(name, style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          Text('-${entry.value.toStringAsFixed(1)} EV',
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () async {
+                final session = context.read<TrainingSessionService>();
+                final tpl = await TrainingPackService.createDrillFromCategory(
+                    context, entry.key);
+                if (tpl == null) return;
+                await session.startSession(tpl);
+                if (context.mounted) {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const TrainingSessionScreen()),
+                  );
+                }
+              },
+              child: const Text('Начать тренировку'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a new PrimaryWeaknessDrillCard at the top of AnalyzerTab
- implement PrimaryWeaknessDrillCard widget

## Testing
- `flutter analyze lib/widgets/primary_weakness_drill_card.dart lib/screens/analyzer_tab.dart`

------
https://chatgpt.com/codex/tasks/task_e_687227b89c38832a868b6ff422a0adbb