### PR TITLE
Add YAML pack quick preview

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -40,6 +40,7 @@ import '../core/training/generation/yaml_reader.dart';
 import 'package:file_picker/file_picker.dart';
 import 'pack_matrix_config_editor_screen.dart';
 import 'yaml_library_preview_screen.dart';
+import 'yaml_pack_quick_preview_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
 import 'pack_filter_debug_screen.dart';
@@ -838,6 +839,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const YamlLibraryPreviewScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📦 Быстрый просмотр YAML'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const YamlPackQuickPreviewScreen(),
                     ),
                   );
                 },

--- a/lib/screens/yaml_pack_quick_preview_screen.dart
+++ b/lib/screens/yaml_pack_quick_preview_screen.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/yaml_pack_preview_engine.dart';
+import '../theme/app_colors.dart';
+import 'yaml_viewer_screen.dart';
+
+class YamlPackQuickPreviewScreen extends StatefulWidget {
+  const YamlPackQuickPreviewScreen({super.key});
+
+  @override
+  State<YamlPackQuickPreviewScreen> createState() => _YamlPackQuickPreviewScreenState();
+}
+
+class _YamlPackQuickPreviewScreenState extends State<YamlPackQuickPreviewScreen> {
+  final List<(File, TrainingPackTemplateV2)> _items = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final libDir = Directory('${dir.path}/training_packs/library');
+    const reader = YamlReader();
+    final list = <(File, TrainingPackTemplateV2)>[];
+    for (final f in libDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
+      try {
+        final map = reader.read(await f.readAsString());
+        list.add((f, TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map))));
+      } catch (_) {}
+    }
+    list.sort((a, b) => b.$1.statSync().modified.compareTo(a.$1.statSync().modified));
+    if (!mounted) return;
+    setState(() {
+      _items
+        ..clear()
+        ..addAll(list);
+      _loading = false;
+    });
+  }
+
+  Future<void> _open(File file) async {
+    final yaml = await file.readAsString();
+    final name = file.path.split(Platform.pathSeparator).last;
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => YamlViewerScreen(yamlText: yaml, title: name)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    final engine = const YamlPackPreviewEngine();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Быстрый просмотр YAML')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: _items.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, i) {
+                final (file, pack) = _items[i];
+                return GestureDetector(
+                  onTap: () => _open(file),
+                  child: engine.buildPreview(pack),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/yaml_pack_preview_engine.dart
+++ b/lib/services/yaml_pack_preview_engine.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../theme/app_colors.dart';
+
+class YamlPackPreviewEngine {
+  const YamlPackPreviewEngine();
+
+  double? _coverage(TrainingPackTemplateV2 p) {
+    final total = (p.meta['totalWeight'] as num?)?.toDouble() ?? p.spotCount.toDouble();
+    if (total == 0) return null;
+    final ev = (p.meta['evCovered'] as num?)?.toDouble() ?? 0;
+    final icm = (p.meta['icmCovered'] as num?)?.toDouble() ?? 0;
+    return (ev + icm) * 100 / (2 * total);
+  }
+
+  Widget buildPreview(TrainingPackTemplateV2 pack) {
+    final ev = (pack.meta['evScore'] as num?)?.toDouble();
+    final icm = (pack.meta['icmScore'] as num?)?.toDouble();
+    final coverage = _coverage(pack);
+    final tags = pack.tags.join(', ');
+    final pos = pack.positions.join(', ');
+    return Card(
+      color: AppColors.cardBackground,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(pack.name, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            if (pack.goal.trim().isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(pack.goal, style: const TextStyle(color: Colors.white70)),
+              ),
+            if (tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text('🏷️ $tags', style: const TextStyle(color: Colors.white70, fontSize: 12)),
+              ),
+            if (pos.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text('🪑 $pos', style: const TextStyle(color: Colors.white70, fontSize: 12)),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Wrap(
+                spacing: 8,
+                children: [
+                  if (ev != null)
+                    Text('EV ${ev.toStringAsFixed(1)}', style: const TextStyle(color: Colors.greenAccent, fontSize: 12)),
+                  if (icm != null)
+                    Text('ICM ${icm.toStringAsFixed(1)}', style: const TextStyle(color: Colors.purpleAccent, fontSize: 12)),
+                  if (coverage != null)
+                    Text('📈 ${coverage.round()}%', style: const TextStyle(color: Colors.white70, fontSize: 12)),
+                  Text('🃏 ${pack.spotCount}', style: const TextStyle(color: Colors.white70, fontSize: 12)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `YamlPackPreviewEngine` to render short cards for YAML packs
- add `YamlPackQuickPreviewScreen` that lists YAML files using the preview engine
- link new quick preview screen from DevMenu

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b8439764832a8c94b8e706abb399