### PR TITLE
Implement suggestion banner AB testing service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,6 +83,7 @@ import 'services/dynamic_pack_adjustment_service.dart';
 import 'services/remote_config_service.dart';
 import 'services/theme_service.dart';
 import 'services/ab_test_engine.dart';
+import 'services/suggestion_banner_ab_test_service.dart';
 import 'services/asset_sync_service.dart';
 import 'services/favorite_pack_service.dart';
 import 'services/evaluation_settings_service.dart';
@@ -157,6 +158,7 @@ Future<void> main() async {
   );
   await EvaluationSettingsService.instance.load();
   await MistakeHintService.instance.load();
+  await SuggestionBannerABTestService.instance.init();
   tagCache = TagCacheService();
   await tagCache.load();
   unawaited(SuggestedPackPushService.instance.schedulePushReminder());

--- a/lib/services/suggestion_banner_ab_test_service.dart
+++ b/lib/services/suggestion_banner_ab_test_service.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'user_action_logger.dart';
+
+/// Possible variants for the suggestion banner A/B test.
+enum SuggestionBannerVariant { control, layoutA, layoutB, aggressiveText }
+
+/// Service that assigns the user to a banner variant and exposes it.
+class SuggestionBannerABTestService {
+  SuggestionBannerABTestService._();
+
+  /// Singleton instance.
+  static final SuggestionBannerABTestService instance =
+      SuggestionBannerABTestService._();
+
+  static const _prefsKey = 'suggestion_banner_variant';
+  final Random _rand = Random();
+
+  SuggestionBannerVariant? _variant;
+  bool _initialized = false;
+
+  /// Initialize the service. Must be called once on startup.
+  Future<void> init() async {
+    if (_initialized) return;
+    final prefs = await SharedPreferences.getInstance();
+
+    // QA override via query parameter (?variant=layoutB)
+    final override = Uri.base.queryParameters['variant'];
+    if (override != null) {
+      _variant = _parseVariant(override);
+    }
+
+    final stored = prefs.getString(_prefsKey);
+    if (_variant == null && stored != null) {
+      _variant = _parseVariant(stored);
+    }
+
+    _variant ??= SuggestionBannerVariant
+        .values[_rand.nextInt(SuggestionBannerVariant.values.length)];
+
+    await prefs.setString(_prefsKey, _variant!.name);
+    _initialized = true;
+
+    await UserActionLogger.instance.logEvent({
+      'event': 'ab_test.variant_suggestion_banner',
+      'variant': _variant!.name,
+    });
+  }
+
+  /// Returns the assigned variant. [init] must be called first.
+  SuggestionBannerVariant getVariant() {
+    if (!_initialized || _variant == null) {
+      throw StateError('SuggestionBannerABTestService not initialized');
+    }
+    return _variant!;
+  }
+
+  SuggestionBannerVariant _parseVariant(String value) {
+    try {
+      return SuggestionBannerVariant.values.byName(value);
+    } catch (_) {
+      return SuggestionBannerVariant.control;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `SuggestionBannerABTestService` for controlled banner experiments
- initialize service during app startup

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca0c33c64832ab1bacd0d9fbe6c11