### PR TITLE
Add YAML library viewer

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -13,6 +13,7 @@ import '../services/tag_service.dart';
 import '../services/pack_batch_generator_service.dart';
 import '../ui/tools/training_pack_yaml_previewer.dart';
 import '../services/training_coverage_service.dart';
+import 'yaml_library_preview_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -339,6 +340,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📊 Покрытие тем (coverage_report.json)'),
                 onTap: _exportCoverage,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📂 Просмотр YAML паков'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const YamlLibraryPreviewScreen(),
+                    ),
+                  );
+                },
               ),
             ],
           ),

--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+import '../theme/app_colors.dart';
+import 'yaml_viewer_screen.dart';
+
+class YamlLibraryPreviewScreen extends StatefulWidget {
+  const YamlLibraryPreviewScreen({super.key});
+
+  @override
+  State<YamlLibraryPreviewScreen> createState() => _YamlLibraryPreviewScreenState();
+}
+
+class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
+  final List<File> _files = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final libDir = Directory('${dir.path}/training_packs/library');
+    final list = libDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    list.sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+    if (mounted) {
+      setState(() {
+        _files
+          ..clear()
+          ..addAll(list);
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _open(File file) async {
+    final yaml = await file.readAsString();
+    final name = file.path.split(Platform.pathSeparator).last;
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => YamlViewerScreen(yamlText: yaml, title: name),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('YAML Library')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: _files.length,
+              itemBuilder: (_, i) {
+                final f = _files[i];
+                final name = f.path.split(Platform.pathSeparator).last;
+                final date = DateFormat('yyyy-MM-dd HH:mm').format(f.statSync().modified);
+                return ListTile(
+                  title: Text(name),
+                  subtitle: Text(date),
+                  onTap: () => _open(f),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/yaml_viewer_screen.dart
+++ b/lib/screens/yaml_viewer_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../theme/app_colors.dart';
+
+class YamlViewerScreen extends StatelessWidget {
+  final String yamlText;
+  final String title;
+  const YamlViewerScreen({super.key, required this.yamlText, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.copy),
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: yamlText));
+              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Copied')));
+            },
+          ),
+        ],
+      ),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: SelectableText(yamlText, style: const TextStyle(color: Colors.white)),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- preview YAML pack library in debug builds
- view YAML files from `training_packs/library`
- open YAML viewer from the dev menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c441f698832a9b76a5eb153c5edf