### PR TITLE
Add TrainingPackExporterV2

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import '../../../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackExporterV2 {
+  const TrainingPackExporterV2();
+
+  String exportYaml(TrainingPackTemplateV2 pack) => pack.toYaml();
+
+  Future<File> exportToFile(
+    TrainingPackTemplateV2 pack, {
+    String? fileName,
+  }) async {
+    final generatedDir = Directory('packs/generated');
+    final exportedDir = Directory('packs/exported');
+    Directory dir;
+    if (await generatedDir.exists()) {
+      dir = generatedDir;
+    } else {
+      dir = exportedDir;
+    }
+    await dir.create(recursive: true);
+    final safeName = (fileName ?? pack.name)
+        .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')
+        .replaceAll(' ', '_');
+    final file = File('${dir.path}/$safeName.yaml');
+    await file.writeAsString(exportYaml(pack));
+    return file;
+  }
+}


### PR DESCRIPTION
## Summary
- support exporting v2 training packs as YAML strings or files

## Testing
- `flutter test` *(fails: HandData.fromSimpleInput errors)*

------
https://chatgpt.com/codex/tasks/task_e_68771739d948832a9d515cca23e58e6c