### PR TITLE
Implement YamlPackRatingEngine

### DIFF
--- a/lib/services/yaml_pack_rating_engine.dart
+++ b/lib/services/yaml_pack_rating_engine.dart
@@ -1,0 +1,63 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'yaml_pack_balance_analyzer.dart';
+
+class YamlPackRatingEngine {
+  const YamlPackRatingEngine();
+
+  int rate(TrainingPackTemplateV2 pack) {
+    final spots = pack.spots;
+    final actions = spots.where(_hasHeroAction).length;
+    final evaluated = spots.where((s) => s.evalResult != null).length;
+    final positions = <String>{
+      ...pack.positions,
+      for (final s in spots) s.hand.position.name
+    }..removeWhere((e) => e.trim().isEmpty);
+    final streets = {for (final s in spots) s.street};
+    final stacks = {
+      for (final s in spots)
+        s.hand.stacks['${s.hand.heroIndex}']?.round() ?? 0
+    };
+    final ev = (pack.meta['evScore'] as num?)?.toDouble() ?? 0;
+    final diff = (pack.meta['rankScore'] as num?)?.toDouble() ?? 0;
+    var score = 0.0;
+    if (pack.description.trim().isNotEmpty) score += 5;
+    if (pack.goal.trim().isNotEmpty) score += 5;
+    if (pack.meta.isNotEmpty) score += 5;
+    score += ev * 0.2;
+    score += diff * 20;
+    score += positions.length.clamp(0, 4) * 2.5;
+    score += streets.length.clamp(0, 4) * 2.5;
+    score += stacks.length.clamp(0, 5) * 2;
+    if (spots.isNotEmpty) {
+      score += actions * 5 / spots.length;
+      score += evaluated * 5 / spots.length;
+    }
+    var penalty = 10.0;
+    for (final i in const YamlPackBalanceAnalyzer().analyze(pack)) {
+      penalty += i.severity * 2;
+    }
+    score -= penalty;
+    if (score < 0) score = 0;
+    if (score > 100) score = 100;
+    return score.round();
+  }
+
+  Map<String, int> rateAll(List<TrainingPackTemplateV2> packs) {
+    final res = <String, int>{};
+    for (final p in packs) {
+      res[p.id] = rate(p);
+    }
+    return res;
+  }
+
+  bool _hasHeroAction(TrainingPackSpot s) {
+    final hero = s.hand.heroIndex;
+    for (final list in s.hand.actions.values) {
+      for (final a in list) {
+        if (a.playerIndex == hero) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/test/yaml_pack_rating_engine_test.dart
+++ b/test/yaml_pack_rating_engine_test.dart
@@ -1,0 +1,47 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/yaml_pack_rating_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TrainingPackSpot spot(int bb) {
+    return TrainingPackSpot(
+      id: 's$bb',
+      hand: HandData(
+        position: HeroPosition.sb,
+        heroIndex: 0,
+        stacks: {'0': bb.toDouble()},
+        actions: {
+          0: [ActionEntry(0, 0, 'push')]
+        },
+      ),
+      evalResult: EvaluationResult(correct: true, expectedAction: 'push', userEquity: 0, expectedEquity: 0),
+    );
+  }
+
+  test('rate returns value between 0 and 100', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Test',
+      description: 'desc',
+      goal: 'goal',
+      meta: {'evScore': 80, 'rankScore': 0.5},
+      type: TrainingType.pushfold,
+      spots: [spot(10), spot(15)],
+    );
+    final rating = const YamlPackRatingEngine().rate(tpl);
+    expect(rating, inInclusiveRange(0, 100));
+  });
+
+  test('rateAll returns map by id', () {
+    final a = TrainingPackTemplateV2(id: 'a', name: 'A', type: TrainingType.pushfold);
+    final b = TrainingPackTemplateV2(id: 'b', name: 'B', type: TrainingType.pushfold);
+    final res = const YamlPackRatingEngine().rateAll([a, b]);
+    expect(res.keys, containsAll(['a', 'b']));
+  });
+}


### PR DESCRIPTION
## Summary
- add a rating engine for yaml packs
- basic tests for the rating engine

## Testing
- `dart format lib/services/yaml_pack_rating_engine.dart test/yaml_pack_rating_engine_test.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687889cc5bf0832aa0cbcb023a6e595f