### PR TITLE
Add in-app learning path reminder modal

### DIFF
--- a/lib/services/daily_app_check_service.dart
+++ b/lib/services/daily_app_check_service.dart
@@ -3,6 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'learning_path_reminder_engine.dart';
 import 'notification_service.dart';
+import '../widgets/learning_path_modal_reminder.dart';
+import 'training_session_service.dart';
 
 /// Performs daily app checks and triggers gentle reminders.
 class DailyAppCheckService {
@@ -32,7 +34,16 @@ class DailyAppCheckService {
 
     final remind = await reminder.shouldRemindUser();
     if (remind) {
-      await NotificationService.scheduleDailyReminder(context);
+      final active =
+          WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed;
+      final sessions = context.read<TrainingSessionService>();
+      final trainingActive =
+          sessions.currentSession != null && !sessions.isCompleted;
+      if (context.mounted && active && !trainingActive) {
+        await LearningPathModalReminder.show(context);
+      } else {
+        await NotificationService.scheduleDailyReminder(context);
+      }
     }
   }
 }

--- a/lib/widgets/learning_path_modal_reminder.dart
+++ b/lib/widgets/learning_path_modal_reminder.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import '../screens/learning_path_overview_screen.dart';
+
+class LearningPathModalReminder extends StatelessWidget {
+  const LearningPathModalReminder({super.key});
+
+  static Future<void> show(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (_) => const LearningPathModalReminder(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return AlertDialog(
+      title: const Text('Продолжим обучение?'),
+      content: const Text(
+        'Ты можешь прокачать свои навыки уже сейчас. Дорога к мастерству ждёт тебя 💡',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Позже'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            Navigator.pop(context);
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const LearningPathOverviewScreen(),
+              ),
+            );
+          },
+          style: ElevatedButton.styleFrom(backgroundColor: accent),
+          child: const Text('Начать тренировку'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `LearningPathModalReminder` dialog prompting users to continue training
- prefer showing the new modal inside `DailyAppCheckService.run`
- fall back to scheduled notification when app is inactive or training is running

## Testing
- `flutter test --no-pub test/accuracy_utils_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687c6f40c500832aaf300783f1c02985