### PR TITLE
Implement LessonStreakEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -108,6 +108,7 @@ import '../services/achievement_trigger_engine.dart';
 import 'achievement_dashboard_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_insight_screen.dart';
+import '../services/lesson_streak_engine.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -158,10 +159,32 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
   bool _achievementsCheckLoading = false;
+  int _lessonStreak = 0;
+  StreamSubscription<int>? _lessonSub;
   static const _basePrompt = 'Создай тренировочный YAML пак';
   static const _apiKey = '';
   String _audience = 'Beginner';
   final Set<String> _tags = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStreak();
+    _lessonSub = LessonStreakEngine.instance.streakStream.listen(
+      (v) => setState(() => _lessonStreak = v),
+    );
+  }
+
+  Future<void> _loadStreak() async {
+    final s = await LessonStreakEngine.instance.getCurrentStreak();
+    if (mounted) setState(() => _lessonStreak = s);
+  }
+
+  @override
+  void dispose() {
+    _lessonSub?.cancel();
+    super.dispose();
+  }
 
   String get _prompt {
     final tagStr = _tags.join(', ');
@@ -2072,14 +2095,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
             if (kDebugMode)
               ListTile(
                 title: const Text('📤 Экспорт прогресса'),
-                onTap:
-                    _progressExportLoading ? null : _exportLearningProgress,
+                onTap: _progressExportLoading ? null : _exportLearningProgress,
               ),
             if (kDebugMode)
               ListTile(
                 title: const Text('📥 Импорт прогресса из буфера'),
-                onTap:
-                    _progressImportLoading ? null : _importLearningProgress,
+                onTap: _progressImportLoading ? null : _importLearningProgress,
               ),
             if (kDebugMode)
               ListTile(
@@ -2096,6 +2117,19 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🔔 Проверить напоминание'),
                 onTap: _reminderLoading ? null : _checkTrainingReminder,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: Text('🔥 Стрик уроков: \$_lessonStreak'),
+                onTap: _loadStreak,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧹 Сбросить streak уроков'),
+                onTap: () async {
+                  await LessonStreakEngine.instance.resetStreak();
+                  await _loadStreak();
+                },
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/lesson_progress_tracker_service.dart
+++ b/lib/services/lesson_progress_tracker_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
+import 'lesson_streak_engine.dart';
 
 /// Tracks progress of lesson steps and completed lessons using local storage.
 ///
@@ -61,8 +62,8 @@ class LessonProgressTrackerService {
 
   Future<void> _saveLesson(String lessonId) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_stepsPrefix + lessonId,
-        _progress[lessonId]?.toList() ?? <String>[]);
+    await prefs.setStringList(
+        _stepsPrefix + lessonId, _progress[lessonId]?.toList() ?? <String>[]);
   }
 
   Future<void> _saveLessons() async {
@@ -81,6 +82,7 @@ class LessonProgressTrackerService {
     }
     // Automatically mark the lesson as completed.
     await markLessonCompleted(lessonId);
+    await LessonStreakEngine.instance.markTodayCompleted();
   }
 
   /// Marks the entire [lessonId] as completed.
@@ -106,7 +108,8 @@ class LessonProgressTrackerService {
   /// Clears all lesson progress from storage. Used for development/testing only.
   Future<void> reset() async {
     final prefs = await SharedPreferences.getInstance();
-    final keys = prefs.getKeys()
+    final keys = prefs
+        .getKeys()
         .where((k) => k == _lessonsKey || k.startsWith(_stepsPrefix))
         .toList();
     for (final k in keys) {

--- a/lib/services/lesson_streak_engine.dart
+++ b/lib/services/lesson_streak_engine.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LessonStreakEngine {
+  LessonStreakEngine._();
+  static final LessonStreakEngine instance = LessonStreakEngine._();
+
+  static const _lastDayKey = 'lesson_streak_last_day';
+  static const _countKey = 'lesson_streak_count';
+
+  final _controller = StreamController<int>.broadcast();
+  Stream<int> get streakStream => _controller.stream;
+
+  Future<void> markTodayCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastDayKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    var count = prefs.getInt(_countKey) ?? 0;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 0) return;
+      if (diff == 1) {
+        count += 1;
+      } else {
+        count = 1;
+      }
+    } else {
+      count = 1;
+    }
+
+    await prefs.setString(
+        _lastDayKey, today.toIso8601String().split('T').first);
+    await prefs.setInt(_countKey, count);
+    _controller.add(count);
+  }
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastDayKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    var count = prefs.getInt(_countKey) ?? 0;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = DateTime.now().difference(lastDay).inDays;
+      if (diff > 1) {
+        count = 0;
+        await prefs.setInt(_countKey, 0);
+      }
+    } else if (count != 0) {
+      count = 0;
+      await prefs.setInt(_countKey, 0);
+    }
+
+    return count;
+  }
+
+  Future<DateTime?> getLastCompletionDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastDayKey);
+    return lastStr != null ? DateTime.tryParse(lastStr) : null;
+  }
+
+  Future<void> resetStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastDayKey);
+    await prefs.remove(_countKey);
+    _controller.add(0);
+  }
+}

--- a/test/services/lesson_streak_engine_test.dart
+++ b/test/services/lesson_streak_engine_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/lesson_streak_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('lesson streak increments and resets', () async {
+    SharedPreferences.setMockInitialValues({});
+    await LessonStreakEngine.instance.markTodayCompleted();
+    var streak = await LessonStreakEngine.instance.getCurrentStreak();
+    expect(streak, 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    final yStr =
+        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    await prefs.setString('lesson_streak_last_day', yStr);
+    await prefs.setInt('lesson_streak_count', 1);
+
+    await LessonStreakEngine.instance.markTodayCompleted();
+    streak = await LessonStreakEngine.instance.getCurrentStreak();
+    expect(streak, 2);
+
+    final old = DateTime.now().subtract(const Duration(days: 3));
+    final oStr =
+        '${old.year.toString().padLeft(4, '0')}-${old.month.toString().padLeft(2, '0')}-${old.day.toString().padLeft(2, '0')}';
+    await prefs.setString('lesson_streak_last_day', oStr);
+    await prefs.setInt('lesson_streak_count', 2);
+
+    streak = await LessonStreakEngine.instance.getCurrentStreak();
+    expect(streak, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- create LessonStreakEngine service to track daily lesson activity
- integrate streak updates into LessonProgressTrackerService
- display streak info and reset option in DevMenu
- add unit test for LessonStreakEngine

## Testing
- `flutter test test/services/lesson_streak_engine_test.dart`
- `flutter test` *(fails: Compilation failed for various tests)*

------
https://chatgpt.com/codex/tasks/task_e_687cedd9cbe4832ab1d70171af0af431