### PR TITLE
Add TrainingPackLibraryV2 to manage V2 packs

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,6 +96,7 @@ flutter:
     - assets/ranges/btn_15bb.json
     - assets/ranges/
     - assets/packs/
+    - assets/packs/v2/
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo


### PR DESCRIPTION
## Summary
- create persistent `TrainingPackLibraryV2`
- integrate V2 pack loading into bootstrap
- include new asset path for V2 packs

## Testing
- ❌ `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687715e4c488832ab986cd11dfe9a086