### PR TITLE
Add similar mistake drill

### DIFF
--- a/lib/screens/analyzer_result_screen.dart
+++ b/lib/screens/analyzer_result_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/saved_hand.dart';
+import '../services/training_pack_service.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
+import '../theme/app_colors.dart';
+
+class AnalyzerResultScreen extends StatelessWidget {
+  final SavedHand hand;
+  const AnalyzerResultScreen({super.key, required this.hand});
+
+  bool get _isMistake {
+    final exp = hand.expectedAction?.trim().toLowerCase();
+    final gto = hand.gtoAction?.trim().toLowerCase();
+    if (exp == null || gto == null) return false;
+    return exp != gto;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Результаты анализа')),
+      backgroundColor: AppColors.background,
+      body: const SizedBox.shrink(),
+      floatingActionButton: _isMistake
+          ? FloatingActionButton.extended(
+              onPressed: () async {
+                final tpl = await TrainingPackService.createDrillFromSimilarHands(
+                    context, hand);
+                if (tpl == null) return;
+                await context.read<TrainingSessionService>().startSession(tpl);
+                if (context.mounted) {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const TrainingSessionScreen()),
+                  );
+                }
+              },
+              label: const Text('Отработать похожие'),
+              icon: const Icon(Icons.fitness_center),
+            )
+          : null,
+    );
+  }
+}

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -211,6 +211,36 @@ class TrainingPackService {
     );
   }
 
+  static Future<TrainingPackTemplate?> createDrillFromSimilarHands(
+      BuildContext context, SavedHand hand) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final cat = hand.category;
+    final pos = hand.heroPosition;
+    final stack = hand.stackSizes[hand.heroIndex];
+    if (cat == null || stack == null) return null;
+    final list = [
+      for (final h in hands)
+        if (h != hand &&
+            h.category == cat &&
+            h.heroPosition == pos &&
+            h.stackSizes[h.heroIndex] == stack &&
+            h.expectedAction != null &&
+            h.gtoAction != null &&
+            h.expectedAction!.trim().toLowerCase() !=
+                h.gtoAction!.trim().toLowerCase())
+          h
+    ];
+    if (list.isEmpty) return null;
+    list.sort((a, b) => (b.evLoss ?? 0).compareTo(a.evLoss ?? 0));
+    final selected = list.take(10).toList();
+    final spots = [for (final h in selected) _spotFromHand(h)];
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Drill: $cat',
+      spots: spots,
+    );
+  }
+
   static Future<TrainingPackTemplate> saveCustomSpot(
       TrainingPackSpot spot) async {
     final hero = spot.hand.stacks['0']?.round() ?? 0;


### PR DESCRIPTION
## Summary
- support creating drills from similar hands
- add AnalyzerResultScreen with drill button

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687268cac7c0832aa09b999c391c95bb