### PR TITLE
Implement DailyReminderScheduler

### DIFF
--- a/lib/services/daily_reminder_scheduler.dart
+++ b/lib/services/daily_reminder_scheduler.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class DailyReminderScheduler {
+  static final DailyReminderScheduler instance = DailyReminderScheduler._();
+  DailyReminderScheduler._();
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+
+  static const _packKey = 'daily_reminder_pack';
+  static const _countKey = 'daily_reminder_count';
+  static const _idBase = 105;
+
+  Future<void> _init() async {
+    if (_initialized) return;
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+    _initialized = true;
+  }
+
+  Future<void> scheduleDailyReminder({required String packName}) async {
+    await _init();
+    final prefs = await SharedPreferences.getInstance();
+    final storedPack = prefs.getString(_packKey);
+    var count = prefs.getInt(_countKey) ?? 0;
+    if (storedPack != packName) {
+      await cancelAll();
+      count = 0;
+      await prefs.setString(_packKey, packName);
+    }
+    if (count >= 3) return;
+
+    final now = tz.TZDateTime.now(tz.local);
+    var first = tz.TZDateTime(local, now.year, now.month, now.day, 18);
+    if (!first.isAfter(now)) first = first.add(const Duration(days: 1));
+
+    final body = '🔁 Напоминание: вы ещё не начали "[$packName]" — давайте улучшим этот спот!';
+
+    for (int i = count; i < 3; i++) {
+      final when = first.add(Duration(days: i));
+      await _plugin.zonedSchedule(
+        _idBase + i,
+        'Poker Analyzer',
+        body,
+        when,
+        const NotificationDetails(
+          android: AndroidNotificationDetails('daily_pack_reminder', 'Daily Pack Reminder'),
+          iOS: DarwinNotificationDetails(),
+        ),
+        androidAllowWhileIdle: true,
+        uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      );
+    }
+    await prefs.setInt(_countKey, 3);
+  }
+
+  Future<void> cancelAll() async {
+    await _init();
+    for (int i = 0; i < 3; i++) {
+      await _plugin.cancel(_idBase + i);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_packKey);
+    await prefs.remove(_countKey);
+  }
+}

--- a/lib/services/suggested_pack_push_service.dart
+++ b/lib/services/suggested_pack_push_service.dart
@@ -5,6 +5,7 @@ import '../models/v2/training_pack_template.dart';
 import 'training_gap_notification_service.dart';
 import 'training_history_service_v2.dart';
 import 'app_settings_service.dart';
+import 'daily_reminder_scheduler.dart';
 
 class SuggestedPackPushService {
   static final SuggestedPackPushService instance = SuggestedPackPushService._();
@@ -60,6 +61,7 @@ class SuggestedPackPushService {
         iOS: DarwinNotificationDetails(),
       ),
     );
+    await DailyReminderScheduler.instance.scheduleDailyReminder(packName: tpl.name);
     await prefs.setString(_lastPushKey, DateTime.now().toIso8601String());
   }
 }

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -20,6 +20,7 @@ import '../models/v2/training_session.dart';
 import '../models/v2/training_action.dart';
 import '../models/v2/focus_goal.dart';
 import '../models/category_progress.dart';
+import 'daily_reminder_scheduler.dart';
 
 class TrainingSessionService extends ChangeNotifier {
   Box<dynamic>? _box;
@@ -313,6 +314,7 @@ class TrainingSessionService extends ChangeNotifier {
     bool persist = true,
   }) async {
     if (persist) await _openBox();
+    unawaited(DailyReminderScheduler.instance.cancelAll());
     _template = template;
     final total = template.totalWeight;
     _preEvPct = total == 0 ? 0 : template.evCovered * 100 / total;


### PR DESCRIPTION
## Summary
- add `DailyReminderScheduler` for repeat push reminders
- trigger daily reminders after the suggested pack push
- cancel all scheduled reminders when a training session starts

## Testing
- `apt-get update` *(passed)*
- `apt-get install -y dart` *(failed: package not found)*
- `dart --version` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4c6c20a0832a8770b8baa445f574