### PR TITLE
Add Lesson Streak banner

### DIFF
--- a/lib/screens/lesson_step_recap_screen.dart
+++ b/lib/screens/lesson_step_recap_screen.dart
@@ -11,6 +11,8 @@ import '../services/learning_track_engine.dart';
 import '../services/learning_path_advisor.dart';
 import '../services/smart_review_service.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../widgets/streak_banner_widget.dart';
+import '../services/lesson_streak_engine.dart';
 import 'lesson_step_screen.dart';
 import 'track_recap_screen.dart';
 
@@ -155,6 +157,14 @@ class _LessonStepRecapScreenState extends State<LessonStepRecapScreen> {
                     style: const TextStyle(color: Colors.redAccent),
                   ),
                 ],
+                FutureBuilder<int>(
+                  future: LessonStreakEngine.instance.getCurrentStreak(),
+                  builder: (context, snapshot) {
+                    final streak = snapshot.data ?? 0;
+                    if (streak < 2) return const SizedBox.shrink();
+                    return const StreakBannerWidget();
+                  },
+                ),
                 const Spacer(),
                 if (!done)
                   const Center(child: CircularProgressIndicator())

--- a/lib/screens/master_mode_screen.dart
+++ b/lib/screens/master_mode_screen.dart
@@ -5,7 +5,7 @@ import '../services/learning_path_completion_service.dart';
 import '../services/learning_track_engine.dart';
 import '../services/lesson_track_meta_service.dart';
 import '../widgets/streak_badge_widget.dart';
-import '../widgets/streak_banner_widget.dart';
+import '../widgets/daily_challenge_streak_banner_widget.dart';
 import '../widgets/reward_banner_widget.dart';
 import 'daily_challenge_history_screen.dart';
 import 'master_achievements_screen.dart';
@@ -72,7 +72,7 @@ class _MasterModeScreenState extends State<MasterModeScreen> {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              const StreakBannerWidget(),
+              const DailyChallengeStreakBannerWidget(),
               const StreakBadgeWidget(),
               const RewardBannerWidget(),
               Text(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -43,6 +43,7 @@ import '../widgets/review_past_mistakes_card.dart';
 import '../widgets/weak_spot_card.dart';
 import '../widgets/achievements_card.dart';
 import '../widgets/daily_spotlight_card.dart';
+import '../widgets/streak_banner_widget.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -108,6 +109,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const StarterPathCard(),
           const NextLearningStepCard(),
           const ResumeLessonCard(),
+          const StreakBannerWidget(),
           if (tablet) const DailySpotlightCard(),
           _RecommendedCarousel(
             key: TrainingHomeScreen.recommendationsKey,

--- a/lib/widgets/daily_challenge_streak_banner_widget.dart
+++ b/lib/widgets/daily_challenge_streak_banner_widget.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../services/daily_challenge_streak_service.dart';
+
+/// Banner displaying current daily challenge streak.
+class DailyChallengeStreakBannerWidget extends StatefulWidget {
+  const DailyChallengeStreakBannerWidget({super.key});
+
+  @override
+  State<DailyChallengeStreakBannerWidget> createState() => _DailyChallengeStreakBannerWidgetState();
+}
+
+class _DailyChallengeStreakBannerWidgetState extends State<DailyChallengeStreakBannerWidget>
+    with SingleTickerProviderStateMixin {
+  int _streak = 0;
+  bool _loading = true;
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    final value =
+        await DailyChallengeStreakService.instance.getCurrentStreak();
+    if (!mounted) return;
+    setState(() {
+      _streak = value;
+      _loading = false;
+    });
+    if (value > 0) _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _streak <= 0) return const SizedBox.shrink();
+    return FadeTransition(
+      opacity: _controller,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.deepOrangeAccent.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          '🔥 Стрик: $_streak дней подряд!',
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/streak_banner_widget.dart
+++ b/lib/widgets/streak_banner_widget.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-import '../services/daily_challenge_streak_service.dart';
+import '../services/lesson_streak_engine.dart';
+import 'confetti_overlay.dart';
 
-/// Banner displaying current daily challenge streak.
+/// Banner displaying current lesson streak.
 class StreakBannerWidget extends StatefulWidget {
   const StreakBannerWidget({super.key});
 
@@ -12,9 +16,13 @@ class StreakBannerWidget extends StatefulWidget {
 
 class _StreakBannerWidgetState extends State<StreakBannerWidget>
     with SingleTickerProviderStateMixin {
+  static const _disabledKey = 'lesson_streak_banner_disabled';
+
   int _streak = 0;
   bool _loading = true;
+  bool _active = false;
   late final AnimationController _controller;
+  StreamSubscription<int>? _sub;
 
   @override
   void initState() {
@@ -24,40 +32,74 @@ class _StreakBannerWidgetState extends State<StreakBannerWidget>
       duration: const Duration(milliseconds: 300),
     );
     _load();
+    _sub = LessonStreakEngine.instance.streakStream.listen(_onStreak);
   }
 
   Future<void> _load() async {
-    final value =
-        await DailyChallengeStreakService.instance.getCurrentStreak();
+    final prefs = await SharedPreferences.getInstance();
+    final disabled = prefs.getBool(_disabledKey) ?? false;
+    final trackId = prefs.getString('lesson_selected_track');
+    final value = await LessonStreakEngine.instance.getCurrentStreak();
     if (!mounted) return;
     setState(() {
       _streak = value;
+      _active = !disabled && trackId != null;
       _loading = false;
     });
-    if (value > 0) _controller.forward();
+    if (_active && value > 0) _controller.forward();
+  }
+
+  void _onStreak(int value) {
+    if (!mounted) return;
+    final increased = value > _streak;
+    setState(() => _streak = value);
+    if (_active && value > 0) {
+      if (increased) {
+        _controller.forward(from: 0);
+        if ([3, 5, 7, 14].contains(value)) {
+          showConfettiOverlay(context);
+        }
+      }
+    }
   }
 
   @override
   void dispose() {
+    _sub?.cancel();
     _controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_loading || _streak <= 0) return const SizedBox.shrink();
+    if (_loading || _streak <= 0 || !_active) return const SizedBox.shrink();
+    final label = '${_streak}-дневная серия${_streak >= 7 ? '!' : ''}';
     return FadeTransition(
       opacity: _controller,
       child: Container(
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
-          color: Colors.deepOrangeAccent.withOpacity(0.2),
+          gradient: const LinearGradient(
+            colors: [Colors.deepOrange, Colors.orangeAccent],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
           borderRadius: BorderRadius.circular(8),
         ),
-        child: Text(
-          '🔥 Стрик: $_streak дней подряд!',
-          style: const TextStyle(color: Colors.white),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.local_fire_department, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- celebrate user's lesson streak with a new `StreakBannerWidget`
- move existing challenge banner to `DailyChallengeStreakBannerWidget`
- show lesson streak banner on TrainingHomeScreen and LessonStepRecapScreen
- adjust MasterModeScreen to use the renamed banner

## Testing
- `dart`/`flutter` commands were unavailable so formatting and tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687cf197ebc8832abd5fa6c79096c48d