### PR TITLE
Add lesson progress tracker service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -90,6 +90,7 @@ import 'services/tag_mastery_service.dart';
 import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
+import 'services/lesson_progress_tracker_service.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -434,6 +435,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         logs: context.read<SessionLogService>(),
       ),
     ),
+    Provider(create: (_) => LessonProgressTrackerService()..load()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];
 }

--- a/lib/services/lesson_progress_tracker_service.dart
+++ b/lib/services/lesson_progress_tracker_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LessonProgressTrackerService {
+  LessonProgressTrackerService._();
+  static final instance = LessonProgressTrackerService._();
+
+  static const _prefsKey = 'lesson_progress';
+  Map<String, bool> _progress = {};
+  bool _loaded = false;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      _progress = {
+        for (final e in data.entries) e.key: e.value == true,
+      };
+    } else {
+      _progress = {};
+    }
+    _loaded = true;
+  }
+
+  Future<void> markStepCompleted(String stepId) async {
+    if (!_loaded) await load();
+    _progress[stepId] = true;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(_progress));
+  }
+
+  Future<bool> isStepCompleted(String stepId) async {
+    if (!_loaded) await load();
+    return _progress[stepId] ?? false;
+  }
+
+  Future<Map<String, bool>> getCompletedSteps() async {
+    if (!_loaded) await load();
+    return Map<String, bool>.from(_progress);
+  }
+}

--- a/test/services/lesson_progress_tracker_service_test.dart
+++ b/test/services/lesson_progress_tracker_service_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('markStepCompleted stores step', () async {
+    SharedPreferences.setMockInitialValues({});
+    await LessonProgressTrackerService.instance.load();
+    await LessonProgressTrackerService.instance.markStepCompleted('step1');
+    expect(await LessonProgressTrackerService.instance.isStepCompleted('step1'), true);
+    final map = await LessonProgressTrackerService.instance.getCompletedSteps();
+    expect(map['step1'], true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LessonProgressTrackerService` for storing lesson progress map in SharedPreferences
- integrate tracker into `AppProviders`
- cover service with a basic unit test

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1bd3613c832a8bb381363d0935b6