### PR TITLE
Add LocalEv plugin and offline evaluation support

### DIFF
--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -30,6 +30,7 @@ import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
 import 'partypoker_converter_plugin.dart';
+import '../../plugins/LocalEvPlugin.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -95,6 +96,7 @@ class PluginLoader {
     return <Plugin>[
       SampleLoggingPlugin(),
       ConverterDiscoveryPlugin(converters),
+      LocalEvPlugin(),
     ];
   }
 
@@ -122,6 +124,8 @@ class PluginLoader {
         return PartyPokerConverterPlugin();
       case 'IpokerConverterPlugin':
         return IpokerConverterPlugin();
+      case 'LocalEvPlugin':
+        return LocalEvPlugin();
     }
     return null;
   }

--- a/lib/plugins/plugin_loader_web.dart
+++ b/lib/plugins/plugin_loader_web.dart
@@ -27,6 +27,7 @@ import 'poker_stars_converter_plugin.dart';
 import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
 import 'partypoker_converter_plugin.dart';
+import '../../plugins/LocalEvPlugin.dart';
 
 class PluginLoader {
   static const String _suffix = 'Plugin.dart';
@@ -100,6 +101,7 @@ class PluginLoader {
     return <Plugin>[
       SampleLoggingPlugin(),
       ConverterDiscoveryPlugin(converters),
+      LocalEvPlugin(),
     ];
   }
 
@@ -127,6 +129,8 @@ class PluginLoader {
         return PartyPokerConverterPlugin();
       case 'IpokerConverterPlugin':
         return IpokerConverterPlugin();
+      case 'LocalEvPlugin':
+        return LocalEvPlugin();
     }
     return null;
   }

--- a/plugins/LocalEvPlugin.dart
+++ b/plugins/LocalEvPlugin.dart
@@ -1,0 +1,88 @@
+import 'package:poker_analyzer/plugins/plugin.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+import 'package:poker_analyzer/services/push_fold_ev_service.dart';
+import 'package:poker_analyzer/services/icm_push_ev_service.dart';
+import 'package:poker_analyzer/helpers/hand_utils.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+class LocalEvService {
+  const LocalEvService();
+
+  Future<void> evaluate(TrainingPackSpot spot, {int anteBb = 0}) async {
+    final hero = spot.hand.heroIndex;
+    final hand = handCode(spot.hand.heroCards);
+    final stack = spot.hand.stacks['$hero']?.round();
+    if (hand == null || stack == null) return;
+    for (final a in spot.hand.actions[0] ?? []) {
+      if (a.playerIndex == hero && a.action == 'push') {
+        a.ev = computePushEV(
+          heroBbStack: stack,
+          bbCount: spot.hand.playerCount - 1,
+          heroHand: hand,
+          anteBb: anteBb,
+        );
+        break;
+      }
+    }
+  }
+
+  Future<void> evaluateIcm(TrainingPackSpot spot,
+      {int anteBb = 0, List<double> payouts = const [0.5, 0.3, 0.2]}) async {
+    final hero = spot.hand.heroIndex;
+    final hand = handCode(spot.hand.heroCards);
+    final stack = spot.hand.stacks['$hero']?.round();
+    if (hand == null || stack == null) return;
+    final stacks = [
+      for (var i = 0; i < spot.hand.playerCount; i++)
+        spot.hand.stacks['$i']?.round() ?? 0
+    ];
+    final callers = [
+      for (final a in spot.hand.actions[0] ?? [])
+        if (a.playerIndex != hero && a.action == 'call') a.playerIndex
+    ];
+    for (final a in spot.hand.actions[0] ?? []) {
+      if (a.playerIndex == hero && a.action == 'push') {
+        final ev = computePushEV(
+          heroBbStack: stack,
+          bbCount: spot.hand.playerCount - 1,
+          heroHand: hand,
+          anteBb: anteBb,
+        );
+        final icm = callers.length > 1
+            ? computeMultiwayIcmEV(
+                chipStacksBb: stacks,
+                heroIndex: hero,
+                chipPushEv: ev,
+                callerIndices: callers,
+                payouts: payouts,
+              )
+            : computeLocalIcmPushEV(
+                chipStacksBb: stacks,
+                heroIndex: hero,
+                heroHand: hand,
+                anteBb: anteBb,
+                payouts: payouts,
+              );
+        a.ev = ev;
+        a.icmEv = icm;
+        break;
+      }
+    }
+  }
+}
+
+class LocalEvPlugin implements Plugin {
+  @override
+  void register(ServiceRegistry registry) {
+    registry.registerIfAbsent<LocalEvService>(const LocalEvService());
+  }
+
+  @override
+  String get name => 'Local EV';
+
+  @override
+  String get description => 'Local EV evaluation';
+
+  @override
+  String get version => '1.0.0';
+}


### PR DESCRIPTION
## Summary
- add LocalEvPlugin with LocalEvService for local EV calculations
- register new plugin in plugin loader
- leverage LocalEvService when evaluating without internet

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687453d2a294832a9e29987bd879047c