### PR TITLE
Implement TrainingPackAudienceService

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -10,6 +10,7 @@ import '../services/pack_filter_service.dart';
 import '../services/pack_favorite_service.dart';
 import '../services/pack_rating_service.dart';
 import '../services/training_pack_tags_service.dart';
+import '../services/training_pack_audience_service.dart';
 import 'pack_library_search_screen.dart';
 
 enum _SortOption { newest, rating, difficulty }
@@ -87,20 +88,12 @@ class _LibraryScreenState extends State<LibraryScreen> {
       if (r != null) ratingMap[p.id] = r;
     }
     if (!mounted) return;
-    final acounts = <String, int>{};
     await TrainingPackTagsService.instance.load(list);
-    for (final p in list) {
-      final a = p.audience ?? p.meta['audience']?.toString();
-      if (a != null && a.isNotEmpty) {
-        acounts[a] = (acounts[a] ?? 0) + 1;
-      }
-    }
-    final auds = acounts.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+    await TrainingPackAudienceService.instance.load(list);
     setState(() {
       _packs = list;
       _tags = TrainingPackTagsService.instance.topTags;
-      _audiences = [for (final e in auds.take(7)) e.key];
+      _audiences = TrainingPackAudienceService.instance.topAudiences;
       _ratings = ratingMap;
       _loading = false;
     });

--- a/lib/services/training_pack_audience_service.dart
+++ b/lib/services/training_pack_audience_service.dart
@@ -1,0 +1,33 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackAudienceService {
+  TrainingPackAudienceService._();
+  static final instance = TrainingPackAudienceService._();
+
+  final Map<String, int> _audienceFrequency = {};
+
+  Map<String, int> get audienceFrequency =>
+      Map.unmodifiable(_audienceFrequency);
+
+  List<String> get topAudiences {
+    final entries = _audienceFrequency.entries.toList()
+      ..sort((a, b) {
+        final c = b.value.compareTo(a.value);
+        if (c != 0) return c;
+        return a.key.compareTo(b.key);
+      });
+    return [for (final e in entries.take(7)) e.key];
+  }
+
+  Future<void> load(List<TrainingPackTemplateV2> templates) async {
+    _audienceFrequency.clear();
+    for (final tpl in templates) {
+      final aud = tpl.audience ?? tpl.meta['audience']?.toString();
+      if (aud == null) continue;
+      final a = aud.trim();
+      if (a.isEmpty) continue;
+      _audienceFrequency[a] = (_audienceFrequency[a] ?? 0) + 1;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `TrainingPackAudienceService` for audience frequency and top audiences
- use new service in `LibraryScreen` to load audiences

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac668388c832abd903d88572796a8