### PR TITLE
Implement SmartPathUXHintsService

### DIFF
--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -2,6 +2,7 @@ class AppConfig {
   AppConfig._();
   static final instance = AppConfig._();
   bool archiveAutoClean = false;
+  bool showSmartPathHints = true;
 }
 
 final appConfig = AppConfig.instance;

--- a/lib/services/smart_path_ux_hints_service.dart
+++ b/lib/services/smart_path_ux_hints_service.dart
@@ -1,0 +1,49 @@
+import '../app_config.dart';
+
+class LearningContext {
+  final String stageTitle;
+  final double stageProgress;
+  final Map<String, int> errorCounts;
+  final List<double> recentEv;
+  final bool afterPackCompleted;
+
+  const LearningContext({
+    required this.stageTitle,
+    required this.stageProgress,
+    this.errorCounts = const {},
+    this.recentEv = const [],
+    this.afterPackCompleted = false,
+  });
+
+  bool get stagnating {
+    if (recentEv.length < 3) return false;
+    final last = recentEv.sublist(recentEv.length - 3);
+    return last.every((e) => e < 0);
+  }
+}
+
+class SmartPathUXHintsService {
+  const SmartPathUXHintsService();
+
+  Future<String?> getHint(LearningContext ctx) async {
+    if (!appConfig.showSmartPathHints) return null;
+
+    if (ctx.afterPackCompleted && ctx.stageProgress >= 0.8) {
+      return 'Продолжай в том же духе — ты почти закрыл эту стадию!';
+    }
+
+    if (ctx.errorCounts.isNotEmpty) {
+      final entry = ctx.errorCounts.entries
+          .reduce((a, b) => a.value >= b.value ? a : b);
+      if (entry.value >= 3) {
+        return 'Ты часто ошибаешься в позиции ${entry.key}. Хочешь попрактиковаться?';
+      }
+    }
+
+    if (ctx.stagnating) {
+      return 'Застопорился? Попробуй «Пак дня» или Повторы ошибок';
+    }
+
+    return null;
+  }
+}

--- a/test/smart_path_ux_hints_service_test.dart
+++ b/test/smart_path_ux_hints_service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/app_config.dart';
+import 'package:poker_analyzer/services/smart_path_ux_hints_service.dart';
+
+void main() {
+  const service = SmartPathUXHintsService();
+
+  test('hint after pack completion', () async {
+    appConfig.showSmartPathHints = true;
+    const ctx = LearningContext(
+      stageTitle: 'Stage 1',
+      stageProgress: 0.85,
+      afterPackCompleted: true,
+    );
+    final hint = await service.getHint(ctx);
+    expect(hint, contains('почти закрыл'));
+  });
+
+  test('hint for frequent errors', () async {
+    const ctx = LearningContext(
+      stageTitle: 'Stage 1',
+      stageProgress: 0.2,
+      errorCounts: {'BB': 4},
+    );
+    final hint = await service.getHint(ctx);
+    expect(hint, contains('позиции BB'));
+  });
+
+  test('hint for stagnation', () async {
+    const ctx = LearningContext(
+      stageTitle: 'Stage 1',
+      stageProgress: 0.5,
+      recentEv: [-1, -0.5, -0.2],
+    );
+    final hint = await service.getHint(ctx);
+    expect(hint, contains('Застопорился'));
+  });
+
+  test('no hint when disabled', () async {
+    appConfig.showSmartPathHints = false;
+    const ctx = LearningContext(stageTitle: 'Stage', stageProgress: 0.9);
+    final hint = await service.getHint(ctx);
+    expect(hint, isNull);
+    appConfig.showSmartPathHints = true;
+  });
+}


### PR DESCRIPTION
## Summary
- add `showSmartPathHints` flag in `AppConfig`
- implement `SmartPathUXHintsService` with `getHint()`
- create basic tests for hint logic

## Testing
- `flutter analyze` *(fails: 6343 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687c20686c78832a88146f02755d430e