### PR TITLE
Implement pack library search screen

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../services/pack_library_index_loader.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
+import 'pack_library_search_screen.dart';
 
 class LibraryScreen extends StatefulWidget {
   const LibraryScreen({super.key});
@@ -108,7 +109,21 @@ class _LibraryScreenState extends State<LibraryScreen> {
     ];
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Library')),
+      appBar: AppBar(
+        title: const Text('Library'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const PackLibrarySearchScreen()),
+              );
+            },
+          ),
+        ],
+      ),
       body: Column(
         children: [
           Padding(

--- a/lib/screens/pack_library_search_screen.dart
+++ b/lib/screens/pack_library_search_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../services/pack_search_index_service.dart';
+import '../services/training_pack_library_loader_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_v2.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
+import '../widgets/pack_card.dart';
+import '../theme/app_colors.dart';
+import 'package:provider/provider.dart';
+
+class PackLibrarySearchScreen extends StatefulWidget {
+  const PackLibrarySearchScreen({super.key});
+
+  @override
+  State<PackLibrarySearchScreen> createState() => _PackLibrarySearchScreenState();
+}
+
+class _PackLibrarySearchScreenState extends State<PackLibrarySearchScreen> {
+  final _controller = TextEditingController();
+  List<TrainingPackTemplateV2> _results = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final templates =
+        TrainingPackLibraryLoaderService.instance.loadedTemplates;
+    PackSearchIndexService.instance.buildIndex(templates);
+    _controller.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onChanged() {
+    final q = _controller.text.trim();
+    final res = PackSearchIndexService.instance.search(q);
+    setState(() => _results = res);
+  }
+
+  Future<void> _open(TrainingPackTemplateV2 tpl) async {
+    final pack = TrainingPackV2.fromTemplate(tpl, tpl.id);
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (!mounted) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TrainingSessionScreen(pack: pack)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Search Library')),
+      backgroundColor: AppColors.background,
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _controller,
+              decoration: const InputDecoration(hintText: 'Search'),
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: _results.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final tpl = _results[index];
+                return PackCard(
+                  template: tpl,
+                  onTap: () => _open(tpl),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../theme/app_colors.dart';
+import '../models/training_type.dart';
+
+class PackCard extends StatelessWidget {
+  final TrainingPackTemplateV2 template;
+  final VoidCallback onTap;
+  const PackCard({super.key, required this.template, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(template.name,
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(template.trainingType.name,
+                  style: const TextStyle(color: Colors.white70)),
+            ),
+            if (template.tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(template.tags.join(', '),
+                    style: const TextStyle(color: Colors.white70, fontSize: 12)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `PackLibrarySearchScreen` with live search
- show pack details with new `PackCard` widget
- link search screen from library

## Testing
- `flutter analyze` *(fails: flutter missing)*

------
https://chatgpt.com/codex/tasks/task_e_687aafdbdfe0832aa1d6fd6a49d90b5a