### PR TITLE
Implement TagCacheService

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,11 +146,8 @@ Future<void> main() async {
   );
   await EvaluationSettingsService.instance.load();
   await MistakeHintService.instance.load();
-  tagCache = TagCacheService(
-    templates: templateStorage,
-    packs: packStorage,
-  );
-  await tagCache.updateFrom(templateStorage.templates, packStorage.packs);
+  tagCache = TagCacheService();
+  await tagCache.load();
   runApp(
     MultiProvider(
       providers: buildAppProviders(cloud),
@@ -258,8 +255,9 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     if (ctx == null) return;
     final templates = TrainingPackTemplateService.getAllTemplates(ctx);
     final prefs = await SharedPreferences.getInstance();
-    final valid =
-        templates.where((t) => !(prefs.getBool('completed_tpl_${t.id}') ?? false)).toList();
+    final valid = templates
+        .where((t) => !(prefs.getBool('completed_tpl_${t.id}') ?? false))
+        .toList();
     if (valid.isEmpty) {
       Navigator.push(
         ctx,
@@ -274,7 +272,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     final stat = await TrainingPackStatsService.getStats(pinned.id);
     final idx = stat?.lastIndex ?? 0;
     if (completed && idx >= pinned.spots.length - 1) {
-      final rec = await ctx.read<PersonalRecommendationService>().getTopRecommended();
+      final rec =
+          await ctx.read<PersonalRecommendationService>().getTopRecommended();
       if (rec == null) return;
       await ctx.read<TrainingSessionService>().startSession(rec);
     } else {

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -188,10 +188,6 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     await _loadStats();
     await _loadHandsCompleted();
     await _loadWeakCategories();
-    await context.read<TagCacheService>().updateFrom(
-          context.read<TemplateStorageService>().templates,
-          context.read<TrainingPackStorageService>().packs,
-        );
     if (!mounted) return;
     Future.delayed(const Duration(milliseconds: 300), () {
       if (mounted) FocusScope.of(context).requestFocus(_searchFocusNode);
@@ -617,7 +613,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final templates = context.read<TemplateStorageService>().templates;
     final ids = await TrainingPackStatsService.getPopularTemplates();
     final map = {for (final t in templates) t.id: t};
-    final list = [for (final id in ids) if (map[id] != null) map[id]!];
+    final list = [
+      for (final id in ids)
+        if (map[id] != null) map[id]!
+    ];
     if (!mounted) return;
     setState(() {
       _popularIds = ids;
@@ -724,7 +723,9 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   double _progressPercentFor(TrainingPackTemplate t) {
     final stat = _stats[t.id];
     if (stat == null || t.spots.isEmpty) return 0;
-    return ((stat.lastIndex + 1) * 100 / t.spots.length).clamp(0, 100).toDouble();
+    return ((stat.lastIndex + 1) * 100 / t.spots.length)
+        .clamp(0, 100)
+        .toDouble();
   }
 
   int _compareCombinedTrending(TrainingPackTemplate a, TrainingPackTemplate b) {
@@ -801,7 +802,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
   List<v2.TrainingPackTemplate> _applyAudienceFilter(
       List<v2.TrainingPackTemplate> list) {
     if (_audienceFilter == 'all') return list;
-    return [for (final t in list) if (t.audience == _audienceFilter) t];
+    return [
+      for (final t in list)
+        if (t.audience == _audienceFilter) t
+    ];
   }
 
   Widget _buildSortButtons(AppLocalizations l) {
@@ -957,8 +961,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     if (_inProgressOnly) {
       visible = [
         for (final t in visible)
-          if (_progressPercentFor(t) > 0 && _progressPercentFor(t) < 100)
-            t
+          if (_progressPercentFor(t) > 0 && _progressPercentFor(t) < 100) t
       ];
     }
     if (_masteredOnly) {
@@ -1448,26 +1451,26 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           dense: true,
           title: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.name,
-              style: t.isBuiltIn
-                  ? TextStyle(
-                      color: Colors.grey[600],
-                      fontWeight: FontWeight.w500,
-                    )
-                  : null,
-            ),
-            if (t.category != null && t.category!.isNotEmpty)
+            children: [
               Text(
-                translateCategory(t.category),
-                style: const TextStyle(fontSize: 12, color: Colors.grey),
+                t.name,
+                style: t.isBuiltIn
+                    ? TextStyle(
+                        color: Colors.grey[600],
+                        fontWeight: FontWeight.w500,
+                      )
+                    : null,
               ),
-            handsProgress(),
-            progress(),
-            if (tags.isNotEmpty) tagsWidget,
-          ],
-        ),
+              if (t.category != null && t.category!.isNotEmpty)
+                Text(
+                  translateCategory(t.category),
+                  style: const TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              handsProgress(),
+              progress(),
+              if (tags.isNotEmpty) tagsWidget,
+            ],
+          ),
           onTap: () async {
             final create = await showDialog<bool>(
               context: context,
@@ -1926,8 +1929,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final continueList = [
       for (final t in nonFavRest)
         if (_progressPercentFor(t) >= 1 && _progressPercentFor(t) < 100) t
-    ]
-      ..sort((a, b) {
+    ]..sort((a, b) {
         final ad = a.lastTrainedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
         final bd = b.lastTrainedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
         return bd.compareTo(ad);
@@ -1974,8 +1976,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final masteredProgress = [
       for (final t in templates)
         if (_progressPercentFor(t) == 100) t
-    ]
-      ..sort((a, b) {
+    ]..sort((a, b) {
         final ad = a.lastTrainedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
         final bd = b.lastTrainedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
         return bd.compareTo(ad);
@@ -2617,7 +2618,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                               Expanded(
                                 child: Text(
                                   'Library: '
-                                      '${_audienceFilter == 'all' ? 'All' : _audienceFilter}',
+                                  '${_audienceFilter == 'all' ? 'All' : _audienceFilter}',
                                   style:
                                       Theme.of(context).textTheme.titleMedium,
                                 ),
@@ -2626,18 +2627,22 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                                 value: _audienceFilter,
                                 dropdownColor: Colors.grey[900],
                                 underline: const SizedBox.shrink(),
-                                onChanged: (v) => v != null ? _setAudience(v) : null,
+                                onChanged: (v) =>
+                                    v != null ? _setAudience(v) : null,
                                 items: const [
                                   DropdownMenuItem(
                                       value: 'all', child: Text('All')),
                                   DropdownMenuItem(
-                                      value: 'Beginner', child: Text('Beginner')),
+                                      value: 'Beginner',
+                                      child: Text('Beginner')),
                                   DropdownMenuItem(
                                       value: 'Intermediate',
                                       child: Text('Intermediate')),
                                   DropdownMenuItem(
-                                      value: 'Advanced', child: Text('Advanced')),
-                                  DropdownMenuItem(value: 'Pro', child: Text('Pro')),
+                                      value: 'Advanced',
+                                      child: Text('Advanced')),
+                                  DropdownMenuItem(
+                                      value: 'Pro', child: Text('Pro')),
                                 ],
                               ),
                             ],
@@ -2663,12 +2668,11 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                               ],
                             ),
                           ),
-                        for (final tag in librarySections)
-                          ...[
-                            ListTile(title: Text(tag)),
-                            for (final t in libraryMap[tag]!) _libraryTile(t),
-                            if (tag != librarySections.last) const Divider(),
-                          ],
+                        for (final tag in librarySections) ...[
+                          ListTile(title: Text(tag)),
+                          for (final t in libraryMap[tag]!) _libraryTile(t),
+                          if (tag != librarySections.last) const Divider(),
+                        ],
                         if (user.isNotEmpty) const Divider(),
                       ] else if (filteringActive) ...[
                         _emptyTile,

--- a/lib/services/tag_cache_service.dart
+++ b/lib/services/tag_cache_service.dart
@@ -1,78 +1,47 @@
-import 'package:flutter/foundation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
 
-import '../models/training_pack.dart';
-import '../models/training_pack_template.dart';
-import 'template_storage_service.dart';
-import 'training_pack_storage_service.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
 class TagCacheService extends ChangeNotifier {
-  static const _tagsKey = 'tag_cache_tags';
-  static const _catsKey = 'tag_cache_cats';
+  TagCacheService._();
+  static final TagCacheService instance = TagCacheService._();
+  factory TagCacheService() => instance;
 
-  final TemplateStorageService templates;
-  final TrainingPackStorageService packs;
-  List<String> _popularTags = [];
-  List<String> _popularCategories = [];
+  Map<String, int> topTags = {};
+  Map<String, int> topCategories = {};
+  bool _loaded = false;
 
-  List<String> get popularTags => List.unmodifiable(_popularTags);
-  List<String> get popularCategories => List.unmodifiable(_popularCategories);
+  List<String> get popularTags => List.unmodifiable(topTags.keys);
+  List<String> get popularCategories => List.unmodifiable(topCategories.keys);
 
-  TagCacheService({required this.templates, required this.packs}) {
-    templates.addListener(_update);
-    packs.addListener(_update);
-    _load();
-    _update();
-  }
-
-  Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
-    _popularTags = prefs.getStringList(_tagsKey) ?? [];
-    _popularCategories = prefs.getStringList(_catsKey) ?? [];
-  }
-
-  Future<void> updateFrom(
-      List<TrainingPackTemplate> tpls, List<TrainingPack> packsList) async {
-    final tagCounts = <String, int>{};
-    final catCounts = <String, int>{};
-    for (final t in tpls) {
-      for (final tag in t.tags) {
-        tagCounts.update(tag, (v) => v + 1, ifAbsent: () => 1);
-      }
-      for (final h in t.hands) {
-        final c = h.category;
-        if (c != null && c.isNotEmpty) {
-          catCounts.update(c, (v) => v + 1, ifAbsent: () => 1);
-        }
-      }
+  Future<void> load() async {
+    if (_loaded) return;
+    _loaded = true;
+    try {
+      final raw =
+          await rootBundle.loadString('assets/packs/v2/tag_frequencies.json');
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      topTags = Map<String, int>.from(
+        (data['tags'] as Map).map(
+          (k, v) => MapEntry(k.toString(), (v as num).toInt()),
+        ),
+      );
+      topCategories = Map<String, int>.from(
+        (data['categories'] as Map).map(
+          (k, v) => MapEntry(k.toString(), (v as num).toInt()),
+        ),
+      );
+    } catch (_) {
+      topTags = {};
+      topCategories = {};
     }
-    for (final p in packsList) {
-      for (final tag in p.tags) {
-        tagCounts.update(tag, (v) => v + 1, ifAbsent: () => 1);
-      }
-      final c = p.category;
-      if (c.isNotEmpty) {
-        catCounts.update(c, (v) => v + 1, ifAbsent: () => 1);
-      }
-    }
-    final tags = tagCounts.keys.toList()
-      ..sort((a, b) => tagCounts[b]!.compareTo(tagCounts[a]!));
-    final cats = catCounts.keys.toList()
-      ..sort((a, b) => catCounts[b]!.compareTo(catCounts[a]!));
-    _popularTags = tags.take(20).toList();
-    _popularCategories = cats.take(20).toList();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_tagsKey, _popularTags);
-    await prefs.setStringList(_catsKey, _popularCategories);
     notifyListeners();
   }
 
-  Future<void> _update() => updateFrom(templates.templates, packs.packs);
+  List<String> getPopularTags({int limit = 10}) =>
+      topTags.keys.take(limit).toList();
 
-  @override
-  void dispose() {
-    templates.removeListener(_update);
-    packs.removeListener(_update);
-    super.dispose();
-  }
+  List<String> getPopularCategories({int limit = 5}) =>
+      topCategories.keys.take(limit).toList();
 }


### PR DESCRIPTION
## Summary
- add TagCacheService for quick access to tag frequencies
- load cache on startup
- remove manual cache rebuild in template library

## Testing
- `dart format lib/services/tag_cache_service.dart lib/screens/template_library_screen.dart lib/main.dart`
- `flutter analyze` *(fails: 6559 issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_6877aa5ad4bc832aa8057f576919de57