### PR TITLE
Add defaultGameType support

### DIFF
--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -145,6 +145,18 @@ packs:
     expect(list.first.gameType, GameType.cash);
   });
 
+  test('parse stores defaultGameType', () {
+    const yaml = '''
+defaultGameType: tournament
+packs:
+  - bb: 5
+    positions: [sb]
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    expect(config.defaultGameType, GameType.tournament);
+  });
+
   test('parse applies default count and multiple positions', () {
     const yaml = '''
 defaultCount: 5


### PR DESCRIPTION
## Summary
- extend `PackYamlConfig` to store a default game type
- parse `defaultGameType` in `PackYamlConfigParser`
- allow pack override for `gameType`
- test new default game type logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687705382ff8832a8bcbd4d32027c2d4