### PR TITLE
Add adaptive learning tip banner

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -3,7 +3,8 @@ import '../services/learning_path_progress_service.dart';
 import '../services/training_pack_template_service.dart';
 import '../main.dart';
 import '../widgets/stage_completion_banner.dart';
-import '../widgets/stage_header_with_progress.dart';
+
+import '../widgets/suggested_tip_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_path_completion_screen.dart';
 
@@ -36,9 +37,10 @@ class LearningPathScreen extends StatelessWidget {
           body: snapshot.connectionState != ConnectionState.done
               ? const Center(child: CircularProgressIndicator())
               : ListView.builder(
-                  itemCount: stages.length,
+                  itemCount: stages.length + 1,
                   itemBuilder: (context, index) {
-                    final stage = stages[index];
+                    if (index == 0) return const SuggestedTipBanner();
+                    final stage = stages[index - 1];
                     return _StageSection(stage: stage);
                   },
                 ),

--- a/lib/services/learning_suggestion_service.dart
+++ b/lib/services/learning_suggestion_service.dart
@@ -1,0 +1,70 @@
+import '../services/learning_path_progress_service.dart';
+
+enum LearningTipAction { continuePack, startStage, repeatStage, exploreNextStage }
+
+class LearningTip {
+  final String title;
+  final String description;
+  final LearningTipAction action;
+  final String targetId;
+
+  const LearningTip({
+    required this.title,
+    required this.description,
+    required this.action,
+    required this.targetId,
+  });
+}
+
+class LearningSuggestionService {
+  const LearningSuggestionService();
+
+  Future<LearningTip?> getTip() async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+
+    for (final stage in stages) {
+      for (final item in stage.items) {
+        if (item.status == LearningItemStatus.inProgress && item.templateId != null) {
+          return LearningTip(
+            title: '🏃 Продолжите пак "${item.title}"',
+            description: 'Вы остановились на паке из стадии "${stage.title}".',
+            action: LearningTipAction.continuePack,
+            targetId: item.templateId!,
+          );
+        }
+      }
+    }
+
+    for (final stage in stages) {
+      if (stage.isLocked) continue;
+      final remaining = stage.items.where((i) => i.status != LearningItemStatus.completed).toList();
+      if (remaining.isEmpty) continue;
+      final title = stage.title;
+      final count = remaining.length;
+      final first = remaining.first.templateId;
+      if (first != null) {
+        return LearningTip(
+          title: '🏁 Завершите стадию "$title"',
+          description: count == 1
+              ? 'Остался всего 1 пак. Отличный момент, чтобы завершить начальный этап!'
+              : 'Осталось $count паков. Продвиньтесь дальше прямо сейчас!',
+          action: LearningTipAction.startStage,
+          targetId: first,
+        );
+      }
+    }
+
+    final allDone = await LearningPathProgressService.instance.isAllStagesCompleted();
+    if (allDone && stages.isNotEmpty) {
+      final first = stages.first.items.first.templateId;
+      return LearningTip(
+        title: '🎉 Путь завершен — отличная работа!',
+        description: 'Можно повторить этапы для закрепления.',
+        action: LearningTipAction.repeatStage,
+        targetId: first ?? '',
+      );
+    }
+
+    return null;
+  }
+}

--- a/lib/widgets/suggested_tip_banner.dart
+++ b/lib/widgets/suggested_tip_banner.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../services/learning_suggestion_service.dart';
+import '../services/training_pack_template_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class SuggestedTipBanner extends StatefulWidget {
+  const SuggestedTipBanner({super.key});
+
+  @override
+  State<SuggestedTipBanner> createState() => _SuggestedTipBannerState();
+}
+
+class _SuggestedTipBannerState extends State<SuggestedTipBanner>
+    with SingleTickerProviderStateMixin {
+  LearningTip? _tip;
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    final tip = await const LearningSuggestionService().getTip();
+    if (mounted) {
+      setState(() => _tip = tip);
+      if (tip != null) _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onAction() async {
+    final tip = _tip;
+    if (tip == null) return;
+    switch (tip.action) {
+      case LearningTipAction.continuePack:
+      case LearningTipAction.startStage:
+      case LearningTipAction.repeatStage:
+        final tpl = TrainingPackTemplateService.getById(tip.targetId, context);
+        if (tpl == null) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TrainingPackPlayScreen(template: tpl, original: tpl),
+          ),
+        );
+        break;
+      case LearningTipAction.exploreNextStage:
+        // Not implemented yet
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tip = _tip;
+    if (tip == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.lightbulb, color: Colors.amber),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                tip.title,
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _onAction,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Перейти'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `LearningSuggestionService` to provide learning tips
- create `SuggestedTipBanner` widget to display tips
- show banner in `LearningPathScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8d029f2c832aa976f3b47e749725