### PR TITLE
Implement share screenshot action

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -48,7 +48,7 @@ class TrainingSessionSummaryScreen extends StatefulWidget {
 }
 
 class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScreen> {
-  final _boundaryKey = GlobalKey();
+  final _shareBoundaryKey = GlobalKey();
   TrainingPackTemplate? _weakPack;
 
   @override
@@ -110,7 +110,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
 
   Future<void> _share(BuildContext context) async {
     final boundary =
-        _boundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+        _shareBoundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
     if (boundary == null) return;
     final bytes = await PngExporter.captureBoundary(boundary);
     if (bytes == null) return;
@@ -140,7 +140,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
           )
     ].where((s) => s.id.isNotEmpty).toList();
     return RepaintBoundary(
-      key: _boundaryKey,
+      key: _shareBoundaryKey,
       child: Scaffold(
         appBar: AppBar(
           title: Text(l.trainingSummary),


### PR DESCRIPTION
## Summary
- rename screen boundary key to `_shareBoundaryKey`
- wire screenshot sharing through the renamed key

## Testing
- `flutter analyze` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc0c3268832aae8462da18299d93