### PR TITLE
Launch training pack from learning path

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../services/learning_path_progress_service.dart';
+import '../services/training_pack_template_service.dart';
+import '../main.dart';
+import 'v2/training_pack_play_screen.dart';
 
 class LearningPathScreen extends StatelessWidget {
   const LearningPathScreen({super.key});
@@ -107,7 +110,33 @@ class _LearningStageTileState extends State<LearningStageTile> {
             leading: Icon(item.icon, color: Colors.white),
             title: Text(item.title),
             trailing: trailing,
-            onTap: item.status == LearningItemStatus.locked ? null : () {},
+            onTap: item.status == LearningItemStatus.locked
+                ? null
+                : () async {
+                    final ctx = navigatorKey.currentContext ?? context;
+                    final id = item.templateId;
+                    if (id == null) {
+                      ScaffoldMessenger.of(ctx).showSnackBar(
+                        const SnackBar(content: Text('Template not found')),
+                      );
+                      return;
+                    }
+                    final tpl =
+                        TrainingPackTemplateService.getById(id, ctx);
+                    if (tpl == null) {
+                      ScaffoldMessenger.of(ctx).showSnackBar(
+                        const SnackBar(content: Text('Template not found')),
+                      );
+                      return;
+                    }
+                    Navigator.push(
+                      ctx,
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            TrainingPackPlayScreen(template: tpl, original: tpl),
+                      ),
+                    );
+                  },
           ),
         ),
       ),

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -7,12 +7,14 @@ class LearningStageItem {
   final IconData icon;
   final double progress;
   final LearningItemStatus status;
+  final String? templateId;
 
   const LearningStageItem({
     required this.title,
     required this.icon,
     required this.progress,
     required this.status,
+    this.templateId,
   });
 }
 
@@ -35,18 +37,21 @@ class LearningPathProgressService {
           icon: Icons.play_circle_fill,
           progress: 1.0,
           status: LearningItemStatus.completed,
+          templateId: 'starter_pushfold_10bb',
         ),
         LearningStageItem(
           title: '10bb Ranges',
           icon: Icons.school,
           progress: 0.6,
           status: LearningItemStatus.available,
+          templateId: 'starter_pushfold_10bb',
         ),
         LearningStageItem(
           title: '15bb Ranges',
           icon: Icons.school,
           progress: 0.0,
           status: LearningItemStatus.locked,
+          templateId: 'starter_pushfold_15bb',
         ),
       ]),
       LearningStageState(title: 'Intermediate', items: const [
@@ -55,12 +60,14 @@ class LearningPathProgressService {
           icon: Icons.insights,
           progress: 0.0,
           status: LearningItemStatus.locked,
+          templateId: 'starter_pushfold_12bb',
         ),
         LearningStageItem(
           title: 'Shoving Charts 20bb',
           icon: Icons.table_chart,
           progress: 0.0,
           status: LearningItemStatus.locked,
+          templateId: 'starter_pushfold_20bb',
         ),
       ]),
       LearningStageState(title: 'Advanced', items: const [

--- a/lib/services/training_pack_template_service.dart
+++ b/lib/services/training_pack_template_service.dart
@@ -9,6 +9,7 @@ import 'pack_generator_service.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'training_pack_asset_loader.dart';
+import 'package:collection/collection.dart';
 
 class TrainingPackTemplateService {
   static final TrainingPackTemplate _starterPushfold10bb = TrainingPackTemplate(
@@ -961,4 +962,8 @@ class TrainingPackTemplateService {
         starterPushfold20bb(ctx),
         ...TrainingPackAssetLoader.instance.getAll(),
       ];
+
+  static TrainingPackTemplate? getById(String id, [BuildContext? ctx]) {
+    return getAllTemplates(ctx).firstWhereOrNull((t) => t.id == id);
+  }
 }


### PR DESCRIPTION
## Summary
- extend `LearningStageItem` with `templateId`
- connect sample stages to built-in pack IDs
- add `TrainingPackTemplateService.getById`
- start training when tapping a stage card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b67de01cc832a980f1efad7d0c95e