### PR TITLE
Implement SuggestedNextPackEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -84,6 +84,7 @@ import 'services/smart_suggestion_service.dart';
 import 'services/training_gap_detector_service.dart';
 import 'services/smart_suggestion_engine.dart';
 import 'services/smart_pack_suggestion_engine.dart';
+import 'services/suggested_next_pack_engine.dart';
 import 'services/smart_review_service.dart';
 import 'services/evaluation_executor_service.dart';
 import 'services/session_analysis_service.dart';
@@ -443,6 +444,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(create: (_) => LessonPathProgressService()),
     Provider(create: (_) => AdaptiveNextStepEngine()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
+    Provider(
+      create: (context) => SuggestedNextPackEngine(
+        mastery: context.read<TagMasteryService>(),
+      ),
+    ),
   ];
 }
 

--- a/lib/screens/pack_stats_screen.dart
+++ b/lib/screens/pack_stats_screen.dart
@@ -7,6 +7,7 @@ import '../services/training_session_service.dart';
 import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
 import 'pack_history_screen.dart';
+import '../widgets/next_pack_recommendation_banner.dart';
 
 class PackStatsScreen extends StatelessWidget {
   final String templateId;
@@ -123,6 +124,7 @@ class PackStatsScreen extends StatelessWidget {
                   child: const Text('History'),
                 ),
               ),
+              NextPackRecommendationBanner(currentPackId: templateId),
             ],
           ),
         ),

--- a/lib/services/suggested_next_pack_engine.dart
+++ b/lib/services/suggested_next_pack_engine.dart
@@ -1,0 +1,68 @@
+import 'package:collection/collection.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'pack_unlocking_rules_engine.dart';
+import 'tag_mastery_service.dart';
+import 'training_progress_service.dart';
+import 'training_pack_stats_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SuggestedNextPackEngine {
+  final TagMasteryService mastery;
+  final List<TrainingPackTemplateV2>? _libraryOverride;
+
+  SuggestedNextPackEngine({required this.mastery, List<TrainingPackTemplateV2>? library})
+      : _libraryOverride = library;
+
+  final Map<String, TrainingPackTemplateV2?> _cache = {};
+  final Map<String, DateTime> _cacheTime = {};
+
+  Future<TrainingPackTemplateV2?> suggestNextPack({required String currentPackId}) async {
+    final cached = _cache[currentPackId];
+    final time = _cacheTime[currentPackId];
+    if (cached != null &&
+        time != null &&
+        DateTime.now().difference(time) < const Duration(hours: 6)) {
+      return cached;
+    }
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = _libraryOverride ?? PackLibraryLoaderService.instance.library;
+    final current = library.firstWhereOrNull((p) => p.id == currentPackId);
+    if (current == null) return null;
+
+    final focusTags = {
+      for (final t in current.tags) t.trim().toLowerCase()
+    };
+    final weakTags = (await mastery.getWeakTags()).map((e) => e.toLowerCase());
+    focusTags.addAll(weakTags);
+
+    final prefs = await SharedPreferences.getInstance();
+    final scored = <(TrainingPackTemplateV2, double)>[];
+
+    for (final p in library) {
+      if (p.id == current.id) continue;
+      if (!await PackUnlockingRulesEngine.instance.isUnlocked(p)) continue;
+      if (await TrainingPackStatsService.isMastered(p.id)) continue;
+
+      final completed = prefs.getBool('completed_tpl_${p.id}') == true;
+      final progress = await TrainingProgressService.instance.getProgress(p.id);
+
+      final tags = {for (final t in p.tags) t.trim().toLowerCase()};
+      final overlap = tags.intersection(focusTags).length.toDouble();
+
+      var score = overlap * 2;
+      score += completed ? 0 : 1;
+      score += (1 - progress);
+      if (p.trainingType == current.trainingType) score += 0.5;
+
+      scored.add((p, score));
+    }
+
+    scored.sort((a, b) => b.$2.compareTo(a.$2));
+    final result = scored.isNotEmpty ? scored.first.$1 : null;
+    _cache[currentPackId] = result;
+    _cacheTime[currentPackId] = DateTime.now();
+    return result;
+  }
+}

--- a/lib/widgets/next_pack_recommendation_banner.dart
+++ b/lib/widgets/next_pack_recommendation_banner.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/suggested_next_pack_engine.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+import '../screens/training_pack_preview_screen.dart';
+
+class NextPackRecommendationBanner extends StatefulWidget {
+  final String currentPackId;
+  const NextPackRecommendationBanner({super.key, required this.currentPackId});
+
+  @override
+  State<NextPackRecommendationBanner> createState() => _NextPackRecommendationBannerState();
+}
+
+class _NextPackRecommendationBannerState extends State<NextPackRecommendationBanner> {
+  bool _loading = true;
+  TrainingPackTemplateV2? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final engine = context.read<SuggestedNextPackEngine>();
+    final tpl = await engine.suggestNextPack(currentPackId: widget.currentPackId);
+    if (mounted) {
+      setState(() {
+        _pack = tpl;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _start() async {
+    final tpl = _pack;
+    if (tpl == null) return;
+    final template = TrainingPackTemplate.fromJson(tpl.toJson());
+    await context.read<TrainingSessionService>().startSession(template);
+    if (!context.mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  void _preview() {
+    final tpl = _pack;
+    if (tpl == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TrainingPackPreviewScreen(template: tpl)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _pack == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final pack = _pack!;
+    return Container(
+      margin: const EdgeInsets.only(top: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '🔜 Next recommended pack:',
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(pack.name, style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              OutlinedButton(onPressed: _preview, child: const Text('Preview')),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _start,
+                style: ElevatedButton.styleFrom(backgroundColor: accent),
+                child: const Text('Start'),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SuggestedNextPackEngine` with logic to recommend the next pack
- provide this engine via `AppProviders`
- show recommended pack banner on the pack stats screen
- new widget `NextPackRecommendationBanner` to display recommendation

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c563da5b0832abf0aceaff369ad94