### PR TITLE
Add track progress service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -91,6 +91,7 @@ import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
+import 'services/lesson_path_progress_service.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -436,6 +437,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     Provider(create: (_) => LessonProgressTrackerService()..load()),
+    Provider(create: (_) => LessonPathProgressService()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];
 }

--- a/lib/services/lesson_path_progress_service.dart
+++ b/lib/services/lesson_path_progress_service.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v3/lesson_track.dart';
 import 'learning_track_engine.dart';
 import 'lesson_progress_service.dart';
+import 'lesson_progress_tracker_service.dart';
 
 class LessonPathProgress {
   final int completed;
@@ -55,5 +56,26 @@ class LessonPathProgressService {
       completedIds: completedIds,
       remainingIds: remainingIds,
     );
+  }
+
+  /// Computes completion percentage for all available lesson tracks.
+  ///
+  /// Returns a map of `trackId` to progress percentage (0-100).
+  Future<Map<String, double>> computeTrackProgress() async {
+    final tracks = const LearningTrackEngine().getTracks();
+    final completed =
+        await LessonProgressTrackerService.instance.getCompletedSteps();
+
+    final Map<String, double> progress = {};
+    for (final track in tracks) {
+      final ids = track.stepIds;
+      if (ids.isEmpty) {
+        progress[track.id] = 0;
+        continue;
+      }
+      final doneCount = ids.where((id) => completed[id] == true).length;
+      progress[track.id] = doneCount / ids.length * 100;
+    }
+    return progress;
   }
 }

--- a/test/services/lesson_path_progress_service_test.dart
+++ b/test/services/lesson_path_progress_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_path_progress_service.dart';
+import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -24,5 +25,24 @@ void main() {
     expect(progress.total, 1);
     expect(progress.completedIds, ['lesson1']);
     expect(progress.percent, 100);
+  });
+
+  test('computeTrackProgress returns map for each track', () async {
+    SharedPreferences.setMockInitialValues({});
+    final map = await LessonPathProgressService.instance.computeTrackProgress();
+    expect(map['mtt_pro'], 0);
+    expect(map['live_exploit'], 0);
+    expect(map['leak_fixer'], 0);
+  });
+
+  test('computeTrackProgress counts completed steps', () async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_progress': '{"lesson1": true}'
+    });
+    await LessonProgressTrackerService.instance.load();
+    final map = await LessonPathProgressService.instance.computeTrackProgress();
+    expect(map['mtt_pro'], 100);
+    expect(map['live_exploit'], 100);
+    expect(map['leak_fixer'], 100);
   });
 }


### PR DESCRIPTION
## Summary
- extend `LessonPathProgressService` to compute progress for all learning tracks
- provide the service through `AppProviders`
- test new computation logic

## Testing
- ❌ `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1e9aae44832a8dad599bff43a2b3