### PR TITLE
Add coverage progress meter

### DIFF
--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -262,6 +262,11 @@ class TrainingPackTemplate {
 
   int get evCovered => meta['evCovered'] as int? ?? 0;
   int get icmCovered => meta['icmCovered'] as int? ?? 0;
+  double? get coveragePercent {
+    final total = spots.length;
+    if (total == 0) return null;
+    return (evCovered + icmCovered) * 100 / (2 * total);
+  }
 
   String posRangeLabel() {
     final heroSet = <HeroPosition>{heroPos};

--- a/lib/widgets/coverage_meter.dart
+++ b/lib/widgets/coverage_meter.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class CoverageMeter extends StatelessWidget {
+  final double percent;
+  const CoverageMeter(this.percent, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: (percent / 100).clamp(0.0, 1.0),
+              backgroundColor: Colors.white24,
+              valueColor: const AlwaysStoppedAnimation<Color>(Colors.green),
+              minHeight: 4,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text('Coverage: ${percent.round()}%',
+            style: const TextStyle(color: Colors.white70, fontSize: 12)),
+      ],
+    );
+  }
+}

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -4,6 +4,7 @@ import '../models/v2/training_pack_template.dart';
 import '../services/pinned_pack_service.dart';
 import '../theme/app_colors.dart';
 import '../helpers/mistake_category_translations.dart';
+import 'coverage_meter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/date_utils.dart';
 import '../services/training_pack_stats_service.dart';
@@ -223,6 +224,12 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
                                 ),
                             ],
                           ),
+                        ),
+                      if (widget.template.coveragePercent != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: CoverageMeter(
+                              widget.template.coveragePercent!),
                         ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- add `CoverageMeter` widget to show coverage completion
- compute `coveragePercent` in `TrainingPackTemplate`
- display coverage meter at bottom of `TrainingPackCard`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a7e46e7c832a95b2028889f32d32