### PR TITLE
Implement LessonStepTagService

### DIFF
--- a/assets/lessons/lesson_without_tags.yaml
+++ b/assets/lessons/lesson_without_tags.yaml
@@ -1,0 +1,6 @@
+meta:
+  schemaVersion: '3.0.0'
+id: 'lesson2'
+title: 'No Tag Lesson'
+introText: 'Another step.'
+linkedPackId: 'pack2'

--- a/assets/lessons/test_lesson.yaml
+++ b/assets/lessons/test_lesson.yaml
@@ -12,3 +12,6 @@ quiz:
   correctIndex: 1
 rangeImageUrl: 'ranges/sample.png'
 linkedPackId: 'pack1'
+tags:
+  - BTN
+  - push

--- a/lib/models/v3/lesson_step.dart
+++ b/lib/models/v3/lesson_step.dart
@@ -36,6 +36,7 @@ class LessonStep {
   final Quiz? quiz;
   final String? rangeImageUrl;
   final String linkedPackId;
+  final List<String>? tags;
   final Map<String, dynamic> meta;
 
   LessonStep({
@@ -45,6 +46,7 @@ class LessonStep {
     this.quiz,
     this.rangeImageUrl,
     required this.linkedPackId,
+    this.tags,
     Map<String, dynamic>? meta,
   }) : meta = meta ?? const {'schemaVersion': '3.0.0'};
 
@@ -60,6 +62,7 @@ class LessonStep {
       quiz: quiz,
       rangeImageUrl: yaml['rangeImageUrl']?.toString(),
       linkedPackId: yaml['linkedPackId']?.toString() ?? '',
+      tags: [for (final t in (yaml['tags'] as List? ?? [])) t.toString()],
       meta: meta,
     );
   }
@@ -73,6 +76,7 @@ class LessonStep {
       if (quiz != null) 'quiz': quiz!.toYaml(),
       if (rangeImageUrl != null) 'rangeImageUrl': rangeImageUrl,
       'linkedPackId': linkedPackId,
+      if (tags != null && tags!.isNotEmpty) 'tags': tags,
     };
   }
 }

--- a/lib/services/lesson_loader_service.dart
+++ b/lib/services/lesson_loader_service.dart
@@ -14,6 +14,7 @@ class LessonLoaderService {
     if (cached != null) return cached;
     const files = [
       'assets/lessons/test_lesson.yaml',
+      'assets/lessons/lesson_without_tags.yaml',
     ];
     final steps = <LessonStep>[];
     for (final path in files) {

--- a/lib/services/lesson_step_tag_service.dart
+++ b/lib/services/lesson_step_tag_service.dart
@@ -1,0 +1,18 @@
+import '../models/v3/lesson_step.dart';
+import 'lesson_loader_service.dart';
+
+class LessonStepTagService {
+  LessonStepTagService._();
+  static final instance = LessonStepTagService._();
+
+  Future<Map<String, List<String>>> getTagsByStepId() async {
+    final steps = await LessonLoaderService.instance.loadAllLessons();
+    final result = <String, List<String>>{};
+    for (final step in steps) {
+      final tags = step.tags;
+      if (tags == null || tags.isEmpty) continue;
+      result[step.id] = List<String>.from(tags);
+    }
+    return result;
+  }
+}

--- a/test/services/lesson_step_tag_service_test.dart
+++ b/test/services/lesson_step_tag_service_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/lesson_step_tag_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getTagsByStepId returns tags for steps with tags', () async {
+    final tags = await LessonStepTagService.instance.getTagsByStepId();
+    expect(tags.containsKey('lesson1'), true);
+    expect(tags['lesson1'], ['BTN', 'push']);
+    expect(tags.containsKey('lesson2'), false);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LessonStepTagService` to map lesson step IDs to tags
- support `tags` in `LessonStep` model
- include sample steps with and without tags
- load new step file in `LessonLoaderService`
- add unit test for `LessonStepTagService`

## Testing
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afc3cfd9c832a931fc3b63d67556b