### PR TITLE
Add configurable ICM payouts

### DIFF
--- a/lib/screens/evaluation_settings_screen.dart
+++ b/lib/screens/evaluation_settings_screen.dart
@@ -12,6 +12,7 @@ class EvaluationSettingsScreen extends StatefulWidget {
 class _EvaluationSettingsScreenState extends State<EvaluationSettingsScreen> {
   late bool _offline;
   late TextEditingController _endpoint;
+  late TextEditingController _payouts;
 
   @override
   void initState() {
@@ -19,6 +20,7 @@ class _EvaluationSettingsScreenState extends State<EvaluationSettingsScreen> {
     final s = EvaluationSettingsService.instance;
     _offline = s.offline;
     _endpoint = TextEditingController(text: s.remoteEndpoint);
+    _payouts = TextEditingController(text: s.payouts.join(','));
   }
 
   Future<void> _setOffline(bool v) async {
@@ -31,9 +33,21 @@ class _EvaluationSettingsScreenState extends State<EvaluationSettingsScreen> {
     await EvaluationSettingsService.instance.update(endpoint: v);
   }
 
+  Future<void> _setPayouts(String v) async {
+    final p = v
+        .split(',')
+        .map((e) => double.tryParse(e.trim()))
+        .whereType<double>()
+        .toList();
+    if (p.isNotEmpty) {
+      await EvaluationSettingsService.instance.update(payouts: p);
+    }
+  }
+
   @override
   void dispose() {
     _endpoint.dispose();
+    _payouts.dispose();
     super.dispose();
   }
 
@@ -58,6 +72,12 @@ class _EvaluationSettingsScreenState extends State<EvaluationSettingsScreen> {
             controller: _endpoint,
             decoration: const InputDecoration(labelText: 'EV API Endpoint'),
             onChanged: _setEndpoint,
+          ),
+          TextField(
+            controller: _payouts,
+            decoration:
+                const InputDecoration(labelText: 'ICM Payouts (comma)'),
+            onChanged: _setPayouts,
           ),
         ],
       ),

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -418,6 +418,7 @@ class EvaluationExecutorService implements EvaluationExecutor {
             'hero': hero,
             'hand': code,
             'ante': anteBb,
+            'payouts': settings.payouts,
           },
         );
         final acts = spot.hand.actions[0] ?? [];
@@ -434,7 +435,8 @@ class EvaluationExecutorService implements EvaluationExecutor {
       await const PushFoldEvService().evaluate(spot, anteBb: anteBb);
     }
     if (spot.heroIcmEv == null) {
-      await const PushFoldEvService().evaluateIcm(spot, anteBb: anteBb);
+      await const PushFoldEvService()
+          .evaluateIcm(spot, anteBb: anteBb, payouts: settings.payouts);
     }
     if ((prevEv == null && spot.heroEv != null) ||
         (prevIcm == null && spot.heroIcmEv != null)) {
@@ -538,6 +540,7 @@ Map<String, double> _computeEv(Map<String, dynamic> args) {
   final hero = args['hero'] as int;
   final hand = args['hand'] as String;
   final ante = args['ante'] as int;
+  final payouts = List<double>.from(args['payouts'] as List);
   final ev = computePushEV(
     heroBbStack: stacks[hero],
     bbCount: stacks.length - 1,
@@ -549,6 +552,7 @@ Map<String, double> _computeEv(Map<String, dynamic> args) {
     heroIndex: hero,
     heroHand: hand,
     anteBb: ante,
+    payouts: payouts,
   );
   return {'ev': ev, 'icm': icm};
 }

--- a/lib/services/evaluation_settings_service.dart
+++ b/lib/services/evaluation_settings_service.dart
@@ -10,11 +10,13 @@ class EvaluationSettingsService {
   static const _icmKey = 'evaluation_use_icm';
   static const _endpointKey = 'evaluation_api_endpoint';
   static const _offlineKey = 'evaluation_offline_mode';
+  static const _payoutsKey = 'evaluation_icm_payouts';
 
   double evThreshold = -0.01;
   bool useIcm = false;
   String remoteEndpoint = '';
   bool offline = false;
+  List<double> payouts = const [0.5, 0.3, 0.2];
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -22,9 +24,13 @@ class EvaluationSettingsService {
     useIcm = prefs.getBool(_icmKey) ?? false;
     remoteEndpoint = prefs.getString(_endpointKey) ?? '';
     offline = prefs.getBool(_offlineKey) ?? false;
+    final p = prefs.getString(_payoutsKey);
+    if (p != null && p.isNotEmpty) {
+      payouts = p.split(',').map(double.parse).toList();
+    }
   }
 
-  Future<void> update({double? threshold, bool? icm, String? endpoint, bool? offline}) async {
+  Future<void> update({double? threshold, bool? icm, String? endpoint, bool? offline, List<double>? payouts}) async {
     final prefs = await SharedPreferences.getInstance();
     if (threshold != null) {
       evThreshold = threshold;
@@ -41,6 +47,10 @@ class EvaluationSettingsService {
     if (offline != null) {
       this.offline = offline;
       await prefs.setBool(_offlineKey, offline);
+    }
+    if (payouts != null) {
+      this.payouts = payouts;
+      await prefs.setString(_payoutsKey, payouts.join(','));
     }
   }
 }

--- a/lib/services/icm_push_ev_service.dart
+++ b/lib/services/icm_push_ev_service.dart
@@ -5,9 +5,9 @@ double computeIcmPushEV({
   required int heroIndex,
   required String heroHand,
   required double chipPushEv,
+  List<double> payouts = const [0.5, 0.3, 0.2],
 }) {
   double icmValue(List<double> stacks, int idx) {
-    final payouts = [0.5, 0.3, 0.2];
     double prob(int rank, List<double> s, int hero) {
       final total = s.fold<double>(0, (p, e) => p + e);
       if (rank == 1) return s[hero] / total;
@@ -40,6 +40,7 @@ double computeLocalIcmPushEV({
   required int heroIndex,
   required String heroHand,
   required int anteBb,
+  List<double> payouts = const [0.5, 0.3, 0.2],
 }) {
   final ev = computePushEV(
     heroBbStack: chipStacksBb[heroIndex],
@@ -52,6 +53,7 @@ double computeLocalIcmPushEV({
     heroIndex: heroIndex,
     heroHand: heroHand,
     chipPushEv: ev,
+    payouts: payouts,
   );
 }
 

--- a/lib/services/push_fold_ev_service.dart
+++ b/lib/services/push_fold_ev_service.dart
@@ -48,7 +48,8 @@ class PushFoldEvService {
     }
   }
 
-  Future<void> evaluateIcm(TrainingPackSpot spot, {int anteBb = 0}) async {
+  Future<void> evaluateIcm(TrainingPackSpot spot,
+      {int anteBb = 0, List<double> payouts = const [0.5, 0.3, 0.2]}) async {
     final hero = spot.hand.heroIndex;
     final hand = handCode(spot.hand.heroCards);
     final stack = spot.hand.stacks['$hero']?.round();
@@ -71,6 +72,7 @@ class PushFoldEvService {
           heroIndex: hero,
           heroHand: hand,
           chipPushEv: chipEv,
+          payouts: payouts,
         );
         break;
       }


### PR DESCRIPTION
## Summary
- allow specifying payouts in EvaluationSettingsService
- pass payouts to ICM EV calculations
- expose payout editing in Evaluation Settings screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cc924628832a916685d68b17b722