### PR TITLE
Add automatic difficulty score

### DIFF
--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -85,4 +85,30 @@ void main() {
     expect(res.first.sourceTemplateId, '2');
     expect(res.last.sourceTemplateId, '1');
   });
+
+  test('estimateDifficulty sets meta', () async {
+    final s1 = TrainingPackSpot(
+      id: 's1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final s2 = TrainingPackSpot(
+      id: 's2',
+      hand: HandData.fromSimpleInput('KdQd', HeroPosition.bb, 20)
+        ..board.addAll(['2h', '3d', '4s']),
+    );
+    final s3 = TrainingPackSpot(
+      id: 's3',
+      hand: HandData.fromSimpleInput('JcJs', HeroPosition.btn, 15)
+        ..board.addAll(['2h', '3d', '4s', '5c']),
+    );
+    final tpl = TrainingPackTemplateV2(
+      id: 't',
+      name: 'T',
+      type: TrainingType.pushfold,
+      spots: [s1, s2, s3],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['difficulty'], 3);
+  });
 }


### PR DESCRIPTION
## Summary
- estimate difficulty score in `PackLibraryGenerator`
- store generated difficulty in template meta
- test auto difficulty meta

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687760602d40832ab5185bb8c2ebaea3