### PR TITLE
Add weekly suggested pack generation

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -67,6 +67,7 @@ import 'services/training_pack_play_controller.dart';
 import 'services/training_session_service.dart';
 import 'services/session_manager.dart';
 import 'services/session_log_service.dart';
+import 'services/suggested_pack_service.dart';
 import 'services/evaluation_executor_service.dart';
 import 'services/session_analysis_service.dart';
 import 'services/user_action_logger.dart';
@@ -360,6 +361,12 @@ List<SingleChildWidget> buildTrainingProviders() {
             create: (context) => SessionLogService(
               sessions: context.read<TrainingSessionService>(),
               cloud: context.read<CloudSyncService>(),
+            )..load(),
+          ),
+          ChangeNotifierProvider(
+            create: (context) => SuggestedPackService(
+              logs: context.read<SessionLogService>(),
+              hands: context.read<SavedHandManagerService>(),
             )..load(),
           ),
   ];

--- a/lib/models/session_log.dart
+++ b/lib/models/session_log.dart
@@ -7,6 +7,7 @@ class SessionLog {
   final DateTime completedAt;
   final int correctCount;
   final int mistakeCount;
+  final Map<String, int> categories;
 
   SessionLog({
     required this.sessionId,
@@ -15,7 +16,8 @@ class SessionLog {
     required this.completedAt,
     required this.correctCount,
     required this.mistakeCount,
-  });
+    Map<String, int>? categories,
+  }) : categories = categories ?? const {};
 
   factory SessionLog.fromJson(Map<String, dynamic> j) => SessionLog(
         sessionId: j['sessionId'] as String? ?? '',
@@ -26,14 +28,19 @@ class SessionLog {
             DateTime.tryParse(j['completedAt'] as String? ?? '') ?? DateTime.now(),
         correctCount: j['correct'] as int? ?? 0,
         mistakeCount: j['mistakes'] as int? ?? 0,
+        categories: {
+          for (final e in (j['categories'] as Map? ?? {}).entries)
+            e.key as String: (e.value as num).toInt()
+        },
       );
 
   Map<String, dynamic> toJson() => {
         'sessionId': sessionId,
         'templateId': templateId,
         'startedAt': startedAt.toIso8601String(),
-        'completedAt': completedAt.toIso8601String(),
-        'correct': correctCount,
-        'mistakes': mistakeCount,
+      'completedAt': completedAt.toIso8601String(),
+      'correct': correctCount,
+      'mistakes': mistakeCount,
+        if (categories.isNotEmpty) 'categories': categories,
       };
 }

--- a/lib/services/suggested_pack_service.dart
+++ b/lib/services/suggested_pack_service.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/training_pack_storage.dart';
+import '../models/v2/training_pack_template.dart';
+import '../models/saved_hand.dart';
+import 'saved_hand_manager_service.dart';
+import 'session_log_service.dart';
+
+class SuggestedPackService extends ChangeNotifier {
+  static const _templateKey = 'suggested_weekly_pack';
+  static const _dateKey = 'suggested_weekly_date';
+
+  final SessionLogService logs;
+  final SavedHandManagerService hands;
+
+  TrainingPackTemplate? _template;
+  DateTime? _date;
+  Timer? _timer;
+
+  SuggestedPackService({required this.logs, required this.hands});
+
+  TrainingPackTemplate? get template => _template;
+  DateTime? get date => _date;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final tplRaw = prefs.getString(_templateKey);
+    final dateStr = prefs.getString(_dateKey);
+    if (tplRaw != null) {
+      try {
+        _template =
+            TrainingPackTemplate.fromJson(jsonDecode(tplRaw) as Map<String, dynamic>);
+      } catch (_) {}
+    }
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    logs.addListener(_check);
+    await _check();
+  }
+
+  Future<void> _check() async {
+    final now = DateTime.now();
+    if (_date == null || now.difference(_date!).inDays >= 7) {
+      await _generate();
+    }
+    _schedule();
+  }
+
+  Future<void> _generate() async {
+    final cats = logs.getRecentMistakes();
+    if (cats.isEmpty) return;
+    final selected = <SavedHand>[];
+    for (final e in cats.entries) {
+      final list = hands.filterByCategory(e.key);
+      for (final h in list) {
+        selected.add(h);
+        if (selected.length >= 10) break;
+      }
+      if (selected.length >= 10) break;
+    }
+    if (selected.isEmpty) return;
+    final tpl = hands
+        .createPack('Suggested Training', selected)
+        .copyWith(id: 'suggested_weekly', createdAt: DateTime.now());
+    final stored = await TrainingPackStorage.load();
+    final idx = stored.indexWhere((t) => t.id == 'suggested_weekly');
+    if (idx == -1) {
+      stored.add(tpl);
+    } else {
+      stored[idx] = tpl;
+    }
+    await TrainingPackStorage.save(stored);
+    _template = tpl;
+    _date = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_templateKey, jsonEncode(tpl.toJson()));
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+    notifyListeners();
+  }
+
+  void _schedule() {
+    _timer?.cancel();
+    if (_date == null) return;
+    final next = _date!.add(const Duration(days: 7));
+    _timer = Timer(next.difference(DateTime.now()), _check);
+  }
+
+  @override
+  void dispose() {
+    logs.removeListener(_check);
+    _timer?.cancel();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- store mistake categories in session logs
- expose recent mistake counts
- generate weekly suggested pack from most common mistake categories
- provide SuggestedPackService in app providers

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b9058dcc832a9f9101046f5d6f41