### PR TITLE
Implement streak badge widget

### DIFF
--- a/lib/screens/daily_challenge_result_screen.dart
+++ b/lib/screens/daily_challenge_result_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/training_spot.dart';
 import 'master_mode_screen.dart';
+import '../widgets/streak_badge_widget.dart';
 
 class DailyChallengeResultScreen extends StatelessWidget {
   final TrainingSpot spot;
@@ -28,6 +29,7 @@ class DailyChallengeResultScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            const StreakBadgeWidget(),
             Text('EV: $evText',
                 style: const TextStyle(color: Colors.white)),
             const SizedBox(height: 8),

--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../services/learning_path_completion_service.dart';
 import '../services/learning_track_engine.dart';
 import '../services/lesson_track_meta_service.dart';
+import '../widgets/streak_badge_widget.dart';
 
 class MasterModeScreen extends StatefulWidget {
   static const route = '/master_mode';
@@ -63,6 +64,7 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              const StreakBadgeWidget(),
               Text(
                 dateText,
                 style: const TextStyle(color: Colors.white70),

--- a/lib/widgets/streak_badge_widget.dart
+++ b/lib/widgets/streak_badge_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../services/daily_challenge_streak_service.dart';
+
+/// Displays the current daily challenge streak.
+class StreakBadgeWidget extends StatelessWidget {
+  const StreakBadgeWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<int>(
+      future: DailyChallengeStreakService.instance.getCurrentStreak(),
+      builder: (context, snapshot) {
+        final streak = snapshot.data;
+        if (streak == null || streak <= 0) {
+          return const SizedBox.shrink();
+        }
+        final label = streak == 1 ? '🔥 Новичок' : 'x$streak';
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          margin: const EdgeInsets.only(bottom: 16),
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              colors: [Colors.deepOrange, Colors.orangeAccent],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.deepOrange.withOpacity(0.6),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.local_fire_department,
+                  color: Colors.white, size: 20),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add StreakBadgeWidget to show current challenge streak
- integrate StreakBadgeWidget into master mode and challenge result screens

## Testing
- `flutter analyze` *(fails: many issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687b511de148832a8bc2dc0fa2281d35