### PR TITLE
Implement custom path tracking

### DIFF
--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -42,6 +42,8 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
 
     final global = await TrainingPackStatsService.getGlobalStats();
     final pathDone = await LearningPathProgressService.instance.isAllStagesCompleted();
+    final customStarted =
+        await LearningPathProgressService.instance.isCustomPathStarted();
     final weakTags = await context.read<TagMasteryService>().topWeakTags(1);
     final hasWeak = weakTags.isNotEmpty;
     final hasMistakes = SmartReviewService.instance.hasMistakes();
@@ -53,7 +55,7 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
         ev: global.averageEV,
         icm: global.averageEV,
         starterPathCompleted: pathDone,
-        customPathStarted: false,
+        customPathStarted: customStarted,
         hasWeakTags: hasWeak,
         hasMistakes: hasMistakes,
       ),
@@ -138,6 +140,9 @@ class _PackCard extends StatelessWidget {
     final pct = pack.pctComplete;
     return GestureDetector(
       onTap: () async {
+        if (pack.tags.contains('customPath')) {
+          await LearningPathProgressService.instance.markCustomPathStarted();
+        }
         await Navigator.push(
           context,
           MaterialPageRoute(builder: (_) => TrainingPackScreen(pack: pack)),

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -46,10 +46,12 @@ class LearningPathProgressService {
   static final instance = LearningPathProgressService._();
 
   static const _introKey = 'learning_intro_seen';
+  static const _customPathKey = 'custom_path_started';
 
   bool mock = false;
   final Map<String, bool> _mockCompleted = {};
   bool _mockIntroSeen = false;
+  bool _mockCustomPathStarted = false;
   bool unlockAllStages = false;
 
   /// Clears all learning path progress. Used for development/testing only.
@@ -91,6 +93,21 @@ class LearningPathProgressService {
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_introKey);
+  }
+
+  Future<void> markCustomPathStarted() async {
+    if (mock) {
+      _mockCustomPathStarted = true;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_customPathKey, true);
+  }
+
+  Future<bool> isCustomPathStarted() async {
+    if (mock) return _mockCustomPathStarted;
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_customPathKey) ?? false;
   }
 
   /// Resets both intro flag and stage progress.

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -11,6 +11,7 @@ import '../helpers/training_pack_storage.dart';
 import '../screens/training_session_summary_screen.dart';
 import 'mistake_review_pack_service.dart';
 import 'smart_review_service.dart';
+import 'learning_path_progress_service.dart';
 import 'cloud_training_history_service.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
@@ -316,6 +317,10 @@ class TrainingSessionService extends ChangeNotifier {
   }) async {
     if (persist) await _openBox();
     unawaited(DailyReminderScheduler.instance.cancelAll());
+    if (template.tags.contains('customPath')) {
+      unawaited(
+          LearningPathProgressService.instance.markCustomPathStarted());
+    }
     _template = template;
     final total = template.totalWeight;
     _preEvPct = total == 0 ? 0 : template.evCovered * 100 / total;

--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -69,4 +69,12 @@ void main() {
     expect(stages.first.items.first.status, LearningItemStatus.available);
     expect(stages.first.items[1].status, LearningItemStatus.locked);
   });
+
+  test('custom path flag persists', () async {
+    var started = await LearningPathProgressService.instance.isCustomPathStarted();
+    expect(started, isFalse);
+    await LearningPathProgressService.instance.markCustomPathStarted();
+    started = await LearningPathProgressService.instance.isCustomPathStarted();
+    expect(started, isTrue);
+  });
 }

--- a/test/services/training_session_service_test.dart
+++ b/test/services/training_session_service_test.dart
@@ -3,6 +3,7 @@ import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/training_pack_template.dart';
 import 'package:poker_analyzer/services/training_session_service.dart';
 import 'package:poker_analyzer/services/smart_review_service.dart';
+import 'package:poker_analyzer/services/learning_path_progress_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -24,5 +25,19 @@ void main() {
     service.submitResult('a', 'fold', true);
     expect(service.results['a'], true);
     expect(service.correctCount, 1);
+  });
+
+  test('custom path session marks started flag', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SmartReviewService.instance.load();
+    LearningPathProgressService.instance
+      ..mock = true;
+    await LearningPathProgressService.instance.resetProgress();
+    final spot = TrainingPackSpot(id: 'c');
+    final tpl = TrainingPackTemplate(id: 'c', name: 'c', spots: [spot], tags: ['customPath']);
+    final service = TrainingSessionService();
+    await service.startSession(tpl, persist: false);
+    final started = await LearningPathProgressService.instance.isCustomPathStarted();
+    expect(started, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- track when a custom learning path has started
- record start automatically when opening custom packs or starting sessions
- consult the flag in the recommendation screen
- test custom path flag behaviour

## Testing
- `flutter pub get`
- `flutter test --run-skipped` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_687bfb27f098832aaca6da67d452fe39