### PR TITLE
Add FilterSummaryBar

### DIFF
--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -46,6 +46,7 @@ import '../../models/mixed_drill_stat.dart';
 import '../../services/bulk_evaluator_service.dart';
 import '../../services/offline_evaluator_service.dart';
 import '../../services/pack_runtime_builder.dart';
+import '../../widgets/filter_summary_bar.dart';
 import '../../services/range_library_service.dart';
 import '../../services/theme_service.dart';
 import '../../services/session_log_service.dart';
@@ -621,6 +622,49 @@ class _TrainingPackTemplateListScreenState
     if (_mixedHandGoalOnly) parts.add('Hand Goal only');
     if (_mixedAutoOnly) parts.add('Auto only');
     return parts.join(' • ');
+  }
+
+  String _filterSummary() {
+    final parts = <String>[];
+    if (_difficultyFilter != null) parts.add(_difficultyFilter!);
+    if (_posFilter != null) parts.add(_posFilter!.label);
+    if (_stackFilter != null) parts.add('${_stackFilter}bb');
+    String sortLabel() {
+      switch (_sort) {
+        case 'coverage':
+          return 'Coverage';
+        case 'created':
+          return 'Newest';
+        case 'spots':
+          return 'Most Spots';
+        case 'tag':
+          return 'Tag';
+        case 'last_trained':
+          return 'Last Trained';
+        default:
+          return 'Name';
+      }
+    }
+    parts.add('Sort: ${sortLabel()}');
+    return parts.join(' • ');
+  }
+
+  Future<void> _resetFilters() async {
+    setState(() {
+      _difficultyFilter = null;
+      _posFilter = null;
+      _stackFilter = null;
+      _streetFilter = null;
+      _selectedTag = null;
+      _tagFilters.clear();
+      _icmOnly = false;
+      _completedOnly = false;
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsDifficultyKey);
+    await prefs.remove(_prefsPosKey);
+    await prefs.remove(_prefsStackKey);
+    await prefs.remove(_prefsStreetKey);
   }
 
   List<String> _topTags(TrainingPackTemplate tpl) {
@@ -3345,6 +3389,14 @@ class _TrainingPackTemplateListScreenState
                       ],
                     ),
                   ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  child: FilterSummaryBar(
+                    summary: _filterSummary(),
+                    onReset: _resetFilters,
+                    onChange: _showFilters,
+                  ),
+                ),
                 Expanded(
                   child: (_groupByStreet || _groupByType)
                       ? ListView(

--- a/lib/widgets/filter_summary_bar.dart
+++ b/lib/widgets/filter_summary_bar.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+
+class FilterSummaryBar extends StatelessWidget {
+  final String summary;
+  final VoidCallback onReset;
+  final VoidCallback onChange;
+  const FilterSummaryBar({super.key, required this.summary, required this.onReset, required this.onChange});
+
+  @override
+  Widget build(BuildContext context) {
+    if (summary.isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: AppColors.cardBackground,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(summary, style: const TextStyle(color: Colors.white)),
+          ),
+          TextButton.icon(
+            onPressed: onReset,
+            icon: const Icon(Icons.refresh, color: Colors.grey),
+            label: const Text('Сбросить всё', style: TextStyle(color: Colors.white)),
+          ),
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: onChange,
+            icon: const Icon(Icons.tune, color: Colors.grey),
+            label: const Text('Изменить', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `FilterSummaryBar` widget
- show active filters and controls in training pack template list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758f3a56c0832aade885619a314656