### PR TITLE
Add random mistake drill

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -3334,6 +3334,22 @@ class _TrainingPackTemplateListScreenState
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(
+            heroTag: 'randomMistakeTplFab',
+            label: const Text('Случайная ошибка'),
+            onPressed: () async {
+              final tpl = await TrainingPackService.createSingleRandomMistakeDrill(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
             heroTag: 'repeatCorrectedDrillTplFab',
             label: const Text('Повтор исправленных'),
             onPressed: () async {

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -205,6 +207,29 @@ class TrainingPackService {
     return TrainingPackTemplate(
       id: const Uuid().v4(),
       name: 'Repeat Incorrect',
+      spots: [spot],
+    );
+  }
+
+  static Future<TrainingPackTemplate?> createSingleRandomMistakeDrill(
+      BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final list = [
+      for (final h in hands)
+        if (!h.corrected &&
+            (h.evLoss?.abs() ?? 0) >= 1.0 &&
+            h.expectedAction != null &&
+            h.gtoAction != null &&
+            h.expectedAction!.trim().toLowerCase() !=
+                h.gtoAction!.trim().toLowerCase())
+          h
+    ];
+    if (list.isEmpty) return null;
+    final hand = list[Random().nextInt(list.length)];
+    final spot = _spotFromHand(hand);
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Random Mistake',
       spots: [spot],
     );
   }


### PR DESCRIPTION
## Summary
- add `createSingleRandomMistakeDrill` helper in `TrainingPackService`
- allow launching a random mistake drill from the template list screen

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c96d18b0832a9633d9d0102546f7