### PR TITLE
Add filter count display

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Beliebt zuerst"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "Filters: {count} selected"
+  ,"filtersNone": "Filters: none"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Popular first"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "Filters: {count} selected"
+  ,"filtersNone": "Filters: none"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Populares primero"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "Filters: {count} selected"
+  ,"filtersNone": "Filters: none"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Populaires d'abord"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "Filters: {count} selected"
+  ,"filtersNone": "Filters: none"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Mais populares"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "Filters: {count} selected"
+  ,"filtersNone": "Filters: none"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -100,4 +100,6 @@
   ,"sortPopular": "Сначала популярные"
   ,"sortRating": "Rating (High \u2192 Low)"
   ,"sortCoverage": "Coverage (High \u2192 Low)"
+  ,"filtersSelected": "\u0424\u0438\u043b\u044c\u0442\u0440\u044b: {count} \u0432\u044b\u0431\u0440\u0430\u043d\u043e"
+  ,"filtersNone": "\u0424\u0438\u043b\u044c\u0442\u0440\u044b: \u043d\u0435\u0442"
 }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1108,6 +1108,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final visible = _applyFilters(templates);
     final sortedVisible = _applySorting(visible);
     final query = _searchCtrl.text.trim().toLowerCase();
+    final filtersCount = _selectedTags.length + _selectedCategories.length;
     final hasResults = sortedVisible.isNotEmpty;
     final filteringActive = query.isNotEmpty ||
         _filter != 'all' ||
@@ -1336,27 +1337,44 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
         if (tagList.isNotEmpty || categoryList.isNotEmpty)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 4,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                for (final tag in tagList)
-                  FilterChip(
-                    label: Text(tag),
-                    selected: _selectedTags.contains(tag),
-                    onSelected: (_) => _toggleTag(tag),
-                  ),
-                for (final cat in categoryList)
-                  FilterChip(
-                    label: Text(translateCategory(cat)),
-                    selected: _selectedCategories.contains(cat),
-                    onSelected: (_) => _toggleCategory(cat),
-                  ),
-                if (_selectedTags.isNotEmpty || _selectedCategories.isNotEmpty)
-                  ActionChip(
-                    label: const Text('Сбросить'),
-                    onPressed: _clearTagFilters,
-                  ),
+                Row(
+                  children: [
+                    Text(
+                      filtersCount > 0
+                          ? l.filtersSelected(filtersCount)
+                          : l.filtersNone,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold, color: Colors.grey),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    for (final tag in tagList)
+                      FilterChip(
+                        label: Text(tag),
+                        selected: _selectedTags.contains(tag),
+                        onSelected: (_) => _toggleTag(tag),
+                      ),
+                    for (final cat in categoryList)
+                      FilterChip(
+                        label: Text(translateCategory(cat)),
+                        selected: _selectedCategories.contains(cat),
+                        onSelected: (_) => _toggleCategory(cat),
+                      ),
+                    if (_selectedTags.isNotEmpty || _selectedCategories.isNotEmpty)
+                      ActionChip(
+                        label: const Text('Сбросить'),
+                        onPressed: _clearTagFilters,
+                      ),
+                  ],
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- show active filter count above tags in template library
- add l10n strings for filter count

## Testing
- `flutter analyze` *(fails: 15139 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875c1242100832ab5f8fa3a7db0d9aa