### PR TITLE
Add repeat corrected drill button

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -3334,6 +3334,23 @@ class _TrainingPackTemplateListScreenState
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(
+            heroTag: 'repeatCorrectedDrillTplFab',
+            label: const Text('Повтор исправленных'),
+            onPressed: () async {
+              final tpl =
+                  await TrainingPackService.createRepeatDrillForCorrected(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
             heroTag: 'weakestCategoryTplFab',
             label: const Text('Слабейшая категория'),
             onPressed: () async {

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -140,6 +140,22 @@ class TrainingPackService {
       BuildContext context) async {
     return createDrillFromTopCategories(context);
   }
+
+  static Future<TrainingPackTemplate?> createRepeatDrillForCorrected(
+      BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final list = [
+      for (final h in hands)
+        if (h.corrected && (h.evLoss ?? 0).abs() >= 1.0) h
+    ];
+    if (list.isEmpty) return null;
+    final spots = [for (final h in list) _spotFromHand(h)];
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Repeat Corrected Drill',
+      spots: spots,
+    );
+  }
   static Future<TrainingPackTemplate?> createRepeatForCorrected(BuildContext context) async {
     final hands = context.read<SavedHandManagerService>().hands;
     final hand = hands.reversed.firstWhereOrNull((h) => h.corrected);


### PR DESCRIPTION
## Summary
- create helper `TrainingPackService.createRepeatDrillForCorrected`
- launch repeat drill from corrected hands via a new button

## Testing
- `flutter analyze` *(fails: 13552 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687243c8a684832a94c7a11182059b7b