### PR TITLE
Add pack filter service

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -25,6 +25,7 @@ import '../services/pack_tag_index_service.dart';
 import 'yaml_library_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
+import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
@@ -562,6 +563,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const PackLibraryConflictsScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🔎 Фильтр паков'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PackFilterDebugScreen(),
                     ),
                   );
                 },

--- a/lib/screens/pack_filter_debug_screen.dart
+++ b/lib/screens/pack_filter_debug_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+import '../services/training_pack_filter_service.dart';
+
+class PackFilterDebugScreen extends StatefulWidget {
+  const PackFilterDebugScreen({super.key});
+
+  @override
+  State<PackFilterDebugScreen> createState() => _PackFilterDebugScreenState();
+}
+
+class _PackFilterDebugScreenState extends State<PackFilterDebugScreen> {
+  final _evCtr = TextEditingController();
+  final _icmCtr = TextEditingController();
+  final _diffCtr = TextEditingController();
+  final _minSpotsCtr = TextEditingController();
+  final _maxSpotsCtr = TextEditingController();
+  final _rarityCtr = TextEditingController();
+  final _matchCtr = TextEditingController();
+  final List<String> _packs = [];
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _evCtr.dispose();
+    _icmCtr.dispose();
+    _diffCtr.dispose();
+    _minSpotsCtr.dispose();
+    _maxSpotsCtr.dispose();
+    _rarityCtr.dispose();
+    _matchCtr.dispose();
+    super.dispose();
+  }
+
+  Future<void> _apply() async {
+    setState(() => _loading = true);
+    final res = await const TrainingPackFilterService().filter(
+      minEv: double.tryParse(_evCtr.text),
+      minIcm: double.tryParse(_icmCtr.text),
+      maxDifficulty: double.tryParse(_diffCtr.text),
+      minSpots: int.tryParse(_minSpotsCtr.text),
+      maxSpots: int.tryParse(_maxSpotsCtr.text),
+      minRarity: double.tryParse(_rarityCtr.text),
+      minTagsMatch: double.tryParse(_matchCtr.text),
+    );
+    if (!mounted) return;
+    setState(() {
+      _packs
+        ..clear()
+        ..addAll(res);
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pack Filter')),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(controller: _evCtr, decoration: const InputDecoration(labelText: 'min EV')),
+            TextField(controller: _icmCtr, decoration: const InputDecoration(labelText: 'min ICM')),
+            TextField(controller: _diffCtr, decoration: const InputDecoration(labelText: 'max difficulty')),
+            TextField(controller: _minSpotsCtr, decoration: const InputDecoration(labelText: 'min spots')),
+            TextField(controller: _maxSpotsCtr, decoration: const InputDecoration(labelText: 'max spots')),
+            TextField(controller: _rarityCtr, decoration: const InputDecoration(labelText: 'min rarity')),
+            TextField(controller: _matchCtr, decoration: const InputDecoration(labelText: 'min tag match')),
+            const SizedBox(height: 12),
+            ElevatedButton(onPressed: _loading ? null : _apply, child: const Text('Apply')),
+            const SizedBox(height: 12),
+            _loading
+                ? const Center(child: CircularProgressIndicator())
+                : Expanded(
+                    child: ListView.builder(
+                      itemCount: _packs.length,
+                      itemBuilder: (_, i) => ListTile(title: Text(_packs[i])),
+                    ),
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/training_pack_filter_service.dart
+++ b/lib/services/training_pack_filter_service.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class TrainingPackFilterService {
+  const TrainingPackFilterService();
+
+  Future<List<String>> filter({
+    double? minEv,
+    double? minIcm,
+    int? minSpots,
+    int? maxSpots,
+    double? maxDifficulty,
+    double? minRarity,
+    double? minTagsMatch,
+    String path = 'training_packs/library',
+  }) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final file = File(p.join(docs.path, path, 'pack_stats.json'));
+    if (!file.existsSync()) return [];
+    List data;
+    try {
+      data = jsonDecode(await file.readAsString()) as List;
+    } catch (_) {
+      return [];
+    }
+    final result = <String>[];
+    for (final item in data) {
+      if (item is! Map) continue;
+      final id = item['id']?.toString();
+      if (id == null || id.isEmpty) continue;
+      final count = (item['count'] as num?)?.toInt() ?? 0;
+      final ev = (item['ev'] as num?)?.toDouble();
+      final icm = (item['icm'] as num?)?.toDouble();
+      final diff = (item['difficulty'] as num?)?.toDouble();
+      final rarity = (item['rarity'] as num?)?.toDouble() ?? 0;
+      final match = (item['tagsMatch'] as num?)?.toDouble() ?? 0;
+      if (minEv != null && (ev == null || ev < minEv)) continue;
+      if (minIcm != null && (icm == null || icm < minIcm)) continue;
+      if (maxDifficulty != null && (diff ?? 0) > maxDifficulty) continue;
+      if (minSpots != null && count < minSpots) continue;
+      if (maxSpots != null && count > maxSpots) continue;
+      if (minRarity != null && rarity < minRarity) continue;
+      if (minTagsMatch != null && match < minTagsMatch) continue;
+      result.add(id);
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrainingPackFilterService` for filtering packs via `pack_stats.json`
- add simple debug screen `PackFilterDebugScreen`
- hook debug filter screen into `DevMenuScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e7ecbd40832a9b45d9eb4d366aac