### PR TITLE
Add Daily Challenge reminder notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,6 +69,7 @@ import 'services/xp_tracker_service.dart';
 import 'services/reward_service.dart';
 import 'services/weekly_challenge_service.dart';
 import 'services/daily_challenge_service.dart';
+import 'services/daily_challenge_notification_service.dart';
 import 'services/daily_goals_service.dart';
 import 'services/session_log_service.dart';
 import 'services/category_usage_service.dart';
@@ -113,6 +114,7 @@ Future<void> main() async {
   if (!CloudSyncService.isLocal) {
     await Firebase.initializeApp();
     await NotificationService.init();
+    await DailyChallengeNotificationService.init();
     await rc.load();
     if (!auth.isSignedIn) {
       final uid = await auth.signInAnonymously();
@@ -249,6 +251,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     _sync = AppBootstrap.sync!;
     context.read<UserActionLogger>().log('opened_app');
     unawaited(NotificationService.scheduleDailyReminder(context));
+    unawaited(DailyChallengeNotificationService.scheduleDailyReminder());
     unawaited(NotificationService.scheduleDailyProgress(context));
     NotificationService.startRecommendedPackTask(context);
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/services/daily_challenge_notification_service.dart
+++ b/lib/services/daily_challenge_notification_service.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'daily_challenge_meta_service.dart';
+
+class DailyChallengeNotificationService {
+  DailyChallengeNotificationService._();
+
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+  static bool _initialized = false;
+  static const int _id = 111; // Unique notification ID
+
+  static Future<void> init() async {
+    if (_initialized) return;
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+    _initialized = true;
+  }
+
+  static Future<void> scheduleDailyReminder({TimeOfDay time = const TimeOfDay(hour: 12, minute: 0)}) async {
+    await init();
+    final state = await DailyChallengeMetaService.instance.getTodayState();
+    if (state == ChallengeState.locked) return;
+    final now = tz.TZDateTime.now(tz.local);
+    var when = tz.TZDateTime(tz.local, now.year, now.month, now.day, time.hour, time.minute);
+    if (!when.isAfter(now)) {
+      when = when.add(const Duration(days: 1));
+    }
+    await _plugin.zonedSchedule(
+      _id,
+      'Poker Analyzer',
+      '🎯 Готов к челленджу дня? Вернись и улучшай свои навыки!',
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('daily_challenge', 'Daily Challenge'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  static Future<void> cancelDailyReminder() async {
+    await init();
+    await _plugin.cancel(_id);
+  }
+}


### PR DESCRIPTION
## Summary
- add `DailyChallengeNotificationService` to manage daily challenge notifications
- initialize the new service in `main`
- schedule the reminder when the app state is initialized

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5fbbeb1c832ab4c4db5bf4cab2b5