### PR TITLE
Add inline markdown preview for YAML library packs

### DIFF
--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -4,7 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import '../theme/app_colors.dart';
-import 'yaml_viewer_screen.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/yaml_pack_markdown_preview_service.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 class YamlLibraryPreviewScreen extends StatefulWidget {
   const YamlLibraryPreviewScreen({super.key});
@@ -16,6 +20,9 @@ class YamlLibraryPreviewScreen extends StatefulWidget {
 class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   final List<File> _files = [];
   bool _loading = true;
+  int _selected = -1;
+  String? _markdown;
+  final ScrollController _mdCtrl = ScrollController();
 
   @override
   void initState() {
@@ -42,16 +49,29 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
     }
   }
 
-  Future<void> _open(File file) async {
-    final yaml = await file.readAsString();
-    final name = file.path.split(Platform.pathSeparator).last;
+  Future<void> _select(File file, int index) async {
+    String? md;
+    try {
+      final yaml = await file.readAsString();
+      final map = const YamlReader().read(yaml);
+      final tpl = TrainingPackTemplateV2.fromJson(
+        Map<String, dynamic>.from(map),
+      );
+      md = const YamlPackMarkdownPreviewService()
+          .generateMarkdownPreview(tpl);
+    } catch (_) {}
     if (!mounted) return;
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => YamlViewerScreen(yamlText: yaml, title: name),
-      ),
-    );
+    setState(() {
+      _selected = index;
+      _markdown = md;
+    });
+    _mdCtrl.jumpTo(0);
+  }
+
+  @override
+  void dispose() {
+    _mdCtrl.dispose();
+    super.dispose();
   }
 
   @override
@@ -62,16 +82,66 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       backgroundColor: AppColors.background,
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : ListView.builder(
-              itemCount: _files.length,
-              itemBuilder: (_, i) {
-                final f = _files[i];
-                final name = f.path.split(Platform.pathSeparator).last;
-                final date = DateFormat('yyyy-MM-dd HH:mm').format(f.statSync().modified);
-                return ListTile(
-                  title: Text(name),
-                  subtitle: Text(date),
-                  onTap: () => _open(f),
+          : LayoutBuilder(
+              builder: (context, c) {
+                final list = ListView.builder(
+                  itemCount: _files.length,
+                  itemBuilder: (_, i) {
+                    final f = _files[i];
+                    final name = f.path.split(Platform.pathSeparator).last;
+                    final date = DateFormat('yyyy-MM-dd HH:mm')
+                        .format(f.statSync().modified);
+                    return ListTile(
+                      selected: i == _selected,
+                      title: Text(name),
+                      subtitle: Text(date),
+                      onTap: () => _select(f, i),
+                    );
+                  },
+                );
+                final preview = Container(
+                  color: AppColors.cardBackground,
+                  padding: const EdgeInsets.all(16),
+                  child: _markdown == null
+                      ? const Text('Нет предпросмотра')
+                      : Column(
+                          children: [
+                            Expanded(
+                              child: Markdown(
+                                data: _markdown!,
+                                controller: _mdCtrl,
+                              ),
+                            ),
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: TextButton(
+                                onPressed: () {
+                                  Clipboard.setData(
+                                      ClipboardData(text: _markdown!));
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                        content: Text('Скопировано')),
+                                  );
+                                },
+                                child: const Text('📋 Скопировать'),
+                              ),
+                            ),
+                          ],
+                        ),
+                );
+                if (c.maxWidth > 600) {
+                  return Row(
+                    children: [
+                      Expanded(child: list),
+                      SizedBox(width: 400, child: preview),
+                    ],
+                  );
+                }
+                return Column(
+                  children: [
+                    Expanded(child: list),
+                    SizedBox(height: 300, child: preview),
+                  ],
                 );
               },
             ),

--- a/lib/services/yaml_pack_markdown_preview_service.dart
+++ b/lib/services/yaml_pack_markdown_preview_service.dart
@@ -1,0 +1,39 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../helpers/hand_utils.dart';
+
+class YamlPackMarkdownPreviewService {
+  const YamlPackMarkdownPreviewService();
+
+  String? generateMarkdownPreview(TrainingPackTemplateV2 pack) {
+    try {
+      final buffer = StringBuffer('# ${pack.name}\n');
+      if (pack.goal.trim().isNotEmpty) buffer.writeln('\n${pack.goal}');
+      if (pack.tags.isNotEmpty) {
+        buffer.writeln('\n**Tags:** ${pack.tags.join(', ')}');
+      }
+      buffer
+        ..writeln('\n**Spots:** ${pack.spotCount}')
+        ..writeln(
+            '**EV:** ${(pack.meta['evScore'] as num?)?.toStringAsFixed(1) ?? ''}')
+        ..writeln(
+            '**ICM:** ${(pack.meta['icmScore'] as num?)?.toStringAsFixed(1) ?? ''}');
+      final preview = pack.spots.take(5);
+      if (preview.isNotEmpty) {
+        buffer
+          ..writeln('\n|Pos|Hero|Board|EV|Tags|')
+          ..writeln('|---|---|---|---|---|');
+        for (final s in preview) {
+          final hero = handCode(s.hand.heroCards) ?? s.hand.heroCards;
+          final board = s.hand.board.join(' ');
+          final ev = s.heroEv?.toStringAsFixed(2) ?? '';
+          final tags = s.tags.join(', ');
+          buffer.writeln(
+              '|${s.hand.position.label}|$hero|$board|$ev|$tags|');
+        }
+      }
+      return buffer.toString().trimRight();
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   hive_flutter: ^1.1.0
   webview_flutter: ^4.2.2
   markdown: ^7.1.1
+  flutter_markdown: ^0.6.17
   table_calendar: ^3.0.9
   flutter_local_notifications: ^17.0.0
   timezone: ^0.9.2


### PR DESCRIPTION
## Summary
- generate markdown previews for YAML packs
- show markdown preview panel in library view
- add flutter_markdown dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792d5289f8832a995a1b86aeb1facf