### PR TITLE
Add custom pack spot constructor

### DIFF
--- a/lib/screens/v2/pack_spot_constructor_screen.dart
+++ b/lib/screens/v2/pack_spot_constructor_screen.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+import '../../models/card_model.dart';
+import '../../widgets/card_picker_widget.dart';
+import '../../widgets/action_editor_list.dart';
+import '../../models/action_entry.dart';
+import '../../models/v2/hero_position.dart';
+import '../../models/v2/hand_data.dart';
+import '../../models/v2/training_pack_spot.dart';
+import '../../services/training_pack_service.dart';
+
+class PackSpotConstructorScreen extends StatefulWidget {
+  const PackSpotConstructorScreen({super.key});
+
+  @override
+  State<PackSpotConstructorScreen> createState() => _PackSpotConstructorScreenState();
+}
+
+class _PackSpotConstructorScreenState extends State<PackSpotConstructorScreen> {
+  final _heroStackCtrl = TextEditingController(text: '10');
+  final _villainStackCtrl = TextEditingController(text: '10');
+  final List<CardModel> _cards = [];
+  List<ActionEntry> _actions = [];
+  HeroPosition _pos = HeroPosition.sb;
+
+  @override
+  void dispose() {
+    _heroStackCtrl.dispose();
+    _villainStackCtrl.dispose();
+    super.dispose();
+  }
+
+  Set<String> _usedCards() => {for (final c in _cards) '${c.rank}${c.suit}'};
+
+  void _setCard(int i, CardModel c) {
+    setState(() {
+      if (_cards.length > i) {
+        _cards[i] = c;
+      } else {
+        _cards.add(c);
+      }
+    });
+  }
+
+  Future<void> _save() async {
+    if (_cards.length < 2) return;
+    final hero = double.tryParse(_heroStackCtrl.text) ?? 0;
+    final vil = double.tryParse(_villainStackCtrl.text) ?? hero;
+    final spot = TrainingPackSpot(
+      id: const Uuid().v4(),
+      hand: HandData(
+        heroCards: _cards.map((e) => '${e.rank}${e.suit}').join(' '),
+        position: _pos,
+        heroIndex: 0,
+        playerCount: 2,
+        stacks: {'0': hero, '1': vil},
+        actions: {0: List<ActionEntry>.from(_actions)},
+      ),
+    );
+    await TrainingPackService.saveCustomSpot(spot);
+    if (mounted) Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom Spot Pack')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text('Hero Cards', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            CardPickerWidget(
+              cards: _cards,
+              onChanged: _setCard,
+              disabledCards: _usedCards(),
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<HeroPosition>(
+              value: _pos,
+              decoration: const InputDecoration(labelText: 'Position'),
+              items: [
+                for (final p in HeroPosition.values)
+                  DropdownMenuItem(value: p, child: Text(p.label))
+              ],
+              onChanged: (v) => setState(() => _pos = v ?? HeroPosition.sb),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _heroStackCtrl,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: 'Hero Stack'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _villainStackCtrl,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: 'Villain Stack'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            const Text('Preflop Actions', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            ActionEditorList(
+              initial: _actions,
+              players: 2,
+              positions: [_pos.label, 'Villain'],
+              onChanged: (v) => setState(() => _actions = v),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(onPressed: _save, child: const Text('Save')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -11,6 +11,7 @@ import '../models/v2/hero_position.dart';
 import '../models/action_entry.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../helpers/poker_position_helper.dart';
+import '../helpers/training_pack_storage.dart';
 
 class TrainingPackService {
   const TrainingPackService._();
@@ -157,5 +158,27 @@ class TrainingPackService {
       name: 'Drill: ${hand.name}',
       spots: [spot],
     );
+  }
+
+  static Future<TrainingPackTemplate> saveCustomSpot(
+      TrainingPackSpot spot) async {
+    final hero = spot.hand.stacks['0']?.round() ?? 0;
+    final players = [
+      for (int i = 0; i < spot.hand.playerCount; i++)
+        (spot.hand.stacks['$i'] ?? 0).round()
+    ];
+    final template = TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Custom Pack',
+      heroBbStack: hero,
+      playerStacksBb: players,
+      heroPos: spot.hand.position,
+      createdAt: DateTime.now(),
+      spots: [spot],
+    );
+    final list = await TrainingPackStorage.load();
+    list.add(template);
+    await TrainingPackStorage.save(list);
+    return template;
   }
 }


### PR DESCRIPTION
## Summary
- add `PackSpotConstructorScreen` for manual spot creation
- allow saving custom spot via `TrainingPackService.saveCustomSpot`

## Testing
- `dart format lib/services/training_pack_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722ba83278832a82810701297acbc5