### PR TITLE
Implement StreakBannerWidget

### DIFF
--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -5,6 +5,7 @@ import '../services/learning_path_completion_service.dart';
 import '../services/learning_track_engine.dart';
 import '../services/lesson_track_meta_service.dart';
 import '../widgets/streak_badge_widget.dart';
+import '../widgets/streak_banner_widget.dart';
 import 'daily_challenge_history_screen.dart';
 
 class MasterModeScreen extends StatefulWidget {
@@ -66,6 +67,7 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              const StreakBannerWidget(),
               const StreakBadgeWidget(),
               Text(
                 dateText,

--- a/lib/widgets/streak_banner_widget.dart
+++ b/lib/widgets/streak_banner_widget.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../services/daily_challenge_streak_service.dart';
+
+/// Banner displaying current daily challenge streak.
+class StreakBannerWidget extends StatefulWidget {
+  const StreakBannerWidget({super.key});
+
+  @override
+  State<StreakBannerWidget> createState() => _StreakBannerWidgetState();
+}
+
+class _StreakBannerWidgetState extends State<StreakBannerWidget>
+    with SingleTickerProviderStateMixin {
+  int _streak = 0;
+  bool _loading = true;
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    final value =
+        await DailyChallengeStreakService.instance.getCurrentStreak();
+    if (!mounted) return;
+    setState(() {
+      _streak = value;
+      _loading = false;
+    });
+    if (value > 0) _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _streak <= 0) return const SizedBox.shrink();
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.deepOrangeAccent.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          '🔥 Стрик: $_streak дней подряд!',
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `StreakBannerWidget` with fade-in animation
- show the new banner in `MasterModeScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5dc2ab2c832aa261ef8c093cbe3b