### PR TITLE
Add GoalAnalyticsService

### DIFF
--- a/lib/services/goal_analytics_service.dart
+++ b/lib/services/goal_analytics_service.dart
@@ -1,0 +1,39 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/user_goal.dart';
+import 'user_action_logger.dart';
+
+class GoalAnalyticsService {
+  GoalAnalyticsService._();
+  static final instance = GoalAnalyticsService._();
+
+  static const _completionPrefix = 'goal_completed_logged_';
+
+  Future<void> logGoalCreated(UserGoal goal) async {
+    await _logEvent('goal_created', goal, 0);
+  }
+
+  Future<void> logGoalProgress(UserGoal goal, double progress) async {
+    await _logEvent('goal_progress', goal, progress);
+  }
+
+  Future<void> logGoalCompleted(UserGoal goal) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_completionPrefix${goal.id}';
+    if (prefs.getBool(key) == true) return;
+    await _logEvent('goal_completed', goal, 100);
+    await prefs.setBool(key, true);
+  }
+
+  Future<void> _logEvent(
+      String type, UserGoal goal, double progress) async {
+    final event = {
+      'event': type,
+      'goalId': goal.id,
+      'tag': goal.tag,
+      'targetAccuracy': goal.targetAccuracy,
+      'progress': progress,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    await UserActionLogger.instance.logEvent(event);
+  }
+}

--- a/lib/services/goal_suggestion_engine.dart
+++ b/lib/services/goal_suggestion_engine.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:collection/collection.dart';
 
 import '../models/user_goal.dart';
@@ -5,6 +6,7 @@ import '../models/v2/training_pack_template_v2.dart';
 import 'pack_library_loader_service.dart';
 import 'session_log_service.dart';
 import 'tag_mastery_service.dart';
+import 'goal_analytics_service.dart';
 
 class GoalSuggestionEngine {
   final TagMasteryService mastery;
@@ -75,6 +77,9 @@ class GoalSuggestionEngine {
 
     _cache = goals.take(5).toList();
     _cacheTime = DateTime.now();
+    for (final g in _cache!) {
+      unawaited(GoalAnalyticsService.instance.logGoalCreated(g));
+    }
     return _cache!;
   }
 }

--- a/lib/services/goal_toast_service.dart
+++ b/lib/services/goal_toast_service.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart';
 import '../models/user_goal.dart';
 import '../widgets/goal_celebration_banner.dart';
+import 'goal_analytics_service.dart';
 
 class GoalToastService {
   static const _progressPrefix = 'goal_toast_progress_';
@@ -18,6 +19,7 @@ class GoalToastService {
 
   Future<void> _maybeShowToast(UserGoal goal, double newProgress) async {
     final prefs = await SharedPreferences.getInstance();
+    await GoalAnalyticsService.instance.logGoalProgress(goal, newProgress);
     final bannerKey = '$_bannerPrefix${goal.id}';
     final bannerShown = prefs.getBool(bannerKey) ?? false;
     final old = prefs.getDouble('$_progressPrefix${goal.id}') ?? 0.0;
@@ -28,6 +30,7 @@ class GoalToastService {
     if (!bannerShown && (goal.completed || newProgress >= 100)) {
       if (ctx != null && ctx.mounted) {
         _showCelebrationBanner(ctx, goal);
+        unawaited(GoalAnalyticsService.instance.logGoalCompleted(goal));
         await prefs.setBool(bannerKey, true);
       }
     }

--- a/lib/services/user_action_logger.dart
+++ b/lib/services/user_action_logger.dart
@@ -47,5 +47,16 @@ class UserActionLogger extends ChangeNotifier {
     await log(action);
   }
 
+  Future<void> logEvent(Map<String, dynamic> event) async {
+    event['time'] ??= DateTime.now().toIso8601String();
+    _events.add(event);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      _events.map((e) => jsonEncode(e)).toList(),
+    );
+    notifyListeners();
+  }
+
   List<Map<String, dynamic>> export() => events;
 }

--- a/lib/services/user_goal_engine.dart
+++ b/lib/services/user_goal_engine.dart
@@ -7,6 +7,7 @@ import '../widgets/confetti_overlay.dart';
 import '../main.dart';
 import 'training_stats_service.dart';
 import 'xp_tracker_service.dart';
+import 'goal_analytics_service.dart';
 
 class UserGoalEngine extends ChangeNotifier {
   static const _prefsKey = 'user_goals';
@@ -61,6 +62,7 @@ class UserGoalEngine extends ChangeNotifier {
       if (!g.completed && progress(g) >= g.target) {
         _goals[i] = g.copyWith(completedAt: DateTime.now());
         _save();
+        unawaited(GoalAnalyticsService.instance.logGoalCompleted(_goals[i]));
         final ctx = navigatorKey.currentContext;
         if (ctx != null) {
           showConfettiOverlay(ctx);
@@ -81,6 +83,7 @@ class UserGoalEngine extends ChangeNotifier {
 
   Future<void> addGoal(UserGoal g) async {
     _goals.add(g);
+    unawaited(GoalAnalyticsService.instance.logGoalCreated(g));
     await _save();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- implement `GoalAnalyticsService` for structured goal analytics
- extend `UserActionLogger` with `logEvent`
- log goal events from `GoalSuggestionEngine`, `GoalToastService` and `UserGoalEngine`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687ae08f2310832a8d8757408b90fdf9