### PR TITLE
Add PackLibraryExportService

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -15,6 +15,7 @@ import '../ui/tools/training_pack_yaml_previewer.dart';
 import '../services/training_coverage_service.dart';
 import '../services/yaml_validation_service.dart';
 import '../services/pack_library_import_service.dart';
+import '../services/pack_library_export_service.dart';
 import 'yaml_library_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 
@@ -30,6 +31,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _batchLoading = false;
   bool _libraryLoading = false;
   bool _importLoading = false;
+  bool _exportLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -319,6 +321,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
   }
 
+  Future<void> _exportLibrary() async {
+    if (_exportLoading || !kDebugMode) return;
+    setState(() => _exportLoading = true);
+    final count = await const PackLibraryExportService().exportAll();
+    if (!mounted) return;
+    setState(() => _exportLoading = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -392,6 +404,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⬇ Импортировать паки из /import'),
                 onTap: _importLoading ? null : _importPacks,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📤 Экспортировать библиотеку'),
+                onTap: _exportLoading ? null : _exportLibrary,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/pack_library_export_service.dart
+++ b/lib/services/pack_library_export_service.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'yaml_validation_service.dart';
+
+class PackLibraryExportService {
+  const PackLibraryExportService();
+
+  Future<int> exportAll({String target = '/export'}) async {
+    if (!kDebugMode) return 0;
+    final docs = await getApplicationDocumentsDirectory();
+    final libDir = Directory('${docs.path}/training_packs/library');
+    if (!libDir.existsSync()) return 0;
+    final dst = Directory(target);
+    await dst.create(recursive: true);
+    final errors = await const YamlValidationService().validateAll(dir: libDir.path);
+    final invalid = {for (final e in errors) File(e.$1).path};
+    var count = 0;
+    for (final f in libDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))) {
+      if (invalid.contains(f.path)) continue;
+      await f.copy(p.join(dst.path, p.basename(f.path)));
+      count++;
+    }
+    for (final name in ['library_index.json', 'coverage_report.json']) {
+      final f = File(p.join(libDir.path, name));
+      if (f.existsSync()) {
+        await f.copy(p.join(dst.path, name));
+      }
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary
- export YAML library via new PackLibraryExportService
- expose export option in the DevMenu for debug builds

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6877cc503c54832abf50dc8253915a4c