### PR TITLE
Refactor suggestion history

### DIFF
--- a/lib/services/suggested_training_packs_history_service.dart
+++ b/lib/services/suggested_training_packs_history_service.dart
@@ -2,79 +2,119 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-class SuggestedPackLog {
-  final String id;
+class SuggestedPackRecord {
+  final String packId;
   final String source;
   final DateTime timestamp;
+  final String? tagContext;
 
-  SuggestedPackLog({
-    required this.id,
+  SuggestedPackRecord({
+    required this.packId,
     required this.source,
     required this.timestamp,
+    this.tagContext,
   });
 
   Map<String, dynamic> toJson() => {
-        'id': id,
+        'id': packId,
         'source': source,
         'ts': timestamp.toIso8601String(),
+        if (tagContext != null) 'tag': tagContext,
       };
 
-  factory SuggestedPackLog.fromJson(Map<String, dynamic> j) => SuggestedPackLog(
-        id: j['id'] as String,
+  factory SuggestedPackRecord.fromJson(Map<String, dynamic> j) =>
+      SuggestedPackRecord(
+        packId: j['id'] as String,
         source: j['source'] as String,
         timestamp: DateTime.parse(j['ts'] as String),
+        tagContext: j['tag'] as String?,
       );
 }
 
 class SuggestedTrainingPacksHistoryService {
   static const _prefsKey = 'suggested_pack_history';
 
-  static Future<List<SuggestedPackLog>> _load() async {
+  static Future<List<SuggestedPackRecord>> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getStringList(_prefsKey) ?? <String>[];
-    final list = <SuggestedPackLog>[];
-    for (final e in raw) {
-      try {
-        final data = jsonDecode(e);
-        if (data is Map<String, dynamic>) {
-          list.add(SuggestedPackLog.fromJson(data));
-        }
-      } catch (_) {}
+
+    // Legacy format: list of JSON strings.
+    final legacy = prefs.getStringList(_prefsKey);
+    if (legacy != null) {
+      final migrated = <SuggestedPackRecord>[];
+      for (final e in legacy) {
+        try {
+          final data = jsonDecode(e);
+          if (data is Map<String, dynamic>) {
+            migrated.add(SuggestedPackRecord.fromJson(data));
+          }
+        } catch (_) {}
+      }
+      await prefs.remove(_prefsKey);
+      await prefs.setString(
+        _prefsKey,
+        jsonEncode([for (final e in migrated) e.toJson()]),
+      );
+      return migrated;
     }
-    return list;
+
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return <SuggestedPackRecord>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [
+          for (final e in data.whereType<Map<String, dynamic>>())
+            SuggestedPackRecord.fromJson(e)
+        ];
+      }
+    } catch (_) {}
+    return <SuggestedPackRecord>[];
   }
 
-  static Future<void> _save(List<SuggestedPackLog> list) async {
+  static Future<void> _save(List<SuggestedPackRecord> list) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(
+    await prefs.setString(
       _prefsKey,
-      [for (final e in list) jsonEncode(e.toJson())],
+      jsonEncode([for (final e in list) e.toJson()]),
     );
   }
 
   static Future<void> logSuggestion({
     required String packId,
     required String source,
+    String? tagContext,
   }) async {
     final list = await _load();
     list.insert(
       0,
-      SuggestedPackLog(
-        id: packId,
+      SuggestedPackRecord(
+        packId: packId,
         source: source,
         timestamp: DateTime.now(),
+        tagContext: tagContext,
       ),
     );
     if (list.length > 100) list.removeRange(100, list.length);
     await _save(list);
   }
 
-  static Future<List<SuggestedPackLog>> getRecentSuggestions({
-    Duration since = const Duration(days: 30),
+  static Future<List<SuggestedPackRecord>> getRecentSuggestions({
+    int limit = 10,
   }) async {
     final list = await _load();
-    final cutoff = DateTime.now().subtract(since);
-    return [for (final e in list) if (e.timestamp.isAfter(cutoff)) e];
+    return list.take(limit).toList();
+  }
+
+  static Future<bool> wasRecentlySuggested(
+    String packId, {
+    Duration within = const Duration(days: 30),
+  }) async {
+    final list = await _load();
+    final cutoff = DateTime.now().subtract(within);
+    for (final e in list) {
+      if (e.packId == packId && e.timestamp.isAfter(cutoff)) return true;
+    }
+    return false;
   }
 
   static Future<void> clearStaleEntries({


### PR DESCRIPTION
## Summary
- add `SuggestedPackRecord` with optional `tagContext`
- store history as JSON array and migrate old format
- expose `wasRecentlySuggested` and update APIs
- update service tests for new storage

## Testing
- `flutter analyze` *(fails: 6470 issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687c951c25d8832ab2eb2cb753745b9c