### PR TITLE
feat: smoother pinned training start

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -266,9 +266,22 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
       await ctx.read<TrainingSessionService>().startSession(pinned);
     }
     if (!mounted) return;
+    showDialog(
+      context: ctx,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+    await Future.delayed(const Duration(milliseconds: 300));
+    if (!mounted) return;
+    Navigator.pop(ctx);
     Navigator.pushReplacement(
       ctx,
-      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+      PageRouteBuilder(
+        transitionDuration: const Duration(milliseconds: 300),
+        pageBuilder: (_, __, ___) => const TrainingSessionScreen(),
+        transitionsBuilder: (_, animation, __, child) =>
+            FadeTransition(opacity: animation, child: child),
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- delay pinned training navigation to show fallback animation
- show a short loader before TrainingSessionScreen

## Testing
- `flutter analyze` *(fails: 6350 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68745390d92c832a8166602571591d6b