### PR TITLE
Implement achievement level stages

### DIFF
--- a/lib/models/achievement_info.dart
+++ b/lib/models/achievement_info.dart
@@ -1,20 +1,54 @@
-import "package:flutter/material.dart";
+import 'package:flutter/material.dart';
+import 'level_stage.dart';
+
 class AchievementInfo {
   final String id;
   final String title;
   final String description;
-  final IconData icon;
   final int progress;
-  final int target;
+  final List<int> thresholds;
+  final List<IconData> iconsPerLevel;
   final String category;
+
   const AchievementInfo({
     required this.id,
     required this.title,
     required this.description,
-    required this.icon,
     required this.progress,
-    required this.target,
+    required this.thresholds,
+    required this.iconsPerLevel,
     required this.category,
   });
-  bool get completed => progress >= target;
+
+  int get levelIndex {
+    var idx = 0;
+    for (final t in thresholds) {
+      if (progress >= t) {
+        idx++;
+      } else {
+        break;
+      }
+    }
+    return idx;
+  }
+
+  LevelStage get level =>
+      LevelStage.values[levelIndex.clamp(0, thresholds.length - 1)];
+
+  LevelStage get maxLevel => LevelStage.values[thresholds.length - 1];
+
+  int get _prevTarget =>
+      levelIndex == 0 ? 0 : thresholds[levelIndex - 1];
+
+  int get target =>
+      levelIndex < thresholds.length ? thresholds[levelIndex] : thresholds.last;
+
+  int get progressInLevel => progress - _prevTarget;
+
+  int get targetInLevel => target - _prevTarget;
+
+  IconData get icon =>
+      iconsPerLevel[level.index.clamp(0, iconsPerLevel.length - 1)];
+
+  bool get completed => levelIndex >= thresholds.length;
 }

--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -11,7 +11,6 @@ class AchievementsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final service = context.watch<AchievementService>();
-    final accent = Theme.of(context).colorScheme.secondary;
     final data = service.allAchievements();
     final Map<String, List<AchievementInfo>> grouped = {};
     for (final a in data) {
@@ -33,7 +32,7 @@ class AchievementsScreen extends StatelessWidget {
               title: Text(entry.key,
                   style: const TextStyle(fontWeight: FontWeight.bold)),
               children: [
-                for (final a in entry.value) _Item(a, accent),
+                for (final a in entry.value) _Item(a),
               ],
             ),
         ],
@@ -44,8 +43,7 @@ class AchievementsScreen extends StatelessWidget {
 
 class _Item extends StatelessWidget {
   final AchievementInfo ach;
-  final Color accent;
-  const _Item(this.ach, this.accent);
+  const _Item(this.ach);
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +58,7 @@ class _Item extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(ach.icon, color: accent),
+          Icon(ach.icon, color: ach.level.color),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -71,13 +69,23 @@ class _Item extends StatelessWidget {
                 const SizedBox(height: 4),
                 Text(ach.description,
                     style: const TextStyle(color: Colors.white70)),
+                const SizedBox(height: 4),
+                Text(
+                  ach.level.label,
+                  style: TextStyle(
+                    color: ach.level.color,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
                 const SizedBox(height: 8),
                 ClipRRect(
                   borderRadius: BorderRadius.circular(4),
                   child: LinearProgressIndicator(
-                    value: (ach.progress / ach.target).clamp(0.0, 1.0),
+                    value: (ach.progressInLevel / ach.targetInLevel)
+                        .clamp(0.0, 1.0),
                     backgroundColor: Colors.white24,
-                    valueColor: AlwaysStoppedAnimation<Color>(accent),
+                    valueColor:
+                        AlwaysStoppedAnimation<Color>(ach.level.color),
                     minHeight: 6,
                   ),
                 ),
@@ -88,7 +96,7 @@ class _Item extends StatelessWidget {
           Column(
             children: [
               if (done) const Icon(Icons.check_circle, color: Colors.green),
-              Text('${ach.progress}/${ach.target}')
+              Text('${ach.progressInLevel}/${ach.targetInLevel}')
             ],
           )
         ],

--- a/lib/services/achievement_service.dart
+++ b/lib/services/achievement_service.dart
@@ -126,11 +126,66 @@ class AchievementService extends ChangeNotifier {
   List<AchievementInfo> allAchievements() {
     final unlocked = {for (final a in _achievements) a.id: a.unlocked};
     return [
-      AchievementInfo(id: "first_pack", title: "Первый пак завершён", description: "Завершите первую тренировку", icon: Icons.flag, progress: stats.sessionsCompleted > 0 ? 1 : 0, target: 1, category: "Volume"),
-      AchievementInfo(id: "hands_100", title: "100 рук сыграно", description: "Разберите 100 сыгранных рук", icon: Icons.pan_tool_alt, progress: stats.handsReviewed, target: 100, category: "Volume"),
-      AchievementInfo(id: "streak_7", title: "7 дней подряд", description: "Тренируйтесь 7 дней подряд", icon: Icons.local_fire_department, progress: streak.streak.value, target: 7, category: "Streaks"),
-      AchievementInfo(id: "error_free_3", title: "Без ошибок 3 дня", description: "Три дня без ошибок подряд", icon: Icons.check_circle, progress: streak.errorFreeStreak, target: 3, category: "Streaks"),
-      AchievementInfo(id: "ev_015", title: "EV-мастер", description: "Средний EV > 0.15 в сессии", icon: Icons.trending_up, progress: unlocked["ev_015"] == true ? 1 : 0, target: 1, category: "Accuracy"),
+      AchievementInfo(
+        id: 'first_pack',
+        title: 'Первый пак завершён',
+        description: 'Завершите первую тренировку',
+        progress: stats.sessionsCompleted > 0 ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.flag],
+        category: 'Volume',
+      ),
+      AchievementInfo(
+        id: 'hands_100',
+        title: 'Руки разобраны',
+        description: 'Разберите сыгранные руки',
+        progress: stats.handsReviewed,
+        thresholds: const [10, 50, 200, 1000],
+        iconsPerLevel: const [
+          Icons.looks_one,
+          Icons.looks_two,
+          Icons.looks_3,
+          Icons.looks_4,
+        ],
+        category: 'Volume',
+      ),
+      AchievementInfo(
+        id: 'streak_7',
+        title: 'Дни подряд',
+        description: 'Тренируйтесь каждый день',
+        progress: streak.streak.value,
+        thresholds: const [3, 7, 30, 100],
+        iconsPerLevel: const [
+          Icons.calendar_view_day,
+          Icons.calendar_today,
+          Icons.calendar_month,
+          Icons.event_available,
+        ],
+        category: 'Streaks',
+      ),
+      AchievementInfo(
+        id: 'error_free_3',
+        title: 'Без ошибок',
+        description: 'Дни без ошибок',
+        progress: streak.errorFreeStreak,
+        thresholds: const [1, 3, 7, 30],
+        iconsPerLevel: const [
+          Icons.check,
+          Icons.check_circle,
+          Icons.check_circle_outline,
+          Icons.verified,
+        ],
+        category: 'Streaks',
+      ),
+      AchievementInfo(
+        id: 'ev_015',
+        title: 'EV-мастер',
+        description: 'Средний EV > 0.15 в сессии',
+        progress: unlocked['ev_015'] == true ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.trending_up],
+        category: 'Accuracy',
+      ),
     ];
   }
 


### PR DESCRIPTION
## Summary
- extend `AchievementInfo` with level data and per-level icons
- compute progress tiers in `AchievementService`
- display level labels and per-level progress in `AchievementsScreen`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687586f476c4832a917d64b0518d6dd0