### PR TITLE
Add EV/ICM trend chart

### DIFF
--- a/lib/screens/progress_overview_screen.dart
+++ b/lib/screens/progress_overview_screen.dart
@@ -6,6 +6,7 @@ import '../models/training_result.dart';
 import '../widgets/ev_icm_trend_chart.dart';
 import '../widgets/common/accuracy_chart.dart';
 import '../widgets/common/average_accuracy_chart.dart';
+import '../widgets/common/ev_icm_trend_chart.dart' as common;
 import '../widgets/sync_status_widget.dart';
 import '../theme/app_colors.dart';
 
@@ -73,6 +74,9 @@ class _ProgressOverviewScreenState extends State<ProgressOverviewScreen> {
           const SizedBox(height: 16),
           if (hasData) AccuracyChart(sessions: sessions) else _placeholder(),
           if (hasData) AverageAccuracyChart(sessions: sessions),
+          if (hasData)
+            common.EvIcmTrendChart(
+                data: context.watch<ProgressForecastService>().evIcmSeries),
         ],
       ),
     );

--- a/lib/services/progress_forecast_service.dart
+++ b/lib/services/progress_forecast_service.dart
@@ -53,6 +53,7 @@ class ProgressForecastService extends ChangeNotifier {
       [for (final e in _history) MapEntry(e.date, e.ev)];
   List<MapEntry<DateTime, double>> get icmSeries =>
       [for (final e in _history) MapEntry(e.date, e.icm)];
+  List<ProgressEntry> get evIcmSeries => List.unmodifiable(_history);
   List<ProgressEntry> positionSeries(String pos) =>
       List.unmodifiable(_positionHistory[pos] ?? const []);
   List<ProgressEntry> tagSeries(String tag) =>

--- a/lib/widgets/common/ev_icm_trend_chart.dart
+++ b/lib/widgets/common/ev_icm_trend_chart.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../services/progress_forecast_service.dart';
+import '../../theme/app_colors.dart';
+import 'animated_line_chart.dart';
+
+class EvIcmTrendChart extends StatelessWidget {
+  final List<ProgressEntry> data;
+  const EvIcmTrendChart({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final ev = [for (final e in data) MapEntry(e.date, e.ev)];
+    final icm = [for (final e in data) MapEntry(e.date, e.icm)];
+    final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
+      ..sort();
+    if (dates.length < 2) return const SizedBox(height: 200);
+    final evMap = {for (final e in ev) e.key: e.value};
+    final icmMap = {for (final e in icm) e.key: e.value};
+    final spotsEv = <FlSpot>[];
+    final spotsIcm = <FlSpot>[];
+    double minY = 0;
+    double maxY = 0;
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final v1 = evMap[d];
+      final v2 = icmMap[d];
+      if (v1 != null) {
+        spotsEv.add(FlSpot(i.toDouble(), v1));
+        if (v1 < minY) minY = v1;
+        if (v1 > maxY) maxY = v1;
+      }
+      if (v2 != null) {
+        spotsIcm.add(FlSpot(i.toDouble(), v2));
+        if (v2 < minY) minY = v2;
+        if (v2 > maxY) maxY = v2;
+      }
+    }
+    if (minY == maxY) {
+      minY -= 1;
+      maxY += 1;
+    }
+    final interval = (maxY - minY) / 4;
+    final step = (dates.length / 6).ceil();
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AnimatedLineChart(
+        data: LineChartData(
+          minY: minY,
+          maxY: maxY,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: interval,
+            getDrawingHorizontalLine: (v) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: interval,
+                reservedSize: 40,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toStringAsFixed(1),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= dates.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != dates.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = dates[i];
+                  return Text(
+                    '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spotsEv,
+              color: AppColors.evPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+            LineChartBarData(
+              spots: spotsIcm,
+              color: AppColors.icmPre,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/ev_icm_trend_chart_test.dart
+++ b/test/ev_icm_trend_chart_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/common/ev_icm_trend_chart.dart';
+import 'package:poker_analyzer/services/progress_forecast_service.dart';
+import 'package:poker_analyzer/widgets/common/animated_line_chart.dart';
+
+void main() {
+  testWidgets('renders correct spots and axis', (tester) async {
+    final data = [
+      ProgressEntry(
+          date: DateTime(2023, 1, 1),
+          accuracy: 0,
+          ev: -1,
+          icm: -0.5,
+          position: ''),
+      ProgressEntry(
+          date: DateTime(2023, 1, 2),
+          accuracy: 0,
+          ev: 0.5,
+          icm: 0.8,
+          position: ''),
+      ProgressEntry(
+          date: DateTime(2023, 1, 3),
+          accuracy: 0,
+          ev: 2,
+          icm: 1.5,
+          position: ''),
+    ];
+    await tester.pumpWidget(MaterialApp(home: EvIcmTrendChart(data: data)));
+    final chart = tester.widget<AnimatedLineChart>(find.byType(AnimatedLineChart));
+    final bars = chart.data.lineBarsData;
+    expect(bars[0].spots.length, data.length);
+    expect(bars[1].spots.length, data.length);
+    expect(chart.data.minY, -1);
+    expect(chart.data.maxY, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add EV/ICM trend chart widget
- expose `evIcmSeries` in `ProgressForecastService`
- show progress EV/ICM chart on overview screen
- test chart line count and axis

## Testing
- `flutter test test/ev_icm_trend_chart_test.dart` *(fails: lib/models/json_converters.dart:22:77: Error: A value of type 'Map<String, dynamic>?' can't be assigned to a variable of type 'bool'.)*

------
https://chatgpt.com/codex/tasks/task_e_6872e5b5faac832aa2d869fa6537b08c