### PR TITLE
Add weekly drill stats card

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -63,6 +63,7 @@ import 'services/daily_focus_recap_service.dart';
 import 'services/feedback_service.dart';
 import 'services/drill_history_service.dart';
 import 'services/mixed_drill_history_service.dart';
+import 'services/weekly_drill_stats_service.dart';
 import 'services/training_pack_play_controller.dart';
 import 'services/training_session_service.dart';
 import 'services/session_manager.dart';
@@ -344,6 +345,11 @@ List<SingleChildWidget> buildTrainingProviders() {
           ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),
           ChangeNotifierProvider(
             create: (_) => MixedDrillHistoryService()..load(),
+          ),
+          ChangeNotifierProvider(
+            create: (context) => WeeklyDrillStatsService(
+              history: context.read<MixedDrillHistoryService>(),
+            )..load(),
           ),
           Provider(create: (_) => const HandAnalyzerService()),
           ChangeNotifierProvider(

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -17,6 +17,7 @@ import 'training_pack_comparison_screen.dart';
 import 'create_pack_screen.dart';
 import 'mixed_drill_history_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../widgets/weekly_drill_stats_card.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_session_service.dart';
 import 'training_session_screen.dart';
@@ -272,6 +273,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              const WeeklyDrillStatsCard(),
               const Icon(Icons.auto_awesome, size: 96, color: Colors.white30),
               const SizedBox(height: 24),
               draftWidget,
@@ -317,6 +319,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       ),
       body: Column(
         children: [
+          const WeeklyDrillStatsCard(),
           draftWidget,
           SwitchListTile(
             title: const Text('Скрыть завершённые'),

--- a/lib/services/weekly_drill_stats_service.dart
+++ b/lib/services/weekly_drill_stats_service.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import 'mixed_drill_history_service.dart';
+import '../models/mixed_drill_stat.dart';
+
+class WeeklyDrillStats {
+  final double accuracy;
+  final int total;
+  final int streak;
+  final double improvementPct;
+  const WeeklyDrillStats({
+    required this.accuracy,
+    required this.total,
+    required this.streak,
+    required this.improvementPct,
+  });
+}
+
+class WeeklyDrillStatsService extends ChangeNotifier {
+  final MixedDrillHistoryService history;
+  WeeklyDrillStats? _stats;
+  Timer? _timer;
+
+  WeeklyDrillStatsService({required this.history});
+
+  WeeklyDrillStats? get stats => _stats;
+
+  void load() {
+    _compute();
+    history.addListener(_compute);
+    _timer = Timer.periodic(const Duration(hours: 1), (_) => _compute());
+  }
+
+  void _compute() {
+    final list = history.stats;
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(const Duration(days: 6));
+    final prevStart = start.subtract(const Duration(days: 7));
+    final lastWeek = <MixedDrillStat>[for (final s in list) if (!s.date.isBefore(start)) s];
+    final prevWeek = <MixedDrillStat>[for (final s in list) if (!s.date.isBefore(prevStart) && s.date.isBefore(start)) s];
+    if (lastWeek.isEmpty || prevWeek.isEmpty) {
+      _stats = null;
+      notifyListeners();
+      return;
+    }
+    int total = 0, correct = 0;
+    for (final s in lastWeek) {
+      total += s.total;
+      correct += s.correct;
+    }
+    final acc = total > 0 ? correct * 100 / total : 0.0;
+    int pTotal = 0, pCorrect = 0;
+    for (final s in prevWeek) {
+      pTotal += s.total;
+      pCorrect += s.correct;
+    }
+    final pAcc = pTotal > 0 ? pCorrect * 100 / pTotal : 0.0;
+    int streak = 0;
+    for (int i = 0;; i++) {
+      final d = DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
+      final any = list.any((s) => s.date.year == d.year && s.date.month == d.month && s.date.day == d.day);
+      if (any) {
+        streak += 1;
+      } else {
+        break;
+      }
+    }
+    _stats = WeeklyDrillStats(
+      accuracy: acc,
+      total: total,
+      streak: streak,
+      improvementPct: acc - pAcc,
+    );
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    history.removeListener(_compute);
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/widgets/weekly_drill_stats_card.dart
+++ b/lib/widgets/weekly_drill_stats_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/weekly_drill_stats_service.dart';
+
+class WeeklyDrillStatsCard extends StatelessWidget {
+  const WeeklyDrillStatsCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = context.watch<WeeklyDrillStatsService>().stats;
+    if (stats == null) return const SizedBox.shrink();
+    final diff = stats.improvementPct;
+    final color = diff > 0
+        ? Colors.green
+        : diff < 0
+            ? Colors.red
+            : Colors.grey;
+    final icon = diff >= 0 ? Icons.trending_up : Icons.trending_down;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.insights, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Weekly Drill Stats',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(
+                  '${stats.accuracy.toStringAsFixed(1)}% • ${stats.total} spots • streak ${stats.streak}',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Row(
+            children: [
+              Icon(icon, color: color, size: 16),
+              const SizedBox(width: 2),
+              Text(
+                '${diff >= 0 ? '+' : ''}${diff.toStringAsFixed(1)}%',
+                style: TextStyle(color: color),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- compute last week's drill stats in new service
- show stats card at top of TrainingPacksScreen
- wire weekly drill stats service in providers

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 13817 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687567473c24832aa09958fe78685d73