### PR TITLE
Add Skill Map dashboard

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -19,7 +19,8 @@ import 'goal_screen.dart';
 enum _SortOption { newest, rating, difficulty }
 
 class LibraryScreen extends StatefulWidget {
-  const LibraryScreen({super.key});
+  final Set<String>? initialTags;
+  const LibraryScreen({super.key, this.initialTags});
 
   @override
   State<LibraryScreen> createState() => _LibraryScreenState();
@@ -70,6 +71,9 @@ class _LibraryScreenState extends State<LibraryScreen> {
   @override
   void initState() {
     super.initState();
+    if (widget.initialTags != null) {
+      _selectedTags.addAll(widget.initialTags!);
+    }
     _load();
   }
 
@@ -182,14 +186,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
               );
             },
           ),
-          IconButton(
-            icon: const Icon(Icons.analytics),
+          TextButton(
             onPressed: () {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const SkillMapScreen()),
               );
             },
+            child: const Text("🧠 Карта навыков"),
           ),
         ],
       ),

--- a/lib/widgets/tag_skill_tile.dart
+++ b/lib/widgets/tag_skill_tile.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class TagSkillTile extends StatelessWidget {
+  final String tag;
+  final double value;
+  final VoidCallback? onTap;
+
+  const TagSkillTile({
+    super.key,
+    required this.tag,
+    required this.value,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Color.lerp(Colors.red, Colors.green, value) ?? Colors.red;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.center,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              tag,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${(value * 100).toStringAsFixed(0)}%',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TagSkillTile` widget with red-green color mapping
- overhaul `SkillMapScreen` to show a sortable grid and filter packs by tag
- add optional `initialTags` to `LibraryScreen` and button to open skill map

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae1c19e78832a94205f81c073519d