### PR TITLE
Add YAML pack duplicate cleaner

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -17,6 +17,7 @@ import '../services/yaml_validation_service.dart';
 import '../services/pack_library_import_service.dart';
 import '../services/pack_library_export_service.dart';
 import '../services/pack_library_duplicate_cleaner.dart';
+import '../services/yaml_pack_duplicate_cleaner_service.dart';
 import '../services/pack_library_merge_service.dart';
 import '../services/pack_library_refactor_service.dart';
 import '../services/training_pack_ranking_engine.dart';
@@ -47,6 +48,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _importLoading = false;
   bool _exportLoading = false;
   bool _cleanLoading = false;
+  bool _yamlDupeLoading = false;
   bool _mergeLoading = false;
   bool _refactorLoading = false;
   bool _rankLoading = false;
@@ -368,6 +370,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     ).showSnackBar(SnackBar(content: Text('Удалено: $count')));
   }
 
+  Future<void> _removeYamlDuplicates() async {
+    if (_yamlDupeLoading || !kDebugMode) return;
+    setState(() => _yamlDupeLoading = true);
+    final list = await const YamlPackDuplicateCleanerService()
+        .removeDuplicates();
+    if (!mounted) return;
+    setState(() => _yamlDupeLoading = false);
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Удалено: ${list.length}')));
+  }
+
   Future<void> _mergeLibraries() async {
     if (_mergeLoading || !kDebugMode) return;
     setState(() => _mergeLoading = true);
@@ -542,6 +556,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🧹 Очистить дубликаты'),
                 onTap: _cleanLoading ? null : _cleanDuplicates,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧹 Удалить дубликаты паков'),
+                onTap: _yamlDupeLoading ? null : _removeYamlDuplicates,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/yaml_pack_duplicate_cleaner_service.dart
+++ b/lib/services/yaml_pack_duplicate_cleaner_service.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class YamlPackDuplicateCleanerService {
+  const YamlPackDuplicateCleanerService();
+
+  Future<List<String>> removeDuplicates({
+    String path = 'training_packs/library',
+  }) async {
+    if (!kDebugMode) return [];
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, path));
+    if (!dir.existsSync()) return [];
+    const reader = YamlReader();
+    final groups = <String, List<(File, int, bool, DateTime)>>{};
+    for (final f
+        in dir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+      try {
+        final map = reader.read(await f.readAsString());
+        final tpl = TrainingPackTemplateV2.fromJson(
+          Map<String, dynamic>.from(map),
+        );
+        final stat = await f.stat();
+        groups.putIfAbsent(tpl.id, () => []).add((
+          f,
+          tpl.spots.length,
+          map['evScore'] != null || tpl.meta['evScore'] != null,
+          stat.modified,
+        ));
+      } catch (_) {}
+    }
+    final removed = <String>[];
+    for (final list in groups.values) {
+      if (list.length < 2) continue;
+      list.sort((a, b) {
+        final c1 = b.$2.compareTo(a.$2);
+        if (c1 != 0) return c1;
+        final c2 = (b.$3 ? 1 : 0) - (a.$3 ? 1 : 0);
+        if (c2 != 0) return c2;
+        return b.$4.compareTo(a.$4);
+      });
+      for (final item in list.skip(1)) {
+        try {
+          item.$1.deleteSync();
+          removed.add(item.$1.path);
+        } catch (_) {}
+      }
+    }
+    return removed;
+  }
+}


### PR DESCRIPTION
## Summary
- add `YamlPackDuplicateCleanerService` for removing duplicate YAML packs by id
- hook new cleaner into Dev menu

## Testing
- `dart analyze`
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68786c361914832a9b43a84c905644e8