### PR TITLE
Add TagCoverageService

### DIFF
--- a/lib/services/lesson_step_tag_service.dart
+++ b/lib/services/lesson_step_tag_service.dart
@@ -1,0 +1,33 @@
+import 'lesson_loader_service.dart';
+import '../models/v3/lesson_step.dart';
+
+/// Provides tags for each lesson step.
+abstract class LessonStepTagProvider {
+  Future<Map<String, List<String>>> getTagsByStepId();
+}
+
+class LessonStepTagService implements LessonStepTagProvider {
+  LessonStepTagService._();
+  static final instance = LessonStepTagService._();
+
+  @override
+  Future<Map<String, List<String>>> getTagsByStepId() async {
+    final steps = await LessonLoaderService.instance.loadAllLessons();
+    final result = <String, List<String>>{};
+    for (final step in steps) {
+      final tags = <String>[];
+      final metaTags = step.meta['tags'];
+      if (metaTags is List) {
+        for (final t in metaTags) {
+          final tag = t.toString().trim();
+          if (tag.isNotEmpty) tags.add(tag);
+        }
+      } else if (metaTags is String) {
+        final tag = metaTags.trim();
+        if (tag.isNotEmpty) tags.add(tag);
+      }
+      result[step.id] = tags;
+    }
+    return result;
+  }
+}

--- a/lib/services/tag_coverage_service.dart
+++ b/lib/services/tag_coverage_service.dart
@@ -1,0 +1,27 @@
+import 'lesson_step_tag_service.dart';
+
+/// Computes how many lesson steps use each tag.
+class TagCoverageService {
+  final LessonStepTagProvider _provider;
+
+  TagCoverageService({LessonStepTagProvider? provider})
+      : _provider = provider ?? LessonStepTagService.instance;
+
+  Future<Map<String, int>> computeTagCoverage() async {
+    final tagsByStep = await _provider.getTagsByStepId();
+    final result = <String, int>{};
+    tagsByStep.forEach((_, tags) {
+      if (tags.isEmpty) return;
+      final unique = <String>{};
+      for (final t in tags) {
+        final tag = t.trim();
+        if (tag.isEmpty) continue;
+        unique.add(tag);
+      }
+      for (final tag in unique) {
+        result[tag] = (result[tag] ?? 0) + 1;
+      }
+    });
+    return result;
+  }
+}

--- a/test/services/tag_coverage_service_test.dart
+++ b/test/services/tag_coverage_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/tag_coverage_service.dart';
+import 'package:poker_analyzer/services/lesson_step_tag_service.dart';
+
+class _FakeStepTagService implements LessonStepTagProvider {
+  final Map<String, List<String>> map;
+  _FakeStepTagService(this.map);
+
+  @override
+  Future<Map<String, List<String>>> getTagsByStepId() async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computeTagCoverage counts tags per step without duplicates', () async {
+    final provider = _FakeStepTagService({
+      'step1': ['a', 'b', 'a'],
+      'step2': ['b', 'c'],
+      'step3': [],
+    });
+
+    final service = TagCoverageService(provider: provider);
+    final coverage = await service.computeTagCoverage();
+
+    expect(coverage.length, 3);
+    expect(coverage['a'], 1);
+    expect(coverage['b'], 2);
+    expect(coverage['c'], 1);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `LessonStepTagService` to provide tags for lesson steps
- implement `TagCoverageService` for aggregating tag usage
- add unit test for tag coverage computation

## Testing
- `flutter test test/services/tag_coverage_service_test.dart` *(fails: command not found)*
- `dart test test/services/tag_coverage_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b182f49d8832a84a462c56fc77592