### PR TITLE
Add EV/ICM chart to session result

### DIFF
--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -8,6 +8,9 @@ import '../widgets/spot_viewer_dialog.dart';
 import '../widgets/common/action_accuracy_chart.dart';
 import '../theme/app_colors.dart';
 import '../widgets/player_note_button.dart';
+import '../widgets/ev_icm_chart.dart';
+import '../helpers/pack_spot_utils.dart';
+import '../models/saved_hand.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
 import 'v2/training_pack_play_screen.dart';
@@ -32,7 +35,6 @@ class SessionResultScreen extends StatefulWidget {
 }
 
 class _SessionResultScreenState extends State<SessionResultScreen> {
-
   Future<void> _retryMistakes() async {
     final service = context.read<TrainingSessionService>();
     final ids = service.results.entries
@@ -123,14 +125,16 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
           ),
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
-          TextButton(onPressed: () => Navigator.pop(ctx, c.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, c.text),
+              child: const Text('Save')),
         ],
       ),
     );
     if (res != null) {
-      final updated =
-          spot.copyWith(note: res.trim(), editedAt: DateTime.now());
+      final updated = spot.copyWith(note: res.trim(), editedAt: DateTime.now());
       await context.read<TrainingSessionService>().updateSpot(updated);
     }
   }
@@ -140,6 +144,13 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
     final rate = widget.total == 0 ? 0 : widget.correct * 100 / widget.total;
     final service = context.watch<TrainingSessionService>();
     final actions = service.actionLog;
+    final ante = service.template?.anteBb ?? 0;
+    final hands = <SavedHand>[];
+    for (var i = 0; i < service.spots.length; i++) {
+      final h = handFromPackSpot(service.spots[i], anteBb: ante)
+          .copyWith(savedAt: DateTime.now().add(Duration(milliseconds: i)));
+      hands.add(h);
+    }
     return Scaffold(
       appBar: AppBar(title: const Text('Session Result')),
       backgroundColor: const Color(0xFF1B1C1E),
@@ -151,113 +162,133 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-            Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    '${widget.correct} / ${widget.total}',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: s(24),
-                      fontWeight: FontWeight.bold,
-                    ),
+                Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '${widget.correct} / ${widget.total}',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: s(24),
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      SizedBox(height: s(8)),
+                      Text('Accuracy: ${rate.toStringAsFixed(1)}%',
+                          style: const TextStyle(color: Colors.white70)),
+                      SizedBox(height: s(8)),
+                      Text('EV ${service.evAverageAll.toStringAsFixed(2)}',
+                          style: const TextStyle(color: Colors.white70)),
+                      SizedBox(height: s(4)),
+                      Text('ICM ${service.icmAverageAll.toStringAsFixed(2)}',
+                          style: const TextStyle(color: Colors.white70)),
+                      SizedBox(height: s(8)),
+                      Text('Time: ${_format(widget.elapsed)}',
+                          style: const TextStyle(color: Colors.white70)),
+                    ],
                   ),
-                  SizedBox(height: s(8)),
-                  Text('Accuracy: ${rate.toStringAsFixed(1)}%',
-                      style: const TextStyle(color: Colors.white70)),
-                  SizedBox(height: s(8)),
-                  Text('EV ${service.evAverageAll.toStringAsFixed(2)}',
-                      style: const TextStyle(color: Colors.white70)),
-                  SizedBox(height: s(4)),
-                  Text('ICM ${service.icmAverageAll.toStringAsFixed(2)}',
-                      style: const TextStyle(color: Colors.white70)),
-                  SizedBox(height: s(8)),
-                  Text('Time: ${_format(widget.elapsed)}',
-                      style: const TextStyle(color: Colors.white70)),
-                ],
-              ),
-            ),
-            SizedBox(height: s(16)),
-            ActionAccuracyChart(actions: actions),
-            SizedBox(height: s(16)),
-            Expanded(
-              child: actions.isEmpty
-                  ? const Center(
-                      child: Text('No actions recorded', style: TextStyle(color: Colors.white70)),
-                    )
-                  : ListView.builder(
-                      itemCount: actions.length,
-                      itemBuilder: (context, index) {
-                        final a = actions[index];
-                        final color = a.isCorrect ? AppColors.cardBackground : AppColors.errorBg;
-                        final time = DateFormat('HH:mm:ss', Intl.getCurrentLocale()).format(a.timestamp);
-                        TrainingPackSpot? spot;
-                        try {
-                          spot = service.spots.firstWhere((s) => s.id == a.spotId);
-                        } catch (_) {}
-                        if (spot == null) return const SizedBox.shrink();
-                        return InkWell(
-                          onTap: () {
-                            showSpotViewerDialog(context, spot);
+                ),
+                SizedBox(height: s(16)),
+                ActionAccuracyChart(actions: actions),
+                SizedBox(height: s(16)),
+                EvIcmChart(hands: hands),
+                SizedBox(height: s(16)),
+                Expanded(
+                  child: actions.isEmpty
+                      ? const Center(
+                          child: Text('No actions recorded',
+                              style: TextStyle(color: Colors.white70)),
+                        )
+                      : ListView.builder(
+                          itemCount: actions.length,
+                          itemBuilder: (context, index) {
+                            final a = actions[index];
+                            final color = a.isCorrect
+                                ? AppColors.cardBackground
+                                : AppColors.errorBg;
+                            final time =
+                                DateFormat('HH:mm:ss', Intl.getCurrentLocale())
+                                    .format(a.timestamp);
+                            TrainingPackSpot? spot;
+                            try {
+                              spot = service.spots
+                                  .firstWhere((s) => s.id == a.spotId);
+                            } catch (_) {}
+                            if (spot == null) return const SizedBox.shrink();
+                            return InkWell(
+                              onTap: () {
+                                showSpotViewerDialog(context, spot);
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.symmetric(vertical: 4),
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  color: color,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Row(
+                                  children: [
+                                    Text('${index + 1}',
+                                        style: const TextStyle(
+                                            color: Colors.white)),
+                                    const SizedBox(width: 8),
+                                    Expanded(
+                                      child: Text(a.chosenAction,
+                                          style: TextStyle(
+                                              color: a.isCorrect
+                                                  ? Colors.white
+                                                  : Colors.red)),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Icon(
+                                        a.isCorrect ? Icons.check : Icons.close,
+                                        color: a.isCorrect
+                                            ? Colors.green
+                                            : Colors.red,
+                                        size: 16),
+                                    const SizedBox(width: 8),
+                                    Text(time,
+                                        style: const TextStyle(
+                                            color: Colors.white70)),
+                                    const SizedBox(width: 8),
+                                    PlayerNoteButton(
+                                      note: spot.note,
+                                      onPressed: () => _editSpotNote(spot),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
                           },
-                          child: Container(
-                            margin: const EdgeInsets.symmetric(vertical: 4),
-                            padding: const EdgeInsets.all(12),
-                            decoration: BoxDecoration(
-                              color: color,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              children: [
-                                Text('${index + 1}', style: const TextStyle(color: Colors.white)),
-                                const SizedBox(width: 8),
-                                Expanded(
-                                  child: Text(a.chosenAction,
-                                      style: TextStyle(color: a.isCorrect ? Colors.white : Colors.red)),
-                                ),
-                                const SizedBox(width: 8),
-                                Icon(a.isCorrect ? Icons.check : Icons.close,
-                                    color: a.isCorrect ? Colors.green : Colors.red, size: 16),
-                                const SizedBox(width: 8),
-                                Text(time, style: const TextStyle(color: Colors.white70)),
-                                const SizedBox(width: 8),
-                                PlayerNoteButton(
-                                  note: spot.note,
-                                  onPressed: () => _editSpotNote(spot),
-                                ),
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-            ),
-            SizedBox(height: s(16)),
-            Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SizedBox(
-                    width: s(200),
-                    child: ElevatedButton(
-                      onPressed: _retryMistakes,
-                      child: const Text('Retry mistakes'),
-                    ),
+                        ),
+                ),
+                SizedBox(height: s(16)),
+                Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: s(200),
+                        child: ElevatedButton(
+                          onPressed: _retryMistakes,
+                          child: const Text('Retry mistakes'),
+                        ),
+                      ),
+                      SizedBox(height: s(8)),
+                      SizedBox(
+                        width: s(200),
+                        child: ElevatedButton(
+                          onPressed: () => widget.authorPreview
+                              ? Navigator.pop(context)
+                              : Navigator.of(context)
+                                  .popUntil((r) => r.isFirst),
+                          child: const Text('Done'),
+                        ),
+                      ),
+                    ],
                   ),
-                  SizedBox(height: s(8)),
-                  SizedBox(
-                    width: s(200),
-                    child: ElevatedButton(
-                      onPressed: () => widget.authorPreview
-                          ? Navigator.pop(context)
-                          : Navigator.of(context).popUntil((r) => r.isFirst),
-                      child: const Text('Done'),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+                ),
               ],
             ),
           );


### PR DESCRIPTION
## Summary
- visualize EV and ICM trend in session results

## Testing
- `flutter analyze` *(fails: some errors in tool/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6874019df33c832ab67f41d10ed63d17