### PR TITLE
Add advanced training pack and adaptive challenge

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -10,6 +10,7 @@ import 'session_result_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/achievement_service.dart';
+import '../services/smart_review_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_session.dart';
 import 'pack_stats_screen.dart';
@@ -265,6 +266,12 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         postIcmPct: icmAfter,
         evSum: 0,
         icmSum: 0,
+      ));
+      unawaited(SmartReviewService.instance.registerCompletion(
+        total == 0 ? 0.0 : correct / total,
+        evAfter / 100,
+        icmAfter / 100,
+        context: context,
       ));
       final prefs = await SharedPreferences.getInstance();
       final acc = total == 0 ? 0.0 : correct * 100 / total;

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -18,6 +18,7 @@ import 'training_pack_template_editor_screen.dart';
 import '../../services/mistake_review_pack_service.dart';
 import '../../services/training_pack_stats_service.dart';
 import '../../services/training_pack_template_storage_service.dart';
+import '../../services/smart_review_service.dart';
 import '../../widgets/common/animated_line_chart.dart';
 
 class TrainingPackResultScreen extends StatefulWidget {
@@ -283,6 +284,12 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       postIcmPct: postIcm,
       evSum: _evDeltaSum,
       icmSum: _icmDeltaSum,
+    ));
+    unawaited(SmartReviewService.instance.registerCompletion(
+      _total == 0 ? 0.0 : _correct / _total,
+      postEv / 100,
+      postIcm / 100,
+      context: context,
     ));
     SharedPreferences.getInstance().then((p) =>
         p.setString('last_trained_tpl_${widget.original.id}', DateTime.now().toIso8601String()));


### PR DESCRIPTION
## Summary
- implement buildAdvancedPack in `TrainingPackTemplateBuilder`
- track session results in `SmartReviewService`
- prompt for advanced pack after three high-accuracy sessions
- start advanced challenge from session and result screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf0d8d924832aab269aa0a126c29b