### PR TITLE
Add position and tag analytics

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -35,6 +35,7 @@ import 'community_plugin_screen.dart';
 import 'onboarding_screen.dart';
 import 'ev_icm_analytics_screen.dart';
 import 'progress_dashboard_screen.dart';
+import 'position_tag_analytics_screen.dart';
 import 'weakness_overview_screen.dart';
 import 'notification_settings_screen.dart';
 import 'package:provider/provider.dart';
@@ -263,6 +264,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                     ),
                   );
                   break;
+                case 'pos_tag':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PositionTagAnalyticsScreen(),
+                    ),
+                  );
+                  break;
                 case 'notifications':
                   Navigator.push(
                     context,
@@ -283,6 +292,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               PopupMenuItem(value: 'community_plugins', child: Text('🌐 Community')),
               PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
               PopupMenuItem(value: 'evicm', child: Text('EV/ICM')),
+              PopupMenuItem(value: 'pos_tag', child: Text('Позиции/Теги')),
               PopupMenuItem(value: 'dashboard', child: Text('📈 Dashboard')),
               PopupMenuItem(value: 'about', child: Text('About')),
             ],

--- a/lib/screens/position_tag_analytics_screen.dart
+++ b/lib/screens/position_tag_analytics_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/progress_forecast_service.dart';
+import '../widgets/ev_icm_series_chart.dart';
+import '../widgets/sync_status_widget.dart';
+
+class PositionTagAnalyticsScreen extends StatefulWidget {
+  static const route = '/position_tag_analytics';
+  const PositionTagAnalyticsScreen({super.key});
+
+  @override
+  State<PositionTagAnalyticsScreen> createState() => _PositionTagAnalyticsScreenState();
+}
+
+class _PositionTagAnalyticsScreenState extends State<PositionTagAnalyticsScreen> {
+  bool _byTag = false;
+  String? _current;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<ProgressForecastService>();
+    final values = _byTag ? service.tags : service.positions;
+    if (_current == null || !values.contains(_current)) {
+      _current = values.isNotEmpty ? values.first : null;
+    }
+    final data = _byTag
+        ? (_current != null ? service.tagSeries(_current!) : const <ProgressEntry>[])
+        : (_current != null ? service.positionSeries(_current!) : const <ProgressEntry>[]);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Position & Tag'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Row(
+            children: [
+              DropdownButton<bool>(
+                value: _byTag,
+                dropdownColor: Colors.black,
+                style: const TextStyle(color: Colors.white),
+                items: const [
+                  DropdownMenuItem(value: false, child: Text('Position')),
+                  DropdownMenuItem(value: true, child: Text('Tag')),
+                ],
+                onChanged: (v) => setState(() => _byTag = v ?? false),
+              ),
+              const SizedBox(width: 16),
+              DropdownButton<String>(
+                value: _current,
+                dropdownColor: Colors.black,
+                style: const TextStyle(color: Colors.white),
+                items: [
+                  for (final v in values) DropdownMenuItem(value: v, child: Text(v))
+                ],
+                onChanged: (v) => setState(() => _current = v),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          EvIcmSeriesChart(data: data),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/ev_icm_series_chart.dart
+++ b/lib/widgets/ev_icm_series_chart.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'common/animated_line_chart.dart';
+import '../theme/app_colors.dart';
+import '../services/progress_forecast_service.dart';
+
+class EvIcmSeriesChart extends StatelessWidget {
+  final List<ProgressEntry> data;
+  const EvIcmSeriesChart({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final ev = [for (final e in data) MapEntry(e.date, e.ev)];
+    final icm = [for (final e in data) MapEntry(e.date, e.icm)];
+    final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
+      ..sort();
+    if (dates.length < 2) return const SizedBox(height: 200);
+    final evMap = {for (final e in ev) e.key: e.value};
+    final icmMap = {for (final e in icm) e.key: e.value};
+    final spotsEv = <FlSpot>[];
+    final spotsIcm = <FlSpot>[];
+    double minY = 0;
+    double maxY = 0;
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final v1 = evMap[d];
+      final v2 = icmMap[d];
+      if (v1 != null) {
+        spotsEv.add(FlSpot(i.toDouble(), v1));
+        if (v1 < minY) minY = v1;
+        if (v1 > maxY) maxY = v1;
+      }
+      if (v2 != null) {
+        spotsIcm.add(FlSpot(i.toDouble(), v2));
+        if (v2 < minY) minY = v2;
+        if (v2 > maxY) maxY = v2;
+      }
+    }
+    if (minY == maxY) {
+      minY -= 1;
+      maxY += 1;
+    }
+    final interval = (maxY - minY) / 4;
+    final step = (dates.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AnimatedLineChart(
+        data: LineChartData(
+          minY: minY,
+          maxY: maxY,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: interval,
+            getDrawingHorizontalLine: (v) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: interval,
+                reservedSize: 40,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toStringAsFixed(1),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= dates.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != dates.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = dates[i];
+                  return Text(
+                    '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spotsEv,
+              color: AppColors.evPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+            LineChartBarData(
+              spots: spotsIcm,
+              color: AppColors.icmPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extend ProgressEntry with position and tag
- compute position/tag aggregates in ProgressForecastService
- plot custom EV/ICM series
- add analytics screen for position/tag trends
- expose screen from navigation menu

## Testing
- `flutter --version` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_6872d0bfa0f4832aad43bd65710318b6