### PR TITLE
Add forecast CSV export

### DIFF
--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -4,12 +4,21 @@ import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
 import '../services/achievement_engine.dart';
+import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
   const TrainingProgressAnalyticsScreen({super.key});
+
+  Future<void> _exportCsv(BuildContext context) async {
+    final file = await context.read<ProgressForecastService>().exportForecastCsv();
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
+    );
+  }
 
   Widget _chart(List<MapEntry<DateTime, int>> data, Color color) {
     if (data.length < 2) return const SizedBox(height: 200);
@@ -123,6 +132,11 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
           _chart(stats.sessionsMonthly(12), Colors.greenAccent),
           const SizedBox(height: 12),
           _chart(stats.mistakesMonthly(12), Colors.redAccent),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () => _exportCsv(context),
+            child: const Text('Export CSV'),
+          ),
         ],
       ),
     );

--- a/lib/services/progress_forecast_service.dart
+++ b/lib/services/progress_forecast_service.dart
@@ -1,4 +1,10 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
 import '../models/saved_hand.dart';
 import 'saved_hand_manager_service.dart';
 import 'player_style_service.dart';
@@ -180,6 +186,24 @@ class ProgressForecastService extends ChangeNotifier {
       ev: data.last.ev + slopeEv,
       icm: data.last.icm + slopeIcm,
     );
+  }
+
+  Future<File> exportForecastCsv() async {
+    final rows = <List<dynamic>>[];
+    rows.add(['Date', 'Accuracy', 'EV', 'ICM']);
+    for (final e in _history) {
+      rows.add([
+        e.date.toIso8601String().split('T').first,
+        (e.accuracy * 100).toStringAsFixed(1),
+        e.ev.toStringAsFixed(2),
+        e.icm.toStringAsFixed(3),
+      ]);
+    }
+    final csv = const ListToCsvConverter().convert(rows, eol: '\r\n');
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/progress_forecast.csv');
+    await file.writeAsString(csv, encoding: utf8);
+    return file;
   }
 
   @override


### PR DESCRIPTION
## Summary
- add `exportForecastCsv` to `ProgressForecastService`
- let `TrainingProgressAnalyticsScreen` export forecast CSV

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6872d6b5fbfc832aa3d40023f4b22e28