### PR TITLE
Add daily EV loss history

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -19,6 +19,7 @@ import '../services/evaluation_executor_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_storage_service.dart';
 import '../services/xp_tracker_service.dart';
+import '../services/training_stats_service.dart';
 import '../models/summary_result.dart';
 import '../models/saved_hand.dart';
 import '../theme/app_colors.dart';
@@ -119,21 +120,14 @@ class _ProgressScreenState extends State<ProgressScreen>
 
     final start = DateTime.now().subtract(const Duration(days: 6));
     final weekStart = DateTime(start.year, start.month, start.day);
-    final packs = context.read<TrainingPackStorageService>().packs;
-    final evMap = <DateTime, double>{};
-    for (final p in packs) {
-      for (final h in p.hands) {
-        final loss = h.evLoss;
-        if (loss == null) continue;
-        final d = DateTime(h.date.year, h.date.month, h.date.day);
-        if (d.isBefore(weekStart)) continue;
-        evMap.update(d, (v) => v + loss, ifAbsent: () => loss);
-      }
-    }
+    final stats = context.read<TrainingStatsService>();
+    final evLossMap = {
+      for (final e in stats.getDailyEvLossData(hands)) e.key: e.value
+    };
     final evLoss = <MapEntry<DateTime, double>>[];
     for (int i = 0; i < 7; i++) {
       final d = weekStart.add(Duration(days: i));
-      evLoss.add(MapEntry(d, -(evMap[d] ?? 0))); 
+      evLoss.add(MapEntry(d, -(evLossMap[d] ?? 0)));
     }
     final weekAcc = <MapEntry<DateTime, double>>[];
     final days = weekMap.keys

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -135,6 +135,18 @@ class TrainingStatsService extends ChangeNotifier {
     ];
   }
 
+  List<MapEntry<DateTime, double>> getDailyEvLossData(List<SavedHand> hands) {
+    final map = <DateTime, double>{};
+    for (final h in hands) {
+      final loss = h.evLoss;
+      if (loss == null) continue;
+      final d = DateTime(h.savedAt.year, h.savedAt.month, h.savedAt.day);
+      map.update(d, (v) => v + loss, ifAbsent: () => loss);
+    }
+    final entries = map.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+    return [for (final e in entries) MapEntry(e.key, e.value)];
+  }
+
   List<MapEntry<DateTime, double>> _groupWeeklyAvg(List<MapEntry<DateTime, double>> daily) {
     final Map<DateTime, List<double>> grouped = {};
     for (final e in daily) {


### PR DESCRIPTION
## Summary
- implement `getDailyEvLossData` in TrainingStatsService
- show weekly EV loss using new method in ProgressScreen

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_6872dd4709d4832aa847fb065c48db32