### PR TITLE
Add trending templates support

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -374,6 +374,7 @@ List<SingleChildWidget> buildTrainingProviders() {
           Provider(
             create: (context) => SmartSuggestionService(
               storage: context.read<TrainingPackStorageService>(),
+              templates: context.read<TemplateStorageService>(),
             ),
           ),
   ];

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -41,6 +41,7 @@ class TrainingPackTemplate {
   String? png;
   bool? isFavorite;
   bool isPinned;
+  bool trending;
 
   TrainingPackTemplate({
     required this.id,
@@ -74,6 +75,7 @@ class TrainingPackTemplate {
     this.png,
     this.isFavorite = false,
     this.isPinned = false,
+    this.trending = false,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         focusTags = focusTags ?? [],
@@ -116,6 +118,7 @@ class TrainingPackTemplate {
     String? png,
     bool? isFavorite,
     bool? isPinned,
+    bool? trending,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -150,6 +153,7 @@ class TrainingPackTemplate {
       png: png ?? this.png,
       isFavorite: isFavorite ?? this.isFavorite,
       isPinned: isPinned ?? this.isPinned,
+      trending: trending ?? this.trending,
     );
   }
 
@@ -203,6 +207,7 @@ class TrainingPackTemplate {
       png: json['png'] as String?,
       isFavorite: json['isFavorite'] as bool? ?? false,
       isPinned: json['isPinned'] as bool? ?? false,
+      trending: json['trending'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') ||
         !tpl.meta.containsKey('icmCovered')) {
@@ -246,6 +251,7 @@ class TrainingPackTemplate {
         if (png != null) 'png': png,
         if (isFavorite == true) 'isFavorite': true,
         if (isPinned) 'isPinned': true,
+        if (trending) 'trending': true,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/services/pack_library_generator.dart
+++ b/lib/services/pack_library_generator.dart
@@ -70,6 +70,7 @@ class PackLibraryGenerator {
         name: t.name,
       );
       tpl.tags = [for (final tag in t.tags) if (tag.trim().isNotEmpty) tag];
+      tpl.trending = t.trending;
       _packs.add(tpl);
     }
   }

--- a/lib/services/smart_suggestion_service.dart
+++ b/lib/services/smart_suggestion_service.dart
@@ -1,15 +1,35 @@
 import '../models/training_pack.dart';
+import '../models/v2/training_pack_template.dart';
 import 'training_pack_storage_service.dart';
+import 'template_storage_service.dart';
 import 'goals_service.dart';
 import 'mistake_review_pack_service.dart';
 
 class SmartSuggestionService {
   final TrainingPackStorageService storage;
-  SmartSuggestionService({required this.storage});
+  final TemplateStorageService templates;
+  SmartSuggestionService({required this.storage, required this.templates});
 
   List<TrainingPack> getSuggestions() {
     final now = DateTime.now();
     final list = storage.packs.toList();
+    if (list.isEmpty) {
+      final tpls = templates.templates.where((t) => t.trending).toList()
+        ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      return [
+        for (final t in tpls.take(3))
+          TrainingPack(
+            name: t.name,
+            description: t.description,
+            gameType: t.gameType,
+            tags: t.tags,
+            hands: const [],
+            spots: const [],
+            difficulty: t.difficultyLevel,
+            isBuiltIn: t.isBuiltIn,
+          )
+      ];
+    }
     list.sort((a, b) {
       final ascore = (1 - a.pctComplete) * 100 + now.difference(a.lastAttemptDate).inDays;
       final bscore = (1 - b.pctComplete) * 100 + now.difference(b.lastAttemptDate).inDays;

--- a/lib/services/yaml_pack_importer_service.dart
+++ b/lib/services/yaml_pack_importer_service.dart
@@ -10,6 +10,7 @@ class YamlPackTemplate {
   final String action;
   final bool icm;
   final List<String> tags;
+  final bool trending;
   YamlPackTemplate({
     required this.name,
     required this.hero,
@@ -18,6 +19,7 @@ class YamlPackTemplate {
     required this.action,
     required this.icm,
     List<String>? tags,
+    this.trending = false,
   }) : tags = tags ?? const [];
 }
 
@@ -37,6 +39,7 @@ class YamlPackImporterService {
       final tags = <String>[
         for (final v in (item['tags'] as YamlList? ?? const [])) v.toString()
       ];
+      final trending = item['trending'] == true;
       list.add(
         YamlPackTemplate(
           name: item['name'].toString(),
@@ -46,6 +49,7 @@ class YamlPackImporterService {
           action: item['action'].toString(),
           icm: item['icm'] == true,
           tags: tags,
+          trending: trending,
         ),
       );
     }

--- a/pack_templates.yaml
+++ b/pack_templates.yaml
@@ -5,6 +5,7 @@
   action: callPush
   icm: true
   tags: [callPush, icm, bbVsSb]
+  trending: true
 
 - name: 'Push vs Fold — SB vs BB (10–15 BB)'
   hero: SB
@@ -13,6 +14,7 @@
   action: push
   icm: false
   tags: [push, sbVsBb]
+  trending: true
 
 - name: 'Minraise/Fold vs Push — BTN vs BB (20 BB, ICM)'
   hero: BTN
@@ -21,3 +23,4 @@
   action: minraiseFold
   icm: true
   tags: [minraiseFold, icm, btnVsBb]
+  trending: true


### PR DESCRIPTION
## Summary
- mark trending templates in YAML and models
- parse `trending` in YAML importer
- pass trending flag when generating pack library
- expose template storage to suggestions and prefer trending templates when no data

## Testing
- `flutter analyze`
- `flutter test test/yaml_pack_importer_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68759b12edc4832ab96f46aa2f3f60d3