### PR TITLE
Add track unlock hint dialog

### DIFF
--- a/lib/models/track_unlock_requirement_progress.dart
+++ b/lib/models/track_unlock_requirement_progress.dart
@@ -1,0 +1,15 @@
+class TrackUnlockRequirementProgress {
+  final String label;
+  final String icon;
+  final int current;
+  final int required;
+  final bool met;
+
+  const TrackUnlockRequirementProgress({
+    required this.label,
+    required this.icon,
+    required this.current,
+    required this.required,
+    required this.met,
+  });
+}

--- a/lib/screens/lesson_track_library_screen.dart
+++ b/lib/screens/lesson_track_library_screen.dart
@@ -8,6 +8,7 @@ import '../services/yaml_lesson_track_loader.dart';
 import '../services/lesson_path_progress_service.dart';
 import '../services/track_visibility_filter_engine.dart';
 import '../services/lesson_track_unlock_engine.dart';
+import '../widgets/dialogs/track_unlock_hint_dialog.dart';
 
 class LessonTrackLibraryScreen extends StatefulWidget {
   const LessonTrackLibraryScreen({super.key});
@@ -56,26 +57,13 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
     };
   }
 
-  void _showUnlockHint() {
-    showDialog<void>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Заблокировано'),
-        content:
-            const Text('Чтобы разблокировать этот трек, выполните требования'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
+  void _showUnlockHint(String trackId) {
+    showTrackUnlockHintDialog(context, trackId);
   }
 
   Future<void> _select(LessonTrack track, String? currentId) async {
     if (_unlocked[track.id] != true) {
-      _showUnlockHint();
+      _showUnlockHint(track.id);
       return;
     }
     bool ok = true;
@@ -163,7 +151,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
                             : ElevatedButton(
                                 onPressed: _unlocked[track.id] == true
                                     ? () => _select(track, selected)
-                                    : _showUnlockHint,
+                                    : () => _showUnlockHint(track.id),
                                 child: const Text('Выбрать'),
                               ),
                       ),
@@ -174,7 +162,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
                         if (_unlocked[track.id] != true)
                           Positioned.fill(
                             child: InkWell(
-                              onTap: _showUnlockHint,
+                              onTap: () => _showUnlockHint(track.id),
                               child: Container(
                                 color: Colors.black54,
                                 alignment: Alignment.center,

--- a/lib/widgets/dialogs/track_unlock_hint_dialog.dart
+++ b/lib/widgets/dialogs/track_unlock_hint_dialog.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import '../../models/v3/lesson_track.dart';
+import '../../models/track_unlock_requirement_progress.dart';
+import '../../services/learning_track_engine.dart';
+import '../../services/yaml_lesson_track_loader.dart';
+import '../../services/lesson_track_unlock_engine.dart';
+
+class TrackUnlockHintDialog extends StatelessWidget {
+  final LessonTrack track;
+  final List<TrackUnlockRequirementProgress> requirements;
+  const TrackUnlockHintDialog({
+    super.key,
+    required this.track,
+    required this.requirements,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final allMet = requirements.isNotEmpty &&
+        requirements.every((r) => r.met);
+    return AlertDialog(
+      backgroundColor: const Color(0xFF1E1E1E),
+      title: Text(track.title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(track.description,
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          for (final r in requirements)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                children: [
+                  Text(r.icon, style: const TextStyle(fontSize: 20)),
+                  const SizedBox(width: 8),
+                  Expanded(child: Text(r.label)),
+                  Text(
+                    '${r.current}/${r.required}',
+                    style: TextStyle(
+                        color: r.met ? Colors.green : Colors.red),
+                  ),
+                  const SizedBox(width: 4),
+                  Icon(
+                    r.met ? Icons.check_circle : Icons.cancel,
+                    color: r.met ? Colors.green : Colors.red,
+                    size: 16,
+                  ),
+                ],
+              ),
+            ),
+          if (allMet) ...[
+            const SizedBox(height: 8),
+            const Text('\uD83D\uDD13 Track will unlock soon!',
+                style: TextStyle(color: Colors.greenAccent)),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showTrackUnlockHintDialog(
+    BuildContext context, String trackId) async {
+  final builtIn = const LearningTrackEngine().getTracks();
+  final yaml = await YamlLessonTrackLoader.instance.loadTracksFromAssets();
+  final tracks = [...builtIn, ...yaml];
+  final track = tracks.firstWhere(
+    (t) => t.id == trackId,
+    orElse: () =>
+        const LessonTrack(id: '', title: '', description: '', stepIds: []),
+  );
+  final reqs =
+      await LessonTrackUnlockEngine.instance.getRequirementProgress(trackId);
+  if (context.mounted) {
+    await showDialog(
+      context: context,
+      builder: (_) => TrackUnlockHintDialog(track: track, requirements: reqs),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TrackUnlockHintDialog` to show personalized unlock requirements
- expose requirement progress in `LessonTrackUnlockEngine`
- update track library screen to use new dialog

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf5533af0832ab28772d7e5494916