### PR TITLE
Add fallback to recommended pack on pinned completion

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -258,8 +258,13 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     final completed = prefs.getBool('completed_tpl_${pinned.id}') ?? false;
     final stat = await TrainingPackStatsService.getStats(pinned.id);
     final idx = stat?.lastIndex ?? 0;
-    if (completed && idx >= pinned.spots.length - 1) return;
-    await ctx.read<TrainingSessionService>().startSession(pinned);
+    if (completed && idx >= pinned.spots.length - 1) {
+      final rec = await ctx.read<PersonalRecommendationService>().getTopRecommended();
+      if (rec == null) return;
+      await ctx.read<TrainingSessionService>().startSession(rec);
+    } else {
+      await ctx.read<TrainingSessionService>().startSession(pinned);
+    }
     if (!mounted) return;
     Navigator.pushReplacement(
       ctx,

--- a/lib/services/personal_recommendation_service.dart
+++ b/lib/services/personal_recommendation_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_pack_template.dart';
 import 'adaptive_training_service.dart';
 import 'achievement_engine.dart';
@@ -8,6 +9,7 @@ import 'weak_spot_recommendation_service.dart';
 import 'player_style_service.dart';
 import 'player_style_forecast_service.dart';
 import 'progress_forecast_service.dart';
+import 'training_pack_stats_service.dart';
 
 class RecommendationTask {
   final String title;
@@ -116,5 +118,16 @@ class PersonalRecommendationService extends ChangeNotifier {
       completer.complete();
     });
     return completer.future;
+  }
+
+  Future<TrainingPackTemplate?> getTopRecommended() async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final t in _packs) {
+      final completed = prefs.getBool('completed_tpl_${t.id}') ?? false;
+      final stat = await TrainingPackStatsService.getStats(t.id);
+      final idx = stat?.lastIndex ?? 0;
+      if (!completed || idx < t.spots.length) return t;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- add ability for PersonalRecommendationService to get the first unfinished pack
- when pinned pack finished, automatically start top recommended pack

## Testing
- `dart analyze lib/services/personal_recommendation_service.dart lib/main.dart`
- `flutter test` *(fails: file_picker plugin issue & missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68744e21a10c832aab49e8c47db66c2c