### PR TITLE
Add lock indicators to training packs

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1875,6 +1875,13 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                   trainingTypeBadge(t.trainingType.name, compact: true),
                 ],
               ),
+              if (locked && reason != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(reason!,
+                      style:
+                          const TextStyle(color: Colors.redAccent, fontSize: 12)),
+                ),
               if (t.category != null && t.category!.isNotEmpty)
                 Text(
                   translateCategory(t.category),
@@ -1918,19 +1925,19 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           children: [
             Opacity(opacity: 0.5, child: widget),
             Positioned.fill(
-              child: Container(
-                color: Colors.black45,
-                alignment: Alignment.center,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Text('🔒 Заблокировано',
-                        style: TextStyle(color: Colors.white)),
-                    if (reason != null)
-                      Text(reason!,
-                          style:
-                              const TextStyle(color: Colors.white, fontSize: 12)),
-                  ],
+              child: Tooltip(
+                message: reason == null
+                    ? 'Пак заблокирован'
+                    : 'Чтобы разблокировать: $reason',
+                child: InkWell(
+                  onTap: reason != null
+                      ? () => _showUnlockHint(reason!)
+                      : null,
+                  child: Container(
+                    color: Colors.black54,
+                    alignment: Alignment.center,
+                    child: const Icon(Icons.lock, color: Colors.white, size: 40),
+                  ),
                 ),
               ),
             ),
@@ -2157,19 +2164,18 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
         children: [
           Opacity(opacity: 0.5, child: widget),
           Positioned.fill(
-            child: Container(
-              color: Colors.black45,
-              alignment: Alignment.center,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Text('🔒 Заблокировано',
-                      style: TextStyle(color: Colors.white)),
-                  if (reason != null)
-                    Text(reason!,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 12)),
-                ],
+            child: Tooltip(
+              message: reason == null
+                  ? 'Пак заблокирован'
+                  : 'Чтобы разблокировать: $reason',
+              child: InkWell(
+                onTap:
+                    reason != null ? () => _showUnlockHint(reason!) : null,
+                child: Container(
+                  color: Colors.black54,
+                  alignment: Alignment.center,
+                  child: const Icon(Icons.lock, color: Colors.white, size: 40),
+                ),
               ),
             ),
           ),
@@ -2282,6 +2288,22 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     );
   }
 
+  void _showUnlockHint(String reason) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Заблокировано'),
+        content: Text('Чтобы разблокировать: $reason'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _libraryTile(v2.TrainingPackTemplate t) {
     Widget row(IconData icon, String text) => Padding(
           padding: const EdgeInsets.only(bottom: 4),
@@ -2319,7 +2341,19 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               ),
           ],
         ),
-        subtitle: Text(t.goal, maxLines: 2, overflow: TextOverflow.ellipsis),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(t.goal, maxLines: 2, overflow: TextOverflow.ellipsis),
+            if (locked && reason != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(reason!,
+                    style:
+                        const TextStyle(color: Colors.redAccent, fontSize: 12)),
+              ),
+          ],
+        ),
         children: [
           if (t.goal.isNotEmpty) row(Icons.flag, t.goal),
           if (t.tags.isNotEmpty) row(Icons.sell, t.tags.join(', ')),

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -16,6 +16,8 @@ class TrainingPackCard extends StatefulWidget {
   final int? progress;
   final Future<void> Function()? onRefresh;
   final bool dimmed;
+  final bool locked;
+  final String? lockReason;
   const TrainingPackCard({
     super.key,
     required this.template,
@@ -23,6 +25,8 @@ class TrainingPackCard extends StatefulWidget {
     this.progress,
     this.onRefresh,
     this.dimmed = false,
+    this.locked = false,
+    this.lockReason,
   });
 
   @override
@@ -71,7 +75,29 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
     await widget.onRefresh?.call();
   }
 
+  void _showUnlockHint() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Заблокировано'),
+        content: Text('Чтобы разблокировать: ${widget.lockReason}'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          )
+        ],
+      ),
+    );
+  }
+
   Future<void> _handleTap() async {
+    if (widget.locked) {
+      if (widget.lockReason != null) {
+        _showUnlockHint();
+      }
+      return;
+    }
     if (!_passed) {
       widget.onTap();
       return;
@@ -245,6 +271,15 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
                           ),
                         ],
                       ),
+                      if (widget.locked && widget.lockReason != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            widget.lockReason!,
+                            style: const TextStyle(
+                                color: Colors.redAccent, fontSize: 12),
+                          ),
+                        ),
                       if (widget.template.description.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(top: 4),
@@ -297,7 +332,7 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
-                  onPressed: _handleTap,
+                  onPressed: widget.locked ? null : _handleTap,
                   child: const Text('Train'),
                 ),
                 PopupMenuButton<String>(
@@ -423,6 +458,22 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
                         ),
                       ),
                   ],
+                ),
+              ),
+            if (widget.locked)
+              Positioned.fill(
+                child: Tooltip(
+                  message: widget.lockReason == null
+                      ? 'Пак заблокирован'
+                      : 'Чтобы разблокировать: ${widget.lockReason}',
+                  child: InkWell(
+                    onTap: widget.lockReason != null ? _showUnlockHint : null,
+                    child: Container(
+                      color: Colors.black54,
+                      alignment: Alignment.center,
+                      child: const Icon(Icons.lock, color: Colors.white, size: 40),
+                    ),
+                  ),
                 ),
               ),
           ],


### PR DESCRIPTION
## Summary
- show lock status in `TrainingPackCard`
- display unlock hints in `TemplateLibraryScreen`
- add overlays with lock icon and tooltip for locked packs

## Testing
- `flutter analyze` *(fails: creation_with_non_type, undefined_getter, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c0b969344832a8392abe8c665c919