### PR TITLE
Implement stage locking in learning path

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -143,6 +143,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _smartValidateLoading = false;
   bool _templateStorageTestLoading = false;
   bool _reminderLoading = false;
+  bool _unlockStages = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -1927,6 +1928,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     MaterialPageRoute(builder: (_) => const LearningPathScreen()),
                   );
                   service.mock = false;
+                },
+              ),
+            if (kDebugMode)
+              CheckboxListTile(
+                title: const Text('🔓 Unlock all stages (for dev)'),
+                value: _unlockStages,
+                activeColor: Colors.greenAccent,
+                onChanged: (v) {
+                  setState(() => _unlockStages = v ?? false);
+                  LearningPathProgressService.instance.unlockAllStages =
+                      _unlockStages;
                 },
               ),
             if (kDebugMode)

--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -58,7 +58,11 @@ class _StageSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        StageHeaderWithProgress(title: stage.title, progress: progress),
+        StageHeaderWithProgress(
+          title: stage.title,
+          progress: progress,
+          showProgress: !stage.isLocked,
+        ),
         const SizedBox(height: 8),
         StageCompletionBanner(title: stage.title),
         const SizedBox(height: 8),

--- a/lib/widgets/stage_header_with_progress.dart
+++ b/lib/widgets/stage_header_with_progress.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 class StageHeaderWithProgress extends StatelessWidget {
   final String title;
   final double progress;
+  final bool showProgress;
   const StageHeaderWithProgress({
     super.key,
     required this.title,
     required this.progress,
+    this.showProgress = true,
   });
 
   Color _color(BuildContext context) {
@@ -33,28 +35,30 @@ class StageHeaderWithProgress extends StatelessWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
-          const SizedBox(height: 4),
-          Text(
-            'Прогресс: $pct%',
-            style: const TextStyle(color: Colors.white70),
-          ),
-          const SizedBox(height: 4),
-          TweenAnimationBuilder<double>(
-            tween: Tween(begin: 0, end: progress),
-            duration: const Duration(milliseconds: 300),
-            builder: (context, value, _) => SizedBox(
-              width: width,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(3),
-                child: LinearProgressIndicator(
-                  value: value,
-                  minHeight: 6.0,
-                  backgroundColor: Colors.white24,
-                  valueColor: AlwaysStoppedAnimation<Color>(barColor),
+          if (showProgress) ...[
+            const SizedBox(height: 4),
+            Text(
+              'Прогресс: $pct%',
+              style: const TextStyle(color: Colors.white70),
+            ),
+            const SizedBox(height: 4),
+            TweenAnimationBuilder<double>(
+              tween: Tween(begin: 0, end: progress),
+              duration: const Duration(milliseconds: 300),
+              builder: (context, value, _) => SizedBox(
+                width: width,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(3),
+                  child: LinearProgressIndicator(
+                    value: value,
+                    minHeight: 6.0,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation<Color>(barColor),
+                  ),
                 ),
               ),
             ),
-          ),
+          ],
         ],
       ),
     );

--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -18,12 +18,24 @@ void main() {
     expect(stages.first.items[1].status, LearningItemStatus.locked);
   });
 
+  test('next stage locked until previous completed', () async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    expect(stages[1].items.first.status, LearningItemStatus.locked);
+  });
+
   test('completing first item unlocks next', () async {
     await LearningPathProgressService.instance.markCompleted('starter_pushfold_10bb');
     final stages = await LearningPathProgressService.instance.getCurrentStageState();
     expect(stages.first.items.first.status, LearningItemStatus.completed);
     expect(stages.first.items[1].status, LearningItemStatus.completed);
     expect(stages.first.items[2].status, LearningItemStatus.available);
+  });
+
+  test('completing first stage unlocks second stage', () async {
+    await LearningPathProgressService.instance.markCompleted('starter_pushfold_10bb');
+    await LearningPathProgressService.instance.markCompleted('starter_pushfold_15bb');
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    expect(stages[1].items.first.status, isNot(LearningItemStatus.locked));
   });
 
   test('isAllStagesCompleted works correctly', () async {


### PR DESCRIPTION
## Summary
- add `isLocked` to stage state and new `unlockAllStages` toggle
- lock entire stages until previous one is completed
- hide progress UI for locked stages
- expose dev menu option to unlock all stages for testing
- update unit tests for stage locking logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8bb1991c832a8bca345dc71c8669