### PR TITLE
Add custom path completion tracking

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -1964,6 +1964,13 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
+                title: const Text('🧹 Сбросить кастомный путь'),
+                onTap: () async {
+                  await LearningPathProgressService.instance.resetCustomPath();
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
                 title: const Text('🔔 Проверить напоминание'),
                 onTap: _reminderLoading ? null : _checkTrainingReminder,
               ),

--- a/lib/screens/training_recommendation_screen.dart
+++ b/lib/screens/training_recommendation_screen.dart
@@ -44,6 +44,8 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
     final pathDone = await LearningPathProgressService.instance.isAllStagesCompleted();
     final customStarted =
         await LearningPathProgressService.instance.isCustomPathStarted();
+    final customCompleted =
+        await LearningPathProgressService.instance.isCustomPathCompleted();
     final weakTags = await context.read<TagMasteryService>().topWeakTags(1);
     final hasWeak = weakTags.isNotEmpty;
     final hasMistakes = SmartReviewService.instance.hasMistakes();
@@ -56,6 +58,7 @@ class _TrainingRecommendationScreenState extends State<TrainingRecommendationScr
         icm: global.averageEV,
         starterPathCompleted: pathDone,
         customPathStarted: customStarted,
+        customPathCompleted: customCompleted,
         hasWeakTags: hasWeak,
         hasMistakes: hasMistakes,
       ),

--- a/lib/services/learning_path_progress_service.dart
+++ b/lib/services/learning_path_progress_service.dart
@@ -47,11 +47,13 @@ class LearningPathProgressService {
 
   static const _introKey = 'learning_intro_seen';
   static const _customPathKey = 'custom_path_started';
+  static const _customPathCompletedKey = 'custom_path_completed';
 
   bool mock = false;
   final Map<String, bool> _mockCompleted = {};
   bool _mockIntroSeen = false;
   bool _mockCustomPathStarted = false;
+  bool _mockCustomPathCompleted = false;
   bool unlockAllStages = false;
 
   /// Clears all learning path progress. Used for development/testing only.
@@ -110,10 +112,37 @@ class LearningPathProgressService {
     return prefs.getBool(_customPathKey) ?? false;
   }
 
+  Future<void> markCustomPathCompleted() async {
+    if (mock) {
+      _mockCustomPathCompleted = true;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_customPathCompletedKey, true);
+  }
+
+  Future<bool> isCustomPathCompleted() async {
+    if (mock) return _mockCustomPathCompleted;
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_customPathCompletedKey) ?? false;
+  }
+
+  Future<void> resetCustomPath() async {
+    if (mock) {
+      _mockCustomPathStarted = false;
+      _mockCustomPathCompleted = false;
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_customPathKey);
+    await prefs.remove(_customPathCompletedKey);
+  }
+
   /// Resets both intro flag and stage progress.
   Future<void> resetAll() async {
     await resetProgress();
     await resetIntroSeen();
+    await resetCustomPath();
   }
 
   Future<void> markCompleted(String templateId) async {

--- a/lib/services/next_step_advisor_service.dart
+++ b/lib/services/next_step_advisor_service.dart
@@ -8,6 +8,7 @@ class LearningStats {
   final double icm;
   final bool starterPathCompleted;
   final bool customPathStarted;
+  final bool customPathCompleted;
   final bool hasWeakTags;
   final bool hasMistakes;
 
@@ -18,6 +19,7 @@ class LearningStats {
     required this.icm,
     required this.starterPathCompleted,
     required this.customPathStarted,
+    required this.customPathCompleted,
     required this.hasWeakTags,
     required this.hasMistakes,
   });
@@ -68,6 +70,13 @@ class NextStepAdvisorService {
         title: 'Начать новый путь',
         description: 'Вы готовы приступить к следующему обучающему пути.',
         action: 'start_new_path',
+      );
+    }
+    if (stats.customPathStarted && !stats.customPathCompleted) {
+      return const NextStepAdvice(
+        title: 'Завершить кастомный путь',
+        description: 'Вы почти у цели. Доведите кастомный путь до конца.',
+        action: 'finish_custom_path',
       );
     }
     return const NextStepAdvice(

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -512,6 +512,10 @@ class TrainingSessionService extends ChangeNotifier {
     _session!.index += 1;
     if (_session!.index >= _spots.length) {
       _session!.completedAt = DateTime.now();
+      if (_template?.tags.contains('customPath') ?? false) {
+        unawaited(
+            LearningPathProgressService.instance.markCustomPathCompleted());
+      }
       if (!_paused && _resumedAt != null) {
         _accumulated += DateTime.now().difference(_resumedAt!);
         _resumedAt = null;

--- a/test/services/learning_path_progress_service_test.dart
+++ b/test/services/learning_path_progress_service_test.dart
@@ -10,6 +10,7 @@ void main() {
     LearningPathProgressService.instance
       ..mock = true;
     await LearningPathProgressService.instance.resetProgress();
+    await LearningPathProgressService.instance.resetCustomPath();
   });
 
   test('first item available when nothing completed', () async {
@@ -76,5 +77,13 @@ void main() {
     await LearningPathProgressService.instance.markCustomPathStarted();
     started = await LearningPathProgressService.instance.isCustomPathStarted();
     expect(started, isTrue);
+  });
+
+  test('custom path completion flag persists', () async {
+    var done = await LearningPathProgressService.instance.isCustomPathCompleted();
+    expect(done, isFalse);
+    await LearningPathProgressService.instance.markCustomPathCompleted();
+    done = await LearningPathProgressService.instance.isCustomPathCompleted();
+    expect(done, isTrue);
   });
 }

--- a/test/services/next_step_advisor_service_test.dart
+++ b/test/services/next_step_advisor_service_test.dart
@@ -12,6 +12,7 @@ void main() {
       icm: 0,
       starterPathCompleted: false,
       customPathStarted: false,
+      customPathCompleted: false,
       hasWeakTags: false,
       hasMistakes: true,
     );
@@ -27,6 +28,7 @@ void main() {
       icm: 0,
       starterPathCompleted: false,
       customPathStarted: false,
+      customPathCompleted: false,
       hasWeakTags: true,
       hasMistakes: false,
     );
@@ -42,6 +44,7 @@ void main() {
       icm: 0,
       starterPathCompleted: false,
       customPathStarted: false,
+      customPathCompleted: false,
       hasWeakTags: false,
       hasMistakes: false,
     );
@@ -57,11 +60,28 @@ void main() {
       icm: 0,
       starterPathCompleted: true,
       customPathStarted: false,
+      customPathCompleted: false,
       hasWeakTags: false,
       hasMistakes: false,
     );
     final advice = service.recommend(stats: stats);
     expect(advice.title, 'Начать новый путь');
+  });
+
+  test('recommends finishing custom path when started', () {
+    const stats = LearningStats(
+      completedPacks: 5,
+      accuracy: 0.9,
+      ev: 0,
+      icm: 0,
+      starterPathCompleted: true,
+      customPathStarted: true,
+      customPathCompleted: false,
+      hasWeakTags: false,
+      hasMistakes: false,
+    );
+    final advice = service.recommend(stats: stats);
+    expect(advice.title, 'Завершить кастомный путь');
   });
 
   test('fallback to playing recommended pack', () {
@@ -72,6 +92,7 @@ void main() {
       icm: 1,
       starterPathCompleted: true,
       customPathStarted: true,
+      customPathCompleted: true,
       hasWeakTags: false,
       hasMistakes: false,
     );

--- a/test/services/training_session_service_test.dart
+++ b/test/services/training_session_service_test.dart
@@ -33,11 +33,28 @@ void main() {
     LearningPathProgressService.instance
       ..mock = true;
     await LearningPathProgressService.instance.resetProgress();
+    await LearningPathProgressService.instance.resetCustomPath();
     final spot = TrainingPackSpot(id: 'c');
     final tpl = TrainingPackTemplate(id: 'c', name: 'c', spots: [spot], tags: ['customPath']);
     final service = TrainingSessionService();
     await service.startSession(tpl, persist: false);
     final started = await LearningPathProgressService.instance.isCustomPathStarted();
     expect(started, isTrue);
+  });
+
+  test('custom path completion marked after finish', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SmartReviewService.instance.load();
+    LearningPathProgressService.instance
+      ..mock = true;
+    await LearningPathProgressService.instance.resetProgress();
+    await LearningPathProgressService.instance.resetCustomPath();
+    final spot = TrainingPackSpot(id: 'd');
+    final tpl = TrainingPackTemplate(id: 'd', name: 'd', spots: [spot], tags: ['customPath']);
+    final service = TrainingSessionService();
+    await service.startSession(tpl, persist: false);
+    service.nextSpot();
+    final done = await LearningPathProgressService.instance.isCustomPathCompleted();
+    expect(done, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- track completion of custom learning paths
- update advice rules to handle custom path completion
- surface completion state in recommendations
- expose dev menu option to reset custom path status
- test coverage for new logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd7421f8832ab0d0720377a09f37