### PR TITLE
Implement LessonProgressTrackerService

### DIFF
--- a/test/services/lesson_progress_tracker_service_test.dart
+++ b/test/services/lesson_progress_tracker_service_test.dart
@@ -5,30 +5,39 @@ import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('markStepCompleted stores step for lesson', () async {
+  test('markStepCompleted stores step and marks lesson', () async {
     SharedPreferences.setMockInitialValues({});
     await LessonProgressTrackerService.instance.load();
     await LessonProgressTrackerService.instance
         .markStepCompleted('lessonA', 'step1');
-    expect(
-        await LessonProgressTrackerService.instance
-            .isStepCompleted('lessonA', 'step1'),
-        true);
-    final list = await LessonProgressTrackerService.instance
-        .getCompletedSteps('lessonA');
-    expect(list, ['step1']);
+    final steps =
+        await LessonProgressTrackerService.instance.getCompletedSteps('lessonA');
+    expect(steps.contains('step1'), true);
+    final lessons =
+        await LessonProgressTrackerService.instance.getCompletedLessons();
+    expect(lessons.contains('lessonA'), true);
   });
 
   test('legacy flat methods still work', () async {
     SharedPreferences.setMockInitialValues({});
     await LessonProgressTrackerService.instance.load();
     await LessonProgressTrackerService.instance.markStepCompletedFlat('step2');
-    expect(
-        await LessonProgressTrackerService.instance
-            .isStepCompletedFlat('step2'),
-        true);
     final map =
         await LessonProgressTrackerService.instance.getCompletedStepsFlat();
     expect(map['step2'], true);
+  });
+
+  test('reset clears all progress', () async {
+    SharedPreferences.setMockInitialValues({});
+    await LessonProgressTrackerService.instance.load();
+    await LessonProgressTrackerService.instance
+        .markStepCompleted('lessonX', 's1');
+    await LessonProgressTrackerService.instance.reset();
+    final lessons =
+        await LessonProgressTrackerService.instance.getCompletedLessons();
+    final steps =
+        await LessonProgressTrackerService.instance.getCompletedSteps('lessonX');
+    expect(lessons.isEmpty, true);
+    expect(steps.isEmpty, true);
   });
 }


### PR DESCRIPTION
## Summary
- implement new lesson progress tracker that persists completed steps and lessons
- update tests for new tracker API

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cdd1571ec832a934c1652e9046811