### PR TITLE
Implement LessonRecapScreen

### DIFF
--- a/assets/lessons/test_lesson.yaml
+++ b/assets/lessons/test_lesson.yaml
@@ -3,6 +3,7 @@ meta:
 id: 'lesson1'
 title: 'Sample Lesson'
 introText: 'Welcome to the trainer.'
+summaryText: 'Вы познакомились с тренажёром и решили простую задачу.'
 quiz:
   question: 'What is 2 + 2?'
   options:

--- a/lib/models/v3/lesson_step.dart
+++ b/lib/models/v3/lesson_step.dart
@@ -33,6 +33,7 @@ class LessonStep {
   final String id;
   final String title;
   final String introText;
+  final String summaryText;
   final Quiz? quiz;
   final String? rangeImageUrl;
   final String linkedPackId;
@@ -42,6 +43,7 @@ class LessonStep {
     required this.id,
     required this.title,
     required this.introText,
+    this.summaryText = '',
     this.quiz,
     this.rangeImageUrl,
     required this.linkedPackId,
@@ -57,6 +59,7 @@ class LessonStep {
       id: yaml['id']?.toString() ?? '',
       title: yaml['title']?.toString() ?? '',
       introText: yaml['introText']?.toString() ?? '',
+      summaryText: yaml['summaryText']?.toString() ?? '',
       quiz: quiz,
       rangeImageUrl: yaml['rangeImageUrl']?.toString(),
       linkedPackId: yaml['linkedPackId']?.toString() ?? '',
@@ -70,6 +73,7 @@ class LessonStep {
       'id': id,
       'title': title,
       'introText': introText,
+      'summaryText': summaryText,
       if (quiz != null) 'quiz': quiz!.toYaml(),
       if (rangeImageUrl != null) 'rangeImageUrl': rangeImageUrl,
       'linkedPackId': linkedPackId,

--- a/lib/screens/lesson_path_screen.dart
+++ b/lib/screens/lesson_path_screen.dart
@@ -10,6 +10,7 @@ import '../services/lesson_progress_tracker_service.dart';
 import '../services/lesson_path_progress_service.dart';
 import '../services/learning_track_engine.dart';
 import 'lesson_step_screen.dart';
+import 'lesson_recap_screen.dart';
 import 'track_selector_screen.dart';
 
 class LessonPathScreen extends StatefulWidget {
@@ -174,7 +175,18 @@ class _LessonPathScreenState extends State<LessonPathScreen> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (_) => LessonStepScreen(step: step),
+                                builder: (_) => LessonStepScreen(
+                                  step: step,
+                                  onStepComplete: (s) async {
+                                    await Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (_) =>
+                                            LessonRecapScreen(step: s),
+                                      ),
+                                    );
+                                  },
+                                ),
                               ),
                             );
                           },

--- a/lib/screens/lesson_recap_screen.dart
+++ b/lib/screens/lesson_recap_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
+import 'package:provider/provider.dart';
+
+import '../models/v3/lesson_step.dart';
+import '../services/adaptive_next_step_engine.dart';
+import '../services/lesson_loader_service.dart';
+import 'lesson_step_screen.dart';
+import 'track_progress_dashboard_screen.dart';
+
+class LessonRecapScreen extends StatefulWidget {
+  final LessonStep step;
+  const LessonRecapScreen({super.key, required this.step});
+
+  @override
+  State<LessonRecapScreen> createState() => _LessonRecapScreenState();
+}
+
+class _LessonRecapScreenState extends State<LessonRecapScreen>
+    with SingleTickerProviderStateMixin {
+  late Future<LessonStep?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<LessonStep?> _load() async {
+    final engine = context.read<AdaptiveNextStepEngine>();
+    final nextId = await engine.suggestNextStep();
+    if (nextId == null || nextId == widget.step.id) return null;
+    final steps = await LessonLoaderService.instance.loadAllLessons();
+    return steps.firstWhereOrNull((s) => s.id == nextId);
+  }
+
+  void _openNext(LessonStep? next) {
+    if (next == null) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+            builder: (_) => const TrackProgressDashboardScreen()),
+      );
+    } else {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => LessonStepScreen(
+            step: next,
+            onStepComplete: (s) async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => LessonRecapScreen(step: s)),
+              );
+            },
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Резюме шага')),
+      backgroundColor: const Color(0xFF121212),
+      body: FutureBuilder<LessonStep?>(
+        future: _future,
+        builder: (context, snapshot) {
+          final next = snapshot.data;
+          final done = snapshot.connectionState == ConnectionState.done;
+          return AnimatedOpacity(
+            duration: const Duration(milliseconds: 300),
+            opacity: done ? 1 : 0,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${widget.step.title} \u2014 \u2713 Завершено',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  if (widget.step.summaryText.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      widget.step.summaryText,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ],
+                  const Spacer(),
+                  if (done)
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (next != null)
+                          Text(
+                            'Следующий шаг: ${next.title}',
+                            style: const TextStyle(color: Colors.white),
+                          )
+                        else
+                          const Text(
+                            'Вы прошли все рекомендованные шаги.',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        const SizedBox(height: 12),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: ElevatedButton(
+                            onPressed: () => _openNext(next),
+                            style: ElevatedButton.styleFrom(
+                                backgroundColor: accent),
+                            child: const Text('Далее \u2192'),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/lesson_step_screen.dart
+++ b/lib/screens/lesson_step_screen.dart
@@ -9,7 +9,8 @@ import 'training_session_screen.dart';
 
 class LessonStepScreen extends StatefulWidget {
   final LessonStep step;
-  const LessonStepScreen({super.key, required this.step});
+  final Future<void> Function(LessonStep step)? onStepComplete;
+  const LessonStepScreen({super.key, required this.step, this.onStepComplete});
 
   @override
   State<LessonStepScreen> createState() => _LessonStepScreenState();
@@ -93,7 +94,11 @@ class _LessonStepScreenState extends State<LessonStepScreen> {
                 onPressed: () async {
                   await LessonProgressService.instance
                       .markCompleted(step.id);
-                  if (mounted) Navigator.pop(context);
+                  if (widget.onStepComplete != null) {
+                    await widget.onStepComplete!(step);
+                  } else if (mounted) {
+                    Navigator.pop(context);
+                  }
                 },
                 child: const Text('Завершить шаг'),
               ),

--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -9,6 +9,7 @@ import '../services/lesson_loader_service.dart';
 import '../services/lesson_path_progress_service.dart';
 import '../services/lesson_progress_tracker_service.dart';
 import 'lesson_step_screen.dart';
+import 'lesson_recap_screen.dart';
 
 class TrackProgressDashboardScreen extends StatefulWidget {
   const TrackProgressDashboardScreen({super.key});
@@ -53,7 +54,17 @@ class _TrackProgressDashboardScreenState
     if (!mounted || step == null) return;
     await Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => LessonStepScreen(step: step)),
+      MaterialPageRoute(
+        builder: (_) => LessonStepScreen(
+          step: step,
+          onStepComplete: (s) async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => LessonRecapScreen(step: s)),
+            );
+          },
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/lesson_suggestion_banner.dart
+++ b/lib/widgets/lesson_suggestion_banner.dart
@@ -6,6 +6,7 @@ import '../services/adaptive_next_step_engine.dart';
 import '../services/lesson_loader_service.dart';
 import '../models/v3/lesson_step.dart';
 import '../screens/lesson_step_screen.dart';
+import '../screens/lesson_recap_screen.dart';
 
 class LessonSuggestionBanner extends StatefulWidget {
   const LessonSuggestionBanner({super.key});
@@ -34,7 +35,17 @@ class _LessonSuggestionBannerState extends State<LessonSuggestionBanner> {
   void _openStep(LessonStep step) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => LessonStepScreen(step: step)),
+      MaterialPageRoute(
+        builder: (_) => LessonStepScreen(
+          step: step,
+          onStepComplete: (s) async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => LessonRecapScreen(step: s)),
+            );
+          },
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- add `LessonRecapScreen` for post‑step recap with next recommendation
- extend `LessonStep` model with `summaryText`
- use new recap screen from `LessonStepScreen`
- show recap after completing lessons from path, track dashboard, and banner
- add summary text to sample lesson

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b260157fc832a8ebdce5c4af5a0ae