### PR TITLE
Enable lesson tracks via YAML loader

### DIFF
--- a/assets/lesson_tracks/sample_track.yaml
+++ b/assets/lesson_tracks/sample_track.yaml
@@ -1,0 +1,7 @@
+meta:
+  track_schema: '1.0.0'
+id: 'yaml_sample'
+title: 'YAML Sample Track'
+description: 'Demo track loaded from YAML.'
+stepIds:
+  - 'lesson1'

--- a/lib/services/yaml_lesson_track_loader.dart
+++ b/lib/services/yaml_lesson_track_loader.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v3/lesson_track.dart';
+import 'lesson_loader_service.dart';
+
+class YamlLessonTrackLoader {
+  YamlLessonTrackLoader._();
+  static final instance = YamlLessonTrackLoader._();
+
+  static const _dir = 'assets/lesson_tracks/';
+
+  Future<List<LessonTrack>> loadTracksFromAssets() async {
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .toList();
+    final lessons = await LessonLoaderService.instance.loadAllLessons();
+    final ids = {for (final s in lessons) s.id};
+    final tracks = <LessonTrack>[];
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        final meta = map['meta'] as Map?;
+        final schema = meta?['track_schema']?.toString() ?? '1.0.0';
+        if (schema != '1.0.0') continue;
+        final stepList = map['stepIds'];
+        if (stepList is! List) continue;
+        final steps = [for (final v in stepList) v.toString()];
+        if (steps.any((id) => !ids.contains(id))) continue;
+        final id = map['id']?.toString() ?? '';
+        final title = map['title']?.toString() ?? '';
+        final desc = map['description']?.toString() ?? '';
+        if (id.isEmpty || title.isEmpty) continue;
+        tracks.add(LessonTrack(
+          id: id,
+          title: title,
+          description: desc,
+          stepIds: steps,
+        ));
+      } catch (_) {}
+    }
+    return tracks;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,6 +102,7 @@ flutter:
     - assets/packs/v2/library_index.json
     - assets/built_in_packs.yaml
     - assets/lessons/
+    - assets/lesson_tracks/
     - assets/pack_matrix.json
     - assets/learning_intro.svg
     - assets/training_paths.yaml

--- a/test/yaml_lesson_track_loader_test.dart
+++ b/test/yaml_lesson_track_loader_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/yaml_lesson_track_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  test('loadTracksFromAssets loads sample track', () async {
+    final loader = YamlLessonTrackLoader.instance;
+    final tracks = await loader.loadTracksFromAssets();
+    expect(tracks.where((t) => t.id == 'yaml_sample').length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add sample lesson track YAML asset
- support loading lesson tracks from assets
- include asset directory in pubspec
- test loader

## Testing
- `flutter analyze` *(fails: 7152 issues)*
- `flutter test test/yaml_lesson_track_loader_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687cd2f0cca8832aaa8e4e5f11c6a406