### PR TITLE
Add tag suggestion engine

### DIFF
--- a/lib/services/tag_suggestion_engine.dart
+++ b/lib/services/tag_suggestion_engine.dart
@@ -1,0 +1,31 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/hero_position.dart';
+
+class TagSuggestionEngine {
+  const TagSuggestionEngine();
+
+  List<String> suggestTags(TrainingPackTemplateV2 pack) {
+    final set = <String>{};
+    final posSet = <HeroPosition>{};
+    for (final s in pack.spots) {
+      posSet.add(s.hand.position);
+    }
+    if (posSet.isNotEmpty && posSet.every((p) => p == HeroPosition.btn || p == HeroPosition.sb || p == HeroPosition.bb)) {
+      set.add('blind_defense');
+    }
+    if (pack.spots.isNotEmpty && pack.spots.every((s) => s.hand.playerCount == 6)) {
+      set.add('6max');
+    }
+    if (pack.bb == 10) set.add('10bb');
+    final aud = pack.audience?.toLowerCase();
+    if (aud == 'beginner') set.add('beginner');
+    final kw = pack.meta['keywords'];
+    if (kw is List) {
+      for (final k in kw) if (k is String && k.isNotEmpty) set.add(k);
+    } else if (kw is String) {
+      for (final w in kw.split(RegExp(r'[;, ]+'))) if (w.isNotEmpty) set.add(w);
+    }
+    final list = set.toList()..sort();
+    return list;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TagSuggestionEngine` to propose tags for training packs
- expose tag suggestions in DevMenu via `💡 Предложить теги для YAML пака`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9a143ec832aba46c6f967aa2e40