### PR TITLE
Implement LibraryPackBadgeRenderer

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -82,6 +82,7 @@ import '../services/training_pack_sampler.dart';
 import 'v2/training_pack_play_screen.dart';
 import '../widgets/pack_progress_overlay.dart';
 import '../widgets/pack_unlock_requirement_badge.dart';
+import '../widgets/library_pack_badge_renderer.dart';
 
 class TemplateLibraryScreen extends StatefulWidget {
   const TemplateLibraryScreen({super.key});
@@ -2067,6 +2068,11 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           right: 4,
           child: PackProgressOverlay(templateId: t.id, size: 20),
         ),
+        Positioned(
+          bottom: 4,
+          right: 4,
+          child: LibraryPackBadgeRenderer(packId: t.id),
+        ),
         if (locked && reason != null)
           Positioned(
             bottom: 4,
@@ -2340,6 +2346,11 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           top: 4,
           right: 4,
           child: PackProgressOverlay(templateId: t.id, size: 20),
+        ),
+        Positioned(
+          bottom: 4,
+          right: 4,
+          child: LibraryPackBadgeRenderer(packId: t.id),
         ),
         if (locked && reason != null)
           Positioned(
@@ -2720,6 +2731,11 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
           top: 4,
           right: 4,
           child: PackProgressOverlay(templateId: t.id, size: 20),
+        ),
+        Positioned(
+          bottom: 4,
+          right: 4,
+          child: LibraryPackBadgeRenderer(packId: t.id),
         ),
         if (locked && reason != null)
           Positioned(

--- a/lib/widgets/library_pack_badge_renderer.dart
+++ b/lib/widgets/library_pack_badge_renderer.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../services/pack_library_completion_service.dart';
+
+/// Renders a small badge for a library pack based on completion stats.
+class LibraryPackBadgeRenderer extends StatefulWidget {
+  final String packId;
+  const LibraryPackBadgeRenderer({super.key, required this.packId});
+
+  @override
+  State<LibraryPackBadgeRenderer> createState() => _LibraryPackBadgeRendererState();
+}
+
+class _LibraryPackBadgeRendererState extends State<LibraryPackBadgeRenderer> {
+  static final _cache = <String, PackCompletionData?>{};
+  late Future<PackCompletionData?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<PackCompletionData?> _load() async {
+    if (_cache.containsKey(widget.packId)) {
+      return _cache[widget.packId];
+    }
+    final data = await PackLibraryCompletionService.instance
+        .getCompletion(widget.packId);
+    _cache[widget.packId] = data;
+    return data;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<PackCompletionData?>(
+      future: _future,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        if (data == null || data.total <= 0) {
+          return const SizedBox.shrink();
+        }
+        final accuracy = data.accuracy;
+        if (accuracy <= 0) return const SizedBox.shrink();
+        String label;
+        if (accuracy >= 1.0) {
+          label = '🌟 Perfect';
+        } else if (accuracy >= 0.8) {
+          label = '✅ Completed';
+        } else {
+          label = '🕓 In Progress';
+        }
+        final color = Theme.of(context).colorScheme.secondary;
+        final pct = (accuracy * 100).round();
+        final badge = Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            '$label $pct%',
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        );
+        return Tooltip(message: label, child: badge);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LibraryPackBadgeRenderer` widget to show completion badges
- display badge in template library pack tiles

## Testing
- `flutter analyze` *(fails: Flutter not available)*

------
https://chatgpt.com/codex/tasks/task_e_687c7f797980832a9042c4577b27f418