### PR TITLE
Add per-tag XP tracking

### DIFF
--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -472,6 +472,14 @@ class TrainingSessionService extends ChangeNotifier {
     int bonus = ((xp * multiplier) - xp).round();
     if (bonus > bonusCap) bonus = bonusCap;
     xp += bonus;
+
+    final Map<String, int> tagXp = {};
+    for (final tag in _template!.tags) {
+      final skill = skills[tag.toLowerCase()] ?? 0.5;
+      final txp = XPTrackerService.targetXp * _xpMultiplier(skill);
+      tagXp[tag.toLowerCase()] = txp.round();
+    }
+    await xpService.addPerTagXP(tagXp, source: 'training');
     await xpService.add(xp: xp, source: 'training');
     unawaited(_clearIndex());
     Navigator.pushReplacement(


### PR DESCRIPTION
## Summary
- extend XPTrackerService with per-tag XP persistence
- track tag XP when completing training sessions

## Testing
- `flutter analyze` *(fails: many issues found)*
- `flutter test --run-skipped` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ca96f77a4832ab62e76044317b1f8