### PR TITLE
Add TrainingPackTemplateStorage

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -40,6 +40,7 @@ import '../services/pack_library_review_engine.dart';
 import '../services/yaml_pack_auto_fix_engine.dart';
 import '../services/pack_library_smart_validator.dart';
 import '../services/training_pack_template_validator.dart';
+import '../services/training_pack_template_storage.dart';
 import '../models/validation_issue.dart';
 import '../models/yaml_pack_review_report.dart';
 import '../models/yaml_pack_validation_report.dart';
@@ -128,6 +129,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _recommendPacksLoading = false;
   bool _jsonLibraryLoading = false;
   bool _smartValidateLoading = false;
+  bool _templateStorageTestLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -1230,6 +1232,27 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
   }
 
+  Future<void> _testTemplateStorage() async {
+    if (_templateStorageTestLoading || !kDebugMode) return;
+    setState(() => _templateStorageTestLoading = true);
+    final storage = TrainingPackTemplateStorage();
+    final tpl = TrainingPackTemplateV2(
+      id: 'test_tpl',
+      name: 'Test Template',
+      trainingType: TrainingType.pushFold,
+    );
+    await storage.saveLocal(tpl);
+    await storage.saveRemote(tpl);
+    final local = await storage.loadLocal(tpl.id);
+    final remote = await storage.loadRemote(tpl.id);
+    if (!mounted) return;
+    setState(() => _templateStorageTestLoading = false);
+    final ok = local != null && remote != null;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(ok ? 'Template roundtrip OK' : 'Storage failed')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -1755,6 +1778,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📌 Цели по истории'),
                 onTap: _goalLoading ? null : _suggestGoals,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧪 Тест выгрузки/загрузки шаблона'),
+                onTap:
+                    _templateStorageTestLoading ? null : _testTemplateStorage,
               ),
           ],
         ),

--- a/lib/services/training_pack_template_storage.dart
+++ b/lib/services/training_pack_template_storage.dart
@@ -1,0 +1,66 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'cloud_retry_policy.dart';
+import '../utils/training_pack_yaml_codec_v2.dart';
+
+class TrainingPackTemplateStorage {
+  static const _boxName = 'training_templates';
+
+  final TrainingPackYamlCodecV2 codec;
+  final FirebaseFirestore _db;
+  Box<dynamic>? _box;
+
+  TrainingPackTemplateStorage({TrainingPackYamlCodecV2? codec, FirebaseFirestore? firestore})
+      : codec = codec ?? const TrainingPackYamlCodecV2(),
+        _db = firestore ?? FirebaseFirestore.instance;
+
+  Future<void> _openBox() async {
+    if (_box != null) return;
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.initFlutter();
+      _box = await Hive.openBox(_boxName);
+    } else {
+      _box = Hive.box(_boxName);
+    }
+  }
+
+  Future<void> saveLocal(TrainingPackTemplateV2 template) async {
+    await _openBox();
+    final yaml = codec.encode(template);
+    await _box!.put(template.id, yaml);
+  }
+
+  Future<TrainingPackTemplateV2?> loadLocal(String id) async {
+    await _openBox();
+    final yaml = _box!.get(id);
+    if (yaml is String) {
+      try {
+        return codec.decode(yaml);
+      } catch (_) {}
+    }
+    return null;
+  }
+
+  Future<void> saveRemote(TrainingPackTemplateV2 template) async {
+    final yaml = codec.encode(template);
+    await CloudRetryPolicy.execute<void>(() async {
+      await _db.collection('trainingTemplates').doc(template.id).set({'yaml': yaml});
+    });
+  }
+
+  Future<TrainingPackTemplateV2?> loadRemote(String id) async {
+    final doc = await CloudRetryPolicy.execute(() =>
+        _db.collection('trainingTemplates').doc(id).get());
+    if (!doc.exists) return null;
+    final data = doc.data();
+    final yaml = data?['yaml'];
+    if (yaml is String) {
+      try {
+        return codec.decode(yaml);
+      } catch (_) {}
+    }
+    return null;
+  }
+}

--- a/lib/utils/training_pack_yaml_codec_v2.dart
+++ b/lib/utils/training_pack_yaml_codec_v2.dart
@@ -1,0 +1,13 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/generation/yaml_reader.dart';
+
+class TrainingPackYamlCodecV2 {
+  const TrainingPackYamlCodecV2();
+
+  String encode(TrainingPackTemplateV2 template) => template.toYamlString();
+
+  TrainingPackTemplateV2 decode(String yaml) {
+    final map = const YamlReader().read(yaml);
+    return TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackTemplateStorage` for saving/loading YAML templates via Hive and Firestore
- introduce `TrainingPackYamlCodecV2` for YAML serialization
- add dev menu option to test template storage roundtrip

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aab5dadd4832a9f1e9956c3fdebd0