### PR TITLE
Add LessonStep schema

### DIFF
--- a/assets/lessons/test_lesson.yaml
+++ b/assets/lessons/test_lesson.yaml
@@ -1,0 +1,14 @@
+meta:
+  schemaVersion: '3.0.0'
+id: 'lesson1'
+title: 'Sample Lesson'
+introText: 'Welcome to the trainer.'
+quiz:
+  question: 'What is 2 + 2?'
+  options:
+    - '3'
+    - '4'
+    - '5'
+  correctIndex: 1
+rangeImageUrl: 'ranges/sample.png'
+linkedPackId: 'pack1'

--- a/lib/models/v3/lesson_step.dart
+++ b/lib/models/v3/lesson_step.dart
@@ -1,0 +1,78 @@
+class Quiz {
+  final String question;
+  final List<String> options;
+  final int correctIndex;
+
+  Quiz({
+    required this.question,
+    required this.options,
+    required this.correctIndex,
+  }) {
+    if (correctIndex < 0 || correctIndex >= options.length) {
+      throw ArgumentError('correctIndex out of range');
+    }
+  }
+
+  factory Quiz.fromYaml(Map yaml) {
+    final question = yaml['question']?.toString() ?? '';
+    final options = [for (final o in (yaml['options'] as List? ?? [])) o.toString()];
+    final index = (yaml['correctIndex'] as num?)?.toInt() ?? 0;
+    return Quiz(question: question, options: options, correctIndex: index);
+  }
+
+  Map<String, dynamic> toYaml() {
+    return {
+      'question': question,
+      'options': options,
+      'correctIndex': correctIndex,
+    };
+  }
+}
+
+class LessonStep {
+  final String id;
+  final String title;
+  final String introText;
+  final Quiz? quiz;
+  final String? rangeImageUrl;
+  final String linkedPackId;
+  final Map<String, dynamic> meta;
+
+  LessonStep({
+    required this.id,
+    required this.title,
+    required this.introText,
+    this.quiz,
+    this.rangeImageUrl,
+    required this.linkedPackId,
+    Map<String, dynamic>? meta,
+  }) : meta = meta ?? const {'schemaVersion': '3.0.0'};
+
+  factory LessonStep.fromYaml(Map yaml) {
+    final meta = Map<String, dynamic>.from(yaml['meta'] as Map? ?? {});
+    meta['schemaVersion'] = meta['schemaVersion']?.toString() ?? '3.0.0';
+    final quizYaml = yaml['quiz'] as Map?;
+    final quiz = quizYaml != null ? Quiz.fromYaml(Map.from(quizYaml)) : null;
+    return LessonStep(
+      id: yaml['id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      introText: yaml['introText']?.toString() ?? '',
+      quiz: quiz,
+      rangeImageUrl: yaml['rangeImageUrl']?.toString(),
+      linkedPackId: yaml['linkedPackId']?.toString() ?? '',
+      meta: meta,
+    );
+  }
+
+  Map<String, dynamic> toYaml() {
+    return {
+      'meta': meta,
+      'id': id,
+      'title': title,
+      'introText': introText,
+      if (quiz != null) 'quiz': quiz!.toYaml(),
+      if (rangeImageUrl != null) 'rangeImageUrl': rangeImageUrl,
+      'linkedPackId': linkedPackId,
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,6 +100,7 @@ flutter:
     - assets/packs/v2/
     - assets/packs/v2/library_index.json
     - assets/built_in_packs.yaml
+    - assets/lessons/
     - assets/pack_matrix.json
 
 # Release build configuration for the demo entry point. Run


### PR DESCRIPTION
## Summary
- implement `LessonStep` and nested `Quiz` model in `lib/models/v3`
- include dev example `test_lesson.yaml`
- register lesson assets path

## Testing
- `flutter analyze` *(fails: many existing issues but command executed)*

------
https://chatgpt.com/codex/tasks/task_e_687aeab619fc832aadf492e1d88b99e0