### PR TITLE
Add grouping bar widget

### DIFF
--- a/lib/services/training_pack_filter_memory_service.dart
+++ b/lib/services/training_pack_filter_memory_service.dart
@@ -15,6 +15,8 @@ class TrainingPackFilterMemoryService {
   Set<HeroPosition> positionFilters = {};
   String? difficulty;
   bool groupByTag = false;
+  bool groupByPosition = false;
+  bool groupByStack = false;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -22,18 +24,16 @@ class TrainingPackFilterMemoryService {
     if (data == null) return;
     try {
       final json = jsonDecode(data) as Map<String, dynamic>;
-      selectedTags = {
-        for (final t in json['tags'] as List? ?? []) t as String
-      };
-      stackFilters = {
-        for (final i in json['stack'] as List? ?? []) i as int
-      };
+      selectedTags = {for (final t in json['tags'] as List? ?? []) t as String};
+      stackFilters = {for (final i in json['stack'] as List? ?? []) i as int};
       positionFilters = {
         for (final p in json['pos'] as List? ?? [])
           HeroPosition.values.byName(p as String)
       };
       difficulty = json['difficulty'] as String?;
       groupByTag = json['groupByTag'] as bool? ?? false;
+      groupByPosition = json['groupByPosition'] as bool? ?? false;
+      groupByStack = json['groupByStack'] as bool? ?? false;
     } catch (_) {}
   }
 
@@ -45,6 +45,8 @@ class TrainingPackFilterMemoryService {
       'pos': [for (final p in positionFilters) p.name],
       'difficulty': difficulty,
       'groupByTag': groupByTag,
+      'groupByPosition': groupByPosition,
+      'groupByStack': groupByStack,
     });
     await prefs.setString(_prefsKey, jsonStr);
   }
@@ -55,6 +57,8 @@ class TrainingPackFilterMemoryService {
     positionFilters.clear();
     difficulty = null;
     groupByTag = false;
+    groupByPosition = false;
+    groupByStack = false;
     await save();
   }
 
@@ -64,12 +68,16 @@ class TrainingPackFilterMemoryService {
     required Set<HeroPosition> pos,
     required String? difficulty,
     required bool groupByTag,
+    required bool groupByPosition,
+    required bool groupByStack,
   }) async {
     selectedTags = {...tags};
     stackFilters = {...stack};
     positionFilters = {...pos};
     this.difficulty = difficulty;
     this.groupByTag = groupByTag;
+    this.groupByPosition = groupByPosition;
+    this.groupByStack = groupByStack;
     await save();
   }
 }

--- a/lib/widgets/training_pack_grouping_bar.dart
+++ b/lib/widgets/training_pack_grouping_bar.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class TrainingPackGroupingBar extends StatefulWidget {
+  final ValueChanged<String> onGroupChanged;
+  final String initialGroup;
+
+  const TrainingPackGroupingBar({
+    super.key,
+    required this.onGroupChanged,
+    this.initialGroup = 'none',
+  });
+
+  @override
+  State<TrainingPackGroupingBar> createState() =>
+      _TrainingPackGroupingBarState();
+}
+
+class _TrainingPackGroupingBarState extends State<TrainingPackGroupingBar> {
+  late String _group;
+
+  @override
+  void initState() {
+    super.initState();
+    _group = widget.initialGroup;
+  }
+
+  void _select(String g) {
+    setState(() => _group = g);
+    widget.onGroupChanged(g);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          ChoiceChip(
+            label: const Text('Без группировки'),
+            selected: _group == 'none',
+            onSelected: (_) => _select('none'),
+          ),
+          const SizedBox(width: 8),
+          ChoiceChip(
+            label: const Text('По тегу'),
+            selected: _group == 'tag',
+            onSelected: (_) => _select('tag'),
+          ),
+          const SizedBox(width: 8),
+          ChoiceChip(
+            label: const Text('По позиции'),
+            selected: _group == 'position',
+            onSelected: (_) => _select('position'),
+          ),
+          const SizedBox(width: 8),
+          ChoiceChip(
+            label: const Text('По стеку'),
+            selected: _group == 'stack',
+            onSelected: (_) => _select('stack'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TrainingPackGroupingBar` widget with chips
- extend `TrainingPackFilterMemoryService` for multiple grouping flags

## Testing
- `dart format lib/services/training_pack_filter_memory_service.dart lib/widgets/training_pack_grouping_bar.dart`
- `dart analyze` *(fails: 58320 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687a7e03ab54832a931d2e18a3881fec