### PR TITLE
Add MasterModeScreen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'core/plugin_runtime.dart';
 import 'screens/main_navigation_screen.dart';
 import 'screens/weakness_overview_screen.dart';
+import 'screens/master_mode_screen.dart';
 import 'services/saved_hand_storage_service.dart';
 import 'services/saved_hand_manager_service.dart';
 import 'services/session_note_service.dart';
@@ -346,6 +347,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
             routes: {
               WeaknessOverviewScreen.route: (_) =>
                   const WeaknessOverviewScreen(),
+              MasterModeScreen.route: (_) => const MasterModeScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -23,6 +23,7 @@ import 'services/ignored_mistake_service.dart';
 import 'services/training_import_export_service.dart';
 import 'services/demo_playback_controller.dart';
 import 'screens/weakness_overview_screen.dart';
+import 'screens/master_mode_screen.dart';
 
 final GlobalKey analyzerKey = GlobalKey();
 
@@ -166,6 +167,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
               ),
               routes: {
                 WeaknessOverviewScreen.route: (_) => const WeaknessOverviewScreen(),
+                MasterModeScreen.route: (_) => const MasterModeScreen(),
               },
               builder: (context, child) {
                 return Stack(

--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../services/learning_path_completion_service.dart';
+import '../services/learning_track_engine.dart';
+import '../services/lesson_track_meta_service.dart';
+
+class MasterModeScreen extends StatefulWidget {
+  static const route = '/master_mode';
+  const MasterModeScreen({super.key});
+
+  @override
+  State<MasterModeScreen> createState() => _MasterModeScreenState();
+}
+
+class _MasterModeScreenState extends State<MasterModeScreen> {
+  late Future<Map<String, dynamic>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<Map<String, dynamic>> _load() async {
+    final date = await LearningPathCompletionService.instance.getCompletionDate();
+    final tracks = const LearningTrackEngine().getTracks();
+    var completedTracks = 0;
+    for (final t in tracks) {
+      final meta = await LessonTrackMetaService.instance.load(t.id);
+      if (meta?.completedAt != null) {
+        completedTracks += 1;
+      }
+    }
+    return {
+      'date': date,
+      'completedTracks': completedTracks,
+      'totalTracks': tracks.length,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('🔥 Мастер-режим'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF121212),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _future,
+        builder: (context, snapshot) {
+          final data = snapshot.data;
+          final date = data?['date'] as DateTime?;
+          final completed = data?['completedTracks'] as int? ?? 0;
+          final total = data?['totalTracks'] as int? ?? 0;
+
+          final stats = 'Завершено треков: $completed / $total';
+          final dateText = date != null
+              ? 'Путь завершён: ${DateFormat('dd.MM.yyyy').format(date)}'
+              : 'Путь завершён';
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                dateText,
+                style: const TextStyle(color: Colors.white70),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                stats,
+                style: const TextStyle(color: Colors.white70),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {},
+                child: const Text('🎯 Начать челлендж'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {},
+                child: const Text('🔁 Повторить трек'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {},
+                child: const Text('📈 Анализ прогресса'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -13,6 +13,7 @@ import '../services/lesson_track_meta_service.dart';
 import '../services/learning_path_completion_service.dart';
 import '../models/mastery_level.dart';
 import '../services/mastery_level_engine.dart';
+import 'master_mode_screen.dart';
 import 'lesson_step_screen.dart';
 import 'lesson_recap_screen.dart';
 
@@ -249,6 +250,27 @@ class _TrackProgressDashboardScreenState
                       },
                     ),
                   ),
+                      FutureBuilder<MasteryLevel>(
+                        future: _levelFuture,
+                        builder: (context, levelSnap) {
+                          if (levelSnap.connectionState != ConnectionState.done) {
+                            return const SizedBox.shrink();
+                          }
+                          final level = levelSnap.data;
+                          final show = pathCompleted && level == MasteryLevel.expert;
+                          if (!show) return const SizedBox.shrink();
+                          return Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: ElevatedButton(
+                              onPressed: () => Navigator.pushNamed(
+                                context,
+                                MasterModeScreen.route,
+                              ),
+                              child: const Text('🔥 Мастер-режим'),
+                            ),
+                          );
+                        },
+                      ),
                 ],
               ),
         );


### PR DESCRIPTION
## Summary
- introduce `MasterModeScreen` with placeholder stats and actions
- link master mode in routing for release/demo
- expose master mode from track progress dashboard when path complete at Expert level

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b48cc1780832a8fd845fcbeecce33