### PR TITLE
Add fresh mistake training pack button

### DIFF
--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -107,6 +107,14 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Ready to Train')),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async {
+          await TrainingPackService.generateFreshMistakeDrill(context);
+          if (mounted) _load();
+        },
+        label: const Text('Новый Пак'),
+        icon: const Icon(Icons.add),
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : RefreshIndicator(


### PR DESCRIPTION
## Summary
- generate "Fresh Mistake" drill from recent uncorrected hands
- expose button on ReadyToTrain screen to create this drill

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 6420 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687476ce7a7c832a90be891bc7cdc5a4