### PR TITLE
Add EV stats chart

### DIFF
--- a/lib/screens/ev_stats_screen.dart
+++ b/lib/screens/ev_stats_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../widgets/ev_stats_chart.dart';
+import '../widgets/sync_status_widget.dart';
+import '../services/saved_hand_manager_service.dart';
+
+class EvStatsScreen extends StatelessWidget {
+  static const route = '/ev_stats';
+  const EvStatsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    context.watch<SavedHandManagerService>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Статистика EV'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [EvStatsChart()],
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -34,6 +34,7 @@ import 'plugin_manager_screen.dart';
 import 'online_plugin_catalog_screen.dart';
 import 'onboarding_screen.dart';
 import 'ev_icm_analytics_screen.dart';
+import 'ev_stats_screen.dart';
 import 'progress_dashboard_screen.dart';
 import 'position_tag_analytics_screen.dart';
 import 'weakness_overview_screen.dart';
@@ -256,6 +257,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                     ),
                   );
                   break;
+                case 'evstats':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const EvStatsScreen(),
+                    ),
+                  );
+                  break;
                 case 'dashboard':
                   Navigator.push(
                     context,
@@ -292,6 +301,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               PopupMenuItem(value: 'community_plugins', child: Text('🌐 Community')),
               PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
               PopupMenuItem(value: 'evicm', child: Text('EV/ICM')),
+              PopupMenuItem(value: 'evstats', child: Text('EV Stats')),
               PopupMenuItem(value: 'pos_tag', child: Text('Позиции/Теги')),
               PopupMenuItem(value: 'dashboard', child: Text('📈 Dashboard')),
               PopupMenuItem(value: 'about', child: Text('About')),

--- a/lib/widgets/ev_stats_chart.dart
+++ b/lib/widgets/ev_stats_chart.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../services/saved_hand_manager_service.dart';
+import 'common/animated_line_chart.dart';
+import '../theme/app_colors.dart';
+import '../utils/responsive.dart';
+
+class EvStatsChart extends StatelessWidget {
+  final int days;
+  const EvStatsChart({super.key, this.days = 30});
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = context.watch<SavedHandManagerService>().hands;
+    final now = DateTime.now().toLocal();
+    final start = DateTime(now.year, now.month, now.day).subtract(Duration(days: days - 1));
+    final dates = [for (int i = 0; i < days; i++) start.add(Duration(days: i))];
+    final map = <DateTime, _DayStat>{};
+    for (final h in hands) {
+      final d = h.savedAt.toLocal();
+      final day = DateTime(d.year, d.month, d.day);
+      if (day.isBefore(start) || day.isAfter(dates.last)) continue;
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      if (exp == null || gto == null || exp == gto) continue;
+      final s = map.putIfAbsent(day, () => _DayStat());
+      s.mistakes += 1;
+      s.evLoss += h.evLoss ?? 0;
+    }
+    final spotsLoss = <FlSpot>[];
+    final spotsMist = <FlSpot>[];
+    double minY = 0;
+    double maxY = 0;
+    for (var i = 0; i < dates.length; i++) {
+      final s = map[dates[i]];
+      final loss = s?.evLoss ?? 0;
+      final m = (s?.mistakes ?? 0).toDouble();
+      spotsLoss.add(FlSpot(i.toDouble(), loss));
+      spotsMist.add(FlSpot(i.toDouble(), m));
+      if (loss < minY) minY = loss;
+      if (loss > maxY) maxY = loss;
+      if (m > maxY) maxY = m;
+    }
+    if (minY == maxY) {
+      minY -= 1;
+      maxY += 1;
+    }
+    final interval = (maxY - minY) / 4;
+    final step = (dates.length / 6).ceil();
+    return Container(
+      height: responsiveSize(context, 200),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AnimatedLineChart(
+        data: LineChartData(
+          minY: minY,
+          maxY: maxY,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: interval,
+            getDrawingHorizontalLine: (v) => FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: interval,
+                reservedSize: 40,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toStringAsFixed(1),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= dates.length) return const SizedBox.shrink();
+                  if (i % step != 0 && i != dates.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = dates[i];
+                  return Text(
+                    '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spotsLoss,
+              color: Colors.redAccent,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+            LineChartBarData(
+              spots: spotsMist,
+              color: Colors.orangeAccent,
+              barWidth: 2,
+              isCurved: false,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DayStat {
+  double evLoss = 0;
+  int mistakes = 0;
+}


### PR DESCRIPTION
## Summary
- visualize daily EV loss and mistake count
- show chart on a new EV stats screen
- link EV stats screen from the main menu

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68738cbf3114832a98a8f25a40f2dc0c