### PR TITLE
Add automatic pack description generation

### DIFF
--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -78,4 +78,16 @@ packs:
     final list = generator.generateFromYaml(yaml);
     expect(list.first.name, 'SB Push 10bb (Tournament)');
   });
+
+  test('generateFromYaml generates description when empty', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.description.isNotEmpty, true);
+  });
 }

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -10,11 +10,8 @@ import 'package:poker_analyzer/core/training/generation/training_pack_generator_
 class FakeEngine extends TrainingPackGeneratorEngine {
   const FakeEngine();
   @override
-  Future<TrainingPackV2> generateFromTemplate(
-      TrainingPackTemplateV2 template) async {
-    final spots = [
-      for (final s in template.spots) TrainingPackSpot.fromJson(s.toJson())
-    ];
+  Future<TrainingPackV2> generateFromTemplate(TrainingPackTemplateV2 template) async {
+    final spots = [for (final s in template.spots) TrainingPackSpot.fromJson(s.toJson())];
     return TrainingPackV2(
       id: template.id,
       sourceTemplateId: template.id,
@@ -28,9 +25,7 @@ class FakeEngine extends TrainingPackGeneratorEngine {
       gameType: template.gameType,
       bb: template.bb,
       positions: List<String>.from(template.positions),
-      difficulty: template.meta['difficulty'] is int
-          ? template.meta['difficulty'] as int
-          : spots.length,
+      difficulty: template.meta['difficulty'] is int ? template.meta['difficulty'] as int : spots.length,
       meta: Map<String, dynamic>.from(template.meta),
     );
   }
@@ -38,16 +33,8 @@ class FakeEngine extends TrainingPackGeneratorEngine {
 
 void main() {
   test('generateFromTemplates skips disabled and empty', () async {
-    final spot = TrainingPackSpot(
-      id: 's1',
-      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
-    );
-    final enabled = TrainingPackTemplateV2(
-      id: '1',
-      name: 'A',
-      type: TrainingType.pushfold,
-      spots: [spot],
-    );
+    final spot = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final enabled = TrainingPackTemplateV2(id: '1', name: 'A', type: TrainingType.pushfold, spots: [spot]);
     final disabled = TrainingPackTemplateV2(
       id: '2',
       name: 'B',
@@ -55,23 +42,15 @@ void main() {
       meta: {'enabled': false},
       spots: [spot],
     );
-    final empty = TrainingPackTemplateV2(
-      id: '3',
-      name: 'C',
-      type: TrainingType.pushfold,
-    );
+    final empty = TrainingPackTemplateV2(id: '3', name: 'C', type: TrainingType.pushfold);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
-    final res =
-        await generator.generateFromTemplates([enabled, disabled, empty]);
+    final res = await generator.generateFromTemplates([enabled, disabled, empty]);
     expect(res.length, 1);
     expect(res.first.sourceTemplateId, '1');
   });
 
   test('generateFromTemplates sorts by priority', () async {
-    final spot = TrainingPackSpot(
-      id: 's1',
-      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
-    );
+    final spot = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
     final high = TrainingPackTemplateV2(
       id: '1',
       name: 'High',
@@ -93,26 +72,16 @@ void main() {
   });
 
   test('estimateDifficulty sets meta', () async {
-    final s1 = TrainingPackSpot(
-      id: 's1',
-      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
-    );
+    final s1 = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
     final s2 = TrainingPackSpot(
       id: 's2',
-      hand: HandData.fromSimpleInput('KdQd', HeroPosition.bb, 20)
-        ..board.addAll(['2h', '3d', '4s']),
+      hand: HandData.fromSimpleInput('KdQd', HeroPosition.bb, 20)..board.addAll(['2h', '3d', '4s']),
     );
     final s3 = TrainingPackSpot(
       id: 's3',
-      hand: HandData.fromSimpleInput('JcJs', HeroPosition.btn, 15)
-        ..board.addAll(['2h', '3d', '4s', '5c']),
+      hand: HandData.fromSimpleInput('JcJs', HeroPosition.btn, 15)..board.addAll(['2h', '3d', '4s', '5c']),
     );
-    final tpl = TrainingPackTemplateV2(
-      id: 't',
-      name: 'T',
-      type: TrainingType.pushfold,
-      spots: [s1, s2, s3],
-    );
+    final tpl = TrainingPackTemplateV2(id: 't', name: 'T', type: TrainingType.pushfold, spots: [s1, s2, s3]);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([tpl]);
     expect(res.first.meta['difficulty'], 3);
@@ -129,12 +98,7 @@ void main() {
         board: ['2h', '3d', '4s', '5c'],
       ),
     );
-    final tpl = TrainingPackTemplateV2(
-      id: 'x',
-      name: 'X',
-      type: TrainingType.pushfold,
-      spots: [spot],
-    );
+    final tpl = TrainingPackTemplateV2(id: 'x', name: 'X', type: TrainingType.pushfold, spots: [spot]);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([tpl]);
     final tags = res.first.tags;
@@ -146,10 +110,7 @@ void main() {
   });
 
   test('generateFromTemplates generates title when empty', () async {
-    final spot = TrainingPackSpot(
-      id: 's1',
-      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
-    );
+    final spot = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
     final tpl = TrainingPackTemplateV2(
       id: 'z',
       name: '',
@@ -162,5 +123,22 @@ void main() {
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([tpl]);
     expect(res.first.name, 'SB Push 10bb (Tournament)');
+  });
+
+  test('generateFromTemplates generates description when empty', () async {
+    final spot = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final tpl = TrainingPackTemplateV2(
+      id: 'y',
+      name: 'T',
+      description: '',
+      type: TrainingType.pushfold,
+      gameType: GameType.tournament,
+      bb: 10,
+      positions: ['sb'],
+      spots: [spot],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.description.isNotEmpty, true);
   });
 }


### PR DESCRIPTION
## Summary
- implement description generator in `PackLibraryGenerator`
- fill descriptions when YAML or templates omit them
- cover new behavior with tests

## Testing
- `dart format -l 120 lib/core/training/generation/pack_library_generator.dart test/pack_library_generator_test.dart test/pack_library_generator_v2_test.dart`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6877679ce8c0832a98d9a3414941959b