### PR TITLE
Auto title generation for packs

### DIFF
--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -66,4 +66,16 @@ packs:
     final list = generator.generateFromYaml(yaml);
     expect(list.first.tags.contains('top10'), true);
   });
+
+  test('generateFromYaml generates default title', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.name, 'SB Push 10bb (Tournament)');
+  });
 }

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -144,4 +144,23 @@ void main() {
     expect(tags.contains('flop'), true);
     expect(tags.contains('turn'), true);
   });
+
+  test('generateFromTemplates generates title when empty', () async {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final tpl = TrainingPackTemplateV2(
+      id: 'z',
+      name: '',
+      type: TrainingType.pushfold,
+      gameType: GameType.tournament,
+      bb: 10,
+      positions: ['sb'],
+      spots: [spot],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.name, 'SB Push 10bb (Tournament)');
+  });
 }


### PR DESCRIPTION
## Summary
- generate readable titles when none are provided
- ensure generated packs get a title from position, stack and format
- test the new functionality for YAML and template generation

## Testing
- `flutter test --run-skipped` *(fails: unable to download dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6877658b42e0832aa70dcbc4df373b63