### PR TITLE
Add YAML duplicate detector

### DIFF
--- a/lib/models/duplicate_group.dart
+++ b/lib/models/duplicate_group.dart
@@ -1,0 +1,8 @@
+import "v2/training_pack_template_v2.dart";
+class DuplicateGroup {
+  final String type;
+  final String key;
+  final List<TrainingPackTemplateV2> matches;
+  const DuplicateGroup({required this.type, required this.key, required this.matches});
+}
+

--- a/lib/services/yaml_duplicate_detector_service.dart
+++ b/lib/services/yaml_duplicate_detector_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+
+import '../models/duplicate_group.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class YamlDuplicateDetectorService {
+  const YamlDuplicateDetectorService();
+
+  List<DuplicateGroup> detectDuplicates(List<TrainingPackTemplateV2> packs) {
+    final nameMap = <String, List<TrainingPackTemplateV2>>{};
+    final idMap = <String, List<TrainingPackTemplateV2>>{};
+    final hashMap = <String, List<TrainingPackTemplateV2>>{};
+    for (final p in packs) {
+      nameMap.putIfAbsent(p.name, () => []).add(p);
+      idMap.putIfAbsent(p.id, () => []).add(p);
+      final hash = md5.convert(utf8.encode(p.toYaml())).toString();
+      hashMap.putIfAbsent(hash, () => []).add(p);
+    }
+    final groups = <DuplicateGroup>[];
+    void add(Map<String, List<TrainingPackTemplateV2>> map, String type) {
+      map.forEach((k, v) {
+        if (v.length > 1) {
+          groups.add(DuplicateGroup(type: type, key: k, matches: v));
+        }
+      });
+    }
+    add(nameMap, 'name');
+    add(idMap, 'id');
+    add(hashMap, 'hash');
+    return groups;
+  }
+}
+

--- a/test/yaml_duplicate_detector_service_test.dart
+++ b/test/yaml_duplicate_detector_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/yaml_duplicate_detector_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+
+void main() {
+  test('detectDuplicates groups by name id and hash', () {
+    final a = TrainingPackTemplateV2(id: '1', name: 'A', type: TrainingType.pushfold);
+    final b = TrainingPackTemplateV2(id: '1', name: 'B', type: TrainingType.pushfold);
+    final c = TrainingPackTemplateV2(id: '2', name: 'A', type: TrainingType.pushfold);
+    final d = TrainingPackTemplateV2(id: '4', name: 'D', type: TrainingType.pushfold);
+    final e = TrainingPackTemplateV2(id: '4', name: 'D', type: TrainingType.pushfold);
+    final service = const YamlDuplicateDetectorService();
+    final res = service.detectDuplicates([a, b, c, d, e]);
+    expect(res.where((g) => g.type == 'id').length, 2);
+    expect(res.where((g) => g.type == 'name').length, 2);
+    expect(res.where((g) => g.type == 'hash').length, 1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- introduce `DuplicateGroup` model
- add `YamlDuplicateDetectorService`
- test detection logic

## Testing
- `flutter test test/yaml_duplicate_detector_service_test.dart --run-skipped` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878804d9358832aa7a3aed1b0502cf7