### PR TITLE
Add Starter Path training flow

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -31,6 +31,7 @@ import '../widgets/quick_continue_card.dart';
 import '../widgets/daily_focus_recap_card.dart';
 import '../widgets/progress_summary_box.dart';
 import '../widgets/progress_summary_card.dart';
+import '../widgets/starter_path_card.dart';
 import '../widgets/position_progress_card.dart';
 import '../widgets/progress_forecast_card.dart';
 import '../widgets/player_style_card.dart';
@@ -101,6 +102,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
       ),
       body: ListView(
         children: [
+          const StarterPathCard(),
           if (tablet) const DailySpotlightCard(),
           _RecommendedCarousel(
             key: TrainingHomeScreen.recommendationsKey,

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -34,6 +34,7 @@ import '../../widgets/poker_table_view.dart' show PlayerAction;
 import 'package:uuid/uuid.dart';
 import '../../helpers/mistake_advice.dart';
 import '../../services/learning_path_progress_service.dart';
+import '../../services/learning_path_service.dart';
 
 
 enum PlayOrder { sequential, random, mistakes }
@@ -453,6 +454,9 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     _summaryShown = true;
     await LearningPathProgressService.instance
         .markCompleted(widget.original.id);
+    if (widget.original.tags.contains('starterPath')) {
+      await LearningPathService.instance.advance(widget.original.id);
+    }
     final spots = widget.spots ?? widget.template.spots;
     final tpl = widget.template.copyWith(spots: spots);
     await Navigator.pushReplacement(

--- a/lib/services/learning_path_service.dart
+++ b/lib/services/learning_path_service.dart
@@ -1,0 +1,102 @@
+import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/game_type.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../services/training_pack_template_service.dart';
+
+class LearningPathService {
+  LearningPathService._();
+  static final instance = LearningPathService._();
+
+  static const _progressKey = 'starter_path_progress';
+
+  Future<int> getStarterPathProgress() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_progressKey) ?? 0;
+  }
+
+  Future<void> _setProgress(int step) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_progressKey, step);
+  }
+
+  Future<void> resetStarterPath() => _setProgress(0);
+
+  Future<void> advance(String packId) async {
+    final list = buildStarterPath();
+    final progress = await getStarterPathProgress();
+    if (progress >= list.length) return;
+    if (list[progress].id == packId) {
+      await _setProgress(progress + 1);
+    }
+  }
+
+  List<TrainingPackTemplateV2> buildStarterPath() {
+    final pack1 = TrainingPackTemplateV2.fromTemplate(
+      TrainingPackTemplateService.starterPushfold10bb(),
+      type: TrainingType.pushFold,
+    )
+      ..name = 'Простейшие ситуации'
+      ..description = 'BTN push/fold 10bb, без ICM'
+      ..tags.addAll(['starterPath', 'step1'])
+      ..gameType = GameType.tournament
+      ..bb = 10
+      ..positions = ['btn'];
+
+    final pack2 = TrainingPackTemplateV2.fromTemplate(
+      TrainingPackTemplateService.starterPushfold15bb(),
+      type: TrainingType.pushFold,
+    )
+      ..name = 'Сложные решения'
+      ..description = 'SB push/fold 15bb, edge-case споты'
+      ..tags.addAll(['starterPath', 'step2'])
+      ..gameType = GameType.tournament
+      ..bb = 15
+      ..positions = ['sb'];
+
+    final pack3 = TrainingPackTemplateV2.fromTemplate(
+      TrainingPackTemplateService.starterPushfold12bb(),
+      type: TrainingType.pushFold,
+    )
+      ..name = 'ICM под давлением'
+      ..description = '8-10bb SB/BTN vs BB, разные стеки'
+      ..tags.addAll(['starterPath', 'step3'])
+      ..gameType = GameType.tournament
+      ..bb = 10
+      ..positions = ['sb', 'btn'];
+
+    final pack4 = TrainingPackTemplateV2.fromTemplate(
+      TrainingPackTemplateService.starterPushfold20bb(),
+      type: TrainingType.pushFold,
+    )
+      ..name = 'Ошибки новичков'
+      ..description = 'Часто ошибаемые споты'
+      ..tags.addAll(['starterPath', 'step4'])
+      ..gameType = GameType.tournament
+      ..bb = 20
+      ..positions = ['sb'];
+
+    final mixSpots = [
+      ...pack1.spots,
+      ...pack2.spots,
+      ...pack3.spots,
+      ...pack4.spots,
+    ]..shuffle(Random());
+    final pack5 = TrainingPackTemplateV2(
+      id: 'starter_path_test',
+      name: 'Финальный тест',
+      description: 'Рандомный микс из предыдущих ситуаций',
+      trainingType: TrainingType.pushFold,
+      spots: mixSpots.take(10).toList(),
+      spotCount: min(10, mixSpots.length),
+      gameType: GameType.tournament,
+      bb: 10,
+      positions: const ['sb', 'btn'],
+      tags: const ['starterPath', 'step5'],
+    );
+
+    return [pack1, pack2, pack3, pack4, pack5];
+  }
+}

--- a/lib/widgets/starter_path_card.dart
+++ b/lib/widgets/starter_path_card.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../services/learning_path_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class StarterPathCard extends StatefulWidget {
+  const StarterPathCard({super.key});
+
+  @override
+  State<StarterPathCard> createState() => _StarterPathCardState();
+}
+
+class _StarterPathCardState extends State<StarterPathCard> {
+  late Future<void> _future;
+  List<TrainingPackTemplateV2>? _packs;
+  int _progress = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<void> _load() async {
+    _packs = LearningPathService.instance.buildStarterPath();
+    _progress = await LearningPathService.instance.getStarterPathProgress();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<void>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        if (_packs == null) return const SizedBox.shrink();
+        final completed = _progress >= _packs!.length;
+        if (completed) {
+          return Container(
+            margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '🎯 Starter Path',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 4),
+                const Text('Путь завершен!',
+                    style: TextStyle(color: Colors.white)),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: OutlinedButton(
+                    onPressed: () async {
+                      await LearningPathService.instance.resetStarterPath();
+                      setState(() => _future = _load());
+                    },
+                    child: const Text('Сбросить'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+        final tpl = _packs![_progress];
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '🎯 Starter Path',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Шаг ${_progress + 1}/${_packs!.length}: ${tpl.name}',
+                style: const TextStyle(color: Colors.white),
+              ),
+              if (tpl.description.isNotEmpty)
+                Text(tpl.description,
+                    style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            TrainingPackPlayScreen(template: tpl, original: tpl),
+                      ),
+                    ).then((_) => setState(() => _future = _load()));
+                  },
+                  child: const Text('Продолжить путь'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `LearningPathService` with a `buildStarterPath` method
- track starter path progress in SharedPreferences
- show progress in new `StarterPathCard`
- add starter path card to home screen
- increment starter path progress on pack completion

## Testing
- `flutter` and `dart` commands unavailable, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687bf43200b8832a9ad6999b73075d69