### PR TITLE
Add progress bar for Learning Path stages

### DIFF
--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -24,6 +24,25 @@ class LearningStageState {
   final List<LearningStageItem> items;
 
   const LearningStageState({required this.title, required this.items});
+
+  static double computeStageProgress(List<LearningStageItem> items) {
+    if (items.isEmpty) return 0.0;
+    var sum = 0.0;
+    for (final item in items) {
+      switch (item.status) {
+        case LearningItemStatus.completed:
+          sum += 1.0;
+          break;
+        case LearningItemStatus.available:
+          sum += 0.5;
+          break;
+        case LearningItemStatus.locked:
+        default:
+          sum += 0.0;
+      }
+    }
+    return sum / items.length;
+  }
 }
 
 class LearningPathProgressService {


### PR DESCRIPTION
## Summary
- compute progress based on stage item status
- refresh Learning Path screen after completing a training pack
- display stage progress with LinearProgressIndicator

## Testing
- `flutter pub get`
- `flutter test --run-skipped` *(fails: The Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_687b7e5a9040832a90e3d50bf2069ddd