### PR TITLE
Implement diff engine for undo history

### DIFF
--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -110,7 +110,7 @@ import '../services/backup_manager_service.dart';
 import '../services/debug_snapshot_service.dart';
 import '../services/action_sync_service.dart';
 import '../services/undo_redo_service.dart';
-import '../services/diff_snapshot_service.dart';
+import '../undo_history/diff_engine.dart';
 import '../services/action_editing_service.dart';
 import '../services/transition_lock_service.dart';
 import '../services/transition_history_service.dart';
@@ -3483,7 +3483,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       potSync: _potSync,
       lockService: lockService,
       transitionHistory: _transitionHistory,
-      diffService: DiffSnapshotService(),
+      diffEngine: DiffEngine(),
     ));
     _undoRedoService = _serviceRegistry.get<UndoRedoService>();
 

--- a/lib/undo_history/command.dart
+++ b/lib/undo_history/command.dart
@@ -1,0 +1,18 @@
+class Command {
+  final String type;
+  final Map<String, dynamic>? payload;
+  final DateTime time;
+
+  Command(this.type, {this.payload}) : time = DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        if (payload != null) 'payload': payload,
+        'time': time.toIso8601String(),
+      };
+
+  factory Command.fromJson(Map<String, dynamic> json) => Command(
+        json['type'] as String,
+        payload: (json['payload'] as Map?)?.cast<String, dynamic>(),
+      );
+}

--- a/lib/undo_history/diff_engine.dart
+++ b/lib/undo_history/diff_engine.dart
@@ -1,0 +1,55 @@
+import 'package:collection/collection.dart';
+
+class StateDiff {
+  final Map<String, dynamic> forward;
+  final Map<String, dynamic> backward;
+  const StateDiff({required this.forward, required this.backward});
+}
+
+class DiffEngine {
+  static const DeepCollectionEquality _eq = DeepCollectionEquality();
+
+  Map<String, dynamic> _diffMap(Map<String, dynamic> a, Map<String, dynamic> b) {
+    final diff = <String, dynamic>{};
+    final keys = {...a.keys, ...b.keys};
+    for (final k in keys) {
+      final av = a[k];
+      final bv = b[k];
+      if (_eq.equals(av, bv)) continue;
+      if (av is Map && bv is Map) {
+        final sub = _diffMap(
+          Map<String, dynamic>.from(av as Map),
+          Map<String, dynamic>.from(bv as Map),
+        );
+        if (sub.isNotEmpty) diff[k] = sub;
+      } else {
+        diff[k] = bv;
+      }
+    }
+    return diff;
+  }
+
+  void _applyMap(Map<String, dynamic> target, Map<String, dynamic> diff) {
+    diff.forEach((k, v) {
+      final tv = target[k];
+      if (v is Map && tv is Map<String, dynamic>) {
+        _applyMap(tv, Map<String, dynamic>.from(v as Map));
+      } else {
+        target[k] = v;
+      }
+    });
+  }
+
+  StateDiff compute(Map<String, dynamic> oldState, Map<String, dynamic> newState) {
+    return StateDiff(
+      forward: _diffMap(oldState, newState),
+      backward: _diffMap(newState, oldState),
+    );
+  }
+
+  Map<String, dynamic> apply(Map<String, dynamic> base, Map<String, dynamic> diff) {
+    final result = Map<String, dynamic>.from(base);
+    _applyMap(result, diff);
+    return result;
+  }
+}

--- a/test/undo_history/diff_engine_test.dart
+++ b/test/undo_history/diff_engine_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/undo_history/diff_engine.dart';
+
+void main() {
+  test('diff round trip', () {
+    final engine = DiffEngine();
+    final a = {
+      'a': 1,
+      'b': {'c': 2, 'd': 3},
+    };
+    final b = {
+      'a': 2,
+      'b': {'c': 2, 'd': 4},
+    };
+    final diff = engine.compute(a, b);
+    final forward = engine.apply(a, diff.forward);
+    expect(forward['a'], 2);
+    expect((forward['b'] as Map)['d'], 4);
+    final back = engine.apply(forward, diff.backward);
+    expect(back['a'], 1);
+    expect((back['b'] as Map)['d'], 3);
+  });
+}


### PR DESCRIPTION
## Summary
- add generic `DiffEngine` with map diff logic
- record command metadata with new model
- use `DiffEngine` in `UndoRedoService`
- wire diff engine in analyzer screen
- test diff engine

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687381a5d748832ab525e67f0e6c5665