### PR TITLE
Support call/raise evaluation

### DIFF
--- a/plugins/LocalEvPlugin.dart
+++ b/plugins/LocalEvPlugin.dart
@@ -14,7 +14,8 @@ class LocalEvService {
     final stack = spot.hand.stacks['$hero']?.round();
     if (hand == null || stack == null) return;
     for (final a in spot.hand.actions[0] ?? []) {
-      if (a.playerIndex == hero && a.action == 'push') {
+      if (a.playerIndex == hero &&
+          (a.action == 'push' || a.action == 'call' || a.action == 'raise')) {
         a.ev = computePushEV(
           heroBbStack: stack,
           bbCount: spot.hand.playerCount - 1,
@@ -41,7 +42,8 @@ class LocalEvService {
         if (a.playerIndex != hero && a.action == 'call') a.playerIndex
     ];
     for (final a in spot.hand.actions[0] ?? []) {
-      if (a.playerIndex == hero && a.action == 'push') {
+      if (a.playerIndex == hero &&
+          (a.action == 'push' || a.action == 'call' || a.action == 'raise')) {
         final ev = computePushEV(
           heroBbStack: stack,
           bbCount: spot.hand.playerCount - 1,

--- a/test/evaluation_executor_service_test.dart
+++ b/test/evaluation_executor_service_test.dart
@@ -55,6 +55,30 @@ void main() {
     expect(res.correct, isFalse);
   });
 
+  test('evaluate returns call when profitable', () {
+    final spot = TrainingSpot(
+      playerCards: [
+        [CardModel(rank: 'A', suit: '♠'), CardModel(rank: 'K', suit: '♠')],
+        [CardModel(rank: '2', suit: '♣'), CardModel(rank: '7', suit: '♦')],
+      ],
+      boardCards: const [],
+      actions: const [
+        ActionEntry(0, 1, 'push', amount: 10),
+        ActionEntry(0, 0, 'call', amount: 10),
+      ],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [],
+      positions: const ['BB', 'SB'],
+      stacks: const [10, 10],
+      createdAt: DateTime.now(),
+    );
+    final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
+    final res = EvaluationExecutorService().evaluateSpot(ctx, spot, 'call');
+    expect(res.expectedAction, 'call');
+    expect(res.correct, isTrue);
+  });
+
   test('evaluate falls back to hero action when stack is deep', () {
     final spot = TrainingSpot(
       playerCards: [
@@ -96,6 +120,29 @@ void main() {
     expect(res.score, 1);
     final cached = await EvaluationExecutorService().evaluate(req);
     expect(cached.score, 1);
+  });
+
+  test('async evaluate returns score for call', () async {
+    final spot = TrainingSpot(
+      playerCards: [
+        [CardModel(rank: 'A', suit: '♠'), CardModel(rank: 'K', suit: '♠')],
+        [CardModel(rank: '2', suit: '♣'), CardModel(rank: '7', suit: '♦')],
+      ],
+      boardCards: const [],
+      actions: const [
+        ActionEntry(0, 1, 'push', amount: 10),
+        ActionEntry(0, 0, 'call', amount: 10),
+      ],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [],
+      positions: const ['BB', 'SB'],
+      stacks: const [10, 10],
+      createdAt: DateTime.now(),
+    );
+    final req = EvalRequest(hash: 'c', spot: spot, action: 'call');
+    final res = await EvaluationExecutorService().evaluate(req);
+    expect(res.score, 1);
   });
 
   testWidgets('evaluateSingle uses multiway icm', (tester) async {


### PR DESCRIPTION
## Summary
- handle `call` and `raise` actions in EvaluationExecutorService
- compute EV/ICM for these actions in LocalEvService
- cover new scenarios in evaluation executor tests

## Testing
- `flutter test test/evaluation_executor_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c848bde0832aacb4508627f0f990