### PR TITLE
Add rangeGroup support in pack generator

### DIFF
--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -9,6 +9,7 @@ class PackGenerationRequest {
   final String description;
   final List<String> tags;
   final int count;
+  final String? rangeGroup;
   final bool multiplePositions;
   const PackGenerationRequest({
     required this.gameType,
@@ -19,6 +20,7 @@ class PackGenerationRequest {
     this.description = '',
     List<String>? tags,
     this.count = 25,
+    this.rangeGroup,
     this.multiplePositions = false,
   }) : tags = tags ?? const [];
 }

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -22,6 +22,7 @@ class PackLibraryGenerator {
         bbList: r.bbList,
         positions: r.positions,
         count: r.count,
+        rangeGroup: r.rangeGroup,
         multiplePositions: r.multiplePositions,
       );
       if (r.title.isNotEmpty) tpl.name = r.title;

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -42,6 +42,7 @@ class PackYamlConfigParser {
             count: item.containsKey('count')
                 ? (item['count'] as num?)?.toInt() ?? 25
                 : (defaultCount ?? 25),
+            rangeGroup: item['rangeGroup']?.toString(),
             multiplePositions: item.containsKey('multiplePositions')
                 ? item['multiplePositions'] == true
                 : defaultMultiplePositions,

--- a/lib/core/training/generation/push_fold_pack_generator.dart
+++ b/lib/core/training/generation/push_fold_pack_generator.dart
@@ -6,6 +6,7 @@ import '../../../models/v2/hero_position.dart';
 import '../../../models/game_type.dart';
 import '../../../models/action_entry.dart';
 import '../../../services/pack_generator_service.dart';
+import '../../../services/hand_range_library.dart';
 import '../../../utils/template_coverage_utils.dart';
 import '../../../helpers/poker_position_helper.dart';
 
@@ -19,13 +20,14 @@ class PushFoldPackGenerator {
     List<int>? bbList,
     required List<String> positions,
     int count = 25,
+    String? rangeGroup,
     bool multiplePositions = false,
   }) {
     final stacks = bbList == null || bbList.isEmpty ? [bb] : bbList;
     final posList = positions.map(parseHeroPosition).toList();
-    final availableHands = PackGeneratorService.topNHands(count).toList();
-    final limit = availableHands.length < count ? availableHands.length : count;
-    final hands = availableHands.take(limit).toList();
+    final hands = rangeGroup != null
+        ? HandRangeLibrary.getGroup(rangeGroup)
+        : PackGeneratorService.topNHands(count).toList();
     final spots = <TrainingPackSpot>[];
     var index = 1;
     for (final stack in stacks) {

--- a/lib/services/hand_range_library.dart
+++ b/lib/services/hand_range_library.dart
@@ -1,0 +1,41 @@
+import 'pack_generator_service.dart';
+
+class HandRangeLibrary {
+  static List<String> getGroup(String name) {
+    final match = RegExp(r'^top(\d+)').firstMatch(name);
+    if (match != null) {
+      final pct = int.parse(match.group(1)!);
+      return PackGeneratorService.topNHands(pct).toList();
+    }
+    switch (name) {
+      case 'tilt':
+        return PackGeneratorService.topNHands(70).toList();
+      case 'icm':
+        return PackGeneratorService.topNHands(10).toList();
+      case 'nash-10bb':
+        return [
+          '22',
+          '33',
+          'A2s',
+          'A3s',
+          'K9s',
+          'Q9s',
+          'J9s',
+          'T9s',
+          '98s',
+          'AJo',
+          'KQo',
+          'A2o',
+          'A3o',
+          'A4o',
+          'A5o',
+          'A6o',
+          'A7o',
+          'A8o',
+          'A9o',
+          'ATo',
+        ];
+    }
+    throw ArgumentError('Range group not found: $name');
+  }
+}

--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/core/training/generation/pack_library_generator.dart';
+import 'package:poker_analyzer/services/hand_range_library.dart';
 
 void main() {
   test('generateFromYaml returns templates', () {
@@ -37,5 +38,19 @@ packs:
     final list = generator.generateFromYaml(yaml);
     expect(list.first.spots.length, 4);
     expect(list.first.spotCount, 4);
+  });
+
+  test('generateFromYaml uses rangeGroup', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    rangeGroup: top10
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.spots.length,
+        HandRangeLibrary.getGroup('top10').length);
   });
 }

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -111,4 +111,18 @@ packs:
     expect(list.first.count, 3);
     expect(list.first.multiplePositions, false);
   });
+
+  test('parse reads rangeGroup', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [btn]
+    rangeGroup: top15
+''';
+    final parser = PackYamlConfigParser();
+    final list = parser.parse(yaml);
+    expect(list.first.rangeGroup, 'top15');
+    expect(list.first.count, 25);
+  });
 }


### PR DESCRIPTION
## Summary
- introduce `HandRangeLibrary` for predefined hand groups
- extend `PackGenerationRequest` with `rangeGroup`
- parse `rangeGroup` from YAML config
- generate packs using selected hand groups
- update unit tests

## Testing
- `dart` was unavailable so tests could not run

------
https://chatgpt.com/codex/tasks/task_e_68768a2c2980832a88773a70e6598c71