### PR TITLE
Implement SmartStageUnlockEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -70,6 +70,7 @@ import 'yaml_pack_previewer_screen.dart';
 import 'yaml_pack_editor_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
+import '../services/smart_stage_unlock_engine.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -2021,6 +2022,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                   setState(() => _unlockStages = v ?? false);
                   LearningPathProgressService.instance.unlockAllStages =
                       _unlockStages;
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🔓 Принудительно открыть следующую стадию'),
+                onTap: () async {
+                  await SmartStageUnlockEngine.instance.forceUnlockNextStage();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Next stage unlocked')),
+                    );
+                  }
                 },
               ),
             if (kDebugMode)

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -29,6 +29,7 @@ import '../services/learning_path_progress_service.dart';
 import '../services/daily_learning_goal_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/pack_library_loader_service.dart';
+import '../services/smart_stage_unlock_engine.dart';
 import 'package:collection/collection.dart';
 
 class _EndlessStats {
@@ -280,6 +281,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       final acc = total == 0 ? 0.0 : correct * 100 / total;
       await prefs.setBool('completed_tpl_${tpl.id}', true);
       await LearningPathProgressService.instance.markCompleted(tpl.id);
+      await SmartStageUnlockEngine.instance.checkAndUnlockNextStage();
       final newly = await PackDependencyMap.instance.getUnlockedAfter(tpl.id);
       if (newly.isNotEmpty && mounted) {
         final lib = PackLibraryLoaderService.instance.library;

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -42,6 +42,7 @@ import '../../services/training_session_service.dart';
 import '../training_recommendation_screen.dart';
 import '../../services/pack_dependency_map.dart';
 import '../../services/pack_library_loader_service.dart';
+import '../../services/smart_stage_unlock_engine.dart';
 
 
 enum PlayOrder { sequential, random, mistakes }
@@ -461,6 +462,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     _summaryShown = true;
     await LearningPathProgressService.instance
         .markCompleted(widget.original.id);
+    await SmartStageUnlockEngine.instance.checkAndUnlockNextStage();
     final newly =
         await PackDependencyMap.instance.getUnlockedAfter(widget.original.id);
     if (newly.isNotEmpty && mounted) {

--- a/lib/services/smart_stage_unlock_engine.dart
+++ b/lib/services/smart_stage_unlock_engine.dart
@@ -1,0 +1,63 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'learning_path_progress_service.dart';
+
+class SmartStageUnlockEngine {
+  SmartStageUnlockEngine._();
+  static final instance = SmartStageUnlockEngine._();
+
+  static const _prefsKey = 'smart_unlocked_stages';
+
+  bool mock = false;
+  final Set<String> _mockUnlocked = {};
+
+  Future<List<String>> _loadUnlocked() async {
+    if (mock) return _mockUnlocked.toList();
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_prefsKey) ?? <String>[];
+  }
+
+  Future<void> _saveUnlocked(List<String> stages) async {
+    if (mock) {
+      _mockUnlocked
+        ..clear()
+        ..addAll(stages);
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, stages);
+  }
+
+  Future<void> setUnlockedStages(List<String> stages) async {
+    await _saveUnlocked(List<String>.from(stages));
+  }
+
+  Future<bool> isStageUnlocked(String title) async {
+    final list = await _loadUnlocked();
+    return list.contains(title);
+  }
+
+  Future<List<String>> getUnlockedStages() async {
+    return _loadUnlocked();
+  }
+
+  Future<void> checkAndUnlockNextStage({bool force = false}) async {
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final unlocked = await _loadUnlocked();
+    for (var i = 0; i < stages.length - 1; i++) {
+      final stage = stages[i];
+      final next = stages[i + 1];
+      final done = LearningPathProgressService.instance.isStageCompleted(stage.items);
+      if ((done || force) && !unlocked.contains(next.title)) {
+        unlocked.add(next.title);
+        await _saveUnlocked(unlocked);
+        break;
+      }
+      if (!done && !force) break;
+    }
+  }
+
+  Future<void> forceUnlockNextStage() async {
+    await checkAndUnlockNextStage(force: true);
+  }
+}


### PR DESCRIPTION
## Summary
- add `SmartStageUnlockEngine` to manage unlocking of stages
- integrate engine with `LearningPathProgressService`
- unlock next stage when a pack is completed
- expose dev menu action to force unlock the next stage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1baca1f4832a9dbe0f159c928c02