### PR TITLE
Add metadata fields to pack index

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -15,6 +15,7 @@ class TrainingPackTemplateV2 {
   String goal;
   String? audience;
   List<String> tags;
+  String? category;
   final TrainingType type;
   List<SpotTemplate> spots;
   int spotCount;
@@ -32,6 +33,7 @@ class TrainingPackTemplateV2 {
     this.goal = '',
     this.audience,
     List<String>? tags,
+    this.category,
     required this.type,
     List<SpotTemplate>? spots,
     this.spotCount = 0,
@@ -45,10 +47,12 @@ class TrainingPackTemplateV2 {
         spots = spots ?? [],
         positions = positions ?? [],
         created = created ?? DateTime.now(),
-        meta = meta ?? {};
+        meta = meta ?? {} {
+    category ??= this.tags.isNotEmpty ? this.tags.first : null;
+  }
 
-  factory TrainingPackTemplateV2.fromJson(Map<String, dynamic> j) =>
-      TrainingPackTemplateV2(
+  factory TrainingPackTemplateV2.fromJson(Map<String, dynamic> j) {
+    final tpl = TrainingPackTemplateV2(
         id: j['id'] as String? ?? '',
         name: j['name'] as String? ?? '',
         description: j['description'] as String? ?? '',
@@ -56,6 +60,7 @@ class TrainingPackTemplateV2 {
         audience: j['audience'] as String? ??
             (j['meta'] is Map ? (j['meta']['audience'] as String?) : null),
         tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
+        category: (j['category'] ?? j['mainTag'])?.toString(),
         type: TrainingType.values.firstWhere(
           (e) => e.name == j['type'],
           orElse: () => TrainingType.pushfold,
@@ -72,7 +77,10 @@ class TrainingPackTemplateV2 {
         meta: j['meta'] != null ? Map<String, dynamic>.from(j['meta']) : {},
         recommended: j['recommended'] as bool? ??
             (j['meta'] is Map ? j['meta']['recommended'] == true : false),
-      );
+    );
+    tpl.category ??= tpl.tags.isNotEmpty ? tpl.tags.first : null;
+    return tpl;
+  }
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -81,6 +89,7 @@ class TrainingPackTemplateV2 {
         if (goal.isNotEmpty) 'goal': goal,
         if (audience != null && audience!.isNotEmpty) 'audience': audience,
         if (tags.isNotEmpty) 'tags': tags,
+        if (category != null && category!.isNotEmpty) 'category': category,
         'type': type.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
         'spotCount': spotCount,
@@ -110,6 +119,7 @@ class TrainingPackTemplateV2 {
         goal: template.goal,
         audience: template.meta['audience'] as String?,
         tags: List<String>.from(template.tags),
+        category: template.tags.isNotEmpty ? template.tags.first : null,
         type: type,
         spots: List<SpotTemplate>.from(template.spots),
         spotCount: template.spotCount,

--- a/test/training_pack_template_v2_from_json_test.dart
+++ b/test/training_pack_template_v2_from_json_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+
+void main() {
+  test('fromJson parses metadata fields', () {
+    final tpl = TrainingPackTemplateV2.fromJson({
+      'id': 't',
+      'name': 'Test',
+      'type': 'pushfold',
+      'tags': ['a', 'b'],
+      'goal': 'Learn',
+      'audience': 'Beginners',
+      'meta': {'x': 1},
+    });
+    expect(tpl.tags, ['a', 'b']);
+    expect(tpl.category, 'a');
+    expect(tpl.goal, 'Learn');
+    expect(tpl.audience, 'Beginners');
+    expect(tpl.meta['x'], 1);
+  });
+
+  test('category falls back to first tag', () {
+    final tpl = TrainingPackTemplateV2.fromJson({
+      'id': 'x',
+      'name': 'X',
+      'type': 'pushfold',
+      'tags': ['m'],
+    });
+    expect(tpl.category, 'm');
+  });
+}

--- a/tool/pack_library_index_generator.dart
+++ b/tool/pack_library_index_generator.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+
+Future<void> main(List<String> args) async {
+  var src = args.isNotEmpty ? args[0] : 'assets/packs/v2';
+  var out = args.length > 1 ? args[1] : 'assets/packs/v2/library_index.json';
+  final dir = Directory(src);
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: $src');
+    exit(1);
+  }
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+      .toList();
+  final reader = const YamlReader();
+  final list = <Map<String, dynamic>>[];
+  for (final file in files) {
+    try {
+      final map = reader.read(await file.readAsString());
+      final tpl = TrainingPackTemplateV2.fromJson(map);
+      list.add({
+        'id': tpl.id,
+        'name': tpl.name,
+        'description': tpl.description,
+        if (tpl.goal.isNotEmpty) 'goal': tpl.goal,
+        if (tpl.audience != null && tpl.audience!.isNotEmpty)
+          'audience': tpl.audience,
+        if (tpl.tags.isNotEmpty) 'tags': tpl.tags,
+        if (tpl.category != null && tpl.category!.isNotEmpty)
+          'mainTag': tpl.category,
+        'type': tpl.type.name,
+        'gameType': tpl.gameType.name,
+        'bb': tpl.bb,
+        'spotCount': tpl.spotCount,
+        if (tpl.positions.isNotEmpty) 'positions': tpl.positions,
+        if (tpl.meta.isNotEmpty) 'meta': tpl.meta,
+      });
+    } catch (_) {}
+  }
+  final file = File(out)..createSync(recursive: true);
+  file.writeAsStringSync(jsonEncode(list));
+  stdout.writeln('Wrote ${list.length} items to ${p.normalize(out)}');
+}


### PR DESCRIPTION
## Summary
- support category in TrainingPackTemplateV2 model
- expose category via JSON/YAML conversion
- generate library index with tags and metadata
- test TrainingPackTemplateV2 parsing

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779bd92244832a9f2fb55ef609228f