### PR TITLE
Add parseCard helper and refactor converters

### DIFF
--- a/lib/helpers/hand_history_parsing.dart
+++ b/lib/helpers/hand_history_parsing.dart
@@ -1,0 +1,20 @@
+import '../models/card_model.dart';
+
+/// Parses a token like `Ah` or `TD` into a [CardModel].
+/// Returns `null` if the token is not valid.
+CardModel? parseCard(String token) {
+  if (token.length < 2) return null;
+  final rank = token.substring(0, token.length - 1).toUpperCase();
+  final suitChar = token[token.length - 1].toLowerCase();
+  switch (suitChar) {
+    case 'h':
+      return CardModel(rank: rank, suit: '♥');
+    case 'd':
+      return CardModel(rank: rank, suit: '♦');
+    case 'c':
+      return CardModel(rank: rank, suit: '♣');
+    case 's':
+      return CardModel(rank: rank, suit: '♠');
+  }
+  return null;
+}

--- a/lib/plugins/converters/888poker_hand_history_converter.dart
+++ b/lib/plugins/converters/888poker_hand_history_converter.dart
@@ -1,7 +1,9 @@
 import '../converter_format_capabilities.dart';
 import '../converter_plugin.dart';
+import 'dart:convert';
 import 'package:poker_analyzer/models/saved_hand.dart';
 import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
@@ -18,28 +20,12 @@ class Poker888HandHistoryConverter extends ConverterPlugin {
           ),
         );
 
-  CardModel? _parseCard(String token) {
-    if (token.length < 2) return null;
-    final rank = token.substring(0, token.length - 1).toUpperCase();
-    final suitChar = token[token.length - 1].toLowerCase();
-    switch (suitChar) {
-      case 'h':
-        return CardModel(rank: rank, suit: '♥');
-      case 'd':
-        return CardModel(rank: rank, suit: '♦');
-      case 'c':
-        return CardModel(rank: rank, suit: '♣');
-      case 's':
-        return CardModel(rank: rank, suit: '♠');
-    }
-    return null;
-  }
 
   double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
 
   @override
   SavedHand? convertFrom(String externalData) {
-    final lines = externalData.split(RegExp(r'\r?\n'));
+    final lines = LineSplitter.split(externalData).toList();
     if (lines.isEmpty || !lines.first.toLowerCase().contains('888')) {
       return null;
     }
@@ -66,8 +52,8 @@ class Poker888HandHistoryConverter extends ConverterPlugin {
       final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
       if (m != null) {
         heroName = m.group(1)!.trim();
-        final c1 = _parseCard(m.group(2)!);
-        final c2 = _parseCard(m.group(3)!);
+        final c1 = parseCard(m.group(2)!);
+        final c2 = parseCard(m.group(3)!);
         if (c1 != null && c2 != null) heroCards = [c1, c2];
         break;
       }

--- a/lib/plugins/converters/ipoker_hand_history_converter.dart
+++ b/lib/plugins/converters/ipoker_hand_history_converter.dart
@@ -1,7 +1,9 @@
 import '../converter_format_capabilities.dart';
 import '../converter_plugin.dart';
+import 'dart:convert';
 import 'package:poker_analyzer/models/saved_hand.dart';
 import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
@@ -18,28 +20,12 @@ class IpokerHandHistoryConverter extends ConverterPlugin {
           ),
         );
 
-  CardModel? _parseCard(String token) {
-    if (token.length < 2) return null;
-    final rank = token.substring(0, token.length - 1).toUpperCase();
-    final suitChar = token[token.length - 1].toLowerCase();
-    switch (suitChar) {
-      case 'h':
-        return CardModel(rank: rank, suit: '♥');
-      case 'd':
-        return CardModel(rank: rank, suit: '♦');
-      case 'c':
-        return CardModel(rank: rank, suit: '♣');
-      case 's':
-        return CardModel(rank: rank, suit: '♠');
-    }
-    return null;
-  }
 
   double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
 
   @override
   SavedHand? convertFrom(String externalData) {
-    final lines = externalData.split(RegExp(r'\r?\n'));
+    final lines = LineSplitter.split(externalData).toList();
     if (lines.isEmpty || !lines.first.toLowerCase().contains('ipoker')) {
       return null;
     }
@@ -66,8 +52,8 @@ class IpokerHandHistoryConverter extends ConverterPlugin {
       final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
       if (m != null) {
         heroName = m.group(1)!.trim();
-        final c1 = _parseCard(m.group(2)!);
-        final c2 = _parseCard(m.group(3)!);
+        final c1 = parseCard(m.group(2)!);
+        final c2 = parseCard(m.group(3)!);
         if (c1 != null && c2 != null) heroCards = [c1, c2];
         break;
       }

--- a/lib/plugins/converters/partypoker_hand_history_converter.dart
+++ b/lib/plugins/converters/partypoker_hand_history_converter.dart
@@ -1,7 +1,9 @@
 import '../converter_format_capabilities.dart';
 import '../converter_plugin.dart';
+import 'dart:convert';
 import 'package:poker_analyzer/models/saved_hand.dart';
 import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
@@ -18,28 +20,12 @@ class PartypokerHandHistoryConverter extends ConverterPlugin {
           ),
         );
 
-  CardModel? _parseCard(String token) {
-    if (token.length < 2) return null;
-    final rank = token.substring(0, token.length - 1).toUpperCase();
-    final suitChar = token[token.length - 1].toLowerCase();
-    switch (suitChar) {
-      case 'h':
-        return CardModel(rank: rank, suit: '♥');
-      case 'd':
-        return CardModel(rank: rank, suit: '♦');
-      case 'c':
-        return CardModel(rank: rank, suit: '♣');
-      case 's':
-        return CardModel(rank: rank, suit: '♠');
-    }
-    return null;
-  }
 
   double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
 
   @override
   SavedHand? convertFrom(String externalData) {
-    final lines = externalData.split(RegExp(r'\r?\n'));
+    final lines = LineSplitter.split(externalData).toList();
     if (lines.isEmpty || !lines.first.toLowerCase().contains('partypoker')) {
       return null;
     }
@@ -66,8 +52,8 @@ class PartypokerHandHistoryConverter extends ConverterPlugin {
       final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
       if (m != null) {
         heroName = m.group(1)!.trim();
-        final c1 = _parseCard(m.group(2)!);
-        final c2 = _parseCard(m.group(3)!);
+        final c1 = parseCard(m.group(2)!);
+        final c2 = parseCard(m.group(3)!);
         if (c1 != null && c2 != null) heroCards = [c1, c2];
         break;
       }

--- a/lib/plugins/converters/winamax_hand_history_converter.dart
+++ b/lib/plugins/converters/winamax_hand_history_converter.dart
@@ -1,7 +1,9 @@
 import '../converter_format_capabilities.dart';
 import '../converter_plugin.dart';
+import 'dart:convert';
 import 'package:poker_analyzer/models/saved_hand.dart';
 import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
@@ -18,28 +20,12 @@ class WinamaxHandHistoryConverter extends ConverterPlugin {
           ),
         );
 
-  CardModel? _parseCard(String token) {
-    if (token.length < 2) return null;
-    final rank = token.substring(0, token.length - 1).toUpperCase();
-    final suitChar = token[token.length - 1].toLowerCase();
-    switch (suitChar) {
-      case 'h':
-        return CardModel(rank: rank, suit: '♥');
-      case 'd':
-        return CardModel(rank: rank, suit: '♦');
-      case 'c':
-        return CardModel(rank: rank, suit: '♣');
-      case 's':
-        return CardModel(rank: rank, suit: '♠');
-    }
-    return null;
-  }
 
   double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
 
   @override
   SavedHand? convertFrom(String externalData) {
-    final lines = externalData.split(RegExp(r'\r?\n'));
+    final lines = LineSplitter.split(externalData).toList();
     if (lines.isEmpty || !lines.first.toLowerCase().contains('winamax')) {
       return null;
     }
@@ -66,8 +52,8 @@ class WinamaxHandHistoryConverter extends ConverterPlugin {
       final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
       if (m != null) {
         heroName = m.group(1)!.trim();
-        final c1 = _parseCard(m.group(2)!);
-        final c2 = _parseCard(m.group(3)!);
+        final c1 = parseCard(m.group(2)!);
+        final c2 = parseCard(m.group(3)!);
         if (c1 != null && c2 != null) heroCards = [c1, c2];
         break;
       }

--- a/lib/plugins/converters/wpn_hand_history_converter.dart
+++ b/lib/plugins/converters/wpn_hand_history_converter.dart
@@ -1,7 +1,9 @@
 import '../converter_format_capabilities.dart';
 import '../converter_plugin.dart';
+import 'dart:convert';
 import 'package:poker_analyzer/models/saved_hand.dart';
 import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/models/player_model.dart';
 
@@ -18,28 +20,12 @@ class WpnHandHistoryConverter extends ConverterPlugin {
           ),
         );
 
-  CardModel? _parseCard(String token) {
-    if (token.length < 2) return null;
-    final rank = token.substring(0, token.length - 1).toUpperCase();
-    final suitChar = token[token.length - 1].toLowerCase();
-    switch (suitChar) {
-      case 'h':
-        return CardModel(rank: rank, suit: '♥');
-      case 'd':
-        return CardModel(rank: rank, suit: '♦');
-      case 'c':
-        return CardModel(rank: rank, suit: '♣');
-      case 's':
-        return CardModel(rank: rank, suit: '♠');
-    }
-    return null;
-  }
 
   double _amount(String s) => double.tryParse(s.replaceAll(',', '.')) ?? 0;
 
   @override
   SavedHand? convertFrom(String externalData) {
-    final lines = externalData.split(RegExp(r'\r?\n'));
+    final lines = LineSplitter.split(externalData).toList();
     if (lines.isEmpty || !lines.first.toLowerCase().contains('winning poker')) {
       return null;
     }
@@ -66,8 +52,8 @@ class WpnHandHistoryConverter extends ConverterPlugin {
       final m = RegExp(r'^Dealt to (.+?) \[(.+?) (.+?)\]').firstMatch(line.trim());
       if (m != null) {
         heroName = m.group(1)!.trim();
-        final c1 = _parseCard(m.group(2)!);
-        final c2 = _parseCard(m.group(3)!);
+        final c1 = parseCard(m.group(2)!);
+        final c2 = parseCard(m.group(3)!);
         if (c1 != null && c2 != null) heroCards = [c1, c2];
         break;
       }

--- a/test/hand_history_parsing_test.dart
+++ b/test/hand_history_parsing_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/helpers/hand_history_parsing.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+
+void main() {
+  group('parseCard', () {
+    test('parses valid tokens', () {
+      expect(parseCard('Ah'), isA<CardModel>());
+      expect(parseCard('Td')?.rank, 'T');
+      expect(parseCard('7c')?.suit, '♣');
+    });
+
+    test('returns null for invalid tokens', () {
+      expect(parseCard(''), isNull);
+      expect(parseCard('Xx'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a new `hand_history_parsing` helper with `parseCard`
- refactor all hand history converters to use `parseCard`
- parse converter input using `LineSplitter.split`
- add unit tests for the new helper

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6fa1f320832aafd5eb7ad29d9025