### PR TITLE
Implement SuggestionBannerEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -84,6 +84,7 @@ import 'services/smart_suggestion_service.dart';
 import 'services/training_gap_detector_service.dart';
 import 'services/smart_suggestion_engine.dart';
 import 'services/smart_pack_suggestion_engine.dart';
+import 'services/suggestion_banner_engine.dart';
 import 'services/suggested_next_pack_engine.dart';
 import 'services/smart_review_service.dart';
 import 'services/evaluation_executor_service.dart';
@@ -433,6 +434,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(
       create: (context) =>
           SmartSuggestionEngine(logs: context.read<SessionLogService>()),
+    ),
+    Provider(
+      create: (context) => SuggestionBannerEngine(
+        logs: context.read<SessionLogService>(),
+      ),
     ),
     Provider(
       create: (context) =>

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -67,8 +67,7 @@ import '../services/user_action_logger.dart';
 import '../widgets/category_section.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../widgets/pack_suggestion_banner.dart';
-import '../widgets/smart_suggestion_banner.dart';
-import '../widgets/suggested_weak_tag_pack_banner.dart';
+import '../widgets/suggestion_banner.dart';
 import '../services/weak_training_type_detector.dart';
 import '../widgets/training_gap_prompt_banner.dart';
 import '../widgets/training_type_gap_prompt_banner.dart';
@@ -80,7 +79,6 @@ import '../widgets/sample_pack_preview_button.dart';
 import '../widgets/sample_pack_preview_tooltip.dart';
 import '../widgets/pack_resume_banner.dart';
 import '../services/training_pack_sampler.dart';
-import '../widgets/dormant_tag_reminder_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 import '../widgets/pack_progress_overlay.dart';
 import '../widgets/pack_unlock_requirement_badge.dart';
@@ -3590,9 +3588,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                 ? ListView(
                     controller: _listCtrl,
                     children: [
-                      SmartSuggestionBanner(selectedTags: _selectedTags),
-                      const DormantTagReminderBanner(),
-                      const SuggestedWeakTagPackBanner(),
+                      const SuggestionBanner(),
                       const PackResumeBanner(),
                       const PackSuggestionBanner(),
                       const SuggestedPackTile(),

--- a/lib/services/dormant_tag_suggestion_service.dart
+++ b/lib/services/dormant_tag_suggestion_service.dart
@@ -1,0 +1,33 @@
+import 'package:collection/collection.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_loader_service.dart';
+import 'training_gap_detector_service.dart';
+import 'pack_suggestion_cooldown_service.dart';
+import 'suggested_training_packs_history_service.dart';
+
+class DormantTagSuggestionService {
+  const DormantTagSuggestionService();
+
+  Future<TrainingPackTemplateV2?> suggestPack() async {
+    final dormant = await TrainingGapDetectorService.detectDormantTags(limit: 1);
+    if (dormant.isEmpty) return null;
+    final tag = dormant.first.tag;
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = PackLibraryLoaderService.instance.library;
+    final tpl = library.firstWhereOrNull(
+      (p) => p.tags.contains(tag) || p.meta['focusTag'] == tag,
+    );
+    if (tpl == null) return null;
+    if (await PackSuggestionCooldownService.isRecentlySuggested(tpl.id)) {
+      return null;
+    }
+    await PackSuggestionCooldownService.markAsSuggested(tpl.id);
+    await SuggestedTrainingPacksHistoryService.logSuggestion(
+      packId: tpl.id,
+      source: 'dormant_tag',
+      tagContext: tag,
+    );
+    return tpl;
+  }
+}

--- a/lib/services/suggestion_banner_engine.dart
+++ b/lib/services/suggestion_banner_engine.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../main.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+import 'smart_resuggestion_engine.dart';
+import 'session_log_service.dart';
+import 'suggested_weak_tag_pack_service.dart';
+import 'dormant_tag_suggestion_service.dart';
+import 'pack_suggestion_cooldown_service.dart';
+import 'training_session_service.dart';
+
+class SuggestionBannerData {
+  final String title;
+  final String subtitle;
+  final String buttonLabel;
+  final VoidCallback onTap;
+
+  SuggestionBannerData({
+    required this.title,
+    required this.subtitle,
+    required this.buttonLabel,
+    required this.onTap,
+  });
+}
+
+class SuggestionBannerEngine {
+  final SessionLogService logs;
+  final SuggestedWeakTagPackService _weakTagService;
+  final DormantTagSuggestionService _dormantService;
+  final SmartReSuggestionEngine _resuggestionEngine;
+
+  SuggestionBannerEngine({
+    required this.logs,
+    SuggestedWeakTagPackService? weakTagService,
+    DormantTagSuggestionService? dormantService,
+    SmartReSuggestionEngine? resuggestionEngine,
+  })  : _weakTagService = weakTagService ?? const SuggestedWeakTagPackService(),
+        _dormantService = dormantService ?? const DormantTagSuggestionService(),
+        _resuggestionEngine =
+            resuggestionEngine ?? SmartReSuggestionEngine(logs: logs);
+
+  Future<bool> shouldShowBanner() async => true;
+
+  Future<SuggestionBannerData?> getBanner() async {
+    if (!await shouldShowBanner()) return null;
+
+    final weak = await _weakTagService.suggestPack();
+    if (weak.pack != null) {
+      final tpl = weak.pack!;
+      await PackSuggestionCooldownService.markAsSuggested(tpl.id);
+      return _dataFor(
+        tpl: tpl,
+        title: '💡 \u0423\u043a\u0440\u0435\u043f\u0438 \u0431\u0430\u0437\u0443',
+      );
+    }
+
+    final dormant = await _dormantService.suggestPack();
+    if (dormant != null) {
+      return _dataFor(
+        tpl: dormant,
+        title: '🔁 \u041e\u0441\u0432\u0435\u0436\u0438 \u043d\u0430\u0432\u044b\u043a',
+      );
+    }
+
+    final re = await _resuggestionEngine.suggestNext();
+    if (re != null) {
+      return _dataFor(
+        tpl: re,
+        title: '♻️ \u041f\u0440\u043e\u0434\u043e\u043b\u0436\u0438 \u043e\u0431\u0443\u0447\u0435\u043d\u0438\u0435',
+      );
+    }
+
+    return null;
+  }
+
+  SuggestionBannerData _dataFor({
+    required TrainingPackTemplateV2 tpl,
+    required String title,
+  }) {
+    return SuggestionBannerData(
+      title: title,
+      subtitle: 'Пак: ${tpl.name}',
+      buttonLabel: 'Начать тренировку',
+      onTap: () async {
+        final ctx = navigatorKey.currentContext;
+        if (ctx == null) return;
+        await ctx.read<TrainingSessionService>().startSession(tpl);
+        if (!ctx.mounted) return;
+        await Navigator.push(
+          ctx,
+          MaterialPageRoute(
+            builder: (_) => TrainingPackPlayScreen(template: tpl, original: tpl),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/suggestion_banner.dart
+++ b/lib/widgets/suggestion_banner.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/suggestion_banner_engine.dart';
+
+class SuggestionBanner extends StatefulWidget {
+  const SuggestionBanner({super.key});
+
+  @override
+  State<SuggestionBanner> createState() => _SuggestionBannerState();
+}
+
+class _SuggestionBannerState extends State<SuggestionBanner> {
+  bool _loading = true;
+  SuggestionBannerData? _data;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final engine = context.read<SuggestionBannerEngine>();
+    final data = await engine.getBanner();
+    if (mounted) {
+      setState(() {
+        _data = data;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final d = _data;
+    if (_loading || d == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            d.title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(d.subtitle, style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: d.onTap,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: Text(d.buttonLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SuggestionBannerEngine` with `getBanner()`
- provide `DormantTagSuggestionService` for dormant tag packs
- add `SuggestionBanner` widget
- wire up provider and show banner in TemplateLibraryScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9c7e495c832a929442310f6eaf7f