### PR TITLE
Fix missing assets reference

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,6 @@ flutter:
     - assets/spots/spots.json
     - assets/training_packs/
     - assets/training_templates/
-    - assets/templates/initial/
     - assets/ranges/
     - assets/packs/
 


### PR DESCRIPTION
## Summary
- remove the empty initial templates asset entry
- ran `flutter pub get` to update assets

## Testing
- `flutter pub get`
- `flutter analyze --no-pub` *(fails: 13550 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68723f94b874832aad688f8baf462dc8