### PR TITLE
Implement weak tag highlighter

### DIFF
--- a/lib/services/tag_mastery_service.dart
+++ b/lib/services/tag_mastery_service.dart
@@ -110,5 +110,11 @@ class TagMasteryService {
       ..sort((a, b) => a.value.compareTo(b.value));
     return [for (final e in list.take(count)) e.key];
   }
+
+  /// Returns all tags with mastery below [threshold].
+  Future<List<String>> getWeakTags([double threshold = 0.7]) async {
+    final map = await computeMastery();
+    return [for (final e in map.entries) if (e.value < threshold) e.key];
+  }
 }
 


### PR DESCRIPTION
## Summary
- add `getWeakTags` to `TagMasteryService`
- load weak tag info in `TemplateLibraryScreen`
- allow filtering packs by weak tags
- display weak-skill badge on pack cards

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c51abdf3c832a879b56c2413d648e