### PR TITLE
Add SuggestedPackTile widget for library recommendations

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -64,6 +64,7 @@ import '../widgets/pack_suggestion_banner.dart';
 import '../services/weak_training_type_detector.dart';
 import '../widgets/training_gap_prompt_banner.dart';
 import '../widgets/training_type_gap_prompt_banner.dart';
+import '../widgets/suggested_pack_tile.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -2666,6 +2667,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 ? ListView(
                     children: [
                       const PackSuggestionBanner(),
+                      const SuggestedPackTile(),
                       if (_popularOnly && popularFiltered.isNotEmpty) ...[
                         ListTile(title: Text(l.popularPacks)),
                         for (final t in popularFiltered) _item(t),

--- a/lib/widgets/suggested_pack_tile.dart
+++ b/lib/widgets/suggested_pack_tile.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../models/v2/training_pack_template.dart';
+import '../services/training_gap_notification_service.dart';
+import '../services/training_gap_detector_service.dart';
+import '../services/pack_library_loader_service.dart';
+import '../services/training_type_stats_service.dart';
+import '../services/weak_training_type_detector.dart';
+import '../services/training_session_service.dart';
+import '../helpers/category_translations.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../screens/training_session_screen.dart';
+
+class SuggestedPackTile extends StatefulWidget {
+  final String? excludeId;
+  const SuggestedPackTile({super.key, this.excludeId});
+
+  @override
+  State<SuggestedPackTile> createState() => _SuggestedPackTileState();
+}
+
+class _SuggestedPackTileState extends State<SuggestedPackTile> {
+  TrainingPackTemplate? _pack;
+  String? _reason;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final tpl = await const TrainingGapNotificationService()
+        .suggestNextPack(excludeId: widget.excludeId);
+    if (tpl == null) return;
+    String? reason;
+    final weakCategory =
+        await const TrainingGapDetectorService().detectWeakCategory();
+    if (weakCategory != null && tpl.category == weakCategory) {
+      reason = 'Слабая категория: ${translateCategory(weakCategory)}';
+    } else {
+      await PackLibraryLoaderService.instance.loadLibrary();
+      final packs = [
+        for (final t in PackLibraryLoaderService.instance.library)
+          TrainingPackTemplate.fromJson(t.toJson())
+      ];
+      final stats = await const TrainingTypeStatsService()
+          .calculateCompletionPercent(packs);
+      final weakType = const WeakTrainingTypeDetector().findWeakestType(stats);
+      if (weakType != null && tpl.trainingType == weakType) {
+        reason = 'Слабый тип: ${weakType.label}';
+      }
+    }
+    if (mounted) {
+      setState(() {
+        _pack = tpl;
+        _reason = reason;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_pack == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final l = AppLocalizations.of(context)!;
+    final pack = _pack!;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: accent),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '🔥 Рекомендуем для прогресса',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(pack.name, style: const TextStyle(color: Colors.white)),
+          if (_reason != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child:
+                  Text(_reason!, style: const TextStyle(color: Colors.white70)),
+            ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: () async {
+                await context.read<TrainingSessionService>().startSession(pack);
+                if (!context.mounted) return;
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const TrainingSessionScreen()),
+                );
+              },
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: Text(l.startTraining),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `SuggestedPackTile` widget that loads and displays the recommended pack from `TrainingGapNotificationService`
- show the tile in `TemplateLibraryScreen` above the pack list

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3cdbecf0832ab1530e9fb210be1b