### PR TITLE
Add plug-in user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ while returning `null` allows the export to proceed.
 Подробнее о подключении сторонних модулей описано в [docs/plugins](docs/plugins/README.md).
 Разработчикам плагинов посвящено руководство [PLUGIN_DEV_GUIDE](docs/plugins/PLUGIN_DEV_GUIDE.md).
 
+## Plug-ins
+
+See [USER_GUIDE](docs/plugins/USER_GUIDE.md) for installation and activation.
+
 ![screenshot](flutter_01.png)
 
 ## Future plans

--- a/docs/plugins/USER_GUIDE.md
+++ b/docs/plugins/USER_GUIDE.md
@@ -1,0 +1,20 @@
+# Plug-in User Guide
+
+## Installation paths
+
+| Platform | Folder |
+|---------|-------|
+| **Android** | `/data/data/<package>/files/plugins` |
+| **iOS** | `Library/Application Support/plugins` inside the app sandbox |
+| **macOS** | `Library/Application Support/plugins` in the app container |
+| **Windows** | `%APPDATA%\poker_analyzer\plugins` |
+| **Linux** | `~/.local/share/poker_analyzer/plugins` |
+| **Web** | use **Download** in `PluginManagerScreen` |
+
+Copy `<Name>Plugin.dart` into the folder for your platform.
+
+## Enabling plug-ins
+
+1. Open `PluginManagerScreen` from the side menu.
+2. Toggle the required files.
+3. Tap **Reload Plugins**.


### PR DESCRIPTION
## Summary
- document plug-in installation paths
- show how to enable plug-ins in the app
- link the user guide from README

## Testing
- `flutter format README.md docs/plugins/USER_GUIDE.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c851344c832a89da9d9e27a1fc80