### PR TITLE
Add bbList support to pack generator

### DIFF
--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -3,6 +3,7 @@ import '../../../models/game_type.dart';
 class PackGenerationRequest {
   final GameType gameType;
   final int bb;
+  final List<int>? bbList;
   final List<String> positions;
   final String title;
   final String description;
@@ -11,7 +12,8 @@ class PackGenerationRequest {
   final bool multiplePositions;
   const PackGenerationRequest({
     required this.gameType,
-    required this.bb,
+    this.bb = 0,
+    this.bbList,
     required this.positions,
     this.title = '',
     this.description = '',

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -19,6 +19,7 @@ class PackLibraryGenerator {
       final tpl = generator.generate(
         gameType: r.gameType,
         bb: r.bb,
+        bbList: r.bbList,
         positions: r.positions,
         count: r.count,
         multiplePositions: r.multiplePositions,

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -21,6 +21,12 @@ class PackYamlConfigParser {
           PackGenerationRequest(
             gameType: parseGameType(item['gameType']),
             bb: (item['bb'] as num?)?.toInt() ?? 0,
+            bbList: item['bbList'] is List
+                ? [
+                    for (final b in item['bbList'])
+                      (b as num).toInt()
+                  ]
+                : null,
             positions: [
               for (final p in (item['positions'] as List? ?? const []))
                 p.toString()

--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -24,4 +24,18 @@ packs:
     expect(tpl.spotCount, tpl.spots.length);
     expect(tpl.id.isNotEmpty, true);
   });
+
+  test('generateFromYaml handles bbList', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bbList: [10, 15]
+    positions: [sb]
+    count: 2
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.spots.length, 4);
+    expect(list.first.spotCount, 4);
+  });
 }

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -26,6 +26,7 @@ packs:
     expect(list.length, 2);
     expect(list.first.gameType, GameType.tournament);
     expect(list.first.bb, 10);
+    expect(list.first.bbList, isNull);
     expect(list.first.positions, ['sb', 'bb']);
     expect(list.first.title, 'Test');
     expect(list.first.tags, ['pushfold']);
@@ -64,5 +65,18 @@ packs:
     final parser = PackYamlConfigParser();
     final list = parser.parse(yaml);
     expect(list.first.multiplePositions, true);
+  });
+
+  test('parse reads bbList', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bbList: [10, 20]
+    positions: [btn]
+''';
+    final parser = PackYamlConfigParser();
+    final list = parser.parse(yaml);
+    expect(list.first.bbList, [10, 20]);
+    expect(list.first.bb, 0);
   });
 }


### PR DESCRIPTION
## Summary
- support multi-stack inputs in `PackGenerationRequest`
- parse `bbList` from YAML
- generate push/fold packs for several stacks
- test `bbList` parsing and generation logic

## Testing
- `flutter test --run-skipped` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687687d09fc8832aa86806b693557803