### PR TITLE
Add filter controls to session history

### DIFF
--- a/lib/screens/session_history_screen.dart
+++ b/lib/screens/session_history_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/date_utils.dart';
 import '../models/v2/training_session.dart';
@@ -21,11 +22,61 @@ class SessionHistoryScreen extends StatefulWidget {
 class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
   final List<TrainingSession> _sessions = [];
   Box<dynamic>? _box;
+  DateTime? _startDate;
+  DateTime? _endDate;
+  String? _tag;
+  String? _template;
+
+  static const _startKey = 'session_history_start';
+  static const _endKey = 'session_history_end';
+  static const _tagKey = 'session_history_tag';
+  static const _tplKey = 'session_history_tpl';
 
   @override
   void initState() {
     super.initState();
-    _load();
+    _loadPrefs().then((_) => _load());
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stats = context.read<TrainingStatsService>();
+    final startStr = prefs.getString(_startKey);
+    final endStr = prefs.getString(_endKey);
+    setState(() {
+      _startDate = startStr != null ? DateTime.tryParse(startStr) : null;
+      _endDate = endStr != null ? DateTime.tryParse(endStr) : null;
+      _tag = prefs.getString(_tagKey);
+      _template = prefs.getString(_tplKey);
+      if (_startDate == null) {
+        final days = stats.sessionsDaily(10000);
+        if (days.isNotEmpty) _startDate = days.first.key;
+      }
+    });
+  }
+
+  Future<void> _savePrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (_startDate != null) {
+      await prefs.setString(_startKey, _startDate!.toIso8601String());
+    } else {
+      await prefs.remove(_startKey);
+    }
+    if (_endDate != null) {
+      await prefs.setString(_endKey, _endDate!.toIso8601String());
+    } else {
+      await prefs.remove(_endKey);
+    }
+    if (_tag != null && _tag!.isNotEmpty) {
+      await prefs.setString(_tagKey, _tag!);
+    } else {
+      await prefs.remove(_tagKey);
+    }
+    if (_template != null && _template!.isNotEmpty) {
+      await prefs.setString(_tplKey, _template!);
+    } else {
+      await prefs.remove(_tplKey);
+    }
   }
 
   Future<void> _load() async {
@@ -53,6 +104,28 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
     });
   }
 
+  List<TrainingSession> get _filtered {
+    final manager = context.read<SavedHandManagerService>();
+    final hands = manager.hands;
+    return [
+      for (final s in _sessions)
+        if ((_startDate == null || !s.startedAt.isBefore(_startDate!)) &&
+            (_endDate == null ||
+                !(s.completedAt ?? DateTime.now()).isAfter(_endDate!)) &&
+            (_template == null ||
+                _template!.isEmpty ||
+                s.templateId == _template) &&
+            (_tag == null || _tag!.isEmpty
+                ? true
+                : hands.any((h) =>
+                    !h.savedAt.isBefore(s.startedAt) &&
+                    (s.completedAt == null ||
+                        !h.savedAt.isAfter(s.completedAt!)) &&
+                    h.tags.contains(_tag))))
+          s
+    ];
+  }
+
   Future<void> _exportNotes() async {
     final notes = context.read<SessionNoteService>();
     final stats = context.read<TrainingStatsService>();
@@ -77,7 +150,7 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
         ],
       ),
       backgroundColor: const Color(0xFF1B1C1E),
-      body: _sessions.isEmpty
+      body: _filtered.isEmpty
           ? const Center(
               child: Text(
                 'No sessions',
@@ -85,9 +158,92 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
               ),
             )
           : ListView.builder(
-              itemCount: _sessions.length,
+              itemCount: _filtered.length + 1,
               itemBuilder: (context, index) {
-                final s = _sessions[index];
+                if (index == 0) {
+                  final manager = context.watch<SavedHandManagerService>();
+                  final tags = manager.allTags.toList()..sort();
+                  final templates = _sessions
+                      .map((e) => e.templateId)
+                      .toSet()
+                      .toList()
+                    ..sort();
+                  return Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        OutlinedButton(
+                          onPressed: () async {
+                            final picked = await showDatePicker(
+                              context: context,
+                              initialDate: _startDate ?? DateTime.now(),
+                              firstDate: DateTime(2000),
+                              lastDate: DateTime.now(),
+                            );
+                            if (picked != null) {
+                              setState(() => _startDate = picked);
+                              _savePrefs();
+                            }
+                          },
+                          child: Text(_startDate == null
+                              ? 'Start'
+                              : formatDate(_startDate!)),
+                        ),
+                        OutlinedButton(
+                          onPressed: () async {
+                            final picked = await showDatePicker(
+                              context: context,
+                              initialDate: _endDate ?? DateTime.now(),
+                              firstDate: DateTime(2000),
+                              lastDate: DateTime.now(),
+                            );
+                            if (picked != null) {
+                              setState(() => _endDate = picked);
+                              _savePrefs();
+                            }
+                          },
+                          child: Text(
+                              _endDate == null ? 'End' : formatDate(_endDate!)),
+                        ),
+                        DropdownButton<String>(
+                          value: _tag?.isEmpty ?? true ? null : _tag,
+                          hint: const Text('Tag'),
+                          dropdownColor: const Color(0xFF2A2B2D),
+                          onChanged: (v) {
+                            setState(
+                                () => _tag = v?.isEmpty ?? true ? null : v);
+                            _savePrefs();
+                          },
+                          items: [
+                            const DropdownMenuItem(
+                                value: '', child: Text('All')),
+                            for (final t in tags)
+                              DropdownMenuItem(value: t, child: Text(t))
+                          ],
+                        ),
+                        DropdownButton<String>(
+                          value: _template?.isEmpty ?? true ? null : _template,
+                          hint: const Text('Template'),
+                          dropdownColor: const Color(0xFF2A2B2D),
+                          onChanged: (v) {
+                            setState(() =>
+                                _template = v?.isEmpty ?? true ? null : v);
+                            _savePrefs();
+                          },
+                          items: [
+                            const DropdownMenuItem(
+                                value: '', child: Text('All')),
+                            for (final t in templates)
+                              DropdownMenuItem(value: t, child: Text(t))
+                          ],
+                        ),
+                      ],
+                    ),
+                  );
+                }
+                final s = _filtered[index - 1];
                 final correct = s.results.values.where((e) => e).length;
                 return Card(
                   color: const Color(0xFF2A2B2D),
@@ -116,17 +272,20 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
                     ),
                   ),
                   onTap: () {
-                    final allHands = context.read<SavedHandManagerService>().hands;
+                    final allHands =
+                        context.read<SavedHandManagerService>().hands;
                     final List<SavedHand> sessionHands = [];
                     for (final h in allHands) {
                       final afterStart = !h.savedAt.isBefore(s.startedAt);
-                      final beforeEnd = s.completedAt == null || !h.savedAt.isAfter(s.completedAt!);
+                      final beforeEnd = s.completedAt == null ||
+                          !h.savedAt.isAfter(s.completedAt!);
                       if (afterStart && beforeEnd) sessionHands.add(h);
                     }
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => SessionAnalysisScreen(hands: sessionHands),
+                        builder: (_) =>
+                            SessionAnalysisScreen(hands: sessionHands),
                       ),
                     );
                   },


### PR DESCRIPTION
## Summary
- filter sessions by date, tag, and template
- remember filters in preferences

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6872cc96b468832ab5a00ec3253e55f3