### PR TITLE
Add Top Packs ranking screen

### DIFF
--- a/lib/screens/top_packs_screen.dart
+++ b/lib/screens/top_packs_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/training_pack_storage_service.dart';
+import '../models/training_pack.dart';
+import '../helpers/color_utils.dart';
+import '../widgets/difficulty_chip.dart';
+import '../theme/app_colors.dart';
+import 'training_pack_screen.dart';
+
+class TopPacksScreen extends StatefulWidget {
+  const TopPacksScreen({super.key});
+
+  @override
+  State<TopPacksScreen> createState() => _TopPacksScreenState();
+}
+
+class _TopPacksScreenState extends State<TopPacksScreen> {
+  late Future<List<(TrainingPack, int)>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future =
+        context.read<TrainingPackStorageService>().getMostCompletedPacks();
+  }
+
+  Future<void> _reload() async {
+    _future =
+        context.read<TrainingPackStorageService>().getMostCompletedPacks();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<(TrainingPack, int)>>(
+      future: _future,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        return Scaffold(
+          appBar: AppBar(title: const Text('Топ паки')),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : (data == null || data.isEmpty)
+                  ? const Center(
+                      child: Text('Пусто',
+                          style: TextStyle(color: Colors.white70)),
+                    )
+                  : ListView.separated(
+                      padding: const EdgeInsets.all(8),
+                      itemCount: data.length,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final item = data[index];
+                        final pack = item.$1;
+                        final count = item.$2;
+                        return ListTile(
+                          leading: Text('${index + 1}',
+                              style: const TextStyle(color: Colors.white)),
+                          title: Text(pack.name),
+                          subtitle: Row(
+                            children: [
+                              if (pack.colorTag.isNotEmpty)
+                                Container(
+                                  width: 12,
+                                  height: 12,
+                                  margin: const EdgeInsets.only(right: 8),
+                                  decoration: BoxDecoration(
+                                    color: colorFromHex(pack.colorTag),
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              DifficultyChip(pack.difficulty),
+                            ],
+                          ),
+                          trailing: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: AppColors.cardBackground,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text('$count',
+                                style:
+                                    const TextStyle(color: Colors.white70)),
+                          ),
+                          onTap: () async {
+                            await Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (_) => TrainingPackScreen(pack: pack)),
+                            );
+                            if (mounted) _reload();
+                          },
+                        );
+                      },
+                    ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -27,6 +27,7 @@ import 'training_recommendation_screen.dart';
 import '../services/smart_suggestion_service.dart';
 import 'training_session_screen.dart';
 import '../models/saved_hand.dart';
+import 'top_packs_screen.dart';
 
 enum _PackSort { recommended, newest, hardest }
 
@@ -72,6 +73,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const DrillHistoryScreen()),
+    );
+  }
+
+  void _openTopPacks() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TopPacksScreen()),
     );
   }
 
@@ -215,6 +223,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
               icon: const Icon(Icons.analytics),
               onPressed: _openHistory,
             ),
+            TextButton(
+              onPressed: _openTopPacks,
+              child: const Text('🏆 Топ паки'),
+            ),
             SyncStatusIcon.of(context)
           ],
         ),
@@ -321,6 +333,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
               icon: const Icon(Icons.analytics),
               onPressed: _openHistory,
             ),
+            TextButton(
+              onPressed: _openTopPacks,
+              child: const Text('🏆 Топ паки'),
+            ),
             SyncStatusIcon.of(context)
           ],
         ),
@@ -370,6 +386,10 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           IconButton(
             icon: const Icon(Icons.analytics),
             onPressed: _openHistory,
+          ),
+          TextButton(
+            onPressed: _openTopPacks,
+            child: const Text('🏆 Топ паки'),
           ),
           SyncStatusIcon.of(context)
         ],

--- a/lib/services/training_pack_storage_service.dart
+++ b/lib/services/training_pack_storage_service.dart
@@ -72,6 +72,34 @@ class TrainingPackStorageService extends ChangeNotifier {
     return list;
   }
 
+  Future<List<(TrainingPack, int)>> getMostCompletedPacks([
+    int limit = 10,
+  ]) async {
+    if (!Hive.isBoxOpen('session_logs')) {
+      await Hive.initFlutter();
+      await Hive.openBox('session_logs');
+    }
+    final box = Hive.box('session_logs');
+    final count = <String, int>{};
+    for (final v in box.values.whereType<Map>()) {
+      final log = SessionLog.fromJson(Map<String, dynamic>.from(v));
+      if (log.mistakeCount == 0) {
+        count.update(log.templateId, (c) => c + 1, ifAbsent: () => 1);
+      }
+    }
+    final list = [
+      for (final p in _packs)
+        if (count[p.id] != null) (p, count[p.id]!)
+    ];
+    list.sort((a, b) {
+      final r = b.$2.compareTo(a.$2);
+      if (r != 0) return r;
+      return b.$1.lastAttemptDate.compareTo(a.$1.lastAttemptDate);
+    });
+    if (limit < list.length) return list.sublist(0, limit);
+    return list;
+  }
+
   final Map<String, List<PackSnapshot>> _snapshots = {};
   List<PackSnapshot> snapshotsOf(TrainingPack pack) =>
       List.unmodifiable(_snapshots[pack.id] ?? const []);


### PR DESCRIPTION
## Summary
- compute top packs by completed sessions
- navigate to new TopPacksScreen from TrainingPacksScreen
- list ranked packs with color and difficulty badges

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687595976eec832aa671d3f0018ccbf8