### PR TITLE
Implement daily pack spotlight

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -38,6 +38,7 @@ import 'services/xp_tracker_service.dart';
 import 'services/reward_service.dart';
 import 'services/goal_engine.dart';
 import 'services/daily_challenge_service.dart';
+import 'services/daily_spotlight_service.dart';
 import 'services/weekly_challenge_service.dart';
 import 'services/streak_counter_service.dart';
 import 'services/spot_of_the_day_service.dart';
@@ -213,6 +214,11 @@ List<SingleChildWidget> buildTrainingProviders() {
               adaptive: context.read<AdaptiveTrainingService>(),
               templates: context.read<TemplateStorageService>(),
               xp: context.read<XPTrackerService>(),
+            )..load(),
+          ),
+          ChangeNotifierProvider(
+            create: (context) => DailySpotlightService(
+              templates: context.read<TemplateStorageService>(),
             )..load(),
           ),
           ChangeNotifierProvider(

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -42,6 +42,7 @@ class TrainingPackTemplate {
   bool? isFavorite;
   bool isPinned;
   bool trending;
+  bool recommended;
 
   TrainingPackTemplate({
     required this.id,
@@ -76,6 +77,7 @@ class TrainingPackTemplate {
     this.isFavorite = false,
     this.isPinned = false,
     this.trending = false,
+    this.recommended = false,
   })  : spots = spots ?? [],
         tags = tags ?? [],
         focusTags = focusTags ?? [],
@@ -119,6 +121,7 @@ class TrainingPackTemplate {
     bool? isFavorite,
     bool? isPinned,
     bool? trending,
+    bool? recommended,
   }) {
     return TrainingPackTemplate(
       id: id ?? this.id,
@@ -154,6 +157,7 @@ class TrainingPackTemplate {
       isFavorite: isFavorite ?? this.isFavorite,
       isPinned: isPinned ?? this.isPinned,
       trending: trending ?? this.trending,
+      recommended: recommended ?? this.recommended,
     );
   }
 
@@ -208,6 +212,7 @@ class TrainingPackTemplate {
       isFavorite: json['isFavorite'] as bool? ?? false,
       isPinned: json['isPinned'] as bool? ?? false,
       trending: json['trending'] as bool? ?? false,
+      recommended: json['recommended'] as bool? ?? false,
     );
     if (!tpl.meta.containsKey('evCovered') ||
         !tpl.meta.containsKey('icmCovered')) {
@@ -252,6 +257,7 @@ class TrainingPackTemplate {
         if (isFavorite == true) 'isFavorite': true,
         if (isPinned) 'isPinned': true,
         if (trending) 'trending': true,
+        if (recommended) 'recommended': true,
       };
 
   int get evCovered => meta['evCovered'] as int? ?? 0;

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -15,6 +15,7 @@ import '../services/dynamic_pack_adjustment_service.dart';
 import '../utils/template_priority.dart';
 import 'training_session_screen.dart';
 import '../services/weak_spot_recommendation_service.dart';
+import '../services/daily_spotlight_service.dart';
 
 import '../services/spot_of_the_day_service.dart';
 import '../widgets/spot_of_the_day_card.dart';
@@ -330,6 +331,8 @@ class _PackCard extends StatelessWidget {
         ? 'Продолжить'
         : 'Начать';
     final color = completed ? Colors.green : Colors.orange;
+    final spotlight = context.watch<DailySpotlightService>().template?.id ==
+        template.id;
     final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(
       template.id,
     );
@@ -349,6 +352,9 @@ class _PackCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (spotlight)
+            const Text('🎯 Пак дня',
+                style: TextStyle(color: Colors.amber, fontSize: 12)),
           Icon(hasMistakes ? Icons.error : Icons.shield, color: color),
           const Spacer(),
           Text(template.name, maxLines: 2, overflow: TextOverflow.ellipsis),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -12,6 +12,7 @@ import '../../theme/app_colors.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../services/pack_import_service.dart';
 import '../../models/v2/training_pack_template.dart';
+import '../../services/daily_spotlight_service.dart';
 import '../../models/v2/hand_data.dart';
 import '../../models/v2/hero_position.dart';
 import '../../models/v2/training_pack_spot.dart';
@@ -1064,6 +1065,8 @@ class _TrainingPackTemplateListScreenState
     final needsEval = total > 0 && (t.evCovered < total || t.icmCovered < total);
     final isNew = t.lastGeneratedAt != null &&
         DateTime.now().difference(t.lastGeneratedAt!).inHours < 48;
+    final spotlight =
+        context.watch<DailySpotlightService>().template?.id == t.id;
     final header = ListTile(
       tileColor:
           t.id == _lastOpenedId ? Theme.of(context).highlightColor : null,
@@ -1113,6 +1116,16 @@ class _TrainingPackTemplateListScreenState
               ),
             ),
           Expanded(child: Text(t.name)),
+          if (spotlight)
+            const Padding(
+              padding: EdgeInsets.only(left: 4),
+              child: Chip(
+                label: Text('🎯 Пак дня', style: TextStyle(fontSize: 12)),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                backgroundColor: Colors.amber,
+              ),
+            ),
           if (isNew)
             const Padding(
               padding: EdgeInsets.only(left: 4),

--- a/lib/services/daily_spotlight_service.dart
+++ b/lib/services/daily_spotlight_service.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/v2/training_pack_template.dart';
+import 'template_storage_service.dart';
+
+class DailySpotlightService extends ChangeNotifier {
+  static const _idKey = 'daily_spotlight_id';
+  static const _dateKey = 'daily_spotlight_date';
+
+  final TemplateStorageService templates;
+  TrainingPackTemplate? _template;
+  DateTime? _date;
+  Timer? _timer;
+
+  DailySpotlightService({required this.templates});
+
+  TrainingPackTemplate? get template => _template;
+  DateTime? get date => _date;
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final id = prefs.getString(_idKey);
+    final dateStr = prefs.getString(_dateKey);
+    _date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    _template = id != null
+        ? templates.templates.firstWhere(
+            (t) => t.id == id,
+            orElse: () => TrainingPackTemplate(id: id, name: id),
+          )
+        : null;
+    await ensureToday();
+  }
+
+  Future<void> ensureToday() async {
+    final now = DateTime.now();
+    if (_template != null && _date != null && _sameDay(_date!, now)) {
+      _schedule();
+      return;
+    }
+    final list = templates.templates.where((t) => t.recommended).toList();
+    if (list.isEmpty) return;
+    final tpl = list[Random().nextInt(list.length)];
+    _template = tpl;
+    _date = DateTime(now.year, now.month, now.day);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_idKey, tpl.id);
+    await prefs.setString(_dateKey, _date!.toIso8601String());
+    _schedule();
+    notifyListeners();
+  }
+
+  void _schedule() {
+    _timer?.cancel();
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day + 1);
+    _timer = Timer(next.difference(now), ensureToday);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/services/pack_library_generator.dart
+++ b/lib/services/pack_library_generator.dart
@@ -71,6 +71,7 @@ class PackLibraryGenerator {
       );
       tpl.tags = [for (final tag in t.tags) if (tag.trim().isNotEmpty) tag];
       tpl.trending = t.trending;
+      tpl.recommended = t.recommended;
       _packs.add(tpl);
     }
   }

--- a/lib/services/yaml_pack_importer_service.dart
+++ b/lib/services/yaml_pack_importer_service.dart
@@ -11,6 +11,7 @@ class YamlPackTemplate {
   final bool icm;
   final List<String> tags;
   final bool trending;
+  final bool recommended;
   YamlPackTemplate({
     required this.name,
     required this.hero,
@@ -20,6 +21,7 @@ class YamlPackTemplate {
     required this.icm,
     List<String>? tags,
     this.trending = false,
+    this.recommended = false,
   }) : tags = tags ?? const [];
 }
 
@@ -40,6 +42,7 @@ class YamlPackImporterService {
         for (final v in (item['tags'] as YamlList? ?? const [])) v.toString()
       ];
       final trending = item['trending'] == true;
+      final recommended = item['recommended'] == true;
       list.add(
         YamlPackTemplate(
           name: item['name'].toString(),
@@ -50,6 +53,7 @@ class YamlPackImporterService {
           icm: item['icm'] == true,
           tags: tags,
           trending: trending,
+          recommended: recommended,
         ),
       );
     }


### PR DESCRIPTION
## Summary
- add `DailySpotlightService` for daily pack rotation
- mark templates with `recommended` flag
- display pack of the day label in home screen and in the template list
- extend YAML importer and library generator to include `recommended`
- wire service in app providers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a2a859a8832a9934ba1578452a7c