### PR TITLE
Add pack changelog and version warnings

### DIFF
--- a/lib/services/yaml_pack_history_service.dart
+++ b/lib/services/yaml_pack_history_service.dart
@@ -22,4 +22,26 @@ class YamlPackHistoryService {
     final map = const YamlReader().read(formatted);
     await const YamlWriter().write(map, file.path);
   }
+
+  TrainingPackTemplateV2 addChangeLog(
+    TrainingPackTemplateV2 pack,
+    String action,
+    String author,
+    String comment,
+  ) {
+    final entry = {
+      'action': action,
+      'author': author,
+      'date': DateFormat('yyyy-MM-dd').format(DateTime.now()),
+      'comment': comment,
+    };
+    final list = (pack.meta['changeLog'] as List?)
+            ?.map((e) => Map<String, String>.from(e as Map))
+            .toList() ??
+        <Map<String, String>>[];
+    list.add(Map<String, String>.from(entry));
+    pack.meta['changeLog'] = list;
+    pack.meta.putIfAbsent('schemaVersion', () => '2.0.0');
+    return pack;
+  }
 }


### PR DESCRIPTION
## Summary
- keep changeLog in pack meta and bump schema version when needed
- warn in YAML screens if schema is outdated
- log change entries on save, format and fix actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793579459c832a9421ccf801b9edb5