### PR TITLE
Improve training home layout

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -56,12 +56,15 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
   void initState() {
     super.initState();
     context.read<SpotOfTheDayService>().ensureTodaySpot();
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => widget.tutorial?.showCurrentStep(context));
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => widget.tutorial?.showCurrentStep(context),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    final narrow = width < 400;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Training'),
@@ -73,7 +76,8 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (_) => const TrainingProgressAnalyticsScreen()),
+                  builder: (_) => const TrainingProgressAnalyticsScreen(),
+                ),
               );
             },
           ),
@@ -83,7 +87,8 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (_) => const TrainingRecommendationScreen()),
+                  builder: (_) => const TrainingRecommendationScreen(),
+                ),
               );
             },
           ),
@@ -91,26 +96,40 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
       ),
       body: ListView(
         children: [
-          _RecommendedCarousel(key: TrainingHomeScreen.recommendationsKey),
-          const QuickContinueCard(),
-          const DailyFocusRecapCard(),
-          const SpotOfTheDayCard(),
-          const ProgressSummaryBox(),
-          const PositionProgressCard(),
-          const SkillProgressCard(),
-          const ProgressForecastCard(),
-          const PlayerStyleCard(),
-          const StreakChart(),
-          const DailyProgressRing(),
-          const GoalsCard(),
-          const DailyGoalsCard(),
-          const DailyChallengeCard(),
-          const WeeklyChallengeCard(),
-          const XPProgressBar(),
-          const AchievementsCard(),
-          const WeakSpotCard(),
-          const ReviewPastMistakesCard(),
-          const RepeatMistakesCard(),
+          _RecommendedCarousel(
+            key: TrainingHomeScreen.recommendationsKey,
+            narrow: narrow,
+          ),
+          if (narrow) ...[
+            const QuickContinueCard(),
+            const DailyProgressRing(),
+            const GoalsCard(),
+            const DailyGoalsCard(),
+            const DailyChallengeCard(),
+            const SpotOfTheDayCard(),
+            const ProgressSummaryBox(),
+            const XPProgressBar(),
+          ] else ...[
+            const QuickContinueCard(),
+            const DailyFocusRecapCard(),
+            const SpotOfTheDayCard(),
+            const ProgressSummaryBox(),
+            const PositionProgressCard(),
+            const SkillProgressCard(),
+            const ProgressForecastCard(),
+            const PlayerStyleCard(),
+            const StreakChart(),
+            const DailyProgressRing(),
+            const GoalsCard(),
+            const DailyGoalsCard(),
+            const DailyChallengeCard(),
+            const WeeklyChallengeCard(),
+            const XPProgressBar(),
+            const AchievementsCard(),
+            const WeakSpotCard(),
+            const ReviewPastMistakesCard(),
+            const RepeatMistakesCard(),
+          ],
         ],
       ),
       floatingActionButton: FloatingActionButton(
@@ -132,7 +151,8 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
 }
 
 class _RecommendedCarousel extends StatefulWidget {
-  const _RecommendedCarousel({super.key});
+  final bool narrow;
+  const _RecommendedCarousel({super.key, required this.narrow});
 
   @override
   State<_RecommendedCarousel> createState() => _RecommendedCarouselState();
@@ -154,7 +174,9 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final service = context.read<AdaptiveTrainingService>();
     await service.refresh();
     final list = service.recommended.toList();
-    final weak = await context.read<WeakSpotRecommendationService>().buildPack();
+    final weak = await context
+        .read<WeakSpotRecommendationService>()
+        .buildPack();
     if (weak != null) list.insert(0, weak);
     final review = await MistakeReviewPackService.latestTemplate(context);
     if (review != null) list.insert(0, review);
@@ -164,7 +186,8 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final adjusted = <TrainingPackTemplate>[];
     for (final t in list) {
       stats[t.id] =
-          service.statFor(t.id) ?? await TrainingPackStatsService.getStats(t.id);
+          service.statFor(t.id) ??
+          await TrainingPackStatsService.getStats(t.id);
       final hist = await TrainingPackStatsService.history(t.id);
       if (hist.length >= 2) {
         delta[t.id] =
@@ -192,11 +215,13 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
       children: [
         const Padding(
           padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Text('Рекомендуем для старта',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          child: Text(
+            'Рекомендуем для старта',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
         ),
         SizedBox(
-          height: 140,
+          height: widget.narrow ? 110 : 140,
           child: ListView.separated(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             scrollDirection: Axis.horizontal,
@@ -206,6 +231,7 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
               stat: _stats[_tpls[i].id],
               delta: _delta[_tpls[i].id],
               onDone: _load,
+              small: widget.narrow,
             ),
             separatorBuilder: (_, __) => const SizedBox(width: 12),
             itemCount: _tpls.length,
@@ -221,12 +247,15 @@ class _PackCard extends StatelessWidget {
   final TrainingPackStat? stat;
   final double? delta;
   final VoidCallback onDone;
-  const _PackCard(
-      {super.key,
-      required this.template,
-      required this.stat,
-      required this.delta,
-      required this.onDone});
+  final bool small;
+  const _PackCard({
+    super.key,
+    required this.template,
+    required this.stat,
+    required this.delta,
+    required this.onDone,
+    this.small = false,
+  });
 
   Future<void> _onDone(BuildContext context) async {
     onDone();
@@ -258,7 +287,9 @@ class _PackCard extends StatelessWidget {
       context: context,
       builder: (ctx) => AlertDialog(
         title: Text('Следующий пак «${next.name}» готов!'),
-        content: Text('Категория: ${translateCategory(next.category)}. Начать прямо сейчас?'),
+        content: Text(
+          'Категория: ${translateCategory(next.category)}. Начать прямо сейчас?',
+        ),
         actions: [
           Semantics(
             label: 'Начать ${next.name}',
@@ -285,10 +316,7 @@ class _PackCard extends StatelessWidget {
       }
       onDone();
     } else if (start == false) {
-      await prefs.setString(
-        snoozeKey,
-        DateTime.now().toIso8601String(),
-      );
+      await prefs.setString(snoozeKey, DateTime.now().toIso8601String());
     }
   }
 
@@ -299,20 +327,20 @@ class _PackCard extends StatelessWidget {
     final label = completed
         ? 'Пройдено'
         : progress > 0
-            ? 'Продолжить'
-            : 'Начать';
+        ? 'Продолжить'
+        : 'Начать';
     final color = completed ? Colors.green : Colors.orange;
-    final hasMistakes =
-        context.read<MistakeReviewPackService>().hasMistakes(template.id);
+    final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(
+      template.id,
+    );
     final ev = stat?.postEvPct ?? 0;
     final icm = stat?.postIcmPct ?? 0;
     final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
     final focus = template.handTypeSummary();
-    final rangePct =
-        ((template.heroRange?.length ?? 0) * 100 / 169).round();
+    final rangePct = ((template.heroRange?.length ?? 0) * 100 / 169).round();
     return Container(
-      width: 120,
-      height: 120,
+      width: small ? 100 : 120,
+      height: small ? 100 : 120,
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: Colors.grey[850],
@@ -323,20 +351,24 @@ class _PackCard extends StatelessWidget {
         children: [
           Icon(hasMistakes ? Icons.error : Icons.shield, color: color),
           const Spacer(),
+          Text(template.name, maxLines: 2, overflow: TextOverflow.ellipsis),
           Text(
-            template.name,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+            'Stack ${template.heroBbStack}bb • R $rangePct%',
+            style: const TextStyle(fontSize: 10, color: Colors.white70),
           ),
-          Text('Stack ${template.heroBbStack}bb • R $rangePct%',
-              style: const TextStyle(fontSize: 10, color: Colors.white70)),
           if (focus.isNotEmpty)
-            Text(focus,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style:
-                    const TextStyle(fontSize: 12, color: Colors.white70)),
-          Row(children:[for(var i=0;i<rating;i++)const Icon(Icons.star,color:Colors.amber,size:12)]),
+            Text(
+              focus,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 12, color: Colors.white70),
+            ),
+          Row(
+            children: [
+              for (var i = 0; i < rating; i++)
+                const Icon(Icons.star, color: Colors.amber, size: 12),
+            ],
+          ),
           const SizedBox(height: 4),
           TweenAnimationBuilder<double>(
             curve: Curves.easeOutCubic,
@@ -356,17 +388,25 @@ class _PackCard extends StatelessWidget {
           const SizedBox(height: 2),
           Row(
             children: [
-              Text('EV ${ev.toStringAsFixed(0)}%  ICM ${icm.toStringAsFixed(0)}%',
-                  style: const TextStyle(fontSize: 10, color: Colors.white70)),
+              Text(
+                'EV ${ev.toStringAsFixed(0)}%  ICM ${icm.toStringAsFixed(0)}%',
+                style: const TextStyle(fontSize: 10, color: Colors.white70),
+              ),
               if (delta != null) ...[
                 const SizedBox(width: 4),
-                Icon(delta! >= 0 ? Icons.arrow_upward : Icons.arrow_downward,
-                    size: 12, color: delta! >= 0 ? Colors.green : Colors.red),
-                Text('${delta!.abs().toStringAsFixed(1)}%',
-                    style: TextStyle(
-                        fontSize: 10,
-                        color: delta! >= 0 ? Colors.green : Colors.red)),
-              ]
+                Icon(
+                  delta! >= 0 ? Icons.arrow_upward : Icons.arrow_downward,
+                  size: 12,
+                  color: delta! >= 0 ? Colors.green : Colors.red,
+                ),
+                Text(
+                  '${delta!.abs().toStringAsFixed(1)}%',
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: delta! >= 0 ? Colors.green : Colors.red,
+                  ),
+                ),
+              ],
             ],
           ),
           const SizedBox(height: 4),
@@ -374,14 +414,15 @@ class _PackCard extends StatelessWidget {
             onPressed: completed
                 ? null
                 : () async {
-                    await context
-                        .read<TrainingSessionService>()
-                        .startSession(template);
+                    await context.read<TrainingSessionService>().startSession(
+                      template,
+                    );
                     if (context.mounted) {
                       await Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (_) => const TrainingSessionScreen()),
+                          builder: (_) => const TrainingSessionScreen(),
+                        ),
                       );
                     }
                     await _onDone(context);
@@ -400,14 +441,15 @@ class _PackCard extends StatelessWidget {
                     .read<MistakeReviewPackService>()
                     .review(context, template.id);
                 if (review != null && context.mounted) {
-                  await context
-                      .read<TrainingSessionService>()
-                      .startSession(review);
+                  await context.read<TrainingSessionService>().startSession(
+                    review,
+                  );
                   if (context.mounted) {
                     await Navigator.push(
                       context,
                       MaterialPageRoute(
-                          builder: (_) => const TrainingSessionScreen()),
+                        builder: (_) => const TrainingSessionScreen(),
+                      ),
                     );
                   }
                 }


### PR DESCRIPTION
## Summary
- adapt TrainingHomeScreen layout for narrow screens

## Testing
- `dart format lib/screens/training_home_screen.dart`
- `dart analyze` *(fails: 51203 issues found)*


------
https://chatgpt.com/codex/tasks/task_e_687453ca5ea8832aa915bebcc001a72a