### PR TITLE
Implement fallback for weak tag pack suggestions

### DIFF
--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -68,6 +68,7 @@ import '../widgets/category_section.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../widgets/pack_suggestion_banner.dart';
 import '../widgets/smart_suggestion_banner.dart';
+import '../widgets/suggested_weak_tag_pack_banner.dart';
 import '../services/weak_training_type_detector.dart';
 import '../widgets/training_gap_prompt_banner.dart';
 import '../widgets/training_type_gap_prompt_banner.dart';
@@ -3589,6 +3590,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                     controller: _listCtrl,
                     children: [
                       SmartSuggestionBanner(selectedTags: _selectedTags),
+                      const SuggestedWeakTagPackBanner(),
                       const PackResumeBanner(),
                       const PackSuggestionBanner(),
                       const SuggestedPackTile(),

--- a/lib/services/suggested_weak_tag_pack_service.dart
+++ b/lib/services/suggested_weak_tag_pack_service.dart
@@ -1,0 +1,54 @@
+import 'package:collection/collection.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'weak_tag_detector_service.dart';
+import 'training_tag_performance_engine.dart';
+
+class SuggestedWeakTagPackResult {
+  final TrainingPackTemplateV2? pack;
+  final bool isFallback;
+  const SuggestedWeakTagPackResult({required this.pack, required this.isFallback});
+}
+
+class SuggestedWeakTagPackService {
+  final List<TrainingPackTemplateV2>? _libraryOverride;
+  final Future<List<TagPerformance>> Function()? _detectWeakTags;
+  const SuggestedWeakTagPackService({
+    List<TrainingPackTemplateV2>? library,
+    Future<List<TagPerformance>> Function()? detectWeakTags,
+  })  : _libraryOverride = library,
+        _detectWeakTags = detectWeakTags;
+
+  Future<SuggestedWeakTagPackResult> suggestPack() async {
+    final weak = _detectWeakTags != null
+        ? await _detectWeakTags!()
+        : await WeakTagDetectorService.detectWeakTags();
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = _libraryOverride ?? PackLibraryLoaderService.instance.library;
+
+    for (final t in weak) {
+      final pack = library.firstWhereOrNull((p) => p.tags.contains(t.tag));
+      if (pack != null) {
+        return SuggestedWeakTagPackResult(pack: pack, isFallback: false);
+      }
+    }
+
+    final fallback = _findFallback(library);
+    return SuggestedWeakTagPackResult(pack: fallback, isFallback: true);
+  }
+
+  TrainingPackTemplateV2? _findFallback(List<TrainingPackTemplateV2> library) {
+    final fund = library.firstWhereOrNull((p) => p.tags.contains('fundamentals'));
+    if (fund != null) return fund;
+    final starter = library.firstWhereOrNull((p) => p.tags.contains('starter'));
+    if (starter != null) return starter;
+    final sorted = [...library]
+      ..sort((a, b) {
+        final pa = (a.meta['popularity'] as num?)?.toDouble() ?? 0;
+        final pb = (b.meta['popularity'] as num?)?.toDouble() ?? 0;
+        return pb.compareTo(pa);
+      });
+    return sorted.firstOrNull;
+  }
+}

--- a/lib/widgets/suggested_weak_tag_pack_banner.dart
+++ b/lib/widgets/suggested_weak_tag_pack_banner.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/suggested_weak_tag_pack_service.dart';
+import '../services/training_session_service.dart';
+import '../services/user_action_logger.dart';
+import '../screens/training_session_screen.dart';
+
+class SuggestedWeakTagPackBanner extends StatefulWidget {
+  const SuggestedWeakTagPackBanner({super.key});
+
+  @override
+  State<SuggestedWeakTagPackBanner> createState() => _SuggestedWeakTagPackBannerState();
+}
+
+class _SuggestedWeakTagPackBannerState extends State<SuggestedWeakTagPackBanner> {
+  bool _loading = true;
+  TrainingPackTemplateV2? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final result = await const SuggestedWeakTagPackService().suggestPack();
+    if (result.isFallback && result.pack != null) {
+      await UserActionLogger.instance.log('suggested_pack_banner.fallback_shown');
+    }
+    if (mounted) {
+      setState(() {
+        _pack = result.pack;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _start() async {
+    final tpl = _pack;
+    if (tpl == null) return;
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (!context.mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _pack == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '💡 \u0423\u043a\u0440\u0435\u043f\u0438 \u0431\u0430\u0437\u0443',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+          ),
+          const SizedBox(height: 4),
+          Text('\u0420\u0435\u043a\u043e\u043c\u0435\u043d\u0434\u0443\u0435\u043c\u044b\u0439 \u043f\u0430\u043a: ${_pack!.name}',
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _start,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('\u041d\u0430\u0447\u0430\u0442\u044c \u0442\u0440\u0435\u043d\u0438\u0440\u043e\u0432\u043a\u0443'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/suggested_weak_tag_pack_service_test.dart
+++ b/test/services/suggested_weak_tag_pack_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/suggested_weak_tag_pack_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_tag_performance_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingPackTemplateV2 tpl({required String id, required List<String> tags, double pop = 0}) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.pushFold,
+      tags: tags,
+      meta: {'popularity': pop},
+    );
+  }
+
+  test('returns pack matching weak tag', () async {
+    final library = [tpl(id: 'a', tags: ['cbet'])];
+    final weak = [
+      const TagPerformance(tag: 'cbet', totalAttempts: 0, correct: 0, accuracy: 0, lastTrained: null),
+    ];
+    final service = SuggestedWeakTagPackService(
+      library: library,
+      detectWeakTags: () async => weak,
+    );
+    final result = await service.suggestPack();
+    expect(result.isFallback, false);
+    expect(result.pack?.id, 'a');
+  });
+
+  test('falls back when no matching pack', () async {
+    final library = [
+      tpl(id: 'b', tags: ['fundamentals']),
+      tpl(id: 'c', tags: ['starter'], pop: 5),
+    ];
+    final service = SuggestedWeakTagPackService(
+      library: library,
+      detectWeakTags: () async => [],
+    );
+    final result = await service.suggestPack();
+    expect(result.isFallback, true);
+    expect(result.pack?.id, 'b');
+  });
+}


### PR DESCRIPTION
## Summary
- add service for weak tag pack suggestions with fallback logic
- show banner suggesting fallback or weak tag pack
- display banner in template library screen
- add unit tests for fallback logic

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c89826b58832ab255c9819717466f