### PR TITLE
Add related pack suggestions

### DIFF
--- a/lib/screens/pack_preview_screen.dart
+++ b/lib/screens/pack_preview_screen.dart
@@ -1,20 +1,56 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../models/action_entry.dart';
 import '../helpers/hand_utils.dart';
 import '../services/pack_generator_service.dart';
 import '../services/training_session_service.dart';
+import '../services/smart_suggestion_service.dart';
+import '../core/training/generation/yaml_reader.dart';
 import 'training_session_screen.dart';
 
-class PackPreviewScreen extends StatelessWidget {
+class PackPreviewScreen extends StatefulWidget {
   final TrainingPackTemplate pack;
   const PackPreviewScreen({super.key, required this.pack});
 
+  @override
+  State<PackPreviewScreen> createState() => _PackPreviewScreenState();
+}
+
+class _PackPreviewScreenState extends State<PackPreviewScreen> {
+  final List<TrainingPackTemplate> _related = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRelated();
+  }
+
+  Future<void> _loadRelated() async {
+    final service = context.read<SmartSuggestionService>();
+    final paths = await service.suggestRelated(widget.pack.tags);
+    final docs = await getApplicationDocumentsDirectory();
+    const reader = YamlReader();
+    for (final rel in paths) {
+      final file = File(p.join(docs.path, 'training_packs', 'library', rel));
+      if (!file.existsSync()) continue;
+      try {
+        final map = reader.read(await file.readAsString());
+        _related.add(TrainingPackTemplate.fromJson(map));
+      } catch (_) {}
+    }
+    if (mounted) setState(() {});
+  }
+
   String _villainRange() {
     final count =
-        (PackGeneratorService.handRanking.length * pack.bbCallPct / 100).round();
+        (PackGeneratorService.handRanking.length * widget.pack.bbCallPct / 100)
+            .round();
     return PackGeneratorService.handRanking.take(count).join(' ');
   }
 
@@ -23,12 +59,13 @@ class PackPreviewScreen extends StatelessWidget {
     final villain = _villainRange();
     return Scaffold(
       appBar: AppBar(
-        title: Text(pack.name),
+        title: Text(widget.pack.name),
         actions: [
           TextButton(
             onPressed: () async {
-              final session =
-                  await context.read<TrainingSessionService>().startFromTemplate(pack);
+              final session = await context
+                  .read<TrainingSessionService>()
+                  .startFromTemplate(widget.pack);
               if (!context.mounted) return;
               Navigator.pushReplacement(
                 context,
@@ -41,33 +78,60 @@ class PackPreviewScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: ListView.builder(
-        itemCount: pack.spots.length,
-        itemBuilder: (_, i) {
-          final s = pack.spots[i];
-          final hero = handCode(s.hand.heroCards) ?? s.hand.heroCards;
-          final actions = s.hand.actions[0] ?? [];
-          ActionEntry? heroAct;
-          for (final a in actions) {
-            if (a.playerIndex == s.hand.heroIndex) {
-              heroAct = a;
-              break;
-            }
-          }
-          final act = heroAct?.customLabel ?? heroAct?.action;
-          return ListTile(
-            leading: Text('${i + 1}'),
-            title: Text(s.title.isEmpty ? 'Spot ${i + 1}' : s.title),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Hero: $hero'),
-                Text('Villain: $villain'),
-                if (act != null) Text('Action: $act'),
-              ],
+      body: ListView(
+        children: [
+          for (var i = 0; i < widget.pack.spots.length; i++)
+            _buildSpot(i, villain),
+          if (_related.isNotEmpty) ...[
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('🎯 Похожее по теме',
+                  style: TextStyle(color: Colors.white, fontSize: 16)),
             ),
-          );
-        },
+            for (final r in _related)
+              ListTile(
+                title: Text(r.name),
+                onTap: () async {
+                  final session = await context
+                      .read<TrainingSessionService>()
+                      .startFromTemplate(r);
+                  if (!mounted) return;
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => TrainingSessionScreen(session: session),
+                    ),
+                  );
+                },
+              ),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSpot(int index, String villain) {
+    final s = widget.pack.spots[index];
+    final hero = handCode(s.hand.heroCards) ?? s.hand.heroCards;
+    final actions = s.hand.actions[0] ?? [];
+    ActionEntry? heroAct;
+    for (final a in actions) {
+      if (a.playerIndex == s.hand.heroIndex) {
+        heroAct = a;
+        break;
+      }
+    }
+    final act = heroAct?.customLabel ?? heroAct?.action;
+    return ListTile(
+      leading: Text('${index + 1}'),
+      title: Text(s.title.isEmpty ? 'Spot ${index + 1}' : s.title),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Hero: $hero'),
+          Text('Villain: $villain'),
+          if (act != null) Text('Action: $act'),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enhance SmartSuggestionService with tag-based suggestions
- show related packs in pack preview
- show related packs on training result screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e341ea30832a90c9171cf10db954