### PR TITLE
Implement SmartResumeEngine for pack continuation

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -27,7 +27,6 @@ import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/streak_widget.dart';
-import '../services/training_pack_play_controller.dart';
 import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../theme/app_colors.dart';
@@ -140,17 +139,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   }
 
   Widget _home() {
-    final ctrl = context.read<TrainingPackPlayController>();
     final ab = context.watch<AbTestEngine>();
     return Column(
       children: [
         ab.isVariant('resume_card', 'B')
-            ? ValueListenableBuilder<bool>(
-                valueListenable: ctrl.hasIncompleteSession,
-                builder: (_, has, __) => has
-                    ? ResumeTrainingCard(controller: ctrl)
-                    : const SizedBox.shrink(),
-              )
+            ? const ResumeTrainingCard()
             : const SizedBox.shrink(),
         const SpotOfTheDayCard(),
         const PackSuggestionBanner(),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/weekly_challenge_card.dart';
 import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
+import '../widgets/resume_training_card.dart';
 import '../widgets/next_learning_step_card.dart';
 import '../widgets/daily_focus_recap_card.dart';
 import '../widgets/progress_summary_box.dart';
@@ -114,6 +115,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           if (!tablet) const DailySpotlightCard(),
           if (narrow) ...[
             const QuickContinueCard(),
+            const ResumeTrainingCard(),
             const DailyProgressRing(),
             const GoalsCard(),
             const DailyGoalsCard(),
@@ -124,6 +126,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const SuggestionCardWeakSpots(),
           ] else ...[
             const QuickContinueCard(),
+            const ResumeTrainingCard(),
             const DailyFocusRecapCard(),
             const SpotOfTheDayCard(),
             const ProgressSummaryBox(),

--- a/lib/services/smart_resume_engine.dart
+++ b/lib/services/smart_resume_engine.dart
@@ -1,0 +1,45 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/training_pack_storage.dart';
+import '../models/v2/training_pack_template.dart';
+
+class UnfinishedPack {
+  final TrainingPackTemplate template;
+  final int index;
+  UnfinishedPack({required this.template, required this.index});
+
+  int get progressPercent =>
+      (((index + 1) / template.spots.length) * 100).round();
+}
+
+class SmartResumeEngine {
+  SmartResumeEngine._();
+  static final instance = SmartResumeEngine._();
+
+  static const _playPrefix = 'tpl_prog_';
+  static const _playTsPrefix = 'tpl_ts_';
+  static const _sessionPrefix = 'ts_idx_';
+  static const _sessionTsPrefix = 'ts_ts_';
+
+  Future<List<UnfinishedPack>> getRecentUnfinished({int limit = 3}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final templates = await TrainingPackStorage.load();
+    final entries = <MapEntry<UnfinishedPack, int>>[];
+    for (final t in templates) {
+      int? idx;
+      int ts = 0;
+      if (prefs.containsKey('$_playPrefix${t.id}')) {
+        idx = prefs.getInt('$_playPrefix${t.id}');
+        ts = prefs.getInt('$_playTsPrefix${t.id}') ?? 0;
+      } else if (prefs.containsKey('$_sessionPrefix${t.id}')) {
+        idx = prefs.getInt('$_sessionPrefix${t.id}');
+        ts = prefs.getInt('$_sessionTsPrefix${t.id}') ?? 0;
+      }
+      if (idx == null) continue;
+      if (idx >= 3 && idx < t.spots.length - 1) {
+        entries.add(MapEntry(UnfinishedPack(template: t, index: idx), ts));
+      }
+    }
+    entries.sort((a, b) => b.value.compareTo(a.value));
+    return [for (final e in entries.take(limit)) e.key];
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -28,6 +28,7 @@ class TrainingSessionService extends ChangeNotifier {
   Box<dynamic>? _box;
   Box<dynamic>? _activeBox;
   static const _indexPrefix = 'ts_idx_';
+  static const _tsPrefix = 'ts_ts_';
   static const _previewKey = 'lib_preview_completed';
   TrainingSession? _session;
   TrainingPackTemplate? _template;
@@ -284,12 +285,15 @@ class TrainingSessionService extends ChangeNotifier {
     if (_template == null) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('$_indexPrefix${_template!.id}', _session?.index ?? 0);
+    await prefs.setInt('$_tsPrefix${_template!.id}',
+        DateTime.now().millisecondsSinceEpoch);
   }
 
   Future<void> _clearIndex() async {
     if (_template == null) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('$_indexPrefix${_template!.id}');
+    await prefs.remove('$_tsPrefix${_template!.id}');
   }
 
   void pause() {

--- a/lib/widgets/pack_resume_banner.dart
+++ b/lib/widgets/pack_resume_banner.dart
@@ -1,58 +1,82 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import '../services/training_pack_play_controller.dart';
+import '../services/smart_resume_engine.dart';
+import '../screens/v2/training_pack_play_screen.dart';
 
-class PackResumeBanner extends StatelessWidget {
+class PackResumeBanner extends StatefulWidget {
   const PackResumeBanner({super.key});
 
   @override
+  State<PackResumeBanner> createState() => _PackResumeBannerState();
+}
+
+class _PackResumeBannerState extends State<PackResumeBanner> {
+  UnfinishedPack? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final list = await SmartResumeEngine.instance.getRecentUnfinished(limit: 1);
+    if (!mounted) return;
+    setState(() => _pack = list.isNotEmpty ? list.first : null);
+  }
+
+  Future<void> _resume() async {
+    final p = _pack;
+    if (p == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackPlayScreen(
+          template: p.template,
+          original: p.template,
+        ),
+      ),
+    );
+    await _load();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Consumer<TrainingPackPlayController>(
-      builder: (context, ctrl, _) {
-        return ValueListenableBuilder<bool>(
-          valueListenable: ctrl.hasIncompleteSession,
-          builder: (context, has, __) {
-            final tpl = ctrl.template;
-            if (!has || tpl == null) return const SizedBox.shrink();
-            final accent = Theme.of(context).colorScheme.secondary;
-            final l = AppLocalizations.of(context)!;
-            return Container(
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey[850],
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(tpl.name,
-                      style:
-                          const TextStyle(color: Colors.white, fontSize: 16)),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(
-                      l.unfinishedSession,
-                      style: const TextStyle(color: Colors.white70),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: ElevatedButton(
-                      onPressed: () => ctrl.resume(context),
-                      style: ElevatedButton.styleFrom(backgroundColor: accent),
-                      child: Text(l.resume),
-                    ),
-                  ),
-                ],
-              ),
-            );
-          },
-        );
-      },
+    final pack = _pack;
+    if (pack == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final l = AppLocalizations.of(context)!;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(pack.template.name,
+              style: const TextStyle(color: Colors.white, fontSize: 16)),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              l.unfinishedSession,
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _resume,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: Text(l.resume),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/resume_training_card.dart
+++ b/lib/widgets/resume_training_card.dart
@@ -1,17 +1,51 @@
 import 'package:flutter/material.dart';
-import '../services/training_pack_play_controller.dart';
+import '../services/smart_resume_engine.dart';
+import '../screens/v2/training_pack_play_screen.dart';
 
-class ResumeTrainingCard extends StatelessWidget {
-  final TrainingPackPlayController controller;
-  const ResumeTrainingCard({super.key, required this.controller});
+class ResumeTrainingCard extends StatefulWidget {
+  const ResumeTrainingCard({super.key});
+
+  @override
+  State<ResumeTrainingCard> createState() => _ResumeTrainingCardState();
+}
+
+class _ResumeTrainingCardState extends State<ResumeTrainingCard> {
+  UnfinishedPack? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final list = await SmartResumeEngine.instance.getRecentUnfinished(limit: 1);
+    if (!mounted) return;
+    setState(() => _pack = list.isNotEmpty ? list.first : null);
+  }
+
+  Future<void> _resume() async {
+    final p = _pack;
+    if (p == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackPlayScreen(
+          template: p.template,
+          original: p.template,
+        ),
+      ),
+    );
+    await _load();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final tpl = controller.template;
-    if (tpl == null) return const SizedBox.shrink();
+    final p = _pack;
+    if (p == null) return const SizedBox.shrink();
     final accent = Theme.of(context).colorScheme.secondary;
     return GestureDetector(
-      onTap: () => controller.resume(context),
+      onTap: _resume,
       child: Container(
         margin: const EdgeInsets.fromLTRB(16, 16, 16, 16),
         padding: const EdgeInsets.all(12),
@@ -20,7 +54,7 @@ class ResumeTrainingCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
         ),
         child: Text(
-          '🔥 Continue training: ${tpl.name} · ${controller.progress}%',
+          '🔥 Continue training: ${p.template.name} · ${p.progressPercent}%',
           style: TextStyle(color: accent, fontWeight: FontWeight.bold),
         ),
       ),


### PR DESCRIPTION
## Summary
- add `SmartResumeEngine` for recent unfinished packs
- track session timestamps in `TrainingSessionService`
- surface resume UI with updated widgets
- show resume card on home screens

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c4d079c60832aa9a0d51df0c9d5b5