### PR TITLE
Add accent color customization

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -248,7 +248,7 @@ List<SingleChildWidget> buildTrainingProviders() {
               final service = UserPreferencesService(
                 cloud: context.read<CloudSyncService>(),
               );
-              UserPreferences.init(service);
+              UserPreferences.init(service, context.read<ThemeService>());
               service.load();
               return service;
             },

--- a/lib/screens/pack_editor_screen.dart
+++ b/lib/screens/pack_editor_screen.dart
@@ -3250,7 +3250,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                               message: 'New',
                               child: InkWell(
                                 onTap: _selectAllNew,
-                                child: const Icon(Icons.fiber_new, color: AppColors.accent),
+                                child: Icon(Icons.fiber_new, color: AppColors.accent),
                               ),
                             ),
                           PopupMenuButton<String>(
@@ -3362,7 +3362,7 @@ class _PackEditorScreenState extends State<PackEditorScreen> {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (hand.isDuplicate)
-                            const Icon(Icons.warning, color: AppColors.accent),
+                            Icon(Icons.warning, color: AppColors.accent),
                           IconButton(
                             icon: const Text('✏️'),
                             onPressed: () => _editComment(hand),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/sync_status_widget.dart';
 import 'evaluation_settings_screen.dart';
 import '../services/notification_service.dart';
 import '../services/remote_config_service.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -28,6 +29,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _showActionHints;
   late bool _coachMode;
   late bool _simpleNavigation;
+  late Color _accentColor;
   TimeOfDay _reminderTime = const TimeOfDay(hour: 20, minute: 0);
 
   @override
@@ -40,6 +42,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _showActionHints = prefs.showActionHints;
     _coachMode = prefs.coachMode;
     _simpleNavigation = prefs.simpleNavigation;
+    _accentColor = prefs.accentColor;
     NotificationService.getReminderTime(context)
         .then((t) => setState(() => _reminderTime = t));
   }
@@ -82,6 +85,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (picked != null) {
       await NotificationService.updateReminderTime(context, picked);
       setState(() => _reminderTime = picked);
+    }
+  }
+
+  Future<void> _pickAccentColor() async {
+    Color selected = _accentColor;
+    final result = await showDialog<Color>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Accent Color'),
+        content: StatefulBuilder(
+          builder: (context, setStateDialog) => BlockPicker(
+            pickerColor: selected,
+            onColorChanged: (c) => setStateDialog(() => selected = c),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, selected),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (result != null) {
+      await UserPreferences.instance.setAccentColor(result);
+      setState(() => _accentColor = result);
     }
   }
 
@@ -199,6 +232,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
               title: const Text('Reminder Time'),
               subtitle: Text(_reminderTime.format(context)),
               onTap: _pickReminderTime,
+            ),
+            ListTile(
+              title: const Text('Accent Color'),
+              leading: CircleAvatar(backgroundColor: _accentColor),
+              onTap: _pickAccentColor,
             ),
             const SizedBox(height: 8),
             ElevatedButton(

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1091,8 +1091,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 child: Card(
                   child: ListTile(
-                    leading:
-                        const Icon(Icons.error, color: AppColors.accent),
+                    leading: Icon(Icons.error, color: AppColors.accent),
                     title: Text(l.reviewMistakes),
                     onTap: () async {
                       final tpl = await service.buildPack(context);

--- a/lib/screens/training_activity_by_weekday_screen.dart
+++ b/lib/screens/training_activity_by_weekday_screen.dart
@@ -47,7 +47,7 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
     const labels = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
     final groups = <BarChartGroupData>[];
     for (var i = 0; i < counts.length; i++) {
-      const color = AppColors.accent;
+      final color = AppColors.accent;
       groups.add(
         BarChartGroupData(
           x: i,

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -580,7 +580,7 @@ class _TrainingPackTemplateListScreenState
                   strokeWidth: 8,
                   backgroundColor: Colors.white24,
                   valueColor:
-                      const AlwaysStoppedAnimation(AppColors.accent),
+                      AlwaysStoppedAnimation(AppColors.accent),
                 ),
                 Text('${(value * 100).round()}%',
                     style: const TextStyle(
@@ -877,7 +877,7 @@ class _TrainingPackTemplateListScreenState
                   strokeWidth: 3,
                   backgroundColor: Colors.white24,
                   valueColor:
-                      const AlwaysStoppedAnimation(AppColors.accent),
+                      AlwaysStoppedAnimation(AppColors.accent),
                 ),
               ),
             ),
@@ -2975,7 +2975,7 @@ class _TrainingPackTemplateListScreenState
                     ),
                     child: Row(
                       children: [
-                        const Icon(Icons.insights, color: AppColors.accent),
+                        Icon(Icons.insights, color: AppColors.accent),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Column(

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -4,13 +4,17 @@ import '../theme/app_colors.dart';
 
 class ThemeService extends ChangeNotifier {
   static const _key = 'theme_mode';
+  static const _accentKey = 'accent_color';
   ThemeMode _mode = ThemeMode.dark;
+  Color _accent = AppColors.accent;
+
   ThemeMode get mode => _mode;
+  Color get accentColor => _accent;
 
   ThemeData get lightTheme => ThemeData(
         brightness: Brightness.light,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: AppColors.accent,
+          seedColor: _accent,
           brightness: Brightness.light,
         ),
         scaffoldBackgroundColor: AppColors.background,
@@ -25,7 +29,7 @@ class ThemeService extends ChangeNotifier {
   ThemeData get darkTheme => ThemeData(
         brightness: Brightness.dark,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: AppColors.accent,
+          seedColor: _accent,
           brightness: Brightness.dark,
         ),
         scaffoldBackgroundColor: AppColors.background,
@@ -45,6 +49,8 @@ class ThemeService extends ChangeNotifier {
     } else {
       _mode = ThemeMode.dark;
     }
+    _accent = Color(prefs.getInt(_accentKey) ?? AppColors.accent.value);
+    AppColors.accent = _accent;
     notifyListeners();
   }
 
@@ -52,6 +58,15 @@ class ThemeService extends ChangeNotifier {
     _mode = _mode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, _mode.name);
+    notifyListeners();
+  }
+
+  Future<void> setAccentColor(Color color) async {
+    if (_accent == color) return;
+    _accent = color;
+    AppColors.accent = color;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_accentKey, color.value);
     notifyListeners();
   }
 }

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -4,7 +4,7 @@ class AppColors {
   static const background = Color(0xFF1A1A1C);
   static const cardBackground = Color(0xFF242428);
   static const button = Color(0xFFB73239);
-  static const accent = Color(0xFFD8B243);
+  static Color accent = const Color(0xFFD8B243);
   static final errorBg = Colors.red.withOpacity(.2);
   static const evPre = Color(0xFF009733);
   static const evPost = Color(0xFFC9A559);

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -1,14 +1,17 @@
+import 'package:flutter/material.dart';
 import 'services/user_preferences_service.dart';
+import 'services/theme_service.dart';
 
 class UserPreferences {
-  UserPreferences._(this.service);
+  UserPreferences._(this.service, this.theme);
 
   static late final UserPreferences instance;
 
   final UserPreferencesService service;
+  final ThemeService theme;
 
-  static void init(UserPreferencesService service) {
-    instance = UserPreferences._(service);
+  static void init(UserPreferencesService service, ThemeService theme) {
+    instance = UserPreferences._(service, theme);
   }
 
   bool get showPotAnimation => service.showPotAnimation;
@@ -19,6 +22,7 @@ class UserPreferences {
   bool get demoMode => service.demoMode;
   bool get tutorialCompleted => service.tutorialCompleted;
   bool get simpleNavigation => service.simpleNavigation;
+  Color get accentColor => theme.accentColor;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
   Future<void> setShowCardReveal(bool value) => service.setShowCardReveal(value);
@@ -28,4 +32,5 @@ class UserPreferences {
   Future<void> setDemoMode(bool value) => service.setDemoMode(value);
   Future<void> setSimpleNavigation(bool value) => service.setSimpleNavigation(value);
   Future<void> setTutorialCompleted(bool value) => service.setTutorialCompleted(value);
+  Future<void> setAccentColor(Color value) => theme.setAccentColor(value);
 }


### PR DESCRIPTION
## Summary
- make accent color mutable in `AppColors`
- persist accent color in `ThemeService`
- surface accent color via `UserPreferences`
- allow users to pick an accent color in Settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc0b43cc832a9ccf3db0be031569