### PR TITLE
Implement YAML archive auto clean

### DIFF
--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,0 +1,7 @@
+class AppConfig {
+  AppConfig._();
+  static final instance = AppConfig._();
+  bool archiveAutoClean = false;
+}
+
+final appConfig = AppConfig.instance;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -100,6 +100,7 @@ import 'services/training_pack_template_service.dart';
 import 'services/training_pack_stats_service.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
+import 'services/app_init_service.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -148,6 +149,7 @@ Future<void> main() async {
   await MistakeHintService.instance.load();
   tagCache = TagCacheService();
   await tagCache.load();
+  await AppInitService.instance.init();
   runApp(
     MultiProvider(
       providers: buildAppProviders(cloud),

--- a/lib/services/app_init_service.dart
+++ b/lib/services/app_init_service.dart
@@ -1,0 +1,10 @@
+import 'yaml_pack_archive_auto_cleaner_service.dart';
+
+class AppInitService {
+  AppInitService._();
+  static final instance = AppInitService._();
+
+  Future<void> init() async {
+    await const YamlPackArchiveAutoCleanerService().clean();
+  }
+}

--- a/lib/services/dev_console_log_service.dart
+++ b/lib/services/dev_console_log_service.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+class DevConsoleLogService {
+  DevConsoleLogService._();
+  static final instance = DevConsoleLogService._();
+  bool enabled = false;
+
+  void log(String message) {
+    if (!enabled) return;
+    debugPrint(message);
+  }
+}

--- a/lib/services/yaml_pack_archive_auto_cleaner_service.dart
+++ b/lib/services/yaml_pack_archive_auto_cleaner_service.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../app_config.dart';
+import 'dev_console_log_service.dart';
+
+class YamlPackArchiveAutoCleanerService {
+  const YamlPackArchiveAutoCleanerService();
+
+  Future<void> clean({int maxAgeDays = 60}) async {
+    if (!kDebugMode && !appConfig.archiveAutoClean) return;
+    try {
+      final docs = await getApplicationDocumentsDirectory();
+      final root = Directory(p.join(docs.path, 'training_packs', 'archive'));
+      if (!await root.exists()) return;
+      final cutoff = DateTime.now().subtract(Duration(days: maxAgeDays));
+      var deleted = 0;
+      for (final entity in root.listSync(recursive: true)) {
+        if (entity is File && entity.path.endsWith('.bak.yaml')) {
+          final stat = entity.statSync();
+          if (stat.modified.isBefore(cutoff)) {
+            try {
+              entity.deleteSync();
+              deleted++;
+            } catch (_) {}
+          }
+        }
+      }
+      if (deleted > 0) {
+        final msg = 'Archive auto-clean removed $deleted files';
+        debugPrint(msg);
+        DevConsoleLogService.instance.log(msg);
+      }
+    } catch (e) {
+      debugPrint('Archive auto-clean failed: $e');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `AppConfig` with `archiveAutoClean` flag
- implement `YamlPackArchiveAutoCleanerService`
- implement `DevConsoleLogService` to optionally log messages
- add `AppInitService` and run cleanup on app start

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879465c635c832a8f410b6a87cd3cd0