### PR TITLE
Implement weakest category drill

### DIFF
--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -118,6 +118,24 @@ class TrainingPackService {
     );
   }
 
+  static Future<TrainingPackTemplate?> createDrillFromWeakestCategory(
+      BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final count = <String, int>{};
+    for (final h in hands) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      count[cat] = (count[cat] ?? 0) + 1;
+    }
+    if (count.isEmpty) return null;
+    final cat = count.entries.reduce((a, b) => a.value >= b.value ? a : b).key;
+    return createDrillFromCategory(context, cat);
+  }
+
   static Future<TrainingPackTemplate?> createTopMistakeDrill(
       BuildContext context) async {
     return createDrillFromTopCategories(context);


### PR DESCRIPTION
## Summary
- add `createDrillFromWeakestCategory` in training pack service

## Testing
- ❌ `flutter format lib/services/training_pack_service.dart`
- ❌ `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68723e8234d0832aa2d30a91b4954dbd