### PR TITLE
Add stage completion reward banner

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../services/learning_path_progress_service.dart';
 import '../services/training_pack_template_service.dart';
 import '../main.dart';
+import '../widgets/stage_completion_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 
 class LearningPathScreen extends StatelessWidget {
@@ -63,6 +64,8 @@ class _StageSection extends StatelessWidget {
             ),
           ),
         ),
+        const SizedBox(height: 8),
+        StageCompletionBanner(title: stage.title),
         const SizedBox(height: 8),
         for (int i = 0; i < stage.items.length; i++)
           LearningStageTile(item: stage.items[i], index: i),

--- a/lib/services/block_completion_reward_service.dart
+++ b/lib/services/block_completion_reward_service.dart
@@ -1,0 +1,33 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'learning_path_progress_service.dart';
+
+class BlockCompletionRewardService {
+  BlockCompletionRewardService._();
+  static final instance = BlockCompletionRewardService._();
+
+  static String _completedKey(String title) =>
+      'stage_completed_${title.toLowerCase()}';
+  static String _bannerKey(String title) =>
+      'stage_banner_${title.toLowerCase()}';
+
+  Future<bool> isStageCompleted(String stageTitle) async {
+    final stages =
+        await LearningPathProgressService.instance.getCurrentStageState();
+    final stage = stages.firstWhere(
+      (s) => s.title.toLowerCase() == stageTitle.toLowerCase(),
+      orElse: () => null,
+    );
+    if (stage == null) return false;
+    final completed =
+        stage.items.every((i) => i.status == LearningItemStatus.completed);
+    if (!completed) return false;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_completedKey(stageTitle), true);
+    return !(prefs.getBool(_bannerKey(stageTitle)) ?? false);
+  }
+
+  Future<void> markBannerShown(String stageTitle) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_bannerKey(stageTitle), true);
+  }
+}

--- a/lib/widgets/stage_completion_banner.dart
+++ b/lib/widgets/stage_completion_banner.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../services/block_completion_reward_service.dart';
+import 'confetti_overlay.dart';
+
+class StageCompletionBanner extends StatefulWidget {
+  final String title;
+  const StageCompletionBanner({super.key, required this.title});
+
+  @override
+  State<StageCompletionBanner> createState() => _StageCompletionBannerState();
+}
+
+class _StageCompletionBannerState extends State<StageCompletionBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  bool _visible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _check();
+  }
+
+  Future<void> _check() async {
+    final show = await BlockCompletionRewardService.instance
+        .isStageCompleted(widget.title);
+    if (show && mounted) {
+      setState(() => _visible = true);
+      _controller.forward();
+      showConfettiOverlay(context);
+      await BlockCompletionRewardService.instance.markBannerShown(widget.title);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible) return const SizedBox.shrink();
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(
+        margin: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.green.shade700,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.check_circle, color: Colors.white),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '✅ Этап "${widget.title}" завершён! Отличная работа!',
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `BlockCompletionRewardService` to manage stage completion flags
- display `StageCompletionBanner` in the Learning Path screen
- trigger confetti when a stage is completed

## Testing
- `flutter analyze` *(fails: Stack Overflow / hung)*

------
https://chatgpt.com/codex/tasks/task_e_687b80d56984832aa0f87e2dc1becfbb