### PR TITLE
Add learning path completion tracking

### DIFF
--- a/lib/services/learning_path_completion_service.dart
+++ b/lib/services/learning_path_completion_service.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LearningPathCompletionService {
+  LearningPathCompletionService._();
+  static final instance = LearningPathCompletionService._();
+
+  static const _completedKey = 'learning_path_completed';
+  static const _dateKey = 'learning_path_completed_at';
+
+  Future<bool> isPathCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_completedKey) ?? false;
+  }
+
+  Future<void> markPathCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    final already = prefs.getBool(_completedKey) ?? false;
+    if (already) return;
+    await prefs.setBool(_completedKey, true);
+    await prefs.setString(_dateKey, DateTime.now().toIso8601String());
+  }
+
+  Future<DateTime?> getCompletionDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_dateKey);
+    return raw != null ? DateTime.tryParse(raw) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `LearningPathCompletionService` to persist completion flag and date
- show completion banner in `TrackProgressDashboardScreen`
- automatically mark learning path completed when all tracks hit 100%

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2b064d40832a9a9d3af5f078914a