### PR TITLE
Add orientation helpers

### DIFF
--- a/lib/screens/daily_progress_history_screen.dart
+++ b/lib/screens/daily_progress_history_screen.dart
@@ -25,10 +25,14 @@ class DailyProgressHistoryScreen extends StatelessWidget {
         actions: [SyncStatusIcon.of(context)],
       ),
       body: GridView.builder(
-        padding: const EdgeInsets.all(16),
+        padding: scaledPadding(context, 16),
         itemCount: days.length,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: isCompactWidth(context) ? 4 : 7,
+          crossAxisCount: isTablet(context) || isLandscape(context)
+              ? 8
+              : isCompactWidth(context)
+                  ? 4
+                  : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),
@@ -48,7 +52,8 @@ class DailyProgressHistoryScreen extends StatelessWidget {
                 Text('${d.day}',
                     style: const TextStyle(color: Colors.white, fontSize: 12)),
                 Text('$count',
-                    style: const TextStyle(color: Colors.white70, fontSize: 10)),
+                    style:
+                        const TextStyle(color: Colors.white70, fontSize: 10)),
               ],
             ),
           );

--- a/lib/screens/goal_overview_screen.dart
+++ b/lib/screens/goal_overview_screen.dart
@@ -22,7 +22,6 @@ class GoalOverviewScreen extends StatefulWidget {
 }
 
 class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
-
   @override
   void initState() {
     super.initState();
@@ -48,9 +47,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
     final categories = tipService.categories;
     final streak = streakService.count;
     final history = streakService.history;
-    final maxStreak = history.isEmpty
-        ? streak
-        : history.map((e) => e.value).reduce(math.max);
+    final maxStreak =
+        history.isEmpty ? streak : history.map((e) => e.value).reduce(math.max);
     final target = targetService.target;
     final now = DateTime.now();
     final start = DateTime(now.year, now.month, now.day)
@@ -62,7 +60,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
       appBar: AppBar(
         title: const Text('Goal'),
         centerTitle: true,
-        actions: [SyncStatusIcon.of(context), 
+        actions: [
+          SyncStatusIcon.of(context),
           IconButton(
             icon: const Icon(Icons.calendar_today),
             onPressed: () {
@@ -124,14 +123,15 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                                     .read<DailyTipService>()
                                     .setCategory(v!),
                                 items: categories
-                                    .map(
-                                        (c) => DropdownMenuItem(value: c, child: Text(c)))
+                                    .map((c) => DropdownMenuItem(
+                                        value: c, child: Text(c)))
                                     .toList(),
                               ),
                             ],
                           ),
                           const SizedBox(height: 4),
-                          Text(tip, style: const TextStyle(color: Colors.white)),
+                          Text(tip,
+                              style: const TextStyle(color: Colors.white)),
                         ],
                       ),
                     ),
@@ -170,7 +170,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                   child: LinearProgressIndicator(
                     value: xpService.progress.clamp(0.0, 1.0),
                     backgroundColor: Colors.white24,
-                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.blueAccent),
+                    valueColor:
+                        const AlwaysStoppedAnimation<Color>(Colors.blueAccent),
                     minHeight: 6,
                   ),
                 ),
@@ -195,7 +196,8 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                   child: LinearProgressIndicator(
                     value: challengeService.progress,
                     backgroundColor: Colors.white24,
-                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.greenAccent),
+                    valueColor:
+                        const AlwaysStoppedAnimation<Color>(Colors.greenAccent),
                     minHeight: 6,
                   ),
                 ),
@@ -240,7 +242,11 @@ class _GoalOverviewScreenState extends State<GoalOverviewScreen> {
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: 7,
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: isCompactWidth(context) ? 4 : 7,
+                    crossAxisCount: isTablet(context) || isLandscape(context)
+                        ? 8
+                        : isCompactWidth(context)
+                            ? 4
+                            : 7,
                     mainAxisSpacing: 4,
                     crossAxisSpacing: 4,
                   ),

--- a/lib/screens/streak_calendar_screen.dart
+++ b/lib/screens/streak_calendar_screen.dart
@@ -65,10 +65,14 @@ class StreakCalendarScreen extends StatelessWidget {
         actions: [SyncStatusIcon.of(context)],
       ),
       body: GridView.builder(
-        padding: const EdgeInsets.all(16),
+        padding: scaledPadding(context, 16),
         itemCount: 42,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: isCompactWidth(context) ? 4 : 7,
+          crossAxisCount: isTablet(context) || isLandscape(context)
+              ? 8
+              : isCompactWidth(context)
+                  ? 4
+                  : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),

--- a/lib/utils/responsive.dart
+++ b/lib/utils/responsive.dart
@@ -1,7 +1,27 @@
 import 'package:flutter/widgets.dart';
 
-bool isCompactWidth(BuildContext context) => MediaQuery.of(context).size.width < 360;
+bool isCompactWidth(BuildContext context) =>
+    MediaQuery.of(context).size.width < 360;
+bool isTablet(BuildContext context) =>
+    MediaQuery.of(context).size.shortestSide >= 600;
+bool isLandscape(BuildContext context) =>
+    MediaQuery.of(context).orientation == Orientation.landscape;
 
-double responsiveSize(BuildContext context, double value) => isCompactWidth(context) ? value / 2 : value;
+double responsiveSize(BuildContext context, double value) {
+  if (isTablet(context)) return value * 1.5;
+  if (isCompactWidth(context)) return value / 2;
+  return value;
+}
 
-EdgeInsets responsiveAll(BuildContext context, double value) => EdgeInsets.all(responsiveSize(context, value));
+EdgeInsets responsiveAll(BuildContext context, double value) =>
+    EdgeInsets.all(responsiveSize(context, value));
+EdgeInsets responsiveSymmetric(BuildContext context,
+        {double horizontal = 0, double vertical = 0}) =>
+    EdgeInsets.symmetric(
+      horizontal: responsiveSize(context, horizontal),
+      vertical: responsiveSize(context, vertical),
+    );
+double paddingSize(BuildContext context, double value) =>
+    responsiveSize(context, value);
+EdgeInsets scaledPadding(BuildContext context, double value) =>
+    EdgeInsets.all(paddingSize(context, value));

--- a/lib/widgets/training_calendar_widget.dart
+++ b/lib/widgets/training_calendar_widget.dart
@@ -25,7 +25,7 @@ class TrainingCalendarWidget extends StatelessWidget {
     final days = [for (var i = 0; i < 42; i++) start.add(Duration(days: i))];
 
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: scaledPadding(context, 12),
       decoration: BoxDecoration(
         color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(8),
@@ -35,7 +35,11 @@ class TrainingCalendarWidget extends StatelessWidget {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: isCompactWidth(context) ? 4 : 7,
+          crossAxisCount: isTablet(context) || isLandscape(context)
+              ? 8
+              : isCompactWidth(context)
+                  ? 4
+                  : 7,
           mainAxisSpacing: 4,
           crossAxisSpacing: 4,
         ),


### PR DESCRIPTION
## Summary
- support tablet breakpoint and device orientation
- expose helpers for orientation and padding
- adjust calendar widgets to use the new helpers

## Testing
- `dart format -o write lib/utils/responsive.dart lib/widgets/training_calendar_widget.dart lib/screens/daily_progress_history_screen.dart lib/screens/goal_overview_screen.dart lib/screens/progress_dashboard_screen.dart lib/screens/streak_calendar_screen.dart`
- `dart analyze` *(fails: Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68738d0a74f0832a83de073d8b9e8ca6