### PR TITLE
Add YAML auto-detection for training type

### DIFF
--- a/lib/core/training/library/training_pack_library_v2.dart
+++ b/lib/core/training/library/training_pack_library_v2.dart
@@ -33,11 +33,10 @@ class TrainingPackLibraryV2 {
     );
     if (paths.isEmpty) return;
     clear();
-    const reader = YamlReader();
     for (final p in paths) {
       try {
-        final map = reader.read(await rootBundle.loadString(p));
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await rootBundle.loadString(p);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         addPack(tpl);
       } catch (_) {}
     }

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -109,6 +109,15 @@ class TrainingPackTemplateV2 {
     return TrainingPackTemplateV2.fromJson(map);
   }
 
+  factory TrainingPackTemplateV2.fromYamlAuto(String source) {
+    final map = const YamlReader().read(source);
+    final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    if ((map['trainingType'] ?? map['type']) == null) {
+      tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
+    }
+    return tpl;
+  }
+
   String toYaml() => const YamlEncoder().convert(toJson());
 
   factory TrainingPackTemplateV2.fromTemplate(

--- a/lib/screens/pack_library_diff_screen.dart
+++ b/lib/screens/pack_library_diff_screen.dart
@@ -44,7 +44,7 @@ class _PackLibraryDiffScreenState extends State<PackLibraryDiffScreen> {
       final yaml = await File(path).readAsString();
       setState(() {
         _fileA = path;
-        _packA = TrainingPackTemplateV2.fromYaml(yaml);
+        _packA = TrainingPackTemplateV2.fromYamlAuto(yaml);
       });
     } catch (_) {}
   }
@@ -60,7 +60,7 @@ class _PackLibraryDiffScreenState extends State<PackLibraryDiffScreen> {
       final yaml = await File(path).readAsString();
       setState(() {
         _fileB = path;
-        _packB = TrainingPackTemplateV2.fromYaml(yaml);
+        _packB = TrainingPackTemplateV2.fromYamlAuto(yaml);
       });
     } catch (_) {}
   }

--- a/lib/screens/pack_merge_duplicates_screen.dart
+++ b/lib/screens/pack_merge_duplicates_screen.dart
@@ -102,8 +102,8 @@ Future<List<YamlPackConflict>> _conflictTask(String _) async {
       .whereType<File>()
       .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
     try {
-      final map = reader.read(await f.readAsString());
-      packs.add(TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map)));
+      final yaml = await f.readAsString();
+      packs.add(TrainingPackTemplateV2.fromYamlAuto(yaml));
     } catch (_) {}
   }
   final res = const YamlPackConflictDetector().detectConflicts(packs);

--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -55,9 +55,8 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       var outdated = false;
       try {
         final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final map = const YamlReader().read(yaml);
-        final tpl =
-            TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
         final v = tpl.meta['schemaVersion']?.toString();
         outdated = _versionLess(v, '2.0.0');
       } catch (_) {}
@@ -78,9 +77,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
     try {
       final yaml = await file.readAsString();
       final map = const YamlReader().read(yaml);
-      final tpl = TrainingPackTemplateV2.fromJson(
-        Map<String, dynamic>.from(map),
-      );
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       md = const YamlPackMarkdownPreviewService().generateMarkdownPreview(tpl);
     } catch (_) {}
     if (!mounted) return;
@@ -94,9 +91,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   Future<void> _validate(File file) async {
     try {
       final yaml = await file.readAsString();
-      final map = const YamlReader().read(yaml);
-      final tpl =
-          TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final report = const YamlPackValidatorService().validate(tpl);
       if (!mounted) return;
       final msg = report.errors.isEmpty && report.warnings.isEmpty
@@ -114,9 +109,8 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   Future<void> _autoFix(File file) async {
     try {
       final yaml = await file.readAsString();
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final map = const YamlReader().read(yaml);
-      final tpl =
-          TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
       await const YamlPackHistoryService().saveSnapshot(tpl, 'fix');
       final fixed = const YamlPackAutoFixEngine().autoFix(tpl);
       const service = YamlPackHistoryService();
@@ -143,9 +137,8 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   Future<void> _formatYaml(File file) async {
     try {
       final yaml = await file.readAsString();
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final map = const YamlReader().read(yaml);
-      final tpl =
-          TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
       await const YamlPackHistoryService().saveSnapshot(tpl, 'format');
       const service = YamlPackHistoryService();
       service.addChangeLog(tpl, 'format', 'editor', 'format');
@@ -173,9 +166,8 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   Future<void> _previewMarkdown(File file) async {
     try {
       final yaml = await file.readAsString();
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final map = const YamlReader().read(yaml);
-      final tpl =
-          TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
       final md =
           const YamlPackMarkdownPreviewService().generateMarkdownPreview(tpl);
       if (md != null && mounted) {
@@ -187,8 +179,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
   Future<void> _showHistory(File file) async {
     try {
       final yaml = await file.readAsString();
-      final map = const YamlReader().read(yaml);
-      final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final md = await const YamlPackChangelogService().loadChangeLog(tpl.id);
       if (!mounted) return;
       if (md == null) {

--- a/lib/screens/yaml_pack_archive_screen.dart
+++ b/lib/screens/yaml_pack_archive_screen.dart
@@ -98,8 +98,8 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
     TrainingPackTemplateV2? a;
     TrainingPackTemplateV2? b;
     try {
-      a = TrainingPackTemplateV2.fromYaml(await files[0].readAsString());
-      b = TrainingPackTemplateV2.fromYaml(await files[1].readAsString());
+      a = TrainingPackTemplateV2.fromYamlAuto(await files[0].readAsString());
+      b = TrainingPackTemplateV2.fromYamlAuto(await files[1].readAsString());
     } catch (_) {
       return;
     }
@@ -113,7 +113,7 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
     final yaml = await file.readAsString();
     late TrainingPackTemplateV2 bak;
     try {
-      bak = TrainingPackTemplateV2.fromYaml(yaml);
+      bak = TrainingPackTemplateV2.fromYamlAuto(yaml);
     } catch (_) {
       return;
     }
@@ -124,7 +124,7 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
       if (await f.exists()) {
         try {
           final y = await f.readAsString();
-          current = TrainingPackTemplateV2.fromYaml(y);
+          current = TrainingPackTemplateV2.fromYamlAuto(y);
         } catch (_) {}
       }
     }

--- a/lib/screens/yaml_pack_archive_validator_screen.dart
+++ b/lib/screens/yaml_pack_archive_validator_screen.dart
@@ -119,7 +119,7 @@ Future<List<Map<String, dynamic>>> _validateTask(String _) async {
             String? err;
             try {
               final content = await f.readAsString();
-              final tpl = TrainingPackTemplateV2.fromYaml(content);
+              final tpl = TrainingPackTemplateV2.fromYamlAuto(content);
               final v = tpl.meta['schemaVersion']?.toString();
               if (versionLess(v)) err = 'outdated';
             } on FormatException catch (_) {

--- a/lib/screens/yaml_pack_quick_preview_screen.dart
+++ b/lib/screens/yaml_pack_quick_preview_screen.dart
@@ -36,8 +36,8 @@ class _YamlPackQuickPreviewScreenState extends State<YamlPackQuickPreviewScreen>
         .whereType<File>()
         .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        list.add((f, TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map))));
+        final yaml = await f.readAsString();
+        list.add((f, TrainingPackTemplateV2.fromYamlAuto(yaml)));
       } catch (_) {}
     }
     list.sort((a, b) => b.$1.statSync().modified.compareTo(a.$1.statSync().modified));

--- a/lib/services/evaluation_scoring_service.dart
+++ b/lib/services/evaluation_scoring_service.dart
@@ -20,8 +20,9 @@ class EvaluationScoringService {
         .whereType<File>()
         .where((f) => f.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await file.readAsString());
-        TrainingPackTemplateV2.fromJson(map);
+        final yaml = await file.readAsString();
+        final map = reader.read(yaml);
+        TrainingPackTemplateV2.fromYamlAuto(yaml);
         final spots = map['spots'] as List? ?? [];
         var evSum = 0.0;
         var evCount = 0;

--- a/lib/services/pack_library_conflict_scanner.dart
+++ b/lib/services/pack_library_conflict_scanner.dart
@@ -26,8 +26,9 @@ class PackLibraryConflictScanner {
         .whereType<File>()
         .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final map = reader.read(yaml);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         if (idMap.containsKey(tpl.id)) {
           duplicates.add(f.path);
         } else {

--- a/lib/services/pack_library_duplicate_cleaner.dart
+++ b/lib/services/pack_library_duplicate_cleaner.dart
@@ -21,8 +21,9 @@ class PackLibraryDuplicateCleaner {
         .whereType<File>()
         .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final map = reader.read(yaml);
         final json = jsonEncode(tpl.toJson());
         if (ids.containsKey(tpl.id) || hashes.containsKey(json)) {
           await f.delete();

--- a/lib/services/pack_library_generation_engine.dart
+++ b/lib/services/pack_library_generation_engine.dart
@@ -24,8 +24,9 @@ class PackLibraryGenerationEngine {
         .where((e) => e.path.toLowerCase().endsWith('.yaml') ||
             e.path.toLowerCase().endsWith('.yml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final map = reader.read(yaml);
         final report = const PackValidationEngine().validate(tpl);
         if (!report.isValid) continue;
         if (audience != null && audience.isNotEmpty) {

--- a/lib/services/pack_library_import_service.dart
+++ b/lib/services/pack_library_import_service.dart
@@ -47,8 +47,8 @@ class PackLibraryImportService {
         final bytes = await f.readAsBytes();
         final hash = md5.convert(bytes).toString();
         if (hashes.contains(hash)) continue;
-        final map = const YamlReader().read(utf8.decode(bytes));
-        TrainingPackTemplateV2.fromJson(map);
+        final yaml = utf8.decode(bytes);
+        TrainingPackTemplateV2.fromYamlAuto(yaml);
         await File(p.join(libDir.path, name)).writeAsBytes(bytes, flush: true);
         names.add(name);
         hashes.add(hash);

--- a/lib/services/pack_library_merge_service.dart
+++ b/lib/services/pack_library_merge_service.dart
@@ -58,8 +58,8 @@ class PackLibraryMergeService {
           final bytes = await f.readAsBytes();
           final hash = sha1.convert(bytes).toString();
           if (hashes.contains(hash)) continue;
-          final map = reader.read(utf8.decode(bytes));
-          final tpl = TrainingPackTemplateV2.fromJson(map);
+          final yaml = utf8.decode(bytes);
+          final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
           if (ids.contains(tpl.id)) continue;
           final dst = File(p.join(libDir.path, p.basename(f.path)));
           await dst.writeAsBytes(bytes, flush: true);

--- a/lib/services/pack_library_refactor_engine.dart
+++ b/lib/services/pack_library_refactor_engine.dart
@@ -31,8 +31,9 @@ class PackLibraryRefactorEngine {
         .where((e) => e.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final map = reader.read(yaml);
         tpl.name = _norm(tpl.name);
         tpl.goal = _norm(tpl.goal);
         tpl.description = _norm(tpl.description);

--- a/lib/services/pack_library_refactor_service.dart
+++ b/lib/services/pack_library_refactor_service.dart
@@ -30,11 +30,12 @@ class PackLibraryRefactorService {
         .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       Map<String, dynamic> map;
       try {
-        map = reader.read(await f.readAsString());
+        final yaml = await f.readAsString();
+        map = reader.read(yaml);
       } catch (_) {
         continue;
       }
-      final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       final tags = <String>{
         for (final t in tpl.tags) t.toString().trim().toLowerCase()
       }..removeWhere((t) => t.isEmpty);

--- a/lib/services/pack_stats_index_service.dart
+++ b/lib/services/pack_stats_index_service.dart
@@ -38,8 +38,9 @@ class PackStatsIndexService {
         .where((f) => f.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final map = reader.read(yaml);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final tags = <String>{for (final t in tpl.tags) t.trim().toLowerCase()}
           ..removeWhere((e) => e.isEmpty);
         final uniq = tags.where((t) => tagCounts[t] == 1).length;

--- a/lib/services/pack_tag_index_service.dart
+++ b/lib/services/pack_tag_index_service.dart
@@ -25,8 +25,8 @@ class PackTagIndexService {
         .where((f) => f.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final rel = p.relative(f.path, from: dir.path);
         final tags = <String>{
           for (final t in tpl.tags) t.trim().toLowerCase()

--- a/lib/services/tag_analytics_service.dart
+++ b/lib/services/tag_analytics_service.dart
@@ -24,8 +24,9 @@ class TagAnalyticsService {
         .where((f) => f.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final map = reader.read(yaml);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final tags = <String>{
           for (final t in tpl.tags) t.trim().toLowerCase()
         }..removeWhere((e) => e.isEmpty);

--- a/lib/services/tag_frequency_analyzer.dart
+++ b/lib/services/tag_frequency_analyzer.dart
@@ -45,8 +45,8 @@ class TagFrequencyAnalyzer {
             .where((f) => f.path.toLowerCase().endsWith('.yaml'));
         for (final f in files) {
           try {
-            final map = reader.read(await f.readAsString());
-            final tpl = TrainingPackTemplateV2.fromJson(map);
+            final yaml = await f.readAsString();
+            final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
             for (final t in tpl.tags) addTag(t);
             final c = tpl.category ??
                 (tpl.tags.isNotEmpty ? tpl.tags.first : null);

--- a/lib/services/tag_health_check_service.dart
+++ b/lib/services/tag_health_check_service.dart
@@ -21,8 +21,8 @@ class TagHealthCheckService {
         .where((f) => f.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         for (final t in tpl.tags) {
           final tag = t.trim().toLowerCase();
           if (tag.isEmpty) continue;

--- a/lib/services/training_coverage_service.dart
+++ b/lib/services/training_coverage_service.dart
@@ -90,8 +90,8 @@ class TrainingCoverageService {
             .where((f) => f.path.toLowerCase().endsWith('.yaml'));
         for (final f in files) {
           try {
-            final map = reader.read(await f.readAsString());
-            list.add(TrainingPackTemplateV2.fromJson(map));
+            final yaml = await f.readAsString();
+            list.add(TrainingPackTemplateV2.fromYamlAuto(yaml));
             processed = true;
           } catch (_) {}
         }

--- a/lib/services/training_pack_filter_engine.dart
+++ b/lib/services/training_pack_filter_engine.dart
@@ -26,8 +26,9 @@ class TrainingPackFilterEngine {
         .whereType<File>()
         .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final map = tpl.toJson();
         final meta = tpl.meta;
         final ev = (meta['evScore'] as num?)?.toDouble();
         final rating = (meta['rating'] as num?)?.toDouble();

--- a/lib/services/training_pack_health_report_service.dart
+++ b/lib/services/training_pack_health_report_service.dart
@@ -24,8 +24,10 @@ class TrainingPackHealthReportService {
         .where((f) => f.path.toLowerCase().endsWith('.yaml'));
     for (final f in files) {
       Map<String, dynamic> map;
+      String yaml;
       try {
-        map = reader.read(await f.readAsString());
+        yaml = await f.readAsString();
+        map = reader.read(yaml);
       } catch (_) {
         issues.add((f.path, 'invalid_yaml'));
         errors++;
@@ -33,7 +35,7 @@ class TrainingPackHealthReportService {
       }
       TrainingPackTemplateV2 tpl;
       try {
-        tpl = TrainingPackTemplateV2.fromJson(map);
+        tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       } catch (_) {
         issues.add((f.path, 'invalid_format'));
         errors++;

--- a/lib/services/training_pack_index_writer.dart
+++ b/lib/services/training_pack_index_writer.dart
@@ -24,8 +24,8 @@ class TrainingPackIndexWriter {
     final list = <Map<String, dynamic>>[];
     for (final file in files) {
       try {
-        final map = reader.read(await file.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await file.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         list.add({
           'title': tpl.name,
           if (tpl.tags.isNotEmpty) 'tags': tpl.tags,

--- a/lib/services/training_pack_ranking_engine.dart
+++ b/lib/services/training_pack_ranking_engine.dart
@@ -36,8 +36,8 @@ class TrainingPackRankingEngine {
     final paths = <TrainingPackTemplateV2, String>{};
     for (final f in files) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await f.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         templates.add(tpl);
         paths[tpl] = f.path;
       } catch (_) {}

--- a/lib/services/training_pack_rating_engine.dart
+++ b/lib/services/training_pack_rating_engine.dart
@@ -96,8 +96,9 @@ class TrainingPackRatingEngine {
             .whereType<File>()
             .where((f) => f.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await file.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(map);
+        final yaml = await file.readAsString();
+        final map = reader.read(yaml);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final rating = _calcRating(tpl);
         final meta = Map<String, dynamic>.from(tpl.meta);
         meta['rating'] = rating;

--- a/lib/services/yaml_pack_duplicate_cleaner_service.dart
+++ b/lib/services/yaml_pack_duplicate_cleaner_service.dart
@@ -24,10 +24,9 @@ class YamlPackDuplicateCleanerService {
             .whereType<File>()
             .where((e) => e.path.toLowerCase().endsWith('.yaml'))) {
       try {
-        final map = reader.read(await f.readAsString());
-        final tpl = TrainingPackTemplateV2.fromJson(
-          Map<String, dynamic>.from(map),
-        );
+        final yaml = await f.readAsString();
+        final map = reader.read(yaml);
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
         final stat = await f.stat();
         groups.putIfAbsent(tpl.id, () => []).add((
           f,

--- a/lib/services/yaml_pack_exporter_service.dart
+++ b/lib/services/yaml_pack_exporter_service.dart
@@ -16,8 +16,7 @@ class YamlPackExporterService {
       tpl = pack;
     } else if (pack is File) {
       final yaml = await pack.readAsString();
-      final map = const YamlReader().read(yaml);
-      tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
     } else {
       throw ArgumentError('pack');
     }

--- a/tool/pack_library_index_generator.dart
+++ b/tool/pack_library_index_generator.dart
@@ -17,12 +17,11 @@ Future<void> main(List<String> args) async {
       .whereType<File>()
       .where((f) => f.path.toLowerCase().endsWith('.yaml'))
       .toList();
-  final reader = const YamlReader();
   final list = <Map<String, dynamic>>[];
   for (final file in files) {
     try {
-      final map = reader.read(await file.readAsString());
-      final tpl = TrainingPackTemplateV2.fromJson(map);
+      final yaml = await file.readAsString();
+      final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
       list.add({
         'id': tpl.id,
         'name': tpl.name,


### PR DESCRIPTION
## Summary
- add `TrainingPackTemplateV2.fromYamlAuto` factory with automatic training type detection
- use the new factory in `TrainingPackLibraryV2.loadFromFolder`
- migrate various YAML parsers in services and screens to use `fromYamlAuto`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0eb4abac832aa25e09f8e87dcced