### PR TITLE
Add YAML pack archive browser

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -74,6 +74,7 @@ import '../services/pack_library_rating_engine.dart';
 import '../models/pack_library_rating_report.dart';
 import '../services/yaml_pack_history_service.dart';
 import 'yaml_pack_history_screen.dart';
+import 'yaml_pack_archive_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -1456,6 +1457,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const YamlPackHistoryScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🗄️ Архив паков'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const YamlPackArchiveScreen(),
                     ),
                   );
                 },

--- a/lib/screens/yaml_pack_archive_screen.dart
+++ b/lib/screens/yaml_pack_archive_screen.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../theme/app_colors.dart';
+import 'yaml_viewer_screen.dart';
+import 'yaml_pack_diff_screen.dart';
+
+class YamlPackArchiveScreen extends StatefulWidget {
+  const YamlPackArchiveScreen({super.key});
+
+  @override
+  State<YamlPackArchiveScreen> createState() => _YamlPackArchiveScreenState();
+}
+
+class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
+  final Map<String, List<File>> _items = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final docs = await getApplicationDocumentsDirectory();
+    final root = Directory('${docs.path}/training_packs/archive');
+    final map = <String, List<File>>{};
+    if (await root.exists()) {
+      for (final dir in root.listSync()) {
+        if (dir is Directory) {
+          final id = p.basename(dir.path);
+          final files = dir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.bak.yaml'))
+              .toList()
+            ..sort((a, b) =>
+                b.statSync().modified.compareTo(a.statSync().modified));
+          if (files.isNotEmpty) map[id] = files;
+        }
+      }
+    }
+    if (!mounted) return;
+    setState(() {
+      _items
+        ..clear()
+        ..addAll(map);
+      _loading = false;
+    });
+  }
+
+  Future<void> _open(String id, File file) async {
+    final yaml = await file.readAsString();
+    late TrainingPackTemplateV2 bak;
+    try {
+      bak = TrainingPackTemplateV2.fromYaml(yaml);
+    } catch (_) {
+      return;
+    }
+    final path = bak.meta['path']?.toString();
+    TrainingPackTemplateV2? current;
+    if (path != null && path.isNotEmpty) {
+      final f = File(path);
+      if (await f.exists()) {
+        try {
+          final y = await f.readAsString();
+          current = TrainingPackTemplateV2.fromYaml(y);
+        } catch (_) {}
+      }
+    }
+    final action = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: AppColors.cardBackground,
+        title: Text(id),
+        actions: [
+          if (current != null)
+            TextButton(
+              onPressed: () => Navigator.pop(context, 'diff'),
+              child: const Text('Сравнить'),
+            ),
+          if (path != null && path.isNotEmpty)
+            TextButton(
+              onPressed: () => Navigator.pop(context, 'restore'),
+              child: const Text('Восстановить'),
+            ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'copy'),
+            child: const Text('Открыть копию'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || action == null) return;
+    if (action == 'diff' && current != null) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => YamlPackDiffScreen(packA: bak, packB: current!),
+        ),
+      );
+    } else if (action == 'restore' && path != null && path.isNotEmpty) {
+      await File(path).writeAsString(yaml);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Восстановлено')));
+      }
+    } else if (action == 'copy') {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) =>
+              YamlViewerScreen(yamlText: yaml, title: '${id}_copy'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Архив паков')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              children: [
+                for (final e in _items.entries)
+                  ExpansionTile(
+                    title: Text(e.key),
+                    children: [
+                      for (final f in e.value)
+                        ListTile(
+                          title: Text(DateFormat('yyyy-MM-dd HH:mm')
+                              .format(f.statSync().modified)),
+                          subtitle: Text(
+                              '${(f.lengthSync() / 1024).toStringAsFixed(1)} KB'),
+                          onTap: () => _open(e.key, f),
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `YamlPackArchiveScreen` to inspect and restore archived `.bak.yaml` files
- link the archive screen in DevMenu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793f33b648832aa38e99d842afaccc