### PR TITLE
Add enabled flag to YAML packs

### DIFF
--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -11,7 +11,7 @@ class PackYamlConfig {
 class PackYamlConfigParser {
   final YamlReader reader;
   const PackYamlConfigParser({YamlReader? yamlReader})
-      : reader = yamlReader ?? const YamlReader();
+    : reader = yamlReader ?? const YamlReader();
 
   PackYamlConfig parse(String yamlSource) {
     final map = reader.read(yamlSource);
@@ -26,7 +26,7 @@ class PackYamlConfigParser {
     if (list is! List) return const PackYamlConfig(requests: []);
     final requests = [
       for (final item in list)
-        if (item is Map)
+        if (item is Map && item['enabled'] != false)
           PackGenerationRequest(
             gameType: parseGameType(item['gameType']),
             bb: (item['bb'] as num?)?.toInt() ?? 0,
@@ -49,8 +49,8 @@ class PackYamlConfigParser {
             count: (item.containsKey('rangeGroup') || defaultRangeGroup != null)
                 ? (item['count'] as num?)?.toInt() ?? (defaultCount ?? 25)
                 : item.containsKey('count')
-                    ? (item['count'] as num?)?.toInt() ?? 25
-                    : (defaultCount ?? 25),
+                ? (item['count'] as num?)?.toInt() ?? 25
+                : (defaultCount ?? 25),
             rangeGroup: item['rangeGroup']?.toString() ?? defaultRangeGroup,
             multiplePositions: item.containsKey('multiplePositions')
                 ? item['multiplePositions'] == true

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -185,4 +185,22 @@ packs:
     final config = parser.parse(yaml);
     expect(config.rangeTags, false);
   });
+
+  test('parse skips disabled packs', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    enabled: false
+  - gameType: cash
+    bb: 5
+    positions: [bb]
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    final list = config.requests;
+    expect(list.length, 1);
+    expect(list.first.gameType, GameType.cash);
+  });
 }


### PR DESCRIPTION
## Summary
- support skipping packs with `enabled: false`
- test PackYamlConfigParser skipping disabled packs

## Testing
- `dart analyze` *(fails: 53627 issues found)*


------
https://chatgpt.com/codex/tasks/task_e_687690ed40f8832ab3bc935b7e740194