### PR TITLE
Add sample pack preview

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -71,6 +71,8 @@ import '../widgets/training_gap_prompt_banner.dart';
 import '../widgets/training_type_gap_prompt_banner.dart';
 import '../widgets/suggested_pack_tile.dart';
 import 'pack_suggestion_preview_screen.dart';
+import '../services/training_pack_sampler.dart';
+import '../models/v2/training_pack_template_v2.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -2129,6 +2131,35 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     },
               child: const Text('▶️ Train'),
             ),
+            if (t.spots.length > 30)
+              Tooltip(
+                message: 'Быстрый просмотр',
+                child: TextButton(
+                  onPressed: locked
+                      ? null
+                      : () {
+                          final sampler = const TrainingPackSampler();
+                          final tplV2 = TrainingPackTemplateV2.fromTemplate(
+                            t,
+                            type:
+                                const TrainingTypeEngine().detectTrainingType(t),
+                          );
+                          final sample = sampler.sample(tplV2, maxSpots: 20);
+                          final preview =
+                              TrainingPackTemplate.fromJson(sample.toJson());
+                          preview.meta['samplePreview'] = true;
+                          context
+                              .read<TrainingSessionService>()
+                              .startSession(preview, persist: false);
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => const TrainingSessionScreen()),
+                          );
+                        },
+                  child: const Text('👁 Preview'),
+                ),
+              ),
           ],
         ),
         onTap: () async {

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -476,6 +476,20 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                           style: const TextStyle(color: Colors.white70),
                           textAlign: TextAlign.center,
                         ),
+                        if (service.template!.meta['samplePreview'] == true)
+                          Container(
+                            margin: const EdgeInsets.only(top: 4),
+                            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                            decoration: BoxDecoration(
+                              color: Colors.orange.withOpacity(0.2),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: const Text(
+                              'Sample preview',
+                              style: TextStyle(color: Colors.orangeAccent),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
                         if (service.template!.description.isNotEmpty) ...[
                           const SizedBox(height: 4),
                           Text(


### PR DESCRIPTION
## Summary
- allow quick preview for large packs from the library
- show banner in session screen when running a sampled pack

## Testing
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c31a0e4a8832a8271fdcb6f2e6d5d