### PR TITLE
Add sample preview button

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -28,6 +28,7 @@ import 'create_pack_from_template_screen.dart';
 import 'create_template_screen.dart';
 import 'template_hands_editor_screen.dart';
 import 'template_preview_dialog.dart';
+import '../widgets/sample_pack_preview_button.dart';
 import '../widgets/sync_status_widget.dart';
 import 'session_history_screen.dart';
 import 'v2/training_pack_template_editor_screen.dart';
@@ -2129,6 +2130,8 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     },
               child: const Text('▶️ Train'),
             ),
+            if (t.spots.length > 30)
+              SamplePackPreviewButton(template: t),
           ],
         ),
         onTap: () async {
@@ -3583,9 +3586,17 @@ class _PackSheetContent extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 16),
-        ElevatedButton(
-          onPressed: onStart,
-          child: Text(l.startTraining),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: onStart,
+              child: Text(l.startTraining),
+            ),
+            if (template.spots.length > 30) ...[
+              const SizedBox(width: 8),
+              SamplePackPreviewButton(template: template),
+            ],
+          ],
         ),
         if (showReview) ...[
           const SizedBox(height: 8),

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -873,6 +873,22 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
             padding: EdgeInsets.all(16 * scale),
             child: Column(
               children: [
+            if (widget.template.meta['sampledPack'] == true)
+              Padding(
+                padding: EdgeInsets.only(bottom: 8 * scale),
+                child: Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: Colors.orange,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text(
+                    'Preview mode: You\'re training with a sample',
+                    style: TextStyle(color: Colors.black),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
             if (widget.template.focusTags.isNotEmpty)
               Padding(
                 padding: EdgeInsets.only(bottom: 8 * scale),

--- a/lib/widgets/sample_pack_preview_button.dart
+++ b/lib/widgets/sample_pack_preview_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_pack_template.dart';
+import '../models/v2/training_pack_template.dart' as v2;
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/training_pack_sampler.dart';
+import '../services/training_session_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+
+class SamplePackPreviewButton extends StatelessWidget {
+  final TrainingPackTemplate template;
+  final int maxSpots;
+
+  const SamplePackPreviewButton({
+    super.key,
+    required this.template,
+    this.maxSpots = 15,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (template.spots.length <= 30) return const SizedBox.shrink();
+
+    return Tooltip(
+      message: 'Preview $maxSpots random spots',
+      child: OutlinedButton(
+        onPressed: () async {
+          final sampler = const TrainingPackSampler();
+          final tplV2 = TrainingPackTemplateV2.fromJson(template.toJson());
+          final sampledV2 = sampler.sample(tplV2, maxSpots: maxSpots);
+          final sampled = v2.TrainingPackTemplate.fromJson(sampledV2.toJson())
+            ..meta['sampledPack'] = true;
+          final original = v2.TrainingPackTemplate.fromJson(template.toJson());
+          await context
+              .read<TrainingSessionService>()
+              .startSession(sampled, persist: false);
+          if (context.mounted) {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) =>
+                    TrainingPackPlayScreen(template: sampled, original: original),
+              ),
+            );
+          }
+        },
+        child: const Text('👁 Preview Sample'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SamplePackPreviewButton` widget
- allow previewing sample packs in template sheet and list
- show banner when training with sampled pack

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c33b9a7e8832aa41c7df8aca7149b