### PR TITLE
Add Ready to Train screen

### DIFF
--- a/lib/helpers/training_onboarding.dart
+++ b/lib/helpers/training_onboarding.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../screens/template_library_screen.dart';
+import '../screens/ready_to_train_screen.dart';
 import '../screens/training_onboarding_screen.dart';
 
 Future<void> openTrainingTemplates(BuildContext context) async {
@@ -10,7 +10,7 @@ Future<void> openTrainingTemplates(BuildContext context) async {
     context,
     MaterialPageRoute(
       builder: (_) => seen
-          ? const TemplateLibraryScreen()
+          ? const ReadyToTrainScreen()
           : const TrainingOnboardingScreen(),
     ),
   );

--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/training_pack_template_service.dart';
+import '../services/training_pack_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/training_session_service.dart';
+import '../models/saved_hand.dart';
+import '../models/v2/training_pack_template.dart';
+import 'training_session_screen.dart';
+import 'package:collection/collection.dart';
+
+class ReadyToTrainScreen extends StatefulWidget {
+  const ReadyToTrainScreen({super.key});
+
+  @override
+  State<ReadyToTrainScreen> createState() => _ReadyToTrainScreenState();
+}
+
+class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
+  final List<TrainingPackTemplate> _templates = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final builtIn = TrainingPackTemplateService.getAllTemplates(context);
+    final top = await TrainingPackService.createTopMistakeDrill(context);
+    final community = await TrainingPackService.createDrillFromGlobalMistakes(context);
+    SavedHand? last = context.read<SavedHandManagerService>().hands.reversed.firstWhereOrNull((h) {
+      final exp = h.expectedAction?.trim().toLowerCase();
+      final gto = h.gtoAction?.trim().toLowerCase();
+      final ev = h.evLoss ?? 0.0;
+      return ev.abs() >= 1.0 && !h.corrected && exp != null && gto != null && exp != gto;
+    });
+    final similar = last != null ? await TrainingPackService.createSimilarMistakeDrill(last) : null;
+    if (!mounted) return;
+    setState(() {
+      _templates
+        ..addAll(builtIn)
+        ..addAll([if (top != null) top, if (community != null) community, if (similar != null) similar]);
+      _loading = false;
+    });
+  }
+
+  Future<void> _start(TrainingPackTemplate tpl) async {
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (context.mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+      );
+    }
+  }
+
+  Widget _card(TrainingPackTemplate t) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(t.name, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+                if (t.description.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(t.description, style: const TextStyle(color: Colors.white70)),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text('${t.spots.length} spots', style: const TextStyle(color: Colors.white70)),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(onPressed: () => _start(t), child: const Text('Train')),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ready to Train')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [for (final t in _templates) _card(t)],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ReadyToTrainScreen` with quick training packs
- redirect template opener to use the new screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68743de3c468832ab5bfca73f64c7690