### PR TITLE
Add SafeArea and theme handling to completion screen

### DIFF
--- a/lib/screens/learning_path_completion_screen.dart
+++ b/lib/screens/learning_path_completion_screen.dart
@@ -68,9 +68,11 @@ class _LearningPathCompletionScreenState extends State<LearningPathCompletionScr
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
-      backgroundColor: const Color(0xFF121212),
-      body: FutureBuilder<_Stats>(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: FutureBuilder<_Stats>(
         future: _statsFuture,
         builder: (context, snapshot) {
           final stats = snapshot.data;
@@ -113,6 +115,7 @@ class _LearningPathCompletionScreenState extends State<LearningPathCompletionScr
             ),
           );
         },
+      ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- make the learning path completion screen use the current theme background
- wrap content in SafeArea

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8aa167b0832a8fec47fae79f4ba3