### PR TITLE
Improve coverage refresh in template editor

### DIFF
--- a/lib/screens/v2/spot_list_section.dart
+++ b/lib/screens/v2/spot_list_section.dart
@@ -392,6 +392,7 @@ part of 'training_pack_template_editor_screen.dart';
     );
     setState(() => widget.template.spots.add(spot));
     await _persist();
+    if (mounted) setState(() {});
     setState(() => _log('Added', spot));
     await _openEditor(spot);
   }
@@ -829,6 +830,7 @@ part of 'training_pack_template_editor_screen.dart';
       _showDupHint = false;
     });
     _persist();
+    if (mounted) setState(() {});
     setState(() => _history.log('Deleted', '${removed.length} spots', ''));
   }
 
@@ -904,6 +906,7 @@ part of 'training_pack_template_editor_screen.dart';
     setState(() => widget.template.focusHandTypes.add(FocusGoal(label, weight)));
     _handTypeCtr.clear();
     _persist();
+    if (mounted) setState(() {});
     final tag = _tagForHandType(label);
     if (tag != null && !widget.template.tags.contains(tag)) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/v2/template_settings_section.dart
+++ b/lib/screens/v2/template_settings_section.dart
@@ -320,6 +320,7 @@ part of 'training_pack_template_editor_screen.dart';
       });
       _markAllDirty();
       await _persist();
+      if (mounted) setState(() {});
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(const SnackBar(content: Text('Template settings updated')));

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -4361,6 +4361,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     onDeleted: () {
                       setState(() => widget.template.focusHandTypes.remove(t));
                       _persist();
+                      if (mounted) setState(() {});
                     },
                   ),
                 SizedBox(
@@ -9654,6 +9655,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     onDeleted: () {
                       setState(() => widget.template.focusHandTypes.remove(t));
                       _persist();
+                      if (mounted) setState(() {});
                     },
                   ),
                 SizedBox(


### PR DESCRIPTION
## Summary
- ensure focus coverage updates when hero range or hand goal list changes
- trigger UI refresh after adding spots or removing hand groups

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f759df34832aa2f38c256d0e9bb3