### PR TITLE
Implement auto-start sample preview when tapping locked packs

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 Pack des Tages"
   ,"levelGoalTitle": "Level Goal"
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 Pack of the Day"
   ,"levelGoalTitle": "Level Goal"
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 Pack del D\u00eda"
   ,"levelGoalTitle": "Level Goal"
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 Pack du Jour"
   ,"levelGoalTitle": "Level Goal"
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 Pacote do Dia"
   ,"levelGoalTitle": "Level Goal"
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -118,4 +118,6 @@
   ,"packOfDay": "\ud83c\udfb2 \u041f\u0430\u043a \u0434\u043d\u044f"
   ,"levelGoalTitle": "\u0426\u0435\u043b\u044c \u0443\u0440\u043e\u0432\u043d\u044f"
   ,"samplePreviewHint": "\u041f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0441\u043d\u0430\u0447\u0430\u043b\u0430 \u043e\u0431\u0440\u0430\u0437\u0435\u0446 \u043f\u0430\u043a\u0430"
+  ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
+  ,"previewSample": "Preview Sample"
 }


### PR DESCRIPTION
## Summary
- add automatic sample preview flow on locked pack tap
- localize sample preview prompt

## Testing
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_687c40ba9fb4832a8eeeab25271da92b