### PR TITLE
Add reset stage option to learning path

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Reset Stage"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Reset Stage"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Reset Stage"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Reset Stage"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Reset Stage"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -75,6 +75,8 @@
   ,"evIcm": "EV {ev}  ICM {icm}"
   ,"packCreated": "Pack \"{name}\" created"
   ,"resetPackPrompt": "Reset progress for '{name}'?"
+  ,"resetStagePrompt": "Reset stage '{name}'?"
+  ,"resetStage": "Сбросить стадию"
   ,"cancel": "Cancel"
   ,"reset": "Reset"
   ,"playerType": "Player Type"

--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -61,4 +61,12 @@ void main() {
     seen = await LearningPathProgressService.instance.hasSeenIntro();
     expect(seen, isFalse);
   });
+
+  test('resetStage clears progress', () async {
+    await LearningPathProgressService.instance.markCompleted('starter_pushfold_10bb');
+    await LearningPathProgressService.instance.resetStage('Beginner');
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    expect(stages.first.items.first.status, LearningItemStatus.available);
+    expect(stages.first.items[1].status, LearningItemStatus.locked);
+  });
 }


### PR DESCRIPTION
## Summary
- add service method to reset a learning stage
- update LearningPathScreen with button to reset completed stages
- add localization strings for resetting a stage
- test LearningPathProgressService.resetStage

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba3780b6c832ab721e7342a6cd170