### PR TITLE
Add hand editing flow

### DIFF
--- a/lib/screens/analyzer_result_screen.dart
+++ b/lib/screens/analyzer_result_screen.dart
@@ -7,6 +7,13 @@ import '../services/training_session_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'training_session_screen.dart';
 import '../theme/app_colors.dart';
+import '../screens/saved_hand_editor_screen.dart';
+import '../services/evaluation_executor_service.dart';
+import '../models/v2/hero_position.dart';
+import '../models/v2/hand_data.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/action_entry.dart';
+import 'package:uuid/uuid.dart';
 
 class AnalyzerResultScreen extends StatefulWidget {
   final SavedHand hand;
@@ -17,11 +24,70 @@ class AnalyzerResultScreen extends StatefulWidget {
 }
 
 class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
+  late SavedHand _hand;
+
+  Future<void> _edit() async {
+    final result = await Navigator.push<SavedHand>(
+      context,
+      MaterialPageRoute(builder: (_) => SavedHandEditorScreen(hand: _hand)),
+    );
+    if (result != null && mounted) {
+      _hand = result;
+      setState(() {});
+      await _evaluate();
+    }
+  }
+
+  TrainingPackSpot _spotFromHand(SavedHand h) {
+    final hero = h.playerCards[h.heroIndex]
+        .map((c) => '${c.rank}${c.suit}')
+        .join(' ');
+    final actions = <int, List<ActionEntry>>{for (var s = 0; s < 4; s++) s: []};
+    for (final a in h.actions) {
+      actions[a.street]!.add(a);
+    }
+    final stacks = <String, double>{
+      for (int i = 0; i < h.numberOfPlayers; i++)
+        '$i': (h.stackSizes[i] ?? 0).toDouble()
+    };
+    return TrainingPackSpot(
+      id: const Uuid().v4(),
+      hand: HandData(
+        heroCards: hero,
+        position: parseHeroPosition(h.heroPosition),
+        heroIndex: h.heroIndex,
+        playerCount: h.numberOfPlayers,
+        stacks: stacks,
+        board: [for (final c in h.boardCards) '${c.rank}${c.suit}'],
+        actions: actions,
+        anteBb: h.anteBb,
+      ),
+    );
+  }
+
+  Future<void> _evaluate() async {
+    final spot = _spotFromHand(_hand);
+    await context
+        .read<EvaluationExecutorService>()
+        .evaluateSingle(context, spot, hand: _hand, anteBb: _hand.anteBb);
+    final acts = <ActionEntry>[];
+    for (final l in spot.hand.actions.values) {
+      acts.addAll(l);
+    }
+    final updated = _hand.copyWith(
+      actions: acts,
+      gtoAction: spot.correctAction,
+    );
+    await context.read<SavedHandManagerService>().save(updated);
+    if (mounted) setState(() => _hand = updated);
+  }
+
   @override
   void initState() {
     super.initState();
+    _hand = widget.hand;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final loss = widget.hand.evLoss ?? 0;
+      final loss = _hand.evLoss ?? 0;
       if (loss.abs() >= 1.0) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -29,7 +95,7 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
             action: SnackBarAction(
               label: 'Тренировать похожее',
               onPressed: () async {
-                final tpl = await TrainingPackService.createSimilarMistakeDrill(widget.hand);
+                final tpl = await TrainingPackService.createSimilarMistakeDrill(_hand);
                 if (tpl == null) return;
                 await context.read<TrainingSessionService>().startSession(tpl);
                 if (context.mounted) {
@@ -47,23 +113,23 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
   }
 
   bool get _isMistake {
-    final exp = widget.hand.expectedAction?.trim().toLowerCase();
-    final gto = widget.hand.gtoAction?.trim().toLowerCase();
+    final exp = _hand.expectedAction?.trim().toLowerCase();
+    final gto = _hand.gtoAction?.trim().toLowerCase();
     if (exp == null || gto == null) return false;
-    if ((widget.hand.evLoss ?? 0).abs() < 1.0) return false;
+    if ((_hand.evLoss ?? 0).abs() < 1.0) return false;
     return exp != gto;
   }
 
   @override
   Widget build(BuildContext context) {
     final similarCount = context.select<SavedHandManagerService, int>((s) {
-      final cat = widget.hand.category;
-      final pos = widget.hand.heroPosition;
-      final stack = widget.hand.stackSizes[widget.hand.heroIndex];
+      final cat = _hand.category;
+      final pos = _hand.heroPosition;
+      final stack = _hand.stackSizes[_hand.heroIndex];
       if (cat == null || stack == null) return 0;
       return s.hands
           .where((h) =>
-              h != widget.hand &&
+              h != _hand &&
               h.category == cat &&
               h.heroPosition == pos &&
               h.stackSizes[h.heroIndex] == stack &&
@@ -75,7 +141,10 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
     });
     final showFab = _isMistake && similarCount > 0;
     return Scaffold(
-      appBar: AppBar(title: const Text('Результаты анализа')),
+      appBar: AppBar(
+        title: const Text('Результаты анализа'),
+        actions: [IconButton(onPressed: _edit, icon: const Icon(Icons.edit))],
+      ),
       backgroundColor: AppColors.background,
       body: const SizedBox.shrink(),
       floatingActionButton: showFab
@@ -86,7 +155,7 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
                   onPressed: () async {
                     final tpl =
                         await TrainingPackService.createSimilarMistakeDrill(
-                            widget.hand);
+                            _hand);
                     if (tpl == null) return;
                     await context
                         .read<TrainingSessionService>()


### PR DESCRIPTION
## Summary
- allow editing hand from AnalyzerResultScreen
- evaluate updated hand after editing

## Testing
- `flutter analyze` *(fails: The current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6872d2c705c0832a89b2f92bba0af3a6