### PR TITLE
Add XP progress card

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -37,6 +37,7 @@ import 'goal_drill_screen.dart';
 import 'weekly_progress_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
+import '../widgets/xp_progress_card.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -874,6 +875,7 @@ class _ProgressScreenState extends State<ProgressScreen>
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          const XPProgressCard(),
           _buildGoalCompletedBadge(),
           _buildAllGoalsCompletedBadge(),
           isPortrait(context)

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -18,6 +18,7 @@ import 'create_pack_screen.dart';
 import 'mixed_drill_history_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../widgets/weekly_drill_stats_card.dart';
+import '../widgets/xp_progress_card.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_session_service.dart';
 import 'training_session_screen.dart';
@@ -274,6 +275,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
             mainAxisSize: MainAxisSize.min,
             children: [
               const WeeklyDrillStatsCard(),
+              const XPProgressCard(),
               const Icon(Icons.auto_awesome, size: 96, color: Colors.white30),
               const SizedBox(height: 24),
               draftWidget,
@@ -320,6 +322,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       body: Column(
         children: [
           const WeeklyDrillStatsCard(),
+          const XPProgressCard(),
           draftWidget,
           SwitchListTile(
             title: const Text('Скрыть завершённые'),

--- a/lib/widgets/xp_progress_card.dart
+++ b/lib/widgets/xp_progress_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/xp_tracker_service.dart';
+import '../models/level_stage.dart';
+
+class XPProgressCard extends StatelessWidget {
+  const XPProgressCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<XPTrackerService>();
+    final level = service.level;
+    final xp = service.xp;
+    final next = service.nextLevelXp;
+    final progress = service.progress.clamp(0.0, 1.0);
+    final stage = stageForLevel(level);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.star, color: stage.color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${stage.label} Level $level',
+                  style: TextStyle(color: stage.color, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 4),
+                Text('$xp / $next XP', style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation(stage.color),
+                    minHeight: 6,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show XP progress card using level stages
- display progress on training packs screen
- display progress on overall progress screen

## Testing
- `flutter analyze` *(fails: issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687577bfec14832aae410e2e3541d872