### PR TITLE
Implement sequential unlocking in learning path

### DIFF
--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/learning_path_progress_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    LearningPathProgressService.instance
+      ..mock = true;
+  });
+
+  test('first item available when nothing completed', () async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    expect(stages.first.items.first.status, LearningItemStatus.available);
+    expect(stages.first.items[1].status, LearningItemStatus.locked);
+  });
+
+  test('completing first item unlocks next', () async {
+    await LearningPathProgressService.instance.markCompleted('starter_pushfold_10bb');
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    expect(stages.first.items.first.status, LearningItemStatus.completed);
+    expect(stages.first.items[1].status, LearningItemStatus.completed);
+    expect(stages.first.items[2].status, LearningItemStatus.available);
+  });
+}


### PR DESCRIPTION
## Summary
- add `isCompleted` helper to `LearningPathProgressService`
- rebuild `getCurrentStageState` to unlock items sequentially
- cover progress logic with unit tests

## Testing
- `flutter test test/services/learning_path_progress_service_test.dart` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6b5039f4832a9c1361f87cc6bb6d