### PR TITLE
Add tag analytics service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -51,6 +51,7 @@ import 'services/action_sync_service.dart';
 import 'services/user_preferences_service.dart';
 import 'services/tag_service.dart';
 import 'services/tag_cache_service.dart';
+import 'services/training_pack_tag_analytics_service.dart';
 import 'services/ignored_mistake_service.dart';
 import 'services/goals_service.dart';
 import 'services/streak_service.dart';
@@ -272,6 +273,9 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     ChangeNotifierProvider(create: (_) => TagService()..load()),
     ChangeNotifierProvider<TagCacheService>.value(value: tagCache),
+    ChangeNotifierProvider(
+      create: (_) => TrainingPackTagAnalyticsService()..loadStats(),
+    ),
     ChangeNotifierProvider(create: (_) => IgnoredMistakeService()..load()),
     ChangeNotifierProvider(create: (_) => GoalsService()..load()),
     ChangeNotifierProvider(

--- a/lib/services/training_pack_tag_analytics_service.dart
+++ b/lib/services/training_pack_tag_analytics_service.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+import 'pack_library_loader_service.dart';
+import 'training_stats_service.dart';
+
+class TagAnalytics {
+  final String tag;
+  final int launches;
+  final int totalTrained;
+  final int mistakes;
+  const TagAnalytics({
+    required this.tag,
+    required this.launches,
+    required this.totalTrained,
+    required this.mistakes,
+  });
+
+  double get valueScore => (launches * 2 + totalTrained - mistakes * 3).toDouble();
+}
+
+class TrainingPackTagAnalyticsService extends ChangeNotifier {
+  final Map<String, _TagStat> _stats = {};
+  bool _loaded = false;
+
+  Future<void> loadStats() async {
+    if (_loaded) return;
+    _loaded = true;
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final packs = PackLibraryLoaderService.instance.library;
+    final statsService = TrainingStatsService.instance;
+    if (statsService == null) return;
+    for (final p in packs) {
+      final stats = await statsService.getStatsForPack(p.id);
+      if (stats.launches == 0 && stats.totalTrained == 0 && stats.mistakes == 0) {
+        continue;
+      }
+      final tags = <String>{for (final t in p.tags) t.trim().toLowerCase()}
+        ..removeWhere((e) => e.isEmpty);
+      for (final t in tags) {
+        final s = _stats.putIfAbsent(t, () => _TagStat());
+        s.launches += stats.launches;
+        s.total += stats.totalTrained;
+        s.mistakes += stats.mistakes;
+      }
+    }
+    notifyListeners();
+  }
+
+  List<TagAnalytics> getPopularTags() {
+    final list = [
+      for (final e in _stats.entries)
+        TagAnalytics(
+          tag: e.key,
+          launches: e.value.launches,
+          totalTrained: e.value.total,
+          mistakes: e.value.mistakes,
+        )
+    ]
+      ..sort((a, b) => b.valueScore.compareTo(a.valueScore));
+    return list;
+  }
+}
+
+class _TagStat {
+  int launches = 0;
+  int total = 0;
+  int mistakes = 0;
+}

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -11,6 +11,8 @@ import 'package:file_saver/file_saver.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
+import 'package:provider/provider.dart';
+import '../../services/training_pack_tag_analytics_service.dart';
 
 import '../../models/training_spot.dart';
 import '../../models/training_pack.dart';
@@ -3929,6 +3931,16 @@ class TrainingSpotListState extends State<TrainingSpotList>
   Future<void> _showTagSelector() async {
     final local = Set<String>.from(_selectedTags);
     String? selectedPreset;
+    final analytics = context.read<TrainingPackTagAnalyticsService>();
+    final popular = [for (final a in analytics.getPopularTags()) a.tag];
+    final tags = [
+      for (final t in popular)
+        if (_availableTags.contains(t)) t,
+      ...[
+        for (final t in _availableTags)
+          if (!popular.contains(t)) t
+      ]
+    ];
     final result = await showDialog<Set<String>>(
       context: context,
       builder: (context) {
@@ -3949,7 +3961,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                       child: ListView(
                         shrinkWrap: true,
                         children: [
-                          for (final tag in _availableTags)
+                          for (final tag in tags)
                             CheckboxListTile(
                               value: local.contains(tag),
                               title:


### PR DESCRIPTION
## Summary
- add `TrainingPackTagAnalyticsService` to analyze tag usage from session logs
- expose `PackPlayStats` and `getStatsForPack` in `TrainingStatsService`
- inject the new service in app providers
- prioritize popular tags in the tag selector dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8ca0477c832aa748d07c8a7fcf83