### PR TITLE
Implement TrainingGapDetectorService

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -75,6 +75,7 @@ import 'services/session_log_service.dart';
 import 'services/suggested_pack_service.dart';
 import 'services/recommended_pack_service.dart';
 import 'services/smart_suggestion_service.dart';
+import 'services/training_gap_detector_service.dart';
 import 'services/smart_suggestion_engine.dart';
 import 'services/smart_pack_suggestion_engine.dart';
 import 'services/evaluation_executor_service.dart';
@@ -403,6 +404,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         templates: context.read<TemplateStorageService>(),
       ),
     ),
+    Provider(create: (_) => const TrainingGapDetectorService()),
     Provider(create: (_) => const SmartSuggestionEngine()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];

--- a/lib/services/smart_suggestion_engine.dart
+++ b/lib/services/smart_suggestion_engine.dart
@@ -1,5 +1,6 @@
 import 'training_history_service_v2.dart';
 import 'training_pack_filter_engine.dart';
+import 'training_gap_detector_service.dart';
 import '../models/v2/training_pack_template_v2.dart';
 
 class SmartSuggestionEngine {
@@ -23,16 +24,37 @@ class SmartSuggestionEngine {
     final sortedTags = tags.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     final selectedTags = [for (final e in sortedTags.take(3)) e.key];
+    final gaps = await const TrainingGapDetectorService().detectNeglectedTags();
+    for (final g in gaps) {
+      if (selectedTags.length >= 3) break;
+      if (!selectedTags.contains(g)) selectedTags.add(g);
+    }
     final sortedAud = audienceCount.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     final audience = sortedAud.isNotEmpty ? sortedAud.first.key : null;
-    final list = await const TrainingPackFilterEngine().filter(
+    final engine = const TrainingPackFilterEngine();
+    final list = await engine.filter(
       minRating: 70,
       tags: selectedTags.isEmpty ? null : selectedTags,
       audience: audience,
     );
     final exclude = seen.toSet();
     final result = [for (final t in list) if (!exclude.contains(t.id)) t];
+    if (result.length < 3 && gaps.isNotEmpty) {
+      for (final tag in gaps) {
+        final alt = await engine.filter(
+          minRating: 70,
+          tags: [tag],
+          audience: audience,
+        );
+        for (final t in alt) {
+          if (exclude.contains(t.id) || result.contains(t)) continue;
+          result.add(t);
+          if (result.length >= 3) break;
+        }
+        if (result.length >= 3) break;
+      }
+    }
     return result.take(3).toList();
   }
 }

--- a/lib/services/training_gap_detector_service.dart
+++ b/lib/services/training_gap_detector_service.dart
@@ -1,0 +1,31 @@
+import 'training_history_service_v2.dart';
+
+class TrainingGapDetectorService {
+  const TrainingGapDetectorService();
+
+  Future<List<String>> detectNeglectedTags({Duration maxAge = const Duration(days: 7)}) async {
+    final history = await TrainingHistoryServiceV2.getHistory(limit: 200);
+    final map = <String, DateTime>{};
+    for (final e in history) {
+      for (final t in e.tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        final last = map[key];
+        if (last == null || e.timestamp.isAfter(last)) {
+          map[key] = e.timestamp;
+        }
+      }
+    }
+    final cutoff = DateTime.now().subtract(maxAge);
+    final list = <String>[];
+    map.forEach((tag, ts) {
+      if (ts.isBefore(cutoff)) list.add(tag);
+    });
+    return list;
+  }
+
+  Future<Set<String>> detectNeglectedCategories({Duration maxAge = const Duration(days: 7)}) async {
+    final tags = await detectNeglectedTags(maxAge: maxAge);
+    return {for (final t in tags) if (t.startsWith('cat:')) t};
+  }
+}


### PR DESCRIPTION
## Summary
- detect unused training tags with TrainingGapDetectorService
- enhance SmartSuggestionEngine to use gap detection
- expose the detector service via provider

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68787c24b080832a865cc2f03928fe90