### PR TITLE
Add centralized pack unlocking rules engine

### DIFF
--- a/lib/models/unlock_rule.dart
+++ b/lib/models/unlock_rule.dart
@@ -1,0 +1,17 @@
+class UnlockRule {
+  final String id;
+  final String? unlockHint;
+  final String? requiresPackCompleted;
+  final double? requiresEV;
+  final String? requiresGoal;
+  final String? requiresStageCompleted;
+
+  const UnlockRule({
+    required this.id,
+    this.unlockHint,
+    this.requiresPackCompleted,
+    this.requiresEV,
+    this.requiresGoal,
+    this.requiresStageCompleted,
+  });
+}

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -834,9 +834,12 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final unlocked = <String, bool>{};
     final reasons = <String, String?>{};
     for (final p in list) {
-      final res = await PackUnlockingRulesEngine.instance.check(p);
-      unlocked[p.id] = res.unlocked;
-      reasons[p.id] = res.reason;
+      final unlockedRes =
+          await PackUnlockingRulesEngine.instance.isUnlocked(p);
+      unlocked[p.id] = unlockedRes;
+      reasons[p.id] = unlockedRes
+          ? null
+          : PackUnlockingRulesEngine.instance.getUnlockRule(p)?.unlockHint;
     }
     if (!mounted) return;
     setState(() {

--- a/lib/services/pack_unlocking_rules_engine.dart
+++ b/lib/services/pack_unlocking_rules_engine.dart
@@ -1,5 +1,6 @@
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/unlock_rules.dart';
+import '../models/unlock_rule.dart';
 import 'learning_path_progress_service.dart';
 import 'learning_path_service.dart';
 import 'training_pack_stats_service.dart';
@@ -18,25 +19,55 @@ class PackUnlockingRulesEngine {
   final Set<String> _mockCompleted = {};
   double _mockAverageEV = 0;
   bool _mockStarterCompleted = false;
+  bool _mockCustomPathCompleted = false;
+
+  final Map<String, UnlockRule> _rules = {
+    // Example rule for demonstration
+    'advanced_pack': const UnlockRule(
+      id: 'advanced_pack',
+      unlockHint: 'Завершите пак 10BB Starter',
+      requiresPackCompleted: 'starter_pushfold_10bb',
+      requiresEV: 0.85,
+      requiresGoal: 'completed_customPath',
+    ),
+  };
 
   set mockAverageEV(double v) => _mockAverageEV = v;
   set mockStarterPathCompleted(bool v) => _mockStarterCompleted = v;
+  set mockCustomPathCompleted(bool v) => _mockCustomPathCompleted = v;
+
+  UnlockRule? getUnlockRule(TrainingPackTemplateV2 pack) {
+    return _rules[pack.id];
+  }
 
   Future<UnlockCheckResult> check(TrainingPackTemplateV2 pack) async {
-    final rules = pack.unlockRules;
+    final rules = getUnlockRule(pack) ?? pack.unlockRules == null
+        ? null
+        : UnlockRule(
+            id: pack.id,
+            unlockHint: pack.unlockRules!.unlockHint,
+            requiresPackCompleted:
+                pack.unlockRules!.requiredPacks.isNotEmpty
+                    ? pack.unlockRules!.requiredPacks.first
+                    : null,
+            requiresEV: pack.unlockRules!.minEV,
+            requiresStageCompleted: pack.unlockRules!.requiresStarterPathCompleted == true
+                ? 'starter'
+                : null,
+          );
     if (rules == null) return const UnlockCheckResult(true);
     String? hint = rules.unlockHint;
 
-    if (rules.requiredPacks.isNotEmpty) {
-      for (final id in rules.requiredPacks) {
+    if (rules.requiresPackCompleted != null) {
+      final id = rules.requiresPackCompleted!;
         final done = mock
             ? _mockCompleted.contains(id)
             : await LearningPathProgressService.instance.isCompleted(id);
-        if (!done) return UnlockCheckResult(false, hint ?? 'Завершите пак $id');
-      }
+      if (!done) return UnlockCheckResult(false, hint ?? 'Завершите пак $id');
     }
 
-    if (rules.requiresStarterPathCompleted == true) {
+    if (rules.requiresStageCompleted != null &&
+        rules.requiresStageCompleted == 'starter') {
       final completed = mock
           ? _mockStarterCompleted
           : await _isStarterPathCompleted();
@@ -45,14 +76,27 @@ class PackUnlockingRulesEngine {
       }
     }
 
-    if (rules.minEV != null) {
+    if (rules.requiresEV != null) {
       final ev = mock
           ? _mockAverageEV
           : (await TrainingPackStatsService.getGlobalStats()).averageEV;
-      if (ev < rules.minEV!) {
+      if (ev < rules.requiresEV!) {
         return UnlockCheckResult(
             false,
-            hint ?? 'Средний EV < ${rules.minEV!.toStringAsFixed(2)}');
+            hint ?? 'Средний EV < ${rules.requiresEV!.toStringAsFixed(2)}');
+      }
+    }
+
+    if (rules.requiresGoal != null) {
+      bool achieved = false;
+      if (rules.requiresGoal == 'completed_customPath') {
+        achieved = mock
+            ? _mockCustomPathCompleted
+            : await LearningPathProgressService.instance
+                .isCustomPathCompleted();
+      }
+      if (!achieved) {
+        return UnlockCheckResult(false, hint);
       }
     }
 
@@ -75,5 +119,6 @@ class PackUnlockingRulesEngine {
     _mockCompleted.clear();
     _mockAverageEV = 0;
     _mockStarterCompleted = false;
+    _mockCustomPathCompleted = false;
   }
 }

--- a/test/pack_unlocking_rules_engine_test.dart
+++ b/test/pack_unlocking_rules_engine_test.dart
@@ -22,8 +22,8 @@ void main() {
       trainingType: TrainingType.pushFold,
       unlockRules: const UnlockRules(requiredPacks: ['a']),
     );
-    final res = await PackUnlockingRulesEngine.instance.check(tpl);
-    expect(res.unlocked, isFalse);
+    final unlocked = await PackUnlockingRulesEngine.instance.isUnlocked(tpl);
+    expect(unlocked, isFalse);
   });
 
   test('unlocked when requirements met', () async {
@@ -36,8 +36,8 @@ void main() {
     PackUnlockingRulesEngine.instance
       ..markMockCompleted('a')
       ..mockAverageEV = 1.5;
-    final res = await PackUnlockingRulesEngine.instance.check(tpl);
-    expect(res.unlocked, isTrue);
+    final unlocked = await PackUnlockingRulesEngine.instance.isUnlocked(tpl);
+    expect(unlocked, isTrue);
   });
 
   test('uses unlock hint when provided', () async {
@@ -50,8 +50,9 @@ void main() {
         unlockHint: 'Complete pack A first',
       ),
     );
-    final res = await PackUnlockingRulesEngine.instance.check(tpl);
-    expect(res.unlocked, isFalse);
-    expect(res.reason, 'Complete pack A first');
+    final unlocked = await PackUnlockingRulesEngine.instance.isUnlocked(tpl);
+    expect(unlocked, isFalse);
+    expect(PackUnlockingRulesEngine.instance.getUnlockRule(tpl)?.unlockHint,
+        'Complete pack A first');
   });
 }


### PR DESCRIPTION
## Summary
- centralize unlocking logic via `UnlockRule`
- extend `PackUnlockingRulesEngine` to check new rules map
- adjust template library screen to use the engine
- update unit tests

## Testing
- `flutter test test/pack_unlocking_rules_engine_test.dart` *(fails: Package file_picker and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c05e752bc832aa7c2eb9b55eeb0ea