### PR TITLE
Add lesson resume engine

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/daily_challenge_card.dart';
 import '../widgets/xp_progress_bar.dart';
 import '../widgets/quick_continue_card.dart';
 import '../widgets/resume_training_card.dart';
+import '../widgets/resume_lesson_card.dart';
 import '../widgets/next_learning_step_card.dart';
 import '../widgets/daily_focus_recap_card.dart';
 import '../widgets/progress_summary_box.dart';
@@ -106,6 +107,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
         children: [
           const StarterPathCard(),
           const NextLearningStepCard(),
+          const ResumeLessonCard(),
           if (tablet) const DailySpotlightCard(),
           _RecommendedCarousel(
             key: TrainingHomeScreen.recommendationsKey,

--- a/lib/services/lesson_resume_engine.dart
+++ b/lib/services/lesson_resume_engine.dart
@@ -1,0 +1,45 @@
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/player_profile.dart';
+import '../models/v3/lesson_step.dart';
+import '../models/v3/lesson_track.dart';
+import 'lesson_loader_service.dart';
+import 'lesson_progress_service.dart';
+import 'lesson_step_filter_engine.dart';
+import 'learning_track_engine.dart';
+
+/// Suggests the most relevant unfinished lesson step to resume.
+class LessonResumeEngine {
+  const LessonResumeEngine();
+
+  Future<LessonStep?> getResumeStep(PlayerProfile profile) async {
+    final steps = await LessonLoaderService.instance.loadAllLessons();
+    final filtered = const LessonStepFilterEngine()
+        .applyFilters(steps, profile: profile);
+    final completed = await LessonProgressService.instance.getCompletedSteps();
+
+    final prefs = await SharedPreferences.getInstance();
+    final trackId = prefs.getString('lesson_selected_track');
+    LessonTrack? track;
+    if (trackId != null) {
+      track = const LearningTrackEngine()
+          .getTracks()
+          .firstWhereOrNull((t) => t.id == trackId);
+    }
+
+    if (track != null) {
+      for (final id in track.stepIds) {
+        if (!completed.contains(id)) {
+          final step = filtered.firstWhereOrNull((s) => s.id == id);
+          if (step != null) return step;
+        }
+      }
+    }
+
+    for (final step in filtered) {
+      if (!completed.contains(step.id)) return step;
+    }
+    return null;
+  }
+}

--- a/lib/widgets/resume_lesson_card.dart
+++ b/lib/widgets/resume_lesson_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import '../models/player_profile.dart';
+import '../models/v3/lesson_step.dart';
+import '../services/lesson_resume_engine.dart';
+import '../screens/lesson_step_screen.dart';
+import '../screens/lesson_recap_screen.dart';
+
+class ResumeLessonCard extends StatefulWidget {
+  const ResumeLessonCard({super.key});
+
+  @override
+  State<ResumeLessonCard> createState() => _ResumeLessonCardState();
+}
+
+class _ResumeLessonCardState extends State<ResumeLessonCard> {
+  LessonStep? _step;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final step =
+        await const LessonResumeEngine().getResumeStep(PlayerProfile());
+    if (mounted) setState(() => _step = step);
+  }
+
+  Future<void> _openStep() async {
+    final step = _step;
+    if (step == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LessonStepScreen(
+          step: step,
+          onStepComplete: (s) async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => LessonRecapScreen(step: s)),
+            );
+          },
+        ),
+      ),
+    );
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final step = _step;
+    if (step == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '📘 Continue lesson',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(step.title, style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              onPressed: _openStep,
+              child: const Text('Open'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LessonResumeEngine` to choose the next unfinished lesson
- show `ResumeLessonCard` on the training home screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce4ec8c40832abaca90968de3bdce