### PR TITLE
Add stage progress header

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -3,6 +3,7 @@ import '../services/learning_path_progress_service.dart';
 import '../services/training_pack_template_service.dart';
 import '../main.dart';
 import '../widgets/stage_completion_banner.dart';
+import '../widgets/stage_header_with_progress.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_path_completion_screen.dart';
 
@@ -57,28 +58,7 @@ class _StageSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: const EdgeInsets.all(16),
-          child: Text(
-            stage.title,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(3),
-            child: LinearProgressIndicator(
-              value: progress,
-              minHeight: 6.0,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-          ),
-        ),
+        StageHeaderWithProgress(title: stage.title, progress: progress),
         const SizedBox(height: 8),
         StageCompletionBanner(title: stage.title),
         const SizedBox(height: 8),

--- a/lib/widgets/stage_header_with_progress.dart
+++ b/lib/widgets/stage_header_with_progress.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class StageHeaderWithProgress extends StatelessWidget {
+  final String title;
+  final double progress;
+  const StageHeaderWithProgress({
+    super.key,
+    required this.title,
+    required this.progress,
+  });
+
+  Color _color(BuildContext context) {
+    if (progress >= 1.0) return Colors.green;
+    if (progress > 0.0) return Colors.yellow;
+    return Colors.grey;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width - 32;
+    final pct = (progress * 100).round();
+    final barColor = _color(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Прогресс: $pct%',
+            style: const TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 4),
+          TweenAnimationBuilder<double>(
+            tween: Tween(begin: 0, end: progress),
+            duration: const Duration(milliseconds: 300),
+            builder: (context, value, _) => SizedBox(
+              width: width,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(3),
+                child: LinearProgressIndicator(
+                  value: value,
+                  minHeight: 6.0,
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation<Color>(barColor),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show an animated progress bar per learning stage
- reuse new widget `StageHeaderWithProgress` in the learning path screen

## Testing
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_687b88856be0832aa675f95c24be5d47