### PR TITLE
Add learning track model and engine

### DIFF
--- a/lib/models/v3/lesson_track.dart
+++ b/lib/models/v3/lesson_track.dart
@@ -1,0 +1,13 @@
+class LessonTrack {
+  final String id;
+  final String title;
+  final String description;
+  final List<String> stepIds;
+
+  const LessonTrack({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.stepIds,
+  });
+}

--- a/lib/services/learning_track_engine.dart
+++ b/lib/services/learning_track_engine.dart
@@ -1,0 +1,28 @@
+import '../models/v3/lesson_track.dart';
+
+class LearningTrackEngine {
+  const LearningTrackEngine();
+
+  static final List<LessonTrack> _tracks = [
+    LessonTrack(
+      id: 'mtt_pro',
+      title: 'MTT Pro Track',
+      description: 'Become a tournament crusher',
+      stepIds: const ['lesson1'],
+    ),
+    LessonTrack(
+      id: 'live_exploit',
+      title: 'Live Exploit Track',
+      description: 'Exploitative lines for live games',
+      stepIds: const ['lesson1'],
+    ),
+    LessonTrack(
+      id: 'leak_fixer',
+      title: 'Leak Fixer',
+      description: 'Fix your weakest spots using tags',
+      stepIds: const ['lesson1'],
+    ),
+  ];
+
+  List<LessonTrack> getTracks() => List.unmodifiable(_tracks);
+}


### PR DESCRIPTION
## Summary
- add `LessonTrack` model for v3 lessons
- implement `LearningTrackEngine` with three prebuilt tracks

## Testing
- `flutter analyze`
- `flutter test` *(fails: Undefined name `_intIntMapFromJson` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687af4976abc832aa4665874956763ed