### PR TITLE
Add PartyPoker converter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ delegates to the plug-in's optional `validate` method. Returning a string from
 `validate` will reject the hand for export and surface the message to the user,
 while returning `null` allows the export to proceed.
 
+- PartyPoker Converter plug-in adds support for Partypoker hand history files.
+
 Подробнее о подключении сторонних модулей описано в [docs/plugins](docs/plugins/README.md).
 Разработчикам плагинов посвящено руководство [PLUGIN_DEV_GUIDE](docs/plugins/PLUGIN_DEV_GUIDE.md).
 

--- a/lib/plugins/converters/partypoker_hand_history_converter.dart
+++ b/lib/plugins/converters/partypoker_hand_history_converter.dart
@@ -5,8 +5,8 @@ import 'package:poker_analyzer/models/card_model.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
-class PartyPokerHandHistoryConverter extends ConverterPlugin {
-  PartyPokerHandHistoryConverter()
+class PartypokerHandHistoryConverter extends ConverterPlugin {
+  PartypokerHandHistoryConverter()
       : super(
           formatId: 'partypoker_hand_history',
           description: 'PartyPoker hand history format',

--- a/lib/plugins/partypoker_converter_plugin.dart
+++ b/lib/plugins/partypoker_converter_plugin.dart
@@ -1,0 +1,21 @@
+import 'package:poker_analyzer/plugins/converter_registry.dart';
+import 'package:poker_analyzer/plugins/plugin.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+import 'converters/partypoker_hand_history_converter.dart';
+
+class PartyPokerConverterPlugin extends PartypokerHandHistoryConverter implements Plugin {
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<ConverterRegistry>(ConverterRegistry());
+    registry.get<ConverterRegistry>().register(this);
+  }
+
+  @override
+  String get name => 'PartyPoker Converter';
+
+  @override
+  String get description => 'Adds PartyPoker hand history conversion';
+
+  @override
+  String get version => '1.0.0';
+}

--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -29,6 +29,7 @@ import 'converters/ipoker_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
+import 'partypoker_converter_plugin.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -78,7 +79,7 @@ class PluginLoader {
       PokerStarsHandHistoryConverter(),
       GGPokerHandHistoryConverter(),
       WinamaxHandHistoryConverter(),
-      PartyPokerHandHistoryConverter(),
+      PartypokerHandHistoryConverter(),
       WpnHandHistoryConverter(),
       Poker888HandHistoryConverter(),
       IpokerHandHistoryConverter(),
@@ -100,7 +101,7 @@ class PluginLoader {
           PokerStarsHandHistoryConverter(),
           GGPokerHandHistoryConverter(),
           WinamaxHandHistoryConverter(),
-          PartyPokerHandHistoryConverter(),
+          PartypokerHandHistoryConverter(),
           WpnHandHistoryConverter(),
           Poker888HandHistoryConverter(),
           IpokerHandHistoryConverter(),
@@ -109,6 +110,8 @@ class PluginLoader {
         return PokerStarsConverterPlugin();
       case 'GGPokerConverterPlugin':
         return GGPokerConverterPlugin();
+      case 'PartyPokerConverterPlugin':
+        return PartyPokerConverterPlugin();
       case 'IpokerConverterPlugin':
         return IpokerConverterPlugin();
     }

--- a/lib/plugins/plugin_loader_web.dart
+++ b/lib/plugins/plugin_loader_web.dart
@@ -26,6 +26,7 @@ import 'converters/ipoker_hand_history_converter.dart';
 import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
+import 'partypoker_converter_plugin.dart';
 
 class PluginLoader {
   static const String _suffix = 'Plugin.dart';
@@ -91,7 +92,7 @@ class PluginLoader {
       PokerStarsHandHistoryConverter(),
       GGPokerHandHistoryConverter(),
       WinamaxHandHistoryConverter(),
-      PartyPokerHandHistoryConverter(),
+      PartypokerHandHistoryConverter(),
       WpnHandHistoryConverter(),
       Poker888HandHistoryConverter(),
       IpokerHandHistoryConverter(),
@@ -113,7 +114,7 @@ class PluginLoader {
           PokerStarsHandHistoryConverter(),
           GGPokerHandHistoryConverter(),
           WinamaxHandHistoryConverter(),
-          PartyPokerHandHistoryConverter(),
+          PartypokerHandHistoryConverter(),
           WpnHandHistoryConverter(),
           Poker888HandHistoryConverter(),
           IpokerHandHistoryConverter(),
@@ -122,6 +123,8 @@ class PluginLoader {
         return PokerStarsConverterPlugin();
       case 'GGPokerConverterPlugin':
         return GGPokerConverterPlugin();
+      case 'PartyPokerConverterPlugin':
+        return PartyPokerConverterPlugin();
       case 'IpokerConverterPlugin':
         return IpokerConverterPlugin();
     }

--- a/plugins/PartyPokerConverterPlugin.dart
+++ b/plugins/PartyPokerConverterPlugin.dart
@@ -1,0 +1,6 @@
+import 'dart:isolate';
+import 'package:poker_analyzer/plugins/partypoker_converter_plugin.dart';
+
+void main(List<String> args, SendPort sendPort) {
+  sendPort.send(PartyPokerConverterPlugin());
+}


### PR DESCRIPTION
## Summary
- implement PartyPoker converter plugin and entrypoint
- rename party poker converter class
- wire up plugin loader discovery for the new plugin
- document PartyPoker converter plugin

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e26a1528832aa6e4ef8ee55ca7be