### PR TITLE
Implement TagGoalTrackerService

### DIFF
--- a/lib/models/tag_goal_progress.dart
+++ b/lib/models/tag_goal_progress.dart
@@ -1,0 +1,13 @@
+class TagGoalProgress {
+  final int trainings;
+  final int xp;
+  final int streak;
+  final DateTime? lastTrainingDate;
+
+  const TagGoalProgress({
+    required this.trainings,
+    required this.xp,
+    required this.streak,
+    required this.lastTrainingDate,
+  });
+}

--- a/lib/services/tag_goal_tracker_service.dart
+++ b/lib/services/tag_goal_tracker_service.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/tag_goal_progress.dart';
+
+class TagGoalTrackerService {
+  TagGoalTrackerService._();
+  static final TagGoalTrackerService instance = TagGoalTrackerService._();
+
+  static const _countPrefix = 'tag_goal_count_';
+  static const _streakPrefix = 'tag_goal_streak_';
+  static const _lastPrefix = 'tag_goal_last_';
+  static const _tagXpPrefix = 'tag_xp_';
+
+  Future<TagGoalProgress> getProgress(String tagId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final tag = tagId.toLowerCase();
+    final count = prefs.getInt('$_countPrefix$tag') ?? 0;
+    final streak = prefs.getInt('$_streakPrefix$tag') ?? 0;
+    final lastStr = prefs.getString('$_lastPrefix$tag');
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+
+    int xp = 0;
+    final raw = prefs.getString('$_tagXpPrefix$tag');
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw) as Map<String, dynamic>;
+        xp = (data['total'] as num?)?.toInt() ?? 0;
+      } catch (_) {}
+    }
+
+    return TagGoalProgress(
+      trainings: count,
+      xp: xp,
+      streak: streak,
+      lastTrainingDate: last,
+    );
+  }
+
+  Future<void> logTraining(String tagId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final tag = tagId.toLowerCase();
+    final countKey = '$_countPrefix$tag';
+    final streakKey = '$_streakPrefix$tag';
+    final lastKey = '$_lastPrefix$tag';
+
+    await prefs.setInt(countKey, (prefs.getInt(countKey) ?? 0) + 1);
+
+    final now = DateTime.now();
+    final lastStr = prefs.getString(lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    int streak = prefs.getInt(streakKey) ?? 0;
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff =
+          DateTime(now.year, now.month, now.day).difference(lastDay).inDays;
+      if (diff == 1) {
+        streak += 1;
+      } else if (diff > 1) {
+        streak = 1;
+      }
+    } else {
+      streak = 1;
+    }
+    await prefs.setInt(streakKey, streak);
+    await prefs.setString(lastKey, now.toIso8601String());
+  }
+}


### PR DESCRIPTION
## Summary
- add `TagGoalProgress` model
- add `TagGoalTrackerService` for tracking training progress per tag

## Testing
- `dart analyze lib/models/tag_goal_progress.dart lib/services/tag_goal_tracker_service.dart`
- `flutter analyze` *(fails: lengthy stack trace)*

------
https://chatgpt.com/codex/tasks/task_e_687cc3f158c0832a9852d13817438505