### PR TITLE
Add pack history screen

### DIFF
--- a/lib/screens/pack_history_screen.dart
+++ b/lib/screens/pack_history_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/training_session_service.dart';
+import '../services/training_pack_template_service.dart';
+import '../models/v2/training_pack_template.dart';
+import 'training_session_screen.dart';
+import '../widgets/training_pack_card.dart';
+
+class PackHistoryScreen extends StatefulWidget {
+  const PackHistoryScreen({super.key});
+
+  @override
+  State<PackHistoryScreen> createState() => _PackHistoryScreenState();
+}
+
+class _PackHistoryScreenState extends State<PackHistoryScreen> {
+  final List<TrainingPackTemplate> _templates = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final templates = TrainingPackTemplateService.getAllTemplates(context);
+    final prefs = await SharedPreferences.getInstance();
+    final list = [
+      for (final t in templates)
+        if (prefs.getBool('completed_tpl_${t.id}') ?? false) t
+    ];
+    if (!mounted) return;
+    setState(() {
+      _templates
+        ..clear()
+        ..addAll(list);
+      _loading = false;
+    });
+  }
+
+  Future<void> _start(TrainingPackTemplate tpl) async {
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (context.mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('История паков')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _templates.isEmpty
+              ? const Center(
+                  child: Text('История пуста',
+                      style: TextStyle(color: Colors.white70)),
+                )
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      for (final t in _templates)
+                        TrainingPackCard(template: t, onTap: () => _start(t)),
+                    ],
+                  ),
+                ),
+    );
+  }
+}

--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -8,6 +8,7 @@ import '../services/pinned_pack_service.dart';
 import '../models/saved_hand.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
+import 'pack_history_screen.dart';
 import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/training_pack_card.dart';
@@ -106,7 +107,20 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Ready to Train')),
+      appBar: AppBar(
+        title: const Text('Ready to Train'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const PackHistoryScreen()),
+              );
+            },
+          ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () async {
           await TrainingPackService.generateFreshMistakeDrill(context);


### PR DESCRIPTION
## Summary
- create `PackHistoryScreen` for finished packs
- open it from ReadyToTrain via history icon

## Testing
- `flutter analyze` *(fails: 6239 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687478fcdea0832a88eacdded2abf189