### PR TITLE
Add basic LearningPathScreen mock

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -95,6 +95,7 @@ import 'tag_matrix_coverage_screen.dart';
 import 'skill_map_screen.dart';
 import 'goal_screen.dart';
 import 'lesson_path_screen.dart';
+import 'learning_path_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -1895,6 +1896,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const LessonPathScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📚 Путь обучения'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const LearningPathScreen()),
                   );
                 },
               ),

--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import '../services/learning_path_progress_service.dart';
+
+class LearningPathScreen extends StatelessWidget {
+  const LearningPathScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<LearningStageState>>(
+      future: LearningPathProgressService.instance.getCurrentStageState(),
+      builder: (context, snapshot) {
+        final stages = snapshot.data ?? [];
+        return Scaffold(
+          appBar: AppBar(title: const Text('📚 Путь обучения')),
+          backgroundColor: const Color(0xFF121212),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : ListView.builder(
+                  itemCount: stages.length,
+                  itemBuilder: (context, index) {
+                    final stage = stages[index];
+                    return _StageSection(stage: stage);
+                  },
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _StageSection extends StatelessWidget {
+  final LearningStageState stage;
+  const _StageSection({required this.stage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            stage.title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        for (int i = 0; i < stage.items.length; i++)
+          LearningStageTile(item: stage.items[i], index: i),
+      ],
+    );
+  }
+}
+
+class LearningStageTile extends StatefulWidget {
+  final LearningStageItem item;
+  final int index;
+  const LearningStageTile({super.key, required this.item, required this.index});
+
+  @override
+  State<LearningStageTile> createState() => _LearningStageTileState();
+}
+
+class _LearningStageTileState extends State<LearningStageTile> {
+  bool _visible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(Duration(milliseconds: widget.index * 100), () {
+      if (mounted) setState(() => _visible = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    Color color;
+    switch (item.status) {
+      case LearningItemStatus.completed:
+        color = Colors.green.shade700;
+        break;
+      case LearningItemStatus.available:
+        color = Colors.blueGrey.shade700;
+        break;
+      case LearningItemStatus.locked:
+      default:
+        color = Colors.grey.shade800;
+        break;
+    }
+    final trailing = item.status == LearningItemStatus.completed
+        ? const Icon(Icons.emoji_events, color: Colors.amber)
+        : Text('${(item.progress * 100).round()}%');
+    return AnimatedSlide(
+      offset: _visible ? Offset.zero : const Offset(0, 0.1),
+      duration: const Duration(milliseconds: 300),
+      child: AnimatedOpacity(
+        opacity: _visible ? 1 : 0,
+        duration: const Duration(milliseconds: 300),
+        child: Card(
+          color: color,
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: ListTile(
+            leading: Icon(item.icon, color: Colors.white),
+            title: Text(item.title),
+            trailing: trailing,
+            onTap: item.status == LearningItemStatus.locked ? null : () {},
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+enum LearningItemStatus { locked, available, completed }
+
+class LearningStageItem {
+  final String title;
+  final IconData icon;
+  final double progress;
+  final LearningItemStatus status;
+
+  const LearningStageItem({
+    required this.title,
+    required this.icon,
+    required this.progress,
+    required this.status,
+  });
+}
+
+class LearningStageState {
+  final String title;
+  final List<LearningStageItem> items;
+
+  const LearningStageState({required this.title, required this.items});
+}
+
+class LearningPathProgressService {
+  LearningPathProgressService._();
+  static final instance = LearningPathProgressService._();
+
+  Future<List<LearningStageState>> getCurrentStageState() async {
+    return [
+      LearningStageState(title: 'Beginner', items: const [
+        LearningStageItem(
+          title: 'Push/Fold Basics',
+          icon: Icons.play_circle_fill,
+          progress: 1.0,
+          status: LearningItemStatus.completed,
+        ),
+        LearningStageItem(
+          title: '10bb Ranges',
+          icon: Icons.school,
+          progress: 0.6,
+          status: LearningItemStatus.available,
+        ),
+        LearningStageItem(
+          title: '15bb Ranges',
+          icon: Icons.school,
+          progress: 0.0,
+          status: LearningItemStatus.locked,
+        ),
+      ]),
+      LearningStageState(title: 'Intermediate', items: const [
+        LearningStageItem(
+          title: 'ICM Concepts',
+          icon: Icons.insights,
+          progress: 0.0,
+          status: LearningItemStatus.locked,
+        ),
+        LearningStageItem(
+          title: 'Shoving Charts 20bb',
+          icon: Icons.table_chart,
+          progress: 0.0,
+          status: LearningItemStatus.locked,
+        ),
+      ]),
+      LearningStageState(title: 'Advanced', items: const [
+        LearningStageItem(
+          title: 'Exploit Spots',
+          icon: Icons.lightbulb_outline,
+          progress: 0.0,
+          status: LearningItemStatus.locked,
+        ),
+      ]),
+    ];
+  }
+}


### PR DESCRIPTION
## Summary
- add learning_path_progress_service with mock data
- implement LearningPathScreen to show learning stages
- link LearningPathScreen from DevMenu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b65927408832a93acc66010a34abd