### PR TITLE
Add converter pipeline import

### DIFF
--- a/lib/plugins/converter_discovery_plugin.dart
+++ b/lib/plugins/converter_discovery_plugin.dart
@@ -1,4 +1,5 @@
 import 'package:poker_analyzer/services/service_registry.dart';
+import 'package:poker_analyzer/import_export/converter_pipeline.dart';
 
 import 'converter_plugin.dart';
 import 'converter_registry.dart';
@@ -21,6 +22,8 @@ class ConverterDiscoveryPlugin implements Plugin {
     for (final ConverterPlugin plugin in plugins) {
       converterRegistry.register(plugin);
     }
+    registry.registerIfAbsent<ConverterPipeline>(
+        ConverterPipeline(converterRegistry));
   }
 
   @override

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -3525,7 +3525,10 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _handManager = context.read<SavedHandManagerService>();
     _handImportExportService =
         widget.handImportExportService ??
-            SavedHandImportExportService(_handManager);
+            SavedHandImportExportService(
+              _handManager,
+              registry: _serviceRegistry,
+            );
   }
 
   void selectCard(int index, CardModel card) {


### PR DESCRIPTION
## Summary
- expose `ConverterPipeline` via `ServiceRegistry`
- integrate pipeline into hand import service
- wire up pipeline when creating services

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687381a80054832ab936f5879512e530