### PR TITLE
Add search index service

### DIFF
--- a/lib/services/pack_search_index_service.dart
+++ b/lib/services/pack_search_index_service.dart
@@ -1,0 +1,51 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+class PackSearchIndexService {
+  PackSearchIndexService._();
+  static final instance = PackSearchIndexService._();
+
+  final Map<String, Set<String>> _index = <String, Set<String>>{};
+  final Map<String, TrainingPackTemplateV2> _templates = <String, TrainingPackTemplateV2>{};
+
+  Future<void> buildIndex(List<TrainingPackTemplateV2> templates) async {
+    _index.clear();
+    _templates.clear();
+    for (final tpl in templates) {
+      _templates[tpl.id] = tpl;
+      final terms = <String>{
+        ..._tokenize(tpl.name),
+        ..._tokenize(tpl.description),
+        ..._tokenize(tpl.goal),
+        for (final t in tpl.tags) _normalize(t),
+      }..removeWhere((e) => e.isEmpty);
+      for (final term in terms) {
+        _index.putIfAbsent(term, () => <String>{}).add(tpl.id);
+      }
+    }
+  }
+
+  List<TrainingPackTemplateV2> search(String query) {
+    final tokens = _tokenize(query);
+    if (tokens.isEmpty) return <TrainingPackTemplateV2>[];
+    final ids = <String>{};
+    for (final t in tokens) {
+      ids.addAll(_index[t] ?? const <String>{});
+    }
+    return [
+      for (final id in ids)
+        if (_templates.containsKey(id)) _templates[id]!,
+    ];
+  }
+
+  Set<String> _tokenize(String text) {
+    return text
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), ' ')
+        .split(RegExp(r'\s+'))
+        .where((e) => e.isNotEmpty)
+        .toSet();
+  }
+
+  String _normalize(String text) => text.trim().toLowerCase();
+}
+

--- a/test/pack_search_index_service_test.dart
+++ b/test/pack_search_index_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/pack_search_index_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  test('builds index and searches templates', () async {
+    final t1 = TrainingPackTemplateV2(
+      id: '1',
+      name: 'Aggressive Push',
+      description: 'Best push strategies',
+      trainingType: TrainingType.pushFold,
+      tags: ['push', 'aggression'],
+    );
+    final t2 = TrainingPackTemplateV2(
+      id: '2',
+      name: 'ICM Defense',
+      description: 'ICM call strategies',
+      trainingType: TrainingType.icm,
+      tags: ['call', 'icm'],
+    );
+
+    await PackSearchIndexService.instance.buildIndex([t1, t2]);
+
+    final res1 = PackSearchIndexService.instance.search('aggression');
+    expect(res1, contains(t1));
+
+    final res2 = PackSearchIndexService.instance.search('ICM');
+    expect(res2, contains(t2));
+
+    final res3 = PackSearchIndexService.instance.search('push');
+    expect(res3, contains(t1));
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `PackSearchIndexService` for keyword search across training pack templates
- add unit test for building and searching the index

## Testing
- `flutter format lib/services/pack_search_index_service.dart test/pack_search_index_service_test.dart` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aae9c22b8832a904b26310e89c83a