### PR TITLE
Add pack library import from external directory

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -14,6 +14,7 @@ import '../services/pack_batch_generator_service.dart';
 import '../ui/tools/training_pack_yaml_previewer.dart';
 import '../services/training_coverage_service.dart';
 import '../services/yaml_validation_service.dart';
+import '../services/pack_library_import_service.dart';
 import 'yaml_library_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 
@@ -28,6 +29,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _loading = false;
   bool _batchLoading = false;
   bool _libraryLoading = false;
+  bool _importLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -271,6 +273,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _libraryLoading = false);
   }
 
+  Future<void> _importPacks() async {
+    if (_importLoading || !kDebugMode) return;
+    setState(() => _importLoading = true);
+    final res = await const PackLibraryImportService().importFromExternalDir();
+    if (!mounted) return;
+    setState(() => _importLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Импортировано: ${res.success}, ошибок: ${res.failed}')),
+    );
+  }
+
   Future<void> _exportCoverage() async {
     if (!kDebugMode) return;
     final ok = await compute(_coverageTask, '');
@@ -374,6 +387,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('Проверка YAML'),
                 onTap: _validateYaml,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⬇ Импортировать паки из /import'),
+                onTap: _importLoading ? null : _importPacks,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/pack_library_import_service.dart
+++ b/lib/services/pack_library_import_service.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_pack_index_writer.dart';
+
+class PackLibraryImportService {
+  const PackLibraryImportService();
+
+  Future<(int success, int failed)> importFromExternalDir([
+    String path = '/import',
+  ]) async {
+    if (!kDebugMode) return (0, 0);
+    final srcDir = Directory(path);
+    if (!srcDir.existsSync()) return (0, 0);
+    final docs = await getApplicationDocumentsDirectory();
+    final libDir = Directory('${docs.path}/training_packs/library');
+    await libDir.create(recursive: true);
+    final existingFiles = libDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    final names = <String>{
+      for (final f in existingFiles)
+        f.path.split(Platform.pathSeparator).last,
+    };
+    final hashes = <String>{
+      for (final f in existingFiles)
+        md5.convert(f.readAsBytesSync()).toString(),
+    };
+    var success = 0;
+    var failed = 0;
+    for (final f in srcDir
+        .listSync()
+        .whereType<File>()
+        .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+      final name = f.path.split(Platform.pathSeparator).last;
+      if (names.contains(name)) continue;
+      try {
+        final bytes = await f.readAsBytes();
+        final hash = md5.convert(bytes).toString();
+        if (hashes.contains(hash)) continue;
+        final map = const YamlReader().read(utf8.decode(bytes));
+        TrainingPackTemplateV2.fromJson(map);
+        await File(p.join(libDir.path, name)).writeAsBytes(bytes, flush: true);
+        names.add(name);
+        hashes.add(hash);
+        success++;
+      } catch (_) {
+        failed++;
+      }
+    }
+    await const TrainingPackIndexWriter().writeIndex(
+      src: libDir.path,
+      out: p.join(libDir.path, 'library_index.json'),
+      md: p.join(libDir.path, 'library_index.md'),
+    );
+    return (success, failed);
+  }
+}


### PR DESCRIPTION
## Summary
- create `PackLibraryImportService` to import YAML packs from `/import`
- integrate import option in `DevMenuScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877cb37f304832a9f1e8170de4aa536