### PR TITLE
Add repeat incorrect session button

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -49,6 +49,7 @@ import '../../services/range_library_service.dart';
 import '../../services/theme_service.dart';
 import '../../services/session_log_service.dart';
 import '../../services/training_pack_stats_service.dart';
+import '../../services/training_pack_service.dart';
 import 'new_training_pack_template_dialog.dart';
 
 import 'package:timeago/timeago.dart' as timeago;
@@ -3295,6 +3296,22 @@ class _TrainingPackTemplateListScreenState
             heroTag: 'addTplFab',
             onPressed: _add,
             child: const Icon(Icons.add),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'repeatIncorrectTplFab',
+            label: const Text('Повторить ошибку'),
+            onPressed: () async {
+              final tpl = await TrainingPackService.createRepeatForIncorrect(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add `training_pack_service` import
- include a quick "Повторить ошибку" action button that starts a session for the last incorrect spot

## Testing
- `flutter test --run-skipped` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68723278bbd4832a8d493d5de1f7d9e8