### PR TITLE
Add AdaptiveNextStepEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -92,6 +92,7 @@ import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
+import 'services/adaptive_next_step_engine.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -438,6 +439,7 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => LessonProgressTrackerService()..load()),
     Provider(create: (_) => LessonPathProgressService()),
+    Provider(create: (_) => AdaptiveNextStepEngine()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
   ];
 }

--- a/lib/services/adaptive_next_step_engine.dart
+++ b/lib/services/adaptive_next_step_engine.dart
@@ -1,0 +1,97 @@
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v3/lesson_step.dart';
+import '../models/v3/lesson_track.dart';
+import 'lesson_progress_tracker_service.dart';
+import 'learning_track_engine.dart';
+import 'lesson_loader_service.dart';
+import 'lesson_step_tag_service.dart';
+import 'tag_coverage_service.dart';
+
+class AdaptiveNextStepEngine {
+  final LessonProgressTrackerService progress;
+  final LearningTrackEngine trackEngine;
+  final LessonLoaderService loader;
+  final LessonStepTagProvider tagProvider;
+  final TagCoverageService coverageService;
+  final List<LessonStep>? _stepsOverride;
+  final List<LessonTrack>? _tracksOverride;
+
+  AdaptiveNextStepEngine({
+    LessonProgressTrackerService? progress,
+    LearningTrackEngine trackEngine = const LearningTrackEngine(),
+    LessonLoaderService? loader,
+    LessonStepTagProvider? tagProvider,
+    TagCoverageService? coverage,
+    List<LessonStep>? steps,
+    List<LessonTrack>? tracks,
+  })  : progress = progress ?? LessonProgressTrackerService.instance,
+        trackEngine = trackEngine,
+        loader = loader ?? LessonLoaderService.instance,
+        tagProvider = tagProvider ?? LessonStepTagService.instance,
+        coverageService =
+            coverage ?? TagCoverageService(provider: tagProvider ?? LessonStepTagService.instance),
+        _stepsOverride = steps,
+        _tracksOverride = tracks;
+
+  static const _recentKey = 'lesson_recent_steps';
+
+  Future<List<LessonStep>> _loadSteps() async {
+    return _stepsOverride ?? await loader.loadAllLessons();
+  }
+
+  List<LessonTrack> _loadTracks() {
+    return _tracksOverride ?? trackEngine.getTracks();
+  }
+
+  Future<String?> suggestNextStep() async {
+    final completed = await progress.getCompletedSteps();
+    final steps = await _loadSteps();
+    final tagsByStep = await tagProvider.getTagsByStepId();
+    final coverage = await coverageService.computeTagCoverage();
+
+    final prefs = await SharedPreferences.getInstance();
+    final trackId = prefs.getString('lesson_selected_track');
+    final trackSteps = <String>{};
+    if (trackId != null) {
+      final track = _loadTracks().firstWhereOrNull((t) => t.id == trackId);
+      if (track != null) trackSteps.addAll(track.stepIds);
+    }
+
+    final recent = prefs.getStringList(_recentKey) ?? <String>[];
+    final recentSet = recent.toSet();
+
+    String? bestId;
+    double bestScore = double.negativeInfinity;
+
+    for (final step in steps) {
+      if (completed[step.id] == true) continue;
+      final tags = tagsByStep[step.id] ?? const <String>[];
+      if (tags.isEmpty) continue;
+      if (recentSet.contains(step.id)) continue;
+
+      double score = 0;
+      for (final tag in tags) {
+        final c = coverage[tag] ?? 0;
+        score -= c.toDouble();
+      }
+      if (trackSteps.contains(step.id)) score += 1000;
+      if (score > bestScore) {
+        bestScore = score;
+        bestId = step.id;
+      }
+    }
+
+    if (bestId != null) {
+      recent.add(bestId!);
+      while (recent.length > 5) {
+        recent.removeAt(0);
+      }
+      await prefs.setStringList(_recentKey, recent);
+    }
+
+    return bestId;
+  }
+}
+

--- a/test/services/adaptive_next_step_engine_test.dart
+++ b/test/services/adaptive_next_step_engine_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/adaptive_next_step_engine.dart';
+import 'package:poker_analyzer/models/v3/lesson_step.dart';
+import 'package:poker_analyzer/models/v3/lesson_track.dart';
+import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
+import 'package:poker_analyzer/services/tag_coverage_service.dart';
+import 'package:poker_analyzer/services/lesson_step_tag_service.dart';
+
+class _FakeTagProvider implements LessonStepTagProvider {
+  final Map<String, List<String>> map;
+  _FakeTagProvider(this.map);
+  @override
+  Future<Map<String, List<String>>> getTagsByStepId() async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final steps = [
+    LessonStep(
+      id: 's1',
+      title: 'one',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {'schemaVersion': '3.0.0', 'tags': ['a']},
+    ),
+    LessonStep(
+      id: 's2',
+      title: 'two',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {'schemaVersion': '3.0.0', 'tags': ['b']},
+    ),
+    LessonStep(
+      id: 's3',
+      title: 'three',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {'schemaVersion': '3.0.0'},
+    ),
+  ];
+
+  final tracks = [
+    const LessonTrack(
+      id: 't1',
+      title: 'Track',
+      description: '',
+      stepIds: ['s2'],
+    ),
+  ];
+
+  test('suggestNextStep prefers track steps', () async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_selected_track': 't1',
+    });
+    await LessonProgressTrackerService.instance.load();
+    final provider = _FakeTagProvider({
+      's1': ['a'],
+      's2': ['b'],
+    });
+    final engine = AdaptiveNextStepEngine(
+      steps: steps,
+      tracks: tracks,
+      tagProvider: provider,
+      coverage: TagCoverageService(provider: provider),
+    );
+    final next = await engine.suggestNextStep();
+    expect(next, 's2');
+  });
+
+  test('suggestNextStep skips recent steps', () async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_selected_track': 't1',
+      'lesson_recent_steps': ['s2'],
+    });
+    await LessonProgressTrackerService.instance.load();
+    final provider = _FakeTagProvider({
+      's1': ['a'],
+      's2': ['b'],
+    });
+    final engine = AdaptiveNextStepEngine(
+      steps: steps,
+      tracks: tracks,
+      tagProvider: provider,
+      coverage: TagCoverageService(provider: provider),
+    );
+    final next = await engine.suggestNextStep();
+    expect(next, 's1');
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `AdaptiveNextStepEngine` with tag-based priority rules
- integrate engine with app providers
- add unit tests for engine logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/adaptive_next_step_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b20adfd4c832aae0d661754e5d4f1