### PR TITLE
Implement TrainingPackSourceTagger

### DIFF
--- a/lib/core/training/generation/training_pack_source_tagger.dart
+++ b/lib/core/training/generation/training_pack_source_tagger.dart
@@ -1,0 +1,17 @@
+import '../../../models/v2/training_pack_template_v2.dart';
+
+enum PackSource { yaml, auto, gpt, manual }
+
+class TrainingPackSourceTagger {
+  const TrainingPackSourceTagger();
+
+  void tag(
+    TrainingPackTemplateV2 template, {
+    required String source,
+  }) {
+    final current = template.meta['source'];
+    if (current == null || current.toString().isEmpty) {
+      template.meta['source'] = source;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackSourceTagger` for tagging pack source
- use tagger when generating packs from YAML and templates

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776a8774bc832a9058ad0f7a5d135e