### PR TITLE
Add pack suggestion preview screen

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -38,6 +38,7 @@ import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
+import 'pack_suggestion_preview_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -591,20 +592,10 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
       );
       return;
     }
-    await showDialog(
-      context: context,
-      builder: (_) => AlertDialog(
-        backgroundColor: const Color(0xFF121212),
-        title: const Text('Следующее по истории'),
-        content: SingleChildScrollView(
-          child: Text(list.map((e) => e.name).join('\n')),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
-          ),
-        ],
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => PackSuggestionPreviewScreen(packs: list),
       ),
     );
   }

--- a/lib/screens/pack_suggestion_preview_screen.dart
+++ b/lib/screens/pack_suggestion_preview_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_v2.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
+import '../theme/app_colors.dart';
+
+class PackSuggestionPreviewScreen extends StatelessWidget {
+  final List<TrainingPackTemplateV2> packs;
+  const PackSuggestionPreviewScreen({super.key, required this.packs});
+
+  Future<void> _start(BuildContext context, TrainingPackTemplateV2 tpl) async {
+    final pack = TrainingPackV2.fromTemplate(tpl, tpl.id);
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingSessionScreen(pack: pack),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Рекомендации')),
+      backgroundColor: AppColors.background,
+      body: packs.isEmpty
+          ? const Center(child: Text('Нет подходящих рекомендаций'))
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: packs.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final p = packs[index];
+                final ev = (p.meta['evScore'] as num?)?.toDouble();
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.cardBackground,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(p.name, style: const TextStyle(fontSize: 16)),
+                      if (p.tags.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(p.tags.join(', '),
+                              style: const TextStyle(color: Colors.white70)),
+                        ),
+                      if (p.audience != null && p.audience!.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text('Audience: ${p.audience!}',
+                              style: const TextStyle(color: Colors.white70)),
+                        ),
+                      if (ev != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text('EV: ${ev.toStringAsFixed(2)}',
+                              style: const TextStyle(color: Colors.white70)),
+                        ),
+                      if (p.description.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(p.description,
+                              style: const TextStyle(color: Colors.white70)),
+                        ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: ElevatedButton(
+                          onPressed: () => _start(context, p),
+                          child: const Text('Начать'),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PackSuggestionPreviewScreen to show recommended packs
- open preview from DevMenu after getting suggestions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687879596944832a9c09eb94c638fca4