### PR TITLE
Implement DailyChallengeMetaService

### DIFF
--- a/lib/screens/daily_challenge_result_screen.dart
+++ b/lib/screens/daily_challenge_result_screen.dart
@@ -1,19 +1,33 @@
 import 'package:flutter/material.dart';
 
 import '../models/training_spot.dart';
+import '../services/daily_challenge_meta_service.dart';
 import 'master_mode_screen.dart';
 import '../widgets/streak_badge_widget.dart';
 
-class DailyChallengeResultScreen extends StatelessWidget {
+class DailyChallengeResultScreen extends StatefulWidget {
   final TrainingSpot spot;
   const DailyChallengeResultScreen({super.key, required this.spot});
 
+  @override
+  State<DailyChallengeResultScreen> createState() =>
+      _DailyChallengeResultScreenState();
+}
+
+class _DailyChallengeResultScreenState
+    extends State<DailyChallengeResultScreen> {
+  @override
+  void initState() {
+    super.initState();
+    DailyChallengeMetaService.instance.markResultShown();
+  }
+
   double? get _ev =>
-      spot.actions.isNotEmpty ? spot.actions.first.ev : null;
+      widget.spot.actions.isNotEmpty ? widget.spot.actions.first.ev : null;
 
-  String get _bestAction => spot.recommendedAction ?? '-';
+  String get _bestAction => widget.spot.recommendedAction ?? '-';
 
-  String? get _explanation => spot.explanation;
+  String? get _explanation => widget.spot.explanation;
 
   @override
   Widget build(BuildContext context) {
@@ -30,23 +44,25 @@ class DailyChallengeResultScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const StreakBadgeWidget(),
-            Text('EV: $evText',
-                style: const TextStyle(color: Colors.white)),
+            Text('EV: $evText', style: const TextStyle(color: Colors.white)),
             const SizedBox(height: 8),
-            Text('Лучшее действие: $_bestAction',
-                style: const TextStyle(color: Colors.white)),
+            Text(
+              'Лучшее действие: $_bestAction',
+              style: const TextStyle(color: Colors.white),
+            ),
             if (_explanation != null) ...[
               const SizedBox(height: 8),
-              Text(_explanation!,
-                  style: const TextStyle(color: Colors.white70)),
+              Text(
+                _explanation!,
+                style: const TextStyle(color: Colors.white70),
+              ),
             ],
             const Spacer(),
             ElevatedButton(
               onPressed: () {
                 Navigator.pushAndRemoveUntil(
                   context,
-                  MaterialPageRoute(
-                      builder: (_) => const MasterModeScreen()),
+                  MaterialPageRoute(builder: (_) => const MasterModeScreen()),
                   (route) => false,
                 );
               },

--- a/lib/services/daily_challenge_meta_service.dart
+++ b/lib/services/daily_challenge_meta_service.dart
@@ -1,0 +1,48 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'daily_challenge_service.dart';
+
+enum ChallengeState { locked, available, completed }
+
+/// Provides meta information about the Daily Challenge state.
+class DailyChallengeMetaService {
+  DailyChallengeMetaService._();
+
+  static final DailyChallengeMetaService instance =
+      DailyChallengeMetaService._();
+
+  factory DailyChallengeMetaService() => instance;
+
+  static const String _shownResultKey = 'daily_challenge_shown_result_at';
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  /// Marks that today's challenge result has been viewed.
+  Future<void> markResultShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    await prefs.setString(_shownResultKey, today.toIso8601String());
+  }
+
+  /// Returns today's [ChallengeState].
+  Future<ChallengeState> getTodayState() async {
+    final prefs = await SharedPreferences.getInstance();
+    final service = DailyChallengeService.instance;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    if (service.isCompletedToday()) {
+      final shownStr = prefs.getString(_shownResultKey);
+      if (shownStr != null) {
+        final shown = DateTime.tryParse(shownStr);
+        if (shown != null && _sameDay(shown, today)) {
+          return ChallengeState.locked;
+        }
+      }
+      return ChallengeState.completed;
+    }
+    return ChallengeState.available;
+  }
+}


### PR DESCRIPTION
## Summary
- add `DailyChallengeMetaService` to determine daily challenge status
- mark result as shown when `DailyChallengeResultScreen` opens
- block replay via state checks in `DailyChallengeCard`

## Testing
- `dart format lib/services/daily_challenge_meta_service.dart lib/screens/daily_challenge_result_screen.dart lib/widgets/daily_challenge_card.dart`
- `dart pub get` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_687b5309b7dc832aa6825ba92cfc015f