### PR TITLE
Add mistake categories on TrainingPackCard

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -156,3 +156,12 @@ class TrainingPackSpot {
     explanation,
   );
 }
+
+extension TrainingPackSpotCategory on TrainingPackSpot {
+  String? get mistakeCategory {
+    for (final t in tags) {
+      if (t.startsWith('cat:')) return t.substring(4);
+    }
+    return null;
+  }
+}

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/v2/training_pack_template.dart';
 import '../services/pinned_pack_service.dart';
 import '../theme/app_colors.dart';
+import '../helpers/mistake_category_translations.dart';
 
 class TrainingPackCard extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -25,6 +26,11 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
 
   @override
   Widget build(BuildContext context) {
+    final categories = widget.template.spots
+        .map((s) => s.mistakeCategory)
+        .whereType<String>()
+        .toSet()
+        .toList();
     return GestureDetector(
       onLongPress: () async {
         await context.read<PinnedPackService>().toggle(widget.template.id);
@@ -76,6 +82,23 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
                       style: const TextStyle(color: Colors.white70),
                     ),
                   ),
+                  if (categories.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Wrap(
+                        spacing: 6,
+                        children: [
+                          for (final c in categories)
+                            InputChip(
+                              label: Text(
+                                translateMistakeCategory(c),
+                                style: const TextStyle(fontSize: 12),
+                              ),
+                              onPressed: () {},
+                            ),
+                        ],
+                      ),
+                    ),
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- expose `mistakeCategory` from pack spot tags
- show mistake categories in `TrainingPackCard`

## Testing
- `dart`/`flutter` not available; tests not run

------
https://chatgpt.com/codex/tasks/task_e_68745cdfdca8832a9f0706bc863cf817