### PR TITLE
Implement PackLibraryMergeService

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -17,6 +17,7 @@ import '../services/yaml_validation_service.dart';
 import '../services/pack_library_import_service.dart';
 import '../services/pack_library_export_service.dart';
 import '../services/pack_library_duplicate_cleaner.dart';
+import '../services/pack_library_merge_service.dart';
 import 'yaml_library_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
@@ -35,6 +36,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _importLoading = false;
   bool _exportLoading = false;
   bool _cleanLoading = false;
+  bool _mergeLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -345,6 +347,19 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
         .showSnackBar(SnackBar(content: Text('Удалено: $count')));
   }
 
+  Future<void> _mergeLibraries() async {
+    if (_mergeLoading || !kDebugMode) return;
+    setState(() => _mergeLoading = true);
+    final res = await const PackLibraryMergeService().mergeAll(
+      ['/import_a', '/import_b'],
+    );
+    if (!mounted) return;
+    setState(() => _mergeLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Объединено: ${res.success}, ошибок: ${res.failed}')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -428,6 +443,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🧹 Очистить дубликаты'),
                 onTap: _cleanLoading ? null : _cleanDuplicates,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📦 Объединить библиотеки'),
+                onTap: _mergeLoading ? null : _mergeLibraries,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/pack_library_merge_service.dart
+++ b/lib/services/pack_library_merge_service.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_pack_index_writer.dart';
+
+class PackLibraryMergeService {
+  const PackLibraryMergeService();
+
+  Future<(int success, int failed)> mergeAll(
+    List<String> paths, {
+    bool clean = false,
+  }) async {
+    if (!kDebugMode) return (0, 0);
+    final docs = await getApplicationDocumentsDirectory();
+    final libDir = Directory('${docs.path}/training_packs/library');
+    await libDir.create(recursive: true);
+    if (clean) {
+      for (final f in libDir
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+        try {
+          f.deleteSync();
+        } catch (_) {}
+      }
+    }
+    final hashes = <String>{};
+    final ids = <String>{};
+    const reader = YamlReader();
+    for (final f in libDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+      try {
+        final bytes = await f.readAsBytes();
+        hashes.add(sha1.convert(bytes).toString());
+        final map = reader.read(utf8.decode(bytes));
+        final id = map['id']?.toString();
+        if (id != null && id.isNotEmpty) ids.add(id);
+      } catch (_) {}
+    }
+    var success = 0;
+    var failed = 0;
+    for (final path in paths) {
+      final dir = Directory(path);
+      if (!dir.existsSync()) continue;
+      for (final f in dir
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+        try {
+          final bytes = await f.readAsBytes();
+          final hash = sha1.convert(bytes).toString();
+          if (hashes.contains(hash)) continue;
+          final map = reader.read(utf8.decode(bytes));
+          final tpl = TrainingPackTemplateV2.fromJson(map);
+          if (ids.contains(tpl.id)) continue;
+          final dst = File(p.join(libDir.path, p.basename(f.path)));
+          await dst.writeAsBytes(bytes, flush: true);
+          hashes.add(hash);
+          ids.add(tpl.id);
+          success++;
+        } catch (_) {
+          failed++;
+        }
+      }
+    }
+    await const TrainingPackIndexWriter().writeIndex(
+      src: libDir.path,
+      out: p.join(libDir.path, 'library_index.json'),
+      md: p.join(libDir.path, 'library_index.md'),
+    );
+    return (success, failed);
+  }
+}


### PR DESCRIPTION
## Summary
- add service to merge YAML libraries with validation and deduplication
- support library merge action from dev menu

## Testing
- `./flutter/bin/dart analyze`
- `./flutter/bin/flutter test --run-skipped` *(fails: The Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6877d3035180832aba104f666f00c646