### PR TITLE
Automate tag frequency update

### DIFF
--- a/lib/services/pack_batch_generator_service.dart
+++ b/lib/services/pack_batch_generator_service.dart
@@ -7,6 +7,7 @@ import '../core/error_logger.dart';
 import '../core/training/generation/gpt_pack_template_generator.dart';
 import '../core/training/generation/pack_yaml_config_parser.dart';
 import 'pack_matrix_config.dart';
+import 'tag_frequency_analyzer.dart';
 
 class PackBatchGeneratorService {
   const PackBatchGeneratorService({required this.gpt, PackYamlConfigParser? parser})
@@ -50,6 +51,7 @@ class PackBatchGeneratorService {
         ErrorLogger.instance.logError('Pack gen error', e as Object?);
       }
     }
+    await const TagFrequencyAnalyzer().generate();
     return success;
   }
 }

--- a/lib/services/tag_frequency_analyzer.dart
+++ b/lib/services/tag_frequency_analyzer.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:path/path.dart' as p;
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TagFrequencyAnalyzer {
+  const TagFrequencyAnalyzer();
+
+  Future<void> generate({
+    String src = 'assets/packs/v2',
+    String out = 'assets/packs/v2/tag_frequencies.json',
+  }) async {
+    final tagCounts = <String, int>{};
+    final categoryCounts = <String, int>{};
+    void addTag(String tag) => tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
+    void addCategory(String tag) =>
+        categoryCounts[tag] = (categoryCounts[tag] ?? 0) + 1;
+    var processed = false;
+    final indexFile = File(p.join(src, 'library_index.json'));
+    if (indexFile.existsSync()) {
+      try {
+        final list = jsonDecode(await indexFile.readAsString());
+        if (list is List) {
+          for (final item in list) {
+            if (item is Map) {
+              for (final t in item['tags'] as List? ?? []) {
+                addTag(t.toString());
+              }
+              final c = (item['mainTag'] ?? item['category'])?.toString();
+              if (c != null && c.isNotEmpty) addCategory(c);
+            }
+          }
+          processed = true;
+        }
+      } catch (_) {}
+    }
+    if (!processed) {
+      final dir = Directory(src);
+      if (dir.existsSync()) {
+        const reader = YamlReader();
+        final files = dir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+        for (final f in files) {
+          try {
+            final map = reader.read(await f.readAsString());
+            final tpl = TrainingPackTemplateV2.fromJson(map);
+            for (final t in tpl.tags) addTag(t);
+            final c = tpl.category ??
+                (tpl.tags.isNotEmpty ? tpl.tags.first : null);
+            if (c != null && c.isNotEmpty) addCategory(c);
+            processed = true;
+          } catch (_) {}
+        }
+      }
+    }
+    final sortedTags = Map.fromEntries(tagCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value)));
+    final sortedCategories = Map.fromEntries(categoryCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value)));
+    final file = File(out)..createSync(recursive: true);
+    file.writeAsStringSync(
+      jsonEncode({'tags': sortedTags, 'categories': sortedCategories}),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add tag frequency analyzer service
- run analyzer after pack library generation to refresh tag data

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba99f6ec832a87e607d50c2e8aab