### PR TITLE
Add completed label for packs after three successful sessions

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -201,6 +201,13 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       await prefs.setString(
           'completed_at_tpl_${tpl.id}', DateTime.now().toIso8601String());
       await prefs.setDouble('last_accuracy_tpl_${tpl.id}', acc);
+      for (var i = 2; i > 0; i--) {
+        final prev = prefs.getDouble('last_accuracy_tpl_${tpl.id}_${i - 1}');
+        if (prev != null) {
+          await prefs.setDouble('last_accuracy_tpl_${tpl.id}_$i', prev);
+        }
+      }
+      await prefs.setDouble('last_accuracy_tpl_${tpl.id}_0', acc);
       final cloud = context.read<CloudSyncService?>();
       if (cloud != null) {
         unawaited(cloud.save('completed_tpl_${tpl.id}', '1'));

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -30,6 +30,7 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
   late bool _pinned;
   String? _completedAt;
   double? _accuracy;
+  bool _passed = false;
 
   Future<void> _resetProgress() async {
     final prefs = await SharedPreferences.getInstance();
@@ -37,6 +38,9 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
     await prefs.remove('completed_tpl_${widget.template.id}');
     await prefs.remove('completed_at_tpl_${widget.template.id}');
     await prefs.remove('last_accuracy_tpl_${widget.template.id}');
+    await prefs.remove('last_accuracy_tpl_${widget.template.id}_0');
+    await prefs.remove('last_accuracy_tpl_${widget.template.id}_1');
+    await prefs.remove('last_accuracy_tpl_${widget.template.id}_2');
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Прогресс сброшен')),
@@ -57,10 +61,15 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
     final ts = DateTime.tryParse(
         prefs.getString('completed_at_tpl_${widget.template.id}') ?? '');
     final acc = prefs.getDouble('last_accuracy_tpl_${widget.template.id}');
+    final a0 = prefs.getDouble('last_accuracy_tpl_${widget.template.id}_0');
+    final a1 = prefs.getDouble('last_accuracy_tpl_${widget.template.id}_1');
+    final a2 = prefs.getDouble('last_accuracy_tpl_${widget.template.id}_2');
     if (mounted) {
       setState(() {
         if (ts != null) _completedAt = formatLongDate(ts);
         if (acc != null) _accuracy = acc;
+        _passed = a0 != null && a1 != null && a2 != null &&
+            a0 >= 80 && a1 >= 80 && a2 >= 80;
       });
     }
   }
@@ -175,6 +184,22 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
             ),
           ],
             ),
+            if (_passed)
+              Positioned(
+                right: 4,
+                top: 4,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.green,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text(
+                    '✅ Completed',
+                    style: TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+                ),
+              ),
             if (widget.dimmed && (_completedAt != null || _accuracy != null))
               Positioned(
                 bottom: 4,


### PR DESCRIPTION
## Summary
- track last three session accuracies
- mark training pack as completed when last three are >=80%
- display a green Completed label on pack card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b33df154832a8f874c711fa616aa