### PR TITLE
Implement SmartSuggestionEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -413,7 +413,10 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     Provider(create: (_) => const TrainingGapDetectorService()),
-    Provider(create: (_) => const SmartSuggestionEngine()),
+    Provider(
+      create: (context) =>
+          SmartSuggestionEngine(logs: context.read<SessionLogService>()),
+    ),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];
 }

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -1171,7 +1171,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (_smartHistoryLoading || !kDebugMode) return;
     setState(() => _smartHistoryLoading = true);
     final engine = context.read<SmartSuggestionEngine>();
-    final list = await engine.suggestNext();
+    final list = await engine.suggestNextPacks();
     if (!mounted) return;
     setState(() => _smartHistoryLoading = false);
     if (list.isEmpty) {

--- a/lib/widgets/pack_suggestion_banner.dart
+++ b/lib/widgets/pack_suggestion_banner.dart
@@ -40,7 +40,8 @@ class _PackSuggestionBannerState extends State<PackSuggestionBanner> {
       if (mounted) setState(() => _loading = false);
       return;
     }
-    final list = await context.read<SmartSuggestionEngine>().suggestNext();
+    final list =
+        await context.read<SmartSuggestionEngine>().suggestNextPacks();
     if (mounted) {
       setState(() {
         _packs = list;


### PR DESCRIPTION
## Summary
- add SmartSuggestionEngine with personalized recommendation logic
- inject `SessionLogService` into provider
- update dev menu and banner to use new suggestions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad25ad494832a847a26b0354af29f