### PR TITLE
Implement corrected hands drill generation

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -3334,6 +3334,23 @@ class _TrainingPackTemplateListScreenState
           ),
           const SizedBox(height: 12),
           FloatingActionButton.extended(
+            heroTag: 'repeatCorrectedTplFab',
+            label: const Text('Повторить исправленное'),
+            onPressed: () async {
+              final tpl =
+                  await TrainingPackService.createRepeatForCorrected(context);
+              if (tpl == null) return;
+              await context.read<TrainingSessionService>().startSession(tpl);
+              if (context.mounted) {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                );
+              }
+            },
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
             heroTag: 'randomMistakeTplFab',
             label: const Text('Случайная ошибка'),
             onPressed: () async {

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -191,21 +191,6 @@ class TrainingPackService {
     return createDrillFromTop3Categories(context);
   }
 
-  static Future<TrainingPackTemplate?> createRepeatDrillForCorrected(
-      BuildContext context) async {
-    final hands = context.read<SavedHandManagerService>().hands;
-    final list = [
-      for (final h in hands)
-        if (h.corrected && (h.evLoss ?? 0).abs() >= 1.0) h
-    ];
-    if (list.isEmpty) return null;
-    final spots = [for (final h in list) _spotFromHand(h)];
-    return TrainingPackTemplate(
-      id: const Uuid().v4(),
-      name: 'Repeat Corrected Drill',
-      spots: spots,
-    );
-  }
 
   static Future<TrainingPackTemplate?> createRepeatForCorrected(
       BuildContext context) async {


### PR DESCRIPTION
## Summary
- support repeating all corrected hands in TrainingPackService
- expose new "Повторить исправленное" drill on template list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872db1d7fec832abe8e2857a121e52c