### PR TITLE
Implement TrainingPackRatingEngine

### DIFF
--- a/lib/models/pack_rating_report.dart
+++ b/lib/models/pack_rating_report.dart
@@ -1,0 +1,20 @@
+class PackRatingReport {
+  final int score;
+  final List<String> warnings;
+  final List<String> insights;
+  const PackRatingReport({
+    this.score = 0,
+    this.warnings = const [],
+    this.insights = const [],
+  });
+  Map<String, dynamic> toJson() => {
+    'score': score,
+    'warnings': warnings,
+    'insights': insights,
+  };
+  factory PackRatingReport.fromJson(Map<String, dynamic> j) => PackRatingReport(
+    score: (j['score'] as num?)?.toInt() ?? 0,
+    warnings: [for (final w in j['warnings'] as List? ?? []) w.toString()],
+    insights: [for (final i in j['insights'] as List? ?? []) i.toString()],
+  );
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -38,6 +38,7 @@ import '../services/pack_library_review_engine.dart';
 import '../services/training_pack_auto_fix_engine.dart';
 import '../models/yaml_pack_review_report.dart';
 import '../models/yaml_pack_validation_report.dart';
+import '../models/pack_rating_report.dart';
 import '../services/yaml_pack_refactor_engine.dart';
 import '../services/pack_validation_engine.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -93,6 +94,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _validatePackLoading = false;
   bool _autoFixLoading = false;
   bool _refactorYamlPackLoading = false;
+  bool _ratePackLoading = false;
   bool _recommendPacksLoading = false;
   bool _jsonLibraryLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
@@ -350,8 +352,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
     if (!mounted) return;
     setState(() => _jsonLibraryLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Готово')));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Готово')));
   }
 
   Future<void> _importPacks() async {
@@ -429,8 +432,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   Future<void> _removeYamlDuplicates() async {
     if (_yamlDupeLoading || !kDebugMode) return;
     setState(() => _yamlDupeLoading = true);
-    final list =
-        await const YamlPackDuplicateCleanerService().removeDuplicates();
+    final list = await const YamlPackDuplicateCleanerService()
+        .removeDuplicates();
     if (!mounted) return;
     setState(() => _yamlDupeLoading = false);
     ScaffoldMessenger.of(
@@ -464,15 +467,19 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
       context,
     ).showSnackBar(SnackBar(content: Text('Отрефакторено: $count')));
   }
+
   Future<void> _normalizeYamlLibrary() async {
     if (_normalizeYamlLoading || !kDebugMode) return;
     setState(() => _normalizeYamlLoading = true);
-    await const PackLibraryRefactorEngine().refactorAll("training_packs/library");
+    await const PackLibraryRefactorEngine().refactorAll(
+      "training_packs/library",
+    );
     if (!mounted) return;
     setState(() => _normalizeYamlLoading = false);
-    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Готово")));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text("Готово")));
   }
-
 
   Future<void> _recalcRating() async {
     if (_ratingLoading || !kDebugMode) return;
@@ -556,9 +563,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _balanceLoading = false);
     if (items.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Баланс OK')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Баланс OK')));
       return;
     }
     final text = items.map((e) => '${e.type}: ${e.description}').join('\n');
@@ -599,7 +606,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (report == null) return;
     final text = [
       if (report.errors.isNotEmpty) 'Errors:\n${report.errors.join('\n')}',
-      if (report.warnings.isNotEmpty) 'Warnings:\n${report.warnings.join('\n')}',
+      if (report.warnings.isNotEmpty)
+        'Warnings:\n${report.warnings.join('\n')}',
     ].join('\n\n');
     await showDialog(
       context: context,
@@ -640,9 +648,10 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     setState(() => _reviewLoading = false);
     if (report == null) return;
     final text = [
-      if (report.warnings.isNotEmpty) 'Warnings:\n${report.warnings.join('\n')}',
+      if (report.warnings.isNotEmpty)
+        'Warnings:\n${report.warnings.join('\n')}',
       if (report.suggestions.isNotEmpty)
-        'Suggestions:\n${report.suggestions.join('\n')}'
+        'Suggestions:\n${report.suggestions.join('\n')}',
     ].join('\n\n');
     await showDialog(
       context: context,
@@ -675,8 +684,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     }
     if (!mounted) return;
     setState(() => _autoFixLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
   }
 
   Future<void> _refactorYamlPack() async {
@@ -693,22 +703,63 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     }
     if (!mounted) return;
     setState(() => _refactorYamlPackLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
+  }
+
+  Future<void> _rateYamlPack() async {
+    if (_ratePackLoading || !kDebugMode) return;
+    setState(() => _ratePackLoading = true);
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['yaml', 'yml'],
+    );
+    PackRatingReport? report;
+    if (result != null && result.files.isNotEmpty) {
+      final path = result.files.single.path;
+      if (path != null) {
+        final data = await compute(_ratePackTask, path);
+        report = PackRatingReport.fromJson(data);
+      }
+    }
+    if (!mounted) return;
+    setState(() => _ratePackLoading = false);
+    if (report == null) return;
+    final text = [
+      'Score: ${report.score}',
+      if (report.warnings.isNotEmpty)
+        'Warnings:\n${report.warnings.join('\n')}',
+      if (report.insights.isNotEmpty)
+        'Insights:\n${report.insights.join('\n')}',
+    ].join('\n\n');
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        content: SingleChildScrollView(
+          child: Text(text, style: const TextStyle(color: Colors.white)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _selectBestPacks() async {
     if (_bestLoading || !kDebugMode) return;
     setState(() => _bestLoading = true);
-    final list = await const TrainingPackFilterEngine().filter(
-      minRating: 80,
-    );
+    final list = await const TrainingPackFilterEngine().filter(minRating: 80);
     if (!mounted) return;
     setState(() => _bestLoading = false);
     if (list.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет паков')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Нет паков')));
       return;
     }
     await showDialog(
@@ -737,7 +788,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     final completed = prefs
         .getKeys()
         .where(
-            (k) => k.startsWith('completed_tpl_') && prefs.getBool(k) == true)
+          (k) => k.startsWith('completed_tpl_') && prefs.getBool(k) == true,
+        )
         .map((k) => k.substring('completed_tpl_'.length))
         .toSet();
     final profile = UserProfile(
@@ -751,9 +803,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _recommendPacksLoading = false);
     if (list.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет рекомендаций')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Нет рекомендаций')));
       return;
     }
     await Navigator.push(
@@ -772,9 +824,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _historyLoading = false);
     if (list.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет рекомендаций')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Нет рекомендаций')));
       return;
     }
     await showDialog(
@@ -803,9 +855,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _smartHistoryLoading = false);
     if (list.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет рекомендаций')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Нет рекомендаций')));
       return;
     }
     await Navigator.push(
@@ -823,7 +875,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     final prefs = await SharedPreferences.getInstance();
     final completed = prefs
         .getKeys()
-        .where((k) => k.startsWith('completed_tpl_') && prefs.getBool(k) == true)
+        .where(
+          (k) => k.startsWith('completed_tpl_') && prefs.getBool(k) == true,
+        )
         .map((k) => k.substring('completed_tpl_'.length))
         .toSet();
     final profile = UserProfile(
@@ -835,9 +889,9 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _goalLoading = false);
     if (goals.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет целей')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Нет целей')));
       return;
     }
     await showDialog(
@@ -963,6 +1017,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🧹 Рефакторинг YAML пака'),
                 onTap: _refactorYamlPackLoading ? null : _refactorYamlPack,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📈 Оценить YAML пак'),
+                onTap: _ratePackLoading ? null : _rateYamlPack,
               ),
             if (kDebugMode)
               ListTile(
@@ -1299,4 +1358,14 @@ Future<bool> _refactorYamlPackTask(String path) async {
   const YamlPackRefactorEngine().refactor(tpl);
   await const YamlWriter().write(tpl.toJson(), path);
   return true;
+}
+
+Future<Map<String, dynamic>> _ratePackTask(String path) async {
+  final file = File(path);
+  if (!file.existsSync()) return const PackRatingReport().toJson();
+  final yaml = await file.readAsString();
+  final map = const YamlReader().read(yaml);
+  final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+  final report = const TrainingPackRatingEngine().rate(tpl);
+  return report.toJson();
 }

--- a/lib/services/training_pack_rating_engine.dart
+++ b/lib/services/training_pack_rating_engine.dart
@@ -6,9 +6,82 @@ import '../core/training/generation/yaml_reader.dart';
 import '../core/training/generation/yaml_writer.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
+import '../models/pack_rating_report.dart';
 
 class TrainingPackRatingEngine {
   const TrainingPackRatingEngine();
+
+  PackRatingReport rate(TrainingPackTemplateV2 pack) {
+    final warnings = <String>[];
+    final insights = <String>[];
+    final positions = <String>{
+      ...pack.positions,
+      for (final s in pack.spots) s.hand.position.name,
+    }..removeWhere((e) => e.trim().isEmpty);
+    final posScore = (positions.length >= 5 ? 20 : positions.length * 4)
+        .toDouble();
+    if (positions.length < 5) warnings.add('low_position_coverage');
+    insights.add('positions:${positions.length}');
+
+    final prCounts = <int, int>{};
+    for (final s in pack.spots) {
+      prCounts[s.priority] = (prCounts[s.priority] ?? 0) + 1;
+    }
+    double spread = 0;
+    final avg = pack.spots.isEmpty ? 0 : pack.spots.length / prCounts.length;
+    for (final c in prCounts.values) {
+      spread += (c - avg).abs();
+    }
+    final prScore = prCounts.isEmpty
+        ? 0
+        : (20 - (spread / pack.spots.length) * 20).clamp(0, 20);
+    if (prScore < 10) warnings.add('priority_bias');
+    insights.add('priority:${prScore.toStringAsFixed(1)}');
+
+    final seen = <String>{};
+    final valid = <String>{};
+    for (final s in pack.spots) {
+      final key = _spotKey(s);
+      seen.add(key);
+      if (_hasHeroAction(s) && s.evalResult != null) valid.add(key);
+    }
+    final validScore = pack.spots.isEmpty
+        ? 0
+        : (valid.length * 20 / pack.spots.length).clamp(0, 20);
+    if (valid.length < pack.spots.length) warnings.add('invalid_or_duplicate');
+    insights.add('valid:${valid.length}/${pack.spots.length}');
+
+    final groups = <String>{};
+    for (final s in pack.spots) {
+      final g = _handGroup(s.hand.heroCards);
+      if (g.isNotEmpty) groups.add(g);
+    }
+    final groupScore = (groups.length >= 10 ? 20 : groups.length * 2)
+        .toDouble();
+    if (groups.length < 10) warnings.add('low_hand_diversity');
+    insights.add('groups:${groups.length}');
+
+    final content = '${pack.name} ${pack.goal} ${pack.description}'
+        .toLowerCase();
+    final rel = [
+      for (final t in pack.tags)
+        if (content.contains(t.toLowerCase())) t,
+    ];
+    final tagScore = pack.tags.isEmpty
+        ? 0
+        : (rel.length * 20 / pack.tags.length).clamp(0, 20);
+    if (tagScore < 10) warnings.add('weak_tag_relevance');
+    insights.add('tags:${rel.length}/${pack.tags.length}');
+
+    var score = posScore + prScore + validScore + groupScore + tagScore;
+    if (score < 0) score = 0;
+    if (score > 100) score = 100;
+    return PackRatingReport(
+      score: score.round(),
+      warnings: warnings,
+      insights: insights,
+    );
+  }
 
   Future<int> rateAll({String path = 'training_packs/library'}) async {
     final docs = await getApplicationDocumentsDirectory();
@@ -17,10 +90,11 @@ class TrainingPackRatingEngine {
     const reader = YamlReader();
     const writer = YamlWriter();
     var count = 0;
-    for (final file in dir
-        .listSync(recursive: true)
-        .whereType<File>()
-        .where((f) => f.path.toLowerCase().endsWith('.yaml'))) {
+    for (final file
+        in dir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.toLowerCase().endsWith('.yaml'))) {
       try {
         final map = reader.read(await file.readAsString());
         final tpl = TrainingPackTemplateV2.fromJson(map);
@@ -36,25 +110,7 @@ class TrainingPackRatingEngine {
   }
 
   int _calcRating(TrainingPackTemplateV2 tpl) {
-    final spots = tpl.spots;
-    final valid = spots
-        .where((s) => _hasHeroAction(s) && s.evalResult != null)
-        .length;
-    final validScore = spots.isEmpty ? 0.0 : valid * 40 / spots.length;
-    final tags = <String>{for (final t in tpl.tags) t.trim().toLowerCase()}
-      ..removeWhere((e) => e.isEmpty);
-    final tagScore = tags.length >= 3 ? 20.0 : tags.length * (20 / 3);
-    final metaScore = (tpl.meta['evScore'] != null ? 10 : 0) +
-        ((tpl.audience ?? '').isNotEmpty ? 10 : 0) +
-        (tpl.name.trim().isNotEmpty ? 10 : 0);
-    final avgStreet = spots.isEmpty
-        ? 0.0
-        : spots.map((s) => s.street).reduce((a, b) => a + b) / spots.length;
-    final streetScore = avgStreet * (10 / 3);
-    var rating = validScore + tagScore + metaScore + streetScore;
-    if (rating < 0) rating = 0;
-    if (rating > 100) rating = 100;
-    return rating.round();
+    return rate(tpl).score;
   }
 
   bool _hasHeroAction(TrainingPackSpot s) {
@@ -65,5 +121,28 @@ class TrainingPackRatingEngine {
       }
     }
     return false;
+  }
+
+  String _spotKey(TrainingPackSpot s) {
+    final map = Map<String, dynamic>.from(s.toJson());
+    map.remove('editedAt');
+    map.remove('createdAt');
+    map.remove('evalResult');
+    map.remove('correctAction');
+    map.remove('explanation');
+    return map.toString();
+  }
+
+  String _handGroup(String cards) {
+    final ranks = cards.replaceAll(RegExp('[^AKQJT98765432]'), '');
+    if (ranks.length < 2) return '';
+    final r1 = ranks[0];
+    final r2 = ranks[1];
+    if (r1 == r2) return '$r1$r2';
+    final suits = cards.replaceAll(RegExp('[AKQJT98765432]'), '');
+    if (suits.length >= 2 && suits[0] == suits[1]) {
+      return '$r1$r2s';
+    }
+    return '$r1$r2o';
   }
 }


### PR DESCRIPTION
## Summary
- add PackRatingReport model for scoring YAML packs
- rebuild TrainingPackRatingEngine with new metrics
- extend DevMenu with YAML pack rating option

## Testing
- `dart format lib/models/pack_rating_report.dart lib/services/training_pack_rating_engine.dart lib/screens/dev_menu_screen.dart`
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6878c6e578cc832aa7de85c39f6ce781