### PR TITLE
Implement prioritized weak tag drills

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -450,6 +450,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                           style: const TextStyle(color: Colors.white70),
                           textAlign: TextAlign.center,
                         ),
+                        if (service.template!.description.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            service.template!.description,
+                            style: const TextStyle(color: Colors.white70),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
                         const SizedBox(height: 4),
                         _progressBar(service),
                         const SizedBox(height: 4),

--- a/lib/services/skill_map_service.dart
+++ b/lib/services/skill_map_service.dart
@@ -1,0 +1,10 @@
+import 'tag_mastery_service.dart';
+
+class SkillMapService {
+  final TagMasteryService mastery;
+  const SkillMapService({required this.mastery});
+
+  Future<List<String>> getWeakestTags([int count = 2]) async {
+    return mastery.topWeakTags(count);
+  }
+}

--- a/lib/services/smart_review_service.dart
+++ b/lib/services/smart_review_service.dart
@@ -5,6 +5,7 @@ import '../models/v2/training_pack_spot.dart';
 import 'template_storage_service.dart';
 import 'training_pack_template_builder.dart';
 import 'training_session_service.dart';
+import 'tag_mastery_service.dart';
 import '../screens/training_session_screen.dart';
 
 /// Stores IDs of spots where the user made a mistake for future review.
@@ -58,7 +59,8 @@ class SmartReviewService {
 
     if (context != null && result.length > 5) {
       final builder = const TrainingPackTemplateBuilder();
-      final tpl = await builder.buildSimplifiedPack(result);
+      final mastery = context.read<TagMasteryService>();
+      final tpl = await builder.buildSimplifiedPack(result, mastery);
       await showDialog<void>(
         context: context,
         builder: (_) => AlertDialog(

--- a/lib/services/training_pack_template_builder.dart
+++ b/lib/services/training_pack_template_builder.dart
@@ -4,35 +4,53 @@ import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hero_position.dart';
 import '../core/training/library/training_pack_library_v2.dart';
 import '../core/training/engine/training_type_engine.dart';
+import 'tag_mastery_service.dart';
 
 class TrainingPackTemplateBuilder {
   const TrainingPackTemplateBuilder();
 
   Future<TrainingPackTemplateV2> buildSimplifiedPack(
-      List<TrainingPackSpot> mistakes) async {
+    List<TrainingPackSpot> mistakes,
+    TagMasteryService mastery,
+  ) async {
     await TrainingPackLibraryV2.instance.reload();
     final library = TrainingPackLibraryV2.instance.packs;
 
     final base = mistakes.take(3).toList();
     final spots = <TrainingPackSpot>[...base];
+    final weakTags = await mastery.topWeakTags(2);
     for (final m in base) {
+      TrainingPackSpot? added;
       for (final tpl in library) {
         for (final s in tpl.spots) {
           if (s.hand.position == m.hand.position && s.street == m.street) {
-            spots.add(TrainingPackSpot.fromJson(s.toJson()));
-            break;
+            final tags = [for (final t in s.tags) t.toLowerCase()];
+            final hasWeak = weakTags.any((t) => tags.contains(t));
+            if (hasWeak) {
+              added = TrainingPackSpot.fromJson(s.toJson());
+              break;
+            }
+            added ??= TrainingPackSpot.fromJson(s.toJson());
           }
         }
-        if (spots.length >= base.length + 3) break;
+        if (added != null) break;
+      }
+      if (added != null && !spots.any((e) => e.id == added.id)) {
+        spots.add(added);
       }
       if (spots.length >= base.length + 3) break;
     }
 
     final positions = <HeroPosition>{for (final s in spots) s.hand.position};
+    final tagLabel = weakTags.isNotEmpty ? weakTags.first : 'основ';
     final tpl = TrainingPackTemplateV2(
       id: const Uuid().v4(),
-      name: 'Закрепление основ',
+      name: 'Закрепление: $tagLabel',
+      description: weakTags.isNotEmpty
+          ? 'Подборка для отработки слабого места: $tagLabel'
+          : '',
       trainingType: TrainingType.pushFold,
+      tags: List<String>.from(weakTags),
       spots: spots,
       spotCount: spots.length,
       created: DateTime.now(),


### PR DESCRIPTION
## Summary
- pick training spots using weakest tags
- include tag names in simplified pack name and description
- expose weakest tags via new `SkillMapService`
- display pack description on training session screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bedd7d940832a9be5aff021c7eaac