### PR TITLE
Add YAML export support

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -12,9 +12,8 @@ class TrainingPackExporterV2 {
     String? fileName,
   }) async {
     final generatedDir = Directory('packs/generated');
-    final dir = await generatedDir.exists()
-        ? generatedDir
-        : Directory('packs/exported');
+    final exportedDir = Directory('packs/exported');
+    final dir = await generatedDir.exists() ? generatedDir : exportedDir;
     await dir.create(recursive: true);
     final safeName = (fileName ?? pack.name)
         .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')


### PR DESCRIPTION
## Summary
- refine TrainingPackExporterV2

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771c25f9b8832ab1d7aed4e7451306