### PR TITLE
Add icon to learning path reminder modal

### DIFF
--- a/lib/widgets/learning_path_modal_reminder.dart
+++ b/lib/widgets/learning_path_modal_reminder.dart
@@ -15,7 +15,13 @@ class LearningPathModalReminder extends StatelessWidget {
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
     return AlertDialog(
-      title: const Text('Продолжим обучение?'),
+      title: Row(
+        children: [
+          Icon(Icons.school, color: accent, size: 28),
+          const SizedBox(width: 8),
+          const Text('Продолжим обучение?'),
+        ],
+      ),
       content: const Text(
         'Ты можешь прокачать свои навыки уже сейчас. Дорога к мастерству ждёт тебя 💡',
       ),


### PR DESCRIPTION
## Summary
- tweak `LearningPathModalReminder` with a school icon in the title

## Testing
- `flutter test --no-pub test/accuracy_utils_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687c71680470832a8896ae8c171af512