### PR TITLE
Add summary screen widget test

### DIFF
--- a/tests/widgets/training_session_summary_screen_test.dart
+++ b/tests/widgets/training_session_summary_screen_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/screens/training_session_summary_screen.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_session.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/weak_spot_recommendation_service.dart';
+import 'package:poker_analyzer/services/mistake_review_pack_service.dart';
+import 'package:poker_analyzer/services/adaptive_training_service.dart';
+import 'package:poker_analyzer/services/daily_tip_service.dart';
+import 'package:poker_analyzer/services/next_step_engine.dart';
+import 'package:poker_analyzer/services/training_pack_stats_service.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('summary shows accuracy and deltas', (tester) async {
+    final template = TrainingPackTemplate(
+      id: 'tpl',
+      name: 'Test',
+      spots: [
+        TrainingPackSpot(id: 's1', hand: HandData()),
+        TrainingPackSpot(id: 's2', hand: HandData()),
+        TrainingPackSpot(id: 's3', hand: HandData()),
+        TrainingPackSpot(id: 's4', hand: HandData()),
+      ],
+      meta: {'evCovered': 2, 'icmCovered': 3},
+      createdAt: DateTime.now(),
+    );
+
+    final session = TrainingSession(
+      id: 'sess',
+      templateId: template.id,
+      completedAt: DateTime.now(),
+      results: {'s1': true, 's2': true, 's3': true, 's4': false},
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AdaptiveTrainingService>(
+            create: (_) => _FakeAdaptiveTrainingService(),
+          ),
+          ChangeNotifierProvider<MistakeReviewPackService>(
+            create: (_) => _FakeMistakeReviewPackService(),
+          ),
+          ChangeNotifierProvider<WeakSpotRecommendationService>(
+            create: (_) => _FakeWeakSpotRecommendationService(),
+          ),
+          ChangeNotifierProvider<DailyTipService>(
+            create: (_) => _FakeDailyTipService(),
+          ),
+          ChangeNotifierProvider<TrainingSessionService>(
+            create: (_) => _DummyTrainingSessionService(),
+          ),
+          ChangeNotifierProvider<NextStepEngine>(
+            create: (_) => _FakeNextStepEngine(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: TrainingSessionSummaryScreen(
+            session: session,
+            template: template,
+            preEvPct: 25,
+            preIcmPct: 25,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('75.0%'), findsOneWidget);
+    expect(find.text('Прогресс EV +25.0%, ICM +50.0%'), findsOneWidget);
+  });
+}
+
+class _DummyTrainingSessionService extends TrainingSessionService {}
+
+class _FakeMistakeReviewPackService extends ChangeNotifier
+    implements MistakeReviewPackService {
+  @override
+  bool hasMistakes() => false;
+  @override
+  Future<TrainingPackTemplate?> buildPack(BuildContext context) async => null;
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeWeakSpotRecommendationService extends ChangeNotifier
+    implements WeakSpotRecommendationService {
+  @override
+  WeakSpotRecommendation? get recommendation => null;
+  @override
+  List<WeakSpotRecommendation> get recommendations => const [];
+  @override
+  Future<TrainingPackTemplate?> buildPack([HeroPosition? pos]) async => null;
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeAdaptiveTrainingService extends ChangeNotifier
+    implements AdaptiveTrainingService {
+  @override
+  final ValueNotifier<List<TrainingPackTemplate>> recommendedNotifier =
+      ValueNotifier(<TrainingPackTemplate>[]);
+  @override
+  List<TrainingPackTemplate> get recommended => const [];
+  @override
+  TrainingPackStat? statFor(String id) => null;
+  @override
+  Future<void> refresh() async {}
+  @override
+  Future<TrainingPackTemplate> buildAdaptivePack() async =>
+      TrainingPackTemplate(id: '', name: '', spots: [], createdAt: DateTime.now());
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDailyTipService extends ChangeNotifier implements DailyTipService {
+  @override
+  String get tip => '';
+  @override
+  Future<void> ensureTodayTip() async {}
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeNextStepEngine extends ChangeNotifier implements NextStepEngine {
+  @override
+  NextStepSuggestion? get suggestion => null;
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary
- add widget test for TrainingSessionSummaryScreen using mock services

## Testing
- `flutter analyze` *(fails: 6337 issues)*
- `flutter test tests/widgets/training_session_summary_screen_test.dart` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6b2f8cc832aa1bdb68bc8d82599