### PR TITLE
Adjust calendar grid for narrow screens

### DIFF
--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -17,6 +17,7 @@ import '../models/training_pack.dart';
 import '../models/game_type.dart';
 import 'session_detail_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class AllSessionsScreen extends StatefulWidget {
   const AllSessionsScreen({super.key});
@@ -691,7 +692,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
             FadeTransition(opacity: animation, child: child),
         child: Container(
           key: ValueKey(_accuracyChartKey),
-          height: 200,
+          height: responsiveSize(context, 200),
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
             color: const Color(0xFF2A2B2E),

--- a/lib/screens/category_analytics_screen.dart
+++ b/lib/screens/category_analytics_screen.dart
@@ -7,6 +7,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../helpers/category_translations.dart';
 import '../theme/app_colors.dart';
 import '../widgets/common/animated_line_chart.dart';
+import '../utils/responsive.dart';
 
 class CategoryAnalyticsScreen extends StatelessWidget {
   static const route = '/category_analytics';
@@ -19,7 +20,7 @@ class CategoryAnalyticsScreen extends StatelessWidget {
       ...icm.map((e) => e.key)
     }.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -48,7 +49,7 @@ class CategoryAnalyticsScreen extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/daily_progress_history_screen.dart
+++ b/lib/screens/daily_progress_history_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class DailyProgressHistoryScreen extends StatelessWidget {
   const DailyProgressHistoryScreen({super.key});
@@ -26,8 +27,8 @@ class DailyProgressHistoryScreen extends StatelessWidget {
       body: GridView.builder(
         padding: const EdgeInsets.all(16),
         itemCount: days.length,
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 7,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: isCompactWidth(context) ? 4 : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -8,6 +8,7 @@ import '../helpers/date_utils.dart';
 import '../models/drill_result.dart';
 import '../services/training_pack_storage_service.dart';
 import '../models/saved_hand.dart';
+import '../utils/responsive.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../helpers/pack_spot_utils.dart';
 import 'package:collection/collection.dart';
@@ -43,8 +44,8 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
 
   Widget _progressChart(List<DrillResult> data) {
     if (data.length < 2) {
-      return const SizedBox(
-        height: 200,
+      return SizedBox(
+        height: responsiveSize(context, 200),
         child: Center(
           child:
               Text('Недостаточно данных', style: TextStyle(color: Colors.white70)),
@@ -60,7 +61,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
     }
     final step = (sorted.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -12,6 +12,7 @@ import '../theme/app_colors.dart';
 import 'daily_progress_history_screen.dart';
 import 'achievements_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class GoalOverviewScreen extends StatefulWidget {
   const GoalOverviewScreen({super.key});
@@ -238,8 +239,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: 7,
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 7,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: isCompactWidth(context) ? 4 : 7,
                     mainAxisSpacing: 4,
                     crossAxisSpacing: 4,
                   ),

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -10,6 +10,7 @@ import 'streak_calendar_screen.dart';
 import '../widgets/mistake_summary_card.dart';
 import '../widgets/sync_status_widget.dart';
 import '../widgets/streak_trend_chart.dart';
+import '../utils/responsive.dart';
 
 enum _Mode { daily, weekly }
 
@@ -31,14 +32,14 @@ class _InsightsScreenState extends State<InsightsScreen> {
       _mode == _Mode.daily ? s.mistakesDaily(7) : s.mistakesWeekly(6);
 
   Widget _chart(List<MapEntry<DateTime, int>> data) {
-    if (data.length < 2) return const SizedBox(height: 200);
+    if (data.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final spots = <FlSpot>[];
     for (var i = 0; i < data.length; i++) {
       spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
     }
     final step = (data.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -111,7 +112,7 @@ class _InsightsScreenState extends State<InsightsScreen> {
 
   Widget _pie(GoalEngine g) {
     final goals = g.goals;
-    if (goals.isEmpty) return const SizedBox(height: 200);
+    if (goals.isEmpty) return SizedBox(height: responsiveSize(context, 200));
     final completed = goals.where((gg) => gg.completed).length;
     final sections = [
       PieChartSectionData(
@@ -136,7 +137,7 @@ class _InsightsScreenState extends State<InsightsScreen> {
       ),
     ];
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -11,6 +11,7 @@ import '../services/cloud_sync_service.dart';
 import '../services/training_pack_cloud_sync_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -79,7 +80,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Widget _buildChart() {
     if (_stats.isEmpty) {
       return Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -14,6 +14,7 @@ import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
+import '../utils/responsive.dart';
 
 class ProgressDashboardScreen extends StatefulWidget {
   const ProgressDashboardScreen({super.key});
@@ -99,8 +100,8 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             itemCount: days.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 7,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: isCompactWidth(context) ? 4 : 7,
               mainAxisSpacing: 4,
               crossAxisSpacing: 4,
             ),

--- a/lib/screens/progress_history_screen.dart
+++ b/lib/screens/progress_history_screen.dart
@@ -5,6 +5,7 @@ import '../services/progress_forecast_service.dart';
 import '../widgets/progress_history_chart.dart';
 import '../widgets/sync_status_widget.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class ProgressHistoryScreen extends StatelessWidget {
   static const route = '/progress_history';
@@ -30,7 +31,7 @@ class ProgressHistoryScreen extends StatelessWidget {
 
   Widget _placeholder() {
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       alignment: Alignment.center,
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/progress_overview_screen.dart
+++ b/lib/screens/progress_overview_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/common/ev_icm_trend_chart.dart' as common;
 import '../widgets/sync_status_widget.dart';
 import '../theme/app_colors.dart';
 import '../services/training_stats_service.dart';
+import '../utils/responsive.dart';
 import '../services/saved_hand_manager_service.dart';
 
 class ProgressOverviewScreen extends StatefulWidget {
@@ -91,7 +92,7 @@ class _ProgressOverviewScreenState extends State<ProgressOverviewScreen> {
 
   Widget _placeholder() {
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       alignment: Alignment.center,
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -36,6 +36,7 @@ import 'drill_history_screen.dart';
 import 'goal_drill_screen.dart';
 import 'weekly_progress_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -258,7 +259,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     if (_streakSpots.length < 2) return const SizedBox.shrink();
     final accent = Theme.of(context).colorScheme.secondary;
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -315,7 +316,7 @@ class _ProgressScreenState extends State<ProgressScreen>
   Widget _buildWeeklyAccuracyChart() {
     if (_weeklyAccuracy.isEmpty) {
       return Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: AppColors.cardBackground,
@@ -332,7 +333,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     }
     final step = (_weeklyAccuracy.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -415,7 +416,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     final interval = minY.abs() < 1 ? 1.0 : (minY.abs() / 5).ceilToDouble();
     final step = (_dailyEvLoss.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -614,7 +615,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     final step = (_mistakesPerDay.length / 6).ceil();
 
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
@@ -713,7 +714,7 @@ class _ProgressScreenState extends State<ProgressScreen>
               pw.Text('Результаты',
                   style: pw.TextStyle(font: boldFont, fontSize: 18)),
               pw.Container(
-                height: 200,
+                height: responsiveSize(context, 200),
                 child: pw.Chart(
                   grid: pw.PieGrid(),
                   datasets: [
@@ -736,7 +737,7 @@ class _ProgressScreenState extends State<ProgressScreen>
               pw.Text('История стрика',
                   style: pw.TextStyle(font: boldFont, fontSize: 18)),
               pw.Container(
-                height: 200,
+                height: responsiveSize(context, 200),
                 child: pw.Chart(
                   grid: pw.CartesianGrid(
                     xAxis: pw.FixedAxis(

--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -14,6 +14,7 @@ import '../services/file_saver_service.dart';
 import 'session_replay_screen.dart';
 import '../widgets/common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 import '../theme/constants.dart';
 import '../services/session_note_service.dart';
 import 'package:provider/provider.dart';
@@ -133,7 +134,7 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
     final interval = (maxAbs / 5).ceilToDouble();
     final step = (_evs.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -14,6 +14,7 @@ import '../services/session_note_service.dart';
 import '../services/progress_export_service.dart';
 import '../services/training_stats_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 import '../widgets/common/session_accuracy_distribution_chart.dart';
 import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
@@ -960,7 +961,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
           SizedBox(height: 16 * scale),
           if (weekly.length > 1)
             Container(
-              height: 200,
+              height: responsiveSize(context, 200),
               padding: EdgeInsets.all(12 * scale),
               decoration: BoxDecoration(
                 color: AppColors.cardBackground,

--- a/lib/screens/streak_calendar_screen.dart
+++ b/lib/screens/streak_calendar_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/training_stats_service.dart';
 import '../widgets/sync_status_widget.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class StreakCalendarScreen extends StatelessWidget {
   const StreakCalendarScreen({super.key});
@@ -66,8 +67,8 @@ class StreakCalendarScreen extends StatelessWidget {
       body: GridView.builder(
         padding: const EdgeInsets.all(16),
         itemCount: 42,
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 7,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: isCompactWidth(context) ? 4 : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -8,6 +8,7 @@ import 'package:share_plus/share_plus.dart';
 import '../helpers/date_utils.dart';
 import '../helpers/action_utils.dart';
 import 'package:provider/provider.dart';
+import '../utils/responsive.dart';
 
 import 'dart:convert';
 import 'dart:io';
@@ -2554,7 +2555,7 @@ class _EvIcmLineChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (len / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -7,6 +7,7 @@ import '../services/achievement_engine.dart';
 import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/responsive.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -21,14 +22,14 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
   }
 
   Widget _chart(List<MapEntry<DateTime, int>> data, Color color) {
-    if (data.length < 2) return const SizedBox(height: 200);
+    if (data.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final spots = <FlSpot>[];
     for (var i = 0; i < data.length; i++) {
       spots.add(FlSpot(i.toDouble(), data[i].value.toDouble()));
     }
     final step = (data.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -6,6 +6,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../../utils/responsive.dart';
 
 import '../../models/v2/training_pack_template.dart';
 import '../../models/v2/training_pack_spot.dart';
@@ -532,7 +533,7 @@ class _DeltaChart extends StatelessWidget {
     final interval = range > 0 ? (range / 5).ceilToDouble() : 1.0;
     final step = (len / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/screens/v2/training_pack_result_screen_v2.dart
+++ b/lib/screens/v2/training_pack_result_screen_v2.dart
@@ -13,6 +13,7 @@ import '../../models/v2/training_pack_spot.dart';
 import '../../theme/app_colors.dart';
 import 'training_pack_play_screen.dart';
 import '../../services/mistake_review_pack_service.dart';
+import '../../utils/responsive.dart';
 
 class TrainingPackResultScreenV2 extends StatelessWidget {
   final TrainingPackTemplate template;
@@ -311,7 +312,7 @@ class _EvDiffChart extends StatelessWidget {
     }
     final interval = maxY / 5;
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,
@@ -406,7 +407,7 @@ class _IcmDiffChart extends StatelessWidget {
     }
     final interval = maxY / 5;
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,

--- a/lib/screens/weekly_progress_screen.dart
+++ b/lib/screens/weekly_progress_screen.dart
@@ -8,6 +8,7 @@ import '../services/icm_push_ev_service.dart';
 import '../models/saved_hand.dart';
 import '../models/action_entry.dart';
 import '../helpers/hand_utils.dart';
+import '../utils/responsive.dart';
 import '../theme/app_colors.dart';
 
 class WeeklyProgressScreen extends StatelessWidget {
@@ -134,7 +135,7 @@ class WeeklyProgressScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         children: [
           Container(
-            height: 200,
+            height: responsiveSize(context, 200),
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               color: AppColors.cardBackground,

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import '../helpers/action_utils.dart';
 import '../services/action_history_service.dart';
+import '../utils/responsive.dart';
 
 class CollapsibleActionHistory extends StatefulWidget {
   final ActionHistoryService actionHistory;
@@ -122,7 +123,7 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
         if (_open)
           Container(
             color: Colors.black54,
-            height: 200,
+            height: responsiveSize(context, 200),
             child: Column(
               children: [
                 TabBar(

--- a/lib/widgets/common/accuracy_chart.dart
+++ b/lib/widgets/common/accuracy_chart.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'animated_line_chart.dart';
 import '../../models/training_result.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class AccuracyChart extends StatelessWidget {
   final List<TrainingResult> sessions;
@@ -33,7 +34,7 @@ class AccuracyChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/accuracy_distribution_chart.dart
+++ b/lib/widgets/common/accuracy_distribution_chart.dart
@@ -5,6 +5,7 @@ import 'package:fl_chart/fl_chart.dart';
 
 import '../../models/training_result.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class AccuracyDistributionChart extends StatelessWidget {
   final List<TrainingResult> sessions;
@@ -63,7 +64,7 @@ class AccuracyDistributionChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/accuracy_trend_chart.dart
+++ b/lib/widgets/common/accuracy_trend_chart.dart
@@ -4,6 +4,7 @@ import 'animated_line_chart.dart';
 
 import '../../models/training_result.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 enum ChartMode { daily, weekly, monthly }
 
@@ -48,7 +49,7 @@ class AccuracyTrendChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/action_accuracy_chart.dart
+++ b/lib/widgets/common/action_accuracy_chart.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'animated_line_chart.dart';
 
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 import '../../models/v2/training_action.dart';
 
 class ActionAccuracyChart extends StatelessWidget {
@@ -35,7 +36,7 @@ class ActionAccuracyChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/average_accuracy_chart.dart
+++ b/lib/widgets/common/average_accuracy_chart.dart
@@ -4,6 +4,7 @@ import 'animated_line_chart.dart';
 
 import '../../models/training_result.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class AverageAccuracyChart extends StatelessWidget {
   final List<TrainingResult> sessions;
@@ -37,7 +38,7 @@ class AverageAccuracyChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/ev_icm_trend_chart.dart
+++ b/lib/widgets/common/ev_icm_trend_chart.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 
 import '../../services/progress_forecast_service.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 import 'animated_line_chart.dart';
 
 class EvIcmTrendChart extends StatelessWidget {
@@ -15,7 +16,7 @@ class EvIcmTrendChart extends StatelessWidget {
     final icm = [for (final e in data) MapEntry(e.date, e.icm)];
     final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -44,7 +45,7 @@ class EvIcmTrendChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/common/mistake_by_street_chart.dart
+++ b/lib/widgets/common/mistake_by_street_chart.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class MistakeByStreetChart extends StatelessWidget {
   final Map<String, int> counts;
@@ -50,7 +51,7 @@ class MistakeByStreetChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/session_accuracy_bar_chart.dart
+++ b/lib/widgets/common/session_accuracy_bar_chart.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/training_result.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class SessionAccuracyBarChart extends StatelessWidget {
   final List<TrainingResult> sessions;
@@ -48,7 +49,7 @@ class SessionAccuracyBarChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/session_accuracy_distribution_chart.dart
+++ b/lib/widgets/common/session_accuracy_distribution_chart.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class SessionAccuracyDistributionChart extends StatelessWidget {
   final List<double> accuracies;
@@ -63,7 +64,7 @@ class SessionAccuracyDistributionChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/common/session_volume_accuracy_chart.dart
+++ b/lib/widgets/common/session_volume_accuracy_chart.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'animated_line_chart.dart';
 
 import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
 
 class SessionVolumeAccuracyPoint {
   final DateTime date;
@@ -64,7 +65,7 @@ class SessionVolumeAccuracyChart extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
-        height: 200,
+        height: responsiveSize(context, 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           color: AppColors.cardBackground,

--- a/lib/widgets/daily_ev_icm_chart.dart
+++ b/lib/widgets/daily_ev_icm_chart.dart
@@ -6,6 +6,7 @@ import '../services/training_stats_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class DailyEvIcmChart extends StatelessWidget {
   final int days;
@@ -22,7 +23,7 @@ class DailyEvIcmChart extends StatelessWidget {
       for (final e in icm) e.key,
     }.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -51,7 +52,7 @@ class DailyEvIcmChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/ev_icm_chart.dart
+++ b/lib/widgets/ev_icm_chart.dart
@@ -8,6 +8,7 @@ import '../services/push_fold_ev_service.dart';
 import '../services/icm_push_ev_service.dart';
 import 'common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class EvIcmChart extends StatelessWidget {
   final List<SavedHand> hands;
@@ -84,7 +85,7 @@ class EvIcmChart extends StatelessWidget {
     final interval = (maxAbs / 5).ceilToDouble();
     final step = (data.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/ev_icm_history_chart.dart
+++ b/lib/widgets/ev_icm_history_chart.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'common/animated_line_chart.dart';
 import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class EvIcmHistoryChart extends StatelessWidget {
   const EvIcmHistoryChart({super.key});
@@ -15,7 +16,7 @@ class EvIcmHistoryChart extends StatelessWidget {
     final icm = service.icmSeries;
     final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -44,7 +45,7 @@ class EvIcmHistoryChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/ev_icm_series_chart.dart
+++ b/lib/widgets/ev_icm_series_chart.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 import '../services/progress_forecast_service.dart';
 
 class EvIcmSeriesChart extends StatelessWidget {
@@ -14,7 +15,7 @@ class EvIcmSeriesChart extends StatelessWidget {
     final icm = [for (final e in data) MapEntry(e.date, e.icm)];
     final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -43,7 +44,7 @@ class EvIcmSeriesChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/ev_icm_trend_chart.dart
+++ b/lib/widgets/ev_icm_trend_chart.dart
@@ -6,6 +6,7 @@ import '../services/training_stats_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 enum EvIcmTrendMode { weekly, monthly }
 
@@ -43,7 +44,7 @@ class EvIcmTrendChart extends StatelessWidget {
       ...icm.map((e) => e.key)
     }.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -170,7 +171,7 @@ class EvIcmTrendChart extends StatelessWidget {
     );
     return Column(
       children: [
-        SizedBox(height: 200, child: chart),
+        SizedBox(height: responsiveSize(context, 200), child: chart),
         const SizedBox(height: 4),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/widgets/progress_history_chart.dart
+++ b/lib/widgets/progress_history_chart.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'common/animated_line_chart.dart';
 import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class ProgressHistoryChart extends StatelessWidget {
   const ProgressHistoryChart({super.key});
@@ -15,7 +16,7 @@ class ProgressHistoryChart extends StatelessWidget {
     final icm = service.icmSeries;
     final dates = {...ev.map((e) => e.key), ...icm.map((e) => e.key)}.toList()
       ..sort();
-    if (dates.length < 2) return const SizedBox(height: 200);
+    if (dates.length < 2) return SizedBox(height: responsiveSize(context, 200));
     final evMap = {for (final e in ev) e.key: e.value};
     final icmMap = {for (final e in icm) e.key: e.value};
     final spotsEv = <FlSpot>[];
@@ -44,7 +45,7 @@ class ProgressHistoryChart extends StatelessWidget {
     final interval = (maxY - minY) / 4;
     final step = (dates.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/streak_trend_chart.dart
+++ b/lib/widgets/streak_trend_chart.dart
@@ -5,6 +5,7 @@ import 'common/animated_line_chart.dart';
 
 import '../services/streak_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class StreakTrendChart extends StatelessWidget {
   const StreakTrendChart({super.key});
@@ -13,14 +14,14 @@ class StreakTrendChart extends StatelessWidget {
   Widget build(BuildContext context) {
     final data = context.watch<StreakService>().history;
     if (data.length < 2) {
-      return const SizedBox(height: 200);
+      return SizedBox(height: responsiveSize(context, 200));
     }
     final spots = <FlSpot>[for (var i = 0; i < data.length; i++) FlSpot(i.toDouble(), data[i].value.toDouble())];
     final maxY = data.map((e) => e.value).reduce((a, b) => a > b ? a : b).toDouble();
     final interval = maxY <= 5 ? 1.0 : (maxY / 5).ceilToDouble();
     final step = (data.length / 6).ceil();
     return Container(
-      height: 200,
+      height: responsiveSize(context, 200),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,

--- a/lib/widgets/training_calendar_widget.dart
+++ b/lib/widgets/training_calendar_widget.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/training_stats_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
 
 class TrainingCalendarWidget extends StatelessWidget {
   const TrainingCalendarWidget({super.key});
@@ -33,8 +34,8 @@ class TrainingCalendarWidget extends StatelessWidget {
         itemCount: 42,
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 7,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: isCompactWidth(context) ? 4 : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),


### PR DESCRIPTION
## Summary
- adapt calendar grids to narrow width
- scale chart widget heights with screen size

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687381b3a618832aa341cfe911b5fba9