### PR TITLE
Enable zoomable charts

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -12,7 +12,7 @@ import 'dart:math';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:confetti/confetti.dart';
-import '../widgets/common/animated_line_chart.dart';
+import '../widgets/common/interactive_line_chart.dart';
 
 import '../services/goals_service.dart';
 import '../services/evaluation_executor_service.dart';
@@ -265,7 +265,7 @@ class _ProgressScreenState extends State<ProgressScreen>
         color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: AnimatedLineChart(
+      child: InteractiveLineChart(
         data: LineChartData(
           minY: 0,
           gridData: FlGridData(
@@ -339,7 +339,7 @@ class _ProgressScreenState extends State<ProgressScreen>
         color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: AnimatedLineChart(
+      child: InteractiveLineChart(
         data: LineChartData(
           minY: 0,
           maxY: 100,
@@ -422,7 +422,7 @@ class _ProgressScreenState extends State<ProgressScreen>
         color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: AnimatedLineChart(
+      child: InteractiveLineChart(
         data: LineChartData(
           minY: minY,
           maxY: 0,

--- a/lib/widgets/common/interactive_line_chart.dart
+++ b/lib/widgets/common/interactive_line_chart.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'animated_line_chart.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+class InteractiveLineChart extends StatelessWidget {
+  final LineChartData data;
+  final Duration duration;
+  final Curve curve;
+  final double minScale;
+  final double maxScale;
+
+  const InteractiveLineChart({
+    super.key,
+    required this.data,
+    this.duration = const Duration(milliseconds: 600),
+    this.curve = Curves.easeOut,
+    this.minScale = 1,
+    this.maxScale = 5,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InteractiveViewer(
+      panAxis: PanAxis.horizontal,
+      minScale: minScale,
+      maxScale: maxScale,
+      child: AnimatedLineChart(
+        data: data,
+        duration: duration,
+        curve: curve,
+      ),
+    );
+  }
+}

--- a/lib/widgets/ev_icm_history_chart.dart
+++ b/lib/widgets/ev_icm_history_chart.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'common/animated_line_chart.dart';
+import 'common/interactive_line_chart.dart';
 import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
 import '../utils/responsive.dart';
@@ -51,7 +51,7 @@ class EvIcmHistoryChart extends StatelessWidget {
         color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: AnimatedLineChart(
+      child: InteractiveLineChart(
         data: LineChartData(
           minY: minY,
           maxY: maxY,


### PR DESCRIPTION
## Summary
- add InteractiveLineChart for pinch-zoom and scroll
- use it in progress charts
- update EV/ICM history chart

## Testing
- `flutter analyze --no-pub --suppress-analytics -v` *(fails: 13720 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68738d10ec2c832a887feb820d0c6bcb