### PR TITLE
Add coverage sort option

### DIFF
--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -138,11 +138,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
         final r = rb.compareTo(ra);
         if (r != 0) return r;
       } else if (_sortMode == _SortMode.coverage) {
-        double cov(TrainingPackTemplate t) {
-          final total = t.spots.length;
-          if (total == 0) return 0;
-          return (t.evCovered + t.icmCovered) / (2 * total);
-        }
+        double cov(TrainingPackTemplate t) => t.coveragePercent ?? -1;
         final r = cov(b).compareTo(cov(a));
         if (r != 0) return r;
       }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -68,12 +68,14 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   static const kSortName = 'name';
   static const kSortProgress = 'progress';
   static const kSortInProgress = 'resume';
+  static const kSortCoverage = 'coverage';
   static const _sortIcons = {
     kSortEdited: Icons.update,
     kSortSpots: Icons.format_list_numbered,
     kSortName: Icons.sort_by_alpha,
     kSortProgress: Icons.bar_chart,
     kSortInProgress: Icons.play_arrow,
+    kSortCoverage: Icons.layers,
   };
   static final _manifestFuture = AssetManifest.instance;
   final TextEditingController _searchCtrl = TextEditingController();
@@ -294,6 +296,17 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   List<TrainingPackTemplate> _applySorting(List<TrainingPackTemplate> list) {
     final copy = [...list];
     switch (_sort) {
+      case kSortCoverage:
+        copy.sort((a, b) {
+          final ca = a.coveragePercent;
+          final cb = b.coveragePercent;
+          if (ca == null && cb == null) return 0;
+          if (ca == null) return 1;
+          if (cb == null) return -1;
+          final r = cb.compareTo(ca);
+          return r == 0 ? a.name.compareTo(b.name) : r;
+        });
+        break;
       case kSortName:
         copy.sort((a, b) => a.name.compareTo(b.name));
         break;
@@ -353,6 +366,11 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
             label: Text(l.sortProgress),
             selected: _sort == kSortProgress,
             onSelected: (_) => _setSort(kSortProgress),
+          ),
+          ChoiceChip(
+            label: Text(l.sortCoverage),
+            selected: _sort == kSortCoverage,
+            onSelected: (_) => _setSort(kSortCoverage),
           ),
           ChoiceChip(
             label: const Text('In Progress'),
@@ -1027,6 +1045,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 PopupMenuItem(
                   value: kSortProgress,
                   child: Text(AppLocalizations.of(ctx)!.sortProgress),
+                ),
+                PopupMenuItem(
+                  value: kSortCoverage,
+                  child: Text(AppLocalizations.of(ctx)!.sortCoverage),
                 ),
                 const PopupMenuItem(
                   value: kSortInProgress,

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -176,19 +176,8 @@ class _TrainingPackTemplateListScreenState
     switch (_sort) {
       case 'coverage':
         _templates.sort((a, b) {
-          double cover(TrainingPackTemplate t) {
-            final total = t.spots.length;
-            if (total == 0) return 0;
-            final evPct =
-                t.spots.where((s) => s.heroEv != null && !s.dirty).length / total;
-            final icmPct = t.spots
-                    .where((s) => s.heroIcmEv != null && !s.dirty)
-                    .length /
-                total;
-            return (evPct + icmPct) / 2;
-          }
-
-          final r = cover(b).compareTo(cover(a));
+          double cov(TrainingPackTemplate t) => t.coveragePercent ?? -1;
+          final r = cov(b).compareTo(cov(a));
           return r == 0
               ? a.name.toLowerCase().compareTo(b.name.toLowerCase())
               : r;
@@ -3112,15 +3101,17 @@ class _TrainingPackTemplateListScreenState
           PopupMenuButton<String>(
             icon: const Icon(Icons.sort),
             onSelected: _setSort,
-            itemBuilder: (_) => const [
-              PopupMenuItem(value: 'coverage', child: Text('Best Coverage')),
-              PopupMenuItem(value: 'name', child: Text('Name A–Z')),
-              PopupMenuItem(value: 'created', child: Text('Newest First')),
+            itemBuilder: (ctx) => [
               PopupMenuItem(
+                  value: 'coverage',
+                  child: Text(AppLocalizations.of(ctx)!.sortCoverage)),
+              const PopupMenuItem(value: 'name', child: Text('Name A–Z')),
+              const PopupMenuItem(value: 'created', child: Text('Newest First')),
+              const PopupMenuItem(
                   value: 'last_trained',
                   child: Text('Last Trained (Recent → Old)')),
-              PopupMenuItem(value: 'spots', child: Text('Most Spots')),
-              PopupMenuItem(value: 'tag', child: Text('Tag A–Z')),
+              const PopupMenuItem(value: 'spots', child: Text('Most Spots')),
+              const PopupMenuItem(value: 'tag', child: Text('Tag A–Z')),
             ],
           ),
           PopupMenuButton<String>(


### PR DESCRIPTION
## Summary
- enable coverage-based sorting for PackLibraryScreen
- add coverage sort chips and menu actions in TemplateLibraryScreen
- use template.coveragePercent in v2 template list sorting

## Testing
- `apt-get update` *(passed)*
- `apt-get install -y flutter` *(failed: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6875aea982b8832abd2625e7a287ede2