### PR TITLE
Add intro tutorial

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,7 +86,7 @@ import 'services/asset_sync_service.dart';
 import 'services/favorite_pack_service.dart';
 import 'services/evaluation_settings_service.dart';
 import 'widgets/sync_status_widget.dart';
-import 'widgets/first_launch_overlay.dart';
+import 'widgets/first_launch_tutorial.dart';
 import 'screens/onboarding_screen.dart';
 import 'app_bootstrap.dart';
 import 'app_providers.dart';
@@ -178,15 +178,19 @@ class PokerAIAnalyzerApp extends StatefulWidget {
 class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
   late final ConnectivitySyncController _sync;
 
-  Future<void> _maybeShowIntroOverlay() async {
+  Future<void> _maybeShowIntroTutorial() async {
     final prefs = await SharedPreferences.getInstance();
-    if (prefs.getBool('seen_intro_overlay') == true) return;
+    var done = true;
+    for (int i = 0; i < 3; i++) {
+      if (prefs.getBool('intro_step_$i') != true) {
+        done = false;
+        break;
+      }
+    }
+    if (done) return;
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
-    showFirstLaunchOverlay(ctx, () async {
-      final p = await SharedPreferences.getInstance();
-      await p.setBool('seen_intro_overlay', true);
-    });
+    showFirstLaunchTutorial(ctx);
   }
 
   Future<void> _maybeResumeTraining() async {
@@ -253,7 +257,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     NotificationService.startRecommendedPackTask(context);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeResumeTraining();
-      _maybeShowIntroOverlay();
+      _maybeShowIntroTutorial();
     });
   }
 

--- a/lib/widgets/first_launch_tutorial.dart
+++ b/lib/widgets/first_launch_tutorial.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_colors.dart';
+
+class FirstLaunchTutorial extends StatefulWidget {
+  final VoidCallback onComplete;
+  const FirstLaunchTutorial({super.key, required this.onComplete});
+
+  @override
+  State<FirstLaunchTutorial> createState() => _FirstLaunchTutorialState();
+}
+
+class _FirstLaunchTutorialState extends State<FirstLaunchTutorial> {
+  final _steps = const [
+    'Progress — track results',
+    'Training Packs — practice spots',
+    'Analyzer — review any hand',
+  ];
+  int _index = 0;
+
+  Future<void> _next() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('intro_step_$_index', true);
+    if (_index == _steps.length - 1) {
+      widget.onComplete();
+      return;
+    }
+    setState(() => _index++);
+  }
+
+  Future<void> _skip() async {
+    final prefs = await SharedPreferences.getInstance();
+    for (int i = 0; i < _steps.length; i++) {
+      await prefs.setBool('intro_step_$i', true);
+    }
+    widget.onComplete();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Material(
+        color: Colors.black87,
+        child: Center(
+          child: Container(
+            margin: const EdgeInsets.all(24),
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.cardBackground,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Welcome',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  _steps[_index],
+                  style: const TextStyle(color: Colors.white70),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: _skip,
+                      child: const Text('Skip'),
+                    ),
+                    ElevatedButton(
+                      onPressed: _next,
+                      child:
+                          Text(_index == _steps.length - 1 ? 'Got it' : 'Next'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void showFirstLaunchTutorial(BuildContext context) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  void close() => entry.remove();
+  entry = OverlayEntry(
+    builder: (_) => FirstLaunchTutorial(onComplete: close),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- implement multi-step intro tutorial overlay
- track completion of each step with SharedPreferences
- trigger tutorial on launch if any step incomplete

## Testing
- `flutter analyze` *(fails: many pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68737cbfc5c8832a8901c80603583b4d