### PR TITLE
Add resume banner for unfinished packs

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "You have an unfinished session"
+  ,"resume": "Resume"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "You have an unfinished session"
+  ,"resume": "Resume"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "You have an unfinished session"
+  ,"resume": "Resume"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "You have an unfinished session"
+  ,"resume": "Resume"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "You have an unfinished session"
+  ,"resume": "Resume"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -121,4 +121,6 @@
   ,"samplePreviewPrompt": "This pack is large. Preview a quick sample first?"
   ,"previewSample": "Preview Sample"
   ,"autoSampleToast": "Quick preview launched automatically for faster start."
+  ,"unfinishedSession": "\u0423 \u0432\u0430\u0441 \u0435\u0441\u0442\u044c \u043d\u0435\u0437\u0430\u0432\u0435\u0440\u0448\u0451\u043d\u043d\u0430\u044f \u0441\u0435\u0441\u0441\u0438\u044f"
+  ,"resume": "\u041f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c"
 }

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -74,6 +74,7 @@ import 'pack_suggestion_preview_screen.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../widgets/sample_pack_preview_button.dart';
 import '../widgets/sample_pack_preview_tooltip.dart';
+import '../widgets/pack_resume_banner.dart';
 import '../services/training_pack_sampler.dart';
 import 'v2/training_pack_play_screen.dart';
 
@@ -1917,12 +1918,10 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
             ],
           ),
           onTap: () async {
-            if (await _maybeAutoSample(
-                TrainingPackTemplateV2.fromTemplate(
-                    t,
-                    type: const TrainingTypeEngine()
-                        .detectTrainingType(t),
-                ))) return;
+            if (await _maybeAutoSample(TrainingPackTemplateV2.fromTemplate(
+              t,
+              type: const TrainingTypeEngine().detectTrainingType(t),
+            ))) return;
             final create = await showDialog<bool>(
               context: context,
               builder: (_) => TemplatePreviewDialog(template: t),
@@ -2146,21 +2145,21 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               color: _favorites.contains(t.id) ? Colors.amber : Colors.white54,
               onPressed: () => _toggleFavorite(t.id),
             ),
-              TextButton(
-                onPressed: locked || previewRequired
-                    ? null
-                    : () {
-                        context.read<TrainingSessionService>().startSession(t);
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (_) => const TrainingSessionScreen()),
-                        );
-                      },
-                child: const Text('▶️ Train'),
-              ),
-              if (previewRequired) const SamplePackPreviewTooltip(),
-              SamplePackPreviewButton(template: t, locked: locked),
+            TextButton(
+              onPressed: locked || previewRequired
+                  ? null
+                  : () {
+                      context.read<TrainingSessionService>().startSession(t);
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const TrainingSessionScreen()),
+                      );
+                    },
+              child: const Text('▶️ Train'),
+            ),
+            if (previewRequired) const SamplePackPreviewTooltip(),
+            SamplePackPreviewButton(template: t, locked: locked),
           ],
         ),
         onTap: () async {
@@ -2367,8 +2366,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     return true;
   }
 
-  Future<void> _onLockedPackTap(
-      TrainingPackTemplate t, String? reason) async {
+  Future<void> _onLockedPackTap(TrainingPackTemplate t, String? reason) async {
     final l = AppLocalizations.of(context)!;
     final previewRequired =
         t.spots.length > 30 && !_previewCompleted.contains(t.id);
@@ -2543,16 +2541,16 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 color: Colors.black45,
                 alignment: Alignment.center,
                 child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Text('🔒 Заблокировано',
-                      style: TextStyle(color: Colors.white)),
-                  if (reason != null)
-                    Text(reason!,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 12)),
-                ],
-              ),
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text('🔒 Заблокировано',
+                        style: TextStyle(color: Colors.white)),
+                    if (reason != null)
+                      Text(reason!,
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 12)),
+                  ],
+                ),
               ),
             ),
           ),
@@ -3308,6 +3306,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     controller: _listCtrl,
                     children: [
                       SmartSuggestionBanner(selectedTags: _selectedTags),
+                      const PackResumeBanner(),
                       const PackSuggestionBanner(),
                       const SuggestedPackTile(),
                       if (_popularOnly && popularFiltered.isNotEmpty) ...[

--- a/lib/widgets/pack_resume_banner.dart
+++ b/lib/widgets/pack_resume_banner.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../services/training_pack_play_controller.dart';
+
+class PackResumeBanner extends StatelessWidget {
+  const PackResumeBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<TrainingPackPlayController>(
+      builder: (context, ctrl, _) {
+        return ValueListenableBuilder<bool>(
+          valueListenable: ctrl.hasIncompleteSession,
+          builder: (context, has, __) {
+            final tpl = ctrl.template;
+            if (!has || tpl == null) return const SizedBox.shrink();
+            final accent = Theme.of(context).colorScheme.secondary;
+            final l = AppLocalizations.of(context)!;
+            return Container(
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(tpl.name,
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 16)),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      l.unfinishedSession,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: ElevatedButton(
+                      onPressed: () => ctrl.resume(context),
+                      style: ElevatedButton.styleFrom(backgroundColor: accent),
+                      child: Text(l.resume),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PackResumeBanner` widget that surfaces unfinished training packs
- display the banner in `TemplateLibraryScreen`
- provide localization strings for "unfinished session" and "resume" in all locales

## Testing
- `flutter format lib/widgets/pack_resume_banner.dart lib/screens/template_library_screen.dart >/tmp/format.log && tail -n 20 /tmp/format.log`
- `flutter test` *(fails: sign_in_with_apple requires SDK >=3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_687c46e3b7c4832aa1e87f77178bc575