### PR TITLE
Add level tips to learning path

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -64,6 +64,7 @@ class _StageSection extends StatelessWidget {
           title: stage.title,
           levelIndex: stage.levelIndex,
           goal: stage.goal,
+          tip: stage.tip,
           progress: progress,
           showProgress: !stage.isLocked,
         ),

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -24,6 +24,7 @@ class LearningStageState {
   final String title;
   final int levelIndex;
   final String goal;
+  final String? tip;
   final List<LearningStageItem> items;
   final bool isLocked;
 
@@ -31,6 +32,7 @@ class LearningStageState {
     required this.title,
     required this.levelIndex,
     required this.goal,
+    this.tip,
     required this.items,
     this.isLocked = false,
   });
@@ -126,6 +128,8 @@ class LearningPathProgressService {
           levelIndex: 1,
           title: 'Beginner',
           goal: 'Освой базовый пуш-фолд',
+          tip:
+              "Попробуй сначала сыграть пак 'Push/Fold Basics', чтобы освоиться с концепцией",
           items: [
         LearningStageItem(
           title: 'Push/Fold Basics',
@@ -153,6 +157,7 @@ class LearningPathProgressService {
           levelIndex: 2,
           title: 'Intermediate',
           goal: 'Изучи ICM и диапазоны 20bb',
+          tip: 'Закрепи навыки прошлого уровня и изучи влияние ICM.',
           items: [
         LearningStageItem(
           title: 'ICM Concepts',
@@ -173,6 +178,7 @@ class LearningPathProgressService {
           levelIndex: 3,
           title: 'Advanced',
           goal: 'Углуби стратегию и эксплойт',
+          tip: 'Ищи возможности для эксплойта соперников.',
           items: [
         LearningStageItem(
           title: 'Exploit Spots',

--- a/lib/widgets/stage_header_with_progress.dart
+++ b/lib/widgets/stage_header_with_progress.dart
@@ -4,6 +4,7 @@ class StageHeaderWithProgress extends StatelessWidget {
   final String title;
   final int levelIndex;
   final String goal;
+  final String? tip;
   final double progress;
   final bool showProgress;
   const StageHeaderWithProgress({
@@ -11,6 +12,7 @@ class StageHeaderWithProgress extends StatelessWidget {
     required this.title,
     required this.levelIndex,
     required this.goal,
+    this.tip,
     required this.progress,
     this.showProgress = true,
   });
@@ -40,15 +42,51 @@ class StageHeaderWithProgress extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 2),
-          TweenAnimationBuilder<double>(
-            tween: Tween(begin: 0, end: 1),
-            duration: const Duration(milliseconds: 300),
-            builder: (context, value, child) =>
-                Opacity(opacity: value, child: child),
-            child: Text(
-              goal,
-              style: const TextStyle(color: Colors.white70),
-            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: TweenAnimationBuilder<double>(
+                  tween: Tween(begin: 0, end: 1),
+                  duration: const Duration(milliseconds: 300),
+                  builder: (context, value, child) =>
+                      Opacity(opacity: value, child: child),
+                  child: Text(
+                    goal,
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+              ),
+              if (tip != null)
+                TweenAnimationBuilder<double>(
+                  tween: Tween(begin: 0, end: 1),
+                  duration: const Duration(milliseconds: 300),
+                  builder: (context, value, child) =>
+                      Opacity(opacity: value, child: child),
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                    icon: const Icon(Icons.info_outline,
+                        color: Colors.white70, size: 20),
+                    onPressed: () {
+                      showDialog(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          backgroundColor: Colors.grey[900],
+                          title: const Text('Совет по уровню'),
+                          content: Text(tip!),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context),
+                              child: const Text('Понятно'),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+            ],
           ),
           if (showProgress) ...[
             const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- extend `LearningStageState` with optional tip text
- update progress service to include tips for each level
- display info button with fade animation
- show tip in dialog from stage header

## Testing
- `flutter pub get`
- `flutter test` *(fails: TimeoutException, undefined members)*
- `flutter analyze` *(fails: thousands of issues)*

------
https://chatgpt.com/codex/tasks/task_e_687b99d57f90832a924afeacbbd5bda2