### PR TITLE
Auto sample preview for large packs

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "Try a sample first to explore this pack!"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -120,4 +120,5 @@
   ,"samplePreviewHint": "\u041f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0441\u043d\u0430\u0447\u0430\u043b\u0430 \u043e\u0431\u0440\u0430\u0437\u0435\u0446 \u043f\u0430\u043a\u0430"
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
+  ,"autoSampleToast": "Quick preview launched automatically for faster start."
 }


### PR DESCRIPTION
## Summary
- start quick sample automatically when a large pack is opened for the first time
- show toast `autoSampleToast` when auto sampling triggers

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_687c454fc4dc832ab11b5f7532d1418d