### PR TITLE
Add training library header

### DIFF
--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -20,6 +20,7 @@ import 'mixed_drill_history_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../widgets/weekly_drill_stats_card.dart';
 import '../widgets/xp_progress_card.dart';
+import '../widgets/training_library_header_card.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_session_service.dart';
 import 'training_recommendation_screen.dart';
@@ -291,6 +292,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              const TrainingLibraryHeaderCard(),
               const WeeklyDrillStatsCard(),
               const XPProgressCard(),
               const Icon(Icons.auto_awesome, size: 96, color: Colors.white30),
@@ -338,6 +340,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
       ),
       body: Column(
         children: [
+          const TrainingLibraryHeaderCard(),
           const WeeklyDrillStatsCard(),
           const XPProgressCard(),
           if (_suggestions.isNotEmpty)

--- a/lib/widgets/training_library_header_card.dart
+++ b/lib/widgets/training_library_header_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+
+class TrainingLibraryHeaderCard extends StatelessWidget {
+  const TrainingLibraryHeaderCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('📚', style: TextStyle(fontSize: 28)),
+          const SizedBox(width: 12),
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Библиотека тренировок',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                SizedBox(height: 4),
+                Text(
+                  'Выбирай паки по сложности, позиции и цели',
+                  style: TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `TrainingLibraryHeaderCard` widget
- include header at top of TrainingPacksScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758cfda9f0832aa6cf147e5769bd11