### PR TITLE
Add SuggestedNextStepEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -98,6 +98,7 @@ import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
 import 'services/training_path_progress_service.dart';
 import 'services/adaptive_next_step_engine.dart';
+import 'services/suggested_next_step_engine.dart';
 
 late final AuthService auth;
 late final RemoteConfigService rc;
@@ -449,6 +450,13 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(
       create: (context) => SuggestedNextPackEngine(
         mastery: context.read<TagMasteryService>(),
+      ),
+    ),
+    Provider(
+      create: (context) => SuggestedNextStepEngine(
+        path: context.read<TrainingPathProgressService>(),
+        mastery: context.read<TagMasteryService>(),
+        storage: context.read<TemplateStorageService>(),
       ),
     ),
   ];

--- a/lib/services/suggested_next_step_engine.dart
+++ b/lib/services/suggested_next_step_engine.dart
@@ -1,0 +1,111 @@
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'pack_unlocking_rules_engine.dart';
+import 'template_storage_service.dart';
+import 'tag_mastery_service.dart';
+import 'training_path_progress_service.dart';
+
+class SuggestedNextStepEngine {
+  final TrainingPathProgressService path;
+  final TagMasteryService mastery;
+  final TemplateStorageService storage;
+
+  SuggestedNextStepEngine({
+    required this.path,
+    required this.mastery,
+    required this.storage,
+  });
+
+  Map<String, List<String>>? _stageCache;
+  Map<String, Set<String>>? _completedCache;
+  DateTime _cacheTime = DateTime.fromMillisecondsSinceEpoch(0);
+
+  Future<void> _loadCache() async {
+    if (_stageCache != null &&
+        DateTime.now().difference(_cacheTime) < const Duration(minutes: 10)) {
+      return;
+    }
+    _stageCache = await path.getStages();
+    final prefs = await SharedPreferences.getInstance();
+    _completedCache = {};
+    for (final entry in _stageCache!.entries) {
+      final done = <String>{};
+      for (final id in entry.value) {
+        if (prefs.getBool('training_path_completed_$id') ?? false) {
+          done.add(id);
+        }
+      }
+      _completedCache![entry.key] = done;
+    }
+    _cacheTime = DateTime.now();
+  }
+
+  bool _stageDone(List<String> ids, Set<String> completed) {
+    for (final id in ids) {
+      if (!completed.contains(id)) return false;
+    }
+    return true;
+  }
+
+  double _packScore(
+    TrainingPackTemplateV2 pack,
+    Map<String, double> masteryMap,
+  ) {
+    var score = 1.0;
+    for (final t in pack.tags) {
+      final m = masteryMap[t.toLowerCase()];
+      if (m != null && m < score) score = m;
+    }
+    return score;
+  }
+
+  Future<TrainingPackTemplateV2?> suggestNext() async {
+    await _loadCache();
+    final stages = _stageCache ?? {};
+    if (stages.isEmpty) return null;
+
+    final masteryMap = await mastery.computeMastery();
+
+    bool previousCompleted = true;
+    for (final entry in stages.entries) {
+      final packs = entry.value;
+      final completed = _completedCache?[entry.key] ?? {};
+      if (!previousCompleted) break;
+
+      final incomplete = [for (final id in packs) if (!completed.contains(id)) id];
+      if (incomplete.isEmpty) {
+        previousCompleted = true;
+        continue;
+      }
+
+      final candidates = <(TrainingPackTemplateV2, double)>[];
+      for (final id in incomplete) {
+        final tpl = storage.templates
+            .firstWhereOrNull((t) => t.id == id);
+        if (tpl == null) continue;
+        final tplV2 = TrainingPackTemplateV2.fromTemplate(
+          tpl,
+          type: TrainingType.pushFold,
+        );
+        tplV2.trainingType = const TrainingTypeEngine().detectTrainingType(tplV2);
+        if (!await PackUnlockingRulesEngine.instance.isUnlocked(tplV2)) {
+          continue;
+        }
+        final score = _packScore(tplV2, masteryMap);
+        candidates.add((tplV2, score));
+      }
+
+      if (candidates.isNotEmpty) {
+        candidates.sort((a, b) => a.$2.compareTo(b.$2));
+        return candidates.first.$1;
+      }
+
+      previousCompleted = _stageDone(packs, completed);
+    }
+
+    return null;
+  }
+}

--- a/test/services/suggested_next_step_engine_test.dart
+++ b/test/services/suggested_next_step_engine_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/suggested_next_step_engine.dart';
+import 'package:poker_analyzer/services/training_path_progress_service.dart';
+import 'package:poker_analyzer/services/template_storage_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/training_pack_template.dart';
+
+class _FakeTagMasteryService extends TagMasteryService {
+  final Map<String, double> _data;
+  _FakeTagMasteryService(this._data)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => _data;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('picks pack with lowest mastery', () async {
+    final storage = TemplateStorageService();
+    storage.addTemplate(TrainingPackTemplate(
+      id: 'starter_pushfold_10bb',
+      name: 'A',
+      gameType: 'tournament',
+      description: '',
+      hands: const [],
+      tags: const ['easy'],
+    ));
+    storage.addTemplate(TrainingPackTemplate(
+      id: 'starter_pushfold_15bb',
+      name: 'B',
+      gameType: 'tournament',
+      description: '',
+      hands: const [],
+      tags: const ['hard'],
+    ));
+    final mastery = _FakeTagMasteryService({'easy': 0.9, 'hard': 0.5});
+    final engine = SuggestedNextStepEngine(
+      path: TrainingPathProgressService.instance,
+      mastery: mastery,
+      storage: storage,
+    );
+    final next = await engine.suggestNext();
+    expect(next?.id, 'starter_pushfold_15bb');
+  });
+
+  test('returns null when all completed', () async {
+    final storage = TemplateStorageService();
+    storage.addTemplate(TrainingPackTemplate(
+      id: 'starter_pushfold_10bb',
+      name: 'A',
+      gameType: 'tournament',
+      description: '',
+      hands: const [],
+    ));
+    storage.addTemplate(TrainingPackTemplate(
+      id: 'starter_pushfold_15bb',
+      name: 'B',
+      gameType: 'tournament',
+      description: '',
+      hands: const [],
+    ));
+    await TrainingPathProgressService.instance
+        .markCompleted('starter_pushfold_10bb');
+    await TrainingPathProgressService.instance
+        .markCompleted('starter_pushfold_15bb');
+    final mastery = _FakeTagMasteryService({});
+    final engine = SuggestedNextStepEngine(
+      path: TrainingPathProgressService.instance,
+      mastery: mastery,
+      storage: storage,
+    );
+    final next = await engine.suggestNext();
+    expect(next, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SuggestedNextStepEngine` for recommending the next training pack
- wire the engine via providers
- cover logic with unit tests

## Testing
- `flutter test test/services/suggested_next_step_engine_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c675ab2f8832a8299fa8494064bf1