### PR TITLE
Implement training recommendations

### DIFF
--- a/lib/services/smart_suggestion_service.dart
+++ b/lib/services/smart_suggestion_service.dart
@@ -1,5 +1,7 @@
 import '../models/training_pack.dart';
 import 'training_pack_storage_service.dart';
+import 'goals_service.dart';
+import 'mistake_review_pack_service.dart';
 
 class SmartSuggestionService {
   final TrainingPackStorageService storage;
@@ -14,5 +16,51 @@ class SmartSuggestionService {
       return bscore.compareTo(ascore);
     });
     return list.take(3).toList();
+  }
+
+  Map<String, List<TrainingPack>> getExtendedSuggestions(
+    GoalsService goals,
+    MistakeReviewPackService mistakes, {
+    int limit = 20,
+  }) {
+    final now = DateTime.now();
+    final packs = storage.packs.toList();
+
+    List<TrainingPack> almost = [
+      for (final p in packs)
+        if (p.pctComplete >= 0.6 && p.pctComplete < 1) p
+    ]
+      ..sort((a, b) => b.pctComplete.compareTo(a.pctComplete));
+
+    List<TrainingPack> stale = [
+      for (final p in packs)
+        if (now.difference(p.lastAttemptDate).inDays > 7) p
+    ]
+      ..sort((a, b) => a.lastAttemptDate.compareTo(b.lastAttemptDate));
+
+    final goal = goals.currentGoal;
+    List<TrainingPack> goalPacks = [];
+    if (goal != null) {
+      for (final p in packs) {
+        if (p.hands.any(goal.isViolatedBy)) {
+          goalPacks.add(p);
+        }
+      }
+    }
+
+    final mistakesPack = mistakes.pack;
+    List<TrainingPack> mistakeList = mistakesPack == null ? [] : [mistakesPack];
+
+    almost = almost.take(limit).toList();
+    stale = stale.take(limit).toList();
+    goalPacks = goalPacks.take(limit).toList();
+    mistakeList = mistakeList.take(limit).toList();
+
+    return {
+      'almost': almost,
+      'stale': stale,
+      'goal': goalPacks,
+      'mistakes': mistakeList,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- extend SmartSuggestionService with extended suggestion categories
- redesign TrainingRecommendationScreen to show suggestion sections

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687588ffd5fc832aa7c6713dc5986279