### PR TITLE
Add Top 3 Mistakes drill

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -615,7 +615,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   }
 
   Future<void> _top3CategoriesDrill() async {
-    final tpl = await TrainingPackService.createDrillFromTop3Categories(context);
+    final tpl = await TrainingPackService.createDrillFromTopCategories(context);
     if (tpl == null) return;
     await context.read<TrainingSessionService>().startSession(tpl);
     if (!mounted) return;
@@ -1276,7 +1276,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           FloatingActionButton.extended(
             heroTag: 'top3CatFab',
             onPressed: _top3CategoriesDrill,
-            label: const Text('Top 3 категории'),
+            label: const Text('Top 3 Mistakes'),
             icon: const Icon(Icons.leaderboard),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- generate Top 3 Mistakes drill from biggest EV loss categories
- hook up Top 3 Mistakes button to new service method

## Testing
- `flutter pub get` *(fails: The current Flutter SDK version is 0.0.0-unknown)*
- `dart pub get --dry-run`
- `flutter test --run-skipped` *(fails: several compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687390f32d00832abfc273344ca66c9c