### PR TITLE
Implement SmartResuggestionEngine

### DIFF
--- a/lib/services/smart_resuggestion_engine.dart
+++ b/lib/services/smart_resuggestion_engine.dart
@@ -1,0 +1,70 @@
+import 'package:collection/collection.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'pack_suggestion_analytics_engine.dart';
+import 'pack_suggestion_cooldown_service.dart';
+import 'session_log_service.dart';
+import 'suggested_training_packs_history_service.dart';
+import 'suggested_weak_tag_pack_service.dart';
+
+/// Resuggests packs that previously showed engagement but were not completed.
+class SmartReSuggestionEngine {
+  final SessionLogService logs;
+  final List<TrainingPackTemplateV2>? _libraryOverride;
+  final SuggestedWeakTagPackService _weakTagService;
+
+  SmartReSuggestionEngine({
+    required this.logs,
+    List<TrainingPackTemplateV2>? library,
+    SuggestedWeakTagPackService? weakTagService,
+  })  : _libraryOverride = library,
+        _weakTagService = weakTagService ?? const SuggestedWeakTagPackService();
+
+  /// Suggests a pack to retry based on past suggestions and engagement stats.
+  Future<TrainingPackTemplateV2?> suggestNext() async {
+    final analytics = PackSuggestionAnalyticsEngine(logs: logs);
+    final stats = await analytics.getStats();
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = _libraryOverride ?? PackLibraryLoaderService.instance.library;
+
+    final entries = <MapEntry<TrainingPackTemplateV2, PackEngagementStats>>[];
+    for (final s in stats) {
+      if (s.shownCount < 2 || s.completedCount > 0) continue;
+      final tpl = library.firstWhereOrNull((p) => p.id == s.packId);
+      if (tpl == null) continue;
+      if (await SuggestedTrainingPacksHistoryService.wasRecentlySuggested(
+            tpl.id,
+            within: const Duration(days: 14),
+          )) {
+        continue;
+      }
+      if (await PackSuggestionCooldownService.isRecentlySuggested(
+            tpl.id,
+            cooldown: const Duration(days: 14),
+          )) {
+        continue;
+      }
+      entries.add(MapEntry(tpl, s));
+    }
+
+    if (entries.isNotEmpty) {
+      entries.sort((a, b) {
+        final cmp = b.value.startedCount.compareTo(a.value.startedCount);
+        if (cmp != 0) return cmp;
+        return b.value.shownCount.compareTo(a.value.shownCount);
+      });
+      final selected = entries.first.key;
+      await PackSuggestionCooldownService.markAsSuggested(selected.id);
+      await SuggestedTrainingPacksHistoryService.logSuggestion(
+        packId: selected.id,
+        source: 'resuggestion_engine',
+      );
+      return selected;
+    }
+
+    final fallback = await _weakTagService.suggestPack();
+    return fallback.pack;
+  }
+}

--- a/test/services/smart_resuggestion_engine_test.dart
+++ b/test/services/smart_resuggestion_engine_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/smart_resuggestion_engine.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/suggested_training_packs_history_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> _list;
+  _FakeLogService(this._list) : super(sessions: TrainingSessionService());
+
+  @override
+  Future<void> load() async {}
+
+  @override
+  List<SessionLog> get logs => List.unmodifiable(_list);
+}
+
+TrainingPackTemplateV2 _tpl(String id) => TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.pushFold,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns pack with highest engagement', () async {
+    final old = DateTime.now().subtract(const Duration(days: 20)).toIso8601String();
+    SharedPreferences.setMockInitialValues({
+      'suggested_pack_history': jsonEncode([
+        {'id': 'a', 'source': 't', 'ts': old},
+        {'id': 'a', 'source': 't', 'ts': old},
+        {'id': 'b', 'source': 't', 'ts': old},
+      ])
+    });
+
+    final engine = SmartReSuggestionEngine(
+      logs: _FakeLogService([]),
+      library: [_tpl('a'), _tpl('b')],
+    );
+    final pack = await engine.suggestNext();
+    expect(pack?.id, 'a');
+  });
+
+  test('respects cooldown window', () async {
+    final recent = DateTime.now().subtract(const Duration(days: 5)).toIso8601String();
+    SharedPreferences.setMockInitialValues({
+      'suggested_pack_history': jsonEncode([
+        {'id': 'a', 'source': 't', 'ts': recent},
+        {'id': 'a', 'source': 't', 'ts': recent},
+      ])
+    });
+
+    final engine = SmartReSuggestionEngine(
+      logs: _FakeLogService([]),
+      library: [_tpl('a')],
+    );
+    final pack = await engine.suggestNext();
+    expect(pack, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartReSuggestionEngine` for targeted re-suggestions
- log suggestions with `resuggestion_engine`
- add unit tests

## Testing
- `flutter test test/services/smart_resuggestion_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9b41dc90832aa09633ccb61d4177