### PR TITLE
Implement tag mastery history service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -95,6 +95,7 @@ import 'services/tag_mastery_service.dart';
 import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
+import 'services/tag_mastery_history_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
 import 'services/training_path_progress_service.dart';
@@ -445,6 +446,7 @@ List<SingleChildWidget> buildTrainingProviders() {
           TagMasteryService(logs: context.read<SessionLogService>()),
     ),
     Provider(create: (_) => TagCoverageService()),
+    Provider(create: (_) => TagMasteryHistoryService()),
     Provider(
       create: (context) => GoalSuggestionEngine(
         mastery: context.read<TagMasteryService>(),

--- a/lib/models/tag_xp_history_entry.dart
+++ b/lib/models/tag_xp_history_entry.dart
@@ -1,0 +1,23 @@
+class TagXpHistoryEntry {
+  final DateTime date;
+  final int xp;
+  final String source;
+
+  TagXpHistoryEntry({
+    required this.date,
+    required this.xp,
+    required this.source,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'xp': xp,
+        'source': source,
+      };
+
+  factory TagXpHistoryEntry.fromJson(Map<String, dynamic> json) => TagXpHistoryEntry(
+        date: DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now(),
+        xp: (json['xp'] as num?)?.toInt() ?? 0,
+        source: json['source'] as String? ?? '',
+      );
+}

--- a/lib/services/tag_mastery_history_service.dart
+++ b/lib/services/tag_mastery_history_service.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:collection';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/tag_xp_history_entry.dart';
+
+class TagMasteryHistoryService {
+  static const _tagXpPrefix = 'tag_xp_';
+
+  /// Returns aggregated XP history per tag grouped by day.
+  Future<Map<String, List<TagXpHistoryEntry>>> getHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, List<TagXpHistoryEntry>>{};
+
+    for (final key in prefs.getKeys()) {
+      if (!key.startsWith(_tagXpPrefix)) continue;
+      final tag = key.substring(_tagXpPrefix.length);
+      final raw = prefs.getString(key);
+      if (raw == null) continue;
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map<String, dynamic>) {
+          final list = data['history'];
+          final entries = <TagXpHistoryEntry>[];
+          if (list is List) {
+            for (final item in list) {
+              if (item is Map) {
+                entries.add(TagXpHistoryEntry.fromJson(
+                    Map<String, dynamic>.from(item as Map)));
+              }
+            }
+          }
+          final map = <DateTime, TagXpHistoryEntry>{};
+          for (final e in entries) {
+            final date = DateTime(e.date.year, e.date.month, e.date.day);
+            final existing = map[date];
+            if (existing == null) {
+              map[date] = TagXpHistoryEntry(
+                date: date,
+                xp: e.xp,
+                source: e.source,
+              );
+            } else {
+              map[date] = TagXpHistoryEntry(
+                date: date,
+                xp: existing.xp + e.xp,
+                source: existing.source,
+              );
+            }
+          }
+          final sorted = map.values.toList()
+            ..sort((a, b) => a.date.compareTo(b.date));
+          result[tag] = sorted;
+        }
+      } catch (_) {}
+    }
+
+    return result;
+  }
+
+  /// Returns total XP per tag grouped by week starting on Monday.
+  Future<Map<String, SplayTreeMap<DateTime, int>>> getWeeklyTotals() async {
+    final hist = await getHistory();
+    final result = <String, SplayTreeMap<DateTime, int>>{};
+    for (final entry in hist.entries) {
+      final byWeek = SplayTreeMap<DateTime, int>();
+      for (final e in entry.value) {
+        final monday = DateTime.utc(
+            e.date.year, e.date.month, e.date.day - (e.date.weekday - 1));
+        byWeek[monday] = (byWeek[monday] ?? 0) + e.xp;
+      }
+      result[entry.key] = byWeek;
+    }
+    return result;
+  }
+
+  /// Determines whether tags are active within [dormant] duration.
+  Future<Map<String, bool>> getActiveFlags({
+    Duration dormant = const Duration(days: 30),
+  }) async {
+    final hist = await getHistory();
+    final now = DateTime.now();
+    final result = <String, bool>{};
+    for (final e in hist.entries) {
+      if (e.value.isEmpty) {
+        result[e.key] = false;
+        continue;
+      }
+      final last = e.value.last.date;
+      result[e.key] = now.difference(last) <= dormant;
+    }
+    return result;
+  }
+}

--- a/test/services/tag_mastery_history_service_test.dart
+++ b/test/services/tag_mastery_history_service_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getHistory aggregates daily xp per tag', () async {
+    final now = DateTime.now();
+    final day1 = DateTime(now.year, now.month, now.day);
+    final day2 = day1.subtract(const Duration(days: 1));
+
+    SharedPreferences.setMockInitialValues({
+      'tag_xp_test': jsonEncode({
+        'total': 30,
+        'history': [
+          {'date': day1.toIso8601String(), 'xp': 10, 'source': 'a'},
+          {
+            'date': day1.add(const Duration(hours: 3)).toIso8601String(),
+            'xp': 5,
+            'source': 'b'
+          },
+          {'date': day2.toIso8601String(), 'xp': 15, 'source': 'c'},
+        ],
+      })
+    });
+
+    final service = TagMasteryHistoryService();
+    final hist = await service.getHistory();
+    expect(hist.containsKey('test'), isTrue);
+    final list = hist['test']!;
+    expect(list.length, 2);
+    expect(list.first.date, day2);
+    expect(list.first.xp, 15);
+    expect(list.last.date, day1);
+    expect(list.last.xp, 15); // 10 + 5
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TagMasteryHistoryService` for per-tag XP history
- store entries in new `TagXpHistoryEntry` model
- expose service via providers
- add unit test for history aggregation

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb2e4bf78832abb54368e94291dd5