### PR TITLE
Implement track unlock conditions engine

### DIFF
--- a/assets/lesson_tracks/sample_track.yaml
+++ b/assets/lesson_tracks/sample_track.yaml
@@ -3,5 +3,8 @@ meta:
 id: 'yaml_sample'
 title: 'YAML Sample Track'
 description: 'Demo track loaded from YAML.'
+unlockCondition:
+  minXp: 500
+  requiredTags: push_fold
 stepIds:
   - 'lesson1'

--- a/lib/models/v3/lesson_track.dart
+++ b/lib/models/v3/lesson_track.dart
@@ -1,13 +1,17 @@
+import 'track_unlock_condition.dart';
+
 class LessonTrack {
   final String id;
   final String title;
   final String description;
   final List<String> stepIds;
+  final TrackUnlockCondition? unlockCondition;
 
   const LessonTrack({
     required this.id,
     required this.title,
     required this.description,
     required this.stepIds,
+    this.unlockCondition,
   });
 }

--- a/lib/models/v3/track_unlock_condition.dart
+++ b/lib/models/v3/track_unlock_condition.dart
@@ -1,0 +1,57 @@
+import '../game_type.dart';
+import '../skill_level.dart';
+import '../training_pack.dart' show parseGameType;
+
+class TrackUnlockCondition {
+  final int? minXp;
+  final Set<String> requiredTags;
+  final Set<String> completedLessonIds;
+  final GameType? gameType;
+  final SkillLevel? skillLevel;
+
+  TrackUnlockCondition({
+    this.minXp,
+    Set<String>? requiredTags,
+    Set<String>? completedLessonIds,
+    this.gameType,
+    this.skillLevel,
+  })  : requiredTags = requiredTags?.toSet() ?? <String>{},
+        completedLessonIds = completedLessonIds?.toSet() ?? <String>{};
+
+  factory TrackUnlockCondition.fromYaml(Map yaml) {
+    final tagsField = yaml['requiredTags'];
+    final tagSet = <String>{};
+    if (tagsField is List) {
+      tagSet.addAll(tagsField.map((e) => e.toString()));
+    } else if (tagsField is String) {
+      tagSet.add(tagsField);
+    }
+    return TrackUnlockCondition(
+      minXp: (yaml['minXp'] as num?)?.toInt(),
+      requiredTags: tagSet,
+      completedLessonIds: [
+        for (final id in (yaml['completedLessonIds'] as List? ?? []))
+          id.toString()
+      ].toSet(),
+      gameType:
+          yaml['gameType'] != null ? parseGameType(yaml['gameType']) : null,
+      skillLevel: yaml['skillLevel'] != null
+          ? SkillLevel.values.firstWhere(
+              (e) => e.name == yaml['skillLevel'].toString(),
+              orElse: () => SkillLevel.beginner,
+            )
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toYaml() => {
+        if (minXp != null) 'minXp': minXp,
+        if (requiredTags.isNotEmpty)
+          'requiredTags':
+              requiredTags.length == 1 ? requiredTags.first : requiredTags.toList(),
+        if (completedLessonIds.isNotEmpty)
+          'completedLessonIds': completedLessonIds.toList(),
+        if (gameType != null) 'gameType': gameType!.name,
+        if (skillLevel != null) 'skillLevel': skillLevel!.name,
+      };
+}

--- a/lib/services/track_unlock_conditions_engine.dart
+++ b/lib/services/track_unlock_conditions_engine.dart
@@ -1,0 +1,32 @@
+import '../models/v3/lesson_track.dart';
+import '../models/v3/track_unlock_condition.dart';
+import '../models/player_profile.dart';
+
+class TrackUnlockConditionsEngine {
+  const TrackUnlockConditionsEngine();
+
+  bool isTrackUnlocked(LessonTrack track, PlayerProfile profile) {
+    return _matches(track.unlockCondition, profile);
+  }
+
+  bool _matches(TrackUnlockCondition? cond, PlayerProfile profile) {
+    if (cond == null) return true;
+    if (cond.minXp != null && profile.xp < cond.minXp!) return false;
+    if (cond.gameType != null && profile.gameType != cond.gameType) {
+      return false;
+    }
+    if (cond.skillLevel != null && profile.skillLevel != cond.skillLevel) {
+      return false;
+    }
+    if (cond.requiredTags.isNotEmpty &&
+        !cond.requiredTags.every((t) => profile.tags.contains(t))) {
+      return false;
+    }
+    if (cond.completedLessonIds.isNotEmpty &&
+        !cond.completedLessonIds
+            .every((id) => profile.completedLessonIds.contains(id))) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/lib/services/yaml_lesson_track_loader.dart
+++ b/lib/services/yaml_lesson_track_loader.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import '../asset_manifest.dart';
 import '../core/training/generation/yaml_reader.dart';
 import '../models/v3/lesson_track.dart';
+import '../models/v3/track_unlock_condition.dart';
 import 'lesson_loader_service.dart';
 
 class YamlLessonTrackLoader {
@@ -33,12 +34,19 @@ class YamlLessonTrackLoader {
         final id = map['id']?.toString() ?? '';
         final title = map['title']?.toString() ?? '';
         final desc = map['description']?.toString() ?? '';
+        TrackUnlockCondition? condition;
+        final condYaml = map['unlockCondition'];
+        if (condYaml is Map) {
+          condition = TrackUnlockCondition.fromYaml(
+              Map<String, dynamic>.from(condYaml));
+        }
         if (id.isEmpty || title.isEmpty) continue;
         tracks.add(LessonTrack(
           id: id,
           title: title,
           description: desc,
           stepIds: steps,
+          unlockCondition: condition,
         ));
       } catch (_) {}
     }

--- a/test/services/track_unlock_conditions_engine_test.dart
+++ b/test/services/track_unlock_conditions_engine_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/skill_level.dart';
+import 'package:poker_analyzer/models/v3/lesson_track.dart';
+import 'package:poker_analyzer/models/v3/track_unlock_condition.dart';
+import 'package:poker_analyzer/services/track_unlock_conditions_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final profile = PlayerProfile(
+    xp: 1500,
+    tags: {'push_fold', 'icm'},
+    gameType: GameType.tournament,
+    skillLevel: SkillLevel.intermediate,
+    completedLessonIds: {'intro'},
+  );
+
+  LessonTrack track(TrackUnlockCondition? cond) => LessonTrack(
+        id: 't',
+        title: 'Track',
+        description: '',
+        stepIds: const ['lesson1'],
+        unlockCondition: cond,
+      );
+
+  test('unlocked by minXp', () {
+    final t = track(TrackUnlockCondition(minXp: 1000));
+    expect(const TrackUnlockConditionsEngine().isTrackUnlocked(t, profile), isTrue);
+  });
+
+  test('locked by minXp', () {
+    final t = track(TrackUnlockCondition(minXp: 2000));
+    expect(const TrackUnlockConditionsEngine().isTrackUnlocked(t, profile), isFalse);
+  });
+
+  test('locked by tag', () {
+    final t = track(TrackUnlockCondition(requiredTags: {'mtt'}));
+    expect(const TrackUnlockConditionsEngine().isTrackUnlocked(t, profile), isFalse);
+  });
+
+  test('locked by completedLessonId', () {
+    final t = track(TrackUnlockCondition(completedLessonIds: {'other'}));
+    expect(const TrackUnlockConditionsEngine().isTrackUnlocked(t, profile), isFalse);
+  });
+}

--- a/test/yaml_lesson_track_loader_test.dart
+++ b/test/yaml_lesson_track_loader_test.dart
@@ -6,6 +6,8 @@ void main() {
   test('loadTracksFromAssets loads sample track', () async {
     final loader = YamlLessonTrackLoader.instance;
     final tracks = await loader.loadTracksFromAssets();
-    expect(tracks.where((t) => t.id == 'yaml_sample').length, 1);
+    final sample = tracks.firstWhere((t) => t.id == 'yaml_sample');
+    expect(sample.unlockCondition?.minXp, 500);
+    expect(sample.unlockCondition?.requiredTags.contains('push_fold'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add optional `unlockCondition` to track YAML schema and model
- parse unlock conditions when loading track YAML files
- implement `TrackUnlockConditionsEngine` for track gating
- add new sample unlock condition data
- test unlocking engine and loader

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cdba70a68832a99bc07f03785543f