### PR TITLE
Add YAML config parser

### DIFF
--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -1,0 +1,18 @@
+import '../../../models/game_type.dart';
+
+class PackGenerationRequest {
+  final GameType gameType;
+  final int bb;
+  final List<String> positions;
+  final String title;
+  final String description;
+  final List<String> tags;
+  const PackGenerationRequest({
+    required this.gameType,
+    required this.bb,
+    required this.positions,
+    this.title = '',
+    this.description = '',
+    List<String>? tags,
+  }) : tags = tags ?? const [];
+}

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -1,0 +1,31 @@
+import 'pack_generation_request.dart';
+import '../../../models/game_type.dart';
+import '../../../models/training_pack.dart' show parseGameType;
+import 'yaml_reader.dart';
+
+class PackYamlConfigParser {
+  final YamlReader reader;
+  const PackYamlConfigParser({YamlReader? yamlReader})
+      : reader = yamlReader ?? const YamlReader();
+
+  List<PackGenerationRequest> parse(String yamlSource) {
+    final map = reader.read(yamlSource);
+    final list = map['packs'];
+    if (list is! List) return const [];
+    return [
+      for (final item in list)
+        if (item is Map)
+          PackGenerationRequest(
+            gameType: parseGameType(item['gameType']),
+            bb: (item['bb'] as num?)?.toInt() ?? 0,
+            positions: [
+              for (final p in (item['positions'] as List? ?? const []))
+                p.toString()
+            ],
+            title: item['title']?.toString() ?? '',
+            description: item['description']?.toString() ?? '',
+            tags: [for (final t in (item['tags'] as List? ?? const [])) t.toString()],
+          )
+    ];
+  }
+}

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/core/training/generation/pack_yaml_config_parser.dart';
+import 'package:poker_analyzer/core/training/generation/pack_generation_request.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+
+void main() {
+  test('parse returns requests', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb, bb]
+    title: Test
+    description: Desc
+    tags: [pushfold]
+  - gameType: cash
+    bb: 50
+    positions: [btn]
+    title: Cash
+    description: Example
+    tags: [cash]
+''';
+    final parser = PackYamlConfigParser();
+    final list = parser.parse(yaml);
+    expect(list.length, 2);
+    expect(list.first.gameType, GameType.tournament);
+    expect(list.first.bb, 10);
+    expect(list.first.positions, ['sb', 'bb']);
+    expect(list.first.title, 'Test');
+    expect(list.first.tags, ['pushfold']);
+    expect(list.last.gameType, GameType.cash);
+  });
+}


### PR DESCRIPTION
## Summary
- create model `PackGenerationRequest`
- implement `PackYamlConfigParser` for reading generation configs
- add unit test

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687674e39108832ab8649aeff7866260