### PR TITLE
Add library health screen

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -15,6 +15,7 @@ import '../ui/tools/training_pack_yaml_previewer.dart';
 import '../services/training_coverage_service.dart';
 import '../services/yaml_validation_service.dart';
 import 'yaml_library_preview_screen.dart';
+import 'pack_library_health_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -373,6 +374,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('Проверка YAML'),
                 onTap: _validateYaml,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📋 Проверка библиотеки'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PackLibraryHealthScreen(),
+                    ),
+                  );
+                },
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/screens/pack_library_health_screen.dart
+++ b/lib/screens/pack_library_health_screen.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../services/yaml_validation_service.dart';
+import '../theme/app_colors.dart';
+
+class PackLibraryHealthScreen extends StatefulWidget {
+  const PackLibraryHealthScreen({super.key});
+
+  @override
+  State<PackLibraryHealthScreen> createState() => _PackLibraryHealthScreenState();
+}
+
+class _PackLibraryHealthScreenState extends State<PackLibraryHealthScreen> {
+  bool _loading = true;
+  final List<List<String>> _topics = [];
+  final List<List<String>> _errors = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final coverage =
+        await compute(_loadCoverageTask, 'assets/packs/v2/coverage_report.json');
+    final errors = await compute(_validateYamlTask, '');
+    if (!mounted) return;
+    _topics
+      ..clear()
+      ..addAll([
+        for (final m in coverage['missing'] as List<List<String>>) [...m, 'miss'],
+        for (final w in coverage['weak'] as List<List<String>>) [...w, 'weak'],
+      ]);
+    _errors
+      ..clear()
+      ..addAll(errors.cast<List<String>>());
+    setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Проверка библиотеки')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                ElevatedButton(
+                  onPressed: _load,
+                  child: const Text('🔄 Обновить'),
+                ),
+                const SizedBox(height: 16),
+                DataTable(
+                  columns: const [
+                    DataColumn(label: Text('Audience')),
+                    DataColumn(label: Text('Tag')),
+                    DataColumn(label: Text('Status')),
+                  ],
+                  rows: [
+                    for (final t in _topics)
+                      DataRow(cells: [
+                        DataCell(Text(t[0])),
+                        DataCell(Text(t[1])),
+                        DataCell(Text(t[2] == 'miss' ? 'missing' : 'weak')),
+                      ]),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                for (final e in _errors)
+                  ListTile(
+                    title: Text(e[0]),
+                    subtitle: Text(e[1]),
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+Future<Map<String, List<List<String>>>> _loadCoverageTask(String path) async {
+  final file = File(path);
+  if (!file.existsSync()) return {'missing': [], 'weak': []};
+  final data = jsonDecode(await file.readAsString());
+  final missing = <List<String>>[];
+  final weak = <List<String>>[];
+  if (data is Map) {
+    final m = data['missing'];
+    if (m is List) {
+      for (final item in m) {
+        if (item is Map) {
+          final a = item['audience']?.toString();
+          final t = item['tag']?.toString();
+          if (a != null && t != null) missing.add([a, t]);
+        }
+      }
+    }
+    final w = data['weak'];
+    if (w is List) {
+      for (final item in w) {
+        if (item is Map) {
+          final a = item['audience']?.toString();
+          final t = item['tag']?.toString();
+          if (a != null && t != null) weak.add([a, t]);
+        }
+      }
+    }
+  }
+  return {'missing': missing, 'weak': weak};
+}
+
+Future<List<List<String>>> _validateYamlTask(String _) async {
+  final res = await const YamlValidationService().validateAll();
+  return [for (final e in res) [e.$1, e.$2]];
+}
+


### PR DESCRIPTION
## Summary
- add `PackLibraryHealthScreen` for reviewing pack library coverage and YAML errors
- link the new screen from `DevMenuScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c8d538fc832a98750593ccbfbecf