### PR TITLE
Add DailyChallengeStreakService

### DIFF
--- a/lib/services/daily_challenge_service.dart
+++ b/lib/services/daily_challenge_service.dart
@@ -9,6 +9,7 @@ import '../models/player_model.dart';
 import '../models/training_spot.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import 'daily_challenge_streak_service.dart';
 
 /// Singleton service managing the Daily Challenge spot logic.
 class DailyChallengeService extends ChangeNotifier {
@@ -85,6 +86,7 @@ class DailyChallengeService extends ChangeNotifier {
     _completed = true;
     await prefs.setString(_dateKey, _date!.toIso8601String());
     await prefs.setBool(_completedKey, true);
+    await DailyChallengeStreakService.instance.updateStreak();
     notifyListeners();
   }
 

--- a/lib/services/daily_challenge_streak_service.dart
+++ b/lib/services/daily_challenge_streak_service.dart
@@ -1,0 +1,37 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DailyChallengeStreakService {
+  DailyChallengeStreakService._();
+
+  static final DailyChallengeStreakService instance = DailyChallengeStreakService._();
+
+  static const String _dateKey = 'lastChallengeDate';
+  static const String _streakKey = 'currentStreak';
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_streakKey) ?? 0;
+  }
+
+  Future<void> updateStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_dateKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 0) return;
+      if (diff == 1) {
+        final streak = (prefs.getInt(_streakKey) ?? 0) + 1;
+        await prefs.setInt(_streakKey, streak);
+      } else {
+        await prefs.setInt(_streakKey, 1);
+      }
+    } else {
+      await prefs.setInt(_streakKey, 1);
+    }
+    await prefs.setString(_dateKey, today.toIso8601String());
+  }
+}


### PR DESCRIPTION
## Summary
- create `DailyChallengeStreakService` for tracking consecutive daily challenge completions
- hook streak update into `DailyChallengeService.markCompleted`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687b4fd9817c832a926c2b0026f2f833