### PR TITLE
Add Mistake Insight Dashboard

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -100,6 +100,7 @@ import 'learning_path_intro_screen.dart';
 import '../services/learning_path_progress_service.dart';
 import 'achievement_dashboard_screen.dart';
 import 'mistake_review_screen.dart';
+import 'mistake_insight_screen.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -481,8 +482,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   Future<void> _removeYamlDuplicates() async {
     if (_yamlDupeLoading || !kDebugMode) return;
     setState(() => _yamlDupeLoading = true);
-    final list = await const YamlPackDuplicateCleanerService()
-        .removeDuplicates();
+    final list =
+        await const YamlPackDuplicateCleanerService().removeDuplicates();
     if (!mounted) return;
     setState(() => _yamlDupeLoading = false);
     ScaffoldMessenger.of(
@@ -1890,9 +1891,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
             if (kDebugMode)
               ListTile(
                 title: const Text('🧪 Тест выгрузки/загрузки шаблона'),
-                onTap: _templateStorageTestLoading
-                    ? null
-                    : _testTemplateStorage,
+                onTap:
+                    _templateStorageTestLoading ? null : _testTemplateStorage,
               ),
             if (kDebugMode)
               ListTile(
@@ -1908,8 +1908,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📚 Путь обучения'),
                 onTap: () async {
-                  final seen = await LearningPathProgressService.instance
-                      .hasSeenIntro();
+                  final seen =
+                      await LearningPathProgressService.instance.hasSeenIntro();
                   final screen = seen
                       ? const LearningPathScreen()
                       : const LearningPathIntroScreen();
@@ -1927,11 +1927,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                   service.mock = true;
                   await Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (_) => const LearningPathScreen()),
+                    MaterialPageRoute(
+                        builder: (_) => const LearningPathScreen()),
                   );
-                service.mock = false;
-              },
-            ),
+                  service.mock = false;
+                },
+              ),
             if (kDebugMode)
               ListTile(
                 title: const Text('🏆 Achievement Dashboard'),
@@ -1974,6 +1975,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                         builder: (_) => const MistakeReviewScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📊 Аналитика ошибок'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const MistakeInsightScreen()),
                   );
                 },
               ),

--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -11,6 +11,7 @@ import 'daily_challenge_history_screen.dart';
 import 'master_achievements_screen.dart';
 import 'player_stats_screen.dart';
 import 'mistake_review_screen.dart';
+import 'mistake_insight_screen.dart';
 
 class MasterModeScreen extends StatefulWidget {
   static const route = '/master_mode';
@@ -128,6 +129,18 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
                   );
                 },
                 child: const Text('🔁 Повтор ошибок'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const MistakeInsightScreen(),
+                    ),
+                  );
+                },
+                child: const Text('📊 Аналитика ошибок'),
               ),
               const SizedBox(height: 16),
               ElevatedButton(

--- a/lib/screens/mistake_insight_screen.dart
+++ b/lib/screens/mistake_insight_screen.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../services/smart_review_service.dart';
+import '../services/template_storage_service.dart';
+import '../helpers/hand_utils.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../theme/app_colors.dart';
+import 'mistake_review_screen.dart';
+
+class MistakeInsightScreen extends StatefulWidget {
+  const MistakeInsightScreen({super.key});
+
+  @override
+  State<MistakeInsightScreen> createState() => _MistakeInsightScreenState();
+}
+
+class _MistakeInsightScreenState extends State<MistakeInsightScreen> {
+  final List<String> _periods = ['7 дней', '30 дней', 'Все время'];
+  String _period = 'Все время';
+  bool _loading = true;
+  List<TrainingPackSpot> _spots = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final templates = context.read<TemplateStorageService>();
+    final spots = await SmartReviewService.instance.getMistakeSpots(templates);
+    if (!mounted) return;
+    setState(() {
+      _spots = spots;
+      _loading = false;
+    });
+  }
+
+  List<TrainingPackSpot> get _filtered {
+    if (_period == 'Все время') return _spots;
+    final days = _period == '7 дней' ? 7 : 30;
+    final cutoff = DateTime.now().subtract(Duration(days: days));
+    return [
+      for (final s in _spots)
+        if (!s.createdAt.isBefore(cutoff)) s
+    ];
+  }
+
+  Map<String, int> _tagCounts(List<TrainingPackSpot> spots) {
+    final map = <String, int>{};
+    for (final s in spots) {
+      for (final t in s.tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        map.update(key, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    final entries = map.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return {for (final e in entries) e.key: e.value};
+  }
+
+  Map<String, int> _handCounts(List<TrainingPackSpot> spots) {
+    final map = <String, int>{};
+    for (final s in spots) {
+      final code = handCode(s.hand.heroCards) ?? '';
+      if (code.isEmpty) continue;
+      map.update(code, (v) => v + 1, ifAbsent: () => 1);
+    }
+    final entries = map.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return {for (final e in entries) e.key: e.value};
+  }
+
+  Widget _tagChart(Map<String, int> data) {
+    final names = data.keys.take(5).toList();
+    if (names.isEmpty) {
+      return const SizedBox(
+        height: 200,
+        child: Center(
+          child: Text('Нет данных', style: TextStyle(color: Colors.white70)),
+        ),
+      );
+    }
+    final maxVal = data[names.first]!.toDouble();
+    final groups = <BarChartGroupData>[];
+    for (var i = 0; i < names.length; i++) {
+      final v = data[names[i]]!.toDouble();
+      final color = AppColors.accent;
+      groups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: v,
+              width: 14,
+              borderRadius: BorderRadius.circular(4),
+              gradient: LinearGradient(
+                colors: [color.withOpacity(0.7), color],
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    return SizedBox(
+      height: 200,
+      child: BarChart(
+        BarChartData(
+          maxY: maxVal,
+          minY: 0,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: maxVal / 4,
+            getDrawingHorizontalLine: (value) =>
+                FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  final i = value.toInt();
+                  if (i < 0 || i >= names.length) {
+                    return const SizedBox.shrink();
+                  }
+                  return Text(names[i],
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 10));
+                },
+              ),
+            ),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: maxVal / 4,
+                reservedSize: 30,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toInt().toString(),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+          ),
+          borderData: FlBorderData(
+            show: true,
+            border: const Border(
+              left: BorderSide(color: Colors.white24),
+              bottom: BorderSide(color: Colors.white24),
+            ),
+          ),
+          barGroups: groups,
+        ),
+      ),
+    );
+  }
+
+  Widget _handChart(Map<String, int> data) {
+    final entries = data.entries.take(5).toList();
+    if (entries.isEmpty) {
+      return const SizedBox(
+        height: 200,
+        child: Center(
+          child: Text('Нет данных', style: TextStyle(color: Colors.white70)),
+        ),
+      );
+    }
+    final sections = <PieChartSectionData>[];
+    for (final e in entries) {
+      sections.add(
+        PieChartSectionData(
+          value: e.value.toDouble(),
+          title: e.key,
+          radius: 80,
+          titleStyle: const TextStyle(color: Colors.white, fontSize: 10),
+        ),
+      );
+    }
+    return SizedBox(
+      height: 200,
+      child: PieChart(
+        PieChartData(sections: sections),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final spots = _filtered;
+    final tags = _tagCounts(spots);
+    final hands = _handCounts(spots);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Аналитика ошибок'),
+        actions: [
+          DropdownButton<String>(
+            value: _period,
+            underline: const SizedBox(),
+            dropdownColor: const Color(0xFF2A2B2E),
+            onChanged: (v) => setState(() => _period = v!),
+            items: [
+              for (final p in _periods)
+                DropdownMenuItem(value: p, child: Text(p))
+            ],
+          )
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _tagChart(tags),
+                const SizedBox(height: 16),
+                _handChart(hands),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const MistakeReviewScreen()),
+                    );
+                  },
+                  child: const Text('Начать повторение'),
+                ),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create MistakeInsightScreen that aggregates mistake tags and hands
- integrate MistakeInsightScreen with DevMenu and MasterMode

## Testing
- `dart format lib/screens/mistake_insight_screen.dart lib/screens/dev_menu_screen.dart lib/screens/master_mode_screen.dart`
- `dart test` *(fails: Failed to load tests due to missing dart:ui)*

------
https://chatgpt.com/codex/tasks/task_e_687bd47ff9d4832a85c134e2ab53f9b2