### PR TITLE
Implement MasteryLevelEngine

### DIFF
--- a/lib/models/mastery_level.dart
+++ b/lib/models/mastery_level.dart
@@ -1,0 +1,14 @@
+enum MasteryLevel { beginner, intermediate, expert }
+
+extension MasteryLevelLabel on MasteryLevel {
+  String get label {
+    switch (this) {
+      case MasteryLevel.beginner:
+        return 'Новичок';
+      case MasteryLevel.intermediate:
+        return 'Продвинутый';
+      case MasteryLevel.expert:
+        return 'Эксперт';
+    }
+  }
+}

--- a/lib/services/mastery_level_engine.dart
+++ b/lib/services/mastery_level_engine.dart
@@ -1,0 +1,39 @@
+import '../models/mastery_level.dart';
+import 'lesson_progress_tracker_service.dart';
+import 'lesson_track_meta_service.dart';
+import 'learning_track_engine.dart';
+
+class MasteryLevelEngine {
+  final LessonProgressTrackerService _progress;
+  final LessonTrackMetaService _trackMeta;
+
+  MasteryLevelEngine({
+    LessonProgressTrackerService? progress,
+    LessonTrackMetaService? trackMeta,
+  })  : _progress = progress ?? LessonProgressTrackerService.instance,
+        _trackMeta = trackMeta ?? LessonTrackMetaService.instance;
+
+  Future<MasteryLevel> computeUserLevel() async {
+    final completedSteps = await _progress.getCompletedSteps();
+    final tracks = const LearningTrackEngine().getTracks();
+    var completedTracks = 0;
+    for (final t in tracks) {
+      final meta = await _trackMeta.load(t.id);
+      if (meta?.completedAt != null) {
+        completedTracks += 1;
+      }
+    }
+
+    final stepCount = completedSteps.length;
+
+    // TODO: incorporate EV/ICM metrics from trainings
+
+    if (stepCount >= 100 && completedTracks >= 3) {
+      return MasteryLevel.expert;
+    }
+    if (stepCount >= 30 || completedTracks >= 1) {
+      return MasteryLevel.intermediate;
+    }
+    return MasteryLevel.beginner;
+  }
+}


### PR DESCRIPTION
## Summary
- add `MasteryLevel` enum with Russian labels
- implement `MasteryLevelEngine` service to compute user level from progress

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687b2d0d3550832a9e2c7595a260a51e