### PR TITLE
Add TrainingPackExporterV2 YAML file handling

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -12,9 +12,8 @@ class TrainingPackExporterV2 {
     String? fileName,
   }) async {
     final generatedDir = Directory('packs/generated');
-    final dir = await generatedDir.exists()
-        ? generatedDir
-        : Directory('packs/exported');
+    final exportedDir = Directory('packs/exported');
+    final dir = await generatedDir.exists() ? generatedDir : exportedDir;
     await dir.create(recursive: true);
     final safeName = (fileName ?? pack.name)
         .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')


### PR DESCRIPTION
## Summary
- refine the directory fallback logic for TrainingPackExporterV2

## Testing
- `flutter test --run-skipped` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68771e6ae70c832aace6cd9b7c1e25f3