### PR TITLE
Refactor training history widgets

### DIFF
--- a/lib/screens/training_history/average_accuracy_summary.dart
+++ b/lib/screens/training_history/average_accuracy_summary.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import '../../theme/app_colors.dart';
+
+class AverageAccuracySummary extends StatelessWidget {
+  final double accuracy;
+  const AverageAccuracySummary({super.key, required this.accuracy});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          'Средняя точность: ${accuracy.toStringAsFixed(1)}%',
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_history/filter_summary.dart
+++ b/lib/screens/training_history/filter_summary.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class FilterSummary extends StatelessWidget {
+  final String summary;
+  const FilterSummary({super.key, required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    if (summary.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Text(
+        summary,
+        style: const TextStyle(color: Colors.white60),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_history/streak_summary.dart
+++ b/lib/screens/training_history/streak_summary.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import '../../theme/app_colors.dart';
+
+class StreakSummary extends StatelessWidget {
+  final bool show;
+  final int current;
+  final int best;
+  const StreakSummary({super.key, required this.show, required this.current, required this.best});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!show) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          children: [
+            Text(
+              'Текущий стрик: $current дней',
+              style: const TextStyle(color: Colors.white),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Лучший стрик: $best дней',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -34,6 +34,9 @@ import '../helpers/date_utils.dart';
 import '../helpers/accuracy_utils.dart';
 import '../tutorial/tutorial_flow.dart';
 import '../widgets/sync_status_widget.dart';
+import 'training_history/average_accuracy_summary.dart';
+import 'training_history/filter_summary.dart';
+import 'training_history/streak_summary.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   final TutorialFlow? tutorial;
@@ -1293,67 +1296,6 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     return parts.join(' + ');
   }
 
-  Widget _buildFilterSummary() {
-    final summary = _getActiveFilterSummary();
-    if (summary.isEmpty) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.only(top: 4),
-      child: Text(
-        summary,
-        style: const TextStyle(color: Colors.white60),
-      ),
-    );
-  }
-
-  Widget _buildAverageAccuracySummary() {
-    final avg = _calculateAverageAccuracy(_getFilteredHistory());
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: AppColors.cardBackground,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Text(
-          'Средняя точность: ${avg.toStringAsFixed(1)}%',
-          textAlign: TextAlign.center,
-          style: const TextStyle(color: Colors.white),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildStreakSummary() {
-    if (_history.isEmpty) return const SizedBox.shrink();
-    final current = _calculateCurrentStreak();
-    final best = _calculateBestStreak();
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: AppColors.cardBackground,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Column(
-          children: [
-            Text(
-              'Текущий стрик: $current дней',
-              style: const TextStyle(color: Colors.white),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Лучший стрик: $best дней',
-              style: const TextStyle(color: Colors.white),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 
   Widget _buildQuickTagRow() {
     final tags = <String>{};
@@ -2890,7 +2832,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                     },
                   ),
                 ),
-                _buildStreakSummary(),
+                StreakSummary(
+                  show: _history.isNotEmpty,
+                  current: _calculateCurrentStreak(),
+                  best: _calculateBestStreak(),
+                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: Row(
@@ -3026,8 +2972,12 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                     ),
                 ],
               ],
-              _buildAverageAccuracySummary(),
-              _buildFilterSummary(),
+              AverageAccuracySummary(
+                accuracy: _calculateAverageAccuracy(_getFilteredHistory()),
+              ),
+              FilterSummary(
+                summary: _getActiveFilterSummary(),
+              ),
               Expanded(
                 child: Builder(builder: (context) {
                     final filtered = _getFilteredHistory();

--- a/test/training_history_widgets_test.dart
+++ b/test/training_history_widgets_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/screens/training_history/average_accuracy_summary.dart';
+import 'package:poker_analyzer/screens/training_history/filter_summary.dart';
+import 'package:poker_analyzer/screens/training_history/streak_summary.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('FilterSummary hides when empty', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: FilterSummary(summary: '')));
+    expect(find.byType(Text), findsNothing);
+  });
+
+  testWidgets('AverageAccuracySummary shows accuracy', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: AverageAccuracySummary(accuracy: 75.5),
+    ));
+    expect(find.textContaining('75.5'), findsOneWidget);
+  });
+
+  testWidgets('StreakSummary shows values when visible', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: StreakSummary(show: true, current: 3, best: 5),
+    ));
+    expect(find.text('Текущий стрик: 3 дней'), findsOneWidget);
+    expect(find.text('Лучший стрик: 5 дней'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- extract `AverageAccuracySummary`, `FilterSummary`, and `StreakSummary` widgets
- use new widgets inside `TrainingHistoryScreen`
- add unit tests for the new widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6fa1e2ac832a9b98327e94f78512