### PR TITLE
Implement learning path reminder engine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -98,6 +98,8 @@ import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
 import 'services/training_path_progress_service.dart';
 import 'services/learning_path_summary_cache.dart';
+import 'services/learning_path_reminder_engine.dart';
+import 'services/daily_app_check_service.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -464,6 +466,16 @@ List<SingleChildWidget> buildTrainingProviders() {
         path: context.read<TrainingPathProgressService>(),
         mastery: context.read<TagMasteryService>(),
         storage: context.read<TemplateStorageService>(),
+      ),
+    ),
+    Provider(
+      create: (context) => LearningPathReminderEngine(
+        cache: context.read<LearningPathSummaryCache>(),
+      ),
+    ),
+    Provider(
+      create: (context) => DailyAppCheckService(
+        reminder: context.read<LearningPathReminderEngine>(),
       ),
     ),
   ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -103,6 +103,8 @@ import 'services/pinned_pack_service.dart';
 import 'services/training_pack_template_service.dart';
 import 'services/training_pack_stats_service.dart';
 import 'services/learning_path_summary_cache.dart';
+import 'services/learning_path_reminder_engine.dart';
+import 'services/daily_app_check_service.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
 import 'services/app_init_service.dart';
@@ -266,6 +268,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     unawaited(NotificationService.scheduleDailyProgress(context));
     NotificationService.startRecommendedPackTask(context);
     unawaited(context.read<LearningPathSummaryCache>().refresh());
+    unawaited(context.read<DailyAppCheckService>().run(context));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeStartPinnedTraining();
       _maybeResumeTraining();

--- a/lib/services/learning_path_reminder_engine.dart
+++ b/lib/services/learning_path_reminder_engine.dart
@@ -1,0 +1,46 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'learning_path_summary_cache.dart';
+import 'training_history_service_v2.dart';
+
+/// Reminds the user about stalled learning path progress.
+class LearningPathReminderEngine {
+  LearningPathReminderEngine._(this.cache);
+
+  static LearningPathReminderEngine? _instance;
+  final LearningPathSummaryCache cache;
+
+  /// Initializes the singleton with required dependencies.
+  factory LearningPathReminderEngine({required LearningPathSummaryCache cache}) {
+    return _instance ??= LearningPathReminderEngine._(cache);
+  }
+
+  static LearningPathReminderEngine get instance => _instance!;
+
+  static const _lastKey = 'learning_path_reminder_last';
+
+  Future<bool> shouldRemindUser() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null && now.difference(last) < const Duration(days: 3)) {
+      return false;
+    }
+
+    await cache.refresh();
+    final summary = cache.summary;
+    if (summary == null) return false;
+    if (summary.remainingPacks <= 0) return false;
+    if (summary.avgMastery >= 0.6) return false;
+
+    final history = await TrainingHistoryServiceV2.getHistory(limit: 1);
+    if (history.isNotEmpty &&
+        now.difference(history.first.timestamp) < const Duration(days: 3)) {
+      return false;
+    }
+
+    await prefs.setString(_lastKey, now.toIso8601String());
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add singleton `LearningPathReminderEngine`
- create `DailyAppCheckService` to run reminder check
- wire reminder services into `app_providers`
- trigger daily app check in `main` on startup

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6d7067ac832a86aa178ca1d3c396