### PR TITLE
Implement difficulty estimation

### DIFF
--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -146,7 +146,6 @@ class PackLibraryGenerator {
   }
 
   int _estimateDifficultyFromSpots(List<TrainingPackSpot> spots) {
-    var diff = 1;
     final streets = <int>{};
     final positions = <HeroPosition>{};
     var customStack = false;
@@ -156,11 +155,13 @@ class PackLibraryGenerator {
       final stack = s.hand.stacks['${s.hand.heroIndex}']?.round();
       if (stack != null && stack != 10 && stack != 20) customStack = true;
     }
-    if (streets.length >= 3) diff++;
-    if (positions.length >= 3) diff++;
-    if (customStack) diff++;
-    if (diff > 3) diff = 3;
-    return diff;
+    if (streets.length >= 3 || positions.length >= 3 || customStack) {
+      return 3;
+    }
+    if (streets.length > 1 || positions.length > 1) {
+      return 2;
+    }
+    return 1;
   }
 
   int estimateDifficulty(TrainingPackTemplate template) => _estimateDifficultyFromSpots(template.spots);
@@ -193,7 +194,9 @@ class PackLibraryGenerator {
       }
       if (tags.isNotEmpty) tpl.tags = tags;
       tpl.spotCount = tpl.spots.length;
-      tpl.meta['difficulty'] = estimateDifficulty(tpl);
+      if (tpl.meta['difficulty'] is! int) {
+        tpl.meta['difficulty'] = estimateDifficulty(tpl);
+      }
       tpl.tags = {...tpl.tags, ...autoTags(tpl)}.toList();
       if (tpl.description.isEmpty) {
         tpl.description = generateDescription(tpl);
@@ -211,7 +214,9 @@ class PackLibraryGenerator {
       if (t.name.isEmpty) {
         t.name = _generateTitleV2(t);
       }
-      t.meta['difficulty'] = estimateDifficultyV2(t);
+      if (t.meta['difficulty'] is! int) {
+        t.meta['difficulty'] = estimateDifficultyV2(t);
+      }
       t.tags = {...t.tags, ..._autoTagsV2(t)}.toList();
       if (t.description.isEmpty) {
         t.description = _generateDescriptionV2(t);

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -87,6 +87,44 @@ void main() {
     expect(res.first.meta['difficulty'], 3);
   });
 
+  test('estimateDifficulty medium pack', () async {
+    final s1 = TrainingPackSpot(
+      id: 'm1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final s2 = TrainingPackSpot(
+      id: 'm2',
+      hand: HandData.fromSimpleInput('KdQd', HeroPosition.sb, 10)
+        ..board.addAll(['2h', '3d', '4s']),
+    );
+    final tpl = TrainingPackTemplateV2(
+      id: 'm',
+      name: 'M',
+      type: TrainingType.pushfold,
+      spots: [s1, s2],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['difficulty'], 2);
+  });
+
+  test('estimateDifficulty respects override', () async {
+    final spot = TrainingPackSpot(
+      id: 'o1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final tpl = TrainingPackTemplateV2(
+      id: 'o',
+      name: 'O',
+      type: TrainingType.pushfold,
+      spots: [spot],
+      meta: {'difficulty': 3},
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['difficulty'], 3);
+  });
+
   test('generateFromTemplates adds auto tags', () async {
     final spot = TrainingPackSpot(
       id: 's1',


### PR DESCRIPTION
## Summary
- auto-estimate training pack difficulty from spots
- keep manual difficulty value
- test medium packs and overrides

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877693a713c832aa7e6c6115995c9e3