### PR TITLE
Implement SkillCard widget

### DIFF
--- a/lib/screens/skill_map_screen.dart
+++ b/lib/screens/skill_map_screen.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/tag_mastery_service.dart';
-import '../widgets/tag_skill_tile.dart';
+import '../services/xp_tracker_service.dart';
+import '../widgets/skill_card.dart';
 import '../utils/responsive.dart';
 import 'library_screen.dart';
 
@@ -16,6 +17,7 @@ class SkillMapScreen extends StatefulWidget {
 class _SkillMapScreenState extends State<SkillMapScreen> {
   bool _loading = true;
   Map<String, double> _data = {};
+  Map<String, int> _xp = {};
   bool _weakFirst = true;
 
   @override
@@ -26,12 +28,15 @@ class _SkillMapScreenState extends State<SkillMapScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final service = context.read<TagMasteryService>();
-    final map = await service.computeMastery(force: true);
+    final masteryService = context.read<TagMasteryService>();
+    final xpService = context.read<XPTrackerService>();
+    final map = await masteryService.computeMastery(force: true);
+    final xpMap = await xpService.getTotalXpPerTag();
     final entries = map.entries.toList();
     _sort(entries);
     setState(() {
       _data = {for (final e in entries) e.key: e.value};
+      _xp = xpMap;
       _loading = false;
     });
   }
@@ -84,9 +89,10 @@ class _SkillMapScreenState extends State<SkillMapScreen> {
               mainAxisSpacing: 8,
               children: [
                 for (final e in _data.entries)
-                  TagSkillTile(
+                  SkillCard(
                     tag: e.key,
-                    value: e.value,
+                    mastery: e.value,
+                    totalXp: _xp[e.key] ?? 0,
                     onTap: () => _openTag(e.key),
                   ),
               ],

--- a/lib/widgets/skill_card.dart
+++ b/lib/widgets/skill_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import 'tag_progress_sparkline.dart';
+
+class SkillCard extends StatelessWidget {
+  final String tag;
+  final double mastery;
+  final int totalXp;
+  final VoidCallback? onTap;
+
+  const SkillCard({
+    super.key,
+    required this.tag,
+    required this.mastery,
+    required this.totalXp,
+    this.onTap,
+  });
+
+  String _capitalize(String s) => s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Color.lerp(Colors.red, Colors.green, mastery.clamp(0.0, 1.0)) ?? Colors.red;
+    final name = _capitalize(tag);
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color, width: 2),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              name,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Mastery: ${(mastery * 100).round()}% \u00b7 XP: $totalXp',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            const SizedBox(height: 8),
+            TagProgressSparkline(tag: tag),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `SkillCard` widget showing mastery, XP, and sparkline
- update `SkillMapScreen` to use `SkillCard` and include XP data

## Testing
- `flutter analyze`
- `flutter test --run-skipped` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_687cb4d65d50832aa6f41acf2273116f