### PR TITLE
Add GoalSyncService for user goal sync

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -88,6 +88,7 @@ import 'services/user_action_logger.dart';
 import 'services/hand_analyzer_service.dart';
 import 'services/tag_mastery_service.dart';
 import 'services/goal_suggestion_engine.dart';
+import 'services/goal_sync_service.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -96,6 +97,7 @@ late final TrainingPackStorageService packStorage;
 late final TrainingPackCloudSyncService packCloud;
 late final MistakePackCloudService mistakeCloud;
 late final GoalProgressCloudService goalCloud;
+late final GoalSyncService goalSync;
 late final TrainingPackTemplateStorageService templateStorage;
 late final TagCacheService tagCache;
 
@@ -113,9 +115,8 @@ List<SingleChildWidget> buildTrainingProviders() {
   return [
     Provider(create: (_) => CloudTrainingHistoryService()..init()),
     ChangeNotifierProvider(
-      create: (context) => TrainingSpotStorageService(
-        cloud: context.read<CloudSyncService>(),
-      ),
+      create: (context) =>
+          TrainingSpotStorageService(cloud: context.read<CloudSyncService>()),
     ),
     ChangeNotifierProvider(
       create: (context) =>
@@ -143,7 +144,8 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     ChangeNotifierProvider(
       create: (context) => PlayerStyleForecastService(
-          hands: context.read<SavedHandManagerService>()),
+        hands: context.read<SavedHandManagerService>(),
+      ),
     ),
     ChangeNotifierProvider(
       create: (context) => RealTimeStackRangeService(
@@ -172,21 +174,21 @@ List<SingleChildWidget> buildTrainingProviders() {
         style: context.read<PlayerStyleService>(),
       ),
     ),
+    ChangeNotifierProvider(create: (_) => MistakeStreakService()..load()),
     ChangeNotifierProvider(
-      create: (_) => MistakeStreakService()..load(),
+      create: (context) =>
+          SessionNoteService(cloud: context.read<CloudSyncService>())..load(),
     ),
     ChangeNotifierProvider(
-        create: (context) =>
-            SessionNoteService(cloud: context.read<CloudSyncService>())
-              ..load()),
-    ChangeNotifierProvider(
-        create: (context) =>
-            SessionPinService(cloud: context.read<CloudSyncService>())..load()),
+      create: (context) =>
+          SessionPinService(cloud: context.read<CloudSyncService>())..load(),
+    ),
     ChangeNotifierProvider<TrainingPackStorageService>.value(
       value: packStorage,
     ),
     Provider<TrainingPackCloudSyncService>.value(value: packCloud),
     Provider<MistakePackCloudService>.value(value: mistakeCloud),
+    Provider<GoalSyncService>.value(value: goalSync),
     ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
     ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..load()),
     ChangeNotifierProvider(
@@ -218,8 +220,9 @@ List<SingleChildWidget> buildTrainingProviders() {
     ChangeNotifierProvider(create: (_) => DailyTargetService()..load()),
     ChangeNotifierProvider(create: (_) => DailyTipService()..load()),
     ChangeNotifierProvider(
-        create: (context) =>
-            XPTrackerService(cloud: context.read<CloudSyncService>())..load()),
+      create: (context) =>
+          XPTrackerService(cloud: context.read<CloudSyncService>())..load(),
+    ),
     ChangeNotifierProvider(create: (_) => RewardService()..load()),
     ChangeNotifierProvider(create: (_) => GoalEngine()),
     ChangeNotifierProvider(
@@ -235,9 +238,9 @@ List<SingleChildWidget> buildTrainingProviders() {
       )..load(),
     ),
     ChangeNotifierProvider(
-      create: (context) => DailyPackService(
-        templates: context.read<TemplateStorageService>(),
-      )..load(),
+      create: (context) =>
+          DailyPackService(templates: context.read<TemplateStorageService>())
+            ..load(),
     ),
     ChangeNotifierProvider(
       create: (context) => WeeklyChallengeService(
@@ -306,8 +309,10 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     ChangeNotifierProvider(
-      create: (context) =>
-          UserGoalEngine(stats: context.read<TrainingStatsService>()),
+      create: (context) => UserGoalEngine(
+        stats: context.read<TrainingStatsService>(),
+        sync: goalSync,
+      ),
     ),
     Provider(create: (_) => GoalToastService()),
     ChangeNotifierProvider(
@@ -368,18 +373,14 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     ChangeNotifierProvider(create: (_) => DrillHistoryService()..load()),
-    ChangeNotifierProvider(
-      create: (_) => MixedDrillHistoryService()..load(),
-    ),
+    ChangeNotifierProvider(create: (_) => MixedDrillHistoryService()..load()),
     ChangeNotifierProvider(
       create: (context) => WeeklyDrillStatsService(
         history: context.read<MixedDrillHistoryService>(),
       )..load(),
     ),
     Provider(create: (_) => const HandAnalyzerService()),
-    ChangeNotifierProvider(
-      create: (_) => TrainingPackPlayController()..load(),
-    ),
+    ChangeNotifierProvider(create: (_) => TrainingPackPlayController()..load()),
     ChangeNotifierProvider(create: (_) => TrainingSessionService()..load()),
     Provider(
       create: (context) => SessionManager(

--- a/lib/services/goal_sync_service.dart
+++ b/lib/services/goal_sync_service.dart
@@ -1,0 +1,83 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/user_goal.dart';
+import 'cloud_retry_policy.dart';
+
+class GoalSyncService {
+  GoalSyncService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+    : _db = firestore ?? FirebaseFirestore.instance,
+      _auth = auth ?? FirebaseAuth.instance;
+
+  final FirebaseFirestore _db;
+  final FirebaseAuth _auth;
+
+  static const _syncKey = 'goals_last_sync';
+
+  String? get uid => _auth.currentUser?.uid;
+
+  Future<bool> _online() async {
+    final r = await Connectivity().checkConnectivity();
+    return r != ConnectivityResult.none;
+  }
+
+  Future<void> upload(List<UserGoal> goals) async {
+    if (uid == null || !await _online()) return;
+    final col = _db.collection('users').doc(uid).collection('goals');
+    final batch = _db.batch();
+    final now = DateTime.now().toIso8601String();
+    for (final g in goals) {
+      final data = {
+        'goalId': g.id,
+        'title': g.title,
+        'type': g.type,
+        'target': g.target,
+        'base': g.base,
+        if (g.tag != null) 'tag': g.tag,
+        if (g.targetAccuracy != null) 'targetAccuracy': g.targetAccuracy,
+        'progress': null,
+        'createdAt': g.createdAt.toIso8601String(),
+        if (g.completedAt != null)
+          'completedAt': g.completedAt!.toIso8601String(),
+        'updatedAt': now,
+      };
+      batch.set(col.doc(g.id), data, SetOptions(merge: true));
+    }
+    await CloudRetryPolicy.execute(() => batch.commit());
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_syncKey, now);
+  }
+
+  Future<List<UserGoal>> download() async {
+    if (uid == null || !await _online()) return [];
+    final snap = await CloudRetryPolicy.execute(
+      () => _db.collection('users').doc(uid).collection('goals').get(),
+    );
+    final result = <UserGoal>[];
+    for (final d in snap.docs) {
+      final data = d.data();
+      result.add(
+        UserGoal(
+          id: data['goalId'] as String? ?? d.id,
+          title: data['title'] as String? ?? '',
+          type: data['type'] as String? ?? 'mistakes',
+          target: (data['target'] as num?)?.toInt() ?? 1,
+          base: (data['base'] as num?)?.toInt() ?? 0,
+          createdAt:
+              DateTime.tryParse(data['createdAt'] as String? ?? '') ??
+              DateTime.now(),
+          completedAt: data['completedAt'] != null
+              ? DateTime.tryParse(data['completedAt'] as String)
+              : null,
+          tag: data['tag'] as String?,
+          targetAccuracy: (data['targetAccuracy'] as num?)?.toDouble(),
+        ),
+      );
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_syncKey, DateTime.now().toIso8601String());
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- create new `GoalSyncService` for syncing user goals to Firestore
- merge remote goals in `UserGoalEngine` and sync on changes
- provide `GoalSyncService` through `app_providers`
- instantiate `GoalSyncService` in `main.dart`

## Testing
- `dart format lib/services/goal_sync_service.dart lib/services/user_goal_engine.dart lib/app_providers.dart lib/main.dart`
- `dart pub get` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_687ae32b27d4832a86c3864ce08fb773