### PR TITLE
Add achievement dashboard with tiles

### DIFF
--- a/lib/screens/achievement_dashboard_screen.dart
+++ b/lib/screens/achievement_dashboard_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/achievement_service.dart';
+import '../models/achievement_info.dart';
+import '../widgets/achievement_tile.dart';
+import '../widgets/xp_progress_card.dart';
+
+class AchievementDashboardScreen extends StatefulWidget {
+  const AchievementDashboardScreen({super.key});
+
+  @override
+  State<AchievementDashboardScreen> createState() =>
+      _AchievementDashboardScreenState();
+}
+
+class _AchievementDashboardScreenState
+    extends State<AchievementDashboardScreen> {
+  bool _unlockedOnly = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<AchievementService>();
+    final data = service.allAchievements();
+    final Map<String, List<AchievementInfo>> grouped = {};
+    for (final a in data) {
+      if (_unlockedOnly && !a.completed) continue;
+      grouped.putIfAbsent(a.category, () => []).add(a);
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Achievements'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: Icon(
+                _unlockedOnly ? Icons.lock_open : Icons.lock_outline),
+            tooltip: _unlockedOnly
+                ? 'Все'
+                : 'Показать только разблокированные',
+            onPressed: () => setState(() => _unlockedOnly = !_unlockedOnly),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const XPProgressCard(),
+          for (final entry in grouped.entries) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                entry.key,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final compact = constraints.maxWidth < 360;
+                final count = compact ? 1 : 2;
+                return GridView.builder(
+                  itemCount: entry.value.length,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: count,
+                    crossAxisSpacing: 12,
+                    mainAxisSpacing: 12,
+                    childAspectRatio: 1.2,
+                  ),
+                  itemBuilder: (context, index) {
+                    final ach = entry.value[index];
+                    final tag = '${ach.id}_hero';
+                    return AchievementTile(
+                      achievement: ach,
+                      heroTag: tag,
+                    );
+                  },
+                );
+              },
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/achievement_detail_screen.dart
+++ b/lib/screens/achievement_detail_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../models/achievement_info.dart';
+
+class AchievementDetailScreen extends StatelessWidget {
+  final AchievementInfo achievement;
+  final String heroTag;
+
+  const AchievementDetailScreen({
+    super.key,
+    required this.achievement,
+    required this.heroTag,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = achievement.level.color;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(achievement.title),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Hero(
+                tag: heroTag,
+                child: Icon(achievement.icon, size: 80, color: color),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              achievement.description,
+              style: const TextStyle(color: Colors.white70),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              achievement.level.label,
+              style: TextStyle(color: color, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value:
+                    (achievement.progressInLevel / achievement.targetInLevel)
+                        .clamp(0.0, 1.0),
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(color),
+                minHeight: 6,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text('${achievement.progressInLevel}/${achievement.targetInLevel}'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -98,6 +98,7 @@ import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
 import 'learning_path_intro_screen.dart';
 import '../services/learning_path_progress_service.dart';
+import 'achievement_dashboard_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -1927,7 +1928,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(builder: (_) => const LearningPathScreen()),
                   );
-                  service.mock = false;
+                service.mock = false;
+              },
+            ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🏆 Achievement Dashboard'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const AchievementDashboardScreen()),
+                  );
                 },
               ),
             if (kDebugMode)

--- a/lib/widgets/achievement_tile.dart
+++ b/lib/widgets/achievement_tile.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import '../models/achievement_info.dart';
+import '../screens/achievement_detail_screen.dart';
+
+class AchievementTile extends StatelessWidget {
+  final AchievementInfo achievement;
+  final String heroTag;
+
+  const AchievementTile({
+    super.key,
+    required this.achievement,
+    required this.heroTag,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final levelColor = achievement.level.color;
+    final completed = achievement.completed;
+    Widget icon = Icon(achievement.icon, size: 40, color: levelColor);
+    if (!completed) {
+      icon = ColorFiltered(
+        colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.saturation),
+        child: icon,
+      );
+    }
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => AchievementDetailScreen(
+              achievement: achievement,
+              heroTag: heroTag,
+            ),
+          ),
+        );
+      },
+      child: Hero(
+        tag: heroTag,
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              icon,
+              const SizedBox(height: 8),
+              Text(
+                achievement.title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const Spacer(),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: (achievement.progressInLevel /
+                          achievement.targetInLevel)
+                      .clamp(0.0, 1.0),
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation<Color>(levelColor),
+                  minHeight: 6,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${achievement.progressInLevel}/${achievement.targetInLevel}',
+                    ),
+                  ),
+                  if (completed)
+                    const Icon(Icons.check_circle, color: Colors.green),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement reusable `AchievementTile` widget
- create dashboard and detail screens with hero animations
- expose Achievement Dashboard in Dev Menu

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bad59b4d8832aa696e4b2356365f0