### PR TITLE
Add trainingType to exported YAML

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -5,7 +5,7 @@ import '../../../models/v2/training_pack_template_v2.dart';
 class TrainingPackExporterV2 {
   const TrainingPackExporterV2();
 
-  String exportYaml(TrainingPackTemplateV2 pack) => pack.toYaml();
+  String exportYaml(TrainingPackTemplateV2 pack) => pack.toYamlString();
 
   Future<File> exportToFile(
     TrainingPackTemplateV2 pack, {

--- a/lib/services/yaml_pack_formatter_service.dart
+++ b/lib/services/yaml_pack_formatter_service.dart
@@ -13,7 +13,9 @@ class YamlPackFormatterService {
 
   Map<String, dynamic> _packMap(TrainingPackTemplateV2 p) {
     final map = LinkedHashMap<String, dynamic>();
-    if (p.meta.isNotEmpty) map['meta'] = _cleanMap(p.meta);
+    final meta = _cleanMap(p.meta);
+    meta['trainingType'] = p.trainingType.name;
+    if (meta.isNotEmpty) map['meta'] = meta;
     map['name'] = p.name;
     if (p.goal.trim().isNotEmpty) map['goal'] = p.goal;
     if (p.tags.isNotEmpty) {

--- a/test/training_pack_template_v2_to_yaml_string_test.dart
+++ b/test/training_pack_template_v2_to_yaml_string_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+
+void main() {
+  test('toYamlString adds meta.trainingType', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 't',
+      name: 'Test',
+      trainingType: TrainingType.pushFold,
+    );
+
+    final yaml = tpl.toYamlString();
+    final map = const YamlReader().read(yaml);
+
+    expect(map['meta']['trainingType'], 'pushFold');
+  });
+}


### PR DESCRIPTION
## Summary
- ensure `meta.trainingType` is written when exporting pack templates
- use new YAML serialization in the exporter
- include the training type in formatted YAML
- cover the new method with a unit test

## Testing
- `flutter pub get` *(fails: desktop_drop requires newer Dart)*
- `flutter test` *(fails to compile due to missing files and errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a10f03e68832a8c5bc9c2a1f2eaa9