### PR TITLE
Add player stats screen

### DIFF
--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/streak_banner_widget.dart';
 import '../widgets/reward_banner_widget.dart';
 import 'daily_challenge_history_screen.dart';
 import 'master_achievements_screen.dart';
+import 'player_stats_screen.dart';
 
 class MasterModeScreen extends StatefulWidget {
   static const route = '/master_mode';
@@ -119,6 +120,18 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
               ElevatedButton(
                 onPressed: () {},
                 child: const Text('📈 Анализ прогресса'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PlayerStatsScreen(),
+                    ),
+                  );
+                },
+                child: const Text('📈 Моя статистика'),
               ),
             ],
           );

--- a/lib/screens/player_stats_screen.dart
+++ b/lib/screens/player_stats_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/reward_system_service.dart';
+import '../services/streak_counter_service.dart';
+import '../services/training_pack_stats_service.dart';
+
+class PlayerStatsScreen extends StatefulWidget {
+  static const route = '/player_stats';
+  const PlayerStatsScreen({super.key});
+
+  @override
+  State<PlayerStatsScreen> createState() => _PlayerStatsScreenState();
+}
+
+class _PlayerStatsScreenState extends State<PlayerStatsScreen> {
+  GlobalPackStats? _stats;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await TrainingPackStatsService.getGlobalStats();
+    if (mounted) setState(() => _stats = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('\uD83D\uDCC8 Моя статистика'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Consumer<RewardSystemService>(
+            builder: (context, rewards, _) => ListTile(
+              leading: const Text('\uD83E\uDDE0', style: TextStyle(fontSize: 20)),
+              title: Text('Уровень: ${rewards.currentLevel}'),
+              subtitle: LinearProgressIndicator(value: rewards.progress),
+              trailing:
+                  Text('${rewards.xpProgress} / ${rewards.xpToNextLevel} XP'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Consumer<StreakCounterService>(
+            builder: (context, streak, _) => ListTile(
+              leading: const Text('\uD83D\uDD25', style: TextStyle(fontSize: 20)),
+              title: const Text('Максимальный стрик'),
+              trailing: Text('${streak.max}'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ListTile(
+            leading: const Text('\uD83C\uDFAF', style: TextStyle(fontSize: 20)),
+            title: const Text('Средняя точность'),
+            trailing: Text(
+              _stats != null
+                  ? '${(_stats!.averageAccuracy * 100).round()}%'
+                  : '...',
+            ),
+          ),
+          const SizedBox(height: 8),
+          ListTile(
+            leading: const Text('\u2705', style: TextStyle(fontSize: 20)),
+            title: const Text('Завершено паков'),
+            trailing: Text(
+              _stats != null ? '${_stats!.packsCompleted}' : '...',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PlayerStatsScreen` with progress overview
- access from `MasterModeScreen`

## Testing
- `flutter format lib/screens/player_stats_screen.dart lib/screens/master_mode_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd530d4c832aaa11f04a1e3de92d