### PR TITLE
Implement TagMasteryTrendService

### DIFF
--- a/lib/services/tag_mastery_trend_service.dart
+++ b/lib/services/tag_mastery_trend_service.dart
@@ -1,0 +1,83 @@
+import '../models/tag_xp_history_entry.dart';
+import 'tag_mastery_history_service.dart';
+
+enum TagTrend { rising, flat, falling }
+
+class TagMasteryTrendService {
+  final TagMasteryHistoryService history;
+  TagMasteryTrendService({TagMasteryHistoryService? history})
+      : history = history ?? TagMasteryHistoryService();
+
+  static Map<String, TagTrend>? _cache;
+  static int _cacheDays = 0;
+  static DateTime _cacheTime = DateTime.fromMillisecondsSinceEpoch(0);
+
+  Future<Map<String, TagTrend>> computeTrends({int days = 14}) async {
+    if (days <= 0) days = 14;
+    final now = DateTime.now();
+    if (_cache != null &&
+        _cacheDays == days &&
+        now.difference(_cacheTime) < const Duration(hours: 1)) {
+      return _cache!;
+    }
+
+    final hist = await history.getHistory();
+    final result = <String, TagTrend>{};
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(Duration(days: days - 1));
+
+    for (final entry in hist.entries) {
+      final data = List<double>.filled(days, 0);
+      for (final e in entry.value) {
+        final d = DateTime(e.date.year, e.date.month, e.date.day);
+        if (d.isBefore(start) || d.isAfter(today)) continue;
+        final idx = d.difference(start).inDays;
+        if (idx >= 0 && idx < days) data[idx] += e.xp.toDouble();
+      }
+      // 3-day moving average
+      final smoothed = List<double>.generate(days, (i) {
+        double sum = 0;
+        int count = 0;
+        for (int j = i - 2; j <= i; j++) {
+          if (j >= 0 && j < days) {
+            sum += data[j];
+            count++;
+          }
+        }
+        return count > 0 ? sum / count : 0;
+      });
+
+      if (smoothed.length < 2) {
+        result[entry.key] = TagTrend.flat;
+        continue;
+      }
+
+      final n = smoothed.length;
+      final xs = [for (var i = 0; i < n; i++) i + 1];
+      final sumX = xs.reduce((a, b) => a + b);
+      final sumX2 = xs.map((e) => e * e).reduce((a, b) => a + b);
+      final sumY = smoothed.reduce((a, b) => a + b);
+      final sumXY = [
+        for (var i = 0; i < n; i++) xs[i] * smoothed[i]
+      ].reduce((a, b) => a + b);
+      final denom = n * sumX2 - sumX * sumX;
+      double slope = 0;
+      if (denom != 0) {
+        slope = (n * sumXY - sumX * sumY) / denom;
+      }
+      const eps = 0.5;
+      if (slope > eps) {
+        result[entry.key] = TagTrend.rising;
+      } else if (slope < -eps) {
+        result[entry.key] = TagTrend.falling;
+      } else {
+        result[entry.key] = TagTrend.flat;
+      }
+    }
+
+    _cache = result;
+    _cacheTime = now;
+    _cacheDays = days;
+    return result;
+  }
+}

--- a/test/services/tag_mastery_trend_service_test.dart
+++ b/test/services/tag_mastery_trend_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/tag_xp_history_entry.dart';
+import 'package:poker_analyzer/services/tag_mastery_trend_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+
+class _FakeHistoryService extends TagMasteryHistoryService {
+  final Map<String, List<TagXpHistoryEntry>> map;
+  _FakeHistoryService(this.map);
+  @override
+  Future<Map<String, List<TagXpHistoryEntry>>> getHistory() async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computeTrends detects rising, flat and falling', () async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day).subtract(const Duration(days: 13));
+    final rising = [
+      for (int i = 0; i < 14; i++)
+        TagXpHistoryEntry(date: start.add(Duration(days: i)), xp: i, source: '')
+    ];
+    final falling = [
+      for (int i = 0; i < 14; i++)
+        TagXpHistoryEntry(date: start.add(Duration(days: i)), xp: 13 - i, source: '')
+    ];
+    final flat = [
+      for (int i = 0; i < 14; i++)
+        TagXpHistoryEntry(date: start.add(Duration(days: i)), xp: 5, source: '')
+    ];
+
+    final service = TagMasteryTrendService(
+      history: _FakeHistoryService({
+        'r': rising,
+        'f': falling,
+        'n': flat,
+      }),
+    );
+
+    final trends = await service.computeTrends(days: 14);
+    expect(trends['r'], TagTrend.rising);
+    expect(trends['f'], TagTrend.falling);
+    expect(trends['n'], TagTrend.flat);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TagMasteryTrendService` to compute XP trend per tag
- provide simple linear regression logic with caching
- test trend detection logic

## Testing
- `flutter test test/services/tag_mastery_trend_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc2f8d190832a9ff590d8a61b1f2e