### PR TITLE
Show 'Practice similar' only when mistakes exist

### DIFF
--- a/lib/screens/analyzer_result_screen.dart
+++ b/lib/screens/analyzer_result_screen.dart
@@ -21,25 +21,8 @@ class AnalyzerResultScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasSimilar = context.select<SavedHandManagerService, bool>((s) {
-      final cat = hand.category;
-      final pos = hand.heroPosition;
-      final stack = hand.stackSizes[hand.heroIndex];
-      if (cat == null || stack == null) return false;
-      for (final h in s.hands) {
-        if (h == hand) continue;
-        if (h.category == cat &&
-            h.heroPosition == pos &&
-            h.stackSizes[h.heroIndex] == stack &&
-            h.expectedAction != null &&
-            h.gtoAction != null &&
-            h.expectedAction!.trim().toLowerCase() !=
-                h.gtoAction!.trim().toLowerCase()) {
-          return true;
-        }
-      }
-      return false;
-    });
+    final hasSimilar = context
+        .select<SavedHandManagerService, bool>((s) => s.hasSimilarMistakes(hand));
     final showFab = _isMistake && hasSimilar;
     return Scaffold(
       appBar: AppBar(title: const Text('Результаты анализа')),

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -1023,6 +1023,24 @@ class SavedHandManagerService extends ChangeNotifier {
     return result;
   }
 
+  bool hasSimilarMistakes(SavedHand hand) {
+    final cat = hand.category;
+    final pos = hand.heroPosition;
+    final stack = hand.stackSizes[hand.heroIndex];
+    if (cat == null || stack == null) return false;
+    return hands.any(
+      (h) =>
+          h != hand &&
+          h.category == cat &&
+          h.heroPosition == pos &&
+          h.stackSizes[h.heroIndex] == stack &&
+          h.expectedAction != null &&
+          h.gtoAction != null &&
+          h.expectedAction!.trim().toLowerCase() !=
+              h.gtoAction!.trim().toLowerCase(),
+    );
+  }
+
   List<MapEntry<String, double>> getTopMistakeCategories({int limit = 3}) {
     final map = <String, double>{};
     for (final h in hands) {


### PR DESCRIPTION
## Summary
- add `hasSimilarMistakes` helper to SavedHandManagerService
- use it in AnalyzerResultScreen to decide on showing the practice action

## Testing
- `dart` and `flutter` commands were unavailable so formatting and tests could not run

------
https://chatgpt.com/codex/tasks/task_e_6872703f7008832ab38aa22d1e972dc5