### PR TITLE
Add daily spotlight card

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -37,6 +37,7 @@ import '../widgets/skill_progress_card.dart';
 import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import '../widgets/achievements_card.dart';
+import '../widgets/daily_spotlight_card.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -66,6 +67,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     final narrow = width < 400;
+    final tablet = width >= 600;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Training'),
@@ -97,10 +99,12 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
       ),
       body: ListView(
         children: [
+          if (tablet) const DailySpotlightCard(),
           _RecommendedCarousel(
             key: TrainingHomeScreen.recommendationsKey,
             narrow: narrow,
           ),
+          if (!tablet) const DailySpotlightCard(),
           if (narrow) ...[
             const QuickContinueCard(),
             const DailyProgressRing(),

--- a/lib/widgets/daily_spotlight_card.dart
+++ b/lib/widgets/daily_spotlight_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/daily_spotlight_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class DailySpotlightCard extends StatefulWidget {
+  const DailySpotlightCard({super.key});
+
+  @override
+  State<DailySpotlightCard> createState() => _DailySpotlightCardState();
+}
+
+class _DailySpotlightCardState extends State<DailySpotlightCard> {
+  bool _hidden = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((p) {
+      if (!mounted) return;
+      setState(() => _hidden = p.getBool('hide_today_card') ?? false);
+    });
+  }
+
+  Future<void> _hide() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('hide_today_card', true);
+    if (mounted) setState(() => _hidden = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tpl = context.watch<DailySpotlightService>().template;
+    if (_hidden || tpl == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [accent.withOpacity(0.4), accent],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text(
+                '🎯 Сегодняшний Пак',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              const Spacer(),
+              TextButton(onPressed: _hide, child: const Text('Скрыть')),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(tpl.name, style: const TextStyle(color: Colors.white)),
+          if (tpl.description.isNotEmpty)
+            Text(tpl.description,
+                style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 4),
+          Text('${tpl.spots.length} спотов',
+              style: const TextStyle(color: Colors.white70, fontSize: 12)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        TrainingPackPlayScreen(template: tpl, original: tpl),
+                  ),
+                );
+              },
+              child: const Text('Начать'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show `DailySpotlightCard` before recommended packs on tablets and below them on phones
- implement `DailySpotlightCard` widget with hide option and quick play

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875a51890d4832ab2f7a70c1dcb2939