### PR TITLE
Add focus request after library init

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -125,12 +125,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   void initState() {
     super.initState();
     _searchCtrl.addListener(() => setState(() {}));
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Future.delayed(const Duration(milliseconds: 100), () {
-        if (mounted) FocusScope.of(context).requestFocus(_searchFocusNode);
-      });
-      _maybeOfferStarter();
-    });
+    WidgetsBinding.instance.addPostFrameCallback((_) => _maybeOfferStarter());
     _init();
   }
 
@@ -146,6 +141,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
       context.read<TemplateStorageService>().templates,
       context.read<TrainingPackStorageService>().packs,
     );
+    if (!mounted) return;
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) FocusScope.of(context).requestFocus(_searchFocusNode);
+    });
   }
 
   Future<void> _maybeOfferStarter() async {


### PR DESCRIPTION
## Summary
- request search field focus after initializing template library state

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6875e1b50394832a9e9de74f1922a970