### PR TITLE
Add TrainingPackSampler service

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -34,6 +34,10 @@ class TrainingPackTemplateV2 {
   /// serialized to or from disk.
   bool isGeneratedPack;
 
+  /// Ephemeral flag – marks packs created by sampling a larger template.
+  /// Never serialized to or from disk.
+  bool isSampledPack;
+
   TrainingPackTemplateV2({
     required this.id,
     required this.name,
@@ -55,12 +59,14 @@ class TrainingPackTemplateV2 {
     this.targetStreet,
     this.unlockRules,
     bool? isGeneratedPack,
+    bool? isSampledPack,
   }) : tags = tags ?? [],
        spots = spots ?? [],
        positions = positions ?? [],
        created = created ?? DateTime.now(),
        meta = meta ?? {},
-       isGeneratedPack = isGeneratedPack ?? false {
+       isGeneratedPack = isGeneratedPack ?? false,
+       isSampledPack = isSampledPack ?? false {
     if (theme != null) meta['theme'] = theme;
     category ??= this.tags.isNotEmpty ? this.tags.first : null;
   }

--- a/lib/services/training_pack_sampler.dart
+++ b/lib/services/training_pack_sampler.dart
@@ -1,0 +1,105 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+
+/// Provides sampling of large training packs to create a smaller
+/// representative subset.
+class TrainingPackSampler {
+  const TrainingPackSampler();
+
+  /// Returns a new [TrainingPackTemplateV2] containing at most [maxSpots]
+  /// spots sampled from [fullPack].
+  TrainingPackTemplateV2 sample(
+    TrainingPackTemplateV2 fullPack, {
+    int maxSpots = 20,
+  }) {
+    if (fullPack.spots.length <= maxSpots) return fullPack;
+
+    final spots = List<TrainingPackSpot>.from(fullPack.spots);
+
+    // Group spots by hero position.
+    final posGroups = <HeroPosition, List<TrainingPackSpot>>{};
+    for (final s in spots) {
+      posGroups.putIfAbsent(s.hand.position, () => []).add(s);
+    }
+
+    final selected = <TrainingPackSpot>[];
+
+    // Ensure at least one spot from each position if available.
+    for (final p in kPositionOrder) {
+      final group = posGroups[p];
+      if (group != null && group.isNotEmpty) {
+        selected.add(group.removeAt(0));
+        if (selected.length >= maxSpots) break;
+      }
+    }
+
+    if (selected.length < maxSpots) {
+      // Diversity buckets for board length and stack size.
+      String boardBucket(TrainingPackSpot s) {
+        final n = s.hand.board.length;
+        if (n >= 5) return 'river';
+        if (n == 4) return 'turn';
+        if (n >= 3) return 'flop';
+        return 'preflop';
+      }
+
+      int stackBucket(TrainingPackSpot s) {
+        final stack =
+            s.hand.stacks['${s.hand.heroIndex}']?.toInt() ?? 0;
+        if (stack <= 10) return 10;
+        if (stack <= 20) return 20;
+        if (stack <= 40) return 40;
+        return 100;
+      }
+
+      final usedComb = <String>{};
+
+      // Round-robin through remaining groups to preserve position balance.
+      bool added;
+      do {
+        added = false;
+        for (final p in kPositionOrder) {
+          final group = posGroups[p];
+          if (group == null || group.isEmpty) continue;
+          final spot = group.removeAt(0);
+          final key = '${p.name}-${boardBucket(spot)}-${stackBucket(spot)}';
+          if (usedComb.add(key)) {
+            selected.add(spot);
+            added = true;
+            if (selected.length >= maxSpots) break;
+          }
+          if (selected.length >= maxSpots) break;
+        }
+      } while (added && selected.length < maxSpots);
+
+      // Fill up with any remaining spots if still below limit.
+      if (selected.length < maxSpots) {
+        final remaining = posGroups.values.expand((e) => e);
+        for (final s in remaining) {
+          selected.add(s);
+          if (selected.length >= maxSpots) break;
+        }
+      }
+    }
+
+    // Sort final list for a polished UX.
+    selected.sort((a, b) {
+      final pa = kPositionOrder.indexOf(a.hand.position);
+      final pb = kPositionOrder.indexOf(b.hand.position);
+      if (pa != pb) return pa.compareTo(pb);
+      final sa = a.hand.stacks['${a.hand.heroIndex}'] ?? 0;
+      final sb = b.hand.stacks['${b.hand.heroIndex}'] ?? 0;
+      return sa.compareTo(sb);
+    });
+
+    final map = fullPack.toJson();
+    map['spots'] = [for (final s in selected) s.toJson()];
+    map['spotCount'] = selected.length;
+    final result =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    result.isSampledPack = true;
+    return result;
+  }
+}
+

--- a/test/training_pack_sampler_test.dart
+++ b/test/training_pack_sampler_test.dart
@@ -1,0 +1,58 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_sampler.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackSpot _spot(String id, HeroPosition pos, int stack, {List<String>? board}) {
+  final hand = HandData.fromSimpleInput('AhAs', pos, stack)
+    ..board.addAll(board ?? []);
+  return TrainingPackSpot(id: id, hand: hand);
+}
+
+void main() {
+  test('sample limits size and preserves metadata', () {
+    final spots = <TrainingPackSpot>[];
+    for (int i = 0; i < 30; i++) {
+      spots.add(_spot('s$i', HeroPosition.values[i % 6], 10 + i));
+    }
+    final pack = TrainingPackTemplateV2(
+      id: 'p',
+      name: 'Full',
+      trainingType: TrainingType.pushFold,
+      tags: ['test'],
+      spots: spots,
+      spotCount: spots.length,
+    );
+    final sampler = TrainingPackSampler();
+    final sample = sampler.sample(pack, maxSpots: 10);
+
+    expect(sample.spots.length, 10);
+    expect(sample.name, pack.name);
+    expect(sample.tags, pack.tags);
+    expect(sample.isSampledPack, true);
+  });
+
+  test('sample includes each position when possible', () {
+    final spots = <TrainingPackSpot>[];
+    var idx = 0;
+    for (final pos in kPositionOrder) {
+      spots.add(_spot('s${idx++}', pos, 10));
+      spots.add(_spot('s${idx++}', pos, 20));
+    }
+    final pack = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Full',
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+    );
+    final sampler = TrainingPackSampler();
+    final sample = sampler.sample(pack, maxSpots: 6);
+    final positions = {for (final s in sample.spots) s.hand.position};
+    expect(positions.containsAll(kPositionOrder), true);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add ephemeral `isSampledPack` flag to training pack templates
- implement `TrainingPackSampler` for subsampling large packs
- test sampler behaviour

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c2f58a838832a97e3c225220d0c9c