### PR TITLE
Add recommended field for new templates

### DIFF
--- a/lib/core/training/generation/pack_generation_request.dart
+++ b/lib/core/training/generation/pack_generation_request.dart
@@ -13,6 +13,7 @@ class PackGenerationRequest {
   final int count;
   final String? rangeGroup;
   final bool multiplePositions;
+  final bool recommended;
   const PackGenerationRequest({
     required this.gameType,
     this.bb = 0,
@@ -26,5 +27,6 @@ class PackGenerationRequest {
     this.count = 25,
     this.rangeGroup,
     this.multiplePositions = false,
+    this.recommended = false,
   }) : tags = tags ?? const [];
 }

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -191,6 +191,10 @@ class PackLibraryGenerator {
         source: PackSource.yaml.name,
       );
       tpl.meta['source'] ??= PackSource.yaml.name;
+      if (r.recommended) {
+        tpl.recommended = true;
+        tpl.meta['recommended'] = true;
+      }
       if (r.title.isNotEmpty) {
         tpl.name = r.title;
       } else {
@@ -227,6 +231,7 @@ class PackLibraryGenerator {
       tagger.tag(t, source: PackSource.auto.name);
       if (t.spots.isEmpty) continue;
       if (t.meta['enabled'] == false) continue;
+      if (t.recommended) t.meta['recommended'] = true;
       if (t.name.isEmpty) {
         t.name = _generateTitleV2(t);
       }

--- a/lib/core/training/generation/pack_yaml_config_parser.dart
+++ b/lib/core/training/generation/pack_yaml_config_parser.dart
@@ -91,6 +91,7 @@ class PackYamlConfigParser {
             multiplePositions: item.containsKey('multiplePositions')
                 ? item['multiplePositions'] == true
                 : defaultMultiplePositions,
+            recommended: item['recommended'] == true,
           ),
     ];
     return PackYamlConfig(

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -23,6 +23,7 @@ class TrainingPackTemplateV2 {
   int bb;
   List<String> positions;
   Map<String, dynamic> meta;
+  bool recommended;
 
   TrainingPackTemplateV2({
     required this.id,
@@ -39,6 +40,7 @@ class TrainingPackTemplateV2 {
     this.bb = 0,
     List<String>? positions,
     Map<String, dynamic>? meta,
+    this.recommended = false,
   })  : tags = tags ?? [],
         spots = spots ?? [],
         positions = positions ?? [],
@@ -68,6 +70,8 @@ class TrainingPackTemplateV2 {
         bb: (j['bb'] as num?)?.toInt() ?? 0,
         positions: [for (final p in (j['positions'] as List? ?? [])) p.toString()],
         meta: j['meta'] != null ? Map<String, dynamic>.from(j['meta']) : {},
+        recommended: j['recommended'] as bool? ??
+            (j['meta'] is Map ? j['meta']['recommended'] == true : false),
       );
 
   Map<String, dynamic> toJson() => {
@@ -85,6 +89,7 @@ class TrainingPackTemplateV2 {
         'bb': bb,
         if (positions.isNotEmpty) 'positions': positions,
         if (meta.isNotEmpty) 'meta': meta,
+        if (recommended) 'recommended': true,
       };
 
   factory TrainingPackTemplateV2.fromYaml(String source) {
@@ -113,5 +118,6 @@ class TrainingPackTemplateV2 {
         bb: template.heroBbStack,
         positions: [template.heroPos.name],
         meta: Map<String, dynamic>.from(template.meta),
+        recommended: template.recommended,
       );
 }

--- a/test/pack_library_generator_test.dart
+++ b/test/pack_library_generator_test.dart
@@ -117,4 +117,18 @@ packs:
     final list = generator.generateFromYaml(yaml);
     expect(list.first.meta['audience'], 'Beginner');
   });
+
+  test('generateFromYaml stores recommended', () {
+    const yaml = '''
+packs:
+  - gameType: tournament
+    bb: 10
+    positions: [sb]
+    recommended: true
+''';
+    final generator = PackLibraryGenerator();
+    final list = generator.generateFromYaml(yaml);
+    expect(list.first.recommended, true);
+    expect(list.first.meta['recommended'], true);
+  });
 }

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -224,4 +224,18 @@ void main() {
     final res = await generator.generateFromTemplates([tpl]);
     expect(res.first.meta['goal'], isNotEmpty);
   });
+
+  test('generateFromTemplates stores recommended', () async {
+    final spot = TrainingPackSpot(id: 'r1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
+    final tpl = TrainingPackTemplateV2(
+      id: 'r',
+      name: 'R',
+      type: TrainingType.pushfold,
+      spots: [spot],
+      recommended: true,
+    );
+    final generator = PackLibraryGenerator(packEngine: const FakeEngine());
+    final res = await generator.generateFromTemplates([tpl]);
+    expect(res.first.meta['recommended'], true);
+  });
 }


### PR DESCRIPTION
## Summary
- allow PackGenerationRequest to mark packs as recommended
- parse recommended flag from YAML config
- persist recommended meta during generation
- support recommended field in TrainingPackTemplateV2
- test recommended handling for YAML and template generation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777084a3cc832ab4b9c6994d432d15