### PR TITLE
Add plugin load status tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,7 +127,7 @@ Future<void> main() async {
   if (await dir.exists()) {
     await for (final entity in dir.list()) {
       if (entity is File && entity.path.endsWith('.dart')) {
-        final plugin = await loader.loadFromFile(entity);
+        final plugin = await loader.loadFromFile(entity, pluginManager);
         if (plugin != null) {
           pluginManager.load(plugin);
         }

--- a/lib/plugins/plugin_loader_web.dart
+++ b/lib/plugins/plugin_loader_web.dart
@@ -10,7 +10,7 @@ class PluginLoader {
 
   Future<Map<String, bool>> loadConfig() async => <String, bool>{};
 
-  Future<Plugin?> loadFromFile(dynamic file) async => null;
+  Future<Plugin?> loadFromFile(dynamic file, PluginManager manager) async => null;
 
   Future<void> downloadFromUrl(String url, {String? checksum}) async {}
 

--- a/lib/plugins/plugin_manager.dart
+++ b/lib/plugins/plugin_manager.dart
@@ -1,3 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:poker_analyzer/services/service_registry.dart';
 
 import 'plugin.dart';
@@ -7,6 +12,42 @@ import 'service_extension.dart';
 class PluginManager {
   /// List of loaded plug-ins.
   final List<Plugin> _plugins = <Plugin>[];
+
+  final Map<String, String> _status = <String, String>{};
+
+  Future<File> _logFile() async {
+    final dir = await getApplicationSupportDirectory();
+    return File(p.join(dir.path, 'plugin_log.json'));
+  }
+
+  Future<void> _loadLog() async {
+    final file = await _logFile();
+    if (await file.exists()) {
+      try {
+        final data = await file.readAsString();
+        final map = jsonDecode(data) as Map<String, dynamic>;
+        _status
+          ..clear()
+          ..addAll(map.map((k, v) => MapEntry(k, v.toString())));
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveLog() async {
+    final file = await _logFile();
+    await file.writeAsString(jsonEncode(_status));
+  }
+
+  Future<Map<String, String>> loadStatus() async {
+    if (_status.isEmpty) await _loadLog();
+    return _status;
+  }
+
+  Future<void> logStatus(String name, String status) async {
+    await _loadLog();
+    _status[name] = status;
+    await _saveLog();
+  }
 
   /// Loads a new [plugin].
   void load(Plugin plugin) {


### PR DESCRIPTION
## Summary
- log plugin load states in a persistent file
- update plugin loader to report status
- show plugin errors in PluginManagerScreen
- allow retrying failed plugins

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68726833af48832aababb6ae2d2df759