### PR TITLE
Implement SmartReviewService for mistake tracking

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -84,6 +84,7 @@ import 'services/smart_suggestion_service.dart';
 import 'services/training_gap_detector_service.dart';
 import 'services/smart_suggestion_engine.dart';
 import 'services/smart_pack_suggestion_engine.dart';
+import 'services/smart_review_service.dart';
 import 'services/evaluation_executor_service.dart';
 import 'services/session_analysis_service.dart';
 import 'services/user_action_logger.dart';
@@ -197,6 +198,7 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider<GoalSyncService>.value(value: goalSync),
     ChangeNotifierProvider(create: (_) => TemplateStorageService()..load()),
     ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..load()),
+    Provider(create: (_) => SmartReviewService.instance..load()),
     ChangeNotifierProvider(
       create: (context) => AdaptiveTrainingService(
         templates: context.read<TemplateStorageService>(),

--- a/lib/services/smart_review_service.dart
+++ b/lib/services/smart_review_service.dart
@@ -1,0 +1,64 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'template_storage_service.dart';
+
+/// Stores IDs of spots where the user made a mistake for future review.
+class SmartReviewService {
+  SmartReviewService._();
+
+  /// Singleton instance.
+  static final SmartReviewService instance = SmartReviewService._();
+
+  static const _prefsKey = 'smart_review_spots';
+
+  final Set<String> _ids = <String>{};
+
+  /// Loads stored mistake spot IDs from [SharedPreferences].
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _ids
+      ..clear()
+      ..addAll(prefs.getStringList(_prefsKey) ?? <String>[]);
+  }
+
+  /// Records a mistake for the given [spot].
+  ///
+  /// Only the spot ID is persisted to avoid storing duplicate data.
+  Future<void> recordMistake(TrainingPackSpot spot) async {
+    if (_ids.contains(spot.id)) return;
+    _ids.add(spot.id);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, _ids.toList());
+  }
+
+  /// Returns the list of spots corresponding to recorded mistakes.
+  Future<List<TrainingPackSpot>> getMistakeSpots(
+      TemplateStorageService templates) async {
+    if (_ids.isEmpty) return <TrainingPackSpot>[];
+    final Map<String, TrainingPackSpot> map = {};
+    for (final tpl in templates.templates) {
+      for (final s in tpl.spots) {
+        if (_ids.contains(s.id) && !map.containsKey(s.id)) {
+          map[s.id] = TrainingPackSpot.fromJson(s.toJson());
+        }
+      }
+    }
+    final result = <TrainingPackSpot>[];
+    for (final id in _ids) {
+      final spot = map[id];
+      if (spot != null) result.add(spot);
+    }
+    return result;
+  }
+
+  /// Clears all stored mistakes.
+  Future<void> clearMistakes() async {
+    _ids.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+  }
+
+  /// Returns true if a mistake for [spotId] is recorded.
+  bool hasMistake(String spotId) => _ids.contains(spotId);
+}
+

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -10,6 +10,7 @@ import '../helpers/hand_type_utils.dart';
 import '../helpers/training_pack_storage.dart';
 import '../screens/training_session_summary_screen.dart';
 import 'mistake_review_pack_service.dart';
+import 'smart_review_service.dart';
 import 'cloud_training_history_service.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
@@ -468,6 +469,9 @@ class TrainingSessionService extends ChangeNotifier {
     final spot =
         _spots.firstWhere((e) => e.id == spotId, orElse: () => TrainingPackSpot(id: ''));
     if (spot.id.isNotEmpty) {
+      if (first && !isCorrect) {
+        unawaited(SmartReviewService.instance.recordMistake(spot));
+      }
       for (final t in spot.tags.where((t) => t.startsWith('cat:'))) {
         final cat = t.substring(4);
         final stat = _categoryStats.putIfAbsent(cat, () => CategoryProgress());

--- a/test/services/training_session_service_test.dart
+++ b/test/services/training_session_service_test.dart
@@ -2,11 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/training_pack_template.dart';
 import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/smart_review_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('basic session flow', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SmartReviewService.instance.load();
     final s1 = TrainingPackSpot(id: 'a');
     final s2 = TrainingPackSpot(id: 'b');
     final tpl = TrainingPackTemplate(id: 't', name: 't', spots: [s1, s2]);


### PR DESCRIPTION
## Summary
- add `SmartReviewService` to persist IDs of mistaken spots
- integrate service with `TrainingSessionService` to record mistakes
- expose the service in `app_providers`
- update unit test setup for the new service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcf4afc88832a8b73ed9319a39bbd