### PR TITLE
Add goal data to learning stages

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -62,14 +62,16 @@ class _StageSection extends StatelessWidget {
       children: [
         StageHeaderWithProgress(
           title: stage.title,
-          progress: progress,
           levelIndex: stage.levelIndex,
+          goal: stage.goal,
+          progress: progress,
           showProgress: !stage.isLocked,
         ),
         const SizedBox(height: 8),
         StageCompletionBanner(
           title: stage.title,
           levelIndex: stage.levelIndex,
+          goal: stage.goal,
         ),
         const SizedBox(height: 8),
         for (int i = 0; i < stage.items.length; i++)

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -22,15 +22,17 @@ class LearningStageItem {
 
 class LearningStageState {
   final String title;
+  final int levelIndex;
+  final String goal;
   final List<LearningStageItem> items;
   final bool isLocked;
-  final int levelIndex;
 
   const LearningStageState({
     required this.title,
+    required this.levelIndex,
+    required this.goal,
     required this.items,
     this.isLocked = false,
-    required this.levelIndex,
   });
 }
 
@@ -120,7 +122,11 @@ class LearningPathProgressService {
     }
 
     final stages = [
-      LearningStageState(levelIndex: 1, title: 'Beginner', items: [
+      LearningStageState(
+          levelIndex: 1,
+          title: 'Beginner',
+          goal: 'Освой базовый пуш-фолд',
+          items: [
         LearningStageItem(
           title: 'Push/Fold Basics',
           icon: Icons.play_circle_fill,
@@ -143,7 +149,11 @@ class LearningPathProgressService {
           templateId: 'starter_pushfold_15bb',
         ),
       ]),
-      LearningStageState(levelIndex: 2, title: 'Intermediate', items: [
+      LearningStageState(
+          levelIndex: 2,
+          title: 'Intermediate',
+          goal: 'Изучи ICM и диапазоны 20bb',
+          items: [
         LearningStageItem(
           title: 'ICM Concepts',
           icon: Icons.insights,
@@ -159,7 +169,11 @@ class LearningPathProgressService {
           templateId: 'starter_pushfold_20bb',
         ),
       ]),
-      LearningStageState(levelIndex: 3, title: 'Advanced', items: [
+      LearningStageState(
+          levelIndex: 3,
+          title: 'Advanced',
+          goal: 'Углуби стратегию и эксплойт',
+          items: [
         LearningStageItem(
           title: 'Exploit Spots',
           icon: Icons.lightbulb_outline,
@@ -207,9 +221,10 @@ class LearningPathProgressService {
       final completedStage = isStageCompleted(items);
       result.add(LearningStageState(
           title: stage.title,
+          levelIndex: stage.levelIndex,
+          goal: stage.goal,
           items: items,
-          isLocked: !stageUnlocked,
-          levelIndex: stage.levelIndex));
+          isLocked: !stageUnlocked));
       prevCompleted = unlockAllStages ? true : completedStage;
     }
     return result;

--- a/lib/widgets/stage_completion_banner.dart
+++ b/lib/widgets/stage_completion_banner.dart
@@ -6,10 +6,12 @@ import 'confetti_overlay.dart';
 class StageCompletionBanner extends StatefulWidget {
   final String title;
   final int levelIndex;
+  final String goal;
   const StageCompletionBanner({
     super.key,
     required this.title,
     required this.levelIndex,
+    required this.goal,
   });
 
   @override
@@ -60,17 +62,10 @@ class _StageCompletionBannerState extends State<StageCompletionBanner>
           color: Colors.green.shade700,
           borderRadius: BorderRadius.circular(8),
         ),
-        child: Row(
-          children: [
-            const Icon(Icons.check_circle, color: Colors.white),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                '🎯 Завершён уровень ${widget.levelIndex} — ${widget.title}!',
-                style: const TextStyle(color: Colors.white),
-              ),
-            ),
-          ],
+        alignment: Alignment.centerLeft,
+        child: Text(
+          '🎯 Цель достигнута: ${widget.goal}',
+          style: const TextStyle(color: Colors.white),
         ),
       ),
     );

--- a/lib/widgets/stage_header_with_progress.dart
+++ b/lib/widgets/stage_header_with_progress.dart
@@ -2,14 +2,16 @@ import 'package:flutter/material.dart';
 
 class StageHeaderWithProgress extends StatelessWidget {
   final String title;
+  final int levelIndex;
+  final String goal;
   final double progress;
   final bool showProgress;
-  final int levelIndex;
   const StageHeaderWithProgress({
     super.key,
     required this.title,
-    required this.progress,
     required this.levelIndex,
+    required this.goal,
+    required this.progress,
     this.showProgress = true,
   });
 
@@ -35,6 +37,17 @@ class StageHeaderWithProgress extends StatelessWidget {
               color: Colors.white,
               fontSize: 18,
               fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 2),
+          TweenAnimationBuilder<double>(
+            tween: Tween(begin: 0, end: 1),
+            duration: const Duration(milliseconds: 300),
+            builder: (context, value, child) =>
+                Opacity(opacity: value, child: child),
+            child: Text(
+              goal,
+              style: const TextStyle(color: Colors.white70),
             ),
           ),
           if (showProgress) ...[


### PR DESCRIPTION
## Summary
- expand `LearningStageState` with a `goal` description
- assign goals when calculating learning path progress
- display goal text with fade animation in `StageHeaderWithProgress`
- show goal in `StageCompletionBanner`

## Testing
- `dart format -o none lib/services/learning_path_progress_service.dart lib/widgets/stage_header_with_progress.dart lib/widgets/stage_completion_banner.dart lib/screens/learning_path_screen.dart`
- `dart analyze` *(fails: 60412 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687b98747938832ab9db1f013842d2be