### PR TITLE
Show pack tags in library cards

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -369,6 +369,38 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
               style: const TextStyle(fontSize: 11, color: Colors.white54),
             ),
           Text(t.description),
+          if (t.tags.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: SizedBox(
+                height: 28,
+                child: Wrap(
+                  spacing: 4,
+                  runSpacing: 2,
+                  children: [
+                    for (final tag in t.tags.take(3))
+                      Chip(
+                        label: Text(tag, style: const TextStyle(fontSize: 11)),
+                        backgroundColor: Colors.grey[800],
+                        materialTapTargetSize:
+                            MaterialTapTargetSize.shrinkWrap,
+                        visualDensity:
+                            const VisualDensity(horizontal: -4, vertical: -4),
+                      ),
+                    if (t.tags.length > 3)
+                      Chip(
+                        label: Text('+${t.tags.length - 3}',
+                            style: const TextStyle(fontSize: 11)),
+                        backgroundColor: Colors.grey[800],
+                        materialTapTargetSize:
+                            MaterialTapTargetSize.shrinkWrap,
+                        visualDensity:
+                            const VisualDensity(horizontal: -4, vertical: -4),
+                      ),
+                  ],
+                ),
+              ),
+            ),
         ],
       ),
       leading: CircleAvatar(child: Text(total.toString())),


### PR DESCRIPTION
## Summary
- display pack tags as chips on the library cards

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fe19100c832abb3d4179dde70186