### PR TITLE
Add updated date on pack tiles

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -370,3 +370,17 @@ class TrainingPackTemplate {
 
   bool hasPlayableContent() => playableVariants().isNotEmpty;
 }
+
+extension TrainingPackTemplateUpdated on TrainingPackTemplate {
+  DateTime? get updatedDate {
+    final u = meta['updated'];
+    if (u is String) return DateTime.tryParse(u);
+    if (u is int) return DateTime.fromMillisecondsSinceEpoch(u);
+    try {
+      final dynamic d = this;
+      if (d.updatedAt is DateTime) return d.updatedAt as DateTime;
+      if (d.lastModified is DateTime) return d.lastModified as DateTime;
+    } catch (_) {}
+    return null;
+  }
+}

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -9,6 +9,7 @@ import '../services/training_pack_asset_loader.dart';
 import 'package:uuid/uuid.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:intl/intl.dart';
 import '../models/session_log.dart';
 
 import '../models/v2/training_pack_template.dart';
@@ -484,11 +485,37 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (t.lastTrainedAt != null)
-            Text(
-              'Trained ${timeago.format(t.lastTrainedAt!, locale: "en_short")}',
-              style: const TextStyle(fontSize: 11, color: Colors.white54),
-            ),
+          (() {
+            final updated = t.updatedDate;
+            final diff = updated == null
+                ? null
+                : DateTime.now().difference(updated).inDays;
+            String? label;
+            if (diff != null) {
+              if (diff > 30) {
+                label =
+                    'Updated: ${DateFormat('d MMM', 'en_US').format(updated)}';
+              } else if (diff < 3) {
+                label = 'Updated Recently';
+              }
+            }
+            if (label == null && t.lastTrainedAt == null) return null;
+            return Row(
+              children: [
+                if (label != null)
+                  Text(label,
+                      style: const TextStyle(
+                          fontSize: 11, color: Colors.white38)),
+                if (label != null && t.lastTrainedAt != null)
+                  const SizedBox(width: 8),
+                if (t.lastTrainedAt != null)
+                  Text(
+                    'Trained ${timeago.format(t.lastTrainedAt!, locale: "en_short")}',
+                    style: const TextStyle(fontSize: 11, color: Colors.white54),
+                  ),
+              ],
+            );
+          })(),
           Text(t.description),
           if (t.tags.isNotEmpty)
             Padding(


### PR DESCRIPTION
## Summary
- extend TrainingPackTemplate with `updatedDate`
- display Updated date next to last trained label

## Testing
- `apt-get update`
- `apt-get install dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68755d09befc832abb05490cf7719873