### PR TITLE
Add changelog viewer

### DIFF
--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -13,6 +13,7 @@ import '../services/yaml_pack_auto_fix_engine.dart';
 import '../services/yaml_pack_formatter_service.dart';
 import '../services/yaml_pack_history_service.dart';
 import '../services/yaml_pack_exporter_service.dart';
+import '../services/yaml_pack_changelog_service.dart';
 import 'package:open_filex/open_filex.dart';
 import '../widgets/markdown_preview_dialog.dart';
 import 'package:flutter/services.dart';
@@ -183,6 +184,22 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
     } catch (_) {}
   }
 
+  Future<void> _showHistory(File file) async {
+    try {
+      final yaml = await file.readAsString();
+      final map = const YamlReader().read(yaml);
+      final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      final md = await const YamlPackChangelogService().loadChangeLog(tpl.id);
+      if (!mounted) return;
+      if (md == null) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('История изменений отсутствует')));
+      } else {
+        await showMarkdownPreviewDialog(context, md);
+      }
+    } catch (_) {}
+  }
+
   Future<void> _export(File file) async {
     final format = await showModalBottomSheet<String>(
       context: context,
@@ -301,6 +318,11 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
                                 tooltip: 'Экспорт',
                                 icon: const Icon(Icons.download),
                                 onPressed: () => _export(f),
+                              ),
+                              IconButton(
+                                tooltip: 'История',
+                                icon: const Icon(Icons.history),
+                                onPressed: () => _showHistory(f),
                               ),
                             ],
                           ),

--- a/lib/screens/yaml_pack_editor_screen.dart
+++ b/lib/screens/yaml_pack_editor_screen.dart
@@ -12,6 +12,7 @@ import '../services/yaml_pack_exporter_service.dart';
 import '../services/yaml_pack_changelog_service.dart';
 import '../theme/app_colors.dart';
 import 'package:open_filex/open_filex.dart';
+import '../widgets/markdown_preview_dialog.dart';
 import 'v2/training_pack_spot_editor_screen.dart';
 
 class YamlPackEditorScreen extends StatefulWidget {
@@ -186,6 +187,20 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
     );
   }
 
+  Future<void> _showHistory() async {
+    final pack = _pack;
+    if (pack == null) return;
+    final md = await const YamlPackChangelogService().loadChangeLog(pack.id);
+    if (!mounted) return;
+    if (md == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('История изменений отсутствует')),
+      );
+    } else {
+      await showMarkdownPreviewDialog(context, md);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!kDebugMode) return const SizedBox.shrink();
@@ -197,6 +212,7 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
         actions: [
           IconButton(icon: const Icon(Icons.save), onPressed: _save),
           IconButton(icon: const Icon(Icons.download), onPressed: _export),
+          IconButton(icon: const Icon(Icons.history), onPressed: _showHistory),
         ],
       ),
       backgroundColor: AppColors.background,

--- a/lib/services/yaml_pack_changelog_service.dart
+++ b/lib/services/yaml_pack_changelog_service.dart
@@ -17,4 +17,12 @@ class YamlPackChangelogService {
     final version = pack.meta['schemaVersion'] ?? '2.0.0';
     await file.writeAsString('- [$date] $reason (v$version)\n', mode: FileMode.append);
   }
+
+  Future<String?> loadChangeLog(String packId) async {
+    if (packId.trim().isEmpty) return null;
+    final docs = await getApplicationDocumentsDirectory();
+    final file = File(p.join(docs.path, 'training_packs', 'history', '${packId}_changelog.md'));
+    if (!await file.exists()) return null;
+    return file.readAsString();
+  }
 }


### PR DESCRIPTION
## Summary
- allow viewing pack history from editor or library
- include a service method to load changelog files

## Testing
- `flutter analyze` *(fails: 6691 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68793b6eb128832a9a160890f8817248