### PR TITLE
Add TrainingPackExporterV2

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -12,13 +12,9 @@ class TrainingPackExporterV2 {
     String? fileName,
   }) async {
     final generatedDir = Directory('packs/generated');
-    final exportedDir = Directory('packs/exported');
-    Directory dir;
-    if (await generatedDir.exists()) {
-      dir = generatedDir;
-    } else {
-      dir = exportedDir;
-    }
+    final dir = await generatedDir.exists()
+        ? generatedDir
+        : Directory('packs/exported');
     await dir.create(recursive: true);
     final safeName = (fileName ?? pack.name)
         .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')


### PR DESCRIPTION
## Summary
- add YAML exporter for v2 packs
- minor refactor of exporter logic

## Testing
- `flutter test` *(fails: MissingPluginException)*

------
https://chatgpt.com/codex/tasks/task_e_68771951adb4832ab38e652da496ec8c