### PR TITLE
Enhance community plugin catalog

### DIFF
--- a/lib/screens/community_plugin_screen.dart
+++ b/lib/screens/community_plugin_screen.dart
@@ -11,12 +11,16 @@ class CommunityPlugin {
   final String version;
   final String? checksum;
   final String? description;
+  final String? category;
+  final double? rating;
   const CommunityPlugin({
     required this.name,
     required this.url,
     required this.version,
     this.checksum,
     this.description,
+    this.category,
+    this.rating,
   });
   factory CommunityPlugin.fromJson(Map<String, dynamic> json) {
     return CommunityPlugin(
@@ -25,6 +29,8 @@ class CommunityPlugin {
       version: json['version'] as String,
       checksum: json['checksum'] as String?,
       description: json['description'] as String?,
+      category: json['category'] as String?,
+      rating: (json['rating'] as num?)?.toDouble(),
     );
   }
 }
@@ -40,6 +46,10 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
   List<CommunityPlugin> _plugins = [];
   Map<String, Map<String, dynamic>> _status = {};
   bool _loading = true;
+  final TextEditingController _searchCtrl = TextEditingController();
+  String _query = '';
+  String _categoryFilter = 'All';
+  List<String> _categories = [];
 
   @override
   void initState() {
@@ -47,13 +57,30 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
     _load();
   }
 
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
   Future<void> _load() async {
+    setState(() => _loading = true);
     try {
       final res = await http.get(Uri.parse(_url));
       if (res.statusCode == 200) {
         final data = jsonDecode(res.body);
         if (data is List) {
-          _plugins = [for (final e in data) CommunityPlugin.fromJson(e as Map<String, dynamic>)];
+          _plugins = [
+            for (final e in data)
+              CommunityPlugin.fromJson(e as Map<String, dynamic>),
+          ];
+          _categories =
+              _plugins
+                  .map((e) => e.category)
+                  .whereType<String>()
+                  .toSet()
+                  .toList()
+                ..sort();
         }
       }
       _status = await PluginManager().loadStatus();
@@ -63,19 +90,25 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
 
   Future<void> _install(CommunityPlugin p) async {
     try {
-      final downloaded =
-          await PluginLoader().downloadFromUrl(p.url, checksum: p.checksum);
+      final downloaded = await PluginLoader().downloadFromUrl(
+        p.url,
+        checksum: p.checksum,
+      );
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(downloaded ? 'Plugin installed' : 'Plugin up to date')),
+          SnackBar(
+            content: Text(
+              downloaded ? 'Plugin installed' : 'Plugin up to date',
+            ),
+          ),
         );
         await _load();
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Install failed: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Install failed: $e')));
       }
     }
   }
@@ -92,30 +125,123 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _plugins.isEmpty
-              ? const Center(child: Text('No plugins'))
-              : ListView.separated(
-                  itemCount: _plugins.length,
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemBuilder: (context, index) {
-                    final plugin = _plugins[index];
-                    final file = p.basename(Uri.parse(plugin.url).path);
-                    final localVersion = _status[file]?['version'] as String?;
-                    final installed = localVersion != null;
-                    final needsUpdate = installed && localVersion != plugin.version;
-                    final subtitle = <Widget>[Text('v${plugin.version}')];
-                    if (plugin.description != null) subtitle.add(Text(plugin.description!));
-                    if (needsUpdate)
-                      subtitle.add(Text('Installed v$localVersion', style: const TextStyle(color: Colors.red)));
-                    return ListTile(
-                      title: Text(plugin.name),
-                      subtitle: Column(crossAxisAlignment: CrossAxisAlignment.start, children: subtitle),
-                      trailing: TextButton(
-                        onPressed: installed && !needsUpdate ? null : () => _install(plugin),
-                        child: Text(needsUpdate ? 'Update' : installed ? 'Installed' : 'Install'),
+          ? const Center(child: Text('No plugins'))
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _searchCtrl,
+                          decoration: InputDecoration(
+                            prefixIcon: const Icon(Icons.search),
+                            hintText: 'Search…',
+                            suffixIcon: _query.isEmpty
+                                ? null
+                                : IconButton(
+                                    icon: const Icon(Icons.clear),
+                                    onPressed: () => setState(() {
+                                      _searchCtrl.clear();
+                                      _query = '';
+                                    }),
+                                  ),
+                          ),
+                          onChanged: (v) =>
+                              setState(() => _query = v.trim().toLowerCase()),
+                        ),
                       ),
-                    );
-                  },
+                      if (_categories.isNotEmpty) ...[
+                        const SizedBox(width: 8),
+                        DropdownButton<String>(
+                          value: _categoryFilter,
+                          dropdownColor: const Color(0xFF2A2B2E),
+                          onChanged: (v) =>
+                              setState(() => _categoryFilter = v ?? 'All'),
+                          items: ['All', ..._categories]
+                              .map(
+                                (c) =>
+                                    DropdownMenuItem(value: c, child: Text(c)),
+                              )
+                              .toList(),
+                        ),
+                      ],
+                    ],
+                  ),
                 ),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: _filtered().length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final plugin = _filtered()[index];
+                      final file = p.basename(Uri.parse(plugin.url).path);
+                      final localVersion = _status[file]?['version'] as String?;
+                      final installed = localVersion != null;
+                      final needsUpdate =
+                          installed && localVersion != plugin.version;
+                      final subtitle = <Widget>[];
+                      if (plugin.category != null)
+                        subtitle.add(Text(plugin.category!));
+                      subtitle.add(Text('v${plugin.version}'));
+                      if (plugin.rating != null)
+                        subtitle.add(
+                          Row(
+                            children: [
+                              for (var i = 0; i < plugin.rating!.round(); i++)
+                                const Icon(
+                                  Icons.star,
+                                  color: Colors.amber,
+                                  size: 16,
+                                ),
+                            ],
+                          ),
+                        );
+                      if (plugin.description != null)
+                        subtitle.add(Text(plugin.description!));
+                      if (needsUpdate)
+                        subtitle.add(
+                          Text(
+                            'Installed v$localVersion',
+                            style: const TextStyle(color: Colors.red),
+                          ),
+                        );
+                      return ListTile(
+                        title: Text(plugin.name),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: subtitle,
+                        ),
+                        trailing: TextButton(
+                          onPressed: installed && !needsUpdate
+                              ? null
+                              : () => _install(plugin),
+                          child: Text(
+                            needsUpdate
+                                ? 'Update'
+                                : installed
+                                ? 'Installed'
+                                : 'Install',
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
     );
+  }
+
+  List<CommunityPlugin> _filtered() {
+    return [
+      for (final p in _plugins)
+        if ((_categoryFilter == 'All' || p.category == _categoryFilter) &&
+            (_query.isEmpty ||
+                p.name.toLowerCase().contains(_query) ||
+                (p.description?.toLowerCase().contains(_query) ?? false)))
+          p,
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- add rating and category fields to community plugin model
- show category and rating in the plugin catalog
- add search and filter UI for plugin catalog
- reload plugin statuses using PluginManager

## Testing
- `dart format lib/screens/community_plugin_screen.dart`
- `flutter test` *(fails: package compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac4481c832ab5f05d880957d800