### PR TITLE
Add 888Poker converter

### DIFF
--- a/lib/plugins/converters/888poker_hand_history_converter.dart
+++ b/lib/plugins/converters/888poker_hand_history_converter.dart
@@ -1,0 +1,144 @@
+import '../converter_format_capabilities.dart';
+import '../converter_plugin.dart';
+import 'package:poker_analyzer/models/saved_hand.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+
+class Poker888HandHistoryConverter extends ConverterPlugin {
+  Poker888HandHistoryConverter()
+      : super(
+          formatId: '888poker_hand_history',
+          description: '888Poker hand history format',
+          capabilities: const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: false,
+          ),
+        );
+
+  CardModel? _parseCard(String token) {
+    if (token.length < 2) return null;
+    final rank = token.substring(0, token.length - 1).toUpperCase();
+    final suitChar = token[token.length - 1].toLowerCase();
+    switch (suitChar) {
+      case 'h':
+        return CardModel(rank: rank, suit: '♥');
+      case 'd':
+        return CardModel(rank: rank, suit: '♦');
+      case 'c':
+        return CardModel(rank: rank, suit: '♣');
+      case 's':
+        return CardModel(rank: rank, suit: '♠');
+    }
+    return null;
+  }
+
+  double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
+
+  @override
+  SavedHand? convertFrom(String externalData) {
+    final lines = externalData.split(RegExp(r'\r?\n'));
+    if (lines.isEmpty || !lines.first.toLowerCase().contains('888')) {
+      return null;
+    }
+    final seatRegex =
+        RegExp(r'^Seat (\d+):\s*(.+?) \(([^)]+)\)', caseSensitive: false);
+    final seatEntries = <Map<String, dynamic>>[];
+    for (final line in lines) {
+      final m = seatRegex.firstMatch(line.trim());
+      if (m != null) {
+        seatEntries.add({
+          'seat': int.parse(m.group(1)!),
+          'name': m.group(2)!.trim(),
+          'stack': _amount(m.group(3)!),
+        });
+      }
+    }
+    if (seatEntries.isEmpty) return null;
+    seatEntries.sort((a, b) => (a['seat'] as int).compareTo(b['seat'] as int));
+    final playerCount = seatEntries.length;
+
+    String? heroName;
+    List<CardModel> heroCards = [];
+    for (final line in lines) {
+      final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
+      if (m != null) {
+        heroName = m.group(1)!.trim();
+        final c1 = _parseCard(m.group(2)!);
+        final c2 = _parseCard(m.group(3)!);
+        if (c1 != null && c2 != null) heroCards = [c1, c2];
+        break;
+      }
+    }
+    final nameToIndex = <String, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      nameToIndex[seatEntries[i]['name'].toString().toLowerCase()] = i;
+    }
+    int heroIndex = 0;
+    if (heroName != null) {
+      heroIndex = nameToIndex[heroName.toLowerCase()] ?? 0;
+    }
+    final playerCards = List.generate(playerCount, (_) => <CardModel>[]);
+    if (heroCards.isNotEmpty) playerCards[heroIndex] = heroCards;
+    final stackSizes = <int, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      stackSizes[i] = (seatEntries[i]['stack'] as double).round();
+    }
+    final actions = <ActionEntry>[];
+    bool preflop = false;
+    for (final line in lines) {
+      final t = line.trim();
+      if (t.startsWith('*** HOLE CARDS')) preflop = true;
+      if (t.startsWith('*** FLOP')) preflop = false;
+      if (!preflop) continue;
+      Match? m;
+      m = RegExp(r'^(.+?): folds').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'fold'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): checks').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'check'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): calls ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'call', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): bets ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'bet', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): raises .* to ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'raise', amount: _amount(m.group(2)!)));
+        continue;
+      }
+    }
+    final positions = {for (int i = 0; i < playerCount; i++) i: ''};
+    return SavedHand(
+      name: '',
+      heroIndex: heroIndex,
+      heroPosition: positions[heroIndex] ?? '',
+      numberOfPlayers: playerCount,
+      playerCards: playerCards,
+      boardCards: const [],
+      boardStreet: 0,
+      actions: actions,
+      stackSizes: stackSizes,
+      playerPositions: positions,
+      comment: '',
+      playerTypes: {for (int i = 0; i < playerCount; i++) i: PlayerType.unknown},
+    );
+  }
+}

--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -23,6 +23,7 @@ import 'converters/ggpoker_hand_history_converter.dart';
 import 'converters/winamax_hand_history_converter.dart';
 import 'converters/partypoker_hand_history_converter.dart';
 import 'converters/wpn_hand_history_converter.dart';
+import 'converters/888poker_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
 
@@ -76,6 +77,7 @@ class PluginLoader {
       WinamaxHandHistoryConverter(),
       PartyPokerHandHistoryConverter(),
       WpnHandHistoryConverter(),
+      Poker888HandHistoryConverter(),
     ];
     return <Plugin>[
       SampleLoggingPlugin(),
@@ -96,6 +98,7 @@ class PluginLoader {
           WinamaxHandHistoryConverter(),
           PartyPokerHandHistoryConverter(),
           WpnHandHistoryConverter(),
+          Poker888HandHistoryConverter(),
         ]);
       case 'PokerStarsConverterPlugin':
         return PokerStarsConverterPlugin();

--- a/tests/converter_validation_test.dart
+++ b/tests/converter_validation_test.dart
@@ -89,6 +89,17 @@ void main() {
               'Villain folds',
             ].join('\n');
             break;
+          case '888poker_hand_history':
+            sample = [
+              '888poker Hand #1',
+              'Seat 1: Hero (1)',
+              'Seat 2: Villain (1)',
+              '*** HOLE CARDS ***',
+              'Dealt to Hero [Ah Kh]',
+              'Hero raises to 2',
+              'Villain folds',
+            ].join('\n');
+            break;
           default:
             sample = '';
         }


### PR DESCRIPTION
## Summary
- add 888Poker hand history converter
- register new converter with plugin loader
- allow picking 888Poker format on session import screen
- cover 888Poker format in converter tests

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687275bcff84832a8a321d15ede6dc4f