### PR TITLE
Implement GoalSuggestionEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -86,6 +86,7 @@ import 'services/session_analysis_service.dart';
 import 'services/user_action_logger.dart';
 import 'services/hand_analyzer_service.dart';
 import 'services/tag_mastery_service.dart';
+import 'services/goal_suggestion_engine.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -421,6 +422,12 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(
       create: (context) =>
           TagMasteryService(logs: context.read<SessionLogService>()),
+    ),
+    Provider(
+      create: (context) => GoalSuggestionEngine(
+        mastery: context.read<TagMasteryService>(),
+        logs: context.read<SessionLogService>(),
+      ),
     ),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];

--- a/lib/models/user_goal.dart
+++ b/lib/models/user_goal.dart
@@ -8,6 +8,8 @@ class UserGoal {
   final int base;
   final DateTime createdAt;
   final DateTime? completedAt;
+  final String? tag;
+  final double? targetAccuracy;
 
   const UserGoal({
     required this.id,
@@ -17,6 +19,8 @@ class UserGoal {
     required this.base,
     required this.createdAt,
     this.completedAt,
+    this.tag,
+    this.targetAccuracy,
   });
 
   bool get completed => completedAt != null;
@@ -29,6 +33,8 @@ class UserGoal {
         base: base,
         createdAt: createdAt,
         completedAt: completedAt,
+        tag: tag,
+        targetAccuracy: targetAccuracy,
       );
 
   Map<String, dynamic> toJson() => {
@@ -39,6 +45,8 @@ class UserGoal {
         'base': base,
         'createdAt': createdAt.toIso8601String(),
         'completedAt': completedAt?.toIso8601String(),
+        if (tag != null) 'tag': tag,
+        if (targetAccuracy != null) 'targetAccuracy': targetAccuracy,
       };
 
   factory UserGoal.fromJson(Map<String, dynamic> json) => UserGoal(
@@ -51,6 +59,8 @@ class UserGoal {
         completedAt: json['completedAt'] != null
             ? DateTime.parse(json['completedAt'] as String)
             : null,
+        tag: json['tag'] as String?,
+        targetAccuracy: (json['targetAccuracy'] as num?)?.toDouble(),
       );
 
   static String encode(List<UserGoal> list) =>

--- a/lib/services/goal_suggestion_engine.dart
+++ b/lib/services/goal_suggestion_engine.dart
@@ -1,0 +1,80 @@
+import 'package:collection/collection.dart';
+
+import '../models/user_goal.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'session_log_service.dart';
+import 'tag_mastery_service.dart';
+
+class GoalSuggestionEngine {
+  final TagMasteryService mastery;
+  final SessionLogService logs;
+
+  GoalSuggestionEngine({required this.mastery, required this.logs});
+
+  List<UserGoal>? _cache;
+  DateTime _cacheTime = DateTime.fromMillisecondsSinceEpoch(0);
+
+  Future<List<UserGoal>> suggestGoals({bool force = false}) async {
+    if (!force &&
+        _cache != null &&
+        DateTime.now().difference(_cacheTime) < const Duration(hours: 12)) {
+      return _cache!;
+    }
+
+    final goals = <UserGoal>[];
+    final masteryMap = await mastery.computeMastery();
+    final weakEntries = masteryMap.entries
+        .where((e) => e.value < 0.8)
+        .toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    final used = <String>{};
+    final now = DateTime.now();
+
+    for (final e in weakEntries.take(3)) {
+      final tag = e.key;
+      if (!used.add('tag:$tag')) continue;
+      goals.add(UserGoal(
+        id: 'tag_${tag}_${now.millisecondsSinceEpoch}',
+        title: 'Тег $tag: цель 80%',
+        type: 'tag',
+        target: 80,
+        base: (e.value * 100).round(),
+        createdAt: now,
+        tag: tag,
+        targetAccuracy: 80.0,
+      ));
+    }
+
+    await logs.load();
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = PackLibraryLoaderService.instance.library;
+
+    for (final log in logs.logs) {
+      if (goals.length >= 5) break;
+      final total = log.correctCount + log.mistakeCount;
+      if (total == 0) continue;
+      final acc = log.correctCount / total;
+      if (acc >= 0.8) continue;
+      final tpl = library.firstWhereOrNull((t) => t.id == log.templateId);
+      if (tpl == null) continue;
+      final key = 'pack:${tpl.id}';
+      if (!used.add(key)) continue;
+      goals.add(UserGoal(
+        id: 'pack_${tpl.id}_${now.millisecondsSinceEpoch}',
+        title: 'Повтори ${tpl.name}',
+        type: 'pack',
+        target: 80,
+        base: (acc * 100).round(),
+        createdAt: now,
+        tag: tpl.id,
+        targetAccuracy: 80.0,
+      ));
+    }
+
+    _cache = goals.take(5).toList();
+    _cacheTime = DateTime.now();
+    return _cache!;
+  }
+}


### PR DESCRIPTION
## Summary
- expand `UserGoal` model with optional `tag` and `targetAccuracy`
- add `GoalSuggestionEngine` service that proposes tag and pack goals
- expose engine via `AppProviders`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad76da0fc832a9fb9377b615843aa