### PR TITLE
Implement streak progress tracking

### DIFF
--- a/lib/services/lesson_progress_service.dart
+++ b/lib/services/lesson_progress_service.dart
@@ -1,4 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'streak_progress_service.dart';
 
 class LessonProgressService {
   LessonProgressService._();
@@ -9,6 +10,7 @@ class LessonProgressService {
   Future<void> markCompleted(String stepId) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_key(stepId), true);
+    await StreakProgressService.instance.registerDailyActivity();
   }
 
   Future<bool> isCompleted(String stepId) async {
@@ -18,9 +20,9 @@ class LessonProgressService {
 
   Future<Set<String>> getCompletedSteps() async {
     final prefs = await SharedPreferences.getInstance();
-    final keys = prefs.getKeys().where((k) => k.startsWith('lesson_completed_'));
-    return keys
-        .map((k) => k.substring('lesson_completed_'.length))
-        .toSet();
+    final keys = prefs.getKeys().where(
+      (k) => k.startsWith('lesson_completed_'),
+    );
+    return keys.map((k) => k.substring('lesson_completed_'.length)).toSet();
   }
 }

--- a/lib/services/streak_progress_service.dart
+++ b/lib/services/streak_progress_service.dart
@@ -1,0 +1,73 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StreakData {
+  final int currentStreak;
+  final int longestStreak;
+  final DateTime? lastActiveDate;
+  final bool isTodayDone;
+
+  const StreakData({
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.lastActiveDate,
+    required this.isTodayDone,
+  });
+}
+
+class StreakProgressService {
+  StreakProgressService._();
+  static final StreakProgressService instance = StreakProgressService._();
+
+  static const _lastKey = 'streak_progress_last';
+  static const _currentKey = 'streak_progress_current';
+  static const _longestKey = 'streak_progress_longest';
+
+  Future<void> registerDailyActivity() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    var current = prefs.getInt(_currentKey) ?? 0;
+    var longest = prefs.getInt(_longestKey) ?? current;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 1) {
+        current += 1;
+      } else if (diff > 1) {
+        current = 1;
+      }
+    } else {
+      current = 1;
+    }
+    if (current > longest) longest = current;
+
+    await prefs.setInt(_currentKey, current);
+    await prefs.setInt(_longestKey, longest);
+    await prefs.setString(_lastKey, today.toIso8601String());
+  }
+
+  Future<StreakData> getStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_currentKey) ?? 0;
+    final longest = prefs.getInt(_longestKey) ?? 0;
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    final today = DateTime(
+      DateTime.now().year,
+      DateTime.now().month,
+      DateTime.now().day,
+    );
+    final isTodayDone =
+        last != null &&
+        DateTime(last.year, last.month, last.day).difference(today).inDays == 0;
+    return StreakData(
+      currentStreak: current,
+      longestStreak: longest,
+      lastActiveDate: last,
+      isTodayDone: isTodayDone,
+    );
+  }
+}

--- a/test/services/streak_progress_service_test.dart
+++ b/test/services/streak_progress_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/streak_progress_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('streak increments on consecutive days', () async {
+    SharedPreferences.setMockInitialValues({});
+    await StreakProgressService.instance.registerDailyActivity();
+    var data = await StreakProgressService.instance.getStreak();
+    expect(data.currentStreak, 1);
+    expect(data.isTodayDone, isTrue);
+
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('streak_progress_last', yesterday.toIso8601String());
+
+    await StreakProgressService.instance.registerDailyActivity();
+    data = await StreakProgressService.instance.getStreak();
+    expect(data.currentStreak, 2);
+    expect(data.longestStreak, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add new `StreakProgressService` using `SharedPreferences`
- record activity on lesson completion and training pack finish
- show streak message in learning path overview
- add unit test

## Testing
- `dart format lib/services/streak_progress_service.dart lib/services/streak_service.dart lib/services/lesson_progress_service.dart lib/screens/learning_path_overview_screen.dart test/services/streak_progress_service_test.dart`
- `dart --version`
- `dart pub get` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_687c73b7ed7c832ab61fba8a6485706c