### PR TITLE
Add Learning Progress Stats screen

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/stage_completion_banner.dart';
 import '../widgets/suggested_tip_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_path_completion_screen.dart';
+import 'learning_progress_stats_screen.dart';
 
 class LearningPathScreen extends StatelessWidget {
   const LearningPathScreen({super.key});
@@ -32,7 +33,20 @@ class LearningPathScreen extends StatelessWidget {
         }
 
         return Scaffold(
-          appBar: AppBar(title: const Text('📚 Путь обучения')),
+          appBar: AppBar(
+            title: const Text('📚 Путь обучения'),
+            actions: [
+              IconButton(
+                icon: const Text('📊', style: TextStyle(fontSize: 20)),
+                tooltip: 'Статистика',
+                onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const LearningProgressStatsScreen()),
+                ),
+              ),
+            ],
+          ),
           backgroundColor: const Color(0xFF121212),
           body: snapshot.connectionState != ConnectionState.done
               ? const Center(child: CircularProgressIndicator())

--- a/lib/screens/learning_progress_stats_screen.dart
+++ b/lib/screens/learning_progress_stats_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../services/learning_path_progress_service.dart';
+
+class LearningProgressStatsScreen extends StatelessWidget {
+  const LearningProgressStatsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<LearningStageState>>(
+      future: LearningPathProgressService.instance.getCurrentStageState(),
+      builder: (context, snapshot) {
+        final stages = snapshot.data ?? [];
+        return Scaffold(
+          appBar: AppBar(title: const Text('\uD83D\uDCCA Статистика')), // '📊 Статистика'
+          backgroundColor: const Color(0xFF121212),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : ListView.builder(
+                  itemCount: stages.length,
+                  itemBuilder: (context, index) {
+                    final stage = stages[index];
+                    return _StageStatsTile(stage: stage);
+                  },
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _StageStatsTile extends StatelessWidget {
+  final LearningStageState stage;
+  const _StageStatsTile({required this.stage});
+
+  Color _color(double progress) {
+    if (progress >= 1.0) return Colors.green;
+    if (progress > 0.0) return Colors.yellow;
+    return Colors.grey;
+  }
+
+  IconData _icon(int index) {
+    switch (index) {
+      case 1:
+        return Icons.filter_1;
+      case 2:
+        return Icons.filter_2;
+      case 3:
+        return Icons.filter_3;
+      default:
+        return Icons.flag;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = computeStageProgress(stage.items);
+    final done = stage.items
+        .where((e) => e.status == LearningItemStatus.completed)
+        .length;
+    final color = _color(progress);
+    return Card(
+      color: const Color(0xFF1E1E1E),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: Icon(_icon(stage.levelIndex), color: color),
+        title: Text(stage.title),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('$done / ${stage.items.length} паков'),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(
+              value: progress,
+              color: color,
+              backgroundColor: Colors.white24,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+double computeStageProgress(List<LearningStageItem> items) {
+  if (items.isEmpty) return 0.0;
+  var sum = 0.0;
+  for (final item in items) {
+    switch (item.status) {
+      case LearningItemStatus.completed:
+        sum += 1.0;
+        break;
+      case LearningItemStatus.available:
+        sum += 0.5;
+        break;
+      case LearningItemStatus.inProgress:
+        sum += 0.75;
+        break;
+      case LearningItemStatus.locked:
+      default:
+        break;
+    }
+  }
+  return sum / items.length;
+}


### PR DESCRIPTION
## Summary
- show learning stage statistics in new `LearningProgressStatsScreen`
- allow navigation to stats from `LearningPathScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9edf0524832abd0456292235609b