### PR TITLE
Add XP tracker card to achievements screen

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../services/achievement_service.dart';
 import '../models/achievement_info.dart';
 import '../widgets/sync_status_widget.dart';
+import '../widgets/xp_progress_card.dart';
 
 class AchievementsScreen extends StatelessWidget {
   const AchievementsScreen({super.key});
@@ -25,6 +26,7 @@ class AchievementsScreen extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          const XPProgressCard(),
           for (final entry in grouped.entries)
             ExpansionTile(
               initiallyExpanded: true,


### PR DESCRIPTION
## Summary
- show XPProgressCard at the top of AchievementsScreen

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get --dry-run` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687579d6f228832a94c556fd5c9ed864