### PR TITLE
Implement LessonGoalEngine

### DIFF
--- a/lib/services/lesson_goal_engine.dart
+++ b/lib/services/lesson_goal_engine.dart
@@ -1,0 +1,84 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class GoalProgress {
+  final int current;
+  final int target;
+  final bool completed;
+
+  const GoalProgress({
+    required this.current,
+    required this.target,
+    required this.completed,
+  });
+}
+
+class LessonGoalEngine {
+  LessonGoalEngine._();
+  static final LessonGoalEngine instance = LessonGoalEngine._();
+
+  static const int _dailyTarget = 5;
+  static const int _weeklyTarget = 25;
+
+  static const String _dailyDateKey = 'goal_daily_date';
+  static const String _dailyCountKey = 'goal_daily_count';
+  static const String _weeklyStartKey = 'goal_weekly_start';
+  static const String _weeklyCountKey = 'goal_weekly_count';
+
+  Future<GoalProgress> getDailyGoal() async {
+    final prefs = await SharedPreferences.getInstance();
+    await _resetDailyIfNeeded(prefs);
+    final count = prefs.getInt(_dailyCountKey) ?? 0;
+    return GoalProgress(
+      current: count,
+      target: _dailyTarget,
+      completed: count >= _dailyTarget,
+    );
+  }
+
+  Future<GoalProgress> getWeeklyGoal() async {
+    final prefs = await SharedPreferences.getInstance();
+    await _resetWeeklyIfNeeded(prefs);
+    final count = prefs.getInt(_weeklyCountKey) ?? 0;
+    return GoalProgress(
+      current: count,
+      target: _weeklyTarget,
+      completed: count >= _weeklyTarget,
+    );
+  }
+
+  Future<void> updateProgress() async {
+    final prefs = await SharedPreferences.getInstance();
+    await _resetDailyIfNeeded(prefs);
+    await _resetWeeklyIfNeeded(prefs);
+    await prefs.setInt(_dailyCountKey, (prefs.getInt(_dailyCountKey) ?? 0) + 1);
+    await prefs.setInt(
+        _weeklyCountKey, (prefs.getInt(_weeklyCountKey) ?? 0) + 1);
+  }
+
+  Future<void> _resetDailyIfNeeded(SharedPreferences prefs) async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final dateStr = prefs.getString(_dailyDateKey);
+    final stored = dateStr != null ? DateTime.tryParse(dateStr) : null;
+    if (stored == null ||
+        DateTime(stored.year, stored.month, stored.day) != today) {
+      await prefs.setString(
+          _dailyDateKey, today.toIso8601String().split('T').first);
+      await prefs.setInt(_dailyCountKey, 0);
+    }
+  }
+
+  Future<void> _resetWeeklyIfNeeded(SharedPreferences prefs) async {
+    final now = DateTime.now();
+    final startOfWeek = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: now.weekday - 1));
+    final startStr = prefs.getString(_weeklyStartKey);
+    final stored = startStr != null ? DateTime.tryParse(startStr) : null;
+    if (stored == null ||
+        DateTime(stored.year, stored.month, stored.day) != startOfWeek) {
+      await prefs.setString(
+          _weeklyStartKey, startOfWeek.toIso8601String().split('T').first);
+      await prefs.setInt(_weeklyCountKey, 0);
+    }
+  }
+}

--- a/lib/services/lesson_progress_tracker_service.dart
+++ b/lib/services/lesson_progress_tracker_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'lesson_streak_engine.dart';
+import 'lesson_goal_engine.dart';
 import 'xp_reward_engine.dart';
 
 /// Tracks progress of lesson steps and completed lessons using local storage.
@@ -82,6 +83,7 @@ class LessonProgressTrackerService {
     if (set.add(stepId)) {
       await _saveLesson(lessonId);
       unawaited(XPRewardEngine.instance.addXp(10));
+      unawaited(LessonGoalEngine.instance.updateProgress());
     }
     // Automatically mark the lesson as completed.
     await markLessonCompleted(lessonId);

--- a/test/services/lesson_goal_engine_test.dart
+++ b/test/services/lesson_goal_engine_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/lesson_goal_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('updateProgress increases counts and resets daily/weekly', () async {
+    SharedPreferences.setMockInitialValues({});
+    final engine = LessonGoalEngine.instance;
+    await engine.updateProgress();
+
+    var daily = await engine.getDailyGoal();
+    var weekly = await engine.getWeeklyGoal();
+    expect(daily.current, 1);
+    expect(weekly.current, 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    final yStr =
+        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    await prefs.setString('goal_daily_date', yStr);
+    await prefs.setInt('goal_daily_count', 3);
+
+    daily = await engine.getDailyGoal();
+    expect(daily.current, 0);
+
+    final lastWeek = DateTime.now().subtract(const Duration(days: 7));
+    final lwStart = DateTime(lastWeek.year, lastWeek.month, lastWeek.day)
+        .subtract(Duration(days: lastWeek.weekday - 1));
+    final lwStr =
+        '${lwStart.year.toString().padLeft(4, '0')}-${lwStart.month.toString().padLeft(2, '0')}-${lwStart.day.toString().padLeft(2, '0')}';
+    await prefs.setString('goal_weekly_start', lwStr);
+    await prefs.setInt('goal_weekly_count', 10);
+
+    weekly = await engine.getWeeklyGoal();
+    expect(weekly.current, 0);
+  });
+}

--- a/test/services/lesson_progress_tracker_service_test.dart
+++ b/test/services/lesson_progress_tracker_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
 import 'package:poker_analyzer/services/xp_reward_engine.dart';
+import 'package:poker_analyzer/services/lesson_goal_engine.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -11,14 +12,18 @@ void main() {
     await LessonProgressTrackerService.instance.load();
     await LessonProgressTrackerService.instance
         .markStepCompleted('lessonA', 'step1');
-    final steps =
-        await LessonProgressTrackerService.instance.getCompletedSteps('lessonA');
+    final steps = await LessonProgressTrackerService.instance
+        .getCompletedSteps('lessonA');
     expect(steps.contains('step1'), true);
     final lessons =
         await LessonProgressTrackerService.instance.getCompletedLessons();
     expect(lessons.contains('lessonA'), true);
     final xp = await XPRewardEngine.instance.getTotalXp();
     expect(xp, 10);
+    final daily = await LessonGoalEngine.instance.getDailyGoal();
+    final weekly = await LessonGoalEngine.instance.getWeeklyGoal();
+    expect(daily.current, 1);
+    expect(weekly.current, 1);
   });
 
   test('legacy flat methods still work', () async {
@@ -38,8 +43,8 @@ void main() {
     await LessonProgressTrackerService.instance.reset();
     final lessons =
         await LessonProgressTrackerService.instance.getCompletedLessons();
-    final steps =
-        await LessonProgressTrackerService.instance.getCompletedSteps('lessonX');
+    final steps = await LessonProgressTrackerService.instance
+        .getCompletedSteps('lessonX');
     expect(lessons.isEmpty, true);
     expect(steps.isEmpty, true);
   });


### PR DESCRIPTION
## Summary
- implement LessonGoalEngine to manage daily and weekly lesson goals
- integrate goal updates into LessonProgressTrackerService
- unit tests for new goal logic and updated tracker service

## Testing
- `dart format lib/services/lesson_goal_engine.dart test/services/lesson_goal_engine_test.dart test/services/lesson_progress_tracker_service_test.dart`
- `flutter test` *(fails: many compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cf88e1398832a8d65429a7e7ff34a