### PR TITLE
Add LessonTrackMetaService

### DIFF
--- a/lib/models/v3/track_meta.dart
+++ b/lib/models/v3/track_meta.dart
@@ -1,0 +1,27 @@
+class TrackMeta {
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final int timesCompleted;
+
+  TrackMeta({
+    this.startedAt,
+    this.completedAt,
+    this.timesCompleted = 0,
+  });
+
+  factory TrackMeta.fromJson(Map<String, dynamic> j) => TrackMeta(
+        startedAt: j['startedAt'] != null
+            ? DateTime.tryParse(j['startedAt'] as String)
+            : null,
+        completedAt: j['completedAt'] != null
+            ? DateTime.tryParse(j['completedAt'] as String)
+            : null,
+        timesCompleted: (j['timesCompleted'] as num?)?.toInt() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (startedAt != null) 'startedAt': startedAt!.toIso8601String(),
+        if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
+        'timesCompleted': timesCompleted,
+      };
+}

--- a/lib/services/lesson_track_meta_service.dart
+++ b/lib/services/lesson_track_meta_service.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v3/track_meta.dart';
+
+class LessonTrackMetaService {
+  LessonTrackMetaService._();
+  static final instance = LessonTrackMetaService._();
+
+  static String _key(String id) => 'lesson_track_meta_$id';
+
+  Future<void> markStarted(String trackId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key(trackId));
+    TrackMeta meta;
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map<String, dynamic>) {
+          meta = TrackMeta.fromJson(data);
+        } else {
+          meta = TrackMeta();
+        }
+      } catch (_) {
+        meta = TrackMeta();
+      }
+    } else {
+      meta = TrackMeta();
+    }
+    if (meta.startedAt != null) return;
+    meta = TrackMeta(
+      startedAt: DateTime.now(),
+      completedAt: meta.completedAt,
+      timesCompleted: meta.timesCompleted,
+    );
+    await prefs.setString(_key(trackId), jsonEncode(meta.toJson()));
+  }
+
+  Future<void> markCompleted(String trackId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key(trackId));
+    TrackMeta meta;
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map<String, dynamic>) {
+          meta = TrackMeta.fromJson(data);
+        } else {
+          meta = TrackMeta();
+        }
+      } catch (_) {
+        meta = TrackMeta();
+      }
+    } else {
+      meta = TrackMeta();
+    }
+    meta = TrackMeta(
+      startedAt: meta.startedAt ?? DateTime.now(),
+      completedAt: DateTime.now(),
+      timesCompleted: meta.timesCompleted + 1,
+    );
+    await prefs.setString(_key(trackId), jsonEncode(meta.toJson()));
+  }
+
+  Future<TrackMeta?> load(String trackId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key(trackId));
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map<String, dynamic>) {
+        return TrackMeta.fromJson(Map<String, dynamic>.from(data));
+      }
+    } catch (_) {}
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrackMeta` model for storing track progress
- implement `LessonTrackMetaService` to save started/completed info

## Testing
- `dart format lib/models/v3/track_meta.dart lib/services/lesson_track_meta_service.dart`
- `flutter analyze` *(fails: 6875 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687b272ca444832a8365b6c28b43dbd4