### PR TITLE
Add LessonTagHeatmapScreen

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -89,6 +89,7 @@ import 'services/hand_analyzer_service.dart';
 import 'services/tag_mastery_service.dart';
 import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
+import 'services/tag_coverage_service.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -426,6 +427,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) =>
           TagMasteryService(logs: context.read<SessionLogService>()),
     ),
+    Provider(create: (_) => TagCoverageService()),
     Provider(
       create: (context) => GoalSuggestionEngine(
         mastery: context.read<TagMasteryService>(),

--- a/lib/screens/lesson_tag_heatmap_screen.dart
+++ b/lib/screens/lesson_tag_heatmap_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_coverage_service.dart';
+import '../utils/responsive.dart';
+import '../widgets/tag_coverage_tile.dart';
+
+class LessonTagHeatmapScreen extends StatefulWidget {
+  const LessonTagHeatmapScreen({super.key});
+
+  @override
+  State<LessonTagHeatmapScreen> createState() => _LessonTagHeatmapScreenState();
+}
+
+class _LessonTagHeatmapScreenState extends State<LessonTagHeatmapScreen> {
+  bool _loading = true;
+  Map<String, int> _data = {};
+  bool _sortByCount = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final service = context.read<TagCoverageService>();
+    final map = await service.computeTagCoverage();
+    final entries = map.entries.toList();
+    _sort(entries);
+    setState(() {
+      _data = {for (final e in entries) e.key: e.value};
+      _loading = false;
+    });
+  }
+
+  void _sort(List<MapEntry<String, int>> list) {
+    if (_sortByCount) {
+      list.sort((a, b) => b.value.compareTo(a.value));
+    } else {
+      list.sort((a, b) => a.key.compareTo(b.key));
+    }
+  }
+
+  void _toggleSort() {
+    setState(() {
+      _sortByCount = !_sortByCount;
+      final entries = _data.entries.toList();
+      _sort(entries);
+      _data = {for (final e in entries) e.key: e.value};
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxCount = _data.values.fold<int>(0, (p, e) => e > p ? e : p);
+    final crossAxisCount = isLandscape(context)
+        ? (isCompactWidth(context) ? 6 : 8)
+        : (isCompactWidth(context) ? 3 : 4);
+    final tagCount = _data.length;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Покрытие тем ($tagCount)'),
+        actions: [
+          IconButton(onPressed: _load, icon: const Icon(Icons.refresh)),
+          IconButton(
+            onPressed: _toggleSort,
+            icon: Icon(_sortByCount ? Icons.sort_by_alpha : Icons.bar_chart),
+          ),
+        ],
+      ),
+      backgroundColor: Colors.black,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : GridView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: _data.length,
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: crossAxisCount,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+              ),
+              itemBuilder: (context, index) {
+                final entry = _data.entries.elementAt(index);
+                return TagCoverageTile(
+                  tag: entry.key,
+                  count: entry.value,
+                  max: maxCount,
+                  onTap: () {},
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/widgets/tag_coverage_tile.dart
+++ b/lib/widgets/tag_coverage_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class TagCoverageTile extends StatelessWidget {
+  final String tag;
+  final int count;
+  final int max;
+  final VoidCallback? onTap;
+
+  const TagCoverageTile({
+    super.key,
+    required this.tag,
+    required this.count,
+    required this.max,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final t = max > 0 ? count / max : 0.0;
+    final color =
+        Color.lerp(const Color(0xFF444444), const Color(0xFFFFA500), t)!;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        padding: const EdgeInsets.all(8),
+        alignment: Alignment.center,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              tag,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '$count',
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TagCoverageTile` widget to show tag and coverage count
- add `LessonTagHeatmapScreen` displaying tag coverage grid
- wire `TagCoverageService` provider

## Testing
- `dart format lib/app_providers.dart lib/screens/lesson_tag_heatmap_screen.dart lib/widgets/tag_coverage_tile.dart`
- `flutter test` *(fails: unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_687b1a1d0ac8832a8e4aaed2a1f3971f