### PR TITLE
Add YAML pack history snapshots

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -72,6 +72,8 @@ import 'pack_conflict_analysis_screen.dart';
 import 'pack_merge_duplicates_screen.dart';
 import '../services/pack_library_rating_engine.dart';
 import '../models/pack_library_rating_report.dart';
+import '../services/yaml_pack_history_service.dart';
+import 'yaml_pack_history_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -898,7 +900,13 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     String? path;
     if (result != null && result.files.isNotEmpty) {
       path = result.files.single.path;
-      if (path != null) json = await compute(_autoFixTask, path);
+      if (path != null) {
+        final raw = await File(path).readAsString();
+        final map = const YamlReader().read(raw);
+        final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+        await const YamlPackHistoryService().saveSnapshot(tpl, 'fix');
+        json = await compute(_autoFixTask, path);
+      }
     }
     if (!mounted) return;
     setState(() => _autoFixLoading = false);
@@ -1436,6 +1444,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const YamlPackQuickPreviewScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📂 История паков'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const YamlPackHistoryScreen(),
                     ),
                   );
                 },

--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -11,6 +11,7 @@ import '../services/yaml_pack_markdown_preview_service.dart';
 import '../services/yaml_pack_validator_service.dart';
 import '../services/yaml_pack_auto_fix_engine.dart';
 import '../services/yaml_pack_formatter_service.dart';
+import '../services/yaml_pack_history_service.dart';
 import '../widgets/markdown_preview_dialog.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -99,6 +100,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       final map = const YamlReader().read(yaml);
       final tpl =
           TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      await const YamlPackHistoryService().saveSnapshot(tpl, 'fix');
       final fixed = const YamlPackAutoFixEngine().autoFix(tpl);
       await const YamlWriter().write(fixed.toJson(), file.path);
       if (mounted) {
@@ -124,6 +126,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       final map = const YamlReader().read(yaml);
       final tpl =
           TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      await const YamlPackHistoryService().saveSnapshot(tpl, 'format');
       final formatted = const YamlPackFormatterService().format(tpl);
       final outMap = const YamlReader().read(formatted);
       await const YamlWriter().write(outMap, file.path);

--- a/lib/screens/yaml_pack_editor_screen.dart
+++ b/lib/screens/yaml_pack_editor_screen.dart
@@ -7,6 +7,7 @@ import '../core/training/generation/yaml_reader.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../services/yaml_pack_history_service.dart';
 import '../theme/app_colors.dart';
 import 'v2/training_pack_spot_editor_screen.dart';
 
@@ -74,6 +75,7 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
           ..clear()
           ..addAll(_tags)
       ..spotCount = pack.spots.length;
+    await const YamlPackHistoryService().saveSnapshot(pack, 'save');
     await file.writeAsString(pack.toYaml());
     if (!mounted) return;
     ScaffoldMessenger.of(context)

--- a/lib/screens/yaml_pack_history_screen.dart
+++ b/lib/screens/yaml_pack_history_screen.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/yaml_pack_markdown_preview_service.dart';
+import '../theme/app_colors.dart';
+import 'yaml_viewer_screen.dart';
+
+class YamlPackHistoryScreen extends StatefulWidget {
+  const YamlPackHistoryScreen({super.key});
+
+  @override
+  State<YamlPackHistoryScreen> createState() => _YamlPackHistoryScreenState();
+}
+
+class _YamlPackHistoryScreenState extends State<YamlPackHistoryScreen> {
+  final List<File> _files = [];
+  bool _loading = true;
+  int _selected = -1;
+  String? _markdown;
+  String? _yaml;
+  final ScrollController _ctrl = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final hist = Directory('${dir.path}/training_packs/history');
+    final list = hist
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    list.sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+    if (mounted) {
+      setState(() {
+        _files
+          ..clear()
+          ..addAll(list);
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _select(File file, int index) async {
+    String? md;
+    String? y;
+    try {
+      final yaml = await file.readAsString();
+      y = yaml;
+      final map = const YamlReader().read(yaml);
+      final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      md = const YamlPackMarkdownPreviewService().generateMarkdownPreview(tpl);
+    } catch (_) {}
+    if (!mounted) return;
+    setState(() {
+      _selected = index;
+      _markdown = md;
+      _yaml = y;
+    });
+    _ctrl.jumpTo(0);
+  }
+
+  Future<void> _open(File file) async {
+    final yaml = await file.readAsString();
+    final name = file.path.split(Platform.pathSeparator).last;
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => YamlViewerScreen(yamlText: yaml, title: name),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Yaml History')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : LayoutBuilder(
+              builder: (context, c) {
+                final list = ListView.builder(
+                  itemCount: _files.length,
+                  itemBuilder: (_, i) {
+                    final f = _files[i];
+                    final name = f.path.split(Platform.pathSeparator).last;
+                    final date = DateFormat('yyyy-MM-dd HH:mm')
+                        .format(f.statSync().modified);
+                    return ListTile(
+                      selected: i == _selected,
+                      title: Text(name),
+                      subtitle: Text(date),
+                      onTap: () => _select(f, i),
+                      onLongPress: () => _open(f),
+                    );
+                  },
+                );
+                final preview = Container(
+                  color: AppColors.cardBackground,
+                  padding: const EdgeInsets.all(16),
+                  child: _selected == -1
+                      ? const Text('Нет файла')
+                      : _markdown != null
+                          ? SingleChildScrollView(
+                              controller: _ctrl,
+                              child: SelectableText(
+                                _markdown!,
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            )
+                          : SingleChildScrollView(
+                              controller: _ctrl,
+                              child: SelectableText(
+                                _yaml ?? '',
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ),
+                );
+                if (c.maxWidth > 600) {
+                  return Row(
+                    children: [
+                      Expanded(child: list),
+                      SizedBox(width: 400, child: preview),
+                    ],
+                  );
+                }
+                return Column(
+                  children: [
+                    Expanded(child: list),
+                    SizedBox(height: 300, child: preview),
+                  ],
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/yaml_pack_history_service.dart
+++ b/lib/services/yaml_pack_history_service.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import 'yaml_pack_formatter_service.dart';
+
+class YamlPackHistoryService {
+  const YamlPackHistoryService();
+
+  Future<void> saveSnapshot(TrainingPackTemplateV2 pack, String action) async {
+    if (pack.id.trim().isEmpty) return;
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'training_packs', 'history'));
+    await dir.create(recursive: true);
+    final ts = DateFormat('yyyyMMddTHHmmss').format(DateTime.now());
+    final name = '${pack.id}_${action}_$ts.yaml';
+    final file = File(p.join(dir.path, name));
+    final formatted = const YamlPackFormatterService().format(pack);
+    final map = const YamlReader().read(formatted);
+    await const YamlWriter().write(map, file.path);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `YamlPackHistoryService` to archive YAML pack snapshots
- provide `YamlPackHistoryScreen` to browse history
- log snapshots before formatting, autofix, and save
- expose history screen in Dev Menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687933c3185c832a8ce9f51bbf42d31c