### PR TITLE
Add defaultCount support in pack yaml parser

### DIFF
--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -5,7 +5,12 @@ import 'yaml_reader.dart';
 class PackYamlConfig {
   final List<PackGenerationRequest> requests;
   final bool rangeTags;
-  const PackYamlConfig({required this.requests, this.rangeTags = false});
+  final int defaultCount;
+  const PackYamlConfig({
+    required this.requests,
+    this.rangeTags = false,
+    this.defaultCount = 25,
+  });
 }
 
 class PackYamlConfigParser {
@@ -34,7 +39,13 @@ class PackYamlConfigParser {
     final defaultMultiplePositions = map['defaultMultiplePositions'] == true;
     final defaultRangeGroup = map['defaultRangeGroup']?.toString();
     final list = map['packs'];
-    if (list is! List) return const PackYamlConfig(requests: []);
+    if (list is! List) {
+      return PackYamlConfig(
+        requests: const [],
+        rangeTags: rangeTags,
+        defaultCount: defaultCount,
+      );
+    }
     final requests = [
       for (final item in list)
         if (item is Map && item['enabled'] != false)
@@ -68,6 +79,10 @@ class PackYamlConfigParser {
                 : defaultMultiplePositions,
           ),
     ];
-    return PackYamlConfig(requests: requests, rangeTags: rangeTags);
+    return PackYamlConfig(
+      requests: requests,
+      rangeTags: rangeTags,
+      defaultCount: defaultCount,
+    );
   }
 }

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -159,6 +159,20 @@ packs:
     expect(list.first.multiplePositions, true);
   });
 
+  test('parse stores defaultCount', () {
+    const yaml = '''
+defaultCount: 40
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [btn]
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    expect(config.defaultCount, 40);
+    expect(config.requests.first.count, 40);
+  });
+
   test('local values override defaults', () {
     const yaml = '''
 defaultCount: 5


### PR DESCRIPTION
## Summary
- add `defaultCount` field in `PackYamlConfig`
- parse `defaultCount` from yaml
- return `defaultCount` with parsed config
- test storing `defaultCount`

## Testing
- `dart pub get`
- `dart test test/pack_yaml_config_parser_test.dart` *(fails: Undefined name '_intIntMapFromJson')*

------
https://chatgpt.com/codex/tasks/task_e_6876a6caccc4832aabe0eaf31101b3e7