### PR TITLE
Add top mistake drill FAB

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -3365,6 +3365,22 @@ class _TrainingPackTemplateListScreenState
               }
             },
           ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'topCategoriesTplFab',
+            label: const Text('Топ ошибки'),
+            onPressed: () async {
+              final tpl = await TrainingPackService.createTopMistakeDrill(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add a `FloatingActionButton` on the template list screen to start the top mistake drill

## Testing
- `flutter analyze` *(fails: 13555 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6872475b7ce8832a9c7849fb841dbe46