### PR TITLE
Implement YAML pack merge tool

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -48,6 +48,7 @@ import 'pack_suggestion_preview_screen.dart';
 import 'yaml_coverage_stats_screen.dart';
 import 'pack_library_qa_screen.dart';
 import 'pack_conflict_analysis_screen.dart';
+import 'pack_merge_duplicates_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -900,6 +901,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const PackConflictAnalysisScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧬 Объединение дубликатов'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PackMergeDuplicatesScreen(),
                     ),
                   );
                 },

--- a/lib/screens/pack_merge_duplicates_screen.dart
+++ b/lib/screens/pack_merge_duplicates_screen.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/yaml_pack_conflict_detector.dart';
+import '../services/yaml_pack_merge_engine.dart';
+import '../theme/app_colors.dart';
+import '../ui/tools/training_pack_yaml_previewer.dart';
+
+class PackMergeDuplicatesScreen extends StatefulWidget {
+  const PackMergeDuplicatesScreen({super.key});
+  @override
+  State<PackMergeDuplicatesScreen> createState() => _PackMergeDuplicatesScreenState();
+}
+
+class _PackMergeDuplicatesScreenState extends State<PackMergeDuplicatesScreen> {
+  bool _loading = true;
+  final List<YamlPackConflict> _items = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await compute(_conflictTask, '');
+    if (!mounted) return;
+    setState(() {
+      _items
+        ..clear()
+        ..addAll(data);
+      _loading = false;
+    });
+  }
+
+  Future<void> _merge(YamlPackConflict c) async {
+    final merged = const YamlPackMergeEngine().merge(c.packA, c.packB);
+    await showTrainingPackYamlPreviewer(context, merged);
+    if (!mounted) return;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: AppColors.background,
+        title: const Text('Сохранить?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Нет'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Да'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await compute(_saveTask, merged.toJson());
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Шаблон сохранён')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Объединение дубликатов')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                ElevatedButton(onPressed: _load, child: const Text('🔄 Обновить')),
+                const SizedBox(height: 16),
+                for (final c in _items)
+                  ListTile(
+                    title: Text('${c.packA.name} ↔ ${c.packB.name}'),
+                    subtitle: Text('${c.type} ${(c.similarityScore * 100).toStringAsFixed(0)}%'),
+                    onTap: () => _merge(c),
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+Future<List<YamlPackConflict>> _conflictTask(String _) async {
+  final docs = await getApplicationDocumentsDirectory();
+  final dir = Directory('${docs.path}/training_packs/library');
+  if (!dir.existsSync()) return [];
+  const reader = YamlReader();
+  final packs = <TrainingPackTemplateV2>[];
+  for (final f in dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+    try {
+      final map = reader.read(await f.readAsString());
+      packs.add(TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map)));
+    } catch (_) {}
+  }
+  final res = const YamlPackConflictDetector().detectConflicts(packs);
+  return [
+    for (final c in res)
+      if (c.type.startsWith('duplicate_') || c.similarityScore > 0.9) c
+  ];
+}
+
+Future<void> _saveTask(Map<String, dynamic> json) async {
+  final tpl = TrainingPackTemplateV2.fromJson(json);
+  final docs = await getApplicationDocumentsDirectory();
+  final dir = Directory('${docs.path}/training_packs/library');
+  await dir.create(recursive: true);
+  final path = '${dir.path}/${tpl.id}.yaml';
+  await const YamlWriter().write(tpl.toJson(), path);
+}

--- a/lib/services/yaml_pack_merge_engine.dart
+++ b/lib/services/yaml_pack_merge_engine.dart
@@ -1,0 +1,73 @@
+import 'package:uuid/uuid.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class YamlPackMergeEngine {
+  final Uuid _uuid;
+  const YamlPackMergeEngine({Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  TrainingPackTemplateV2 merge(
+    TrainingPackTemplateV2 a,
+    TrainingPackTemplateV2 b,
+  ) {
+    final id = _uuid.v4();
+    final tags = <String>{...a.tags, ...b.tags}
+      ..removeWhere((e) => e.trim().isEmpty);
+    final spots = <TrainingPackSpot>[];
+    final keys = <String>{};
+    String key(TrainingPackSpot s) =>
+        '${s.hand.toJson()}|${s.correctAction}|${s.explanation}';
+    void add(TrainingPackSpot s) {
+      final k = key(s);
+      if (keys.add(k)) spots.add(s);
+    }
+
+    for (final s in a.spots) add(s);
+    for (final s in b.spots) add(s);
+
+    final meta = <String, dynamic>{...a.meta};
+    b.meta.forEach((k, v) => meta.putIfAbsent(k, () => v));
+    double? avg(String k) {
+      final x = (a.meta[k] as num?)?.toDouble();
+      final y = (b.meta[k] as num?)?.toDouble();
+      if (x != null && y != null) return (x + y) / 2;
+      return x ?? y;
+    }
+    final evScore = avg('evScore');
+    final icmScore = avg('icmScore');
+    if (evScore != null) meta['evScore'] = evScore;
+    if (icmScore != null) meta['icmScore'] = icmScore;
+
+    var ev = 0;
+    var icm = 0;
+    var total = 0;
+    for (final s in spots) {
+      final w = s.priority;
+      total += w;
+      if (!s.dirty && s.heroEv != null) ev += w;
+      if (!s.dirty && s.heroIcmEv != null) icm += w;
+    }
+    meta['evCovered'] = ev;
+    meta['icmCovered'] = icm;
+    meta['totalWeight'] = total;
+
+    return TrainingPackTemplateV2(
+      id: id,
+      name: '${a.name} + ${b.name}',
+      description: a.description.isNotEmpty ? a.description : b.description,
+      goal: a.goal.isNotEmpty ? a.goal : b.goal,
+      audience: a.audience?.isNotEmpty == true ? a.audience : b.audience,
+      tags: tags.toList(),
+      category: a.category ?? b.category,
+      type: a.type,
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: a.gameType,
+      bb: a.bb,
+      positions: {...a.positions, ...b.positions}.toList(),
+      meta: meta,
+      recommended: a.recommended || b.recommended,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `YamlPackMergeEngine` for joining duplicate packs
- add `PackMergeDuplicatesScreen` to preview and save merged templates
- expose the merge screen in DevMenu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878b6684db4832ab9b80d7756ba11cd