### PR TITLE
Add AutoAdvancePackEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -88,6 +88,9 @@ import 'yaml_pack_archive_stats_screen.dart';
 import 'yaml_pack_archive_duplicates_screen.dart';
 import 'yaml_pack_archive_validator_screen.dart';
 import 'yaml_pack_validator_screen.dart';
+import '../services/auto_advance_pack_engine.dart';
+import '../services/training_session_service.dart';
+import 'training_session_screen.dart';
 
 import 'pack_tag_analyzer_screen.dart';
 
@@ -150,6 +153,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _reminderLoading = false;
   bool _progressExportLoading = false;
   bool _progressImportLoading = false;
+  bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
@@ -1379,6 +1383,25 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _progressImportLoading = false);
   }
 
+  Future<void> _autoAdvancePack() async {
+    if (_autoAdvanceLoading || !kDebugMode) return;
+    setState(() => _autoAdvanceLoading = true);
+    final tpl = await AutoAdvancePackEngine.instance.getNextRecommendedPack();
+    if (!mounted) return;
+    setState(() => _autoAdvanceLoading = false);
+    if (tpl == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Путь завершен')),
+      );
+      return;
+    }
+    await context.read<TrainingSessionService>().startSession(tpl);
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -1958,6 +1981,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     MaterialPageRoute(builder: (_) => screen),
                   );
                 },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🎯 Следующий обучающий пак'),
+                onTap: _autoAdvanceLoading ? null : _autoAdvancePack,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/auto_advance_pack_engine.dart
+++ b/lib/services/auto_advance_pack_engine.dart
@@ -1,0 +1,38 @@
+import 'package:collection/collection.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'learning_path_progress_service.dart';
+import 'pack_library_service.dart';
+
+/// Provides the next training pack along the learning path.
+class AutoAdvancePackEngine {
+  AutoAdvancePackEngine._();
+  static final instance = AutoAdvancePackEngine._();
+
+  /// When true, templates are taken from [_mockTemplates] instead of assets.
+  bool mock = false;
+  final Map<String, TrainingPackTemplateV2> _mockTemplates = {};
+
+  /// Registers a template used when [mock] is true.
+  void registerMockTemplate(TrainingPackTemplateV2 tpl) {
+    _mockTemplates[tpl.id] = tpl;
+  }
+
+  /// Clears all registered mock templates.
+  void resetMock() => _mockTemplates.clear();
+
+  /// Returns the next recommended training pack or `null` if all are done.
+  Future<TrainingPackTemplateV2?> getNextRecommendedPack() async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final activeStage = stages.firstWhereOrNull(
+      (s) => !LearningPathProgressService.instance.isStageCompleted(s.items),
+    );
+    if (activeStage == null) return null;
+    final item = activeStage.items.firstWhereOrNull(
+      (i) => i.templateId != null && i.status != LearningItemStatus.completed,
+    );
+    if (item == null || item.templateId == null) return null;
+    final id = item.templateId!;
+    if (mock) return _mockTemplates[id];
+    return PackLibraryService.instance.getById(id);
+  }
+}

--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -14,4 +14,10 @@ class PackLibraryService {
     }
     return list.isNotEmpty ? list.first : null;
   }
+
+  /// Loads a template by [id] from the library.
+  Future<TrainingPackTemplateV2?> getById(String id) async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    return TrainingPackLibraryV2.instance.getById(id);
+  }
 }

--- a/test/services/auto_advance_pack_engine_test.dart
+++ b/test/services/auto_advance_pack_engine_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/auto_advance_pack_engine.dart';
+import 'package:poker_analyzer/services/learning_path_progress_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    LearningPathProgressService.instance
+      ..mock = true;
+    await LearningPathProgressService.instance.resetProgress();
+    AutoAdvancePackEngine.instance
+      ..mock = true
+      ..resetMock()
+      ..registerMockTemplate(TrainingPackTemplateV2(
+        id: 'starter_pushfold_10bb',
+        name: 'A',
+        trainingType: TrainingType.pushFold,
+      ))
+      ..registerMockTemplate(TrainingPackTemplateV2(
+        id: 'starter_pushfold_15bb',
+        name: 'B',
+        trainingType: TrainingType.pushFold,
+      ));
+  });
+
+  test('returns first pack when none completed', () async {
+    final tpl = await AutoAdvancePackEngine.instance.getNextRecommendedPack();
+    expect(tpl?.id, 'starter_pushfold_10bb');
+  });
+
+  test('returns next pack after completion', () async {
+    await LearningPathProgressService.instance.markCompleted('starter_pushfold_10bb');
+    final tpl = await AutoAdvancePackEngine.instance.getNextRecommendedPack();
+    expect(tpl?.id, 'starter_pushfold_15bb');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `AutoAdvancePackEngine` to auto select next training pack
- expose `getById` in `PackLibraryService`
- add dev menu button to launch next learning pack
- add tests for the new engine

## Testing
- `flutter analyze` *(fails: The current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_687c13503fdc832aa75d8800074bb959