### PR TITLE
Implement XP heatmap summary screen

### DIFF
--- a/lib/screens/tag_training_heatmap_summary_screen.dart
+++ b/lib/screens/tag_training_heatmap_summary_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_mastery_history_service.dart';
+import '../widgets/training_heatmap.dart';
+import '../widgets/sync_status_widget.dart';
+
+class TagTrainingHeatmapSummaryScreen extends StatefulWidget {
+  static const route = '/training/heatmap_summary';
+  const TagTrainingHeatmapSummaryScreen({super.key});
+
+  @override
+  State<TagTrainingHeatmapSummaryScreen> createState() =>
+      _TagTrainingHeatmapSummaryScreenState();
+}
+
+class _TagTrainingHeatmapSummaryScreenState
+    extends State<TagTrainingHeatmapSummaryScreen> {
+  bool _loading = true;
+  Map<DateTime, int> _data = {};
+  bool _xpOnly = false;
+  int _streak = 0;
+  double _avgXp = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final service = context.read<TagMasteryHistoryService>();
+    final hist = await service.getHistory();
+    final map = <DateTime, int>{};
+    for (final list in hist.values) {
+      for (final e in list) {
+        final d = DateTime(e.date.year, e.date.month, e.date.day);
+        map[d] = (map[d] ?? 0) + e.xp;
+      }
+    }
+    const days = 90;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(const Duration(days: days - 1));
+    final values = <int>[];
+    for (int i = 0; i < days; i++) {
+      final date = start.add(Duration(days: i));
+      values.add(map[date] ?? 0);
+    }
+    int streak = 0;
+    for (int i = values.length - 1; i >= 0; i--) {
+      if (values[i] > 0) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    final total = values.fold<int>(0, (p, e) => p + e);
+    final avg = days > 0 ? total / days : 0.0;
+    setState(() {
+      _data = map;
+      _streak = streak;
+      _avgXp = avg;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('XP Heatmap'),
+        centerTitle: true,
+        actions: [SyncStatusIcon.of(context)],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                const Text(
+                  '🎯 Твоя активность по дням',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TrainingHeatmap(dailyXp: _data, xpOnly: _xpOnly),
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Стрик: $_streak',
+                        style: const TextStyle(color: Colors.white)),
+                    Text('Среднее XP: ${_avgXp.toStringAsFixed(1)}',
+                        style: const TextStyle(color: Colors.white)),
+                  ],
+                ),
+                SwitchListTile(
+                  value: _xpOnly,
+                  onChanged: (v) => setState(() => _xpOnly = v),
+                  title: const Text('Только активные дни',
+                      style: TextStyle(color: Colors.white)),
+                  activeColor: Colors.greenAccent,
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/widgets/training_heatmap.dart
+++ b/lib/widgets/training_heatmap.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class TrainingHeatmap extends StatelessWidget {
+  final Map<DateTime, int> dailyXp;
+  final int days;
+  final bool xpOnly;
+  const TrainingHeatmap({
+    super.key,
+    required this.dailyXp,
+    this.days = 90,
+    this.xpOnly = false,
+  });
+
+  Color _color(BuildContext context, int value, int max) {
+    if (value == 0 && xpOnly) return Colors.transparent;
+    if (max <= 0) return Colors.transparent;
+    final t = value / max;
+    return Color.lerp(Colors.green[100], Colors.green[800], t) ?? Colors.green;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(Duration(days: days - 1));
+    final values = List<int>.filled(days, 0);
+    for (final entry in dailyXp.entries) {
+      final d = DateTime(entry.key.year, entry.key.month, entry.key.day);
+      if (d.isBefore(start) || d.isAfter(today)) continue;
+      final idx = d.difference(start).inDays;
+      if (idx >= 0 && idx < days) values[idx] += entry.value;
+    }
+    final maxVal = values.fold<int>(0, (p, e) => e > p ? e : p);
+    final weeks = (days / 7).ceil();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int row = 0; row < 7; row++)
+          Row(
+            children: [
+              for (int col = 0; col < weeks; col++)
+                Builder(
+                  builder: (context) {
+                    final idx = col * 7 + row;
+                    if (idx >= values.length) {
+                      return const SizedBox(width: 10, height: 10);
+                    }
+                    final date = start.add(Duration(days: idx));
+                    final val = values[idx];
+                    final color = _color(context, val, maxVal);
+                    final tooltip =
+                        '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')} - $val XP';
+                    return Padding(
+                      padding: const EdgeInsets.all(1),
+                      child: Tooltip(
+                        message: tooltip,
+                        child: Container(
+                          width: 10,
+                          height: 10,
+                          color: color,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingHeatmap` widget for generic calendar heatmaps
- implement `TagTrainingHeatmapSummaryScreen` to show global XP activity

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbc8d36d8832a82fd19031bf4d11b