### PR TITLE
Add PackLibraryGenerator for TrainingPackV2 generation

### DIFF
--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -1,15 +1,21 @@
 import 'pack_yaml_config_parser.dart';
 import 'push_fold_pack_generator.dart';
+import 'training_pack_generator_engine.dart';
 import '../../../models/v2/training_pack_template.dart';
+import '../../../models/v2/training_pack_template_v2.dart';
+import '../../../models/v2/training_pack_v2.dart';
 
 class PackLibraryGenerator {
   final PackYamlConfigParser parser;
   final PushFoldPackGenerator generator;
+  final TrainingPackGeneratorEngine engine;
   const PackLibraryGenerator({
     PackYamlConfigParser? yamlParser,
     PushFoldPackGenerator? pushFoldGenerator,
+    TrainingPackGeneratorEngine? generatorEngine,
   })  : parser = yamlParser ?? const PackYamlConfigParser(),
-        generator = pushFoldGenerator ?? const PushFoldPackGenerator();
+        generator = pushFoldGenerator ?? const PushFoldPackGenerator(),
+        engine = generatorEngine ?? const TrainingPackGeneratorEngine();
 
   List<TrainingPackTemplate> generateFromYaml(String yaml) {
     final config = parser.parse(yaml);
@@ -38,6 +44,25 @@ class PackLibraryGenerator {
       tpl.spotCount = tpl.spots.length;
       list.add(tpl);
     }
+    return list;
+  }
+
+  Future<List<TrainingPackV2>> generateFromTemplates(
+      List<TrainingPackTemplateV2> templates) async {
+    final list = <TrainingPackV2>[];
+    for (final t in templates) {
+      if (t.spots.isEmpty) continue;
+      if (t.meta['enabled'] == false) continue;
+      final pack = await engine.generateFromTemplate(t);
+      list.add(pack);
+    }
+    list.sort((a, b) {
+      final ap = a.meta['priority'];
+      final bp = b.meta['priority'];
+      final ai = ap is int ? ap : a.difficulty;
+      final bi = bp is int ? bp : b.difficulty;
+      return ai.compareTo(bi);
+    });
     return list;
   }
 }


### PR DESCRIPTION
## Summary
- extend `PackLibraryGenerator` with TrainingPackGeneratorEngine
- add `generateFromTemplates` to convert templates to evaluated packs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877274cc48c832a82b46fcd3c282f4d