### PR TITLE
Add spot priority system

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -13,6 +13,7 @@ class TrainingPackSpot {
   DateTime createdAt;
   bool pinned;
   bool dirty;
+  int priority;
 
   /// Ephemeral flag — used only in RAM to highlight freshly imported spots.
   /// Never written to / read from JSON.
@@ -32,6 +33,7 @@ class TrainingPackSpot {
     DateTime? createdAt,
     this.pinned = false,
     this.dirty = false,
+    this.priority = 3,
     bool? isNew,
     this.evalResult,
     this.correctAction,
@@ -54,6 +56,7 @@ class TrainingPackSpot {
     DateTime? createdAt,
     bool? pinned,
     bool? dirty,
+    int? priority,
     bool? isNew,
     EvaluationResult? evalResult,
     String? correctAction,
@@ -69,6 +72,7 @@ class TrainingPackSpot {
     createdAt: createdAt ?? this.createdAt,
     pinned: pinned ?? this.pinned,
     dirty: dirty ?? this.dirty,
+    priority: priority ?? this.priority,
     isNew: isNew ?? this.isNew,
     evalResult: evalResult ?? this.evalResult,
     correctAction: correctAction ?? this.correctAction,
@@ -90,6 +94,7 @@ class TrainingPackSpot {
         DateTime.tryParse(j['createdAt'] as String? ?? '') ?? DateTime.now(),
     pinned: j['pinned'] == true,
     dirty: j['dirty'] == true,
+    priority: (j['priority'] as num?)?.toInt() ?? 3,
     // `isNew` never restored from disk
     isNew: false,
     evalResult: j['evalResult'] != null
@@ -110,6 +115,7 @@ class TrainingPackSpot {
     'createdAt': createdAt.toIso8601String(),
     if (pinned) 'pinned': true,
     if (dirty) 'dirty': true,
+    if (priority != 3) 'priority': priority,
     if (evalResult != null) 'evalResult': evalResult!.toJson(),
     if (correctAction != null) 'correctAction': correctAction,
     if (explanation != null) 'explanation': explanation,
@@ -144,6 +150,7 @@ class TrainingPackSpot {
           const ListEquality().equals(categories, other.categories) &&
           pinned == other.pinned &&
           dirty == other.dirty &&
+          priority == other.priority &&
           isNew == other.isNew &&
           evalResult == other.evalResult &&
           correctAction == other.correctAction &&
@@ -159,6 +166,7 @@ class TrainingPackSpot {
     const ListEquality().hash(categories),
     pinned,
     dirty,
+    priority,
     isNew,
     evalResult,
     correctAction,

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -268,8 +268,9 @@ class TrainingPackTemplate {
 
   int get evCovered => meta['evCovered'] as int? ?? 0;
   int get icmCovered => meta['icmCovered'] as int? ?? 0;
+  int get totalWeight => meta['totalWeight'] as int? ?? spots.length;
   double? get coveragePercent {
-    final total = spots.length;
+    final total = totalWeight;
     if (total == 0) return null;
     return (evCovered + icmCovered) * 100 / (2 * total);
   }

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -102,7 +102,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
       var statusOk = true;
       if (_statusFilters.isNotEmpty) {
         final now = DateTime.now();
-        final total = p.spots.length;
+        final total = p.totalWeight;
         final evPct = total == 0 ? 0 : p.evCovered * 100 / total;
         final icmPct = total == 0 ? 0 : p.icmCovered * 100 / total;
         final isNew = now.difference(p.createdAt).inDays < 3;
@@ -150,7 +150,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
           if (r != 0) return r;
           return b.createdAt.compareTo(a.createdAt);
         case 'mostSpots':
-          final r = b.spots.length.compareTo(a.spots.length);
+          final r = b.totalWeight.compareTo(a.totalWeight);
           if (r != 0) return r;
           return b.createdAt.compareTo(a.createdAt);
         case 'newest':
@@ -393,14 +393,16 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
         DateTime.now().difference(t.createdAt).inDays < 3;
     final isUpdated = t.updatedDate != null &&
         DateTime.now().difference(t.updatedDate!).inDays < 3;
-    final total = t.spots.length;
+    final total = t.totalWeight;
     final trained = _trainedHands[t.id] ?? 0;
     final done = trained.clamp(0, total);
     final ratio = total == 0 ? 0.0 : done / total;
-    final evDone =
-        t.spots.where((s) => s.heroEv != null && !s.dirty).length;
-    final icmDone =
-        t.spots.where((s) => s.heroIcmEv != null && !s.dirty).length;
+    final evDone = t.spots
+        .where((s) => s.heroEv != null && !s.dirty)
+        .fold(0, (a, b) => a + b.priority);
+    final icmDone = t.spots
+        .where((s) => s.heroIcmEv != null && !s.dirty)
+        .fold(0, (a, b) => a + b.priority);
     final solvedAll =
         t.spots.every((s) => s.heroEv != null && s.heroIcmEv != null);
     final coveragePct = total == 0
@@ -807,7 +809,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                       return const SizedBox.shrink();
                     }
                     final progress =
-                        (session.index / template.spots.length * 100).clamp(0, 100);
+                        (session.index / template.totalWeight * 100).clamp(0, 100);
                     return Padding(
                       padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                       child: Card(
@@ -823,7 +825,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                                         style: const TextStyle(fontSize: 16)),
                                     const SizedBox(height: 4),
                                     Text(
-                                      '${session.index + 1} / ${template.spots.length}',
+                                      '${session.index + 1} / ${template.totalWeight}',
                                       style: const TextStyle(color: Colors.white70),
                                     ),
                                     const SizedBox(height: 4),
@@ -855,11 +857,11 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                   builder: (context) {
                     final suggest = _packs
                         .where((p) =>
-                            (p.evCovered + p.icmCovered) < p.spots.length * 2)
+                            (p.evCovered + p.icmCovered) < p.totalWeight * 2)
                         .minBy((p) =>
-                            (p.evCovered + p.icmCovered) / p.spots.length);
+                            (p.evCovered + p.icmCovered) / p.totalWeight);
                     if (suggest == null) return const SizedBox.shrink();
-                    final total = suggest.spots.length;
+                    final total = suggest.totalWeight;
                     final evPct =
                         total == 0 ? 0 : suggest.evCovered * 100 / total;
                     final icmPct =

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -180,7 +180,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     if (tpl != null) {
       final correct = service.correctCount;
       final total = service.totalCount;
-      final totalSpots = tpl.spots.length;
+      final totalSpots = tpl.totalWeight;
       final evAfter = totalSpots == 0 ? 0.0 : tpl.evCovered * 100 / totalSpots;
       final icmAfter =
           totalSpots == 0 ? 0.0 : tpl.icmCovered * 100 / totalSpots;

--- a/lib/screens/v2/spot_list_section.dart
+++ b/lib/screens/v2/spot_list_section.dart
@@ -33,6 +33,9 @@ part of 'training_pack_template_editor_screen.dart';
       if (_quickFilter == 'Mistake spots' && !(res != null && !res.correct)) {
         return false;
       }
+      if (_quickFilter == 'High priority' && s.priority < 4) {
+        return false;
+      }
       if (_heroPushOnly) {
         final acts = s.hand.actions[0] ?? [];
         final hero = acts.where((a) => a.playerIndex == s.hand.heroIndex);

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -107,11 +107,16 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
     return 'Keep training!';
   }
 
-  List<double> get _evs => [for (final s in widget.template.spots) if (s.heroEv != null && widget.results.containsKey(s.id)) s.heroEv!];
+  List<double> get _evs => [
+        for (final s in widget.template.spots)
+          if (s.heroEv != null && widget.results.containsKey(s.id))
+            s.heroEv! * s.priority
+      ];
 
   List<double> get _icmEvs => [
         for (final s in widget.template.spots)
-          if (s.heroIcmEv != null && widget.results.containsKey(s.id)) s.heroIcmEv!
+          if (s.heroIcmEv != null && widget.results.containsKey(s.id))
+            s.heroIcmEv! * s.priority
       ];
 
   double get _evSum => _evs.fold(0.0, (a, b) => a + b);
@@ -124,7 +129,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       if (ans == null) continue;
       final hero = _actionEv(s, ans);
       final best = _bestEv(s);
-      if (hero != null && best != null) list.add(hero - best);
+      if (hero != null && best != null) list.add((hero - best) * s.priority);
     }
     return list;
   }
@@ -136,7 +141,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       if (ans == null) continue;
       final hero = _actionIcmEv(s, ans);
       final best = _bestIcmEv(s);
-      if (hero != null && best != null) list.add(hero - best);
+      if (hero != null && best != null) list.add((hero - best) * s.priority);
     }
     return list;
   }
@@ -263,7 +268,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
         );
       }
     }
-    final total = widget.template.spots.length;
+    final total = widget.template.totalWeight;
     final preEv = total == 0 ? 0.0 : widget.original.evCovered * 100 / total;
     final preIcm = total == 0 ? 0.0 : widget.original.icmCovered * 100 / total;
     final postEv = total == 0 ? 0.0 : widget.template.evCovered * 100 / total;

--- a/lib/screens/v2/training_pack_spot_editor_screen.dart
+++ b/lib/screens/v2/training_pack_spot_editor_screen.dart
@@ -33,6 +33,7 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
   late List<CardModel> _heroCards;
   late HeroPosition _position;
   late List<ActionEntry> _actions;
+  int _priority = 3;
   bool _loading = false;
 
   Set<String> _usedCards() {
@@ -197,6 +198,7 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
     _position = widget.spot.hand.position;
     if (_position == HeroPosition.unknown) _position = HeroPosition.sb;
     _actions = List<ActionEntry>.from(widget.spot.hand.actions[0] ?? []);
+    _priority = widget.spot.priority;
     widget.spot.hand.playerCount = 2;
     widget.spot.hand.heroIndex = 0;
   }
@@ -221,6 +223,7 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
     widget.spot.hand.playerCount = 2;
     widget.spot.hand.heroIndex = 0;
     widget.spot.hand.actions[0] = List<ActionEntry>.from(_actions);
+    widget.spot.priority = _priority;
   }
 
   Future<void> _save() async {
@@ -302,6 +305,15 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
                   onPressed: _addTagDialog,
                 ),
               ],
+            ),
+            const SizedBox(height: 16),
+            DropdownButton<int>(
+              value: _priority,
+              items: [
+                for (int i = 1; i <= 5; i++)
+                  DropdownMenuItem(value: i, child: Text('Priority $i'))
+              ],
+              onChanged: (v) => setState(() => _priority = v ?? 3),
             ),
             const SizedBox(height: 24),
             const Text('Hero Cards', style: TextStyle(fontWeight: FontWeight.bold)),

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -1,7 +1,7 @@
 part of 'training_pack_template_editor_screen.dart';
 
 enum SortBy { manual, title, evDesc, edited, autoEv }
-enum SpotSort { original, evDesc, evAsc, icmDesc, icmAsc }
+enum SpotSort { original, evDesc, evAsc, icmDesc, icmAsc, priorityDesc }
 enum SortMode { position, chronological }
 
 enum _RowKind { header, spot }
@@ -111,7 +111,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     'BTN',
     'SB',
     'Hero push only',
-    'Mistake spots'
+    'Mistake spots',
+    'High priority'
   ];
   String? _quickFilter;
   String? _positionFilter;
@@ -3269,6 +3270,9 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
           cmp = (a, b) =>
               (a.heroIcmEv ?? double.infinity).compareTo(b.heroIcmEv ?? double.infinity);
           break;
+        case SpotSort.priorityDesc:
+          cmp = (a, b) => b.priority.compareTo(a.priority);
+          break;
         default:
           cmp = (a, b) => 0;
       }
@@ -4648,6 +4652,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   DropdownMenuItem(value: SpotSort.evAsc, child: Text('EV ↑')),
                   DropdownMenuItem(value: SpotSort.icmDesc, child: Text('ICM ↓')),
                   DropdownMenuItem(value: SpotSort.icmAsc, child: Text('ICM ↑')),
+                  DropdownMenuItem(
+                      value: SpotSort.priorityDesc, child: Text('Priority')),
                 ],
                 onChanged: (v) =>
                     setState(() => _spotSort = v ?? SpotSort.original),
@@ -5325,7 +5331,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     'BTN',
     'SB',
     'Hero push only',
-    'Mistake spots'
+    'Mistake spots',
+    'High priority'
   ];
   String? _quickFilter;
   String? _positionFilter;
@@ -9873,6 +9880,8 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                   DropdownMenuItem(value: SpotSort.evAsc, child: Text('EV ↑')),
                   DropdownMenuItem(value: SpotSort.icmDesc, child: Text('ICM ↓')),
                   DropdownMenuItem(value: SpotSort.icmAsc, child: Text('ICM ↑')),
+                  DropdownMenuItem(
+                      value: SpotSort.priorityDesc, child: Text('Priority')),
                 ],
                 onChanged: (v) =>
                     setState(() => _spotSort = v ?? SpotSort.original),

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -859,8 +859,8 @@ class _TrainingPackTemplateListScreenState
         ? streetFiltered
         : [
             for (final t in streetFiltered)
-              if (t.evCovered < t.spots.length ||
-                  t.icmCovered < t.spots.length)
+              if (t.evCovered < t.totalWeight ||
+                  t.icmCovered < t.totalWeight)
                 t
           ];
     final completed = _completedOnly
@@ -910,7 +910,7 @@ class _TrainingPackTemplateListScreenState
       final messenger = ScaffoldMessenger.maybeOf(context);
       final list = [
         for (final t in _visibleTemplates())
-          if (t.evCovered < t.spots.length || t.icmCovered < t.spots.length) t
+          if (t.evCovered < t.totalWeight || t.icmCovered < t.totalWeight) t
       ];
       var refreshed = 0;
       for (final t in list) {
@@ -1468,7 +1468,7 @@ class _TrainingPackTemplateListScreenState
                     child: Text(l.noContent, style: const TextStyle(color: Colors.white54)),
                   ),
             if (!_showNeedsEvalOnly &&
-                (t.evCovered < t.spots.length || t.icmCovered < t.spots.length))
+                (t.evCovered < t.totalWeight || t.icmCovered < t.totalWeight))
               const Tooltip(
                 message: 'Some spots are missing EV/ICM analysis',
                 child: Icon(Icons.auto_fix_high, color: Colors.redAccent, size: 16),
@@ -2568,7 +2568,7 @@ class _TrainingPackTemplateListScreenState
   Future<void> _generateMissingEvIcmAll() async {
     final list = [
       for (final t in _templates)
-        if (t.evCovered < t.spots.length || t.icmCovered < t.spots.length) t
+        if (t.evCovered < t.totalWeight || t.icmCovered < t.totalWeight) t
     ];
     if (list.isEmpty) {
       ScaffoldMessenger.of(context)
@@ -3046,8 +3046,8 @@ class _TrainingPackTemplateListScreenState
         ? posFiltered
         : [
             for (final t in posFiltered)
-              if (t.evCovered < t.spots.length ||
-                  t.icmCovered < t.spots.length)
+              if (t.evCovered < t.totalWeight ||
+                  t.icmCovered < t.totalWeight)
                 t
           ];
     final completed = _completedOnly

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -314,7 +314,7 @@ class TrainingSessionService extends ChangeNotifier {
   }) async {
     if (persist) await _openBox();
     _template = template;
-    final total = template.spots.length;
+    final total = template.totalWeight;
     _preEvPct = total == 0 ? 0 : template.evCovered * 100 / total;
     _preIcmPct = total == 0 ? 0 : template.icmCovered * 100 / total;
     _spots = List<TrainingPackSpot>.from(template.spots);

--- a/lib/utils/template_coverage_utils.dart
+++ b/lib/utils/template_coverage_utils.dart
@@ -6,11 +6,15 @@ class TemplateCoverageUtils {
     final List<TrainingPackSpot> list = template.spots;
     int ev = 0;
     int icm = 0;
+    int total = 0;
     for (final s in list) {
-      if (!s.dirty && s.heroEv != null) ev++;
-      if (!s.dirty && s.heroIcmEv != null) icm++;
+      final w = s.priority;
+      total += w;
+      if (!s.dirty && s.heroEv != null) ev += w;
+      if (!s.dirty && s.heroIcmEv != null) icm += w;
     }
     template.meta['evCovered'] = ev;
     template.meta['icmCovered'] = icm;
+    template.meta['totalWeight'] = total;
   }
 }

--- a/lib/widgets/quick_continue_card.dart
+++ b/lib/widgets/quick_continue_card.dart
@@ -18,7 +18,7 @@ class QuickContinueCard extends StatelessWidget {
         }
         final focus =
             service.focusHandTypes.map((e) => e.label).join(', ');
-        final total = template.spots.length;
+        final total = template.totalWeight;
         final progress = '${session.index}/${total}';
         final evPct = total == 0 ? 0.0 : template.evCovered * 100 / total;
         final icmPct = total == 0 ? 0.0 : template.icmCovered * 100 / total;

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -57,6 +57,21 @@ class _TrainingPackSpotPreviewCardState
   final FocusNode _titleFocus = FocusNode();
   bool _editing = false;
 
+  Color _priorityColor(int p) {
+    switch (p) {
+      case 5:
+        return Colors.red;
+      case 4:
+        return Colors.orange;
+      case 3:
+        return Colors.green;
+      case 2:
+        return Colors.blue;
+      default:
+        return Colors.grey;
+    }
+  }
+
   void _duplicate() {
     final tpl = widget.template;
     final persist = widget.persist;
@@ -547,6 +562,25 @@ class _TrainingPackSpotPreviewCardState
                 ),
               ),
             ),
+          Positioned(
+            bottom: 4,
+            left: 4,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              decoration: BoxDecoration(
+                color: _priorityColor(spot.priority),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                '${spot.priority}',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- allow spots to store priority weight
- recalc template coverage with priority weight
- show and edit priority in spot editor
- display priority indicator on preview cards
- add high priority quick filter and sorting option
- weight EV stats by priority

## Testing
- `dart format` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875eecec514832a867bec6755bf7098