### PR TITLE
Add YAML pack changelog service

### DIFF
--- a/lib/screens/yaml_pack_editor_screen.dart
+++ b/lib/screens/yaml_pack_editor_screen.dart
@@ -9,6 +9,7 @@ import '../models/v2/training_pack_spot.dart';
 import '../services/training_pack_template_storage_service.dart';
 import '../services/yaml_pack_history_service.dart';
 import '../services/yaml_pack_exporter_service.dart';
+import '../services/yaml_pack_changelog_service.dart';
 import '../theme/app_colors.dart';
 import 'package:open_filex/open_filex.dart';
 import 'v2/training_pack_spot_editor_screen.dart';
@@ -96,6 +97,8 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
     await const YamlPackHistoryService().saveSnapshot(pack, 'save');
     const service = YamlPackHistoryService();
     service.addChangeLog(pack, 'save', 'editor', 'save');
+    await const YamlPackChangelogService()
+        .appendChangeLog(pack, 'ручное обновление');
     await file.writeAsString(pack.toYaml());
     if (!mounted) return;
     ScaffoldMessenger.of(context)

--- a/lib/services/yaml_pack_auto_fix_engine.dart
+++ b/lib/services/yaml_pack_auto_fix_engine.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'package:uuid/uuid.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hero_position.dart';
+import 'yaml_pack_changelog_service.dart';
 
 class YamlPackAutoFixEngine {
   final Uuid _uuid;
@@ -30,7 +32,7 @@ class YamlPackAutoFixEngine {
       spots.add(s);
     }
 
-    return TrainingPackTemplateV2(
+    final result = TrainingPackTemplateV2(
       id: id,
       name: pack.name,
       description: pack.description,
@@ -48,5 +50,12 @@ class YamlPackAutoFixEngine {
       meta: meta,
       recommended: pack.recommended,
     );
+    unawaited(
+      const YamlPackChangelogService().appendChangeLog(
+        result,
+        'Автофикс: добавлены id, удалены дубликаты',
+      ),
+    );
+    return result;
   }
 }

--- a/lib/services/yaml_pack_changelog_service.dart
+++ b/lib/services/yaml_pack_changelog_service.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class YamlPackChangelogService {
+  const YamlPackChangelogService();
+
+  Future<void> appendChangeLog(TrainingPackTemplateV2 pack, String reason) async {
+    if (pack.id.trim().isEmpty) return;
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'training_packs', 'history'));
+    await dir.create(recursive: true);
+    final file = File(p.join(dir.path, '${pack.id}_changelog.md'));
+    final date = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    final version = pack.meta['schemaVersion'] ?? '2.0.0';
+    await file.writeAsString('- [$date] $reason (v$version)\n', mode: FileMode.append);
+  }
+}


### PR DESCRIPTION
## Summary
- log YAML pack updates to per-pack markdown changelogs
- append changelog entries on autofix
- record manual updates in the editor

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793a8dd2f0832a9ced81879dde2ec1