### PR TITLE
Implement pack dependency unlocking

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -35,6 +35,7 @@ import '../services/training_pack_suggestion_service.dart';
 import '../services/smart_suggestion_engine.dart';
 import '../services/yaml_pack_balance_analyzer.dart';
 import '../services/pack_library_loader_service.dart';
+import '../services/pack_dependency_map.dart';
 import '../services/training_goal_suggestion_engine.dart';
 import '../services/smart_goal_recommender_service.dart';
 import '../services/session_log_service.dart';
@@ -1967,6 +1968,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 title: const Text('🧹 Сбросить кастомный путь'),
                 onTap: () async {
                   await LearningPathProgressService.instance.resetCustomPath();
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🔄 Пересчитать доступные паки'),
+                onTap: () async {
+                  await PackDependencyMap.instance.recalc();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Паки пересчитаны')));
+                  }
                 },
               ),
             if (kDebugMode)

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -40,6 +40,8 @@ import '../../services/tag_mastery_service.dart';
 import '../../services/training_pack_template_builder.dart';
 import '../../services/training_session_service.dart';
 import '../training_recommendation_screen.dart';
+import '../../services/pack_dependency_map.dart';
+import '../../services/pack_library_loader_service.dart';
 
 
 enum PlayOrder { sequential, random, mistakes }
@@ -459,6 +461,19 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     _summaryShown = true;
     await LearningPathProgressService.instance
         .markCompleted(widget.original.id);
+    final newly =
+        await PackDependencyMap.instance.getUnlockedAfter(widget.original.id);
+    if (newly.isNotEmpty && mounted) {
+      final lib = PackLibraryLoaderService.instance.library;
+      for (final id in newly) {
+        final pack = lib.firstWhereOrNull((p) => p.id == id);
+        if (pack != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('\uD83D\uDD13 Новый пак разблокирован: ${pack.name}')),
+          );
+        }
+      }
+    }
     final isFinalStep =
         widget.original.tags.contains('starterPath') &&
             widget.original.tags.contains('step5');

--- a/lib/services/pack_dependency_map.dart
+++ b/lib/services/pack_dependency_map.dart
@@ -1,0 +1,72 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'learning_path_progress_service.dart';
+import 'pack_library_loader_service.dart';
+
+class PackDependencyMap {
+  PackDependencyMap._();
+  static final instance = PackDependencyMap._();
+
+  static const _prefsKey = 'unlocked_pack_ids';
+
+  final Map<String, List<String>> _deps = {};
+  final Map<String, List<String>> _reverse = {};
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final library = await PackLibraryLoaderService.instance.loadLibrary();
+    for (final pack in library) {
+      final req = pack.unlockRules?.requiredPacks ?? const [];
+      if (req.isNotEmpty) {
+        _deps[pack.id] = req;
+        for (final r in req) {
+          _reverse.putIfAbsent(r, () => []).add(pack.id);
+        }
+      }
+    }
+    _loaded = true;
+  }
+
+  Future<List<String>> getUnlockedAfter(String packId) async {
+    await _load();
+    final prefs = await SharedPreferences.getInstance();
+    final unlocked = prefs.getStringList(_prefsKey) ?? <String>[];
+    final dependents = _reverse[packId] ?? const [];
+    final newlyUnlocked = <String>[];
+    for (final dep in dependents) {
+      if (unlocked.contains(dep)) continue;
+      final reqs = _deps[dep] ?? const [];
+      final allDone = await Future.wait(
+              reqs.map((r) => LearningPathProgressService.instance.isCompleted(r)))
+          .then((v) => v.every((e) => e));
+      if (allDone) {
+        unlocked.add(dep);
+        newlyUnlocked.add(dep);
+      }
+    }
+    if (newlyUnlocked.isNotEmpty) {
+      await prefs.setStringList(_prefsKey, unlocked);
+    }
+    return newlyUnlocked;
+  }
+
+  Future<void> recalc() async {
+    await _load();
+    final prefs = await SharedPreferences.getInstance();
+    final unlocked = <String>[];
+    for (final entry in _deps.entries) {
+      final reqs = entry.value;
+      final allDone = await Future.wait(
+              reqs.map((r) => LearningPathProgressService.instance.isCompleted(r)))
+          .then((v) => v.every((e) => e));
+      if (allDone) unlocked.add(entry.key);
+    }
+    await prefs.setStringList(_prefsKey, unlocked);
+  }
+
+  Future<List<String>> getUnlockedPackIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_prefsKey) ?? <String>[];
+  }
+}


### PR DESCRIPTION
## Summary
- add `PackDependencyMap` to manage pack dependencies
- unlock dependent packs automatically when a pack is completed
- persist unlocked pack IDs in `SharedPreferences`
- provide dev menu option to recalc available packs
- show snackbar notification for newly unlocked packs

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0faa778c832ab31fed8f52dcdbcb