### PR TITLE
Add lesson suggestion banner

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -53,6 +53,7 @@ import '../widgets/sync_status_widget.dart';
 import 'weakness_overview_screen.dart';
 import 'training_home_screen.dart';
 import 'ready_to_train_screen.dart';
+import '../widgets/lesson_suggestion_banner.dart';
 
 class _MenuItem {
   final IconData icon;
@@ -564,16 +565,20 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 const Expanded(
                   child: Text(
                     'Новая подборка тренировок!',
-                    style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold, color: Colors.white),
                   ),
                 ),
                 ElevatedButton(
                   onPressed: () async {
-                    await context.read<TrainingSessionService>().startSession(tpl!);
+                    await context
+                        .read<TrainingSessionService>()
+                        .startSession(tpl!);
                     if (!context.mounted) return;
                     await Navigator.push(
                       context,
-                      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                      MaterialPageRoute(
+                          builder: (_) => const TrainingSessionScreen()),
                     );
                   },
                   child: const Text('Начать тренировку'),
@@ -811,6 +816,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    const LessonSuggestionBanner(),
                     _buildSuggestedBanner(context),
                     _buildStreakCard(context),
                     _buildDailyGoalCard(context),

--- a/lib/widgets/lesson_suggestion_banner.dart
+++ b/lib/widgets/lesson_suggestion_banner.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+
+import '../services/adaptive_next_step_engine.dart';
+import '../services/lesson_loader_service.dart';
+import '../models/v3/lesson_step.dart';
+import '../screens/lesson_step_screen.dart';
+
+class LessonSuggestionBanner extends StatefulWidget {
+  const LessonSuggestionBanner({super.key});
+
+  @override
+  State<LessonSuggestionBanner> createState() => _LessonSuggestionBannerState();
+}
+
+class _LessonSuggestionBannerState extends State<LessonSuggestionBanner> {
+  late Future<LessonStep?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<LessonStep?> _load() async {
+    final engine = context.read<AdaptiveNextStepEngine>();
+    final id = await engine.suggestNextStep();
+    if (id == null) return null;
+    final steps = await LessonLoaderService.instance.loadAllLessons();
+    return steps.firstWhereOrNull((s) => s.id == id);
+  }
+
+  void _openStep(LessonStep step) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => LessonStepScreen(step: step)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<LessonStep?>(
+      future: _future,
+      builder: (context, snapshot) {
+        final step = snapshot.data;
+        if (snapshot.connectionState != ConnectionState.done || step == null) {
+          return const SizedBox.shrink();
+        }
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                step.title,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              if (step.introText.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    step.introText,
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: () => _openStep(step),
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  child: const Text('Продолжить обучение'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `LessonSuggestionBanner` widget that uses `AdaptiveNextStepEngine`
- display the banner on `MainMenuScreen` before suggested packs

## Testing
- `dart analyze lib/widgets/lesson_suggestion_banner.dart lib/screens/main_menu_screen.dart`
- `flutter test test/services/adaptive_next_step_engine_test.dart -j 1` *(fails: Dart SDK version 3.3.4 incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_687b227e0264832a8fbc6ebde95a9ddf