### PR TITLE
Add difficulty service to library screen

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -11,6 +11,7 @@ import '../services/pack_favorite_service.dart';
 import '../services/pack_rating_service.dart';
 import '../services/training_pack_tags_service.dart';
 import '../services/training_pack_audience_service.dart';
+import '../services/training_pack_difficulty_service.dart';
 import 'pack_library_search_screen.dart';
 
 enum _SortOption { newest, rating, difficulty }
@@ -27,6 +28,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   List<TrainingPackTemplateV2> _packs = [];
   List<String> _tags = [];
   List<String> _audiences = [];
+  List<int> _difficulties = [];
   final Set<String> _selectedTags = {};
   final Set<int> _selectedDifficulties = {};
   final Set<String> _selectedAudiences = {};
@@ -40,13 +42,15 @@ class _LibraryScreenState extends State<LibraryScreen> {
 
   _SortOption _sort = _SortOption.newest;
 
-  String _difficultyIcon(TrainingPackTemplateV2 pack) {
-    final diff = _difficultyLevel(pack);
-    if (diff == 1) return '🟢';
-    if (diff == 2) return '🟡';
-    if (diff >= 3) return '🔴';
+  String _difficultyIconFromLevel(int level) {
+    if (level == 1) return '🟢';
+    if (level == 2) return '🟡';
+    if (level >= 3) return '🔴';
     return '⚪️';
   }
+
+  String _difficultyIcon(TrainingPackTemplateV2 pack) =>
+      _difficultyIconFromLevel(_difficultyLevel(pack));
 
   int _difficultyLevel(TrainingPackTemplateV2 pack) {
     final diff = (pack.meta['difficulty'] as num?)?.toInt();
@@ -90,10 +94,12 @@ class _LibraryScreenState extends State<LibraryScreen> {
     if (!mounted) return;
     await TrainingPackTagsService.instance.load(list);
     await TrainingPackAudienceService.instance.load(list);
+    await TrainingPackDifficultyService.instance.load(list);
     setState(() {
       _packs = list;
       _tags = TrainingPackTagsService.instance.topTags;
       _audiences = TrainingPackAudienceService.instance.topAudiences;
+      _difficulties = TrainingPackDifficultyService.instance.topDifficulties;
       _ratings = ratingMap;
       _loading = false;
     });
@@ -271,11 +277,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
                             ? 0
                             : _selectedDifficulties.first,
                         hint: const Text('Difficulty'),
-                        items: const [
-                          DropdownMenuItem(value: 0, child: Text('Any')),
-                          DropdownMenuItem(value: 1, child: Text('🟢 1')),
-                          DropdownMenuItem(value: 2, child: Text('🟡 2')),
-                          DropdownMenuItem(value: 3, child: Text('🔴 3')),
+                        items: [
+                          const DropdownMenuItem(value: 0, child: Text('Any')),
+                          for (final d in _difficulties)
+                            DropdownMenuItem(
+                              value: d,
+                              child:
+                                  Text('${_difficultyIconFromLevel(d)} $d'),
+                            ),
                         ],
                         onChanged: (v) {
                           setState(() {

--- a/lib/services/training_pack_difficulty_service.dart
+++ b/lib/services/training_pack_difficulty_service.dart
@@ -1,0 +1,33 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+class TrainingPackDifficultyService {
+  TrainingPackDifficultyService._();
+  static final instance = TrainingPackDifficultyService._();
+
+  final Map<int, int> _difficultyFrequency = {};
+
+  Map<int, int> get difficultyFrequency =>
+      Map.unmodifiable(_difficultyFrequency);
+
+  List<int> get topDifficulties {
+    final entries = _difficultyFrequency.entries.toList()
+      ..sort((a, b) {
+        final c = b.value.compareTo(a.value);
+        if (c != 0) return c;
+        return a.key.compareTo(b.key);
+      });
+    return [for (final e in entries) e.key];
+  }
+
+  Future<void> load(List<TrainingPackTemplateV2> templates) async {
+    _difficultyFrequency.clear();
+    for (final tpl in templates) {
+      final v = tpl.meta['difficulty'];
+      int? diff;
+      if (v is num) diff = v.toInt();
+      if (v is String) diff ??= int.tryParse(v);
+      if (diff == null) continue;
+      _difficultyFrequency[diff] = (_difficultyFrequency[diff] ?? 0) + 1;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackDifficultyService` to compute difficulty frequencies
- show most frequent difficulties in library filter dropdown

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac74169ec832a97b05b3482ec8d00