### PR TITLE
Add SmartSuggestionEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -75,6 +75,7 @@ import 'services/session_log_service.dart';
 import 'services/suggested_pack_service.dart';
 import 'services/recommended_pack_service.dart';
 import 'services/smart_suggestion_service.dart';
+import 'services/smart_suggestion_engine.dart';
 import 'services/smart_pack_suggestion_engine.dart';
 import 'services/evaluation_executor_service.dart';
 import 'services/session_analysis_service.dart';
@@ -402,6 +403,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         templates: context.read<TemplateStorageService>(),
       ),
     ),
+    Provider(create: (_) => const SmartSuggestionEngine()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];
 }

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -28,6 +28,7 @@ import '../services/auto_tag_generator_service.dart';
 import '../services/training_pack_filter_engine.dart';
 import '../services/smart_pack_recommendation_engine.dart';
 import '../services/training_pack_suggestion_service.dart';
+import '../services/smart_suggestion_engine.dart';
 import '../models/v2/training_pack_template.dart';
 import '../core/training/generation/yaml_reader.dart';
 import 'package:file_picker/file_picker.dart';
@@ -62,6 +63,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _bestLoading = false;
   bool _recommendLoading = false;
   bool _historyLoading = false;
+  bool _smartHistoryLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -576,6 +578,37 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
   }
 
+  Future<void> _smartSuggestNext() async {
+    if (_smartHistoryLoading || !kDebugMode) return;
+    setState(() => _smartHistoryLoading = true);
+    final engine = context.read<SmartSuggestionEngine>();
+    final list = await engine.suggestNext();
+    if (!mounted) return;
+    setState(() => _smartHistoryLoading = false);
+    if (list.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Нет рекомендаций')),
+      );
+      return;
+    }
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Следующее по истории'),
+        content: SingleChildScrollView(
+          child: Text(list.map((e) => e.name).join('\n')),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -781,6 +814,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📈 Следующие паки по истории'),
                 onTap: _historyLoading ? null : _suggestNext,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧠 Следующее по истории'),
+                onTap: _smartHistoryLoading ? null : _smartSuggestNext,
               ),
           ],
         ),

--- a/lib/services/smart_suggestion_engine.dart
+++ b/lib/services/smart_suggestion_engine.dart
@@ -1,0 +1,38 @@
+import 'training_history_service_v2.dart';
+import 'training_pack_filter_engine.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class SmartSuggestionEngine {
+  const SmartSuggestionEngine();
+
+  Future<List<TrainingPackTemplateV2>> suggestNext() async {
+    final history = await TrainingHistoryServiceV2.getHistory();
+    final tags = <String, int>{};
+    final audienceCount = <String, int>{};
+    final seen = <String>[];
+    for (final e in history) {
+      if (seen.length < 10) seen.add(e.packId);
+      if (e.audience != null && e.audience!.isNotEmpty) {
+        audienceCount.update(e.audience!, (v) => v + 1, ifAbsent: () => 1);
+      }
+      for (final t in e.tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isNotEmpty) tags.update(key, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    final sortedTags = tags.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final selectedTags = [for (final e in sortedTags.take(3)) e.key];
+    final sortedAud = audienceCount.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final audience = sortedAud.isNotEmpty ? sortedAud.first.key : null;
+    final list = await const TrainingPackFilterEngine().filter(
+      minRating: 70,
+      tags: selectedTags.isEmpty ? null : selectedTags,
+      audience: audience,
+    );
+    final exclude = seen.toSet();
+    final result = [for (final t in list) if (!exclude.contains(t.id)) t];
+    return result.take(3).toList();
+  }
+}


### PR DESCRIPTION
## Summary
- implement SmartSuggestionEngine for training pack recommendations
- add provider wiring
- use new engine in DevMenu

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687878021a94832a94071a815c7ce18a