### PR TITLE
Add pack recommendation notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -252,6 +252,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     context.read<UserActionLogger>().log('opened_app');
     unawaited(NotificationService.scheduleDailyReminder(context));
     unawaited(NotificationService.scheduleDailyProgress(context));
+    NotificationService.startRecommendedPackTask(context);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeResumeTraining();
       _maybeShowIntroOverlay();

--- a/lib/services/adaptive_training_service.dart
+++ b/lib/services/adaptive_training_service.dart
@@ -205,4 +205,14 @@ class AdaptiveTrainingService extends ChangeNotifier {
       heroRange: range,
     );
   }
+
+  Future<TrainingPackTemplate?> nextRecommendedPack() async {
+    await refresh();
+    final prefs = await SharedPreferences.getInstance();
+    for (final t in _recommended) {
+      final idx = prefs.getInt('tpl_prog_${t.id}') ?? 0;
+      if (idx < t.spots.length) return t;
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- recommend next training pack from adaptive service
- send repeating notification about the next pack
- start repeating task on app startup

## Testing
- `flutter analyze` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6872e9b76fd8832a8c380c444eda25ac