### PR TITLE
Add service and plugin loader tests

### DIFF
--- a/test/plugin_loader_io_test.dart
+++ b/test/plugin_loader_io_test.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/plugins/plugin_loader_io.dart';
+import 'package:poker_analyzer/plugins/sample_logging_plugin.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+}
+
+class _FakeHttpClient extends HttpClient {
+  _FakeHttpClient(this.data);
+  final List<int> data;
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => _Request(data);
+  @override
+  void close({bool force = false}) {}
+}
+
+class _Request implements HttpClientRequest {
+  _Request(this.data);
+  final List<int> data;
+  @override
+  Future<HttpClientResponse> close() async => _Response(data);
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Response extends Stream<List<int>> implements HttpClientResponse {
+  _Response(this.data);
+  final List<int> data;
+  @override
+  int get statusCode => HttpStatus.ok;
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int>)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    return Stream<List<int>>.fromIterable([data])
+        .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadBuiltInPlugins includes logger', () {
+    final loader = PluginLoader();
+    final plugins = loader.loadBuiltInPlugins();
+    expect(plugins.whereType<SampleLoggingPlugin>().length, 1);
+  });
+
+  test('loadConfig reads config file', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    final pluginsDir = Directory('${dir.path}/plugins');
+    await pluginsDir.create();
+    await File('${pluginsDir.path}/plugin_config.json')
+        .writeAsString('{"X.dart": false}');
+    final loader = PluginLoader();
+    final config = await loader.loadConfig();
+    expect(config['X.dart'], false);
+  });
+
+  test('loadFromFile spawns isolate', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    final pluginsDir = Directory('${dir.path}/plugins');
+    await pluginsDir.create();
+    await File('${pluginsDir.path}/plugin_config.json').writeAsString('{}');
+    final file = File('${pluginsDir.path}/TestPlugin.dart');
+    await file.writeAsString('''
+import 'dart:isolate';
+import 'package:poker_analyzer/plugins/sample_logging_plugin.dart';
+void main(List<String> args, SendPort port) {
+  port.send(SampleLoggingPlugin());
+}
+''');
+    final loader = PluginLoader();
+    final plugin = await loader.loadFromFile(file);
+    expect(plugin, isA<SampleLoggingPlugin>());
+  });
+
+  test('downloadFromUrl saves file', () async {
+    final bytes = utf8.encode('data');
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    HttpOverrides.runZoned(() async {
+      final loader = PluginLoader();
+      await loader.downloadFromUrl('http://x/TestPlugin.dart');
+      final file = File('${dir.path}/plugins/TestPlugin.dart');
+      expect(await file.exists(), true);
+      expect(await file.readAsString(), 'data');
+    }, createHttpClient: (_) => _FakeHttpClient(bytes));
+  });
+}

--- a/test/services/cloud_sync_local_test.dart
+++ b/test/services/cloud_sync_local_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/cloud_sync_service.dart';
+
+class _PathProvider extends PathProviderPlatform {
+  _PathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('save and load local value', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _PathProvider(dir.path);
+    SharedPreferences.setMockInitialValues({});
+    final service = CloudSyncService(
+      firestore: FakeFirebaseFirestore(),
+      auth: MockFirebaseAuth(mockUser: MockUser(uid: 'u')),
+    );
+    await service.init();
+    await service.save('k', 'v');
+    final v = await service.load('k');
+    expect(v, 'v');
+  });
+}

--- a/test/services/training_session_service_test.dart
+++ b/test/services/training_session_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('basic session flow', () async {
+    final s1 = TrainingPackSpot(id: 'a');
+    final s2 = TrainingPackSpot(id: 'b');
+    final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [s1, s2]);
+    final service = TrainingSessionService();
+    await service.startSession(tpl, persist: false);
+    expect(service.currentSpot?.id, 'a');
+    service.nextSpot();
+    expect(service.currentSpot?.id, 'b');
+    service.prevSpot();
+    expect(service.currentSpot?.id, 'a');
+    service.submitResult('a', 'fold', true);
+    expect(service.results['a'], true);
+    expect(service.correctCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add PluginLoader I/O tests
- test TrainingSessionService basic flow
- cover CloudSyncService prefs

## Testing
- `flutter test` *(fails: dart compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872682b7bec832abe6867f296286e5d