### PR TITLE
Implement Top 3 categories drill

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -36,6 +36,7 @@ import '../services/cloud_sync_service.dart';
 import '../services/bulk_evaluator_service.dart';
 import '../utils/template_coverage_utils.dart';
 import '../services/mistake_review_pack_service.dart';
+import '../services/training_pack_service.dart';
 import 'mistake_review_screen.dart';
 import 'package:intl/intl.dart';
 import 'training_stats_screen.dart';
@@ -604,6 +605,17 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
         return builtIn[Random().nextInt(builtIn.length)];
       }()
     );
+    if (tpl == null) return;
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  Future<void> _top3CategoriesDrill() async {
+    final tpl = await TrainingPackService.createDrillFromTop3Categories(context);
     if (tpl == null) return;
     await context.read<TrainingSessionService>().startSession(tpl);
     if (!mounted) return;
@@ -1260,6 +1272,13 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
             onPressed: _quickPractice,
             label: const Text('Quick Practice'),
             icon: const Icon(Icons.play_arrow),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'top3CatFab',
+            onPressed: _top3CategoriesDrill,
+            label: const Text('Top 3 категории'),
+            icon: const Icon(Icons.leaderboard),
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -87,6 +87,42 @@ class TrainingPackService {
     return createDrillFromCategory(context, category);
   }
 
+  static Future<TrainingPackTemplate?> createDrillFromTop3Categories(
+      BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final byCat = <String, List<SavedHand>>{};
+    final ev = <String, double>{};
+    for (final h in hands) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      byCat.putIfAbsent(cat, () => []).add(h);
+      ev[cat] = (ev[cat] ?? 0) + (h.evLoss ?? 0);
+    }
+    if (ev.length < 3) return null;
+    final rng = Random();
+    final cats = ev.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final spots = <TrainingPackSpot>[];
+    for (final e in cats.take(3)) {
+      final list = byCat[e.key]!
+        ..sort((a, b) => (b.evLoss ?? 0).compareTo(a.evLoss ?? 0));
+      final count = min(list.length, 3 + rng.nextInt(3));
+      for (final h in list.take(count)) {
+        spots.add(_spotFromHand(h));
+      }
+    }
+    if (spots.isEmpty) return null;
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Drill: топ-3 категории',
+      spots: spots,
+    );
+  }
+
   static Future<TrainingPackTemplate?> createDrillFromTopCategories(
       BuildContext context) async {
     final hands = context.read<SavedHandManagerService>().hands;
@@ -141,7 +177,7 @@ class TrainingPackService {
 
   static Future<TrainingPackTemplate?> createTopMistakeDrill(
       BuildContext context) async {
-    return createDrillFromTopCategories(context);
+    return createDrillFromTop3Categories(context);
   }
 
   static Future<TrainingPackTemplate?> createRepeatDrillForCorrected(


### PR DESCRIPTION
## Summary
- create `createDrillFromTop3Categories` for TrainingPackService
- update TemplateLibraryScreen with button to start Top 3 Categories drill
- hook Top Mistake drill to use new method

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d696526c832ab22076a1067d72d1