### PR TITLE
Implement lesson onboarding overlay

### DIFF
--- a/lib/screens/lesson_step_screen.dart
+++ b/lib/screens/lesson_step_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/v3/lesson_step.dart';
 import '../services/training_pack_template_storage_service.dart';
 import '../services/training_session_service.dart';
 import '../services/lesson_progress_tracker_service.dart';
+import '../services/learning_track_engine.dart';
+import '../widgets/lesson_onboarding_overlay.dart';
 import 'training_session_screen.dart';
 import 'lesson_step_recap_screen.dart';
 
@@ -26,6 +30,30 @@ class _LessonStepScreenState extends State<LessonStepScreen> {
   void initState() {
     super.initState();
     _checkCompleted();
+    _maybeShowOnboarding();
+  }
+
+  Future<void> _maybeShowOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getBool('lesson_onboarding_seen') ?? false;
+    if (seen) return;
+    final trackId = prefs.getString('lesson_selected_track');
+    bool isFirst = false;
+    if (trackId != null) {
+      final track = const LearningTrackEngine()
+          .getTracks()
+          .firstWhereOrNull((t) => t.id == trackId);
+      if (track != null && track.stepIds.isNotEmpty) {
+        isFirst = track.stepIds.first == widget.step.id;
+      }
+    }
+    if (!isFirst) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showLessonOnboardingOverlay(context, onDismiss: () async {
+        final p = await SharedPreferences.getInstance();
+        await p.setBool('lesson_onboarding_seen', true);
+      });
+    });
   }
 
   Future<void> _checkCompleted() async {

--- a/lib/widgets/lesson_onboarding_overlay.dart
+++ b/lib/widgets/lesson_onboarding_overlay.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+class LessonOnboardingOverlay extends StatefulWidget {
+  final VoidCallback onDismiss;
+  const LessonOnboardingOverlay({super.key, required this.onDismiss});
+
+  @override
+  State<LessonOnboardingOverlay> createState() => _LessonOnboardingOverlayState();
+}
+
+class _LessonOnboardingOverlayState extends State<LessonOnboardingOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+  }
+
+  Future<void> _close() async {
+    await _controller.reverse();
+    if (mounted) widget.onDismiss();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor =
+        isDark ? Colors.black.withOpacity(0.8) : Colors.white.withOpacity(0.8);
+    final cardColor = isDark ? Colors.black54 : Colors.white;
+    final textColor = isDark ? Colors.white : Colors.black;
+    final secondary = isDark ? Colors.white70 : Colors.black54;
+    return Positioned.fill(
+      child: FadeTransition(
+        opacity: _controller,
+        child: Material(
+          color: bgColor,
+          child: InkWell(
+            onTap: _close,
+            child: Center(
+              child: Container(
+                margin: const EdgeInsets.all(24),
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: cardColor,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: DefaultTextStyle(
+                  style: TextStyle(color: textColor),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Как работают шаги урока',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: textColor,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        '1. Изучите цель шага и выполните тренировку.\n'
+                        '2. После ответа получите фидбек и XP.\n'
+                        '3. Откроется резюме и следующий шаг.',
+                        style: TextStyle(color: secondary),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Нажмите в любом месте, чтобы продолжить',
+                        style: TextStyle(color: secondary, fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void showLessonOnboardingOverlay(BuildContext context, {VoidCallback? onDismiss}) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => LessonOnboardingOverlay(
+      onDismiss: () {
+        entry.remove();
+        onDismiss?.call();
+      },
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- add `LessonOnboardingOverlay` widget for first‑time tutorial
- show onboarding overlay on the first lesson step

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cec61ab1c832abf49e96f3d642569