### PR TITLE
Auto evaluate CSV import spots

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -28,6 +28,7 @@ import '../../services/generated_pack_history_service.dart';
 import 'package:intl/intl.dart';
 import 'package:collection/collection.dart';
 import 'package:provider/provider.dart';
+import '../../services/evaluation_executor_service.dart';
 import 'training_pack_template_editor_screen.dart';
 import '../../widgets/range_matrix_picker.dart';
 import '../../widgets/preset_range_buttons.dart';
@@ -2247,6 +2248,15 @@ class _TrainingPackTemplateListScreenState
         templateId: const Uuid().v4(),
         templateName: p.basenameWithoutExtension(file.name),
       );
+      final exec = context.read<EvaluationExecutorService>();
+      for (final spot in tpl.spots) {
+        await exec.evaluateSingle(
+          context,
+          spot,
+          template: tpl,
+          anteBb: tpl.anteBb,
+        );
+      }
       final skipped = allRows.length - 1 - tpl.spots.length;
       setState(() {
         _templates.add(tpl);
@@ -2277,6 +2287,15 @@ class _TrainingPackTemplateListScreenState
         templateId: const Uuid().v4(),
         templateName: 'Pasted Pack',
       );
+      final exec = context.read<EvaluationExecutorService>();
+      for (final spot in tpl.spots) {
+        await exec.evaluateSingle(
+          context,
+          spot,
+          template: tpl,
+          anteBb: tpl.anteBb,
+        );
+      }
       final skipped = rows.length - 1 - tpl.spots.length;
       setState(() {
         _templates.add(tpl);


### PR DESCRIPTION
## Summary
- auto compute EV/ICM when importing CSV packs

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872398b620c832a9282c3de934200a7