### PR TITLE
Add PackLibraryRefactorEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -23,6 +23,7 @@ import '../services/pack_library_refactor_service.dart';
 import '../services/training_pack_ranking_engine.dart';
 import '../services/training_pack_rating_engine.dart';
 import '../services/tag_health_check_service.dart';
+import '../services/pack_library_refactor_engine.dart';
 import '../services/pack_tag_index_service.dart';
 import '../services/auto_tag_generator_service.dart';
 import '../services/training_pack_filter_engine.dart';
@@ -71,6 +72,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _refactorLoading = false;
   bool _ratingLoading = false;
   bool _tagHealthLoading = false;
+  bool _normalizeYamlLoading = false;
   bool _tagIndexLoading = false;
   bool _tagSuggestLoading = false;
   bool _bestLoading = false;
@@ -432,6 +434,15 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
       context,
     ).showSnackBar(SnackBar(content: Text('Отрефакторено: $count')));
   }
+  Future<void> _normalizeYamlLibrary() async {
+    if (_normalizeYamlLoading || !kDebugMode) return;
+    setState(() => _normalizeYamlLoading = true);
+    await const PackLibraryRefactorEngine().refactorAll("training_packs/library");
+    if (!mounted) return;
+    setState(() => _normalizeYamlLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Готово")));
+  }
+
 
   Future<void> _recalcRating() async {
     if (_ratingLoading || !kDebugMode) return;
@@ -809,6 +820,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🧹 Рефакторинг библиотеки'),
                 onTap: _refactorLoading ? null : _refactorLibrary,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text("🧹 Нормализовать YAML библиотеку"),
+                onTap: _normalizeYamlLoading ? null : _normalizeYamlLibrary,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/pack_library_refactor_engine.dart
+++ b/lib/services/pack_library_refactor_engine.dart
@@ -1,0 +1,78 @@
+import 'dart:collection';
+import 'dart:io';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/hero_position.dart';
+import 'yaml_pack_auto_tagger.dart';
+
+class PackLibraryRefactorEngine {
+  final YamlReader reader;
+  final YamlWriter writer;
+  final YamlPackAutoTagger tagger;
+  const PackLibraryRefactorEngine({
+    YamlReader? yamlReader,
+    YamlWriter? yamlWriter,
+    YamlPackAutoTagger? autoTagger,
+  })  : reader = yamlReader ?? const YamlReader(),
+        writer = yamlWriter ?? const YamlWriter(),
+        tagger = autoTagger ?? const YamlPackAutoTagger();
+
+  Future<void> refactorAll(String path) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, path));
+    if (!dir.existsSync()) return;
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((e) => e.path.toLowerCase().endsWith('.yaml'));
+    for (final f in files) {
+      try {
+        final map = reader.read(await f.readAsString());
+        final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+        tpl.name = _norm(tpl.name);
+        tpl.goal = _norm(tpl.goal);
+        tpl.description = _norm(tpl.description);
+        tpl.tags = tagger.generateTags(tpl);
+        final pos = <HeroPosition>{
+          for (final p in tpl.positions) parseHeroPosition(p)
+        }..remove(HeroPosition.unknown);
+        final sorted = pos.toList()
+          ..sort((a, b) =>
+              kPositionOrder.indexOf(a).compareTo(kPositionOrder.indexOf(b)));
+        tpl.positions = [for (final p in sorted) p.label];
+        await writer.write(_orderedMap(tpl), f.path);
+        final safeA = (tpl.audience ?? 'any').replaceAll(' ', '_').toLowerCase();
+        final safeT = (tpl.category ?? 'pack').replaceAll(' ', '_').toLowerCase();
+        final ts = DateFormat('yyyyMMdd').format(tpl.created);
+        final newPath = p.join(f.parent.path, 'lib_${safeA}_${safeT}_$ts.yaml');
+        if (p.basename(f.path) != p.basename(newPath)) {
+          await File(newPath).writeAsString(await f.readAsString());
+          await f.delete();
+        }
+      } catch (_) {}
+    }
+  }
+
+  String _norm(String s) {
+    final v = s.trim();
+    if (v.isEmpty) return '';
+    return v[0].toUpperCase() + v.substring(1);
+  }
+
+  Map<String, dynamic> _orderedMap(TrainingPackTemplateV2 tpl) {
+    final json = tpl.toJson();
+    json['title'] = json.remove('name');
+    final map = LinkedHashMap<String, dynamic>();
+    for (final k in ['id', 'title', 'tags', 'meta', 'spots']) {
+      if (json.containsKey(k)) map[k] = json.remove(k);
+    }
+    for (final e in json.entries) {
+      map[e.key] = e.value;
+    }
+    return map;
+  }
+}


### PR DESCRIPTION
## Summary
- add `PackLibraryRefactorEngine` for normalizing YAML packs
- expose normalization in DevMenu

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878bb07c07c832a8f0c0927c7c3f50f