### PR TITLE
Add weakest category drill

### DIFF
--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -688,6 +688,21 @@ class _TrainingPackTemplateListScreenState
               );
             },
           ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'weakestCategoryTplFab',
+            label: const Text('Слабейшая категория'),
+            onPressed: () async {
+              final tpl = await TrainingPackService.createDrillFromWeakestCategory(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (!mounted) return;
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+              );
+            },
+          ),
         ],
       ),
       body: templates.isEmpty


### PR DESCRIPTION
## Summary
- make weakest category drill pull 5-7 toughest hands
- add weakest category FAB in template list screen

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6872d80a731c832a82a680abbc362bcc