### PR TITLE
Add active tag goal banner

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/spot_quiz_widget.dart';
 import '../widgets/style_hint_bar.dart';
 import '../widgets/stack_range_bar.dart';
 import '../widgets/dynamic_progress_row.dart';
+import '../widgets/active_tag_goal_banner.dart';
 import 'session_result_screen.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/cloud_sync_service.dart';
@@ -550,6 +551,12 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                           style: const TextStyle(color: Colors.white70),
                         ),
                         const SizedBox(height: 4),
+                        if (spot.tags.isNotEmpty)
+                          ActiveTagGoalBanner(
+                              tagId: spot.tags.firstWhere(
+                            (t) => !t.startsWith('cat:'),
+                            orElse: () => spot.tags.first,
+                          )),
                       ],
                       Text(
                         'Elapsed: ${_format(service.elapsedTime)}',

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -15,6 +15,7 @@ import 'learning_path_progress_service.dart';
 import 'cloud_training_history_service.dart';
 import 'learning_path_personalization_service.dart';
 import 'xp_tracker_service.dart';
+import 'tag_goal_tracker_service.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
 
@@ -481,6 +482,9 @@ class TrainingSessionService extends ChangeNotifier {
     }
     await xpService.addPerTagXP(tagXp, source: 'training');
     await xpService.add(xp: xp, source: 'training');
+    for (final tag in _template!.tags) {
+      unawaited(TagGoalTrackerService.instance.logTraining(tag));
+    }
     unawaited(_clearIndex());
     Navigator.pushReplacement(
       context,

--- a/lib/services/user_preferences_service.dart
+++ b/lib/services/user_preferences_service.dart
@@ -18,6 +18,7 @@ class UserPreferencesService extends ChangeNotifier {
   static const _weakCatCountKey = 'weak_cat_count';
   static const _evRangeStartKey = 'ev_range_start';
   static const _evRangeEndKey = 'ev_range_end';
+  static const _tagGoalBannerKey = 'show_tag_goal_banner';
 
   bool _showPotAnimation = true;
   bool _showCardReveal = true;
@@ -30,6 +31,7 @@ class UserPreferencesService extends ChangeNotifier {
   DateTimeRange? _weakRange;
   int _weakCatCount = 5;
   RangeValues _evRange = const RangeValues(0, 5);
+  bool _showTagGoalBanner = true;
   final CloudSyncService? cloud;
 
   UserPreferencesService({this.cloud});
@@ -45,6 +47,7 @@ class UserPreferencesService extends ChangeNotifier {
   DateTimeRange? get weaknessRange => _weakRange;
   int get weaknessCategoryCount => _weakCatCount;
   RangeValues get evRange => _evRange;
+  bool get showTagGoalBanner => _showTagGoalBanner;
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -56,6 +59,7 @@ class UserPreferencesService extends ChangeNotifier {
     _demoMode = prefs.getBool(_demoModeKey) ?? false;
     _tutorialCompleted = prefs.getBool(_tutorialCompletedKey) ?? false;
     _simpleNavigation = prefs.getBool(_simpleNavKey) ?? false;
+    _showTagGoalBanner = prefs.getBool(_tagGoalBannerKey) ?? true;
     final startStr = prefs.getString(_weakRangeStartKey);
     final endStr = prefs.getString(_weakRangeEndKey);
     if (startStr != null && endStr != null) {
@@ -81,6 +85,7 @@ class UserPreferencesService extends ChangeNotifier {
         'demoMode': _demoMode,
         'tutorialCompleted': _tutorialCompleted,
         'simpleNavigation': _simpleNavigation,
+        'showTagGoalBanner': _showTagGoalBanner,
         if (_weakRange != null) 'weakRangeStart': _weakRange!.start.toIso8601String(),
         if (_weakRange != null) 'weakRangeEnd': _weakRange!.end.toIso8601String(),
         'evRangeStart': _evRange.start,
@@ -195,6 +200,13 @@ class UserPreferencesService extends ChangeNotifier {
       await cloud!.queueMutation('preferences', 'main', data);
       unawaited(cloud!.syncUp());
     }
+    notifyListeners();
+  }
+
+  Future<void> setShowTagGoalBanner(bool value) async {
+    if (_showTagGoalBanner == value) return;
+    _showTagGoalBanner = value;
+    await _save(_tagGoalBannerKey, value);
     notifyListeners();
   }
 }

--- a/lib/user_preferences.dart
+++ b/lib/user_preferences.dart
@@ -22,6 +22,7 @@ class UserPreferences {
   bool get demoMode => service.demoMode;
   bool get tutorialCompleted => service.tutorialCompleted;
   bool get simpleNavigation => service.simpleNavigation;
+  bool get showTagGoalBanner => service.showTagGoalBanner;
   Color get accentColor => theme.accentColor;
 
   Future<void> setShowPotAnimation(bool value) => service.setShowPotAnimation(value);
@@ -32,5 +33,6 @@ class UserPreferences {
   Future<void> setDemoMode(bool value) => service.setDemoMode(value);
   Future<void> setSimpleNavigation(bool value) => service.setSimpleNavigation(value);
   Future<void> setTutorialCompleted(bool value) => service.setTutorialCompleted(value);
+  Future<void> setShowTagGoalBanner(bool value) => service.setShowTagGoalBanner(value);
   Future<void> setAccentColor(Color value) => theme.setAccentColor(value);
 }

--- a/lib/widgets/active_tag_goal_banner.dart
+++ b/lib/widgets/active_tag_goal_banner.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/color_utils.dart';
+import '../models/tag_goal_progress.dart';
+import '../services/tag_goal_tracker_service.dart';
+import '../services/tag_service.dart';
+import '../user_preferences.dart';
+
+class ActiveTagGoalBanner extends StatefulWidget {
+  final String tagId;
+  const ActiveTagGoalBanner({super.key, required this.tagId});
+
+  @override
+  State<ActiveTagGoalBanner> createState() => _ActiveTagGoalBannerState();
+}
+
+class _ActiveTagGoalBannerState extends State<ActiveTagGoalBanner> {
+  late Future<TagGoalProgress> _progress;
+
+  @override
+  void initState() {
+    super.initState();
+    _progress = TagGoalTrackerService.instance.getProgress(widget.tagId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!UserPreferences.instance.showTagGoalBanner) {
+      return const SizedBox.shrink();
+    }
+    final tagService = context.read<TagService>();
+    final color = colorFromHex(tagService.colorOf(widget.tagId));
+    return FutureBuilder<TagGoalProgress>(
+      future: _progress,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return const SizedBox.shrink();
+        final p = snapshot.data!;
+        final hasProgress = p.trainings > 0 || p.xp > 0;
+        if (!hasProgress) return const SizedBox.shrink();
+        // Use XP goal if XP progress exists, otherwise trainings goal.
+        final bool useXp = p.xp > 0;
+        final int target = useXp ? 100 : 10;
+        final int current = useXp ? p.xp : p.trainings;
+        final double pct = (current / target).clamp(0.0, 1.0);
+        final goalText = useXp ? '$target XP' : '$target тренировок';
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: color.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '#${widget.tagId}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  if (p.streak > 2) const Text('🔥'),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Цель: $goalText',
+                style: const TextStyle(color: Colors.white),
+              ),
+              const SizedBox(height: 4),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: pct,
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation<Color>(color),
+                  minHeight: 6,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  '$current/$target',
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new widget `ActiveTagGoalBanner`
- allow enabling/disabling banner via `UserPreferences`
- display active tag progress in `TrainingSessionScreen`
- track tag goal progress on session completion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cc58344f8832abf85e23c9a886d69