### PR TITLE
Implement TrainingPackTemplateV2

### DIFF
--- a/lib/core/training/engine/training_type_engine.dart
+++ b/lib/core/training/engine/training_type_engine.dart
@@ -1,11 +1,12 @@
 import '../generation/push_fold_pack_generator.dart';
 import '../generation/pack_generation_request.dart';
 import '../../../models/v2/training_pack_template.dart';
+import '../../../models/v2/training_pack_template_v2.dart';
 
 enum TrainingType { pushfold, postflop, exploit, bluffcatch, callrange }
 
 abstract class TrainingPackBuilder {
-  Future<TrainingPackTemplate> build(PackGenerationRequest request);
+  Future<TrainingPackTemplateV2> build(PackGenerationRequest request);
 }
 
 class PushFoldPackBuilder implements TrainingPackBuilder {
@@ -14,7 +15,7 @@ class PushFoldPackBuilder implements TrainingPackBuilder {
       : _generator = generator ?? const PushFoldPackGenerator();
 
   @override
-  Future<TrainingPackTemplate> build(PackGenerationRequest request) async {
+  Future<TrainingPackTemplateV2> build(PackGenerationRequest request) async {
     final tpl = _generator.generate(
       gameType: request.gameType,
       bb: request.bb,
@@ -28,7 +29,10 @@ class PushFoldPackBuilder implements TrainingPackBuilder {
     if (request.description.isNotEmpty) tpl.description = request.description;
     if (request.tags.isNotEmpty) tpl.tags = List<String>.from(request.tags);
     tpl.spotCount = tpl.spots.length;
-    return tpl;
+    return TrainingPackTemplateV2.fromTemplate(
+      tpl,
+      type: TrainingType.pushfold,
+    );
   }
 }
 
@@ -38,7 +42,7 @@ class TrainingTypeEngine {
       : _builders =
             builders ?? const {TrainingType.pushfold: PushFoldPackBuilder()};
 
-  Future<TrainingPackTemplate> build(
+  Future<TrainingPackTemplateV2> build(
     TrainingType type,
     PackGenerationRequest request,
   ) {

--- a/lib/models/v2/spot_template.dart
+++ b/lib/models/v2/spot_template.dart
@@ -1,0 +1,3 @@
+import 'training_pack_spot.dart';
+
+typedef SpotTemplate = TrainingPackSpot;

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'package:yaml/yaml.dart';
+
+import '../../core/training/generation/yaml_reader.dart';
+import '../game_type.dart';
+import '../training_pack.dart' show parseGameType;
+import '../../core/training/engine/training_type_engine.dart';
+import 'training_pack_spot.dart';
+import 'spot_template.dart';
+
+class TrainingPackTemplateV2 {
+  final String id;
+  String name;
+  String description;
+  List<String> tags;
+  final TrainingType type;
+  List<SpotTemplate> spots;
+  int spotCount;
+  final DateTime created;
+  GameType gameType;
+  int bb;
+  List<String> positions;
+  Map<String, dynamic> meta;
+
+  TrainingPackTemplateV2({
+    required this.id,
+    required this.name,
+    this.description = '',
+    List<String>? tags,
+    required this.type,
+    List<SpotTemplate>? spots,
+    this.spotCount = 0,
+    DateTime? created,
+    this.gameType = GameType.cash,
+    this.bb = 0,
+    List<String>? positions,
+    Map<String, dynamic>? meta,
+  })  : tags = tags ?? [],
+        spots = spots ?? [],
+        positions = positions ?? [],
+        created = created ?? DateTime.now(),
+        meta = meta ?? {};
+
+  factory TrainingPackTemplateV2.fromJson(Map<String, dynamic> j) =>
+      TrainingPackTemplateV2(
+        id: j['id'] as String? ?? '',
+        name: j['name'] as String? ?? '',
+        description: j['description'] as String? ?? '',
+        tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
+        type: TrainingType.values.firstWhere(
+          (e) => e.name == j['type'],
+          orElse: () => TrainingType.pushfold,
+        ),
+        spots: [
+          for (final s in (j['spots'] as List? ?? []))
+            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s))
+        ],
+        spotCount: j['spotCount'] as int? ?? (j['spots'] as List? ?? []).length,
+        created: DateTime.tryParse(j['created'] as String? ?? '') ?? DateTime.now(),
+        gameType: parseGameType(j['gameType']),
+        bb: (j['bb'] as num?)?.toInt() ?? 0,
+        positions: [for (final p in (j['positions'] as List? ?? [])) p.toString()],
+        meta: j['meta'] != null ? Map<String, dynamic>.from(j['meta']) : {},
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        if (tags.isNotEmpty) 'tags': tags,
+        'type': type.name,
+        if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
+        'spotCount': spotCount,
+        'created': created.toIso8601String(),
+        'gameType': gameType.name,
+        'bb': bb,
+        if (positions.isNotEmpty) 'positions': positions,
+        if (meta.isNotEmpty) 'meta': meta,
+      };
+
+  factory TrainingPackTemplateV2.fromYaml(String source) {
+    final map = const YamlReader().read(source);
+    return TrainingPackTemplateV2.fromJson(map);
+  }
+
+  String toYaml() => const YamlEncoder().convert(toJson());
+
+  factory TrainingPackTemplateV2.fromTemplate(
+    TrainingPackTemplate template, {
+    required TrainingType type,
+  }) =>
+      TrainingPackTemplateV2(
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        tags: List<String>.from(template.tags),
+        type: type,
+        spots: List<SpotTemplate>.from(template.spots),
+        spotCount: template.spotCount,
+        created: template.createdAt,
+        gameType: template.gameType,
+        bb: template.heroBbStack,
+        positions: [template.heroPos.name],
+        meta: Map<String, dynamic>.from(template.meta),
+      );
+}


### PR DESCRIPTION
## Summary
- create SpotTemplate alias for TrainingPackSpot
- add TrainingPackTemplateV2 model with YAML/JSON serialization
- update TrainingTypeEngine to build TrainingPackTemplateV2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687710b370cc832aa585a17c73665f86