### PR TITLE
Implement TrainingPackExporterV2

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -12,8 +12,9 @@ class TrainingPackExporterV2 {
     String? fileName,
   }) async {
     final generatedDir = Directory('packs/generated');
-    final exportedDir = Directory('packs/exported');
-    final dir = await generatedDir.exists() ? generatedDir : exportedDir;
+    final dir = await generatedDir.exists()
+        ? generatedDir
+        : Directory('packs/exported');
     await dir.create(recursive: true);
     final safeName = (fileName ?? pack.name)
         .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')


### PR DESCRIPTION
## Summary
- export v2 packs to YAML format
- write YAML files to either `packs/generated` or `packs/exported`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771d2c5020832aa1aed7e0e2eff86f