### PR TITLE
Implement learning path completion tracking

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -23,6 +23,7 @@ import '../services/training_gap_notification_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/user_goal_engine.dart';
 import '../services/goal_toast_service.dart';
+import '../services/learning_path_progress_service.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -265,6 +266,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       final prefs = await SharedPreferences.getInstance();
       final acc = total == 0 ? 0.0 : correct * 100 / total;
       await prefs.setBool('completed_tpl_${tpl.id}', true);
+      await LearningPathProgressService.instance.markCompleted(tpl.id);
       await prefs.setString(
           'completed_at_tpl_${tpl.id}', DateTime.now().toIso8601String());
       await prefs.setString(

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -33,6 +33,7 @@ import '../../models/mistake.dart';
 import '../../widgets/poker_table_view.dart' show PlayerAction;
 import 'package:uuid/uuid.dart';
 import '../../helpers/mistake_advice.dart';
+import '../../services/learning_path_progress_service.dart';
 
 
 enum PlayOrder { sequential, random, mistakes }
@@ -450,6 +451,8 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   Future<void> _showCompletion() async {
     if (_summaryShown) return;
     _summaryShown = true;
+    await LearningPathProgressService.instance
+        .markCompleted(widget.original.id);
     final spots = widget.spots ?? widget.template.spots;
     final tpl = widget.template.copyWith(spots: spots);
     await Navigator.pushReplacement(

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 enum LearningItemStatus { locked, available, completed }
 
@@ -29,10 +30,31 @@ class LearningPathProgressService {
   LearningPathProgressService._();
   static final instance = LearningPathProgressService._();
 
+  bool mock = false;
+  final Map<String, bool> _mockCompleted = {};
+
+  static String _key(String id) => 'learning_completed_$id';
+
+  Future<void> markCompleted(String templateId) async {
+    if (mock) {
+      _mockCompleted[templateId] = true;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key(templateId), true);
+  }
+
   Future<List<LearningStageState>> getCurrentStageState() async {
+    final prefs = mock ? null : await SharedPreferences.getInstance();
+
+    bool completed(String id) {
+      if (mock) return _mockCompleted[id] == true;
+      return prefs?.getBool(_key(id)) ?? false;
+    }
+
     return [
-      LearningStageState(title: 'Beginner', items: const [
-        LearningStageItem(
+      LearningStageState(title: 'Beginner', items: [
+        const LearningStageItem(
           title: 'Push/Fold Basics',
           icon: Icons.play_circle_fill,
           progress: 1.0,
@@ -43,34 +65,42 @@ class LearningPathProgressService {
           title: '10bb Ranges',
           icon: Icons.school,
           progress: 0.6,
-          status: LearningItemStatus.available,
+          status: completed('starter_pushfold_10bb')
+              ? LearningItemStatus.completed
+              : LearningItemStatus.available,
           templateId: 'starter_pushfold_10bb',
         ),
         LearningStageItem(
           title: '15bb Ranges',
           icon: Icons.school,
           progress: 0.0,
-          status: LearningItemStatus.locked,
+          status: completed('starter_pushfold_15bb')
+              ? LearningItemStatus.completed
+              : LearningItemStatus.locked,
           templateId: 'starter_pushfold_15bb',
         ),
       ]),
-      LearningStageState(title: 'Intermediate', items: const [
+      LearningStageState(title: 'Intermediate', items: [
         LearningStageItem(
           title: 'ICM Concepts',
           icon: Icons.insights,
           progress: 0.0,
-          status: LearningItemStatus.locked,
+          status: completed('starter_pushfold_12bb')
+              ? LearningItemStatus.completed
+              : LearningItemStatus.locked,
           templateId: 'starter_pushfold_12bb',
         ),
         LearningStageItem(
           title: 'Shoving Charts 20bb',
           icon: Icons.table_chart,
           progress: 0.0,
-          status: LearningItemStatus.locked,
+          status: completed('starter_pushfold_20bb')
+              ? LearningItemStatus.completed
+              : LearningItemStatus.locked,
           templateId: 'starter_pushfold_20bb',
         ),
       ]),
-      LearningStageState(title: 'Advanced', items: const [
+      const LearningStageState(title: 'Advanced', items: [
         LearningStageItem(
           title: 'Exploit Spots',
           icon: Icons.lightbulb_outline,


### PR DESCRIPTION
## Summary
- persist learning path progress in new `markCompleted` method
- update play and session screens to save completion
- reflect saved status in learning path UI

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b697a78d4832a8335653c93d3fad5