### PR TITLE
Implement TrainingPackTagsService

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -9,6 +9,7 @@ import '../core/training/engine/training_type_engine.dart';
 import '../services/pack_filter_service.dart';
 import '../services/pack_favorite_service.dart';
 import '../services/pack_rating_service.dart';
+import '../services/training_pack_tags_service.dart';
 import 'pack_library_search_screen.dart';
 
 enum _SortOption { newest, rating, difficulty }
@@ -86,24 +87,19 @@ class _LibraryScreenState extends State<LibraryScreen> {
       if (r != null) ratingMap[p.id] = r;
     }
     if (!mounted) return;
-    final counts = <String, int>{};
     final acounts = <String, int>{};
+    await TrainingPackTagsService.instance.load(list);
     for (final p in list) {
-      for (final t in p.tags) {
-        counts[t] = (counts[t] ?? 0) + 1;
-      }
       final a = p.audience ?? p.meta['audience']?.toString();
       if (a != null && a.isNotEmpty) {
         acounts[a] = (acounts[a] ?? 0) + 1;
       }
     }
-    final tags = counts.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
     final auds = acounts.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     setState(() {
       _packs = list;
-      _tags = [for (final e in tags.take(20)) e.key];
+      _tags = TrainingPackTagsService.instance.topTags;
       _audiences = [for (final e in auds.take(7)) e.key];
       _ratings = ratingMap;
       _loading = false;

--- a/lib/services/training_pack_tags_service.dart
+++ b/lib/services/training_pack_tags_service.dart
@@ -1,0 +1,31 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackTagsService {
+  TrainingPackTagsService._();
+  static final instance = TrainingPackTagsService._();
+
+  final Map<String, int> _tagFrequency = {};
+
+  Map<String, int> get tagFrequency => Map.unmodifiable(_tagFrequency);
+
+  List<String> get topTags {
+    final entries = _tagFrequency.entries.toList()
+      ..sort((a, b) {
+        final c = b.value.compareTo(a.value);
+        if (c != 0) return c;
+        return a.key.compareTo(b.key);
+      });
+    return [for (final e in entries.take(20)) e.key];
+  }
+
+  Future<void> load(List<TrainingPackTemplateV2> templates) async {
+    _tagFrequency.clear();
+    for (final tpl in templates) {
+      for (final t in tpl.tags) {
+        final tag = t.trim();
+        if (tag.isEmpty) continue;
+        _tagFrequency[tag] = (_tagFrequency[tag] ?? 0) + 1;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackTagsService` with methods to count tag usage
- use the service in `LibraryScreen` when loading training packs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac596edd8832a8a445710a9912193