### PR TITLE
Add similar mistake drill button

### DIFF
--- a/lib/screens/analyzer_result_screen.dart
+++ b/lib/screens/analyzer_result_screen.dart
@@ -174,7 +174,9 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
                   h.gtoAction!.trim().toLowerCase())
           .length;
     });
-    final showFab = _isMistake && similarCount > 0;
+    final hasSimilar = context.select<SavedHandManagerService, bool>(
+        (s) => s.hasSimilarMistakes(_hand));
+    final showFab = hasSimilar;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Результаты анализа'),
@@ -189,8 +191,8 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
                 FloatingActionButton.extended(
                   onPressed: () async {
                     final tpl =
-                        await TrainingPackService.createSimilarMistakeDrill(
-                            _hand);
+                        await TrainingPackService.createDrillFromSimilarHands(
+                            context, _hand);
                     if (tpl == null) return;
                     await context
                         .read<TrainingSessionService>()
@@ -203,7 +205,7 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
                       );
                     }
                   },
-                  label: const Text('Отработать похожие'),
+                  label: const Text('Train Similar Mistakes'),
                   icon: const Icon(Icons.fitness_center),
                 ),
                 const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- show `Train Similar Mistakes` button on AnalyzerResultScreen when similar mistakes exist
- start a new training session from similar mistakes when pressed

## Testing
- `flutter analyze` *(fails: numerous warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_687384bc8244832aa557f4024d24ccb3