### PR TITLE
Implement TrainingPathProgressService

### DIFF
--- a/assets/training_paths.yaml
+++ b/assets/training_paths.yaml
@@ -1,0 +1,7 @@
+stages:
+  beginner:
+    - starter_pushfold_10bb
+    - starter_pushfold_15bb
+  intermediate:
+    - starter_pushfold_12bb
+    - starter_pushfold_20bb

--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -96,6 +96,7 @@ import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
+import 'services/training_path_progress_service.dart';
 import 'services/adaptive_next_step_engine.dart';
 
 late final AuthService auth;
@@ -442,6 +443,7 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => LessonProgressTrackerService()..load()),
     Provider(create: (_) => LessonPathProgressService()),
+    Provider(create: (_) => TrainingPathProgressService()),
     Provider(create: (_) => AdaptiveNextStepEngine()),
     Provider(create: (_) => const SmartPackSuggestionEngine()),
     Provider(

--- a/lib/services/training_path_progress_service.dart
+++ b/lib/services/training_path_progress_service.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:yaml/yaml.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TrainingPathProgressService {
+  TrainingPathProgressService._();
+  static final instance = TrainingPathProgressService._();
+
+  static const _prefsPrefix = 'training_path_completed_';
+  static const _assetPath = 'assets/training_paths.yaml';
+
+  Map<String, List<String>>? _cache;
+
+  Future<Map<String, List<String>>> _loadStages() async {
+    final cached = _cache;
+    if (cached != null) return cached;
+    try {
+      final raw = await rootBundle.loadString(_assetPath);
+      final map = loadYaml(raw) as Map;
+      final result = <String, List<String>>{};
+      map.forEach((key, value) {
+        if (key is String && value is Map && value['packs'] is List) {
+          result[key] = [for (final v in value['packs']) v.toString()];
+        } else if (key is String && value is List) {
+          result[key] = [for (final v in value) v.toString()];
+        }
+      });
+      _cache = result;
+      return result;
+    } catch (_) {
+      _cache = <String, List<String>>{};
+      return _cache!;
+    }
+  }
+
+  Future<void> markCompleted(String packId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('$_prefsPrefix$packId', true);
+  }
+
+  Future<double> getProgressInStage(String stageId) async {
+    final stages = await _loadStages();
+    final packs = stages[stageId] ?? const <String>[];
+    if (packs.isEmpty) return 0.0;
+    final prefs = await SharedPreferences.getInstance();
+    final completed = packs.where((id) => prefs.getBool('$_prefsPrefix$id') ?? false).length;
+    return completed / packs.length;
+  }
+
+  Future<List<String>> getCompletedPacksInStage(String stageId) async {
+    final stages = await _loadStages();
+    final packs = stages[stageId] ?? const <String>[];
+    if (packs.isEmpty) return const <String>[];
+    final prefs = await SharedPreferences.getInstance();
+    final done = <String>[];
+    for (final id in packs) {
+      if (prefs.getBool('$_prefsPrefix$id') ?? false) {
+        done.add(id);
+      }
+    }
+    return done;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,6 +104,7 @@ flutter:
     - assets/lessons/
     - assets/pack_matrix.json
     - assets/learning_intro.svg
+    - assets/training_paths.yaml
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo

--- a/test/services/training_path_progress_service_test.dart
+++ b/test/services/training_path_progress_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/training_path_progress_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('progress updates correctly', () async {
+    final service = TrainingPathProgressService.instance;
+    var progress = await service.getProgressInStage('beginner');
+    expect(progress, 0.0);
+
+    await service.markCompleted('starter_pushfold_10bb');
+    progress = await service.getProgressInStage('beginner');
+    expect(progress, closeTo(0.5, 0.001));
+
+    final completed = await service.getCompletedPacksInStage('beginner');
+    expect(completed, ['starter_pushfold_10bb']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPathProgressService` to track stage progress
- store example stage data in `assets/training_paths.yaml`
- wire new service via providers
- list new asset in pubspec
- basic unit test covering progress logic

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: many pre-existing issues)*
- `flutter test --run-skipped` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687c5b6472fc832aa09a55d0371a039d