### PR TITLE
Implement fixed tag order

### DIFF
--- a/lib/services/tag_cache_service.dart
+++ b/lib/services/tag_cache_service.dart
@@ -4,6 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 class TagCacheService extends ChangeNotifier {
+  static const kFixedTagOrder = [
+    'Push/Fold',
+    'ICM',
+    'Blind Defense',
+  ];
   TagCacheService._();
   static final TagCacheService instance = TagCacheService._();
   factory TagCacheService() => instance;
@@ -12,7 +17,7 @@ class TagCacheService extends ChangeNotifier {
   Map<String, int> topCategories = {};
   bool _loaded = false;
 
-  List<String> get popularTags => List.unmodifiable(topTags.keys);
+  List<String> get popularTags => List.unmodifiable(_sortedTags());
   List<String> get popularCategories => List.unmodifiable(topCategories.keys);
 
   Future<void> load() async {
@@ -40,8 +45,28 @@ class TagCacheService extends ChangeNotifier {
   }
 
   List<String> getPopularTags({int limit = 10}) =>
-      topTags.keys.take(limit).toList();
+      _sortedTags(limit: limit);
 
   List<String> getPopularCategories({int limit = 5}) =>
       topCategories.keys.take(limit).toList();
+
+  List<String> _sortedTags({int? limit}) {
+    final map = {
+      for (var i = 0; i < kFixedTagOrder.length; i++) kFixedTagOrder[i]: i
+    };
+    final list = topTags.entries.toList()
+      ..sort((a, b) {
+        final ai = map[a.key];
+        final bi = map[b.key];
+        if (ai != null || bi != null) {
+          if (ai == null) return 1;
+          if (bi == null) return -1;
+          return ai.compareTo(bi);
+        }
+        final c = b.value.compareTo(a.value);
+        if (c != 0) return c;
+        return a.key.compareTo(b.key);
+      });
+    return [for (final e in list.take(limit ?? list.length)) e.key];
+  }
 }


### PR DESCRIPTION
## Summary
- prioritize selected tags by creating a fixed order list
- sort tags with the fixed order before falling back to frequency

## Testing
- ❌ `flutter test --run-skipped` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b899eef4832aa84300a29fb40f79