### PR TITLE
Add training history service v2

### DIFF
--- a/lib/models/training_history_entry.dart
+++ b/lib/models/training_history_entry.dart
@@ -1,0 +1,35 @@
+class TrainingHistoryEntry {
+  final String packId;
+  final DateTime timestamp;
+  final List<String> tags;
+  final String? audience;
+  final int? rating;
+  final double? evScore;
+
+  TrainingHistoryEntry({
+    required this.packId,
+    required this.timestamp,
+    required this.tags,
+    this.audience,
+    this.rating,
+    this.evScore,
+  });
+
+  factory TrainingHistoryEntry.fromJson(Map<String, dynamic> j) => TrainingHistoryEntry(
+        packId: j['packId'] as String? ?? '',
+        timestamp: DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
+        tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
+        audience: j['audience'] as String?,
+        rating: (j['rating'] as num?)?.toInt(),
+        evScore: (j['evScore'] as num?)?.toDouble(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'packId': packId,
+        'timestamp': timestamp.toIso8601String(),
+        if (tags.isNotEmpty) 'tags': tags,
+        if (audience != null) 'audience': audience,
+        if (rating != null) 'rating': rating,
+        if (evScore != null) 'evScore': evScore,
+      };
+}

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -14,6 +14,9 @@ import '../models/v2/training_session.dart';
 import 'pack_stats_screen.dart';
 import '../models/v2/training_pack_v2.dart';
 import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/training_history_service_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hero_position.dart';
 
@@ -157,6 +160,11 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         await prefs.setBool('completed_tpl_${tpl.id}', true);
         await prefs.setString(
             'completed_at_tpl_${tpl.id}', DateTime.now().toIso8601String());
+        unawaited(TrainingHistoryServiceV2.logCompletion(
+            TrainingPackTemplateV2.fromTemplate(
+          tpl,
+          type: TrainingType.pushfold,
+        )));
       } else {
         await prefs.setInt(
             'progress_tpl_${tpl.id}', service.session?.index ?? 0);

--- a/lib/services/training_history_service_v2.dart
+++ b/lib/services/training_history_service_v2.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../models/training_history_entry.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingHistoryServiceV2 {
+  static Future<File> _file() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File(p.join(dir.path, 'app_data', 'training_history.json'));
+  }
+
+  static Future<List<TrainingHistoryEntry>> _load(File file) async {
+    if (!await file.exists()) return [];
+    try {
+      final data = jsonDecode(await file.readAsString());
+      if (data is List) {
+        return [
+          for (final e in data)
+            if (e is Map)
+              TrainingHistoryEntry.fromJson(Map<String, dynamic>.from(e as Map))
+        ];
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  static Future<void> logCompletion(TrainingPackTemplateV2 pack) async {
+    final file = await _file();
+    final list = await _load(file);
+    list.insert(
+      0,
+      TrainingHistoryEntry(
+        packId: pack.id,
+        timestamp: DateTime.now(),
+        tags: List<String>.from(pack.tags),
+        audience: pack.audience,
+        rating: (pack.meta['rating'] as num?)?.toInt(),
+        evScore: (pack.meta['evScore'] as num?)?.toDouble(),
+      ),
+    );
+    await file.create(recursive: true);
+    await file.writeAsString(
+      jsonEncode([for (final e in list) e.toJson()]),
+      flush: true,
+    );
+  }
+
+  static Future<List<TrainingHistoryEntry>> getHistory({int limit = 20}) async {
+    final file = await _file();
+    final list = await _load(file);
+    return list.take(limit).toList();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrainingHistoryServiceV2` for detailed YAML pack completion logs
- record pack completion in `TrainingSessionScreen`
- define `TrainingHistoryEntry` model

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878765b7e1c832ab2a61a194bd261d7