### PR TITLE
Implement suggested pack history tracking

### DIFF
--- a/lib/services/skill_recovery_pack_engine.dart
+++ b/lib/services/skill_recovery_pack_engine.dart
@@ -5,6 +5,7 @@ import 'pack_cooldown_tracker.dart';
 import 'pack_library_loader_service.dart';
 import 'training_gap_detector_service.dart';
 import 'training_tag_performance_engine.dart';
+import 'suggested_training_packs_history_service.dart';
 
 class SkillRecoveryPackEngine {
   const SkillRecoveryPackEngine._();
@@ -60,7 +61,12 @@ class SkillRecoveryPackEngine {
       }
 
       candidates.sort((a, b) => score(b).compareTo(score(a)));
-      return candidates.first;
+      final selected = candidates.first;
+      await SuggestedTrainingPacksHistoryService.logSuggestion(
+        packId: selected.id,
+        source: 'skill_recovery',
+      );
+      return selected;
     }
 
     return await _findFallback(lib, exclude);
@@ -74,6 +80,10 @@ class SkillRecoveryPackEngine {
       if (exclude.contains(p.id)) continue;
       if (p.tags.map((e) => e.toLowerCase()).contains('fundamentals') &&
           !await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'skill_recovery',
+        );
         return p;
       }
     }
@@ -81,6 +91,10 @@ class SkillRecoveryPackEngine {
       if (exclude.contains(p.id)) continue;
       if (p.tags.map((e) => e.toLowerCase()).contains('starter') &&
           !await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'skill_recovery',
+        );
         return p;
       }
     }
@@ -93,7 +107,13 @@ class SkillRecoveryPackEngine {
         return pb.compareTo(pa);
       });
     for (final p in sorted) {
-      if (!await PackCooldownTracker.isRecentlySuggested(p.id)) return p;
+      if (!await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'skill_recovery',
+        );
+        return p;
+      }
     }
     return null;
   }

--- a/lib/services/suggested_training_packs_history_service.dart
+++ b/lib/services/suggested_training_packs_history_service.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SuggestedPackLog {
+  final String id;
+  final String source;
+  final DateTime timestamp;
+
+  SuggestedPackLog({
+    required this.id,
+    required this.source,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'source': source,
+        'ts': timestamp.toIso8601String(),
+      };
+
+  factory SuggestedPackLog.fromJson(Map<String, dynamic> j) => SuggestedPackLog(
+        id: j['id'] as String,
+        source: j['source'] as String,
+        timestamp: DateTime.parse(j['ts'] as String),
+      );
+}
+
+class SuggestedTrainingPacksHistoryService {
+  static const _prefsKey = 'suggested_pack_history';
+
+  static Future<List<SuggestedPackLog>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_prefsKey) ?? <String>[];
+    final list = <SuggestedPackLog>[];
+    for (final e in raw) {
+      try {
+        final data = jsonDecode(e);
+        if (data is Map<String, dynamic>) {
+          list.add(SuggestedPackLog.fromJson(data));
+        }
+      } catch (_) {}
+    }
+    return list;
+  }
+
+  static Future<void> _save(List<SuggestedPackLog> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      [for (final e in list) jsonEncode(e.toJson())],
+    );
+  }
+
+  static Future<void> logSuggestion({
+    required String packId,
+    required String source,
+  }) async {
+    final list = await _load();
+    list.insert(
+      0,
+      SuggestedPackLog(
+        id: packId,
+        source: source,
+        timestamp: DateTime.now(),
+      ),
+    );
+    if (list.length > 100) list.removeRange(100, list.length);
+    await _save(list);
+  }
+
+  static Future<List<SuggestedPackLog>> getRecentSuggestions({
+    Duration since = const Duration(days: 30),
+  }) async {
+    final list = await _load();
+    final cutoff = DateTime.now().subtract(since);
+    return [for (final e in list) if (e.timestamp.isAfter(cutoff)) e];
+  }
+
+  static Future<void> clearStaleEntries({
+    Duration maxAge = const Duration(days: 60),
+  }) async {
+    final list = await _load();
+    final cutoff = DateTime.now().subtract(maxAge);
+    list.removeWhere((e) => e.timestamp.isBefore(cutoff));
+    await _save(list);
+  }
+}

--- a/lib/services/suggested_weak_tag_pack_service.dart
+++ b/lib/services/suggested_weak_tag_pack_service.dart
@@ -5,6 +5,7 @@ import 'pack_cooldown_tracker.dart';
 import 'pack_library_loader_service.dart';
 import 'weak_tag_detector_service.dart';
 import 'training_tag_performance_engine.dart';
+import 'suggested_training_packs_history_service.dart';
 
 class SuggestedWeakTagPackResult {
   final TrainingPackTemplateV2? pack;
@@ -32,6 +33,10 @@ class SuggestedWeakTagPackService {
       final pack = library.firstWhereOrNull((p) => p.tags.contains(t.tag));
       if (pack != null &&
           !await PackCooldownTracker.isRecentlySuggested(pack.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: pack.id,
+          source: 'weak_tag',
+        );
         return SuggestedWeakTagPackResult(pack: pack, isFallback: false);
       }
     }
@@ -45,12 +50,20 @@ class SuggestedWeakTagPackService {
     for (final p in library) {
       if (p.tags.contains('fundamentals') &&
           !await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'weak_tag',
+        );
         return p;
       }
     }
     for (final p in library) {
       if (p.tags.contains('starter') &&
           !await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'weak_tag',
+        );
         return p;
       }
     }
@@ -61,7 +74,13 @@ class SuggestedWeakTagPackService {
         return pb.compareTo(pa);
       });
     for (final p in sorted) {
-      if (!await PackCooldownTracker.isRecentlySuggested(p.id)) return p;
+      if (!await PackCooldownTracker.isRecentlySuggested(p.id)) {
+        await SuggestedTrainingPacksHistoryService.logSuggestion(
+          packId: p.id,
+          source: 'weak_tag',
+        );
+        return p;
+      }
     }
     return null;
   }

--- a/lib/widgets/recovery_prompt_banner.dart
+++ b/lib/widgets/recovery_prompt_banner.dart
@@ -7,6 +7,7 @@ import '../services/training_history_service_v2.dart';
 import '../services/user_action_logger.dart';
 import '../services/training_session_service.dart';
 import '../services/pack_cooldown_tracker.dart';
+import '../services/suggested_training_packs_history_service.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../screens/v2/training_pack_play_screen.dart';
@@ -53,6 +54,10 @@ class _RecoveryPromptBannerState extends State<RecoveryPromptBanner> {
     if (pack != null) {
       await UserActionLogger.instance.log('recovery_prompt.shown');
       await PackCooldownTracker.markAsSuggested(pack.id);
+      await SuggestedTrainingPacksHistoryService.logSuggestion(
+        packId: pack.id,
+        source: 'recovery_prompt_banner',
+      );
     }
     if (mounted) {
       setState(() {

--- a/test/services/suggested_training_packs_history_service_test.dart
+++ b/test/services/suggested_training_packs_history_service_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/suggested_training_packs_history_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('log keeps max 100 entries', () async {
+    for (var i = 0; i < 120; i++) {
+      await SuggestedTrainingPacksHistoryService.logSuggestion(
+        packId: 'id$i',
+        source: 'test',
+      );
+    }
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList('suggested_pack_history')!;
+    expect(list.length, 100);
+    final first = jsonDecode(list.first) as Map<String, dynamic>;
+    final last = jsonDecode(list.last) as Map<String, dynamic>;
+    expect(first['id'], 'id119');
+    expect(last['id'], 'id20');
+  });
+
+  test('getRecentSuggestions filters by age', () async {
+    final old = DateTime.now().subtract(const Duration(days: 40));
+    final recent = DateTime.now().subtract(const Duration(days: 5));
+    SharedPreferences.setMockInitialValues({
+      'suggested_pack_history': [
+        jsonEncode({'id': 'old', 'source': 's', 'ts': old.toIso8601String()}),
+        jsonEncode({'id': 'new', 'source': 's', 'ts': recent.toIso8601String()}),
+      ]
+    });
+    final list = await SuggestedTrainingPacksHistoryService.getRecentSuggestions(
+      since: const Duration(days: 30),
+    );
+    expect(list.length, 1);
+    expect(list.first.id, 'new');
+  });
+
+  test('clearStaleEntries removes old logs', () async {
+    final old = DateTime.now().subtract(const Duration(days: 70));
+    final recent = DateTime.now().subtract(const Duration(days: 5));
+    SharedPreferences.setMockInitialValues({
+      'suggested_pack_history': [
+        jsonEncode({'id': 'old', 'source': 's', 'ts': old.toIso8601String()}),
+        jsonEncode({'id': 'new', 'source': 's', 'ts': recent.toIso8601String()}),
+      ]
+    });
+    await SuggestedTrainingPacksHistoryService.clearStaleEntries(
+      maxAge: const Duration(days: 60),
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList('suggested_pack_history')!;
+    expect(list.length, 1);
+    final data = jsonDecode(list.first) as Map<String, dynamic>;
+    expect(data['id'], 'new');
+  });
+}


### PR DESCRIPTION
## Summary
- add `SuggestedTrainingPacksHistoryService` to store suggested pack logs
- track suggestions in recovery banner and recommendation engines
- test logging, filtering and cleanup logic

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c92a9d084832a99bffcdbaf8ac254