### PR TITLE
Add pack export CLI

### DIFF
--- a/tool/config.yaml
+++ b/tool/config.yaml
@@ -1,0 +1,13 @@
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb, bb]
+    title: Example Pack
+    description: Example tournament pack
+    tags: [pushfold]
+  - gameType: cash
+    bb: 50
+    positions: [btn]
+    title: Cash Pack
+    description: Example cash pack
+    tags: [cash]

--- a/tool/generate_and_export_packs.dart
+++ b/tool/generate_and_export_packs.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/core/training/generation/pack_library_generator.dart';
+import 'package:poker_analyzer/core/training/generation/pack_library_exporter.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+
+Future<void> main() async {
+  const configPath = 'tool/config.yaml';
+  const outputDir = 'tool/output';
+  final file = File(configPath);
+  if (!file.existsSync()) {
+    stderr.writeln('Config not found: $configPath');
+    exit(1);
+  }
+  String source;
+  try {
+    source = file.readAsStringSync();
+  } catch (e) {
+    stderr.writeln('Failed to read $configPath');
+    exit(1);
+  }
+  final generator = PackLibraryGenerator();
+  late final List<TrainingPackTemplate> packs;
+  try {
+    packs = generator.generateFromYaml(source);
+  } catch (e) {
+    stderr.writeln('Invalid config');
+    exit(1);
+  }
+  await Directory(outputDir).create(recursive: true);
+  final exporter = const PackLibraryExporter();
+  List<String> paths;
+  try {
+    paths = await exporter.export(packs, outputDir);
+  } catch (e) {
+    stderr.writeln('Export failed');
+    exit(1);
+  }
+  stdout.writeln('Generated ${paths.length} files in $outputDir/');
+}


### PR DESCRIPTION
## Summary
- allow generating training packs via CLI
- store pack configs in `tool/config.yaml`
- output generated pack files to `tool/output/`

## Testing
- `apt-get update`
- `apt-cache search dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767aa0de74832a8dabc5ef6391b818