### PR TITLE
Remove saved training progress after session ends

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -106,7 +106,11 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final tpl = service.template;
     if (tpl != null) {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setInt('progress_tpl_${tpl.id}', service.session?.index ?? 0);
+      if (next == null) {
+        await prefs.remove('progress_tpl_${tpl.id}');
+      } else {
+        await prefs.setInt('progress_tpl_${tpl.id}', service.session?.index ?? 0);
+      }
     }
     if (!mounted) return;
     if (next == null) {


### PR DESCRIPTION
## Summary
- clear saved `progress_tpl_{id}` once the pack finishes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747e71d970832ab4978c85796f2cf4