### PR TITLE
Update tutorial with recommendations step

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -50,6 +50,7 @@ import '../services/goals_service.dart';
 import '../widgets/focus_of_the_week_card.dart';
 import '../widgets/sync_status_widget.dart';
 import 'weakness_overview_screen.dart';
+import 'training_home_screen.dart';
 
 class _MenuItem {
   final IconData icon;
@@ -626,7 +627,22 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       TutorialStep(
         targetKey: _trainingButtonKey,
         description: 'Выберите тренировочный пак',
-        onNext: (_, __) {},
+        onNext: (ctx, flow) {
+          Navigator.push(
+            ctx,
+            MaterialPageRoute(
+                builder: (_) => TrainingHomeScreen(tutorial: flow)),
+          );
+        },
+      ),
+      TutorialStep(
+        targetKey: TrainingHomeScreen.recommendationsKey,
+        description: 'Персональные дриллы. Запустите предложенный пак',
+        onNext: (ctx, flow) {
+          final nav = Navigator.of(ctx);
+          nav.pop();
+          flow.showCurrentStep(nav.context);
+        },
       ),
       TutorialStep(
         targetKey: _newHandButtonKey,

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -40,9 +40,12 @@ import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
 import '../widgets/sync_status_widget.dart';
+import '../tutorial/tutorial_flow.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
-  const TrainingHomeScreen({super.key});
+  final TutorialFlow? tutorial;
+  static final GlobalKey recommendationsKey = GlobalKey();
+  const TrainingHomeScreen({super.key, this.tutorial});
 
   @override
   State<TrainingHomeScreen> createState() => _TrainingHomeScreenState();
@@ -53,6 +56,8 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
   void initState() {
     super.initState();
     context.read<SpotOfTheDayService>().ensureTodaySpot();
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => widget.tutorial?.showCurrentStep(context));
   }
 
   @override
@@ -86,7 +91,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
       ),
       body: ListView(
         children: [
-          const _RecommendedCarousel(),
+          _RecommendedCarousel(key: TrainingHomeScreen.recommendationsKey),
           const QuickContinueCard(),
           const DailyFocusRecapCard(),
           const SpotOfTheDayCard(),
@@ -127,7 +132,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
 }
 
 class _RecommendedCarousel extends StatefulWidget {
-  const _RecommendedCarousel();
+  const _RecommendedCarousel({super.key});
 
   @override
   State<_RecommendedCarousel> createState() => _RecommendedCarouselState();


### PR DESCRIPTION
## Summary
- add tutorial step to highlight personal drills
- provide TrainingHomeScreen key to target the recommendations carousel

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687381b15340832a9f5a7c9fa18c54bd