### PR TITLE
Add learning path pack recommendations

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -5,6 +5,7 @@ import '../main.dart';
 import '../widgets/stage_completion_banner.dart';
 
 import '../widgets/suggested_tip_banner.dart';
+import '../widgets/learning_path_recommendation_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_path_completion_screen.dart';
 import 'learning_progress_stats_screen.dart';
@@ -51,10 +52,11 @@ class LearningPathScreen extends StatelessWidget {
           body: snapshot.connectionState != ConnectionState.done
               ? const Center(child: CircularProgressIndicator())
               : ListView.builder(
-                  itemCount: stages.length + 1,
+                  itemCount: stages.length + 2,
                   itemBuilder: (context, index) {
                     if (index == 0) return const SuggestedTipBanner();
-                    final stage = stages[index - 1];
+                    if (index == 1) return const LearningPathRecommendationBanner();
+                    final stage = stages[index - 2];
                     return _StageSection(stage: stage);
                   },
                 ),

--- a/lib/services/learning_suggestion_service.dart
+++ b/lib/services/learning_suggestion_service.dart
@@ -1,4 +1,12 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
 import '../services/learning_path_progress_service.dart';
+import '../services/training_pack_template_service.dart';
+import '../services/training_progress_service.dart';
+import '../services/training_pack_stats_service.dart';
+import '../services/tag_mastery_service.dart';
 
 enum LearningTipAction { continuePack, startStage, repeatStage, exploreNextStage }
 
@@ -16,8 +24,64 @@ class LearningTip {
   });
 }
 
+class LearningPackSuggestion {
+  final String templateId;
+  final String suggestionReason;
+
+  const LearningPackSuggestion({
+    required this.templateId,
+    required this.suggestionReason,
+  });
+}
+
 class LearningSuggestionService {
   const LearningSuggestionService();
+
+  /// Suggests the next best pack to train based on progress and weak spots.
+  Future<LearningPackSuggestion?> nextSuggestedPack(BuildContext context) async {
+    final list = await getSuggestions(context);
+    return list.isNotEmpty ? list.first : null;
+  }
+
+  /// Returns extended suggestions for the learning path.
+  /// The list is ordered by priority.
+  Future<List<LearningPackSuggestion>> getSuggestions(BuildContext context) async {
+    final mastery = context.read<TagMasteryService>();
+    final weakTags = await mastery.topWeakTags(5);
+
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final result = <LearningPackSuggestion>[];
+
+    for (final stage in stages) {
+      if (stage.isLocked) continue;
+      for (final item in stage.items) {
+        final id = item.templateId;
+        if (id == null) continue;
+        final progress = await TrainingProgressService.instance.getProgress(id);
+        if (progress >= 1.0) continue;
+
+        String? reason;
+        final stat = await TrainingPackStatsService.getStats(id);
+        if (stat != null && (stat.accuracy < 0.8 || stat.evSum < 0)) {
+          reason = 'Низкий результат в предыдущих сессиях';
+        } else if (progress > 0) {
+          reason = 'Уровень завершён частично';
+        }
+
+        final tpl = TrainingPackTemplateService.getById(id, context);
+        final match = tpl == null
+            ? null
+            : weakTags.firstWhereOrNull((t) => tpl.tags.contains(t));
+        if (match != null) {
+          reason = 'Слабая зона: $match';
+        }
+
+        result.add(LearningPackSuggestion(templateId: id, suggestionReason: reason ?? 'Непройденный пак'));
+      }
+    }
+
+    return result;
+  }
 
   Future<LearningTip?> getTip() async {
     final stages = await LearningPathProgressService.instance.getCurrentStageState();

--- a/lib/widgets/learning_path_recommendation_banner.dart
+++ b/lib/widgets/learning_path_recommendation_banner.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../services/learning_suggestion_service.dart';
+import '../services/training_pack_template_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class LearningPathRecommendationBanner extends StatefulWidget {
+  const LearningPathRecommendationBanner({super.key});
+
+  @override
+  State<LearningPathRecommendationBanner> createState() => _LearningPathRecommendationBannerState();
+}
+
+class _LearningPathRecommendationBannerState extends State<LearningPathRecommendationBanner> {
+  late Future<LearningPackSuggestion?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = const LearningSuggestionService().nextSuggestedPack(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<LearningPackSuggestion?>(
+      future: _future,
+      builder: (context, snapshot) {
+        final suggestion = snapshot.data;
+        if (snapshot.connectionState != ConnectionState.done || suggestion == null) {
+          return const SizedBox.shrink();
+        }
+        final tpl = TrainingPackTemplateService.getById(suggestion.templateId, context);
+        if (tpl == null) return const SizedBox.shrink();
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '📌 \u0420\u0435\u043a\u043e\u043c\u0435\u043d\u0434\u0443\u0435\u0442\u0441\u044f \u043f\u0440\u043e\u0439\u0442\u0438',
+                style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(tpl.name, style: const TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              Text(suggestion.suggestionReason, style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TrainingPackPlayScreen(template: tpl, original: tpl),
+                      ),
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  child: const Text('\u041f\u0435\u0440\u0435\u0439\u0442\u0438'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extend `LearningSuggestionService` with advanced pack suggestions
- show recommended pack banner on the learning path screen
- implement `LearningPathRecommendationBanner` widget

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba1bee7ac832aa32b759e68e17230