### PR TITLE
Add iPoker converter plugin

### DIFF
--- a/lib/plugins/converters/ipoker_hand_history_converter.dart
+++ b/lib/plugins/converters/ipoker_hand_history_converter.dart
@@ -1,0 +1,144 @@
+import '../converter_format_capabilities.dart';
+import '../converter_plugin.dart';
+import 'package:poker_analyzer/models/saved_hand.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+
+class IpokerHandHistoryConverter extends ConverterPlugin {
+  IpokerHandHistoryConverter()
+      : super(
+          formatId: 'ipoker_hand_history',
+          description: 'iPoker hand history format',
+          capabilities: const ConverterFormatCapabilities(
+            supportsImport: true,
+            supportsExport: false,
+            requiresBoard: false,
+            supportsMultiStreet: false,
+          ),
+        );
+
+  CardModel? _parseCard(String token) {
+    if (token.length < 2) return null;
+    final rank = token.substring(0, token.length - 1).toUpperCase();
+    final suitChar = token[token.length - 1].toLowerCase();
+    switch (suitChar) {
+      case 'h':
+        return CardModel(rank: rank, suit: '♥');
+      case 'd':
+        return CardModel(rank: rank, suit: '♦');
+      case 'c':
+        return CardModel(rank: rank, suit: '♣');
+      case 's':
+        return CardModel(rank: rank, suit: '♠');
+    }
+    return null;
+  }
+
+  double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
+
+  @override
+  SavedHand? convertFrom(String externalData) {
+    final lines = externalData.split(RegExp(r'\r?\n'));
+    if (lines.isEmpty || !lines.first.toLowerCase().contains('ipoker')) {
+      return null;
+    }
+    final seatRegex =
+        RegExp(r'^Seat (\d+):\s*(.+?) \(([^)]+)\)', caseSensitive: false);
+    final seatEntries = <Map<String, dynamic>>[];
+    for (final line in lines) {
+      final m = seatRegex.firstMatch(line.trim());
+      if (m != null) {
+        seatEntries.add({
+          'seat': int.parse(m.group(1)!),
+          'name': m.group(2)!.trim(),
+          'stack': _amount(m.group(3)!),
+        });
+      }
+    }
+    if (seatEntries.isEmpty) return null;
+    seatEntries.sort((a, b) => (a['seat'] as int).compareTo(b['seat'] as int));
+    final playerCount = seatEntries.length;
+
+    String? heroName;
+    List<CardModel> heroCards = [];
+    for (final line in lines) {
+      final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
+      if (m != null) {
+        heroName = m.group(1)!.trim();
+        final c1 = _parseCard(m.group(2)!);
+        final c2 = _parseCard(m.group(3)!);
+        if (c1 != null && c2 != null) heroCards = [c1, c2];
+        break;
+      }
+    }
+    final nameToIndex = <String, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      nameToIndex[seatEntries[i]['name'].toString().toLowerCase()] = i;
+    }
+    int heroIndex = 0;
+    if (heroName != null) {
+      heroIndex = nameToIndex[heroName.toLowerCase()] ?? 0;
+    }
+    final playerCards = List.generate(playerCount, (_) => <CardModel>[]);
+    if (heroCards.isNotEmpty) playerCards[heroIndex] = heroCards;
+    final stackSizes = <int, int>{};
+    for (int i = 0; i < playerCount; i++) {
+      stackSizes[i] = (seatEntries[i]['stack'] as double).round();
+    }
+    final actions = <ActionEntry>[];
+    bool preflop = false;
+    for (final line in lines) {
+      final t = line.trim();
+      if (t.startsWith('*** HOLE CARDS')) preflop = true;
+      if (t.startsWith('*** FLOP')) preflop = false;
+      if (!preflop) continue;
+      Match? m;
+      m = RegExp(r'^(.+?): folds').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'fold'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): checks').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'check'));
+        continue;
+      }
+      m = RegExp(r'^(.+?): calls ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'call', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): bets ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'bet', amount: _amount(m.group(2)!)));
+        continue;
+      }
+      m = RegExp(r'^(.+?): raises .* to ([\d.,]+)').firstMatch(t);
+      if (m != null) {
+        final idx = nameToIndex[m.group(1)!.toLowerCase()];
+        if (idx != null) actions.add(ActionEntry(0, idx, 'raise', amount: _amount(m.group(2)!)));
+        continue;
+      }
+    }
+    final positions = {for (int i = 0; i < playerCount; i++) i: ''};
+    return SavedHand(
+      name: '',
+      heroIndex: heroIndex,
+      heroPosition: positions[heroIndex] ?? '',
+      numberOfPlayers: playerCount,
+      playerCards: playerCards,
+      boardCards: const [],
+      boardStreet: 0,
+      actions: actions,
+      stackSizes: stackSizes,
+      playerPositions: positions,
+      comment: '',
+      playerTypes: {for (int i = 0; i < playerCount; i++) i: PlayerType.unknown},
+    );
+  }
+}

--- a/lib/plugins/ipoker_converter_plugin.dart
+++ b/lib/plugins/ipoker_converter_plugin.dart
@@ -1,0 +1,21 @@
+import 'package:poker_analyzer/plugins/converters/ipoker_hand_history_converter.dart';
+import 'package:poker_analyzer/plugins/plugin.dart';
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+
+class IpokerConverterPlugin extends IpokerHandHistoryConverter implements Plugin {
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
+    registry.get<ConverterRegistry>().register(this);
+  }
+
+  @override
+  String get name => 'iPoker Converter';
+
+  @override
+  String get description => 'Adds iPoker hand history conversion';
+
+  @override
+  String get version => '1.0.0';
+}

--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -24,8 +24,10 @@ import 'converters/winamax_hand_history_converter.dart';
 import 'converters/partypoker_hand_history_converter.dart';
 import 'converters/wpn_hand_history_converter.dart';
 import 'converters/888poker_hand_history_converter.dart';
+import 'converters/ipoker_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
+import 'ipoker_converter_plugin.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -78,6 +80,7 @@ class PluginLoader {
       PartyPokerHandHistoryConverter(),
       WpnHandHistoryConverter(),
       Poker888HandHistoryConverter(),
+      IpokerHandHistoryConverter(),
     ];
     return <Plugin>[
       SampleLoggingPlugin(),
@@ -99,11 +102,14 @@ class PluginLoader {
           PartyPokerHandHistoryConverter(),
           WpnHandHistoryConverter(),
           Poker888HandHistoryConverter(),
+          IpokerHandHistoryConverter(),
         ]);
       case 'PokerStarsConverterPlugin':
         return PokerStarsConverterPlugin();
       case 'GGPokerConverterPlugin':
         return GGPokerConverterPlugin();
+      case 'IpokerConverterPlugin':
+        return IpokerConverterPlugin();
     }
     return null;
   }

--- a/lib/plugins/plugin_loader_web.dart
+++ b/lib/plugins/plugin_loader_web.dart
@@ -21,8 +21,10 @@ import 'converters/winamax_hand_history_converter.dart';
 import 'converters/partypoker_hand_history_converter.dart';
 import 'converters/wpn_hand_history_converter.dart';
 import 'converters/888poker_hand_history_converter.dart';
+import 'converters/ipoker_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
+import 'ipoker_converter_plugin.dart';
 
 class PluginLoader {
   static const String _suffix = 'Plugin.dart';
@@ -91,6 +93,7 @@ class PluginLoader {
       PartyPokerHandHistoryConverter(),
       WpnHandHistoryConverter(),
       Poker888HandHistoryConverter(),
+      IpokerHandHistoryConverter(),
     ];
     return <Plugin>[
       SampleLoggingPlugin(),
@@ -112,11 +115,14 @@ class PluginLoader {
           PartyPokerHandHistoryConverter(),
           WpnHandHistoryConverter(),
           Poker888HandHistoryConverter(),
+          IpokerHandHistoryConverter(),
         ]);
       case 'PokerStarsConverterPlugin':
         return PokerStarsConverterPlugin();
       case 'GGPokerConverterPlugin':
         return GGPokerConverterPlugin();
+      case 'IpokerConverterPlugin':
+        return IpokerConverterPlugin();
     }
     return null;
   }

--- a/plugins/IpokerConverterPlugin.dart
+++ b/plugins/IpokerConverterPlugin.dart
@@ -1,0 +1,6 @@
+import 'dart:isolate';
+import 'package:poker_analyzer/plugins/ipoker_converter_plugin.dart';
+
+void main(List<String> args, SendPort sendPort) {
+  sendPort.send(IpokerConverterPlugin());
+}

--- a/tests/converter_validation_test.dart
+++ b/tests/converter_validation_test.dart
@@ -100,6 +100,17 @@ void main() {
               'Villain folds',
             ].join('\n');
             break;
+          case 'ipoker_hand_history':
+            sample = [
+              'iPoker Hand #1',
+              'Seat 1: Hero (1)',
+              'Seat 2: Villain (1)',
+              '*** HOLE CARDS ***',
+              'Dealt to Hero [Ah Kh]',
+              'Hero raises to 2',
+              'Villain folds',
+            ].join('\n');
+            break;
           default:
             sample = '';
         }


### PR DESCRIPTION
## Summary
- implement IpokerHandHistoryConverter
- create IpokerConverterPlugin wrapper
- register iPoker plugin in plugin loaders
- add entrypoint script
- cover sample conversion for iPoker in tests

## Testing
- `apt-get update`
- `flutter format lib/plugins/converters/ipoker_hand_history_converter.dart lib/plugins/ipoker_converter_plugin.dart plugins/IpokerConverterPlugin.dart lib/plugins/plugin_loader_io.dart lib/plugins/plugin_loader_web.dart tests/converter_validation_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d69c7024832a83c7acfbc99c4601