### PR TITLE
Add learning path intro screen

### DIFF
--- a/assets/learning_intro.svg
+++ b/assets/learning_intro.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFD700"/>
+      <stop offset="100%" stop-color="#FFA000"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="45" fill="url(#g)"/>
+  <path d="M50 15 L58 38 H82 L62 52 L70 75 L50 60 L30 75 L38 52 L18 38 H42 Z" fill="#FFFFFF"/>
+</svg>

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -96,6 +96,8 @@ import 'skill_map_screen.dart';
 import 'goal_screen.dart';
 import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
+import 'learning_path_intro_screen.dart';
+import '../services/learning_path_progress_service.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -1902,12 +1904,23 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
             if (kDebugMode)
               ListTile(
                 title: const Text('📚 Путь обучения'),
-                onTap: () {
+                onTap: () async {
+                  final seen = await LearningPathProgressService.instance
+                      .hasSeenIntro();
+                  final screen = seen
+                      ? const LearningPathScreen()
+                      : const LearningPathIntroScreen();
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                        builder: (_) => const LearningPathScreen()),
+                    MaterialPageRoute(builder: (_) => screen),
                   );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧹 Сбросить интро обучения'),
+                onTap: () async {
+                  await LearningPathProgressService.instance.resetIntroSeen();
                 },
               ),
             if (kDebugMode)

--- a/lib/screens/learning_path_completion_screen.dart
+++ b/lib/screens/learning_path_completion_screen.dart
@@ -23,6 +23,7 @@ class _LearningPathCompletionScreenState extends State<LearningPathCompletionScr
 
   Future<void> _reset() async {
     await LearningPathProgressService.instance.resetProgress();
+    await LearningPathProgressService.instance.resetIntroSeen();
     if (!mounted) return;
     Navigator.pushReplacement(
       context,

--- a/lib/screens/learning_path_intro_screen.dart
+++ b/lib/screens/learning_path_intro_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../services/learning_path_progress_service.dart';
+import 'learning_path_screen.dart';
+
+class LearningPathIntroScreen extends StatelessWidget {
+  const LearningPathIntroScreen({super.key});
+
+  Future<void> _start(BuildContext context) async {
+    await LearningPathProgressService.instance.markIntroSeen();
+    if (!context.mounted) return;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const LearningPathScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                'assets/learning_intro.svg',
+                width: 200,
+                height: 200,
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                '🎯 Добро пожаловать в путь обучения',
+                style: TextStyle(fontSize: 24),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 32),
+                child: Text(
+                  'Освой ключевые споты, прокачай навыки, открой продвинутые режимы',
+                  style: TextStyle(color: Colors.white70),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: () => _start(context),
+                child: const Text('Начать обучение'),
+              ),
+              if (kDebugMode) ...[
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () async {
+                    await LearningPathProgressService.instance.resetIntroSeen();
+                  },
+                  child: const Text('Сбросить флаг'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -30,8 +30,11 @@ class LearningPathProgressService {
   LearningPathProgressService._();
   static final instance = LearningPathProgressService._();
 
+  static const _introKey = 'learning_intro_seen';
+
   bool mock = false;
   final Map<String, bool> _mockCompleted = {};
+  bool _mockIntroSeen = false;
 
   /// Clears all learning path progress. Used for development/testing only.
   Future<void> resetProgress() async {
@@ -49,6 +52,30 @@ class LearningPathProgressService {
   }
 
   static String _key(String id) => 'learning_completed_$id';
+
+  Future<bool> hasSeenIntro() async {
+    if (mock) return _mockIntroSeen;
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_introKey) ?? false;
+  }
+
+  Future<void> markIntroSeen() async {
+    if (mock) {
+      _mockIntroSeen = true;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_introKey, true);
+  }
+
+  Future<void> resetIntroSeen() async {
+    if (mock) {
+      _mockIntroSeen = false;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_introKey);
+  }
 
   Future<void> markCompleted(String templateId) async {
     if (mock) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   connectivity_plus: ^6.0.4
   url_launcher: ^6.1.11
+  flutter_svg: ^2.0.7
 
 dependency_overrides:
   intl: ^0.20.2
@@ -102,6 +103,7 @@ flutter:
     - assets/built_in_packs.yaml
     - assets/lessons/
     - assets/pack_matrix.json
+    - assets/learning_intro.svg
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo

--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -38,4 +38,15 @@ void main() {
     done = await LearningPathProgressService.instance.isAllStagesCompleted();
     expect(done, isTrue);
   });
+
+  test('intro flag persists', () async {
+    var seen = await LearningPathProgressService.instance.hasSeenIntro();
+    expect(seen, isFalse);
+    await LearningPathProgressService.instance.markIntroSeen();
+    seen = await LearningPathProgressService.instance.hasSeenIntro();
+    expect(seen, isTrue);
+    await LearningPathProgressService.instance.resetIntroSeen();
+    seen = await LearningPathProgressService.instance.hasSeenIntro();
+    expect(seen, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- create introductory screen for the learning path with hero SVG
- store intro flag via `LearningPathProgressService`
- show intro screen from dev menu on first launch
- add reset intro flag debug option and reset on completion screen
- test intro flag behaviour
- include `flutter_svg` dependency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b84e228c4832a97bd6d8eebf532d7