### PR TITLE
Implement EmptyTrainingScreen

### DIFF
--- a/lib/screens/empty_training_screen.dart
+++ b/lib/screens/empty_training_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class EmptyTrainingScreen extends StatelessWidget {
+  const EmptyTrainingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Training')),
+      body: const Center(
+        child: Text('Нет доступных паков для тренировки'),
+      ),
+    );
+  }
+}

--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -10,6 +10,7 @@ import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
 import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'empty_training_screen.dart';
 
 class ReadyToTrainScreen extends StatefulWidget {
   const ReadyToTrainScreen({super.key});
@@ -74,6 +75,13 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
         similar,
     ];
     if (!mounted) return;
+    if (list.isEmpty) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const EmptyTrainingScreen()),
+      );
+      return;
+    }
     setState(() {
       _templates
         ..clear()


### PR DESCRIPTION
## Summary
- add EmptyTrainingScreen for when no packs are available
- redirect ReadyToTrainScreen and startup pinned training flow to this screen when no packs found

## Testing
- `flutter analyze` *(fails: 6225 issues)*
- `flutter test` *(fails to run due to build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687455bd92a8832a9c499c5ed341ee19