### PR TITLE
Add plugin metadata support

### DIFF
--- a/lib/plugins/converter_discovery_plugin.dart
+++ b/lib/plugins/converter_discovery_plugin.dart
@@ -22,4 +22,13 @@ class ConverterDiscoveryPlugin implements Plugin {
       converterRegistry.register(plugin);
     }
   }
+
+  @override
+  String get name => 'Converter Discovery';
+
+  @override
+  String get description => 'Registers converters into a registry';
+
+  @override
+  String get version => '1.0.0';
 }

--- a/lib/plugins/gg_poker_converter_plugin.dart
+++ b/lib/plugins/gg_poker_converter_plugin.dart
@@ -9,5 +9,14 @@ class GGPokerConverterPlugin extends GGPokerHandHistoryConverter implements Plug
     registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
     registry.get<ConverterRegistry>().register(this);
   }
+
+  @override
+  String get name => 'GGPoker Converter';
+
+  @override
+  String get description => 'Adds GGPoker hand history conversion';
+
+  @override
+  String get version => '1.0.0';
 }
 

--- a/lib/plugins/plugin.dart
+++ b/lib/plugins/plugin.dart
@@ -15,6 +15,12 @@ abstract class Plugin implements PluginInterface {
   @override
   List<ServiceExtension<dynamic>> get extensions => <ServiceExtension<dynamic>>[];
 
+  String get name;
+
+  String get description;
+
+  String get version;
+
   @override
   void unregister(ServiceRegistry registry) {}
 }

--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -148,7 +148,7 @@ class PluginLoader {
       }
       if (plugin != null) {
         ErrorLogger.instance.logError('Plugin loaded: $name');
-        await manager.logStatus(name, 'loaded');
+        await manager.logStatus(name, 'loaded', plugin: plugin);
         return plugin;
       }
       ErrorLogger.instance.logError('Plugin failed: $name');

--- a/lib/plugins/poker_stars_converter_plugin.dart
+++ b/lib/plugins/poker_stars_converter_plugin.dart
@@ -9,4 +9,13 @@ class PokerStarsConverterPlugin extends PokerStarsHandHistoryConverter implement
     registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
     registry.get<ConverterRegistry>().register(this);
   }
+
+  @override
+  String get name => 'PokerStars Converter';
+
+  @override
+  String get description => 'Adds PokerStars hand history conversion';
+
+  @override
+  String get version => '1.0.0';
 }

--- a/lib/plugins/sample_logging_plugin.dart
+++ b/lib/plugins/sample_logging_plugin.dart
@@ -27,5 +27,14 @@ class SampleLoggingPlugin implements Plugin {
   @override
   List<ServiceExtension<dynamic>> get extensions =>
       <ServiceExtension<dynamic>>[LoggerServiceExtension()];
+
+  @override
+  String get name => 'Sample Logging';
+
+  @override
+  String get description => 'Provides a simple logger service';
+
+  @override
+  String get version => '1.0.0';
 }
 

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -20,7 +20,7 @@ class PluginManagerScreen extends StatefulWidget {
 class _PluginManagerScreenState extends State<PluginManagerScreen> {
   Map<String, bool> _config = <String, bool>{};
   List<String> _files = <String>[];
-  Map<String, String> _status = <String, String>{};
+  Map<String, Map<String, dynamic>> _status = <String, Map<String, dynamic>>{};
   final TextEditingController _urlCtr = TextEditingController();
 
   @override
@@ -60,7 +60,9 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
     setState(() {
       _config = Map<String, bool>.from(config);
       _files = files;
-      _status = Map<String, String>.from(status);
+      _status = status.map(
+        (k, v) => MapEntry(k, Map<String, dynamic>.from(v)),
+      );
     });
   }
 
@@ -173,12 +175,27 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
               itemBuilder: (context, index) {
                 final file = _files[index];
                 final enabled = _config[file] ?? true;
-                final status = _status[file];
+                final info = _status[file];
+                final status = info?['status'] as String?;
+                final name = info?['name'] as String?;
+                final desc = info?['description'] as String?;
+                final version = info?['version'] as String?;
+                final subtitleWidgets = <Widget>[];
+                if (name != null) subtitleWidgets.add(Text(name));
+                if (version != null)
+                  subtitleWidgets.add(Text('v$version'));
+                if (desc != null) subtitleWidgets.add(Text(desc));
+                if (status != null && status != 'loaded')
+                  subtitleWidgets.add(
+                      Text(status, style: const TextStyle(color: Colors.red)));
                 return ListTile(
                   title: Text(file),
-                  subtitle: status != null && status != 'loaded'
-                      ? Text(status, style: const TextStyle(color: Colors.red))
-                      : null,
+                  subtitle: subtitleWidgets.isEmpty
+                      ? null
+                      : Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: subtitleWidgets,
+                        ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/tests/architecture/plugin_manager_test.dart
+++ b/tests/architecture/plugin_manager_test.dart
@@ -20,6 +20,15 @@ class _PluginA implements Plugin {
 
   @override
   List<ServiceExtension<dynamic>> get extensions => <ServiceExtension<dynamic>>[_IntExtension()];
+
+  @override
+  String get name => 'A';
+
+  @override
+  String get description => '';
+
+  @override
+  String get version => '1.0.0';
 }
 
 class _PluginB implements Plugin {
@@ -30,6 +39,15 @@ class _PluginB implements Plugin {
     registerCount++;
     registry.register<bool>(true);
   }
+
+  @override
+  String get name => 'B';
+
+  @override
+  String get description => '';
+
+  @override
+  String get version => '1.0.0';
 }
 
 void main() {

--- a/tools/plugin_scaffold.dart
+++ b/tools/plugin_scaffold.dart
@@ -35,6 +35,15 @@ class $name implements Plugin {
   List<ServiceExtension<dynamic>> get extensions => <ServiceExtension<dynamic>>[
         ${name}Extension(),
       ];
+
+  @override
+  String get name => '$name';
+
+  @override
+  String get description => '';
+
+  @override
+  String get version => '1.0.0';
 }
 ''';
   file.writeAsStringSync(content);


### PR DESCRIPTION
## Summary
- support name, description and version in `Plugin`
- log metadata via `PluginManager`
- expose plugin metadata in `PluginManagerScreen`
- adapt built-in plugins and scaffold to new API

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d0c4482c832a9a75fc85a7c08dba