### PR TITLE
Implement goal celebration banner

### DIFF
--- a/lib/widgets/goal_celebration_banner.dart
+++ b/lib/widgets/goal_celebration_banner.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import '../models/user_goal.dart';
+
+class GoalCelebrationBanner extends StatelessWidget {
+  final UserGoal goal;
+  final VoidCallback onClose;
+  const GoalCelebrationBanner({
+    Key? key,
+    required this.goal,
+    required this.onClose,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final tag = goal.tag ?? goal.title;
+    return MaterialBanner(
+      leading: const Icon(Icons.emoji_events, color: Colors.amber),
+      content: Text('🎉 Цель #$tag достигнута!'),
+      actions: [
+        TextButton(onPressed: onClose, child: const Text('Закрыть')),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show toast progress and celebration banner in `GoalToastService`
- add `GoalCelebrationBanner` widget

## Testing
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_687ade23dc40832aa2c570cf39c3d7a9