### PR TITLE
Implement SkillRecoveryPackEngine

### DIFF
--- a/lib/services/skill_recovery_pack_engine.dart
+++ b/lib/services/skill_recovery_pack_engine.dart
@@ -1,0 +1,90 @@
+import 'package:collection/collection.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'training_gap_detector_service.dart';
+import 'training_tag_performance_engine.dart';
+
+class SkillRecoveryPackEngine {
+  const SkillRecoveryPackEngine._();
+
+  /// Suggests a training pack aimed at refreshing dormant skills.
+  ///
+  /// [excludedPackIds] prevents already suggested packs from being returned.
+  /// [library] and [detectDormantTags] are used for testing.
+  static Future<TrainingPackTemplateV2?> suggestRecoveryPack({
+    Set<String>? excludedPackIds,
+    List<TrainingPackTemplateV2>? library,
+    Future<List<TagPerformance>> Function()? detectDormantTags,
+  }) async {
+    final dormant = detectDormantTags != null
+        ? await detectDormantTags()
+        : await TrainingGapDetectorService.detectDormantTags(limit: 3);
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final lib = library ?? PackLibraryLoaderService.instance.library;
+    final exclude = excludedPackIds ?? <String>{};
+
+    for (final item in dormant) {
+      final tag = item.tag.toLowerCase();
+      final candidates = lib.where((p) {
+        if (exclude.contains(p.id)) return false;
+        final tags = {
+          for (final t in p.tags) t.toLowerCase(),
+        };
+        final metaTags = p.meta['tags'];
+        if (metaTags is List) {
+          tags.addAll(metaTags.map((e) => e.toString().toLowerCase()));
+        }
+        final focusTags = p.meta['focusTags'];
+        if (focusTags is List) {
+          tags.addAll(focusTags.map((e) => e.toString().toLowerCase()));
+        }
+        final focusTag = p.meta['focusTag'];
+        if (focusTag is String) tags.add(focusTag.toLowerCase());
+        return tags.contains(tag);
+      }).toList();
+
+      if (candidates.isEmpty) continue;
+
+      int score(TrainingPackTemplateV2 p) {
+        var s = 0;
+        if (p.meta['suggested'] == true) s += 2;
+        if (p.meta['starter'] == true) s += 1;
+        return s;
+      }
+
+      candidates.sort((a, b) => score(b).compareTo(score(a)));
+      return candidates.first;
+    }
+
+    return _findFallback(lib, exclude);
+  }
+
+  static TrainingPackTemplateV2? _findFallback(
+    List<TrainingPackTemplateV2> library,
+    Set<String> exclude,
+  ) {
+    final fund = library.firstWhereOrNull(
+      (p) =>
+          !exclude.contains(p.id) &&
+          p.tags.map((e) => e.toLowerCase()).contains('fundamentals'),
+    );
+    if (fund != null) return fund;
+    final starter = library.firstWhereOrNull(
+      (p) =>
+          !exclude.contains(p.id) &&
+          p.tags.map((e) => e.toLowerCase()).contains('starter'),
+    );
+    if (starter != null) return starter;
+    final sorted = [
+      for (final p in library)
+        if (!exclude.contains(p.id)) p
+    ]..sort((a, b) {
+        final pa = (a.meta['popularity'] as num?)?.toDouble() ?? 0;
+        final pb = (b.meta['popularity'] as num?)?.toDouble() ?? 0;
+        return pb.compareTo(pa);
+      });
+    return sorted.firstOrNull;
+  }
+}

--- a/test/services/skill_recovery_pack_engine_test.dart
+++ b/test/services/skill_recovery_pack_engine_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/skill_recovery_pack_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_tag_performance_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingPackTemplateV2 tpl({
+    required String id,
+    required List<String> tags,
+    bool suggested = false,
+    double pop = 0,
+  }) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.pushFold,
+      tags: tags,
+      meta: {
+        'popularity': pop,
+        if (suggested) 'suggested': true,
+      },
+    );
+  }
+
+  test('returns pack matching dormant tag', () async {
+    final library = [
+      tpl(id: 'a', tags: ['cbet'], suggested: true)
+    ];
+    final dormant = [
+      const TagPerformance(
+          tag: 'cbet',
+          totalAttempts: 0,
+          correct: 0,
+          accuracy: 0,
+          lastTrained: null),
+    ];
+    final result = await SkillRecoveryPackEngine.suggestRecoveryPack(
+      library: library,
+      detectDormantTags: () async => dormant,
+    );
+    expect(result?.id, 'a');
+  });
+
+  test('respects excluded ids', () async {
+    final library = [
+      tpl(id: 'a', tags: ['cbet'], suggested: true),
+      tpl(id: 'b', tags: ['cbet']),
+    ];
+    final dormant = [
+      const TagPerformance(
+          tag: 'cbet',
+          totalAttempts: 0,
+          correct: 0,
+          accuracy: 0,
+          lastTrained: null),
+    ];
+    final result = await SkillRecoveryPackEngine.suggestRecoveryPack(
+      library: library,
+      detectDormantTags: () async => dormant,
+      excludedPackIds: {'a'},
+    );
+    expect(result?.id, 'b');
+  });
+
+  test('falls back when no match', () async {
+    final library = [
+      tpl(id: 'f', tags: ['fundamentals']),
+      tpl(id: 's', tags: ['starter'], pop: 5),
+    ];
+    final result = await SkillRecoveryPackEngine.suggestRecoveryPack(
+      library: library,
+      detectDormantTags: () async => [],
+    );
+    expect(result?.id, 'f');
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillRecoveryPackEngine` to suggest packs for dormant skills
- test recovery pack suggestions

## Testing
- `flutter test test/services/skill_recovery_pack_engine_test.dart` *(fails: TrainingPackTemplate type errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d78add8832aa969b4c9e5a55085