### PR TITLE
Implement Markdown index generation

### DIFF
--- a/lib/services/training_pack_index_writer.dart
+++ b/lib/services/training_pack_index_writer.dart
@@ -11,6 +11,7 @@ class TrainingPackIndexWriter {
   Future<void> writeIndex({
     String src = 'assets/packs/v2',
     String out = 'assets/packs/v2/library_index.json',
+    String md = 'assets/packs/v2/library_index.md',
   }) async {
     final dir = Directory(src);
     if (!dir.existsSync()) return;
@@ -39,5 +40,19 @@ class TrainingPackIndexWriter {
     }
     final file = File(out)..createSync(recursive: true);
     await file.writeAsString(jsonEncode(list), flush: true);
+
+    final mdFile = File(md)..createSync(recursive: true);
+    final buffer = StringBuffer()
+      ..writeln('|Название|Аудитория|Основной тег|Цель|Теги|')
+      ..writeln('|---|---|---|---|---|');
+    for (final item in list) {
+      final title = (item['title'] ?? '').toString().replaceAll('|', '\\|');
+      final audience = (item['audience'] ?? '').toString().replaceAll('|', '\\|');
+      final mainTag = (item['mainTag'] ?? '').toString().replaceAll('|', '\\|');
+      final goal = (item['goal'] ?? '').toString().replaceAll('|', '\\|');
+      final tags = (item['tags'] as List?)?.join(', ').replaceAll('|', '\\|') ?? '';
+      buffer.writeln('|$title|$audience|$mainTag|$goal|$tags|');
+    }
+    await mdFile.writeAsString(buffer.toString(), flush: true);
   }
 }


### PR DESCRIPTION
## Summary
- generate a Markdown `library_index.md` alongside `library_index.json`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: `Unable to locate package dart`)*
- `flutter --version` *(failed: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6877c0b696b0832a86fbb4d2ba4406db