### PR TITLE
Add YAML export/import for postflop fields

### DIFF
--- a/lib/models/v2/hand_data.dart
+++ b/lib/models/v2/hand_data.dart
@@ -69,9 +69,8 @@ class HandData {
           },
         if (stacks.isNotEmpty) 'stacks': stacks,
         if (board.isNotEmpty) 'board': board,
-        'anteBb': anteBb,
-      }; 
-}
+      'anteBb': anteBb,
+      };
 
   factory HandData.fromSimpleInput(
     String cards,

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -159,6 +159,36 @@ class TrainingPackSpot {
         if (heroOptions.isNotEmpty) 'heroOptions': heroOptions,
       };
 
+  /// Converts this spot to a YAML-compatible map.
+  ///
+  /// The returned map omits empty or null values, mirroring [toJson].
+  Map<String, dynamic> toYaml() => toJson();
+
+  /// Creates a [TrainingPackSpot] from a YAML map.
+  ///
+  /// The method is tolerant to missing fields and invalid values to maintain
+  /// backwards compatibility with older pack versions.
+  factory TrainingPackSpot.fromYaml(Map yaml) {
+    final map = <String, dynamic>{};
+    yaml.forEach((k, v) => map[k.toString()] = v);
+
+    final board = <String>[for (final c in (yaml['board'] as List? ?? [])) c.toString()];
+    if (board.length >= 3 && board.length <= 5) map['board'] = board;
+
+    final street = (yaml['street'] as num?)?.toInt() ?? 0;
+    if (street >= 1 && street <= 3) map['street'] = street;
+
+    final villain = yaml['villainAction']?.toString();
+    if (villain != null && ['none', 'check', 'bet'].contains(villain)) {
+      map['villainAction'] = villain;
+    }
+
+    final heroOptions = <String>[for (final o in (yaml['heroOptions'] as List? ?? [])) o.toString()];
+    if (heroOptions.isNotEmpty) map['heroOptions'] = heroOptions;
+
+    return TrainingPackSpot.fromJson(Map<String, dynamic>.from(map));
+  }
+
   double? get heroEv {
     final acts = hand.actions[0] ?? [];
     for (final a in acts) {

--- a/test/training_pack_spot_yaml_test.dart
+++ b/test/training_pack_spot_yaml_test.dart
@@ -1,0 +1,51 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+
+void main() {
+  test('toYaml and fromYaml round trip with postflop fields', () {
+    final combos = [
+      {'street': 1, 'action': 'none'},
+      {'street': 1, 'action': 'check'},
+      {'street': 1, 'action': 'bet'},
+      {'street': 2, 'action': 'none'},
+      {'street': 2, 'action': 'check'},
+      {'street': 2, 'action': 'bet'},
+      {'street': 3, 'action': 'none'},
+      {'street': 3, 'action': 'check'},
+      {'street': 3, 'action': 'bet'},
+    ];
+
+    for (var i = 0; i < combos.length; i++) {
+      final c = combos[i];
+      final spot = TrainingPackSpot(
+        id: 's$i',
+        hand: HandData(),
+        board: ['Ah', 'Kd', 'Qs'],
+        street: c['street'] as int,
+        villainAction: c['action'] as String?,
+        heroOptions: ['call', 'raise'],
+      );
+      final yamlMap = spot.toYaml();
+      final restored = TrainingPackSpot.fromYaml(yamlMap);
+      expect(restored.street, spot.street);
+      expect(restored.board, spot.board);
+      expect(restored.villainAction, spot.villainAction);
+      expect(restored.heroOptions, spot.heroOptions);
+    }
+  });
+
+  test('fromYaml applies defaults for missing fields', () {
+    const yamlStr = '''
+id: a1
+title: Test
+''';
+    final map = const YamlReader().read(yamlStr);
+    final spot = TrainingPackSpot.fromYaml(map);
+    expect(spot.street, 0);
+    expect(spot.board, isEmpty);
+    expect(spot.villainAction, isNull);
+    expect(spot.heroOptions, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add toYaml/fromYaml methods for TrainingPackSpot
- fix HandData class braces so factory constructor compiles
- test spot YAML round trip for various streets and villain actions

## Testing
- `flutter test test/training_pack_spot_yaml_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687be113f9a4832ab203f27a6a8eb8c4