### PR TITLE
Show revealed opponent cards

### DIFF
--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../models/card_model.dart';
+
+class PlayingCardWidget extends StatelessWidget {
+  final CardModel card;
+  final double scale;
+  const PlayingCardWidget({
+    Key? key,
+    required this.card,
+    this.scale = 1.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final isRed = card.suit == '♥' || card.suit == '♦';
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: 2 * scale),
+      width: 18 * scale,
+      height: 26 * scale,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(4),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.25),
+            blurRadius: 3,
+            offset: const Offset(1, 2),
+          )
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '${card.rank}${card.suit}',
+        style: TextStyle(
+          color: isRed ? Colors.red : Colors.black,
+          fontWeight: FontWeight.bold,
+          fontSize: 12 * scale,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create reusable `PlayingCardWidget`
- add `showRevealedCards` flag to `PokerTableView`
- render hero or revealed opponent cards with fade animation using the new widget

## Testing
- `apt-get update`
- `apt-cache search dart` *(fails: no dart packages)*


------
https://chatgpt.com/codex/tasks/task_e_687a7441d0d0832aad22c6e47c991d7e