### PR TITLE
Add YAML templates for pack generation

### DIFF
--- a/lib/services/pack_library_generator.dart
+++ b/lib/services/pack_library_generator.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/hero_position.dart';
 import 'spot_template_engine.dart';
+import 'yaml_pack_importer_service.dart';
 
 class PackLibraryGenerator {
   final SpotTemplateEngine engine;
@@ -52,6 +53,23 @@ class PackLibraryGenerator {
           }
         }
       }
+    }
+  }
+
+  Future<void> generateFromYaml(String path) async {
+    final importer = YamlPackImporterService();
+    final list = await importer.loadFromYaml(path);
+    _packs.clear();
+    for (final t in list) {
+      final tpl = await engine.generate(
+        heroPosition: t.hero,
+        villainPosition: t.villain,
+        stackRange: t.stacks,
+        actionType: t.action,
+        withIcm: t.icm,
+        name: t.name,
+      );
+      _packs.add(tpl);
     }
   }
 

--- a/lib/services/yaml_pack_importer_service.dart
+++ b/lib/services/yaml_pack_importer_service.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:yaml/yaml.dart';
+import '../models/v2/hero_position.dart';
+
+class YamlPackTemplate {
+  final String name;
+  final HeroPosition hero;
+  final HeroPosition villain;
+  final List<int> stacks;
+  final String action;
+  final bool icm;
+  YamlPackTemplate({
+    required this.name,
+    required this.hero,
+    required this.villain,
+    required this.stacks,
+    required this.action,
+    required this.icm,
+  });
+}
+
+class YamlPackImporterService {
+  Future<List<YamlPackTemplate>> loadFromYaml(String path) async {
+    final file = File(path);
+    if (!file.existsSync()) return [];
+    final doc = loadYaml(await file.readAsString());
+    if (doc is! YamlList) return [];
+    final list = <YamlPackTemplate>[];
+    for (final item in doc) {
+      if (item is! YamlMap) continue;
+      final stacks = <int>[
+        for (final v in (item['stacks'] as YamlList? ?? const []))
+          (v as num).toInt(),
+      ];
+      list.add(
+        YamlPackTemplate(
+          name: item['name'].toString(),
+          hero: parseHeroPosition(item['hero'].toString()),
+          villain: parseHeroPosition(item['villain'].toString()),
+          stacks: stacks,
+          action: item['action'].toString(),
+          icm: item['icm'] == true,
+        ),
+      );
+    }
+    return list;
+  }
+}

--- a/pack_templates.yaml
+++ b/pack_templates.yaml
@@ -1,0 +1,20 @@
+- name: 'Call vs Push — BB vs SB (10–15 BB, ICM)'
+  hero: BB
+  villain: SB
+  stacks: [10, 15]
+  action: callPush
+  icm: true
+
+- name: 'Push vs Fold — SB vs BB (10–15 BB)'
+  hero: SB
+  villain: BB
+  stacks: [10, 15]
+  action: push
+  icm: false
+
+- name: 'Minraise/Fold vs Push — BTN vs BB (20 BB, ICM)'
+  hero: BTN
+  villain: BB
+  stacks: [20]
+  action: minraiseFold
+  icm: true

--- a/test/yaml_pack_importer_service_test.dart
+++ b/test/yaml_pack_importer_service_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/yaml_pack_importer_service.dart';
+
+void main() {
+  test('loadFromYaml returns templates', () async {
+    final service = YamlPackImporterService();
+    final list = await service.loadFromYaml('pack_templates.yaml');
+    expect(list, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- support generating packs from YAML
- load YAML pack templates with `YamlPackImporterService`
- expose `generateFromYaml` in `PackLibraryGenerator`
- provide example `pack_templates.yaml`
- add importer unit test

## Testing
- `dart format -o write lib/services/yaml_pack_importer_service.dart lib/services/pack_library_generator.dart test/yaml_pack_importer_service_test.dart`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6874ebd30240832abeb82878d0f1cf7c