### PR TITLE
Add Skill Map screen

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -85,6 +85,7 @@ import 'services/evaluation_executor_service.dart';
 import 'services/session_analysis_service.dart';
 import 'services/user_action_logger.dart';
 import 'services/hand_analyzer_service.dart';
+import 'services/tag_mastery_service.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -416,6 +417,10 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(
       create: (context) =>
           SmartSuggestionEngine(logs: context.read<SessionLogService>()),
+    ),
+    Provider(
+      create: (context) =>
+          TagMasteryService(logs: context.read<SessionLogService>()),
     ),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -88,6 +88,7 @@ import 'pack_tag_analyzer_screen.dart';
 import 'pack_library_diff_screen.dart';
 import 'pack_merge_explorer_screen.dart';
 import 'tag_matrix_coverage_screen.dart';
+import 'skill_map_screen.dart';
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
 
@@ -1657,6 +1658,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const TagMatrixCoverageScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧪 Открыть Skill Map'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const SkillMapScreen(),
                     ),
                   );
                 },

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -13,6 +13,7 @@ import '../services/training_pack_tags_service.dart';
 import '../services/training_pack_audience_service.dart';
 import '../services/training_pack_difficulty_service.dart';
 import 'pack_library_search_screen.dart';
+import 'skill_map_screen.dart';
 
 enum _SortOption { newest, rating, difficulty }
 
@@ -168,6 +169,15 @@ class _LibraryScreenState extends State<LibraryScreen> {
                 context,
                 MaterialPageRoute(
                     builder: (_) => const PackLibrarySearchScreen()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.analytics),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SkillMapScreen()),
               );
             },
           ),

--- a/lib/screens/skill_map_screen.dart
+++ b/lib/screens/skill_map_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_mastery_service.dart';
+
+class SkillMapScreen extends StatefulWidget {
+  const SkillMapScreen({super.key});
+
+  @override
+  State<SkillMapScreen> createState() => _SkillMapScreenState();
+}
+
+class _SkillMapScreenState extends State<SkillMapScreen> {
+  bool _loading = true;
+  Map<String, double> _data = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final service = context.read<TagMasteryService>();
+    final map = await service.computeMastery(force: true);
+    final entries = map.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    setState(() {
+      _data = {for (final e in entries) e.key: e.value};
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('🧠 Карта навыков'),
+        actions: [
+          IconButton(onPressed: _load, icon: const Icon(Icons.refresh)),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: _data.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final tag = _data.keys.elementAt(index);
+                final mastery = _data[tag] ?? 0.0;
+                return ListTile(
+                  title: Text('#$tag'),
+                  subtitle: LinearProgressIndicator(value: mastery),
+                  trailing: Text('${(mastery * 100).toStringAsFixed(0)}%'),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show Skill Map progress
- expose TagMasteryService via providers
- add button in LibraryScreen
- link screen from DevMenu

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_687ad5a67044832a960b06d655dc22ca