### PR TITLE
Implement XPRewardEngine for Learning Path

### DIFF
--- a/lib/services/lesson_progress_tracker_service.dart
+++ b/lib/services/lesson_progress_tracker_service.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
+import 'dart:async';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'lesson_streak_engine.dart';
+import 'xp_reward_engine.dart';
 
 /// Tracks progress of lesson steps and completed lessons using local storage.
 ///
@@ -79,6 +81,7 @@ class LessonProgressTrackerService {
     final set = _progress.putIfAbsent(lessonId, () => <String>{});
     if (set.add(stepId)) {
       await _saveLesson(lessonId);
+      unawaited(XPRewardEngine.instance.addXp(10));
     }
     // Automatically mark the lesson as completed.
     await markLessonCompleted(lessonId);

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -16,6 +16,7 @@ import 'cloud_training_history_service.dart';
 import 'learning_path_personalization_service.dart';
 import 'xp_tracker_service.dart';
 import 'tag_goal_tracker_service.dart';
+import 'xp_reward_engine.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
 
@@ -482,6 +483,7 @@ class TrainingSessionService extends ChangeNotifier {
     }
     await xpService.addPerTagXP(tagXp, source: 'training');
     await xpService.add(xp: xp, source: 'training');
+    unawaited(XPRewardEngine.instance.addXp(25));
     for (final tag in _template!.tags) {
       unawaited(TagGoalTrackerService.instance.logTraining(tag));
     }

--- a/lib/services/xp_reward_engine.dart
+++ b/lib/services/xp_reward_engine.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class XPRewardEngine {
+  XPRewardEngine._();
+  static final XPRewardEngine instance = XPRewardEngine._();
+
+  static const String _xpKey = 'xp_total';
+
+  Future<void> addXp(int amount) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_xpKey) ?? 0;
+    await prefs.setInt(_xpKey, current + amount);
+  }
+
+  Future<int> getTotalXp() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_xpKey) ?? 0;
+  }
+}

--- a/test/services/lesson_progress_tracker_service_test.dart
+++ b/test/services/lesson_progress_tracker_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
+import 'package:poker_analyzer/services/xp_reward_engine.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -16,6 +17,8 @@ void main() {
     final lessons =
         await LessonProgressTrackerService.instance.getCompletedLessons();
     expect(lessons.contains('lessonA'), true);
+    final xp = await XPRewardEngine.instance.getTotalXp();
+    expect(xp, 10);
   });
 
   test('legacy flat methods still work', () async {

--- a/test/services/xp_reward_engine_test.dart
+++ b/test/services/xp_reward_engine_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/xp_reward_engine.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('addXp accumulates total', () async {
+    SharedPreferences.setMockInitialValues({});
+    final engine = XPRewardEngine.instance;
+    await engine.addXp(10);
+    await engine.addXp(5);
+    final total = await engine.getTotalXp();
+    expect(total, 15);
+  });
+}


### PR DESCRIPTION
## Summary
- add `XPRewardEngine` to store xp rewards in `SharedPreferences`
- hook XP gain on lesson step completion via `LessonProgressTrackerService`
- reward training session completion in `TrainingSessionService`
- test XP reward accumulation and step completion XP

## Testing
- `flutter pub get` *(succeeds)*
- `flutter test` *(fails: numerous compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cf66599ec832ab676979118c2bbc6