### PR TITLE
Add LessonStep filter engine

### DIFF
--- a/assets/lessons/test_lesson.yaml
+++ b/assets/lessons/test_lesson.yaml
@@ -4,6 +4,11 @@ id: 'lesson1'
 title: 'Sample Lesson'
 introText: 'Welcome to the trainer.'
 summaryText: 'Вы познакомились с тренажёром и решили простую задачу.'
+filter:
+  minXp: 500
+  tag: push_fold
+  gameType: tournament
+  skillLevel: beginner
 quiz:
   question: 'What is 2 + 2?'
   options:

--- a/lib/models/player_profile.dart
+++ b/lib/models/player_profile.dart
@@ -1,0 +1,19 @@
+import 'game_type.dart';
+import 'skill_level.dart';
+
+class PlayerProfile {
+  int xp;
+  Set<String> tags;
+  GameType gameType;
+  SkillLevel skillLevel;
+  Set<String> completedLessonIds;
+
+  PlayerProfile({
+    this.xp = 0,
+    Set<String>? tags,
+    this.gameType = GameType.tournament,
+    this.skillLevel = SkillLevel.beginner,
+    Set<String>? completedLessonIds,
+  })  : tags = tags ?? <String>{},
+        completedLessonIds = completedLessonIds ?? <String>{};
+}

--- a/lib/models/skill_level.dart
+++ b/lib/models/skill_level.dart
@@ -1,0 +1,16 @@
+enum SkillLevel { beginner, intermediate, advanced, expert }
+
+extension SkillLevelLabel on SkillLevel {
+  String get label {
+    switch (this) {
+      case SkillLevel.beginner:
+        return 'Beginner';
+      case SkillLevel.intermediate:
+        return 'Intermediate';
+      case SkillLevel.advanced:
+        return 'Advanced';
+      case SkillLevel.expert:
+        return 'Expert';
+    }
+  }
+}

--- a/lib/models/v3/lesson_step.dart
+++ b/lib/models/v3/lesson_step.dart
@@ -1,3 +1,5 @@
+import 'lesson_step_filter.dart';
+
 class Quiz {
   final String question;
   final List<String> options;
@@ -37,6 +39,7 @@ class LessonStep {
   final Quiz? quiz;
   final String? rangeImageUrl;
   final String linkedPackId;
+  final LessonStepFilter? filter;
   final Map<String, dynamic> meta;
 
   LessonStep({
@@ -47,6 +50,7 @@ class LessonStep {
     this.quiz,
     this.rangeImageUrl,
     required this.linkedPackId,
+    this.filter,
     Map<String, dynamic>? meta,
   }) : meta = meta ?? const {'schemaVersion': '3.0.0'};
 
@@ -55,6 +59,12 @@ class LessonStep {
     meta['schemaVersion'] = meta['schemaVersion']?.toString() ?? '3.0.0';
     final quizYaml = yaml['quiz'] as Map?;
     final quiz = quizYaml != null ? Quiz.fromYaml(Map.from(quizYaml)) : null;
+    final filterYaml = yaml['filter'];
+    LessonStepFilter? filter;
+    if (filterYaml is Map) {
+      filter = LessonStepFilter.fromYaml(
+          Map<String, dynamic>.from(filterYaml));
+    }
     return LessonStep(
       id: yaml['id']?.toString() ?? '',
       title: yaml['title']?.toString() ?? '',
@@ -63,6 +73,7 @@ class LessonStep {
       quiz: quiz,
       rangeImageUrl: yaml['rangeImageUrl']?.toString(),
       linkedPackId: yaml['linkedPackId']?.toString() ?? '',
+      filter: filter,
       meta: meta,
     );
   }
@@ -77,6 +88,7 @@ class LessonStep {
       if (quiz != null) 'quiz': quiz!.toYaml(),
       if (rangeImageUrl != null) 'rangeImageUrl': rangeImageUrl,
       'linkedPackId': linkedPackId,
+      if (filter != null) 'filter': filter!.toYaml(),
     };
   }
 }

--- a/lib/models/v3/lesson_step_filter.dart
+++ b/lib/models/v3/lesson_step_filter.dart
@@ -1,0 +1,56 @@
+import '../game_type.dart';
+import '../skill_level.dart';
+import '../training_pack.dart' show parseGameType;
+
+class LessonStepFilter {
+  final int? minXp;
+  final Set<String> tags;
+  final Set<String> completedLessonIds;
+  final GameType? gameType;
+  final SkillLevel? skillLevel;
+
+  LessonStepFilter({
+    this.minXp,
+    Set<String>? tags,
+    Set<String>? completedLessonIds,
+    this.gameType,
+    this.skillLevel,
+  })  : tags = tags?.toSet() ?? <String>{},
+        completedLessonIds = completedLessonIds?.toSet() ?? <String>{};
+
+  factory LessonStepFilter.fromYaml(Map yaml) {
+    final tagsField = yaml['tag'] ?? yaml['tags'];
+    final tagSet = <String>{};
+    if (tagsField is List) {
+      tagSet.addAll(tagsField.map((e) => e.toString()));
+    } else if (tagsField is String) {
+      tagSet.add(tagsField);
+    }
+    return LessonStepFilter(
+      minXp: (yaml['minXp'] as num?)?.toInt(),
+      tags: tagSet,
+      completedLessonIds: [
+        for (final id in (yaml['completedLessonIds'] as List? ?? []))
+          id.toString()
+      ].toSet(),
+      gameType:
+          yaml['gameType'] != null ? parseGameType(yaml['gameType']) : null,
+      skillLevel: yaml['skillLevel'] != null
+          ? SkillLevel.values.firstWhere(
+              (e) => e.name == yaml['skillLevel'].toString(),
+              orElse: () => SkillLevel.beginner,
+            )
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toYaml() => {
+        if (minXp != null) 'minXp': minXp,
+        if (tags.isNotEmpty)
+          'tag': tags.length == 1 ? tags.first : tags.toList(),
+        if (completedLessonIds.isNotEmpty)
+          'completedLessonIds': completedLessonIds.toList(),
+        if (gameType != null) 'gameType': gameType!.name,
+        if (skillLevel != null) 'skillLevel': skillLevel!.name,
+      };
+}

--- a/lib/services/lesson_step_filter_engine.dart
+++ b/lib/services/lesson_step_filter_engine.dart
@@ -1,0 +1,36 @@
+import '../models/v3/lesson_step.dart';
+import '../models/player_profile.dart';
+import '../models/v3/lesson_step_filter.dart';
+
+class LessonStepFilterEngine {
+  const LessonStepFilterEngine();
+
+  List<LessonStep> applyFilters(List<LessonStep> allSteps,
+      {required PlayerProfile profile}) {
+    return [
+      for (final step in allSteps)
+        if (_matches(step.filter, profile)) step,
+    ];
+  }
+
+  bool _matches(LessonStepFilter? filter, PlayerProfile profile) {
+    if (filter == null) return true;
+    if (filter.minXp != null && profile.xp < filter.minXp!) return false;
+    if (filter.gameType != null && profile.gameType != filter.gameType) {
+      return false;
+    }
+    if (filter.skillLevel != null && profile.skillLevel != filter.skillLevel) {
+      return false;
+    }
+    if (filter.tags.isNotEmpty &&
+        !filter.tags.every((t) => profile.tags.contains(t))) {
+      return false;
+    }
+    if (filter.completedLessonIds.isNotEmpty &&
+        !filter.completedLessonIds
+            .every((id) => profile.completedLessonIds.contains(id))) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/test/services/lesson_step_filter_engine_test.dart
+++ b/test/services/lesson_step_filter_engine_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/skill_level.dart';
+import 'package:poker_analyzer/models/v3/lesson_step.dart';
+import 'package:poker_analyzer/models/v3/lesson_step_filter.dart';
+import 'package:poker_analyzer/services/lesson_step_filter_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final profile = PlayerProfile(
+    xp: 1500,
+    tags: {'push_fold', 'icm'},
+    gameType: GameType.tournament,
+    skillLevel: SkillLevel.intermediate,
+    completedLessonIds: {'intro'},
+  );
+
+  LessonStep step(String id, LessonStepFilter? filter) => LessonStep(
+        id: id,
+        title: id,
+        introText: '',
+        linkedPackId: 'p',
+        filter: filter,
+        meta: const {'schemaVersion': '3.0.0'},
+      );
+
+  test('filters by minXp', () {
+    final steps = [
+      step('a', LessonStepFilter(minXp: 1000)),
+      step('b', LessonStepFilter(minXp: 2000)),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+
+  test('filters by tag', () {
+    final steps = [
+      step('a', LessonStepFilter(tags: {'push_fold'})),
+      step('b', LessonStepFilter(tags: {'mtt'})),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+
+  test('filters by completedLessonIds', () {
+    final steps = [
+      step('a', LessonStepFilter(completedLessonIds: {'intro'})),
+      step('b', LessonStepFilter(completedLessonIds: {'other'})),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+
+  test('filters by gameType', () {
+    final steps = [
+      step('a', LessonStepFilter(gameType: GameType.tournament)),
+      step('b', LessonStepFilter(gameType: GameType.cash)),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+
+  test('filters by skillLevel', () {
+    final steps = [
+      step('a', LessonStepFilter(skillLevel: SkillLevel.intermediate)),
+      step('b', LessonStepFilter(skillLevel: SkillLevel.advanced)),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+
+  test('filters by multiple conditions', () {
+    final steps = [
+      step(
+          'a',
+          LessonStepFilter(
+            minXp: 1000,
+            tags: {'push_fold'},
+            gameType: GameType.tournament,
+          )),
+      step(
+          'b',
+          LessonStepFilter(
+            minXp: 1600,
+            tags: {'push_fold'},
+            gameType: GameType.tournament,
+          )),
+    ];
+    final result =
+        const LessonStepFilterEngine().applyFilters(steps, profile: profile);
+    expect(result.map((s) => s.id), ['a']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `PlayerProfile` and `SkillLevel` models
- support optional `filter` field in `LessonStep`
- implement `LessonStepFilter` and `LessonStepFilterEngine`
- show example filter in `test_lesson.yaml`
- unit tests for new engine

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cda4a035c832aa4679f7d2b090f0c