### PR TITLE
Add confirmation dialog for completed pack

### DIFF
--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -49,6 +49,39 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
     await widget.onRefresh?.call();
   }
 
+  Future<void> _handleTap() async {
+    if (!_passed) {
+      widget.onTap();
+      return;
+    }
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Пак пройден'),
+        content: const Text('Повторить или сбросить прогресс?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'cancel'),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'reset'),
+            child: const Text('Сбросить прогресс'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'repeat'),
+            child: const Text('Повторить'),
+          ),
+        ],
+      ),
+    );
+    if (result == 'repeat') {
+      widget.onTap();
+    } else if (result == 'reset') {
+      await _resetProgress();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -170,7 +203,7 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
               ),
             ),
             const SizedBox(width: 8),
-            ElevatedButton(onPressed: widget.onTap, child: const Text('Train')),
+            ElevatedButton(onPressed: _handleTap, child: const Text('Train')),
             PopupMenuButton<String>(
               onSelected: (v) {
                 if (v == 'reset') _resetProgress();


### PR DESCRIPTION
## Summary
- guard completed pack tap with `_handleTap`
- show dialog offering to repeat or reset progress

## Testing
- `flutter analyze` *(fails: 13744 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b41a6fcc832a919a0a459f830ab5