### PR TITLE
Implement ranking engine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -19,6 +19,7 @@ import '../services/pack_library_export_service.dart';
 import '../services/pack_library_duplicate_cleaner.dart';
 import '../services/pack_library_merge_service.dart';
 import '../services/pack_library_refactor_service.dart';
+import '../services/training_pack_ranking_engine.dart';
 import 'yaml_library_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
@@ -40,6 +41,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _cleanLoading = false;
   bool _mergeLoading = false;
   bool _refactorLoading = false;
+  bool _rankLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -373,6 +375,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
         .showSnackBar(SnackBar(content: Text('Отрефакторено: $count')));
   }
 
+  Future<void> _recalcRanking() async {
+    if (_rankLoading || !kDebugMode) return;
+    setState(() => _rankLoading = true);
+    final count = await compute(_rankTask, '');
+    if (!mounted) return;
+    setState(() => _rankLoading = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Пересчитано: $count')));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -464,6 +476,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
+                title: const Text('🏅 Пересчитать рейтинг паков'),
+                onTap: _rankLoading ? null : _recalcRanking,
+              ),
+            if (kDebugMode)
+              ListTile(
                 title: const Text('📦 Объединить библиотеки'),
                 onTap: _mergeLoading ? null : _mergeLibraries,
               ),
@@ -533,4 +550,8 @@ Future<bool> _coverageTask(String _) async {
 
 Future<List<(String, String)>> _validateYamlTask(String _) async {
   return const YamlValidationService().validateAll();
+}
+
+Future<int> _rankTask(String _) async {
+  return const TrainingPackRankingEngine().computeRankings();
 }

--- a/lib/services/training_pack_ranking_engine.dart
+++ b/lib/services/training_pack_ranking_engine.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackRankingEngine {
+  const TrainingPackRankingEngine();
+
+  static const _w1 = 0.2;
+  static const _w2 = 0.2;
+  static const _w3 = 0.2;
+  static const _w4 = 0.2;
+  static const _w5 = 0.2;
+
+  Future<int> computeRankings({String path = 'training_packs/library'}) async {
+    if (!kDebugMode) return 0;
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory('${docs.path}/$path');
+    if (!dir.existsSync()) return 0;
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    const reader = YamlReader();
+    const writer = YamlWriter();
+    final templates = <TrainingPackTemplateV2>[];
+    final paths = <TrainingPackTemplateV2, String>{};
+    for (final f in files) {
+      try {
+        final map = reader.read(await f.readAsString());
+        final tpl = TrainingPackTemplateV2.fromJson(map);
+        templates.add(tpl);
+        paths[tpl] = f.path;
+      } catch (_) {}
+    }
+    if (templates.isEmpty) return 0;
+    final tagCounts = <String, int>{};
+    final tagSets = <String, int>{};
+    var maxSpots = 0;
+    final evs = <double>[];
+    final icms = <double>[];
+    final covs = <double>[];
+    for (final t in templates) {
+      maxSpots = t.spotCount > maxSpots ? t.spotCount : maxSpots;
+      evs.add((t.meta['evScore'] as num?)?.toDouble() ?? 0);
+      icms.add((t.meta['icmScore'] as num?)?.toDouble() ?? 0);
+      covs.add(t.coveragePercent ?? 0);
+      final tags = <String>{for (final x in t.tags) x.trim().toLowerCase()}
+        ..removeWhere((e) => e.isEmpty);
+      final key = tags.isEmpty ? '' : (tags.toList()..sort()).join('|');
+      tagSets[key] = (tagSets[key] ?? 0) + 1;
+      for (final tag in tags) {
+        tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
+      }
+    }
+    final maxTag = tagCounts.isEmpty ? 0 : tagCounts.values.reduce((a, b) => a > b ? a : b);
+    final minEv = evs.reduce((a, b) => a < b ? a : b);
+    final maxEv = evs.reduce((a, b) => a > b ? a : b);
+    final minIcm = icms.reduce((a, b) => a < b ? a : b);
+    final maxIcm = icms.reduce((a, b) => a > b ? a : b);
+    final maxCov = covs.isEmpty ? 0.0 : covs.reduce((a, b) => a > b ? a : b);
+    final list = <Map<String, dynamic>>[];
+    for (var i = 0; i < templates.length; i++) {
+      final t = templates[i];
+      final evNorm = maxEv == minEv ? 0 : (evs[i] - minEv) / (maxEv - minEv);
+      final icmNorm = maxIcm == minIcm ? 0 : (icms[i] - minIcm) / (maxIcm - minIcm);
+      final covNorm = maxCov == 0 ? 0 : covs[i] / maxCov;
+      final tags = <String>{for (final x in t.tags) x.trim().toLowerCase()}
+        ..removeWhere((e) => e.isEmpty);
+      double tagPop = 0;
+      if (tags.isNotEmpty && maxTag > 0) {
+        for (final tag in tags) {
+          tagPop += (tagCounts[tag] ?? 0) / maxTag;
+        }
+        tagPop /= tags.length;
+      }
+      final key = tags.isEmpty ? '' : (tags.toList()..sort()).join('|');
+      final uniqNorm = 1 / (tagSets[key] ?? 1);
+      final lenNorm = maxSpots == 0 ? 0 : t.spotCount / maxSpots;
+      final rank = _w1 * evNorm + _w2 * icmNorm + _w3 * covNorm + _w4 * uniqNorm + _w5 * lenNorm;
+      final map = t.toJson();
+      final meta = Map<String, dynamic>.from(map['meta'] as Map? ?? {});
+      meta['rankScore'] = double.parse(rank.toStringAsFixed(4));
+      map['meta'] = meta;
+      await writer.write(map, paths[t]!);
+      list.add(map);
+    }
+    list.sort((a, b) {
+      final ar = (a['meta']?['rankScore'] as num?)?.toDouble() ?? 0;
+      final br = (b['meta']?['rankScore'] as num?)?.toDouble() ?? 0;
+      return br.compareTo(ar);
+    });
+    final indexFile = File(p.join(dir.path, 'library_index.json'));
+    await indexFile.create(recursive: true);
+    await indexFile.writeAsString(jsonEncode(list), flush: true);
+    return templates.length;
+  }
+}


### PR DESCRIPTION
## Summary
- add TrainingPackRankingEngine to score YAML packs
- hook ranking engine into DevMenu for debug builds

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: package not found)*
- `apt-get install -y flutter` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d84c94b0832a8d40dcace6dcf3c3