### PR TITLE
Add challenge history screen

### DIFF
--- a/lib/screens/daily_challenge_history_screen.dart
+++ b/lib/screens/daily_challenge_history_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../services/daily_challenge_history_service.dart';
+import '../services/daily_challenge_streak_service.dart';
+
+/// Displays a simple history of Daily Challenge completions.
+class DailyChallengeHistoryScreen extends StatefulWidget {
+  const DailyChallengeHistoryScreen({super.key});
+
+  @override
+  State<DailyChallengeHistoryScreen> createState() =>
+      _DailyChallengeHistoryScreenState();
+}
+
+class _DailyChallengeHistoryScreenState
+    extends State<DailyChallengeHistoryScreen> {
+  late Future<Set<DateTime>> _historyFuture;
+  late Future<int> _streakFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _historyFuture = DailyChallengeHistoryService.instance.loadHistorySet();
+    _streakFuture = DailyChallengeStreakService.instance.getCurrentStreak();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История челленджей'),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFF121212),
+      body: FutureBuilder<List<dynamic>>(
+        future: Future.wait([_historyFuture, _streakFuture]),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final history = snapshot.data![0] as Set<DateTime>;
+          final streak = snapshot.data![1] as int? ?? 0;
+          final now = DateTime.now();
+          final start = DateTime(now.year, now.month, now.day)
+              .subtract(const Duration(days: 13));
+          final days = [
+            for (int i = 0; i < 14; i++) start.add(Duration(days: i))
+          ];
+          return ListView(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            scrollDirection: Axis.horizontal,
+            children: [
+              const SizedBox(width: 16),
+              for (final d in days) _buildDay(d, history, streak, now),
+              const SizedBox(width: 16),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildDay(
+      DateTime day, Set<DateTime> history, int streak, DateTime now) {
+    final key = DateTime(day.year, day.month, day.day);
+    final completed = history.contains(key);
+    final diff = now.difference(key).inDays;
+    final inStreak = completed && diff < streak;
+    final dateText = DateFormat('dd.MM').format(day);
+    final color = completed ? Colors.greenAccent : Colors.grey;
+
+    return Container(
+      width: 60,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: inStreak ? Colors.deepOrange : Colors.transparent,
+          width: 2,
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(dateText,
+              style: const TextStyle(color: Colors.white, fontSize: 12)),
+          const SizedBox(height: 8),
+          Icon(
+            completed ? Icons.check_circle : Icons.radio_button_unchecked,
+            color: color,
+            size: 20,
+          ),
+          if (inStreak) ...[
+            const SizedBox(height: 4),
+            const Icon(Icons.local_fire_department,
+                color: Colors.deepOrange, size: 16),
+          ]
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -5,6 +5,7 @@ import '../services/learning_path_completion_service.dart';
 import '../services/learning_track_engine.dart';
 import '../services/lesson_track_meta_service.dart';
 import '../widgets/streak_badge_widget.dart';
+import 'daily_challenge_history_screen.dart';
 
 class MasterModeScreen extends StatefulWidget {
   static const route = '/master_mode';
@@ -24,7 +25,8 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
   }
 
   Future<Map<String, dynamic>> _load() async {
-    final date = await LearningPathCompletionService.instance.getCompletionDate();
+    final date =
+        await LearningPathCompletionService.instance.getCompletionDate();
     final tracks = const LearningTrackEngine().getTracks();
     var completedTracks = 0;
     for (final t in tracks) {
@@ -78,6 +80,18 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
               ElevatedButton(
                 onPressed: () {},
                 child: const Text('🎯 Начать челлендж'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const DailyChallengeHistoryScreen(),
+                    ),
+                  );
+                },
+                child: const Text('📅 История'),
               ),
               const SizedBox(height: 16),
               ElevatedButton(

--- a/lib/services/daily_challenge_history_service.dart
+++ b/lib/services/daily_challenge_history_service.dart
@@ -1,0 +1,44 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages completion history for Daily Challenges.
+class DailyChallengeHistoryService {
+  DailyChallengeHistoryService._();
+
+  /// Singleton instance.
+  static final DailyChallengeHistoryService instance =
+      DailyChallengeHistoryService._();
+
+  static const String _historyKey = 'daily_challenge_history';
+
+  /// Returns the list of completion dates.
+  Future<List<DateTime>> loadHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_historyKey) ?? [];
+    return [
+      for (final s in raw)
+        if (DateTime.tryParse(s) != null) DateTime.parse(s)
+    ];
+  }
+
+  /// Convenience method returning a set of days without time component.
+  Future<Set<DateTime>> loadHistorySet() async {
+    final list = await loadHistory();
+    return {for (final d in list) DateTime(d.year, d.month, d.day)};
+  }
+
+  /// Adds today's date to the history if absent.
+  Future<void> addToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_historyKey) ?? [];
+    final now = DateTime.now();
+    final todayStr = DateTime(now.year, now.month, now.day).toIso8601String();
+    if (!list.contains(todayStr)) {
+      list.add(todayStr);
+      // Keep up to 60 entries to limit storage growth.
+      if (list.length > 60) {
+        list.removeRange(0, list.length - 60);
+      }
+      await prefs.setStringList(_historyKey, list);
+    }
+  }
+}

--- a/lib/services/daily_challenge_service.dart
+++ b/lib/services/daily_challenge_service.dart
@@ -10,6 +10,7 @@ import '../models/training_spot.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import 'daily_challenge_streak_service.dart';
+import 'daily_challenge_history_service.dart';
 
 /// Singleton service managing the Daily Challenge spot logic.
 class DailyChallengeService extends ChangeNotifier {
@@ -87,6 +88,7 @@ class DailyChallengeService extends ChangeNotifier {
     await prefs.setString(_dateKey, _date!.toIso8601String());
     await prefs.setBool(_completedKey, true);
     await DailyChallengeStreakService.instance.updateStreak();
+    await DailyChallengeHistoryService.instance.addToday();
     notifyListeners();
   }
 
@@ -147,8 +149,7 @@ class DailyChallengeService extends ChangeNotifier {
       }
     }
     final stacks = [
-      for (var i = 0; i < hand.playerCount; i++)
-        hand.stacks['$i']?.round() ?? 0
+      for (var i = 0; i < hand.playerCount; i++) hand.stacks['$i']?.round() ?? 0
     ];
     final positions = List.generate(hand.playerCount, (_) => '');
     if (hand.heroIndex < positions.length) {


### PR DESCRIPTION
## Summary
- add DailyChallengeHistoryService to persist completion dates
- track history when marking daily challenge completed
- implement DailyChallengeHistoryScreen to show 14-day streak
- add history button to MasterModeScreen

## Testing
- `flutter analyze` *(fails: 6878 issues found)*
- `flutter test --run-skipped` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687b5428a780832a8f095a26c93a0db5