### PR TITLE
Add range import/export

### DIFF
--- a/lib/screens/v2/template_settings_section.dart
+++ b/lib/screens/v2/template_settings_section.dart
@@ -213,6 +213,37 @@ part of 'training_pack_template_editor_screen.dart';
                   ),
                 ],
               ),
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: () async {
+                      final range = await const RangeImportExportService()
+                          .readRange(widget.template.id);
+                      if (range != null) set(() {
+                        _rangeStr = range.join(' ');
+                        rangeCtr.text = _rangeStr;
+                        rangeErr = _rangeStr.trim().isNotEmpty &&
+                            PackGeneratorService.parseRangeString(_rangeStr).isEmpty;
+                      });
+                    },
+                    child: const Text('Import Range'),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: () async {
+                      final list =
+                          PackGeneratorService.parseRangeString(_rangeStr).toList();
+                      await const RangeImportExportService()
+                          .writeRange(widget.template.id, list);
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context)
+                            .showSnackBar(const SnackBar(content: Text('Range saved')));
+                      }
+                    },
+                    child: const Text('Export Range'),
+                  ),
+                ],
+              ),
               SwitchListTile(
                 title: const Text('PNG with JSON'),
                 value: _previewJsonPng,

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -47,6 +47,7 @@ import '../../widgets/range_matrix_picker.dart';
 import '../../services/evaluation_executor_service.dart';
 import '../../services/pack_generator_service.dart';
 import '../../models/v2/training_pack_variant.dart';
+import '../../services/range_import_export_service.dart';
 import '../../services/training_pack_template_ui_service.dart';
 import '../../services/bulk_evaluator_service.dart';
 import '../../services/offline_evaluator_service.dart';

--- a/lib/services/range_import_export_service.dart
+++ b/lib/services/range_import_export_service.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+class RangeImportExportService {
+  const RangeImportExportService();
+
+  Future<File> _fileFor(String id) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final folder = Directory('${dir.path}/ranges');
+    if (!await folder.exists()) await folder.create(recursive: true);
+    return File('${folder.path}/$id.json');
+  }
+
+  Future<List<String>?> readRange(String id) async {
+    final file = await _fileFor(id);
+    if (!await file.exists()) return null;
+    try {
+      final content = await file.readAsString();
+      final decoded = jsonDecode(content);
+      if (decoded is List) {
+        return [for (final e in decoded) if (e is String) e];
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<void> writeRange(String id, List<String> range) async {
+    final file = await _fileFor(id);
+    await file.writeAsString(jsonEncode(range));
+  }
+}

--- a/lib/services/range_library_service.dart
+++ b/lib/services/range_library_service.dart
@@ -1,15 +1,23 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
+import 'range_import_export_service.dart';
 
 class RangeLibraryService {
-  RangeLibraryService._();
+  RangeLibraryService._([RangeImportExportService? io]) : _io = io ?? const RangeImportExportService();
   static final instance = RangeLibraryService._();
+
+  final RangeImportExportService _io;
 
   final Map<String, List<String>> _cache = {};
 
   Future<List<String>> getRange(String id) async {
     final cached = _cache[id];
     if (cached != null) return cached;
+    final custom = await _io.readRange(id);
+    if (custom != null) {
+      _cache[id] = custom;
+      return custom;
+    }
     try {
       final data = await rootBundle.loadString('assets/ranges/$id.json');
       final list = jsonDecode(data);


### PR DESCRIPTION
## Summary
- support reading and writing range files in documents directory
- allow custom range overrides in `RangeLibraryService`
- import or export ranges from template settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc064904832a97d6fe5430f6afdc