### PR TITLE
Implement TrainingTypeEngine detection

### DIFF
--- a/lib/core/training/bootstrap/built_in_pack_seeder.dart
+++ b/lib/core/training/bootstrap/built_in_pack_seeder.dart
@@ -14,7 +14,7 @@ class BuiltInPackSeeder {
     final typeEngine = TrainingTypeEngine();
     final templates = <TrainingPackTemplateV2>[];
     for (final r in config.requests) {
-      final t = await typeEngine.build(TrainingType.pushfold, r);
+      final t = await typeEngine.build(TrainingType.pushFold, r);
       if (config.rangeTags &&
           r.rangeGroup != null &&
           r.rangeGroup!.isNotEmpty &&

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -86,11 +86,11 @@ class PackLibraryGenerator {
     return autoTags(tmp);
   }
 
-  String generateTitle(TrainingPackTemplate template, [TrainingType type = TrainingType.pushfold]) {
+  String generateTitle(TrainingPackTemplate template, [TrainingType type = TrainingType.pushFold]) {
     final pos = template.heroPos.label;
     final bb = template.heroBbStack;
     final game = template.gameType.label;
-    if (type == TrainingType.pushfold) {
+    if (type == TrainingType.pushFold) {
       return '$pos Push ${bb}bb ($game)';
     }
     final stack = bb >= 40 ? 'DeepStack Pack' : '${bb}bb Pack';
@@ -101,7 +101,7 @@ class PackLibraryGenerator {
     final pos = t.positions.isNotEmpty ? parseHeroPosition(t.positions.first).label : HeroPosition.unknown.label;
     final bb = t.bb;
     final game = t.gameType.label;
-    if (t.type == TrainingType.pushfold) {
+    if (t.trainingType == TrainingType.pushFold) {
       return '$pos Push ${bb}bb ($game)';
     }
     final stack = bb >= 40 ? 'DeepStack Pack' : '${bb}bb Pack';
@@ -191,7 +191,7 @@ class PackLibraryGenerator {
         multiplePositions: r.multiplePositions,
       );
       tagger.tag(
-        TrainingPackTemplateV2.fromTemplate(tpl, type: TrainingType.pushfold),
+        TrainingPackTemplateV2.fromTemplate(tpl, type: TrainingType.pushFold),
         source: PackSource.yaml.name,
       );
       tpl.meta['source'] ??= PackSource.yaml.name;
@@ -214,7 +214,7 @@ class PackLibraryGenerator {
       if (tags.isNotEmpty) tpl.tags = tags;
       final tV2 = TrainingPackTemplateV2.fromTemplate(
         tpl,
-        type: TrainingType.pushfold,
+        type: TrainingType.pushFold,
       );
       final autoTagList = tagsEngine.generate(tV2);
       tpl.spotCount = tpl.spots.length;

--- a/lib/core/training/library/training_pack_library_v2.dart
+++ b/lib/core/training/library/training_pack_library_v2.dart
@@ -53,7 +53,7 @@ class TrainingPackLibraryV2 {
     return [
       for (final p in _packs)
         if ((gameType == null || p.gameType == gameType) &&
-            (type == null || p.type == type) &&
+            (type == null || p.trainingType == type) &&
             (tags == null || tags.every((t) => p.tags.contains(t))))
           p
     ];

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -16,7 +16,7 @@ class TrainingPackTemplateV2 {
   String? audience;
   List<String> tags;
   String? category;
-  final TrainingType type;
+  TrainingType trainingType;
   List<SpotTemplate> spots;
   int spotCount;
   final DateTime created;
@@ -34,7 +34,7 @@ class TrainingPackTemplateV2 {
     this.audience,
     List<String>? tags,
     this.category,
-    required this.type,
+    required this.trainingType,
     List<SpotTemplate>? spots,
     this.spotCount = 0,
     DateTime? created,
@@ -61,9 +61,9 @@ class TrainingPackTemplateV2 {
             (j['meta'] is Map ? (j['meta']['audience'] as String?) : null),
         tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
         category: (j['category'] ?? j['mainTag'])?.toString(),
-        type: TrainingType.values.firstWhere(
-          (e) => e.name == j['type'],
-          orElse: () => TrainingType.pushfold,
+        trainingType: TrainingType.values.firstWhere(
+          (e) => e.name == (j['trainingType'] ?? j['type']),
+          orElse: () => TrainingType.pushFold,
         ),
         spots: [
           for (final s in (j['spots'] as List? ?? []))
@@ -79,6 +79,9 @@ class TrainingPackTemplateV2 {
             (j['meta'] is Map ? j['meta']['recommended'] == true : false),
     );
     tpl.category ??= tpl.tags.isNotEmpty ? tpl.tags.first : null;
+    if ((j['trainingType'] ?? j['type']) == null) {
+      tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
+    }
     return tpl;
   }
 
@@ -90,7 +93,7 @@ class TrainingPackTemplateV2 {
         if (audience != null && audience!.isNotEmpty) 'audience': audience,
         if (tags.isNotEmpty) 'tags': tags,
         if (category != null && category!.isNotEmpty) 'category': category,
-        'type': type.name,
+        'trainingType': trainingType.name,
         if (spots.isNotEmpty) 'spots': [for (final s in spots) s.toJson()],
         'spotCount': spotCount,
         'created': created.toIso8601String(),
@@ -120,7 +123,7 @@ class TrainingPackTemplateV2 {
         audience: template.meta['audience'] as String?,
         tags: List<String>.from(template.tags),
         category: template.tags.isNotEmpty ? template.tags.first : null,
-        type: type,
+        trainingType: type,
         spots: List<SpotTemplate>.from(template.spots),
         spotCount: template.spotCount,
         created: template.createdAt,

--- a/lib/models/v2/training_pack_v2.dart
+++ b/lib/models/v2/training_pack_v2.dart
@@ -48,7 +48,7 @@ class TrainingPackV2 {
     tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
     type: TrainingType.values.firstWhere(
       (e) => e.name == j['type'],
-      orElse: () => TrainingType.pushfold,
+      orElse: () => TrainingType.pushFold,
     ),
     spots: [
       for (final s in (j['spots'] as List? ?? []))
@@ -88,7 +88,7 @@ class TrainingPackV2 {
         name: t.name,
         description: t.description,
         tags: List<String>.from(t.tags),
-        type: t.type,
+        type: t.trainingType,
         spots: [for (final s in t.spots) TrainingPackSpot.fromJson(s.toJson())],
         spotCount: t.spotCount,
         generatedAt: DateTime.now(),

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -226,7 +226,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
           }
         }
         final tpl = await TrainingTypeEngine().build(
-          TrainingType.pushfold,
+          TrainingType.pushFold,
           config.requests.first,
         );
         await showTrainingPackYamlPreviewer(context, tpl);

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -93,7 +93,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
     }
     final visible = [
       for (final p in _packs)
-        if ((_selectedTags.isEmpty ||
+        if ((_selectedTypes.isEmpty || _selectedTypes.contains(p.trainingType)) &&
+            (_selectedTags.isEmpty ||
                 p.tags.toSet().intersection(_selectedTags).isNotEmpty) &&
             (_selectedDifficulties.isEmpty
                 ? true
@@ -145,6 +146,38 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       ],
                     ),
                   ),
+                if (_types.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        for (final t in _types)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            child: ChoiceChip(
+                              label: Text(t.name),
+                              selected: _selectedTypes.contains(t),
+                              selectedColor: AppColors.accent,
+                              backgroundColor: Colors.grey[700],
+                              visualDensity: VisualDensity.compact,
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              onSelected: (_) {
+                                setState(() {
+                                  if (_selectedTypes.contains(t)) {
+                                    _selectedTypes.remove(t);
+                                  } else {
+                                    _selectedTypes.add(t);
+                                  }
+                                });
+                              },
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
                 if (_tags.isNotEmpty) const SizedBox(height: 8),
                 if (_audiences.isNotEmpty)
                   Row(
@@ -202,18 +235,21 @@ class _LibraryScreenState extends State<LibraryScreen> {
                   children: [
                     if (_selectedTags.isNotEmpty ||
                         _selectedDifficulties.isNotEmpty ||
-                        _selectedAudiences.isNotEmpty)
+                        _selectedAudiences.isNotEmpty ||
+                        _selectedTypes.isNotEmpty)
                       TextButton(
                         onPressed: () => setState(() {
                           _selectedTags.clear();
                           _selectedDifficulties.clear();
                           _selectedAudiences.clear();
+                          _selectedTypes.clear();
                         }),
                         child: const Text('Сбросить'),
                       ),
                     if (_selectedTags.isNotEmpty ||
                         _selectedDifficulties.isNotEmpty ||
-                        _selectedAudiences.isNotEmpty)
+                        _selectedAudiences.isNotEmpty ||
+                        _selectedTypes.isNotEmpty)
                       const SizedBox(width: 12),
                     Text('Найдено: ${visible.length}')
                   ],
@@ -230,12 +266,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
                         const Text('По текущему фильтру пакетов не найдено'),
                         if (_selectedTags.isNotEmpty ||
                             _selectedDifficulties.isNotEmpty ||
-                            _selectedAudiences.isNotEmpty)
+                            _selectedAudiences.isNotEmpty ||
+                            _selectedTypes.isNotEmpty)
                           TextButton(
                             onPressed: () => setState(() {
                               _selectedTags.clear();
                               _selectedDifficulties.clear();
                               _selectedAudiences.clear();
+                              _selectedTypes.clear();
                             }),
                             child: const Text('Сбросить'),
                           ),

--- a/lib/screens/pack_coverage_stats_screen.dart
+++ b/lib/screens/pack_coverage_stats_screen.dart
@@ -136,7 +136,7 @@ Future<Map<String, dynamic>> _statsTask(String filter) async {
       final map = reader.read(await f.readAsString());
       final tpl = TrainingPackTemplateV2.fromJson(map);
       final c = tpl.spots.length;
-      type[tpl.type.name] = (type[tpl.type.name] ?? 0) + c;
+      type[tpl.trainingType.name] = (type[tpl.trainingType.name] ?? 0) + c;
       for (final s in tpl.spots) {
         total++;
         final p = s.hand.position.name.toUpperCase();

--- a/lib/screens/tag_matrix_coverage_screen.dart
+++ b/lib/screens/tag_matrix_coverage_screen.dart
@@ -196,7 +196,7 @@ Future<Map<String, dynamic>> _coverageTask(Map args) async {
         final map = reader.read(await f.readAsString());
         final tpl = TrainingPackTemplateV2.fromJson(map);
         final type = args['type'] as String?;
-        if (type != null && type.isNotEmpty && tpl.type.name != type) continue;
+        if (type != null && type.isNotEmpty && tpl.trainingType.name != type) continue;
         if (args['starter'] == true &&
             !tpl.tags.any((t) => t.toLowerCase().contains('starter'))) {
           continue;

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -163,7 +163,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         unawaited(TrainingHistoryServiceV2.logCompletion(
             TrainingPackTemplateV2.fromTemplate(
           tpl,
-          type: TrainingType.pushfold,
+          type: TrainingType.pushFold,
         )));
       } else {
         await prefs.setInt(

--- a/lib/services/pack_library_assembler_service.dart
+++ b/lib/services/pack_library_assembler_service.dart
@@ -34,7 +34,7 @@ class PackLibraryAssemblerService {
         final requestsJson = <Map<String, dynamic>>[];
         final templates = <TrainingPackTemplateV2>[];
         for (final r in config.requests) {
-          final tpl = await engine.build(TrainingType.pushfold, r);
+          final tpl = await engine.build(TrainingType.pushFold, r);
           templates.add(tpl);
           requestsJson.add({
             'gameType': r.gameType.name,

--- a/lib/services/pack_library_auto_fix_engine.dart
+++ b/lib/services/pack_library_auto_fix_engine.dart
@@ -35,7 +35,7 @@ class PackLibraryAutoFixEngine {
       audience: pack.audience,
       tags: tags.toList(),
       category: pack.category,
-      type: pack.type,
+      trainingType: pack.trainingType,
       spots: pack.spots,
       spotCount: pack.spots.length,
       created: pack.created,

--- a/lib/services/smart_pack_recommendation_engine.dart
+++ b/lib/services/smart_pack_recommendation_engine.dart
@@ -44,12 +44,12 @@ class SmartPackRecommendationEngine {
       if (selected.length >= limit) break;
       final pack = e.key;
       final pos = pack.positions.isEmpty ? '' : pack.positions.first;
-      final skip = types.contains(pack.type) &&
+      final skip = types.contains(pack.trainingType) &&
           stacks.contains(pack.bb) &&
           positions.contains(pos);
       if (skip) continue;
       selected.add(pack);
-      types.add(pack.type);
+      types.add(pack.trainingType);
       stacks.add(pack.bb);
       positions.add(pos);
     }

--- a/lib/services/yaml_pack_auto_fix_engine.dart
+++ b/lib/services/yaml_pack_auto_fix_engine.dart
@@ -40,7 +40,7 @@ class YamlPackAutoFixEngine {
       audience: pack.audience,
       tags: List<String>.from(pack.tags),
       category: pack.category,
-      type: pack.type,
+      trainingType: pack.trainingType,
       spots: spots,
       spotCount: spots.length,
       created: pack.created,

--- a/lib/services/yaml_pack_auto_tagger.dart
+++ b/lib/services/yaml_pack_auto_tagger.dart
@@ -23,7 +23,7 @@ class YamlPackAutoTagger {
     }
     final aud = pack.audience?.trim();
     if (aud != null && aud.isNotEmpty) set.add(aud);
-    if (pack.type == TrainingType.pushfold) set.add('pushfold');
+    if (pack.trainingType == TrainingType.pushFold) set.add('pushfold');
     final total = pack.meta['totalWeight'] as int? ?? pack.spots.length;
     if (total > 0) {
       final ev = (pack.meta['evCovered'] as int? ?? 0) * 100 ~/ total;

--- a/lib/services/yaml_pack_formatter_service.dart
+++ b/lib/services/yaml_pack_formatter_service.dart
@@ -36,7 +36,7 @@ class YamlPackFormatterService {
     if (p.category != null && p.category!.trim().isNotEmpty) {
       map['category'] = p.category;
     }
-    map['type'] = p.type.name;
+    map['trainingType'] = p.trainingType.name;
     map['spotCount'] = spots.length;
     map['created'] = p.created.toIso8601String();
     map['gameType'] = p.gameType.name;

--- a/lib/services/yaml_pack_merge_engine.dart
+++ b/lib/services/yaml_pack_merge_engine.dart
@@ -14,7 +14,7 @@ class YamlPackMergeEngine {
         id: _uuid.v4(),
         name: 'Combined Pack',
         description: 'Combined Pack',
-        type: TrainingType.pushfold,
+        trainingType: TrainingType.pushFold,
       );
     }
     final first = list.first;
@@ -90,7 +90,7 @@ class YamlPackMergeEngine {
       audience: first.audience,
       tags: tags.toList(),
       category: first.category,
-      type: first.type,
+      trainingType: first.trainingType,
       spots: spots,
       spotCount: spots.length,
       created: DateTime.now(),

--- a/test/pack_library_generator_v2_test.dart
+++ b/test/pack_library_generator_v2_test.dart
@@ -18,7 +18,7 @@ class FakeEngine extends TrainingPackGeneratorEngine {
       name: template.name,
       description: template.description,
       tags: List<String>.from(template.tags),
-      type: template.type,
+      type: template.trainingType,
       spots: spots,
       spotCount: spots.length,
       generatedAt: DateTime.now(),
@@ -34,15 +34,15 @@ class FakeEngine extends TrainingPackGeneratorEngine {
 void main() {
   test('generateFromTemplates skips disabled and empty', () async {
     final spot = TrainingPackSpot(id: 's1', hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10));
-    final enabled = TrainingPackTemplateV2(id: '1', name: 'A', type: TrainingType.pushfold, spots: [spot]);
+    final enabled = TrainingPackTemplateV2(id: '1', name: 'A', trainingType: TrainingType.pushFold, spots: [spot]);
     final disabled = TrainingPackTemplateV2(
       id: '2',
       name: 'B',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       meta: {'enabled': false},
       spots: [spot],
     );
-    final empty = TrainingPackTemplateV2(id: '3', name: 'C', type: TrainingType.pushfold);
+    final empty = TrainingPackTemplateV2(id: '3', name: 'C', trainingType: TrainingType.pushFold);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([enabled, disabled, empty]);
     expect(res.length, 1);
@@ -54,14 +54,14 @@ void main() {
     final high = TrainingPackTemplateV2(
       id: '1',
       name: 'High',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       meta: {'priority': 2},
       spots: [spot],
     );
     final low = TrainingPackTemplateV2(
       id: '2',
       name: 'Low',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       meta: {'priority': 1},
       spots: [spot],
     );
@@ -81,7 +81,7 @@ void main() {
       id: 's3',
       hand: HandData.fromSimpleInput('JcJs', HeroPosition.btn, 15)..board.addAll(['2h', '3d', '4s', '5c']),
     );
-    final tpl = TrainingPackTemplateV2(id: 't', name: 'T', type: TrainingType.pushfold, spots: [s1, s2, s3]);
+    final tpl = TrainingPackTemplateV2(id: 't', name: 'T', trainingType: TrainingType.pushFold, spots: [s1, s2, s3]);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([tpl]);
     expect(res.first.meta['difficulty'], 3);
@@ -100,7 +100,7 @@ void main() {
     final tpl = TrainingPackTemplateV2(
       id: 'm',
       name: 'M',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [s1, s2],
     );
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
@@ -116,7 +116,7 @@ void main() {
     final tpl = TrainingPackTemplateV2(
       id: 'o',
       name: 'O',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot],
       meta: {'difficulty': 3},
     );
@@ -136,7 +136,7 @@ void main() {
         board: ['2h', '3d', '4s', '5c'],
       ),
     );
-    final tpl = TrainingPackTemplateV2(id: 'x', name: 'X', type: TrainingType.pushfold, spots: [spot]);
+    final tpl = TrainingPackTemplateV2(id: 'x', name: 'X', trainingType: TrainingType.pushFold, spots: [spot]);
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
     final res = await generator.generateFromTemplates([tpl]);
     final tags = res.first.tags;
@@ -152,7 +152,7 @@ void main() {
     final tpl = TrainingPackTemplateV2(
       id: 'z',
       name: '',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       gameType: GameType.tournament,
       bb: 10,
       positions: ['sb'],
@@ -169,7 +169,7 @@ void main() {
       id: 'y',
       name: 'T',
       description: '',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       gameType: GameType.tournament,
       bb: 10,
       positions: ['sb'],
@@ -186,7 +186,7 @@ void main() {
       id: 'g',
       name: 'T',
       goal: 'Push practice',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot],
     );
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
@@ -200,7 +200,7 @@ void main() {
       id: 'a',
       name: 'T',
       audience: 'Advanced',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot],
     );
     final generator = PackLibraryGenerator(packEngine: const FakeEngine());
@@ -214,7 +214,7 @@ void main() {
       id: 'ag',
       name: 'Auto',
       goal: '',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       gameType: GameType.tournament,
       bb: 10,
       positions: ['sb'],
@@ -230,7 +230,7 @@ void main() {
     final tpl = TrainingPackTemplateV2(
       id: 'r',
       name: 'R',
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot],
       recommended: true,
     );

--- a/test/training_pack_ranking_engine_test.dart
+++ b/test/training_pack_ranking_engine_test.dart
@@ -29,14 +29,14 @@ void main() {
       id: 'a',
       name: 'A',
       meta: {'evScore': 80},
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot(10)],
     );
     final b = TrainingPackTemplateV2(
       id: 'b',
       name: 'B',
       meta: {'evScore': 60},
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot(12)],
     );
     final rank = const TrainingPackRankingEngine().rank(a, [a, b]);
@@ -44,8 +44,8 @@ void main() {
   });
 
   test('rankAll returns map by id', () {
-    final a = TrainingPackTemplateV2(id: 'a', name: 'A', type: TrainingType.pushfold);
-    final b = TrainingPackTemplateV2(id: 'b', name: 'B', type: TrainingType.pushfold);
+    final a = TrainingPackTemplateV2(id: 'a', name: 'A', trainingType: TrainingType.pushFold);
+    final b = TrainingPackTemplateV2(id: 'b', name: 'B', trainingType: TrainingType.pushFold);
     final res = const TrainingPackRankingEngine().rankAll([a, b]);
     expect(res.keys, containsAll(['a', 'b']));
   });

--- a/test/training_pack_template_v2_from_json_test.dart
+++ b/test/training_pack_template_v2_from_json_test.dart
@@ -6,7 +6,7 @@ void main() {
     final tpl = TrainingPackTemplateV2.fromJson({
       'id': 't',
       'name': 'Test',
-      'type': 'pushfold',
+      'trainingType': 'pushFold',
       'tags': ['a', 'b'],
       'goal': 'Learn',
       'audience': 'Beginners',
@@ -23,7 +23,7 @@ void main() {
     final tpl = TrainingPackTemplateV2.fromJson({
       'id': 'x',
       'name': 'X',
-      'type': 'pushfold',
+      'trainingType': 'pushFold',
       'tags': ['m'],
     });
     expect(tpl.category, 'm');

--- a/test/yaml_duplicate_detector_service_test.dart
+++ b/test/yaml_duplicate_detector_service_test.dart
@@ -4,11 +4,11 @@ import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
 
 void main() {
   test('detectDuplicates groups by name id and hash', () {
-    final a = TrainingPackTemplateV2(id: '1', name: 'A', type: TrainingType.pushfold);
-    final b = TrainingPackTemplateV2(id: '1', name: 'B', type: TrainingType.pushfold);
-    final c = TrainingPackTemplateV2(id: '2', name: 'A', type: TrainingType.pushfold);
-    final d = TrainingPackTemplateV2(id: '4', name: 'D', type: TrainingType.pushfold);
-    final e = TrainingPackTemplateV2(id: '4', name: 'D', type: TrainingType.pushfold);
+    final a = TrainingPackTemplateV2(id: '1', name: 'A', trainingType: TrainingType.pushFold);
+    final b = TrainingPackTemplateV2(id: '1', name: 'B', trainingType: TrainingType.pushFold);
+    final c = TrainingPackTemplateV2(id: '2', name: 'A', trainingType: TrainingType.pushFold);
+    final d = TrainingPackTemplateV2(id: '4', name: 'D', trainingType: TrainingType.pushFold);
+    final e = TrainingPackTemplateV2(id: '4', name: 'D', trainingType: TrainingType.pushFold);
     final service = const YamlDuplicateDetectorService();
     final res = service.detectDuplicates([a, b, c, d, e]);
     expect(res.where((g) => g.type == 'id').length, 2);

--- a/test/yaml_pack_auto_tagger_test.dart
+++ b/test/yaml_pack_auto_tagger_test.dart
@@ -10,7 +10,7 @@ void main() {
       name: 'Push SB',
       category: 'Push/Fold',
       positions: ['sb'],
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
     );
     final tagger = YamlPackAutoTagger();
     final tags = tagger.generateTags(tpl);

--- a/test/yaml_pack_rating_engine_test.dart
+++ b/test/yaml_pack_rating_engine_test.dart
@@ -31,7 +31,7 @@ void main() {
       description: 'desc',
       goal: 'goal',
       meta: {'evScore': 80, 'rankScore': 0.5},
-      type: TrainingType.pushfold,
+      trainingType: TrainingType.pushFold,
       spots: [spot(10), spot(15)],
     );
     final rating = const YamlPackRatingEngine().rate(tpl);
@@ -39,8 +39,8 @@ void main() {
   });
 
   test('rateAll returns map by id', () {
-    final a = TrainingPackTemplateV2(id: 'a', name: 'A', type: TrainingType.pushfold);
-    final b = TrainingPackTemplateV2(id: 'b', name: 'B', type: TrainingType.pushfold);
+    final a = TrainingPackTemplateV2(id: 'a', name: 'A', trainingType: TrainingType.pushFold);
+    final b = TrainingPackTemplateV2(id: 'b', name: 'B', trainingType: TrainingType.pushFold);
     final res = const YamlPackRatingEngine().rateAll([a, b]);
     expect(res.keys, containsAll(['a', 'b']));
   });


### PR DESCRIPTION
## Summary
- add training type detection engine and new enum values
- store trainingType in templates and auto-detect on load
- update pack generation and utilities for new enum
- allow filtering by training type in library
- adjust tests for trainingType field

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: Unable to locate package)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a62a97dc832a804685dca4ebfd04