### PR TITLE
Implement AchievementTriggerEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -104,6 +104,7 @@ import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
 import 'learning_path_intro_screen.dart';
 import '../services/learning_path_progress_service.dart';
+import '../services/achievement_trigger_engine.dart';
 import 'achievement_dashboard_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_insight_screen.dart';
@@ -156,6 +157,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _progressImportLoading = false;
   bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
+  bool _achievementsCheckLoading = false;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
@@ -1403,6 +1405,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
   }
 
+  Future<void> _forceCheckAchievements() async {
+    if (_achievementsCheckLoading || !kDebugMode) return;
+    setState(() => _achievementsCheckLoading = true);
+    await AchievementTriggerEngine.instance.checkAndTriggerAchievements();
+    if (!mounted) return;
+    setState(() => _achievementsCheckLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Achievements checked')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -2012,6 +2025,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                         builder: (_) => const AchievementDashboardScreen()),
                   );
                 },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🎖 Принудительно проверить достижения'),
+                onTap:
+                    _achievementsCheckLoading ? null : _forceCheckAchievements,
               ),
             if (kDebugMode)
               CheckboxListTile(

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -10,6 +10,7 @@ import 'session_result_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
 import '../services/achievement_service.dart';
+import '../services/achievement_trigger_engine.dart';
 import '../services/smart_review_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_session.dart';
@@ -330,6 +331,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         ),
       );
       AchievementService.instance.checkAll();
+      await AchievementTriggerEngine.instance.checkAndTriggerAchievements();
       await _checkGoalProgress();
     }
   }

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -38,6 +38,8 @@ import '../../services/learning_path_service.dart';
 import '../../services/smart_review_service.dart';
 import '../../services/tag_mastery_service.dart';
 import '../../services/training_pack_template_builder.dart';
+import '../../services/achievement_service.dart';
+import '../../services/achievement_trigger_engine.dart';
 import '../../services/training_session_service.dart';
 import '../training_recommendation_screen.dart';
 import '../../services/pack_dependency_map.dart';
@@ -548,6 +550,8 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
         }
       }
     }
+    AchievementService.instance.checkAll();
+    await AchievementTriggerEngine.instance.checkAndTriggerAchievements();
   }
 
   Future<void> _next() async {

--- a/lib/services/achievement_service.dart
+++ b/lib/services/achievement_service.dart
@@ -112,6 +112,34 @@ class AchievementService extends ChangeNotifier {
         unlocked: prefs.getBool('${_key}tag_analyst') ?? false,
         date: _parse(prefs.getString('${_key}tag_analyst_date')),
       ),
+      SimpleAchievement(
+        id: 'first_training_done',
+        title: 'Первая тренировка',
+        icon: Icons.play_circle,
+        unlocked: prefs.getBool('${_key}first_training_done') ?? false,
+        date: _parse(prefs.getString('${_key}first_training_done_date')),
+      ),
+      SimpleAchievement(
+        id: 'learning_path_3',
+        title: '3 стадии пройдены',
+        icon: Icons.grade,
+        unlocked: prefs.getBool('${_key}learning_path_3') ?? false,
+        date: _parse(prefs.getString('${_key}learning_path_3_date')),
+      ),
+      SimpleAchievement(
+        id: 'beginner_master',
+        title: 'Мастер Beginner',
+        icon: Icons.workspace_premium,
+        unlocked: prefs.getBool('${_key}beginner_master') ?? false,
+        date: _parse(prefs.getString('${_key}beginner_master_date')),
+      ),
+      SimpleAchievement(
+        id: 'path_completed',
+        title: 'Путь завершён',
+        icon: Icons.emoji_events,
+        unlocked: prefs.getBool('${_key}path_completed') ?? false,
+        date: _parse(prefs.getString('${_key}path_completed_date')),
+      ),
     ]);
     stats.sessionsStream.listen((_) => checkAll());
     stats.handsStream.listen((_) => checkAll());
@@ -142,6 +170,15 @@ class AchievementService extends ChangeNotifier {
       showAchievementUnlockedOverlay(ctx, a.icon, a.title);
     }
     notifyListeners();
+  }
+
+  /// Public wrapper to unlock an achievement by [id].
+  Future<void> unlock(String id) => _unlock(id);
+
+  /// Returns `true` if achievement with [id] has been unlocked.
+  bool isUnlocked(String id) {
+    final i = _achievements.indexWhere((a) => a.id == id);
+    return i != -1 && _achievements[i].unlocked;
   }
 
   Future<void> checkAll() async {
@@ -312,6 +349,42 @@ class AchievementService extends ChangeNotifier {
         progress: unlocked['tag_analyst'] == true ? 1 : 0,
         thresholds: const [1],
         iconsPerLevel: const [Icons.search],
+        category: 'Learning',
+      ),
+      AchievementInfo(
+        id: 'first_training_done',
+        title: 'Первая тренировка',
+        description: 'Завершите любой тренировочный пак',
+        progress: unlocked['first_training_done'] == true ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.play_circle],
+        category: 'Learning',
+      ),
+      AchievementInfo(
+        id: 'learning_path_3',
+        title: '3 стадии пройдены',
+        description: 'Завершите три стадии обучения',
+        progress: unlocked['learning_path_3'] == true ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.grade],
+        category: 'Learning',
+      ),
+      AchievementInfo(
+        id: 'beginner_master',
+        title: 'Мастер Beginner',
+        description: 'Все паки уровня Beginner пройдены',
+        progress: unlocked['beginner_master'] == true ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.workspace_premium],
+        category: 'Learning',
+      ),
+      AchievementInfo(
+        id: 'path_completed',
+        title: 'Путь завершён',
+        description: 'Завершите все стадии обучения',
+        progress: unlocked['path_completed'] == true ? 1 : 0,
+        thresholds: const [1],
+        iconsPerLevel: const [Icons.emoji_events],
         category: 'Learning',
       ),
     ];

--- a/lib/services/achievement_trigger_engine.dart
+++ b/lib/services/achievement_trigger_engine.dart
@@ -1,0 +1,84 @@
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/achievement_service.dart';
+import 'learning_path_progress_service.dart';
+import 'learning_path_completion_service.dart';
+import 'training_progress_service.dart';
+import 'training_stats_service.dart';
+
+/// Engine that unlocks achievements based on learning path progress.
+class AchievementTriggerEngine {
+  AchievementTriggerEngine._();
+  static final instance = AchievementTriggerEngine._();
+
+  /// When true, preferences are not touched and state is kept in memory.
+  bool mock = false;
+  final Set<String> _mockUnlocked = {};
+
+  static String _key(String id) => 'ach_trigger_$id';
+
+  Future<bool> _isUnlocked(String id) async {
+    if (mock) return _mockUnlocked.contains(id);
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key(id)) ?? false;
+  }
+
+  Future<void> _markUnlocked(String id) async {
+    if (mock) {
+      _mockUnlocked.add(id);
+    } else {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_key(id), true);
+    }
+    if (!AchievementService.instance.isUnlocked(id)) {
+      await AchievementService.instance.unlock(id);
+    }
+  }
+
+  /// Checks all triggers and unlocks achievements if conditions met.
+  Future<void> checkAndTriggerAchievements() async {
+    await _checkFirstTraining();
+    await _checkBeginnerStage();
+    await _checkThreeStages();
+    await _checkPathCompleted();
+  }
+
+  Future<void> _checkFirstTraining() async {
+    if (await _isUnlocked('first_training_done')) return;
+    final stats = TrainingStatsService.instance;
+    if (stats != null && stats.sessionsCompleted > 0) {
+      await _markUnlocked('first_training_done');
+    }
+  }
+
+  Future<void> _checkThreeStages() async {
+    if (await _isUnlocked('learning_path_3')) return;
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final completedCount = stages
+        .where((s) => LearningPathProgressService.instance.isStageCompleted(s.items))
+        .length;
+    if (completedCount >= 3) {
+      await _markUnlocked('learning_path_3');
+    }
+  }
+
+  Future<void> _checkBeginnerStage() async {
+    if (await _isUnlocked('beginner_master')) return;
+    final stages = await LearningPathProgressService.instance.getCurrentStageState();
+    final stage = stages.firstWhereOrNull((s) => s.title.toLowerCase() == 'beginner');
+    if (stage != null &&
+        LearningPathProgressService.instance.isStageCompleted(stage.items)) {
+      await _markUnlocked('beginner_master');
+    }
+  }
+
+  Future<void> _checkPathCompleted() async {
+    if (await _isUnlocked('path_completed')) return;
+    final done = await LearningPathProgressService.instance.isAllStagesCompleted();
+    if (done) {
+      await LearningPathCompletionService.instance.markPathCompleted();
+      await _markUnlocked('path_completed');
+    }
+  }
+}

--- a/lib/widgets/stage_completion_banner.dart
+++ b/lib/widgets/stage_completion_banner.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/block_completion_reward_service.dart';
 import 'confetti_overlay.dart';
 import '../services/achievement_service.dart';
+import '../services/achievement_trigger_engine.dart';
 
 class StageCompletionBanner extends StatefulWidget {
   final String title;
@@ -42,6 +43,7 @@ class _StageCompletionBannerState extends State<StageCompletionBanner>
       _controller.forward();
       showConfettiOverlay(context);
       AchievementService.instance.checkAll();
+      await AchievementTriggerEngine.instance.checkAndTriggerAchievements();
       await BlockCompletionRewardService.instance.markBannerShown(widget.title);
     }
   }


### PR DESCRIPTION
## Summary
- add `AchievementTriggerEngine` for automatic achievement checks
- expose unlock & status helpers in `AchievementService`
- integrate achievement triggering into training screens and stage banner
- add dev menu button to force achievement check
- create new learning-path achievements

## Testing
- `dart` and `flutter` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_687c1e4204e8832ab88ea8d5f76297ee