### PR TITLE
Add simplified training pack generation on many mistakes

### DIFF
--- a/lib/onboarding/onboarding_flow_manager.dart
+++ b/lib/onboarding/onboarding_flow_manager.dart
@@ -128,7 +128,8 @@ class _MistakeRepeatStep implements OnboardingStep {
   @override
   Future<void> run(BuildContext context, OnboardingFlowManager manager) async {
     final templates = context.read<TemplateStorageService>();
-    final spots = await SmartReviewService.instance.getMistakeSpots(templates);
+    final spots = await SmartReviewService.instance
+        .getMistakeSpots(templates, context: context);
     if (spots.isEmpty) return;
     await Navigator.push(
       context,

--- a/lib/screens/mistake_insight_screen.dart
+++ b/lib/screens/mistake_insight_screen.dart
@@ -30,7 +30,8 @@ class _MistakeInsightScreenState extends State<MistakeInsightScreen> {
 
   Future<void> _load() async {
     final templates = context.read<TemplateStorageService>();
-    final spots = await SmartReviewService.instance.getMistakeSpots(templates);
+    final spots = await SmartReviewService.instance
+        .getMistakeSpots(templates, context: context);
     if (!mounted) return;
     setState(() {
       _spots = spots;

--- a/lib/screens/mistake_review_screen.dart
+++ b/lib/screens/mistake_review_screen.dart
@@ -32,7 +32,8 @@ class _MistakeReviewScreenState extends State<MistakeReviewScreen> {
       return;
     }
     final templates = context.read<TemplateStorageService>();
-    final spots = await SmartReviewService.instance.getMistakeSpots(templates);
+    final spots = await SmartReviewService.instance
+        .getMistakeSpots(templates, context: context);
     if (!mounted) return;
     if (spots.isNotEmpty) {
       final tpl = TrainingPackTemplate(

--- a/lib/services/training_pack_template_builder.dart
+++ b/lib/services/training_pack_template_builder.dart
@@ -1,0 +1,46 @@
+import 'package:uuid/uuid.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+class TrainingPackTemplateBuilder {
+  const TrainingPackTemplateBuilder();
+
+  Future<TrainingPackTemplateV2> buildSimplifiedPack(
+      List<TrainingPackSpot> mistakes) async {
+    await TrainingPackLibraryV2.instance.reload();
+    final library = TrainingPackLibraryV2.instance.packs;
+
+    final base = mistakes.take(3).toList();
+    final spots = <TrainingPackSpot>[...base];
+    for (final m in base) {
+      for (final tpl in library) {
+        for (final s in tpl.spots) {
+          if (s.hand.position == m.hand.position && s.street == m.street) {
+            spots.add(TrainingPackSpot.fromJson(s.toJson()));
+            break;
+          }
+        }
+        if (spots.length >= base.length + 3) break;
+      }
+      if (spots.length >= base.length + 3) break;
+    }
+
+    final positions = <HeroPosition>{for (final s in spots) s.hand.position};
+    final tpl = TrainingPackTemplateV2(
+      id: const Uuid().v4(),
+      name: 'Закрепление основ',
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      bb: 0,
+      positions: [for (final p in positions) p.name],
+    );
+    tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
+    return tpl;
+  }
+}


### PR DESCRIPTION
## Summary
- extend `SmartReviewService.getMistakeSpots` to optionally run a simplified session if more than five mistakes are recorded
- create `TrainingPackTemplateBuilder` helper
- hook updated logic into mistake screens and onboarding

## Testing
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_687be6954714832ab19cabad6da986ec