### PR TITLE
Add pack unlock requirement badge

### DIFF
--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -3,6 +3,7 @@ class AppConfig {
   static final instance = AppConfig._();
   bool archiveAutoClean = false;
   bool showSmartPathHints = true;
+  bool devUnlockOverride = false;
 }
 
 final appConfig = AppConfig.instance;

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -58,6 +58,7 @@ import '../services/pack_library_loader_service.dart';
 import '../services/training_type_stats_service.dart';
 import '../services/pack_unlocking_rules_engine.dart';
 import '../services/user_profile_preference_service.dart';
+import '../app_config.dart';
 import 'package:intl/intl.dart';
 import 'training_stats_screen.dart';
 import '../helpers/category_translations.dart';
@@ -80,6 +81,7 @@ import '../widgets/pack_resume_banner.dart';
 import '../services/training_pack_sampler.dart';
 import 'v2/training_pack_play_screen.dart';
 import '../widgets/pack_progress_overlay.dart';
+import '../widgets/pack_unlock_requirement_badge.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -224,6 +226,8 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
     final prefs = await SharedPreferences.getInstance();
     await UserProfilePreferenceService.instance.load();
     await PackLibraryLoaderService.instance.loadLibrary();
+    PackUnlockingRulesEngine.instance.devOverride =
+        kDebugMode && appConfig.devUnlockOverride;
     final counts = <String, int>{};
     for (final t in PackLibraryLoaderService.instance.library) {
       for (final tag in t.tags) {
@@ -2058,13 +2062,22 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
               ),
             ),
           ),
+        Positioned(
+          top: 4,
+          right: 4,
+          child: PackProgressOverlay(templateId: t.id, size: 20),
+        ),
+        if (locked && reason != null)
           Positioned(
-            top: 4,
-            right: 4,
-            child: PackProgressOverlay(templateId: t.id, size: 20),
+            bottom: 4,
+            left: 4,
+            child: PackUnlockRequirementBadge(
+              text: reason!,
+              tooltip: reason,
+            ),
           ),
-        ],
-      );
+      ],
+    );
       if (_isStarter(t)) {
         card = Container(
           decoration: BoxDecoration(
@@ -2328,6 +2341,15 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           right: 4,
           child: PackProgressOverlay(templateId: t.id, size: 20),
         ),
+        if (locked && reason != null)
+          Positioned(
+            bottom: 4,
+            left: 4,
+            child: PackUnlockRequirementBadge(
+              text: reason!,
+              tooltip: reason,
+            ),
+          ),
       ],
     );
     if (_isStarter(t)) {
@@ -2699,6 +2721,15 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           right: 4,
           child: PackProgressOverlay(templateId: t.id, size: 20),
         ),
+        if (locked && reason != null)
+          Positioned(
+            bottom: 4,
+            left: 4,
+            child: PackUnlockRequirementBadge(
+              text: reason!,
+              tooltip: reason,
+            ),
+          ),
       ],
     );
     if (locked) {

--- a/lib/services/pack_unlocking_rules_engine.dart
+++ b/lib/services/pack_unlocking_rules_engine.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/unlock_rules.dart';
 import '../models/unlock_rule.dart';
@@ -16,6 +18,7 @@ class PackUnlockingRulesEngine {
   static final instance = PackUnlockingRulesEngine._();
 
   bool mock = false;
+  bool devOverride = false;
   final Set<String> _mockCompleted = {};
   double _mockAverageEV = 0;
   bool _mockStarterCompleted = false;
@@ -41,6 +44,7 @@ class PackUnlockingRulesEngine {
   }
 
   Future<UnlockCheckResult> check(TrainingPackTemplateV2 pack) async {
+    if (kDebugMode && devOverride) return const UnlockCheckResult(true);
     final rules = getUnlockRule(pack) ?? pack.unlockRules == null
         ? null
         : UnlockRule(
@@ -120,5 +124,6 @@ class PackUnlockingRulesEngine {
     _mockAverageEV = 0;
     _mockStarterCompleted = false;
     _mockCustomPathCompleted = false;
+    devOverride = false;
   }
 }

--- a/lib/widgets/pack_unlock_requirement_badge.dart
+++ b/lib/widgets/pack_unlock_requirement_badge.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// Small badge showing unlock requirements for a training pack.
+class PackUnlockRequirementBadge extends StatelessWidget {
+  final String text;
+  final String? tooltip;
+  const PackUnlockRequirementBadge({
+    super.key,
+    required this.text,
+    this.tooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final child = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.lock, size: 14, color: Colors.white70),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              text,
+              style: const TextStyle(fontSize: 11, color: Colors.white70),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+    return tooltip == null ? child : Tooltip(message: tooltip!, child: child);
+  }
+}

--- a/test/pack_unlocking_rules_engine_test.dart
+++ b/test/pack_unlocking_rules_engine_test.dart
@@ -12,6 +12,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     PackUnlockingRulesEngine.instance
       ..mock = true
+      ..devOverride = false
       ..resetMock();
   });
 
@@ -54,5 +55,17 @@ void main() {
     expect(unlocked, isFalse);
     expect(PackUnlockingRulesEngine.instance.getUnlockRule(tpl)?.unlockHint,
         'Complete pack A first');
+  });
+
+  test('dev override unlocks in debug mode', () async {
+    final tpl = TrainingPackTemplateV2(
+      id: 'b',
+      name: 'B',
+      trainingType: TrainingType.pushFold,
+      unlockRules: const UnlockRules(requiredPacks: ['a']),
+    );
+    PackUnlockingRulesEngine.instance.devOverride = true;
+    final unlocked = await PackUnlockingRulesEngine.instance.isUnlocked(tpl);
+    expect(unlocked, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add `PackUnlockRequirementBadge` widget for locked packs
- support developer override via `devUnlockOverride`
- expose `devOverride` flag in unlock engine
- show requirement badge in `TemplateLibraryScreen`
- update tests for new override logic

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c54621e00832a9d6b8507a770a3d8