### PR TITLE
Add dry-run option to pack generator

### DIFF
--- a/tool/generate_and_export_packs.dart
+++ b/tool/generate_and_export_packs.dart
@@ -7,9 +7,11 @@ import 'package:poker_analyzer/models/v2/training_pack_template.dart';
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
-    ..addOption('config', defaultsTo: 'tool/config.yaml');
+    ..addOption('config', defaultsTo: 'tool/config.yaml')
+    ..addFlag('dry-run', defaultsTo: false);
   final argResults = parser.parse(args);
   final configPath = argResults['config'] as String;
+  final dryRun = argResults['dry-run'] as bool;
   stdout.writeln('Using config: $configPath');
   const outputDir = 'tool/output';
   final file = File(configPath);
@@ -31,6 +33,15 @@ Future<void> main(List<String> args) async {
   } catch (e) {
     stderr.writeln('Invalid config');
     exit(1);
+  }
+  if (dryRun) {
+    var total = 0;
+    for (final p in packs) {
+      stdout.writeln('${p.name}: ${p.spots.length} hands, ${p.gameType.name} ${p.heroBbStack}bb');
+      total += p.spots.length;
+    }
+    stdout.writeln('Total packs: ${packs.length}, total hands: $total');
+    return;
   }
   await Directory(outputDir).create(recursive: true);
   final exporter = const PackLibraryExporter();


### PR DESCRIPTION
## Summary
- update `generate_and_export_packs.dart` with `--dry-run` flag
- print generated pack data when using dry-run without writing files

## Testing
- `flutter test test/pack_library_generator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767d2c7500832a85c601c678a44b17