### PR TITLE
Add shareProgress export

### DIFF
--- a/lib/screens/training_stats_screen.dart
+++ b/lib/screens/training_stats_screen.dart
@@ -43,14 +43,30 @@ class _TrainingStatsScreenState extends State<TrainingStatsScreen> {
   @override
   Widget build(BuildContext context) {
     if (_stats == null) {
-      return const Scaffold(
-        appBar: AppBar(title: Text('My Stats')),
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('My Stats'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.share),
+              onPressed: () => context.read<TrainingStatsService>().shareProgress(),
+            )
+          ],
+        ),
+        body: const Center(child: CircularProgressIndicator()),
       );
     }
     final s = _stats!;
     return Scaffold(
-      appBar: AppBar(title: const Text('My Stats')),
+      appBar: AppBar(
+        title: const Text('My Stats'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () => context.read<TrainingStatsService>().shareProgress(),
+          )
+        ],
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/screens/weakness_overview_screen.dart
+++ b/lib/screens/weakness_overview_screen.dart
@@ -8,6 +8,7 @@ import 'package:pdf/pdf.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
+import '../services/training_stats_service.dart';
 import '../helpers/category_translations.dart';
 import '../theme/app_colors.dart';
 import 'training_session_screen.dart';
@@ -367,6 +368,10 @@ class _WeaknessOverviewScreenState extends State<WeaknessOverviewScreen> {
             icon: const Icon(Icons.picture_as_pdf),
             tooltip: 'Экспорт',
             onPressed: () => _exportPdf(context),
+          ),
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () => context.read<TrainingStatsService>().shareProgress(),
           )
         ],
       ),

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:share_plus/share_plus.dart';
+import 'progress_export_service.dart';
 import 'cloud_sync_service.dart';
 import '../models/training_stats.dart';
 import '../models/saved_hand.dart';
@@ -264,6 +266,13 @@ class TrainingStatsService extends ChangeNotifier {
       rows.add([key, sMap[d] ?? 0, hMap[d] ?? 0, mMap[d] ?? 0]);
     }
     return rows;
+  }
+
+  Future<void> shareProgress({bool weekly = false}) async {
+    final exporter = ProgressExportService(stats: this);
+    final csv = await exporter.exportCsv(weekly: weekly);
+    final pdf = await exporter.exportPdf(weekly: weekly);
+    await Share.shareXFiles([XFile(csv.path), XFile(pdf.path)]);
   }
 
   Map<String, int> _loadMap(SharedPreferences prefs, String key) {


### PR DESCRIPTION
## Summary
- enable sharing CSV and PDF of progress stats
- add share button on Training Stats screen
- add share button on Weakness Overview

## Testing
- `dart --version` *(fails: command not found)*
- `flutter format lib/services/training_stats_service.dart lib/screens/training_stats_screen.dart lib/screens/weakness_overview_screen.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687268303d04832a9f865a98a5146aba