### PR TITLE
Add tag cache service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -86,6 +86,7 @@ late final TrainingPackCloudSyncService packCloud;
 late final MistakePackCloudService mistakeCloud;
 late final GoalProgressCloudService goalCloud;
 late final TrainingPackTemplateStorageService templateStorage;
+late final TagCacheService tagCache;
 
 List<SingleChildWidget> buildCoreProviders(CloudSyncService cloud) {
   return [
@@ -263,10 +264,7 @@ List<SingleChildWidget> buildTrainingProviders() {
             },
           ),
           ChangeNotifierProvider(create: (_) => TagService()..load()),
-          ChangeNotifierProvider(
-            create: (context) =>
-                TagCacheService(templates: context.read<TemplateStorageService>()),
-          ),
+          ChangeNotifierProvider<TagCacheService>.value(value: tagCache),
           ChangeNotifierProvider(create: (_) => IgnoredMistakeService()..load()),
           ChangeNotifierProvider(create: (_) => GoalsService()..load()),
           ChangeNotifierProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'services/folded_players_service.dart';
 import 'services/all_in_players_service.dart';
 import 'services/user_preferences_service.dart';
 import 'services/tag_service.dart';
+import 'services/tag_cache_service.dart';
 import 'services/ignored_mistake_service.dart';
 import 'services/goals_service.dart';
 import 'services/cloud_sync_service.dart';
@@ -145,6 +146,11 @@ Future<void> main() async {
   );
   await EvaluationSettingsService.instance.load();
   await MistakeHintService.instance.load();
+  tagCache = TagCacheService(
+    templates: templateStorage,
+    packs: packStorage,
+  );
+  await tagCache.updateFrom(templateStorage.templates, packStorage.packs);
   runApp(
     MultiProvider(
       providers: buildAppProviders(cloud),

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -37,6 +37,7 @@ import '../services/bulk_evaluator_service.dart';
 import '../utils/template_coverage_utils.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../services/training_pack_service.dart';
+import '../services/training_pack_storage_service.dart';
 import 'mistake_review_screen.dart';
 import '../services/tag_cache_service.dart';
 import '../services/recommended_pack_service.dart';
@@ -136,7 +137,9 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     await _loadStats();
     await _loadPlayCounts();
     await context.read<TagCacheService>().updateFrom(
-        context.read<TemplateStorageService>().templates);
+      context.read<TemplateStorageService>().templates,
+      context.read<TrainingPackStorageService>().packs,
+    );
   }
 
   Future<void> _maybeOfferStarter() async {


### PR DESCRIPTION
## Summary
- extend TagCacheService with pack support
- preload tag cache in `main.dart`
- expose TagCacheService via providers
- refresh tag cache during template library initialization

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875dc2631b0832a88e1d11f355f3244