### PR TITLE
Add TrainingSpotExpander module

### DIFF
--- a/lib/core/training/generation/training_spot_expander.dart
+++ b/lib/core/training/generation/training_spot_expander.dart
@@ -1,0 +1,84 @@
+import 'package:uuid/uuid.dart';
+import '../../../models/v2/training_pack_spot.dart';
+import '../../../models/v2/training_pack_template_v2.dart';
+import '../../../models/v2/hand_data.dart';
+import '../../../models/v2/hero_position.dart';
+
+class TrainingSpotExpander {
+  final Uuid _uuid;
+  const TrainingSpotExpander({Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  List<TrainingPackSpot> expand(TrainingPackSpot spot) {
+    final results = <TrainingPackSpot>[spot];
+    if (spot.hand.board.length >= 3) {
+      results.add(_boardVariant(spot));
+    }
+    results.add(_stackVariant(spot, diff: 2));
+    results.add(_stackVariant(spot, diff: -2));
+    if (spot.hand.position != HeroPosition.unknown) {
+      results.add(_positionVariant(spot));
+    }
+    return results;
+  }
+
+  TrainingPackTemplateV2 expandPack(TrainingPackTemplateV2 pack) {
+    final expanded = <TrainingPackSpot>[];
+    for (final s in pack.spots) {
+      expanded.addAll(expand(s));
+    }
+    final map = pack.toJson();
+    map['spots'] = [for (final s in expanded) s.toJson()];
+    map['spotCount'] = expanded.length;
+    return TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+  }
+
+  TrainingPackSpot _clone(TrainingPackSpot spot) {
+    final hand = HandData.fromJson(Map<String, dynamic>.from(spot.hand.toJson()));
+    final copy = spot.copyWith(
+      id: _uuid.v4(),
+      hand: hand,
+    );
+    copy.isGenerated = true;
+    return copy;
+  }
+
+  TrainingPackSpot _boardVariant(TrainingPackSpot spot) {
+    final clone = _clone(spot);
+    final board = List<String>.from(clone.hand.board);
+    if (board.length >= 3) {
+      const ranks = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+      final next = {
+        for (int i = 0; i < ranks.length; i++)
+          ranks[i]: ranks[(i + 1) % ranks.length]
+      };
+      for (int i = 0; i < 3 && i < board.length; i++) {
+        final c = board[i];
+        final r = c[0].toUpperCase();
+        final s = c.substring(1);
+        final nr = next[r] ?? r;
+        board[i] = '$nr$s';
+      }
+      clone.hand.board = board;
+    }
+    return clone;
+  }
+
+  TrainingPackSpot _stackVariant(TrainingPackSpot spot, {int diff = 2}) {
+    final clone = _clone(spot);
+    clone.hand.stacks = {
+      for (final e in spot.hand.stacks.entries)
+        e.key: e.value + diff
+    };
+    return clone;
+  }
+
+  TrainingPackSpot _positionVariant(TrainingPackSpot spot) {
+    final clone = _clone(spot);
+    final values = HeroPosition.values;
+    final idx = values.indexOf(spot.hand.position);
+    if (idx >= 0 && idx + 1 < values.length) {
+      clone.hand.position = values[idx + 1];
+    }
+    return clone;
+  }
+}

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -18,6 +18,9 @@ class TrainingPackSpot {
   /// Ephemeral flag — used only in RAM to highlight freshly imported spots.
   /// Never written to / read from JSON.
   bool isNew = false;
+  /// Ephemeral flag – marks automatically generated variations.
+  /// Never written to / read from JSON.
+  bool isGenerated = false;
   EvaluationResult? evalResult;
   String? correctAction;
   String? explanation;
@@ -40,6 +43,7 @@ class TrainingPackSpot {
     this.dirty = false,
     this.priority = 3,
     bool? isNew,
+    bool? isGenerated,
     this.evalResult,
     this.correctAction,
     this.explanation,
@@ -49,6 +53,7 @@ class TrainingPackSpot {
     this.villainAction,
     List<String>? heroOptions,
   })  : isNew = isNew ?? false,
+        isGenerated = isGenerated ?? false,
         hand = hand ?? HandData(),
         board = board ?? const [],
         heroOptions = heroOptions ?? const [],
@@ -70,6 +75,7 @@ class TrainingPackSpot {
     bool? dirty,
     int? priority,
     bool? isNew,
+    bool? isGenerated,
     EvaluationResult? evalResult,
     String? correctAction,
     String? explanation,
@@ -92,6 +98,7 @@ class TrainingPackSpot {
         dirty: dirty ?? this.dirty,
         priority: priority ?? this.priority,
         isNew: isNew ?? this.isNew,
+        isGenerated: isGenerated ?? this.isGenerated,
         evalResult: evalResult ?? this.evalResult,
         correctAction: correctAction ?? this.correctAction,
         explanation: explanation ?? this.explanation,

--- a/test/training_spot_expander_test.dart
+++ b/test/training_spot_expander_test.dart
@@ -1,0 +1,40 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/core/training/generation/training_spot_expander.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  test('expand generates variations', () {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10)
+        ..board.addAll(['Kh', 'Qd', '2c']),
+    );
+    final expander = TrainingSpotExpander();
+    final list = expander.expand(spot);
+    expect(list.length > 1, true);
+    expect(list.first.id, 's1');
+    final generated = list.where((s) => s.id != 's1');
+    expect(generated.every((s) => s.isGenerated), true);
+  });
+
+  test('expandPack updates spotCount', () {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Test',
+      trainingType: TrainingType.pushFold,
+      spots: [spot],
+    );
+    final expander = TrainingSpotExpander();
+    final res = expander.expandPack(pack);
+    expect(res.spots.length, greaterThan(1));
+    expect(res.spotCount, res.spots.length);
+  });
+}


### PR DESCRIPTION
## Summary
- add `isGenerated` flag to `TrainingPackSpot`
- implement `TrainingSpotExpander` to create spot variants
- test spot expander functionality

## Testing
- `flutter analyze` *(fails: many issues in repo)*
- `flutter test` *(fails: repo has build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c264598a8832a940d18c9e22522ff