### PR TITLE
Implement daily goal streak

### DIFF
--- a/lib/widgets/daily_learning_goal_banner.dart
+++ b/lib/widgets/daily_learning_goal_banner.dart
@@ -13,6 +13,8 @@ class DailyLearningGoalBanner extends StatelessWidget {
     final text = completed
         ? '✅ Цель выполнена!'
         : '🎯 Цель дня: завершить 1 пак. Ты сможешь!';
+    final streak = service.getCurrentStreak();
+    final streakText = '🔥 Стрик: $streak дня подряд!';
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
       padding: const EdgeInsets.all(12),
@@ -20,7 +22,10 @@ class DailyLearningGoalBanner extends StatelessWidget {
         color: color,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Text(text, style: const TextStyle(color: Colors.white)),
+      child: Text(
+        '$text\n$streakText',
+        style: const TextStyle(color: Colors.white),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- track consecutive daily completions
- show current streak in the daily learning goal banner

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba73b2dd0832a9ef0eb5ca3b7f21c