### PR TITLE
Add session replay button

### DIFF
--- a/lib/screens/session_analysis_import_screen.dart
+++ b/lib/screens/session_analysis_import_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/ev_icm_chart.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../plugins/converters/888poker_hand_history_converter.dart';
 import 'v2/training_pack_play_screen.dart';
+import 'session_replay_screen.dart';
 
 class SessionAnalysisImportScreen extends StatefulWidget {
   const SessionAnalysisImportScreen({super.key});
@@ -175,6 +176,14 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     );
   }
 
+  void _replay() {
+    if (_hands.isEmpty) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => SessionReplayScreen(hands: _hands)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -217,6 +226,8 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
               Text('Accuracy: ${_summary!.accuracy.toStringAsFixed(1)}%', style: const TextStyle(color: Colors.white)),
               const SizedBox(height: 16),
               EvIcmChart(hands: _hands),
+              const SizedBox(height: 16),
+              ElevatedButton(onPressed: _replay, child: const Text('Replay Session')),
               const SizedBox(height: 16),
               if (_hands.any((h) => h.expectedAction != null && h.gtoAction != null && h.expectedAction!.toLowerCase() != h.gtoAction!.toLowerCase()))
                 ElevatedButton(onPressed: _review, child: const Text('🔥 Review mistakes')),


### PR DESCRIPTION
## Summary
- add button to replay session in import analysis

## Testing
- `flutter analyze` *(fails: 6131 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6ae35f8832a9b154a137c3145a3