### PR TITLE
Implement LearningPathAdvisor

### DIFF
--- a/lib/models/mistake_profile.dart
+++ b/lib/models/mistake_profile.dart
@@ -1,0 +1,4 @@
+class MistakeProfile {
+  final Set<String> weakTags;
+  const MistakeProfile({required this.weakTags});
+}

--- a/lib/services/learning_path_advisor.dart
+++ b/lib/services/learning_path_advisor.dart
@@ -1,0 +1,51 @@
+import '../models/v3/lesson_step.dart';
+import '../models/v3/lesson_track.dart';
+import '../models/mistake_profile.dart';
+
+class LearningPathAdvisor {
+  final List<LessonStep> steps;
+
+  LearningPathAdvisor({required this.steps});
+
+  LessonStep? recommendNextStep({
+    required List<LessonTrack> availableTracks,
+    required Map<String, Set<String>> completedSteps,
+    required MistakeProfile profile,
+  }) {
+    final stepMap = {for (final s in steps) s.id: s};
+    final done = <String>{};
+    for (final set in completedSteps.values) {
+      done.addAll(set);
+    }
+
+    LessonStep? best;
+    double bestScore = double.negativeInfinity;
+
+    for (final track in availableTracks) {
+      final ids = track.stepIds;
+      final started = ids.any(done.contains);
+      final finished = ids.every(done.contains);
+
+      for (final id in ids) {
+        if (done.contains(id)) continue;
+        final step = stepMap[id];
+        if (step == null) continue;
+
+        double score = 0;
+        if (started && !finished) score += 2;
+        final tags =
+            (step.meta['tags'] as List?)?.map((e) => e.toString()).toSet() ??
+                const <String>{};
+        for (final tag in tags) {
+          if (profile.weakTags.contains(tag)) score += 1;
+        }
+        if (score > bestScore) {
+          bestScore = score;
+          best = step;
+        }
+      }
+    }
+
+    return best;
+  }
+}

--- a/test/services/learning_path_advisor_test.dart
+++ b/test/services/learning_path_advisor_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/learning_path_advisor.dart';
+import 'package:poker_analyzer/models/v3/lesson_step.dart';
+import 'package:poker_analyzer/models/v3/lesson_track.dart';
+import 'package:poker_analyzer/models/mistake_profile.dart';
+
+void main() {
+  final steps = [
+    LessonStep(
+      id: 's1',
+      title: 'one',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {
+        'schemaVersion': '3.0.0',
+        'tags': ['a']
+      },
+    ),
+    LessonStep(
+      id: 's2',
+      title: 'two',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {
+        'schemaVersion': '3.0.0',
+        'tags': ['b']
+      },
+    ),
+    LessonStep(
+      id: 's3',
+      title: 'three',
+      introText: '',
+      linkedPackId: 'p',
+      meta: const {'schemaVersion': '3.0.0'},
+    ),
+  ];
+
+  final tracks = [
+    const LessonTrack(
+      id: 't1',
+      title: 'T1',
+      description: '',
+      stepIds: ['s1', 's2'],
+    ),
+    const LessonTrack(
+      id: 't2',
+      title: 'T2',
+      description: '',
+      stepIds: ['s3'],
+    ),
+  ];
+
+  test('prefers step with matching weak tag', () {
+    final advisor = LearningPathAdvisor(steps: steps);
+    final step = advisor.recommendNextStep(
+      availableTracks: tracks,
+      completedSteps: const {},
+      profile: const MistakeProfile(weakTags: {'b'}),
+    );
+    expect(step?.id, 's2');
+  });
+
+  test('prefers step from started track', () {
+    final advisor = LearningPathAdvisor(steps: steps);
+    final step = advisor.recommendNextStep(
+      availableTracks: tracks,
+      completedSteps: {
+        'l': {'s1'}
+      },
+      profile: const MistakeProfile(weakTags: {}),
+    );
+    expect(step?.id, 's2');
+  });
+
+  test('returns null when all steps completed', () {
+    final advisor = LearningPathAdvisor(steps: steps);
+    final step = advisor.recommendNextStep(
+      availableTracks: tracks,
+      completedSteps: {
+        'l': {'s1', 's2', 's3'}
+      },
+      profile: const MistakeProfile(weakTags: {'a'}),
+    );
+    expect(step, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add `MistakeProfile` model
- implement `LearningPathAdvisor` service for recommending next lesson step
- test recommendation logic

## Testing
- `flutter test --run-skipped test/services/learning_path_advisor_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687cc89a9780832a82a71a607ddf106b