### PR TITLE
Add achievement system

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -299,6 +299,8 @@ List<SingleChildWidget> buildTrainingProviders() {
         stats: context.read<TrainingStatsService>(),
         hands: context.read<SavedHandManagerService>(),
         streak: context.read<StreakService>(),
+        dailyGoal: context.read<DailyLearningGoalService>(),
+        mastery: context.read<TagMasteryService>(),
         xp: context.read<XPTrackerService>(),
       ),
     ),

--- a/lib/models/achievement_v2.dart
+++ b/lib/models/achievement_v2.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Simple representation of an unlockable achievement.
+class AchievementV2 {
+  final String id;
+  final String title;
+  final String description;
+  final IconData icon;
+  final bool Function() condition;
+  DateTime? unlockedAt;
+
+  AchievementV2({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.condition,
+    this.unlockedAt,
+  });
+
+  bool get unlocked => unlockedAt != null;
+}

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/dynamic_progress_row.dart';
 import 'session_result_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
+import '../services/achievement_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_session.dart';
 import 'pack_stats_screen.dart';
@@ -304,6 +305,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
           categoryCounts: counts,
         ),
       );
+      AchievementService.instance.checkAll();
       await _checkGoalProgress();
     }
   }

--- a/lib/services/daily_learning_goal_service.dart
+++ b/lib/services/daily_learning_goal_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'achievement_service.dart';
 
 class DailyLearningGoalService extends ChangeNotifier {
   static const _prefKey = 'daily_learning_goal_completed_at';
@@ -65,6 +66,7 @@ class DailyLearningGoalService extends ChangeNotifier {
       await prefs.setInt(_maxStreakKey, maxStreak);
     }
     _lastCompleted = now;
+    AchievementService.instance.checkAll();
     notifyListeners();
   }
 

--- a/lib/widgets/stage_completion_banner.dart
+++ b/lib/widgets/stage_completion_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../services/block_completion_reward_service.dart';
 import 'confetti_overlay.dart';
+import '../services/achievement_service.dart';
 
 class StageCompletionBanner extends StatefulWidget {
   final String title;
@@ -40,6 +41,7 @@ class _StageCompletionBannerState extends State<StageCompletionBanner>
       setState(() => _visible = true);
       _controller.forward();
       showConfettiOverlay(context);
+      AchievementService.instance.checkAll();
       await BlockCompletionRewardService.instance.markBannerShown(widget.title);
     }
   }


### PR DESCRIPTION
## Summary
- create `AchievementV2` model
- extend `AchievementService` with new achievements and checks
- track daily goal completions for achievements
- trigger achievement checks after stage completion and training sessions

## Testing
- `flutter analyze` *(fails: file_picker plugin warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687ba95395d4832aa73076db10734473