### PR TITLE
Add learning path completion screen

### DIFF
--- a/lib/screens/learning_path_completion_screen.dart
+++ b/lib/screens/learning_path_completion_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../widgets/confetti_overlay.dart';
 import '../services/learning_path_progress_service.dart';
@@ -12,18 +13,43 @@ class LearningPathCompletionScreen extends StatefulWidget {
   State<LearningPathCompletionScreen> createState() => _LearningPathCompletionScreenState();
 }
 
+class _Stats {
+  final int stages;
+  final int packs;
+  final double progress;
+
+  const _Stats({required this.stages, required this.packs, required this.progress});
+}
+
 class _LearningPathCompletionScreenState extends State<LearningPathCompletionScreen> {
+  late Future<_Stats> _statsFuture;
+
   @override
   void initState() {
     super.initState();
+    _statsFuture = _loadStats();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showConfettiOverlay(context);
     });
   }
 
+  Future<_Stats> _loadStats() async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final int stageCount = stages.length;
+    int total = 0;
+    double sum = 0.0;
+    for (final s in stages) {
+      total += s.items.length;
+      for (final i in s.items) {
+        sum += i.progress;
+      }
+    }
+    final progress = total == 0 ? 0.0 : sum / total;
+    return _Stats(stages: stageCount, packs: total, progress: progress);
+  }
+
   Future<void> _reset() async {
-    await LearningPathProgressService.instance.resetProgress();
-    await LearningPathProgressService.instance.resetIntroSeen();
+    await LearningPathProgressService.instance.resetAll();
     if (!mounted) return;
     Navigator.pushReplacement(
       context,
@@ -31,27 +57,62 @@ class _LearningPathCompletionScreenState extends State<LearningPathCompletionScr
     );
   }
 
+  void _goHome() {
+    Navigator.popUntil(context, (route) => route.isFirst);
+  }
+
+  Future<void> _leaveFeedback() async {
+    const uri = Uri(scheme: 'mailto', path: 'poker.analyzer.app@gmail.com');
+    await launchUrl(uri);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFF121212),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              '🎓 Вы завершили весь путь обучения!',
-              style: TextStyle(fontSize: 24),
-              textAlign: TextAlign.center,
+      body: FutureBuilder<_Stats>(
+        future: _statsFuture,
+        builder: (context, snapshot) {
+          final stats = snapshot.data;
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.emoji_events, color: Colors.amber, size: 48),
+                const SizedBox(height: 16),
+                const Text(
+                  'Поздравляем! Вы завершили путь обучения 🎉',
+                  style: TextStyle(fontSize: 24),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                if (stats != null) ...[
+                  Text('Кол-во стадий: ${stats.stages}'),
+                  Text('Всего паков: ${stats.packs}'),
+                  Text('Средний % прогресса: ${(stats.progress * 100).toStringAsFixed(1)}%'),
+                  const SizedBox(height: 24),
+                ],
+                ElevatedButton.icon(
+                  onPressed: _reset,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Повторить путь'),
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton.icon(
+                  onPressed: _goHome,
+                  icon: const Icon(Icons.home),
+                  label: const Text('Вернуться в меню'),
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton.icon(
+                  onPressed: _leaveFeedback,
+                  icon: const Icon(Icons.chat),
+                  label: const Text('Оставить отзыв'),
+                ),
+              ],
             ),
-            const SizedBox(height: 24),
-            if (kDebugMode)
-              ElevatedButton(
-                onPressed: _reset,
-                child: const Text('Вернуться к началу'),
-              ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -78,6 +78,12 @@ class LearningPathProgressService {
     await prefs.remove(_introKey);
   }
 
+  /// Resets both intro flag and stage progress.
+  Future<void> resetAll() async {
+    await resetProgress();
+    await resetIntroSeen();
+  }
+
   Future<void> markCompleted(String templateId) async {
     if (mock) {
       _mockCompleted[templateId] = true;


### PR DESCRIPTION
## Summary
- add resetAll method to reset learning path intro and progress
- implement LearningPathCompletionScreen with final stats and buttons

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b89972054832a88106883dc33704c