### PR TITLE
Implement tag training heatmap

### DIFF
--- a/lib/screens/tag_skill_detail_screen.dart
+++ b/lib/screens/tag_skill_detail_screen.dart
@@ -9,6 +9,7 @@ import '../services/pack_library_loader_service.dart';
 import '../services/pack_unlocking_rules_engine.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../widgets/tag_progress_sparkline.dart';
+import '../widgets/tag_training_heatmap.dart';
 import '../widgets/training_pack_template_card.dart';
 import '../screens/training_session_screen.dart';
 import '../services/training_session_service.dart';
@@ -109,18 +110,25 @@ class _TagSkillDetailScreenState extends State<TagSkillDetailScreen> {
     final pct = (_trend.abs() * 100).toStringAsFixed(1);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          TagProgressSparkline(tag: widget.tag),
-          const SizedBox(width: 8),
-          if (_trend != 0)
-            Row(
-              children: [
-                Icon(arrow, size: 16, color: color),
-                const SizedBox(width: 2),
-                Text('$pct%', style: TextStyle(color: color)),
-              ],
-            ),
+          Row(
+            children: [
+              TagProgressSparkline(tag: widget.tag),
+              const SizedBox(width: 8),
+              if (_trend != 0)
+                Row(
+                  children: [
+                    Icon(arrow, size: 16, color: color),
+                    const SizedBox(width: 2),
+                    Text('$pct%', style: TextStyle(color: color)),
+                  ],
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TagTrainingHeatmap(tag: widget.tag),
         ],
       ),
     );

--- a/lib/widgets/tag_training_heatmap.dart
+++ b/lib/widgets/tag_training_heatmap.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_mastery_history_service.dart';
+import '../models/tag_xp_history_entry.dart';
+
+class TagTrainingHeatmap extends StatelessWidget {
+  final String tag;
+  final int days;
+  const TagTrainingHeatmap({super.key, required this.tag, this.days = 60});
+
+  static final Map<String, _HeatmapData> _cache = {};
+
+  static void clearCache(String tag) => _cache.remove(tag.toLowerCase());
+
+  Future<_HeatmapData> _load(BuildContext context) async {
+    final lower = tag.toLowerCase();
+    if (_cache.containsKey(lower)) return _cache[lower]!;
+    final service = context.read<TagMasteryHistoryService>();
+    final hist = await service.getHistory();
+    final list = hist[lower] ?? <TagXpHistoryEntry>[];
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(Duration(days: days - 1));
+    final values = List<int>.filled(days, 0);
+    for (final e in list) {
+      final d = DateTime(e.date.year, e.date.month, e.date.day);
+      if (d.isBefore(start) || d.isAfter(today)) continue;
+      final idx = d.difference(start).inDays;
+      if (idx >= 0 && idx < days) values[idx] += e.xp;
+    }
+    final result = _HeatmapData(start: start, values: values);
+    _cache[lower] = result;
+    return result;
+  }
+
+  Color _color(BuildContext context, int value, int max) {
+    if (max <= 0) return Colors.transparent;
+    final t = value / max;
+    return Color.lerp(Colors.green[100], Colors.green[800], t) ?? Colors.green;
+  }
+
+  Widget _buildGrid(_HeatmapData data, BuildContext context) {
+    final weeks = (days / 7).ceil();
+    final maxVal = data.values.fold<int>(0, (p, e) => e > p ? e : p);
+    final cells = List.generate(days, (i) => data.values[i]);
+    final first = data.start;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int row = 0; row < 7; row++)
+          Row(
+            children: [
+              for (int col = 0; col < weeks; col++)
+                Builder(builder: (context) {
+                  final idx = col * 7 + row;
+                  if (idx >= cells.length) {
+                    return const SizedBox(width: 10, height: 10);
+                  }
+                  final date = first.add(Duration(days: idx));
+                  final val = cells[idx];
+                  final color = _color(context, val, maxVal);
+                  final tooltip = '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')} - $val XP';
+                  return Padding(
+                    padding: const EdgeInsets.all(1),
+                    child: Tooltip(
+                      message: tooltip,
+                      child: Container(
+                        width: 10,
+                        height: 10,
+                        color: color,
+                      ),
+                    ),
+                  );
+                }),
+            ],
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_HeatmapData>(
+      future: _load(context),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(height: 80);
+        }
+        return _buildGrid(snapshot.data!, context);
+      },
+    );
+  }
+}
+
+class _HeatmapData {
+  final DateTime start;
+  final List<int> values;
+  _HeatmapData({required this.start, required this.values});
+}


### PR DESCRIPTION
## Summary
- visualize daily XP accumulation with `TagTrainingHeatmap`
- import and show heatmap under progress sparkline

## Testing
- `flutter analyze` *(fails: 6669 issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687cb8c72cd8832aa5fb432d9ec1ac60