### PR TITLE
Add YAML validation tool

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -13,6 +13,7 @@ import '../services/tag_service.dart';
 import '../services/pack_batch_generator_service.dart';
 import '../ui/tools/training_pack_yaml_previewer.dart';
 import '../services/training_coverage_service.dart';
+import '../services/yaml_validation_service.dart';
 import 'yaml_library_preview_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
@@ -277,6 +278,33 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
         .showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
   }
 
+  Future<void> _validateYaml() async {
+    if (!kDebugMode) return;
+    final errors = await compute(_validateYamlTask, '');
+    if (!mounted) return;
+    if (errors.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Ошибок нет')));
+      return;
+    }
+    final text = errors.map((e) => '${e.$1}: ${e.$2}').join('\n');
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        content: SingleChildScrollView(
+          child: Text(text, style: const TextStyle(color: Colors.white)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -343,6 +371,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
+                title: const Text('Проверка YAML'),
+                onTap: _validateYaml,
+              ),
+            if (kDebugMode)
+              ListTile(
                 title: const Text('📂 Просмотр YAML паков'),
                 onTap: () {
                   Navigator.push(
@@ -367,4 +400,8 @@ Future<bool> _coverageTask(String _) async {
   } catch (_) {
     return false;
   }
+}
+
+Future<List<(String, String)>> _validateYamlTask(String _) async {
+  return const YamlValidationService().validateAll();
 }

--- a/lib/services/yaml_validation_service.dart
+++ b/lib/services/yaml_validation_service.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class YamlValidationService {
+  const YamlValidationService();
+
+  Future<List<(String, String)>> validateAll({String dir = 'assets/packs/v2'}) async {
+    final errors = <(String, String)>[];
+    final directory = Directory(dir);
+    if (!directory.existsSync()) return errors;
+    const reader = YamlReader();
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+    for (final f in files) {
+      try {
+        final map = reader.read(await f.readAsString());
+        TrainingPackTemplateV2.fromJson(map);
+      } catch (e) {
+        errors.add((f.path, e.toString()));
+      }
+    }
+    return errors;
+  }
+}


### PR DESCRIPTION
## Summary
- add service to validate YAML training packs
- expose YAML validation in DevMenuScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c54c89cc832a995bc67563d43cb7