### PR TITLE
Add mixed drill history screen

### DIFF
--- a/lib/screens/mixed_drill_history_screen.dart
+++ b/lib/screens/mixed_drill_history_screen.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/date_utils.dart';
+import '../models/mixed_drill_stat.dart';
+import '../services/mixed_drill_history_service.dart';
+import '../theme/app_colors.dart';
+
+class DrillHistoryScreen extends StatefulWidget {
+  const DrillHistoryScreen({super.key});
+
+  @override
+  State<DrillHistoryScreen> createState() => _DrillHistoryScreenState();
+}
+
+class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
+  static const _prefsKey = 'drill_history_filter';
+  String _street = 'any';
+  String? _tag;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final m = jsonDecode(raw);
+        _street = m['street'] as String? ?? 'any';
+        _tag = m['tag'] as String?;
+      } catch (_) {}
+    }
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({'street': _street, 'tag': _tag}),
+    );
+  }
+
+  List<MixedDrillStat> _filter(List<MixedDrillStat> list) {
+    return [
+      for (final s in list)
+        if ((_street == 'any' || s.street == _street) &&
+            (_tag == null || s.tags.contains(_tag)))
+          s
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<MixedDrillHistoryService>().stats;
+    final tags = <String>{for (final s in stats) ...s.tags};
+    final filtered = _filter(stats);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Drill History'),
+      ),
+      body: stats.isEmpty
+          ? const Center(
+              child: Text('Empty', style: TextStyle(color: Colors.white70)),
+            )
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DropdownButton<String>(
+                    value: _street,
+                    underline: const SizedBox.shrink(),
+                    onChanged: (v) {
+                      setState(() => _street = v ?? 'any');
+                      _save();
+                    },
+                    items: const [
+                      DropdownMenuItem(value: 'any', child: Text('All')),
+                      DropdownMenuItem(value: 'preflop', child: Text('Preflop')),
+                      DropdownMenuItem(value: 'flop', child: Text('Flop')),
+                      DropdownMenuItem(value: 'turn', child: Text('Turn')),
+                      DropdownMenuItem(value: 'river', child: Text('River')),
+                    ],
+                  ),
+                ),
+                if (tags.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Wrap(
+                      spacing: 8,
+                      children: [
+                        ChoiceChip(
+                          label: const Text('All'),
+                          selected: _tag == null,
+                          onSelected: (_) {
+                            setState(() => _tag = null);
+                            _save();
+                          },
+                        ),
+                        for (final t in tags)
+                          ChoiceChip(
+                            label: Text(t),
+                            selected: _tag == t,
+                            onSelected: (_) {
+                              setState(() => _tag = _tag == t ? null : t);
+                              _save();
+                            },
+                          ),
+                      ],
+                    ),
+                  ),
+                Expanded(
+                  child: filtered.isEmpty
+                      ? const Center(
+                          child: Text('No results',
+                              style: TextStyle(color: Colors.white70)),
+                        )
+                      : ListView.builder(
+                          padding: const EdgeInsets.all(16),
+                          itemCount: filtered.length,
+                          itemBuilder: (context, index) {
+                            final s = filtered[index];
+                            final pct = s.accuracy.toStringAsFixed(1);
+                            final sub = [
+                              s.street,
+                              if (s.tags.isNotEmpty) s.tags.join(', ')
+                            ].join(' • ');
+                            return Card(
+                              color: AppColors.cardBackground,
+                              child: ListTile(
+                                title: Text(formatDate(s.date),
+                                    style:
+                                        const TextStyle(color: Colors.white)),
+                                subtitle: Text(sub,
+                                    style: const TextStyle(color: Colors.white70)),
+                                trailing: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: [
+                                    Text('$pct%',
+                                        style: const TextStyle(color: Colors.white)),
+                                    Text('${s.total}',
+                                        style:
+                                            const TextStyle(color: Colors.white70)),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -15,6 +15,7 @@ import 'training_pack_screen.dart';
 import '../helpers/training_onboarding.dart';
 import 'training_pack_comparison_screen.dart';
 import 'create_pack_screen.dart';
+import 'mixed_drill_history_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_session_service.dart';
@@ -52,6 +53,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(msg ?? 'Пак импортирован')),
+    );
+  }
+
+  void _openHistory() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const DrillHistoryScreen()),
     );
   }
 
@@ -148,7 +156,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       return Scaffold(
         appBar: AppBar(
           title: const Text('Тренировочные споты'),
-          actions: [SyncStatusIcon.of(context)],
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.analytics),
+              onPressed: _openHistory,
+            ),
+            SyncStatusIcon.of(context)
+          ],
         ),
         body: const Center(child: CircularProgressIndicator()),
       );
@@ -246,7 +260,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       return Scaffold(
         appBar: AppBar(
           title: const Text('Тренировочные споты'),
-          actions: [SyncStatusIcon.of(context)],
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.analytics),
+              onPressed: _openHistory,
+            ),
+            SyncStatusIcon.of(context)
+          ],
         ),
         body: Center(
           child: Column(
@@ -287,7 +307,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Тренировочные споты'),
-        actions: [SyncStatusIcon.of(context)],
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.analytics),
+            onPressed: _openHistory,
+          ),
+          SyncStatusIcon.of(context)
+        ],
       ),
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- show mixed drill history with filters
- link from training packs screen via analytics icon

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756562f614832ab63388e2329887b1