### PR TITLE
Add defaultDescription support

### DIFF
--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -11,11 +11,12 @@ class PackYamlConfig {
 class PackYamlConfigParser {
   final YamlReader reader;
   const PackYamlConfigParser({YamlReader? yamlReader})
-    : reader = yamlReader ?? const YamlReader();
+      : reader = yamlReader ?? const YamlReader();
 
   PackYamlConfig parse(String yamlSource) {
     final map = reader.read(yamlSource);
     final rangeTags = map['defaultRangeTags'] == true;
+    final defaultDescription = map['defaultDescription']?.toString() ?? '';
     final defaultTags = <String>[
       for (final t in (map['defaultTags'] as List? ?? const [])) t.toString(),
     ];
@@ -38,7 +39,10 @@ class PackYamlConfigParser {
                 p.toString(),
             ],
             title: item['title']?.toString() ?? '',
-            description: item['description']?.toString() ?? '',
+            description: () {
+              final desc = item['description']?.toString() ?? '';
+              return desc.isNotEmpty ? desc : defaultDescription;
+            }(),
             tags: () {
               final local = item['tags'] as List?;
               final tags = local == null || local.isEmpty
@@ -49,8 +53,8 @@ class PackYamlConfigParser {
             count: (item.containsKey('rangeGroup') || defaultRangeGroup != null)
                 ? (item['count'] as num?)?.toInt() ?? (defaultCount ?? 25)
                 : item.containsKey('count')
-                ? (item['count'] as num?)?.toInt() ?? 25
-                : (defaultCount ?? 25),
+                    ? (item['count'] as num?)?.toInt() ?? 25
+                    : (defaultCount ?? 25),
             rangeGroup: item['rangeGroup']?.toString() ?? defaultRangeGroup,
             multiplePositions: item.containsKey('multiplePositions')
                 ? item['multiplePositions'] == true

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -203,4 +203,33 @@ packs:
     expect(list.length, 1);
     expect(list.first.gameType, GameType.cash);
   });
+
+  test('parse applies defaultDescription', () {
+    const yaml = '''
+defaultDescription: Generated
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    final list = config.requests;
+    expect(list.first.description, 'Generated');
+  });
+
+  test('local description overrides defaultDescription', () {
+    const yaml = '''
+defaultDescription: Generated
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    description: Local
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    final list = config.requests;
+    expect(list.first.description, 'Local');
+  });
 }


### PR DESCRIPTION
## Summary
- allow defaultDescription in pack YAML configs
- use defaultDescription when description is missing
- test parsing of defaultDescription

## Testing
- `flutter test test/pack_yaml_config_parser_test.dart -r expanded` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876937475c8832a9cc0f20211966e08