### PR TITLE
Refactor evaluation executor

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -3,6 +3,8 @@ import 'services/favorite_pack_service.dart';
 import 'services/cloud_sync_service.dart';
 import 'services/session_note_service.dart';
 import 'services/connectivity_sync_controller.dart';
+import 'services/evaluation_executor_service.dart';
+import 'services/service_registry.dart';
 
 class AppBootstrap {
   const AppBootstrap._();
@@ -10,7 +12,10 @@ class AppBootstrap {
   static ConnectivitySyncController? _sync;
   static ConnectivitySyncController? get sync => _sync;
 
-  static Future<void> init({CloudSyncService? cloud}) async {
+  static Future<void> init({
+    CloudSyncService? cloud,
+    required ServiceRegistry registry,
+  }) async {
     await TrainingPackAssetLoader.instance.loadAll();
     await FavoritePackService.instance.init();
     if (cloud != null) {
@@ -22,6 +27,7 @@ class AppBootstrap {
       _sync = ConnectivitySyncController(cloud: cloud);
     }
     await SessionNoteService(cloud: cloud).load();
+    registry.registerIfAbsent<EvaluationExecutor>(EvaluationExecutorService());
   }
 
   static void dispose() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -118,8 +118,8 @@ Future<void> main() async {
   ab = AbTestEngine(remote: rc);
   await ab.init();
   final cloud = CloudSyncService();
-  await AppBootstrap.init(cloud: cloud);
   final registry = ServiceRegistry();
+  await AppBootstrap.init(cloud: cloud, registry: registry);
   final pluginManager = PluginManager();
   final loader = PluginLoader();
   final dir = Directory('plugins');

--- a/lib/plugins/evaluation_executor_extension.dart
+++ b/lib/plugins/evaluation_executor_extension.dart
@@ -1,0 +1,11 @@
+import 'package:poker_analyzer/services/evaluation_executor_service.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+
+import 'service_extension.dart';
+
+class EvaluationExecutorExtension extends ServiceExtension<EvaluationExecutor> {
+  const EvaluationExecutorExtension();
+
+  @override
+  EvaluationExecutor create(ServiceRegistry registry) => EvaluationExecutorService();
+}

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3337,6 +3337,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
           EvaluationProcessingService(
             queueService: _queueService,
             debugPrefs: _debugPrefs,
+            registry: _serviceRegistry,
             debugSnapshotService: _debugSnapshotService,
           ));
     _processingService = _serviceRegistry.get<EvaluationProcessingService>();

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -54,6 +54,7 @@ import '../services/error_logger_service.dart';
 import '../models/training_spot.dart';
 import '../models/evaluation_result.dart';
 import '../services/evaluation_executor_service.dart';
+import '../services/service_registry.dart';
 import '../services/training_session_controller.dart';
 import '../services/goals_service.dart';
 import '../widgets/replay_spot_widget.dart';
@@ -1899,8 +1900,16 @@ body { font-family: sans-serif; padding: 16px; }
                   providers: [
                     ChangeNotifierProvider(create: (_) => PlayerProfileService()),
                     ChangeNotifierProvider(create: (_) => PlayerManagerService(context.read<PlayerProfileService>())),
-                    Provider.value(value: EvaluationExecutorService()),
-                    Provider(create: (_) => TrainingSessionController()),
+                    Provider<ServiceRegistry>(
+                      create: (_) => ServiceRegistry()
+                        ..register<EvaluationExecutor>(
+                            EvaluationExecutorService()),
+                    ),
+                    Provider(
+                      create: (context) => TrainingSessionController(
+                        registry: context.read<ServiceRegistry>(),
+                      ),
+                    ),
                   ],
                   child: Builder(
                     builder: (context) => ChangeNotifierProvider(

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -49,13 +49,9 @@ abstract class EvaluationExecutor {
 
 /// Handles execution of a single evaluation request.
 class EvaluationExecutorService implements EvaluationExecutor {
-  EvaluationExecutorService._internal() {
+  EvaluationExecutorService() {
     _initFuture;
   }
-  static final EvaluationExecutorService _instance =
-      EvaluationExecutorService._internal();
-
-  factory EvaluationExecutorService() => _instance;
 
   final Queue<_QueueItem> _queue = Queue();
   final Map<String, EvalResult> _cache = {};

--- a/lib/services/evaluation_processing_service.dart
+++ b/lib/services/evaluation_processing_service.dart
@@ -5,6 +5,7 @@ import '../models/action_evaluation_request.dart';
 import 'evaluation_queue_service.dart';
 import 'retry_evaluation_service.dart';
 import 'evaluation_executor_service.dart';
+import 'service_registry.dart';
 import 'backup_manager_service.dart';
 import 'debug_snapshot_service.dart';
 import 'debug_panel_preferences.dart';
@@ -14,15 +15,16 @@ class EvaluationProcessingService {
   EvaluationProcessingService({
     required this.queueService,
     required this.debugPrefs,
+    required this.registry,
     this.backupManager,
     this.debugSnapshotService,
     this.debugPanelCallback,
-    EvaluationExecutorService? executorService,
+    EvaluationExecutor? executor,
     RetryEvaluationService? retryService,
   }) {
-    _executorService = executorService ?? EvaluationExecutorService();
-    _retryService =
-        retryService ?? RetryEvaluationService(executorService: _executorService);
+    _executor = executor ?? registry.get<EvaluationExecutor>();
+    _retryService = retryService ??
+        RetryEvaluationService(registry: registry, executor: _executor);
     debugPrefs.addListener(_onPrefsChanged);
     _initFuture = _initialize();
     queueService.debugPanelCallback = debugPanelCallback;
@@ -30,10 +32,11 @@ class EvaluationProcessingService {
 
   final EvaluationQueueService queueService;
   final DebugPanelPreferences debugPrefs;
+  final ServiceRegistry registry;
   BackupManagerService? backupManager;
   DebugSnapshotService? debugSnapshotService;
 
-  late final EvaluationExecutorService _executorService;
+  late final EvaluationExecutor _executor;
   late final RetryEvaluationService _retryService;
 
   late final Future<void> _initFuture;

--- a/lib/services/retry_evaluation_service.dart
+++ b/lib/services/retry_evaluation_service.dart
@@ -1,13 +1,16 @@
 import '../models/action_evaluation_request.dart';
 import 'evaluation_executor_service.dart';
+import 'service_registry.dart';
 import 'evaluation_queue_service.dart';
 
 /// Handles retry operations for evaluation requests.
 class RetryEvaluationService {
-  final EvaluationExecutorService _executorService;
+  final EvaluationExecutor _executor;
 
-  RetryEvaluationService({EvaluationExecutorService? executorService})
-      : _executorService = executorService ?? EvaluationExecutorService();
+  RetryEvaluationService({
+    required ServiceRegistry registry,
+    EvaluationExecutor? executor,
+  }) : _executor = executor ?? registry.get<EvaluationExecutor>();
 
   /// Attempts to execute an evaluation until it succeeds or [maxAttempts] is
   /// reached. The [req]'s `attempts` field will be updated on each failure.
@@ -19,7 +22,7 @@ class RetryEvaluationService {
     var success = false;
     while (!success && req.attempts < maxAttempts) {
       try {
-        await _executorService.execute(req);
+        await _executor.execute(req);
         success = true;
       } catch (_) {
         req.attempts++;

--- a/lib/services/training_session_controller.dart
+++ b/lib/services/training_session_controller.dart
@@ -3,12 +3,15 @@ import 'package:flutter/widgets.dart';
 import '../models/training_spot.dart';
 import '../models/evaluation_result.dart';
 import 'evaluation_executor_service.dart';
+import 'service_registry.dart';
 
 class TrainingSessionController {
-  TrainingSessionController({EvaluationExecutorService? executor})
-      : _executor = executor ?? EvaluationExecutorService();
+  TrainingSessionController({
+    required ServiceRegistry registry,
+    EvaluationExecutor? executor,
+  }) : _executor = executor ?? registry.get<EvaluationExecutor>();
 
-  final EvaluationExecutorService _executor;
+  final EvaluationExecutor _executor;
   TrainingSpot? _currentSpot;
 
   TrainingSpot? get currentSpot => _currentSpot;


### PR DESCRIPTION
## Summary
- remove singleton from `EvaluationExecutorService`
- register default executor during boot
- inject executor through `ServiceRegistry`
- allow plug-ins to override with `EvaluationExecutorExtension`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cc8e56a0832aabc0db39b3f70d9a