### PR TITLE
Add category overview for weekly summary

### DIFF
--- a/lib/screens/pack_stats_screen.dart
+++ b/lib/screens/pack_stats_screen.dart
@@ -13,12 +13,14 @@ class PackStatsScreen extends StatelessWidget {
   final int correct;
   final int total;
   final DateTime completedAt;
+  final Map<String, int>? categoryCounts;
   const PackStatsScreen({
     super.key,
     required this.templateId,
     required this.correct,
     required this.total,
     required this.completedAt,
+    this.categoryCounts,
   });
 
   TrainingPackTemplate? _template(BuildContext context) {
@@ -46,10 +48,7 @@ class PackStatsScreen extends StatelessWidget {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => PackHistoryScreen(
-          templateId: tpl.id,
-          title: tpl.name,
-        ),
+        builder: (_) => PackHistoryScreen(templateId: tpl.id, title: tpl.name),
       ),
     );
   }
@@ -85,13 +84,29 @@ class PackStatsScreen extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 8),
-                    Text('Accuracy ${acc.toStringAsFixed(1)}%',
-                        style: const TextStyle(color: Colors.white70)),
+                    Text(
+                      'Accuracy ${acc.toStringAsFixed(1)}%',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
                     const SizedBox(height: 8),
                     Text(date, style: const TextStyle(color: Colors.white54)),
                   ],
                 ),
               ),
+              if (categoryCounts != null && categoryCounts!.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    for (final e in categoryCounts!.entries)
+                      Text(
+                        '${e.key} — ${e.value}',
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                  ],
+                ),
+              ],
               const SizedBox(height: 16),
               SizedBox(
                 width: 200,

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -35,7 +35,6 @@ class _EndlessStats {
   }
 }
 
-
 class TrainingSessionScreen extends StatefulWidget {
   final VoidCallback? onSessionEnd;
   final TrainingSession? session;
@@ -113,7 +112,8 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         await prefs.setString(
             'completed_at_tpl_${tpl.id}', DateTime.now().toIso8601String());
       } else {
-        await prefs.setInt('progress_tpl_${tpl.id}', service.session?.index ?? 0);
+        await prefs.setInt(
+            'progress_tpl_${tpl.id}', service.session?.index ?? 0);
       }
     }
     if (!mounted) return;
@@ -212,6 +212,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       if (cloud != null) {
         unawaited(cloud.save('completed_tpl_${tpl.id}', '1'));
       }
+      Map<String, int>? counts;
+      if (tpl.id == 'suggested_weekly') {
+        counts = {};
+        for (final e in service.getCategoryStats().entries) {
+          final n = e.value.played - e.value.correct;
+          if (n > 0) counts[e.key] = n;
+        }
+      }
       await service.complete(
         context,
         resultBuilder: (_) => PackStatsScreen(
@@ -219,6 +227,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
           correct: correct,
           total: total,
           completedAt: DateTime.now(),
+          categoryCounts: counts,
         ),
       );
     }
@@ -251,18 +260,15 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final segments = <Widget>[];
     if (correct > 0) {
       segments.add(Expanded(
-          flex: correct,
-          child: Container(height: 4, color: Colors.green)));
+          flex: correct, child: Container(height: 4, color: Colors.green)));
     }
     if (incorrect > 0) {
       segments.add(Expanded(
-          flex: incorrect,
-          child: Container(height: 4, color: Colors.red)));
+          flex: incorrect, child: Container(height: 4, color: Colors.red)));
     }
     if (remaining > 0) {
       segments.add(Expanded(
-          flex: remaining,
-          child: Container(height: 4, color: Colors.grey)));
+          flex: remaining, child: Container(height: 4, color: Colors.grey)));
     }
     return Row(children: segments);
   }
@@ -314,8 +320,8 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
             orElse: () => '',
           );
           final categoryName = tag.isNotEmpty ? tag.substring(4) : null;
-          final showCategory =
-              service.template?.id == 'suggested_weekly' && categoryName != null;
+          final showCategory = service.template?.id == 'suggested_weekly' &&
+              categoryName != null;
           return Scaffold(
             appBar: AppBar(
               title: const Text('Training'),


### PR DESCRIPTION
## Summary
- include optional `categoryCounts` section on `PackStatsScreen`
- show mistake distribution for `suggested_weekly` sessions in the final summary

## Testing
- `dart format lib/screens/pack_stats_screen.dart lib/screens/training_session_screen.dart`
- `flutter analyze` *(fails: 6450 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6874c5f87158832a8c423ba4ed3410e6