### PR TITLE
Add weak training type banner

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1673,15 +1673,6 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     return TrainingGapPromptBanner(category: cat, pack: pack);
   }
 
-  /// Banner prompting the user to improve the weakest training type.
-  Widget _weakTypeBanner() {
-    final type = _weakestType;
-    if (type == null) return const SizedBox.shrink();
-    final pack = PackLibraryLoaderService.instance.library
-        .firstWhereOrNull((p) => p.trainingType == type);
-    if (pack == null) return const SizedBox.shrink();
-    return TrainingTypeGapPromptBanner(type: type, pack: pack);
-  }
 
   Widget _item(TrainingPackTemplate t, [String? note]) {
     final l = AppLocalizations.of(context)!;
@@ -2519,7 +2510,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           ),
           _recommendedCategoryCard(),
           _weakCategoryBanner(),
-          _weakTypeBanner(),
+          TrainingTypeGapPromptBanner(
+            selectedTags: _selectedTags,
+            activeFilter: _trainingType,
+          ),
           SwitchListTile(
             title: Text(l.favorites),
             value: _favoritesOnly,

--- a/lib/widgets/training_type_gap_prompt_banner.dart
+++ b/lib/widgets/training_type_gap_prompt_banner.dart
@@ -1,26 +1,112 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_template.dart';
+import '../services/pack_library_loader_service.dart';
 import '../services/training_session_service.dart';
+import '../services/weak_spot_recommendation_service.dart';
 import '../screens/training_session_screen.dart';
 
-/// Banner suggesting a training pack for the player's weakest [TrainingType].
+/// Banner prompting the user to train the weakest [TrainingType].
 ///
-/// Displays the type label and the first available pack in the library for that
-/// type, offering a quick start button to launch a session.
-class TrainingTypeGapPromptBanner extends StatelessWidget {
-  /// Weak training type that should be improved.
-  final TrainingType type;
+/// The banner automatically determines the weakest type using
+/// [WeakSpotRecommendationService.detectWeakTrainingType] and suggests the first
+/// available pack for that type. The banner can be dismissed for a day.
+class TrainingTypeGapPromptBanner extends StatefulWidget {
+  /// Currently selected tags. When not empty, the banner is hidden.
+  final Set<String> selectedTags;
 
-  /// Pack matching the [type] that will be used to start the session.
-  final TrainingPackTemplate pack;
+  /// Active training type filter. When not `null`, the banner is hidden.
+  final TrainingType? activeFilter;
 
-  const TrainingTypeGapPromptBanner({super.key, required this.type, required this.pack});
+  const TrainingTypeGapPromptBanner({
+    super.key,
+    required this.selectedTags,
+    required this.activeFilter,
+  });
+
+  @override
+  State<TrainingTypeGapPromptBanner> createState() => _TrainingTypeGapPromptBannerState();
+}
+
+class _TrainingTypeGapPromptBannerState extends State<TrainingTypeGapPromptBanner> {
+  static const _hideKey = 'hideWeakTypeUntil';
+
+  bool _loading = true;
+  TrainingType? _type;
+  TrainingPackTemplate? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final hideStr = prefs.getString(_hideKey);
+    final now = DateTime.now();
+    if (hideStr != null) {
+      final hideUntil = DateTime.tryParse(hideStr);
+      if (hideUntil != null && now.isBefore(hideUntil)) {
+        if (mounted) setState(() => _loading = false);
+        return;
+      }
+    }
+
+    final service = context.read<WeakSpotRecommendationService>();
+    final result = await service.detectWeakTrainingType();
+    if (result == null) {
+      if (mounted) setState(() => _loading = false);
+      return;
+    }
+
+    final type = TrainingType.values.firstWhereOrNull((e) => e.name == result);
+    if (type == null) {
+      if (mounted) setState(() => _loading = false);
+      return;
+    }
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final pack = PackLibraryLoaderService.instance.library
+        .firstWhereOrNull((p) => p.trainingType == type);
+
+    if (mounted) {
+      setState(() {
+        _type = type;
+        _pack = pack;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _start() async {
+    final tpl = _pack;
+    if (tpl == null) return;
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (!context.mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  Future<void> _hide() async {
+    final prefs = await SharedPreferences.getInstance();
+    final until = DateTime.now().add(const Duration(days: 1));
+    await prefs.setString(_hideKey, until.toIso8601String());
+    if (mounted) setState(() => _pack = null);
+  }
 
   @override
   Widget build(BuildContext context) {
+    if (_loading || _pack == null || _type == null) return const SizedBox.shrink();
+    if (widget.selectedTags.isNotEmpty || widget.activeFilter != null) {
+      return const SizedBox.shrink();
+    }
     final accent = Theme.of(context).colorScheme.secondary;
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -33,27 +119,30 @@ class TrainingTypeGapPromptBanner extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('📉 Слабый тип: ${type.label}',
-              style: const TextStyle(color: Colors.white)),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '🎯 Ваша слабая зона: ${_type!.label}',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _hide,
+              ),
+            ],
+          ),
           const SizedBox(height: 4),
-          Text('🃏 Пак: ${pack.name}',
+          Text('🃏 Пак: ${_pack!.name}',
               style: const TextStyle(color: Colors.white70)),
           const SizedBox(height: 8),
           Align(
             alignment: Alignment.centerRight,
             child: ElevatedButton(
-              onPressed: () async {
-                await context.read<TrainingSessionService>().startSession(pack);
-                if (context.mounted) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (_) => const TrainingSessionScreen()),
-                  );
-                }
-              },
+              onPressed: _start,
               style: ElevatedButton.styleFrom(backgroundColor: accent),
-              child: const Text('Начать тренировку'),
+              child: const Text('Тренировать'),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- implement `TrainingTypeGapPromptBanner` to recommend training based on weakest type
- show the banner in `TemplateLibraryScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9e742d7c832a96310df86725dca8