### PR TITLE
Add postflop training spot support

### DIFF
--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -1,1 +1,57 @@
-[]
+[
+  {
+    "id": "cbet_ip",
+    "name": "CBet IP",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 40,
+    "spotCount": 2,
+    "positions": ["btn", "bb"],
+    "tags": ["postflop", "cbet"]
+  },
+  {
+    "id": "check_raise_oop",
+    "name": "Check-Raise OOP",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 50,
+    "spotCount": 1,
+    "positions": ["bb", "btn"],
+    "tags": ["postflop", "check-raise"]
+  },
+  {
+    "id": "float_turn",
+    "name": "Turn Float IP",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 50,
+    "spotCount": 1,
+    "positions": ["btn", "sb"],
+    "tags": ["postflop", "float"]
+  },
+  {
+    "id": "donk_bet_flop",
+    "name": "Donk Bet Flop",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 30,
+    "spotCount": 1,
+    "positions": ["bb", "btn"],
+    "tags": ["postflop", "donk"]
+  },
+  {
+    "id": "river_bluffcatch",
+    "name": "River Bluffcatch",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 40,
+    "spotCount": 1,
+    "positions": ["bb", "btn"],
+    "tags": ["postflop", "bluffcatch"]
+  }
+]

--- a/assets/packs/v2/postflop/cbet_ip.yaml
+++ b/assets/packs/v2/postflop/cbet_ip.yaml
@@ -1,0 +1,35 @@
+id: cbet_ip
+name: CBet IP
+trainingType: postflop
+bb: 40
+gameType: tournament
+positions: [btn, bb]
+tags: [postflop, cbet]
+spots:
+  - id: cbet_ip_1
+    title: Dry flop
+    board: [8h,4d,2s]
+    street: 1
+    villainAction: check
+    heroOptions: [bet, check]
+    hand:
+      heroCards: 'Ah Kd'
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 40, '1': 40}
+      board: [8h,4d,2s]
+  - id: cbet_ip_2
+    title: Rainbow board
+    board: [9s,4d,2c]
+    street: 1
+    villainAction: check
+    heroOptions: [bet, check]
+    hand:
+      heroCards: 'As Qh'
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 40, '1': 40}
+      board: [9s,4d,2c]
+spotCount: 2

--- a/assets/packs/v2/postflop/check_raise_oop.yaml
+++ b/assets/packs/v2/postflop/check_raise_oop.yaml
@@ -1,0 +1,22 @@
+id: check_raise_oop
+name: Check-Raise OOP
+trainingType: postflop
+bb: 50
+gameType: tournament
+positions: [bb, btn]
+tags: [postflop, check-raise]
+spots:
+  - id: cr_oop_1
+    title: Versus cbet
+    board: [Kd,7h,3s]
+    street: 1
+    villainAction: bet
+    heroOptions: [raise, call]
+    hand:
+      heroCards: '9d 9c'
+      position: bb
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 50, '1': 50}
+      board: [Kd,7h,3s]
+spotCount: 1

--- a/assets/packs/v2/postflop/donk_bet_flop.yaml
+++ b/assets/packs/v2/postflop/donk_bet_flop.yaml
@@ -1,0 +1,22 @@
+id: donk_bet_flop
+name: Donk Bet Flop
+trainingType: postflop
+bb: 30
+gameType: tournament
+positions: [bb, btn]
+tags: [postflop, donk]
+spots:
+  - id: donk_flop_1
+    title: Lead into raiser
+    board: [Ts,9d,4c]
+    street: 1
+    villainAction: none
+    heroOptions: [bet, check]
+    hand:
+      heroCards: '7h 7c'
+      position: bb
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 30, '1': 30}
+      board: [Ts,9d,4c]
+spotCount: 1

--- a/assets/packs/v2/postflop/float_turn.yaml
+++ b/assets/packs/v2/postflop/float_turn.yaml
@@ -1,0 +1,22 @@
+id: float_turn
+name: Turn Float IP
+trainingType: postflop
+bb: 50
+gameType: tournament
+positions: [btn, sb]
+tags: [postflop, float]
+spots:
+  - id: float_turn_1
+    title: Barrel turn
+    board: [Qh,8d,2s,4c]
+    street: 2
+    villainAction: bet
+    heroOptions: [call, fold, raise]
+    hand:
+      heroCards: 'Ac Jh'
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 50, '1': 50}
+      board: [Qh,8d,2s,4c]
+spotCount: 1

--- a/assets/packs/v2/postflop/river_bluffcatch.yaml
+++ b/assets/packs/v2/postflop/river_bluffcatch.yaml
@@ -1,0 +1,22 @@
+id: river_bluffcatch
+name: River Bluffcatch
+trainingType: postflop
+bb: 40
+gameType: tournament
+positions: [bb, btn]
+tags: [postflop, bluffcatch]
+spots:
+  - id: bluffcatch_1
+    title: Facing shove
+    board: [Qs,9h,3d,2c,7s]
+    street: 3
+    villainAction: bet
+    heroOptions: [call, fold]
+    hand:
+      heroCards: 'Jh Jc'
+      position: bb
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 40, '1': 40}
+      board: [Qs,9h,3d,2c,7s]
+spotCount: 1

--- a/lib/core/training/generation/training_pack_tags_engine.dart
+++ b/lib/core/training/generation/training_pack_tags_engine.dart
@@ -16,10 +16,30 @@ class TrainingPackTagsEngine {
       final st = s.hand.stacks['${s.hand.heroIndex}']?.round();
       if (st != null && st == 10) pushfold = true;
       if (s.hand.board.length >= 5) river = true;
+      if (s.villainAction == 'check' &&
+          s.heroOptions.contains('bet') &&
+          s.street == 1) {
+        set.add('cbet');
+      }
+      if (s.villainAction == 'bet' && s.heroOptions.contains('raise')) {
+        set.add('check-raise');
+      }
+      if (s.villainAction == 'bet' && s.heroOptions.contains('call')) {
+        if (s.street == 3) {
+          set.add('bluffcatch');
+        } else {
+          set.add('float');
+        }
+      }
+      if ((s.villainAction == null || s.villainAction == 'none') &&
+          s.heroOptions.contains('bet')) {
+        set.add('donk');
+      }
     }
     if (streets.length >= 2) set.add('postflop');
     if (pushfold || template.bb == 10) set.add('pushfold');
-    if (positions.length >= 3 || template.positions.length >= 3) set.add('multiway');
+    if (positions.length >= 3 || template.positions.length >= 3)
+      set.add('multiway');
     if (river) set.add('river');
     final list = set.toList();
     list.sort();

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -22,6 +22,10 @@ class TrainingPackSpot {
   String? correctAction;
   String? explanation;
   bool streetMode;
+  List<String> board;
+  int street;
+  String? villainAction;
+  List<String> heroOptions;
 
   TrainingPackSpot({
     required this.id,
@@ -40,12 +44,18 @@ class TrainingPackSpot {
     this.correctAction,
     this.explanation,
     this.streetMode = false,
-  }) : isNew = isNew ?? false,
-       hand = hand ?? HandData(),
-       tags = tags ?? [],
-       categories = categories ?? [],
-       editedAt = editedAt ?? DateTime.now(),
-       createdAt = createdAt ?? DateTime.now();
+    List<String>? board,
+    this.street = 0,
+    this.villainAction,
+    List<String>? heroOptions,
+  })  : isNew = isNew ?? false,
+        hand = hand ?? HandData(),
+        board = board ?? const [],
+        heroOptions = heroOptions ?? const [],
+        tags = tags ?? [],
+        categories = categories ?? [],
+        editedAt = editedAt ?? DateTime.now(),
+        createdAt = createdAt ?? DateTime.now();
 
   TrainingPackSpot copyWith({
     String? id,
@@ -64,68 +74,90 @@ class TrainingPackSpot {
     String? correctAction,
     String? explanation,
     bool? streetMode,
-  }) => TrainingPackSpot(
-    id: id ?? this.id,
-    title: title ?? this.title,
-    note: note ?? this.note,
-    hand: hand ?? this.hand,
-    tags: tags ?? List<String>.from(this.tags),
-    categories: categories ?? List<String>.from(this.categories),
-    editedAt: editedAt ?? this.editedAt,
-    createdAt: createdAt ?? this.createdAt,
-    pinned: pinned ?? this.pinned,
-    dirty: dirty ?? this.dirty,
-    priority: priority ?? this.priority,
-    isNew: isNew ?? this.isNew,
-    evalResult: evalResult ?? this.evalResult,
-    correctAction: correctAction ?? this.correctAction,
-    explanation: explanation ?? this.explanation,
-    streetMode: streetMode ?? this.streetMode,
-  );
+    List<String>? board,
+    int? street,
+    String? villainAction,
+    List<String>? heroOptions,
+  }) =>
+      TrainingPackSpot(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        note: note ?? this.note,
+        hand: hand ?? this.hand,
+        tags: tags ?? List<String>.from(this.tags),
+        categories: categories ?? List<String>.from(this.categories),
+        editedAt: editedAt ?? this.editedAt,
+        createdAt: createdAt ?? this.createdAt,
+        pinned: pinned ?? this.pinned,
+        dirty: dirty ?? this.dirty,
+        priority: priority ?? this.priority,
+        isNew: isNew ?? this.isNew,
+        evalResult: evalResult ?? this.evalResult,
+        correctAction: correctAction ?? this.correctAction,
+        explanation: explanation ?? this.explanation,
+        streetMode: streetMode ?? this.streetMode,
+        board: board ?? List<String>.from(this.board),
+        street: street ?? this.street,
+        villainAction: villainAction ?? this.villainAction,
+        heroOptions: heroOptions ?? List<String>.from(this.heroOptions),
+      );
 
   factory TrainingPackSpot.fromJson(Map<String, dynamic> j) => TrainingPackSpot(
-    id: j['id'] as String? ?? '',
-    title: j['title'] as String? ?? '',
-    note: j['note'] as String? ?? '',
-    hand: j['hand'] != null
-        ? HandData.fromJson(Map<String, dynamic>.from(j['hand']))
-        : HandData(),
-    tags: [for (final t in (j['tags'] as List? ?? [])) t as String],
-    categories: [for (final t in (j['categories'] as List? ?? [])) t as String],
-    editedAt:
-        DateTime.tryParse(j['editedAt'] as String? ?? '') ?? DateTime.now(),
-    createdAt:
-        DateTime.tryParse(j['createdAt'] as String? ?? '') ?? DateTime.now(),
-    pinned: j['pinned'] == true,
-    dirty: j['dirty'] == true,
-    priority: (j['priority'] as num?)?.toInt() ?? 3,
-    // `isNew` never restored from disk
-    isNew: false,
-    evalResult: j['evalResult'] != null
-        ? EvaluationResult.fromJson(Map<String, dynamic>.from(j['evalResult']))
-        : null,
-    correctAction: j['correctAction'] as String?,
-    explanation: j['explanation'] as String?,
-    streetMode: j['streetMode'] == true,
-  );
+        id: j['id'] as String? ?? '',
+        title: j['title'] as String? ?? '',
+        note: j['note'] as String? ?? '',
+        hand: j['hand'] != null
+            ? HandData.fromJson(Map<String, dynamic>.from(j['hand']))
+            : HandData(),
+        tags: [for (final t in (j['tags'] as List? ?? [])) t as String],
+        categories: [
+          for (final t in (j['categories'] as List? ?? [])) t as String
+        ],
+        editedAt:
+            DateTime.tryParse(j['editedAt'] as String? ?? '') ?? DateTime.now(),
+        createdAt: DateTime.tryParse(j['createdAt'] as String? ?? '') ??
+            DateTime.now(),
+        pinned: j['pinned'] == true,
+        dirty: j['dirty'] == true,
+        priority: (j['priority'] as num?)?.toInt() ?? 3,
+        // `isNew` never restored from disk
+        isNew: false,
+        evalResult: j['evalResult'] != null
+            ? EvaluationResult.fromJson(
+                Map<String, dynamic>.from(j['evalResult']))
+            : null,
+        correctAction: j['correctAction'] as String?,
+        explanation: j['explanation'] as String?,
+        streetMode: j['streetMode'] == true,
+        board: [for (final c in (j['board'] as List? ?? [])) c.toString()],
+        street: (j['street'] as num?)?.toInt() ?? 0,
+        villainAction: j['villainAction'] as String?,
+        heroOptions: [
+          for (final a in (j['heroOptions'] as List? ?? [])) a.toString()
+        ],
+      );
 
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'title': title,
-    'note': note,
-    'hand': hand.toJson(),
-    if (tags.isNotEmpty) 'tags': tags,
-    if (categories.isNotEmpty) 'categories': categories,
-    'editedAt': editedAt.toIso8601String(),
-    'createdAt': createdAt.toIso8601String(),
-    if (pinned) 'pinned': true,
-    if (dirty) 'dirty': true,
-    if (priority != 3) 'priority': priority,
-    if (evalResult != null) 'evalResult': evalResult!.toJson(),
-    if (correctAction != null) 'correctAction': correctAction,
-    if (explanation != null) 'explanation': explanation,
-    if (streetMode) 'streetMode': true,
-  };
+        'id': id,
+        'title': title,
+        'note': note,
+        'hand': hand.toJson(),
+        if (tags.isNotEmpty) 'tags': tags,
+        if (categories.isNotEmpty) 'categories': categories,
+        'editedAt': editedAt.toIso8601String(),
+        'createdAt': createdAt.toIso8601String(),
+        if (pinned) 'pinned': true,
+        if (dirty) 'dirty': true,
+        if (priority != 3) 'priority': priority,
+        if (evalResult != null) 'evalResult': evalResult!.toJson(),
+        if (correctAction != null) 'correctAction': correctAction,
+        if (explanation != null) 'explanation': explanation,
+        if (streetMode) 'streetMode': true,
+        if (board.isNotEmpty) 'board': board,
+        if (street > 0) 'street': street,
+        if (villainAction != null) 'villainAction': villainAction,
+        if (heroOptions.isNotEmpty) 'heroOptions': heroOptions,
+      };
 
   double? get heroEv {
     final acts = hand.actions[0] ?? [];
@@ -161,29 +193,38 @@ class TrainingPackSpot {
           evalResult == other.evalResult &&
           correctAction == other.correctAction &&
           explanation == other.explanation &&
-          streetMode == other.streetMode;
+          streetMode == other.streetMode &&
+          const ListEquality().equals(board, other.board) &&
+          street == other.street &&
+          villainAction == other.villainAction &&
+          const ListEquality().equals(heroOptions, other.heroOptions);
 
   @override
   int get hashCode => Object.hash(
-    id,
-    title,
-    note,
-    hand,
-    const ListEquality().hash(tags),
-    const ListEquality().hash(categories),
-    pinned,
-    dirty,
-    priority,
-    isNew,
-    evalResult,
-    correctAction,
-    explanation,
-    streetMode,
-  );
+        id,
+        title,
+        note,
+        hand,
+        const ListEquality().hash(tags),
+        const ListEquality().hash(categories),
+        pinned,
+        dirty,
+        priority,
+        isNew,
+        evalResult,
+        correctAction,
+        explanation,
+        streetMode,
+        const ListEquality().hash(board),
+        street,
+        villainAction,
+        const ListEquality().hash(heroOptions),
+      );
 }
 
 extension TrainingPackSpotStreet on TrainingPackSpot {
   int get street {
+    if (this.street > 0) return this.street;
     final n = hand.board.length;
     if (n >= 5) return 3;
     if (n == 4) return 2;


### PR DESCRIPTION
## Summary
- extend `TrainingPackSpot` with board, street, villainAction and heroOptions
- auto-tag postflop actions like cbet, check-raise and bluffcatch
- add example postflop training packs
- update library index with postflop packs

## Testing
- `flutter analyze` *(fails: 6923 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687bd8a631b4832aa19c32e95529f9e2