### PR TITLE
Implement pack library completion tracking

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -16,6 +16,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/v2/training_session.dart';
 import 'pack_stats_screen.dart';
 import 'training_recap_screen.dart';
+import '../services/pack_library_completion_service.dart';
 import '../models/v2/training_pack_v2.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_template_v2.dart';
@@ -318,6 +319,12 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         unawaited(cloud.save('completed_tpl_${tpl.id}', '1'));
       }
       final elapsed = service.elapsedTime;
+      unawaited(PackLibraryCompletionService.instance.registerCompletion(
+        tpl.id,
+        correct: correct,
+        total: total,
+        elapsed: elapsed,
+      ));
       if (service.totalCount < 3) {
         Map<String, int>? counts;
         if (tpl.id == 'suggested_weekly') {

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -23,6 +23,7 @@ import '../../widgets/common/animated_line_chart.dart';
 import '../../services/weak_spot_recommendation_service.dart';
 import '../training_session_screen.dart';
 import '../../services/training_session_service.dart';
+import '../../services/pack_library_completion_service.dart';
 
 class TrainingPackResultScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -293,6 +294,11 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       postEv / 100,
       postIcm / 100,
       context: context,
+    ));
+    unawaited(PackLibraryCompletionService.instance.registerCompletion(
+      widget.original.id,
+      correct: _correct,
+      total: _total,
     ));
     SharedPreferences.getInstance().then((p) =>
         p.setString('last_trained_tpl_${widget.original.id}', DateTime.now().toIso8601String()));

--- a/lib/services/pack_library_completion_service.dart
+++ b/lib/services/pack_library_completion_service.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PackCompletionData {
+  final DateTime completedAt;
+  final int correct;
+  final int total;
+  final double accuracy;
+  final Duration elapsed;
+
+  bool get isPerfect => accuracy >= 1.0;
+
+  const PackCompletionData({
+    required this.completedAt,
+    required this.correct,
+    required this.total,
+    required this.accuracy,
+    required this.elapsed,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'completedAt': completedAt.toIso8601String(),
+        'correct': correct,
+        'total': total,
+        'accuracy': accuracy,
+        'elapsed': elapsed.inSeconds,
+      };
+
+  factory PackCompletionData.fromJson(Map<String, dynamic> json) => PackCompletionData(
+        completedAt: DateTime.tryParse(json['completedAt'] as String? ?? '') ??
+            DateTime.fromMillisecondsSinceEpoch(0),
+        correct: (json['correct'] as num?)?.toInt() ?? 0,
+        total: (json['total'] as num?)?.toInt() ?? 0,
+        accuracy: (json['accuracy'] as num?)?.toDouble() ?? 0.0,
+        elapsed: Duration(seconds: (json['elapsed'] as num?)?.toInt() ?? 0),
+      );
+}
+
+class PackLibraryCompletionService {
+  PackLibraryCompletionService._();
+  static final instance = PackLibraryCompletionService._();
+
+  static const _prefix = 'pack_progress_';
+
+  Future<void> registerCompletion(
+    String packId, {
+    required int correct,
+    required int total,
+    Duration? elapsed,
+  }) async {
+    if (packId.isEmpty || total <= 0) return;
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final accuracy = correct / total;
+    final existingRaw = prefs.getString('$_prefix$packId');
+    if (existingRaw != null) {
+      try {
+        final data = PackCompletionData.fromJson(
+            jsonDecode(existingRaw) as Map<String, dynamic>);
+        var should = false;
+        if (now.isAfter(data.completedAt)) {
+          should = true;
+        } else if (now.isAtSameMomentAs(data.completedAt)) {
+          should = accuracy > data.accuracy;
+        } else if (accuracy > data.accuracy) {
+          should = true;
+        }
+        if (!should) return;
+      } catch (_) {}
+    }
+    final info = PackCompletionData(
+      completedAt: now,
+      correct: correct,
+      total: total,
+      accuracy: accuracy,
+      elapsed: elapsed ?? Duration.zero,
+    );
+    await prefs.setString('$_prefix$packId', jsonEncode(info.toJson()));
+  }
+
+  Future<PackCompletionData?> getCompletion(String packId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_prefix$packId');
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        return PackCompletionData.fromJson(
+            Map<String, dynamic>.from(data as Map));
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<Map<String, PackCompletionData>> getAllCompletions() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, PackCompletionData>{};
+    for (final k in prefs.getKeys()) {
+      if (k.startsWith(_prefix)) {
+        final raw = prefs.getString(k);
+        if (raw == null) continue;
+        try {
+          final data = jsonDecode(raw);
+          if (data is Map) {
+            final id = k.substring(_prefix.length);
+            result[id] = PackCompletionData.fromJson(
+                Map<String, dynamic>.from(data as Map));
+          }
+        } catch (_) {}
+      }
+    }
+    return result;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `PackLibraryCompletionService` for tracking per-pack completion stats
- record completion data after finishing a training session
- update template result screen to register pack completion

## Testing
- `dart format` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c77767a5c832a9de21c975a727500