### PR TITLE
Implement thumbnail caching

### DIFF
--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -10,6 +10,8 @@ import 'dart:typed_data';
 import 'package:path_provider/path_provider.dart';
 import 'package:open_filex/open_filex.dart';
 
+import 'thumbnail_cache_service.dart';
+
 import '../models/training_pack_template.dart';
 
 class TemplateStorageService extends ChangeNotifier {
@@ -46,6 +48,7 @@ class TemplateStorageService extends ChangeNotifier {
   void addTemplate(TrainingPackTemplate template) {
     if (_templates.any((t) => t.id == template.id)) return;
     _templates.add(template);
+    ThumbnailCacheService.instance.invalidate(template.id);
     _resort();
     notifyListeners();
   }
@@ -55,6 +58,7 @@ class TemplateStorageService extends ChangeNotifier {
     final index = _templates.indexWhere((t) => t.id == template.id);
     if (index == -1) return;
     _templates[index] = template;
+    ThumbnailCacheService.instance.invalidate(template.id);
     _resort();
     notifyListeners();
   }
@@ -62,12 +66,14 @@ class TemplateStorageService extends ChangeNotifier {
   void removeTemplate(TrainingPackTemplate template) {
     if (template.isBuiltIn) return;
     _templates.remove(template);
+    ThumbnailCacheService.instance.invalidate(template.id);
     notifyListeners();
   }
 
   void restoreTemplate(TrainingPackTemplate template, int index) {
     final insertIndex = index.clamp(0, _templates.length);
     _templates.insert(insertIndex, template);
+    ThumbnailCacheService.instance.invalidate(template.id);
     notifyListeners();
   }
 
@@ -86,6 +92,7 @@ class TemplateStorageService extends ChangeNotifier {
       } else {
         _templates[index] = template;
       }
+      ThumbnailCacheService.instance.invalidate(template.id);
       _resort();
       notifyListeners();
       return null;
@@ -162,6 +169,7 @@ class TemplateStorageService extends ChangeNotifier {
           );
           if (replace == true) {
             _templates[index] = template;
+            ThumbnailCacheService.instance.invalidate(template.id);
             notifyListeners();
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
@@ -210,6 +218,7 @@ class TemplateStorageService extends ChangeNotifier {
           );
           if (action == 'replace') {
             _templates[index] = template;
+            ThumbnailCacheService.instance.invalidate(template.id);
             notifyListeners();
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
@@ -246,6 +255,7 @@ class TemplateStorageService extends ChangeNotifier {
         }
       }
       _templates.add(template);
+      ThumbnailCacheService.instance.invalidate(template.id);
       _resort();
       notifyListeners();
       if (context.mounted) {

--- a/lib/services/thumbnail_cache_service.dart
+++ b/lib/services/thumbnail_cache_service.dart
@@ -1,0 +1,33 @@
+import '../models/v2/training_pack_template.dart';
+import 'preview_cache_service.dart';
+
+class ThumbnailCacheService {
+  ThumbnailCacheService._();
+  static final instance = ThumbnailCacheService._();
+
+  final Map<String, Future<String?>> _inFlight = {};
+  final Map<String, String?> _cache = {};
+
+  Future<String?> getThumbnail(TrainingPackTemplate template) {
+    final id = template.id;
+    if (_cache.containsKey(id)) return Future.value(_cache[id]);
+    final png = template.png;
+    if (png == null) return Future.value(null);
+    if (_inFlight.containsKey(id)) return _inFlight[id]!;
+    final future = PreviewCacheService.instance.getPreviewPath(png).then((p) {
+      _cache[id] = p;
+      return p;
+    });
+    _inFlight[id] = future.whenComplete(() => _inFlight.remove(id));
+    return future;
+  }
+
+  void invalidate(String id) {
+    _cache.remove(id);
+  }
+
+  void clear() {
+    _cache.clear();
+    _inFlight.clear();
+  }
+}

--- a/lib/widgets/training_pack_template_card.dart
+++ b/lib/widgets/training_pack_template_card.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import '../models/v2/training_pack_template.dart';
-import '../services/preview_cache_service.dart';
+import '../services/thumbnail_cache_service.dart';
 
 class TrainingPackTemplateCard extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -21,12 +21,9 @@ class _TrainingPackTemplateCardState extends State<TrainingPackTemplateCard> {
   }
 
   void _load() async {
-    final png = widget.template.png;
-    if (png != null) {
-      final path = await PreviewCacheService.instance.getPreviewPath(png);
-      if (!mounted) return;
-      setState(() => previewPath = path);
-    }
+    final path = await ThumbnailCacheService.instance.getThumbnail(widget.template);
+    if (!mounted) return;
+    setState(() => previewPath = path);
   }
 
   @override


### PR DESCRIPTION
## Summary
- add `ThumbnailCacheService` for caching preview images
- invalidate cache on template modifications
- load template card previews from the new cache

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687651c5417c832aa8d9d7afecbcbea3