### PR TITLE
Add library index writer

### DIFF
--- a/lib/services/pack_batch_generator_service.dart
+++ b/lib/services/pack_batch_generator_service.dart
@@ -8,6 +8,7 @@ import '../core/training/generation/gpt_pack_template_generator.dart';
 import '../core/training/generation/pack_yaml_config_parser.dart';
 import 'pack_matrix_config.dart';
 import 'tag_frequency_analyzer.dart';
+import 'training_pack_index_writer.dart';
 
 class PackBatchGeneratorService {
   const PackBatchGeneratorService({required this.gpt, PackYamlConfigParser? parser})
@@ -51,6 +52,7 @@ class PackBatchGeneratorService {
         ErrorLogger.instance.logError('Pack gen error', e as Object?);
       }
     }
+    await const TrainingPackIndexWriter().writeIndex();
     await const TagFrequencyAnalyzer().generate();
     return success;
   }

--- a/lib/services/training_pack_index_writer.dart
+++ b/lib/services/training_pack_index_writer.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackIndexWriter {
+  const TrainingPackIndexWriter();
+
+  Future<void> writeIndex({
+    String src = 'assets/packs/v2',
+    String out = 'assets/packs/v2/library_index.json',
+  }) async {
+    final dir = Directory(src);
+    if (!dir.existsSync()) return;
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    final reader = const YamlReader();
+    final list = <Map<String, dynamic>>[];
+    for (final file in files) {
+      try {
+        final map = reader.read(await file.readAsString());
+        final tpl = TrainingPackTemplateV2.fromJson(map);
+        list.add({
+          'title': tpl.name,
+          if (tpl.tags.isNotEmpty) 'tags': tpl.tags,
+          if (tpl.audience != null && tpl.audience!.isNotEmpty)
+            'audience': tpl.audience,
+          if (tpl.category != null && tpl.category!.isNotEmpty)
+            'mainTag': tpl.category,
+          if (tpl.goal.isNotEmpty) 'goal': tpl.goal,
+          'path': p.relative(file.path, from: src),
+        });
+      } catch (_) {}
+    }
+    final file = File(out)..createSync(recursive: true);
+    await file.writeAsString(jsonEncode(list), flush: true);
+  }
+}


### PR DESCRIPTION
## Summary
- generate a training pack index after building the YAML library
- write the index into assets/packs/v2/library_index.json

## Testing
- `dart` not available in container

------
https://chatgpt.com/codex/tasks/task_e_6877bf7c22c0832ab6e1b9a5a64948fc