### PR TITLE
Add audience field to pack templates

### DIFF
--- a/lib/core/training/engine/training_type_engine.dart
+++ b/lib/core/training/engine/training_type_engine.dart
@@ -28,12 +28,15 @@ class PushFoldPackBuilder implements TrainingPackBuilder {
     if (request.title.isNotEmpty) tpl.name = request.title;
     if (request.description.isNotEmpty) tpl.description = request.description;
     if (request.goal.isNotEmpty) tpl.goal = request.goal;
+    if (request.audience.isNotEmpty) tpl.meta['audience'] = request.audience;
     if (request.tags.isNotEmpty) tpl.tags = List<String>.from(request.tags);
     tpl.spotCount = tpl.spots.length;
-    return TrainingPackTemplateV2.fromTemplate(
+    final res = TrainingPackTemplateV2.fromTemplate(
       tpl,
       type: TrainingType.pushfold,
     );
+    res.audience = tpl.meta['audience'] as String?;
+    return res;
   }
 }
 

--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -8,6 +8,7 @@ class PackGenerationRequest {
   final String title;
   final String description;
   final String goal;
+  final String audience;
   final List<String> tags;
   final int count;
   final String? rangeGroup;
@@ -20,6 +21,7 @@ class PackGenerationRequest {
     this.title = '',
     this.description = '',
     this.goal = '',
+    this.audience = '',
     List<String>? tags,
     this.count = 25,
     this.rangeGroup,

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -198,6 +198,7 @@ class PackLibraryGenerator {
       }
       if (r.description.isNotEmpty) tpl.description = r.description;
       if (r.goal.isNotEmpty) tpl.goal = r.goal;
+      if (r.audience.isNotEmpty) tpl.meta['audience'] = r.audience;
       final tags = List<String>.from(r.tags);
       if (config.rangeTags && r.rangeGroup != null && r.rangeGroup!.isNotEmpty && !tags.contains(r.rangeGroup)) {
         tags.add(r.rangeGroup!);
@@ -231,6 +232,9 @@ class PackLibraryGenerator {
       }
       if (t.meta['difficulty'] is! int) {
         t.meta['difficulty'] = estimateDifficultyV2(t);
+      }
+      if (t.audience != null && t.audience!.isNotEmpty) {
+        t.meta['audience'] = t.audience;
       }
       t.tags = {...t.tags, ..._autoTagsV2(t)}.toList();
       if (t.description.isEmpty) {

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -79,6 +79,7 @@ class PackYamlConfigParser {
               return desc.isNotEmpty ? desc : defaultDescription;
             }(),
             goal: item['goal']?.toString() ?? '',
+            audience: item['audience']?.toString() ?? '',
             tags: () {
               final tags = item.containsKey('tags')
                   ? _readTags(item['tags'])

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -13,6 +13,7 @@ class TrainingPackTemplateV2 {
   String name;
   String description;
   String goal;
+  String? audience;
   List<String> tags;
   final TrainingType type;
   List<SpotTemplate> spots;
@@ -28,6 +29,7 @@ class TrainingPackTemplateV2 {
     required this.name,
     this.description = '',
     this.goal = '',
+    this.audience,
     List<String>? tags,
     required this.type,
     List<SpotTemplate>? spots,
@@ -49,6 +51,8 @@ class TrainingPackTemplateV2 {
         name: j['name'] as String? ?? '',
         description: j['description'] as String? ?? '',
         goal: j['goal'] as String? ?? '',
+        audience: j['audience'] as String? ??
+            (j['meta'] is Map ? (j['meta']['audience'] as String?) : null),
         tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
         type: TrainingType.values.firstWhere(
           (e) => e.name == j['type'],
@@ -71,6 +75,7 @@ class TrainingPackTemplateV2 {
         'name': name,
         'description': description,
         if (goal.isNotEmpty) 'goal': goal,
+        if (audience != null && audience!.isNotEmpty) 'audience': audience,
         if (tags.isNotEmpty) 'tags': tags,
         'type': type.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
@@ -98,6 +103,7 @@ class TrainingPackTemplateV2 {
         name: template.name,
         description: template.description,
         goal: template.goal,
+        audience: template.meta['audience'] as String?,
         tags: List<String>.from(template.tags),
         type: type,
         spots: List<SpotTemplate>.from(template.spots),

--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -104,4 +104,17 @@ packs:
     expect(list.first.goal, 'Learn push');
     expect(list.first.meta['goal'], 'Learn push');
   });
+
+  test('generateFromYaml stores audience', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    audience: Beginner
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.meta['audience'], 'Beginner');
+  });
 }

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -194,6 +194,20 @@ void main() {
     expect(res.first.meta['goal'], 'Push practice');
   });
 
+  test('generateFromTemplates stores audience', () async {
+    final spot = TrainingPackSpot(id: 'a1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final tpl = TrainingPackTemplateV2(
+      id: 'a',
+      name: 'T',
+      audience: 'Advanced',
+      type: TrainingType.pushfold,
+      spots: [spot],
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['audience'], 'Advanced');
+  });
+
   test('generateFromTemplates auto generates goal', () async {
     final spot = TrainingPackSpot(id: 'ag1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
     final tpl = TrainingPackTemplateV2(

--- a/test/pack_yaml_config_parser_test.dart
+++ b/test/pack_yaml_config_parser_test.dart
@@ -131,6 +131,19 @@ packs:
     expect(config.requests.first.goal, 'Learn push');
   });
 
+  test('parse reads audience', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    audience: Beginner
+''';
+    final parser = PackYamlConfigParser();
+    final config = parser.parse(yaml);
+    expect(config.requests.first.audience, 'Beginner');
+  });
+
   test('parse applies defaultGameType', () {
     const yaml = '''
 defaultGameType: tournament


### PR DESCRIPTION
## Summary
- parse `audience` in YAML config
- handle `audience` in generation logic
- expose `audience` in `TrainingPackTemplateV2`
- update tests for new field

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776eda44c0832aa88fcbc975bbd248