### PR TITLE
Add drill for worst mistake category

### DIFF
--- a/lib/helpers/mistake_category_translations.dart
+++ b/lib/helpers/mistake_category_translations.dart
@@ -1,0 +1,15 @@
+const Map<String, String> kMistakeCategoryTranslations = {
+  'Overfold': 'Чрезмерный пас',
+  'Overcall': 'Слишком широкий колл',
+  'Wrong Push': 'Неверный пуш',
+  'Wrong Call': 'Неверный колл',
+  'Missed Value': 'Упущенное вэлью',
+  'Too Passive': 'Слишком пассивно',
+  'Too Aggro': 'Слишком агрессивно',
+  'Unclassified': 'Без категории',
+};
+
+String translateMistakeCategory(String? category) {
+  if (category == null) return '';
+  return kMistakeCategoryTranslations[category] ?? category;
+}

--- a/lib/services/training_pack_service.dart
+++ b/lib/services/training_pack_service.dart
@@ -14,6 +14,7 @@ import '../models/action_entry.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../helpers/poker_position_helper.dart';
 import '../helpers/training_pack_storage.dart';
+import '../helpers/mistake_category_translations.dart';
 import 'pack_generator_service.dart';
 import '../main.dart';
 
@@ -185,6 +186,35 @@ class TrainingPackService {
       spots: spots,
     );
   }
+  static Future<TrainingPackTemplate?> createDrillFromWorstCategory(
+      BuildContext context) async {
+    final hands = context.read<SavedHandManagerService>().hands;
+    final byCat = <String, List<SavedHand>>{};
+    for (final h in hands) {
+      final cat = h.category;
+      final exp = h.expectedAction;
+      final gto = h.gtoAction;
+      if (cat == null || cat.isEmpty) continue;
+      if (exp == null || gto == null) continue;
+      if (exp.trim().toLowerCase() == gto.trim().toLowerCase()) continue;
+      if (h.corrected) continue;
+      byCat.putIfAbsent(cat, () => []).add(h);
+    }
+    if (byCat.isEmpty) return null;
+    final entry = byCat.entries
+        .reduce((a, b) => a.value.length >= b.value.length ? a : b);
+    final list = entry.value
+      ..sort((a, b) => (b.evLoss ?? 0).compareTo(a.evLoss ?? 0));
+    final rng = Random();
+    final count = min(list.length, 5 + rng.nextInt(4));
+    final spots = [for (final h in list.take(count)) _spotFromHand(h)];
+    return TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: translateMistakeCategory(entry.key),
+      spots: spots,
+    );
+  }
+
 
   static Future<TrainingPackTemplate?> createTopMistakeDrill(
       BuildContext context) async {


### PR DESCRIPTION
## Summary
- introduce translations for mistake categories
- support auto drill creation for the worst mistake category

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 6160 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2b9d1c4832aa730f1699026be84