### PR TITLE
Add defaultCount parsing

### DIFF
--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -21,7 +21,7 @@ class PackYamlConfigParser {
     final defaultTags = <String>[
       for (final t in (map['defaultTags'] as List? ?? const [])) t.toString(),
     ];
-    final defaultCount = (map['defaultCount'] as num?)?.toInt();
+    final defaultCount = (map['defaultCount'] as num?)?.toInt() ?? 25;
     final defaultMultiplePositions = map['defaultMultiplePositions'] == true;
     final defaultRangeGroup = map['defaultRangeGroup']?.toString();
     final list = map['packs'];
@@ -51,11 +51,7 @@ class PackYamlConfigParser {
                   : [for (final t in local) t.toString()];
               return List<String>.from(tags);
             }(),
-            count: (item.containsKey('rangeGroup') || defaultRangeGroup != null)
-                ? (item['count'] as num?)?.toInt() ?? (defaultCount ?? 25)
-                : item.containsKey('count')
-                ? (item['count'] as num?)?.toInt() ?? 25
-                : (defaultCount ?? 25),
+            count: (item['count'] as num?)?.toInt() ?? defaultCount,
             rangeGroup: item['rangeGroup']?.toString() ?? defaultRangeGroup,
             multiplePositions: item.containsKey('multiplePositions')
                 ? item['multiplePositions'] == true


### PR DESCRIPTION
## Summary
- support `defaultCount` key in YAML library parser

## Testing
- `flutter test test/pack_yaml_config_parser_test.dart` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876991bc450832ab67f211cbd4fecc8