### PR TITLE
Add weakest training type prompt banner

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -63,6 +63,7 @@ import '../services/weak_spot_recommendation_service.dart';
 import '../widgets/pack_suggestion_banner.dart';
 import '../services/weak_training_type_detector.dart';
 import '../widgets/training_gap_prompt_banner.dart';
+import '../widgets/training_type_gap_prompt_banner.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -1483,6 +1484,15 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     return TrainingGapPromptBanner(category: cat, pack: pack);
   }
 
+  Widget _weakTypeBanner() {
+    final type = _weakestType;
+    if (type == null) return const SizedBox.shrink();
+    final pack = PackLibraryLoaderService.instance.library
+        .firstWhereOrNull((p) => p.trainingType == type);
+    if (pack == null) return const SizedBox.shrink();
+    return TrainingTypeGapPromptBanner(type: type, pack: pack);
+  }
+
   Widget _item(TrainingPackTemplate t, [String? note]) {
     final l = AppLocalizations.of(context)!;
     final parts = t.version.split('.');
@@ -2277,6 +2287,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           ),
           _recommendedCategoryCard(),
           _weakCategoryBanner(),
+          _weakTypeBanner(),
           SwitchListTile(
             title: Text(l.favorites),
             value: _favoritesOnly,

--- a/lib/widgets/training_type_gap_prompt_banner.dart
+++ b/lib/widgets/training_type_gap_prompt_banner.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../core/training/engine/training_type_engine.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class TrainingTypeGapPromptBanner extends StatelessWidget {
+  final TrainingType type;
+  final TrainingPackTemplate pack;
+  const TrainingTypeGapPromptBanner({super.key, required this.type, required this.pack});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.redAccent),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('📉 Слабый тип: ${type.label}',
+              style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          Text('🃏 Пак: ${pack.name}',
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: () async {
+                await context.read<TrainingSessionService>().startSession(pack);
+                if (context.mounted) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const TrainingSessionScreen()),
+                  );
+                }
+              },
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Начать тренировку'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show the `TrainingTypeGapPromptBanner` in template library if a weak type exists
- implement banner widget to recommend training for the weakest type

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687a37591bf8832ab040a9086dbb4d15