### PR TITLE
Add mistake category display

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -309,6 +309,13 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
             );
           }
           final expected = _expectedAction(spot);
+          final tag = spot.tags.firstWhere(
+            (t) => t.startsWith('cat:'),
+            orElse: () => '',
+          );
+          final categoryName = tag.isNotEmpty ? tag.substring(4) : null;
+          final showCategory =
+              service.template?.id == 'suggested_weekly' && categoryName != null;
           return Scaffold(
             appBar: AppBar(
               title: const Text('Training'),
@@ -471,6 +478,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                             ),
                           ],
                         ),
+                        if (showCategory)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8),
+                            child: Text(
+                              categoryName!,
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                          ),
                       ],
                     ],
                   ),


### PR DESCRIPTION
## Summary
- show mistake category from spot tags when running the suggested weekly pack

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c351df4c832a8e0a6a822c2da57f