### PR TITLE
Add milestone engine

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -32,6 +32,8 @@ import '../services/daily_learning_goal_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/pack_library_loader_service.dart';
 import '../services/smart_stage_unlock_engine.dart';
+import '../services/training_milestone_engine.dart';
+import '../widgets/confetti_overlay.dart';
 import 'package:collection/collection.dart';
 
 class _EndlessStats {
@@ -349,6 +351,15 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       AchievementService.instance.checkAll();
       await AchievementTriggerEngine.instance.checkAndTriggerAchievements();
       await _checkGoalProgress();
+      final stats =
+          await TrainingPackStatsService.getGlobalStats(force: true);
+      final milestone = await TrainingMilestoneEngine.instance
+          .checkAndTrigger(completedPacks: stats.packsCompleted);
+      if (milestone.triggered && mounted) {
+        showConfettiOverlay(context);
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(milestone.message)));
+      }
     }
   }
 

--- a/lib/services/training_milestone_engine.dart
+++ b/lib/services/training_milestone_engine.dart
@@ -1,0 +1,59 @@
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MilestoneResult {
+  final bool triggered;
+  final int? milestoneValue;
+  final String message;
+
+  const MilestoneResult({
+    required this.triggered,
+    this.milestoneValue,
+    this.message = '',
+  });
+}
+
+class TrainingMilestoneEngine {
+  TrainingMilestoneEngine._();
+  static final instance = TrainingMilestoneEngine._();
+
+  static const List<int> milestones = [10, 30, 50, 100, 200];
+  static const _prefsKey = 'training_milestones_triggered';
+
+  Set<int>? _triggered;
+
+  Future<Set<int>> _load() async {
+    if (_triggered != null) return _triggered!;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_prefsKey);
+    _triggered = raw?.map((e) => int.tryParse(e) ?? 0).where((e) => e > 0).toSet() ?? {};
+    return _triggered!;
+  }
+
+  Future<void> _save() async {
+    if (_triggered == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      _triggered!.map((e) => e.toString()).toList(),
+    );
+  }
+
+  Future<MilestoneResult> checkAndTrigger({required int completedPacks}) async {
+    final triggered = await _load();
+    final milestone = milestones.firstWhereOrNull(
+      (m) => completedPacks >= m && !triggered.contains(m),
+    );
+    if (milestone != null) {
+      triggered.add(milestone);
+      await _save();
+      final msg = '🎉 $milestone паков — отличное начало!';
+      return MilestoneResult(
+        triggered: true,
+        milestoneValue: milestone,
+        message: msg,
+      );
+    }
+    return const MilestoneResult(triggered: false);
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingMilestoneEngine` service for milestone celebrations
- integrate milestone checks after completing a training pack

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c766825d8832abc9b7d161d2bfd6d