### PR TITLE
Add EV/ICM improvement view

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -10,10 +10,10 @@ import 'package:flutter/rendering.dart';
 import '../widgets/combined_progress_bar.dart';
 import '../widgets/combined_progress_change_bar.dart';
 import '../widgets/ev_icm_history_chart.dart';
+import '../widgets/ev_icm_improvement_row.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_session.dart';
-import '../models/v2/hero_position.dart';
 import '../services/training_session_service.dart';
 import '../services/adaptive_training_service.dart';
 import '../services/weak_spot_recommendation_service.dart';
@@ -175,6 +175,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
             ),
             const SizedBox(height: 12),
             const EvIcmHistoryChart(),
+            const EvIcmImprovementRow(),
             const SizedBox(height: 16),
             Builder(
               builder: (context) {

--- a/lib/services/progress_forecast_service.dart
+++ b/lib/services/progress_forecast_service.dart
@@ -59,6 +59,23 @@ class ProgressForecastService extends ChangeNotifier {
   List<ProgressEntry> tagSeries(String tag) =>
       List.unmodifiable(_tagHistory[tag] ?? const []);
 
+  MapEntry<double, double> avgPrevEvIcm([int sessions = 5]) {
+    if (_history.length <= 1) return const MapEntry(0, 0);
+    final end = _history.length - 1;
+    var start = end - sessions;
+    if (start < 0) start = 0;
+    final slice = _history.sublist(start, end);
+    if (slice.isEmpty) return const MapEntry(0, 0);
+    double ev = 0;
+    double icm = 0;
+    for (final e in slice) {
+      ev += e.ev;
+      icm += e.icm;
+    }
+    final c = slice.length;
+    return MapEntry(ev / c, icm / c);
+  }
+
   ProgressForecastService({required this.hands, required this.style}) {
     _update();
     hands.addListener(_update);

--- a/lib/widgets/ev_icm_improvement_row.dart
+++ b/lib/widgets/ev_icm_improvement_row.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/progress_forecast_service.dart';
+
+class EvIcmImprovementRow extends StatelessWidget {
+  final int sessions;
+  const EvIcmImprovementRow({super.key, this.sessions = 5});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<ProgressForecastService>();
+    final hist = service.history;
+    if (hist.length <= 1) return const SizedBox.shrink();
+    final prev = service.avgPrevEvIcm(sessions);
+    final last = hist.last;
+    final evDelta = last.ev - prev.key;
+    final icmDelta = last.icm - prev.value;
+    Widget item(String label, double v) {
+      final up = v >= 0;
+      final color = up ? Colors.green : Colors.red;
+      final icon = up ? Icons.trending_up : Icons.trending_down;
+      return Row(
+        children: [
+          Icon(icon, size: 12, color: color),
+          const SizedBox(width: 2),
+          Text(
+            '$label ${(v >= 0 ? '+' : '')}${v.toStringAsFixed(2)}',
+            style: TextStyle(color: color, fontSize: 12),
+          ),
+        ],
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          item('EV', evDelta),
+          const SizedBox(width: 12),
+          item('ICM', icmDelta),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- track average EV/ICM from previous sessions
- show change in EV/ICM relative to recent history

## Testing
- `flutter analyze lib/services/progress_forecast_service.dart lib/screens/training_session_summary_screen.dart lib/widgets/ev_icm_improvement_row.dart` *(fails: issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac69418832a899b8c90c5d2e448