### PR TITLE
Add TrainingPackCard widget

### DIFF
--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -10,6 +10,7 @@ import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
 import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../widgets/training_pack_card.dart';
 import 'empty_training_screen.dart';
 
 class ReadyToTrainScreen extends StatefulWidget {
@@ -64,7 +65,8 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
         : null;
     final prefs = await SharedPreferences.getInstance();
     final list = [
-      ...builtIn.where((t) => !(prefs.getBool('completed_tpl_${t.id}') ?? false)),
+      ...builtIn
+          .where((t) => !(prefs.getBool('completed_tpl_${t.id}') ?? false)),
       if (top != null && !(prefs.getBool('completed_tpl_${top.id}') ?? false))
         top,
       if (community != null &&
@@ -101,62 +103,6 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
     }
   }
 
-  Widget _card(TrainingPackTemplate t) {
-    return GestureDetector(
-      onLongPress: () async {
-        await context.read<PinnedPackService>().toggle(t.id);
-        if (mounted) setState(() {
-          t.isPinned = !t.isPinned;
-          _applyPinned();
-        });
-      },
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 12),
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: Colors.grey[850],
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    if (t.isPinned) const Text('📌 '),
-                    Expanded(
-                      child: Text(t.name,
-                          style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold)),
-                    ),
-                  ],
-                ),
-                if (t.description.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(t.description,
-                        style: const TextStyle(color: Colors.white70)),
-                  ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Text('${t.spots.length} spots',
-                      style: const TextStyle(color: Colors.white70)),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 8),
-          ElevatedButton(
-              onPressed: () => _start(t), child: const Text('Train')),
-        ],
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -167,7 +113,10 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
               onRefresh: _load,
               child: ListView(
                 padding: const EdgeInsets.all(16),
-                children: [for (final t in _templates) _card(t)],
+                children: [
+                  for (final t in _templates)
+                    TrainingPackCard(template: t, onTap: () => _start(t)),
+                ],
               ),
             ),
     );

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/pinned_pack_service.dart';
+import '../theme/app_colors.dart';
+
+class TrainingPackCard extends StatefulWidget {
+  final TrainingPackTemplate template;
+  final VoidCallback onTap;
+  const TrainingPackCard(
+      {super.key, required this.template, required this.onTap});
+
+  @override
+  State<TrainingPackCard> createState() => _TrainingPackCardState();
+}
+
+class _TrainingPackCardState extends State<TrainingPackCard> {
+  late bool _pinned;
+
+  @override
+  void initState() {
+    super.initState();
+    _pinned = widget.template.isPinned;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPress: () async {
+        await context.read<PinnedPackService>().toggle(widget.template.id);
+        if (mounted)
+          setState(() {
+            _pinned = !_pinned;
+            widget.template.isPinned = _pinned;
+          });
+      },
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      if (_pinned)
+                        const Text('📌 ',
+                            style: TextStyle(color: Colors.white)),
+                      Expanded(
+                        child: Text(
+                          widget.template.name,
+                          style: const TextStyle(
+                              color: Colors.white, fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (widget.template.description.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        widget.template.description,
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      '${widget.template.spots.length} spots',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(onPressed: widget.onTap, child: const Text('Train')),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable TrainingPackCard widget
- replace pack cards in ReadyToTrainScreen with TrainingPackCard

## Testing
- `flutter test -j 1` *(fails: LocalEvPlugin.dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_687459d80534832a94c0bc842a114479