### PR TITLE
Optimize plugin download with checksum cache

### DIFF
--- a/lib/screens/community_plugin_screen.dart
+++ b/lib/screens/community_plugin_screen.dart
@@ -56,10 +56,11 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
 
   Future<void> _install(CommunityPlugin p) async {
     try {
-      await PluginLoader().downloadFromUrl(p.url, checksum: p.checksum);
+      final downloaded =
+          await PluginLoader().downloadFromUrl(p.url, checksum: p.checksum);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Plugin installed')),
+          SnackBar(content: Text(downloaded ? 'Plugin installed' : 'Plugin up to date')),
         );
       }
     } catch (e) {

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -118,9 +118,11 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
       ),
     );
     try {
-      await PluginLoader().downloadFromUrl(url);
+      final downloaded = await PluginLoader().downloadFromUrl(url);
       if (mounted) {
-        messenger.showSnackBar(const SnackBar(content: Text('Plugin downloaded')));
+        messenger.showSnackBar(
+          SnackBar(content: Text(downloaded ? 'Plugin downloaded' : 'Plugin up to date')),
+        );
       }
       _urlCtr.clear();
     } catch (e) {

--- a/test/plugin_loader_io_test.dart
+++ b/test/plugin_loader_io_test.dart
@@ -91,7 +91,8 @@ void main(List<String> args, SendPort port) {
     PathProviderPlatform.instance = _FakePathProvider(dir.path);
     HttpOverrides.runZoned(() async {
       final loader = PluginLoader();
-      await loader.downloadFromUrl('http://x/TestPlugin.dart');
+      final downloaded = await loader.downloadFromUrl('http://x/TestPlugin.dart');
+      expect(downloaded, true);
       final file = File('${dir.path}/plugins/TestPlugin.dart');
       expect(await file.exists(), true);
       expect(await file.readAsString(), 'data');


### PR DESCRIPTION
## Summary
- skip plugin download when cached checksum matches
- notify user via snackbar when plugin is up to date
- update community plugin UI and plugin manager UI to display download status
- update plugin loader tests

## Testing
- `flutter test test/plugin_loader_io_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc0300b0832a872ca632eb0912f1