### PR TITLE
Add TrainingPackGeneratorEngine

### DIFF
--- a/lib/core/training/generation/training_pack_generator_engine.dart
+++ b/lib/core/training/generation/training_pack_generator_engine.dart
@@ -1,0 +1,65 @@
+import 'package:uuid/uuid.dart';
+import '../../../models/v2/training_pack_template_v2.dart';
+import '../../../models/v2/training_pack_v2.dart';
+import '../../../models/v2/training_pack_spot.dart';
+import '../../../services/offline_evaluator_service.dart';
+
+class TrainingPackGeneratorEngine {
+  final OfflineEvaluatorService evaluator;
+  final Uuid _uuid;
+  const TrainingPackGeneratorEngine({
+    OfflineEvaluatorService? evaluator,
+    Uuid? uuid,
+  }) : evaluator = evaluator ?? OfflineEvaluatorService(),
+       _uuid = uuid ?? const Uuid();
+
+  Future<TrainingPackV2> generateFromTemplate(
+    TrainingPackTemplateV2 template,
+  ) async {
+    final now = DateTime.now();
+    final spots = [
+      for (final s in template.spots) TrainingPackSpot.fromJson(s.toJson()),
+    ];
+    for (final s in spots) {
+      await evaluator.evaluate(s, anteBb: template.bb);
+      await evaluator.evaluateIcm(s, anteBb: template.bb);
+    }
+    final pack = TrainingPackV2(
+      id: _uuid.v4(),
+      sourceTemplateId: template.id,
+      name: template.name,
+      description: template.description,
+      tags: List<String>.from(template.tags),
+      type: template.type,
+      spots: spots,
+      spotCount: spots.length,
+      generatedAt: now,
+      gameType: template.gameType,
+      bb: template.bb,
+      positions: List<String>.from(template.positions),
+      difficulty: template.meta['difficulty'] is int
+          ? template.meta['difficulty'] as int
+          : template.spotCount ~/ 10 + 1,
+      meta: Map<String, dynamic>.from(template.meta),
+    );
+    pack.meta['generatedAt'] = now.toIso8601String();
+    pack.meta['sourceTemplateId'] = template.id;
+    _recountCoverage(pack);
+    return pack;
+  }
+
+  void _recountCoverage(TrainingPackV2 pack) {
+    var ev = 0;
+    var icm = 0;
+    var total = 0;
+    for (final s in pack.spots) {
+      final w = s.priority;
+      total += w;
+      if (!s.dirty && s.heroEv != null) ev += w;
+      if (!s.dirty && s.heroIcmEv != null) icm += w;
+    }
+    pack.meta['evCovered'] = ev;
+    pack.meta['icmCovered'] = icm;
+    pack.meta['totalWeight'] = total;
+  }
+}

--- a/lib/models/v2/training_pack_v2.dart
+++ b/lib/models/v2/training_pack_v2.dart
@@ -1,0 +1,100 @@
+import 'training_pack_spot.dart';
+import '../game_type.dart';
+import '../../core/training/engine/training_type_engine.dart';
+import 'training_pack_template_v2.dart' show TrainingPackTemplateV2;
+
+class TrainingPackV2 {
+  final String id;
+  final String sourceTemplateId;
+  String name;
+  String description;
+  List<String> tags;
+  final TrainingType type;
+  List<TrainingPackSpot> spots;
+  int spotCount;
+  final DateTime generatedAt;
+  GameType gameType;
+  int bb;
+  List<String> positions;
+  int difficulty;
+  Map<String, dynamic> meta;
+
+  TrainingPackV2({
+    required this.id,
+    required this.sourceTemplateId,
+    required this.name,
+    this.description = '',
+    List<String>? tags,
+    required this.type,
+    List<TrainingPackSpot>? spots,
+    this.spotCount = 0,
+    DateTime? generatedAt,
+    this.gameType = GameType.cash,
+    this.bb = 0,
+    List<String>? positions,
+    this.difficulty = 0,
+    Map<String, dynamic>? meta,
+  }) : tags = tags ?? [],
+       spots = spots ?? [],
+       positions = positions ?? [],
+       generatedAt = generatedAt ?? DateTime.now(),
+       meta = meta ?? {};
+
+  factory TrainingPackV2.fromJson(Map<String, dynamic> j) => TrainingPackV2(
+    id: j['id'] as String? ?? '',
+    sourceTemplateId: j['sourceTemplateId'] as String? ?? '',
+    name: j['name'] as String? ?? '',
+    description: j['description'] as String? ?? '',
+    tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
+    type: TrainingType.values.firstWhere(
+      (e) => e.name == j['type'],
+      orElse: () => TrainingType.pushfold,
+    ),
+    spots: [
+      for (final s in (j['spots'] as List? ?? []))
+        TrainingPackSpot.fromJson(Map<String, dynamic>.from(s)),
+    ],
+    spotCount: j['spotCount'] as int? ?? 0,
+    generatedAt:
+        DateTime.tryParse(j['generatedAt'] as String? ?? '') ?? DateTime.now(),
+    gameType: parseGameType(j['gameType']),
+    bb: (j['bb'] as num?)?.toInt() ?? 0,
+    positions: [for (final p in (j['positions'] as List? ?? [])) p.toString()],
+    difficulty: (j['difficulty'] as num?)?.toInt() ?? 0,
+    meta: j['meta'] != null ? Map<String, dynamic>.from(j['meta']) : {},
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'sourceTemplateId': sourceTemplateId,
+    'name': name,
+    'description': description,
+    if (tags.isNotEmpty) 'tags': tags,
+    'type': type.name,
+    if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
+    'spotCount': spotCount,
+    'generatedAt': generatedAt.toIso8601String(),
+    'gameType': gameType.name,
+    'bb': bb,
+    if (positions.isNotEmpty) 'positions': positions,
+    'difficulty': difficulty,
+    if (meta.isNotEmpty) 'meta': meta,
+  };
+
+  factory TrainingPackV2.fromTemplate(TrainingPackTemplateV2 t, String id) =>
+      TrainingPackV2(
+        id: id,
+        sourceTemplateId: t.id,
+        name: t.name,
+        description: t.description,
+        tags: List<String>.from(t.tags),
+        type: t.type,
+        spots: [for (final s in t.spots) TrainingPackSpot.fromJson(s.toJson())],
+        spotCount: t.spotCount,
+        generatedAt: DateTime.now(),
+        gameType: t.gameType,
+        bb: t.bb,
+        positions: List<String>.from(t.positions),
+        meta: Map<String, dynamic>.from(t.meta),
+      );
+}


### PR DESCRIPTION
## Summary
- implement `TrainingPackV2` model
- add `TrainingPackGeneratorEngine` for building packs from templates

## Testing
- `dart format lib/models/v2/training_pack_v2.dart lib/core/training/generation/training_pack_generator_engine.dart`
- `dart analyze` *(fails: many missing Flutter packages)*

------
https://chatgpt.com/codex/tasks/task_e_687724f9b4e0832a9837ebce9013c867