### PR TITLE
Add weekly EV recovery goal

### DIFF
--- a/lib/models/ev_recovery_goal.dart
+++ b/lib/models/ev_recovery_goal.dart
@@ -1,0 +1,13 @@
+class EvRecoveryGoal {
+  final String type;
+  final double target;
+  final double progress;
+  final bool completed;
+
+  const EvRecoveryGoal({
+    required this.type,
+    required this.target,
+    required this.progress,
+    required this.completed,
+  });
+}

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -10,6 +10,8 @@ import '../screens/progress_screen.dart';
 import '../models/goal_progress_entry.dart';
 import '../models/drill_session_result.dart';
 import '../models/saved_hand.dart';
+import '../models/ev_recovery_goal.dart';
+import 'saved_hand_manager_service.dart';
 import 'streak_service.dart';
 import 'user_action_logger.dart';
 
@@ -200,6 +202,24 @@ class GoalsService extends ChangeNotifier {
     if (list.isEmpty) return 0;
     final sum = list.map((e) => e.accuracy).reduce((a, b) => a + b);
     return sum / list.length * 100;
+  }
+
+  EvRecoveryGoal? get weeklyEvRecoveryGoal {
+    final stats = TrainingStatsService.instance;
+    final hands = SavedHandManagerService.instance?.hands;
+    if (stats == null || hands == null) return null;
+    final list = stats.evWeekly(hands, 2);
+    if (list.length < 2) return null;
+    final prev = list[list.length - 2].value;
+    final curr = list.last.value;
+    final target = prev < 0 ? -prev : 0.0;
+    final progress = curr < 0 ? -curr : 0.0;
+    return EvRecoveryGoal(
+      type: 'recovery',
+      target: target,
+      progress: progress,
+      completed: progress < target,
+    );
   }
 
   List<GoalProgressEntry> historyFor(int index) =>

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -44,13 +44,18 @@ class _SessionStats {
 }
 
 class SavedHandManagerService extends ChangeNotifier {
+  static SavedHandManagerService? _instance;
+  static SavedHandManagerService? get instance => _instance;
+
   SavedHandManagerService({
     required SavedHandStorageService storage,
     CloudSyncService? cloud,
     TrainingStatsService? stats,
   })  : _storage = storage,
         _cloud = cloud,
-        _stats = stats;
+        _stats = stats {
+    _instance = this;
+  }
 
   final SavedHandStorageService _storage;
   final TrainingStatsService? _stats;


### PR DESCRIPTION
## Summary
- track SavedHandManagerService via a static instance
- define `EvRecoveryGoal` model
- compute weekly EV recovery goal in GoalsService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dfa5ab08832a9e96090c5dacfc8d