### PR TITLE
Add session markers to EV/ICM trend chart

### DIFF
--- a/lib/screens/progress_overview_screen.dart
+++ b/lib/screens/progress_overview_screen.dart
@@ -9,6 +9,8 @@ import '../widgets/common/average_accuracy_chart.dart';
 import '../widgets/common/ev_icm_trend_chart.dart' as common;
 import '../widgets/sync_status_widget.dart';
 import '../theme/app_colors.dart';
+import '../services/training_stats_service.dart';
+import '../services/saved_hand_manager_service.dart';
 
 class ProgressOverviewScreen extends StatefulWidget {
   static const route = '/progress_overview';
@@ -70,7 +72,12 @@ class _ProgressOverviewScreenState extends State<ProgressOverviewScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          EvIcmTrendChart(mode: _mode),
+          EvIcmTrendChart(
+            mode: _mode,
+            sessionDates: context
+                .watch<TrainingStatsService>()
+                .sessionHistory(context.watch<SavedHandManagerService>().hands),
+          ),
           const SizedBox(height: 16),
           if (hasData) AccuracyChart(sessions: sessions) else _placeholder(),
           if (hasData) AverageAccuracyChart(sessions: sessions),

--- a/lib/screens/training_stats_screen.dart
+++ b/lib/screens/training_stats_screen.dart
@@ -5,6 +5,7 @@ import '../models/training_stats.dart';
 import '../services/template_storage_service.dart';
 import '../services/training_stats_service.dart';
 import '../services/streak_service.dart';
+import '../services/saved_hand_manager_service.dart';
 import '../widgets/ev_icm_trend_chart.dart';
 
 class TrainingStatsScreen extends StatefulWidget {
@@ -87,7 +88,11 @@ class _TrainingStatsScreenState extends State<TrainingStatsScreen> {
             ),
           ),
           const SizedBox(height: 16),
-          const EvIcmTrendChart(),
+          EvIcmTrendChart(
+            sessionDates: context
+                .watch<TrainingStatsService>()
+                .sessionHistory(context.watch<SavedHandManagerService>().hands),
+          ),
           if (s.topPacks.isNotEmpty) ...[
             const SizedBox(height: 16),
             const Text('Best Packs'),

--- a/lib/services/training_stats_service.dart
+++ b/lib/services/training_stats_service.dart
@@ -318,6 +318,21 @@ class TrainingStatsService extends ChangeNotifier {
     return _groupMonthly(daily);
   }
 
+  List<DateTime> sessionHistory(List<SavedHand> hands, [int limit = 30]) {
+    final Map<int, DateTime> map = {};
+    for (final h in hands) {
+      final saved = map[h.sessionId];
+      if (saved == null || h.savedAt.isAfter(saved)) {
+        map[h.sessionId] = h.savedAt;
+      }
+    }
+    final list = map.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    final dates = [for (final e in list) e.value];
+    if (dates.length > limit) dates.removeRange(0, dates.length - limit);
+    return dates;
+  }
+
   List<List<dynamic>> progressRows({bool weekly = false, int count = 30}) {
     final sessions = weekly ? sessionsWeekly(count) : sessionsDaily(count);
     final hands = weekly ? handsWeekly(count) : handsDaily(count);

--- a/lib/widgets/ev_icm_trend_chart.dart
+++ b/lib/widgets/ev_icm_trend_chart.dart
@@ -11,7 +11,12 @@ enum EvIcmTrendMode { weekly, monthly }
 
 class EvIcmTrendChart extends StatelessWidget {
   final EvIcmTrendMode mode;
-  const EvIcmTrendChart({super.key, this.mode = EvIcmTrendMode.weekly});
+  final List<DateTime> sessionDates;
+  const EvIcmTrendChart({
+    super.key,
+    this.mode = EvIcmTrendMode.weekly,
+    this.sessionDates = const [],
+  });
 
   String _format(DateTime d) {
     if (mode == EvIcmTrendMode.monthly) {
@@ -66,6 +71,34 @@ class EvIcmTrendChart extends StatelessWidget {
     }
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
+    final verticalLines = <VerticalLine>[];
+    for (var i = 0; i < sessionDates.length; i++) {
+      final d = sessionDates[i];
+      for (var j = 0; j < dates.length; j++) {
+        final start = dates[j];
+        final end = j == dates.length - 1
+            ? (mode == EvIcmTrendMode.weekly
+                ? start.add(const Duration(days: 7))
+                : DateTime(start.year, start.month + 1))
+            : dates[j + 1];
+        if (!d.isBefore(start) && d.isBefore(end)) {
+          verticalLines.add(
+            VerticalLine(
+              x: j.toDouble(),
+              color: Colors.white24,
+              dashArray: [2, 2],
+              label: VerticalLineLabel(
+                show: true,
+                alignment: Alignment.topCenter,
+                style: const TextStyle(color: Colors.white70, fontSize: 8),
+                labelResolver: (_) => '${i + 1}',
+              ),
+            ),
+          );
+          break;
+        }
+      }
+    }
     final chart = AnimatedLineChart(
       data: LineChartData(
         minY: minY,
@@ -132,6 +165,7 @@ class EvIcmTrendChart extends StatelessWidget {
             dotData: FlDotData(show: false),
           ),
         ],
+        extraLinesData: ExtraLinesData(verticalLines: verticalLines),
       ),
     );
     return Column(


### PR DESCRIPTION
## Summary
- compute session history in `TrainingStatsService`
- mark sessions in `EvIcmTrendChart`
- provide session dates from service to charts

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737ccb5b08832aa0999baf0748981e