### PR TITLE
Add goal field to training packs

### DIFF
--- a/lib/core/training/engine/training_type_engine.dart
+++ b/lib/core/training/engine/training_type_engine.dart
@@ -27,6 +27,7 @@ class PushFoldPackBuilder implements TrainingPackBuilder {
     );
     if (request.title.isNotEmpty) tpl.name = request.title;
     if (request.description.isNotEmpty) tpl.description = request.description;
+    if (request.goal.isNotEmpty) tpl.goal = request.goal;
     if (request.tags.isNotEmpty) tpl.tags = List<String>.from(request.tags);
     tpl.spotCount = tpl.spots.length;
     return TrainingPackTemplateV2.fromTemplate(

--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -7,6 +7,7 @@ class PackGenerationRequest {
   final List<String> positions;
   final String title;
   final String description;
+  final String goal;
   final List<String> tags;
   final int count;
   final String? rangeGroup;
@@ -18,6 +19,7 @@ class PackGenerationRequest {
     required this.positions,
     this.title = '',
     this.description = '',
+    this.goal = '',
     List<String>? tags,
     this.count = 25,
     this.rangeGroup,

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -197,6 +197,7 @@ class PackLibraryGenerator {
         tpl.name = generateTitle(tpl);
       }
       if (r.description.isNotEmpty) tpl.description = r.description;
+      if (r.goal.isNotEmpty) tpl.goal = r.goal;
       final tags = List<String>.from(r.tags);
       if (config.rangeTags && r.rangeGroup != null && r.rangeGroup!.isNotEmpty && !tags.contains(r.rangeGroup)) {
         tags.add(r.rangeGroup!);
@@ -210,6 +211,10 @@ class PackLibraryGenerator {
       if (tpl.description.isEmpty) {
         tpl.description = generateDescription(tpl);
       }
+      if (tpl.goal.isEmpty) {
+        tpl.goal = generateDescription(tpl);
+      }
+      tpl.meta['goal'] = tpl.goal;
       list.add(tpl);
     }
     return list;
@@ -231,6 +236,10 @@ class PackLibraryGenerator {
       if (t.description.isEmpty) {
         t.description = _generateDescriptionV2(t);
       }
+      if (t.goal.isEmpty) {
+        t.goal = _generateDescriptionV2(t);
+      }
+      t.meta['goal'] = t.goal;
       final pack = await engine.generateFromTemplate(t);
       list.add(pack);
     }

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -78,6 +78,7 @@ class PackYamlConfigParser {
               final desc = item['description']?.toString() ?? '';
               return desc.isNotEmpty ? desc : defaultDescription;
             }(),
+            goal: item['goal']?.toString() ?? '',
             tags: () {
               final tags = item.containsKey('tags')
                   ? _readTags(item['tags'])

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -13,6 +13,7 @@ class TrainingPackTemplate {
   String slug;
   String name;
   String description;
+  String goal;
   String category;
   GameType gameType;
   List<TrainingPackSpot> spots;
@@ -51,6 +52,7 @@ class TrainingPackTemplate {
     this.slug = '',
     required this.name,
     this.description = '',
+    this.goal = '',
     this.category = '',
     this.gameType = GameType.tournament,
     List<TrainingPackSpot>? spots,
@@ -97,6 +99,7 @@ class TrainingPackTemplate {
     String? slug,
     String? name,
     String? description,
+    String? goal,
     String? category,
     GameType? gameType,
     List<TrainingPackSpot>? spots,
@@ -134,6 +137,7 @@ class TrainingPackTemplate {
       slug: slug ?? this.slug,
       name: name ?? this.name,
       description: description ?? this.description,
+      goal: goal ?? this.goal,
       category: category ?? this.category,
       gameType: gameType ?? this.gameType,
       spots: spots ?? List<TrainingPackSpot>.from(this.spots),
@@ -175,6 +179,7 @@ class TrainingPackTemplate {
       slug: json['slug'] as String? ?? '',
       name: json['name'] as String? ?? '',
       description: json['description'] as String? ?? '',
+      goal: json['goal'] as String? ?? '',
       category: json['category'] as String? ?? '',
       gameType: parseGameType(json['gameType']),
       spots: [
@@ -236,6 +241,7 @@ class TrainingPackTemplate {
         'slug': slug,
         'name': name,
         'description': description,
+        if (goal.isNotEmpty) 'goal': goal,
         'category': category,
         'gameType': gameType.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -12,6 +12,7 @@ class TrainingPackTemplateV2 {
   final String id;
   String name;
   String description;
+  String goal;
   List<String> tags;
   final TrainingType type;
   List<SpotTemplate> spots;
@@ -26,6 +27,7 @@ class TrainingPackTemplateV2 {
     required this.id,
     required this.name,
     this.description = '',
+    this.goal = '',
     List<String>? tags,
     required this.type,
     List<SpotTemplate>? spots,
@@ -46,6 +48,7 @@ class TrainingPackTemplateV2 {
         id: j['id'] as String? ?? '',
         name: j['name'] as String? ?? '',
         description: j['description'] as String? ?? '',
+        goal: j['goal'] as String? ?? '',
         tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
         type: TrainingType.values.firstWhere(
           (e) => e.name == j['type'],
@@ -67,6 +70,7 @@ class TrainingPackTemplateV2 {
         'id': id,
         'name': name,
         'description': description,
+        if (goal.isNotEmpty) 'goal': goal,
         if (tags.isNotEmpty) 'tags': tags,
         'type': type.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
@@ -93,6 +97,7 @@ class TrainingPackTemplateV2 {
         id: template.id,
         name: template.name,
         description: template.description,
+        goal: template.goal,
         tags: List<String>.from(template.tags),
         type: type,
         spots: List<SpotTemplate>.from(template.spots),

--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -90,4 +90,18 @@ packs:
     final list = generator.generateFromYaml(yaml);
     expect(list.first.description.isNotEmpty, true);
   });
+
+  test('generateFromYaml stores goal', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    goal: Learn push
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.goal, 'Learn push');
+    expect(list.first.meta['goal'], 'Learn push');
+  });
 }

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -179,4 +179,35 @@ void main() {
     final res = await generator.generateFromTemplates([tpl]);
     expect(res.first.description.isNotEmpty, true);
   });
+
+  test('generateFromTemplates stores goal', () async {
+    final spot = TrainingPackSpot(id: 'g1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final tpl = TrainingPackTemplateV2(
+      id: 'g',
+      name: 'T',
+      goal: 'Push practice',
+      type: TrainingType.pushfold,
+      spots: [spot],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['goal'], 'Push practice');
+  });
+
+  test('generateFromTemplates auto generates goal', () async {
+    final spot = TrainingPackSpot(id: 'ag1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final tpl = TrainingPackTemplateV2(
+      id: 'ag',
+      name: 'Auto',
+      goal: '',
+      type: TrainingType.pushfold,
+      gameType: GameType.tournament,
+      bb: 10,
+      positions: ['sb'],
+      spots: [spot],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['goal'], isNotEmpty);
+  });
 }

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -118,6 +118,19 @@ packs:
     expect(list.first.bb, 0);
   });
 
+  test('parse reads goal', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    goal: Learn push
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    expect(config.requests.first.goal, 'Learn push');
+  });
+
   test('parse applies defaultGameType', () {
     const yaml = '''
 defaultGameType: tournament


### PR DESCRIPTION
## Summary
- support `goal` in `PackGenerationRequest`
- parse `goal` from YAML config
- store goal in templates and packs
- auto-generate goal when missing
- tests for new goal functionality

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68776bdaa598832a9b2fa38f9dcd12c2