### PR TITLE
Add goal progress bars

### DIFF
--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -13,6 +13,8 @@ import '../services/lesson_track_meta_service.dart';
 import '../services/learning_path_completion_service.dart';
 import '../models/mastery_level.dart';
 import '../services/mastery_level_engine.dart';
+import '../services/lesson_goal_engine.dart';
+import '../widgets/goal_progress_bar.dart';
 import 'master_mode_screen.dart';
 import 'lesson_step_screen.dart';
 import 'lesson_step_recap_screen.dart';
@@ -40,6 +42,8 @@ class _TrackProgressDashboardScreenState
 
   Future<Map<String, dynamic>> _load() async {
     final tracks = const LearningTrackEngine().getTracks();
+    final dailyGoal = await LessonGoalEngine.instance.getDailyGoal();
+    final weeklyGoal = await LessonGoalEngine.instance.getWeeklyGoal();
     final progress =
         await LessonPathProgressService.instance.computeTrackProgress();
     final completed =
@@ -72,6 +76,8 @@ class _TrackProgressDashboardScreenState
       'steps': steps,
       'meta': meta,
       'pathCompleted': pathCompleted,
+      'dailyGoal': dailyGoal,
+      'weeklyGoal': weeklyGoal,
     };
   }
 
@@ -129,6 +135,8 @@ class _TrackProgressDashboardScreenState
         final steps = data?['steps'] as List<LessonStep>? ?? [];
         final meta = data?['meta'] as Map<String, TrackMeta?>? ?? {};
         final pathCompleted = data?['pathCompleted'] == true;
+        final dailyGoal = data?['dailyGoal'] as GoalProgress?;
+        final weeklyGoal = data?['weeklyGoal'] as GoalProgress?;
 
         if (pathCompleted && !_bannerShown) {
           _bannerShown = true;
@@ -166,6 +174,8 @@ class _TrackProgressDashboardScreenState
                     )
                   : Column(
                       children: [
+                        if (dailyGoal != null && weeklyGoal != null)
+                          GoalCard(daily: dailyGoal, weekly: weeklyGoal),
                         FutureBuilder<MasteryLevel>(
                           future: _levelFuture,
                           builder: (context, levelSnap) {

--- a/lib/widgets/goal_progress_bar.dart
+++ b/lib/widgets/goal_progress_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../services/lesson_goal_engine.dart';
+
+class GoalProgressBar extends StatelessWidget {
+  final GoalProgress progress;
+  final String label;
+
+  const GoalProgressBar({
+    super.key,
+    required this.progress,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final pct = (progress.current / progress.target).clamp(0.0, 1.0);
+    final completed = progress.completed;
+    final color = completed ? Colors.green : accent;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(label,
+                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            const Spacer(),
+            Text('${progress.current} / ${progress.target}',
+                style: const TextStyle(color: Colors.white70)),
+            if (completed)
+              const Padding(
+                padding: EdgeInsets.only(left: 4),
+                child: Icon(Icons.check_circle, color: Colors.greenAccent, size: 16),
+              ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        TweenAnimationBuilder<double>(
+          tween: Tween<double>(begin: 0, end: pct),
+          duration: const Duration(milliseconds: 300),
+          builder: (context, value, _) {
+            return ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: value,
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(color),
+                minHeight: 6,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class GoalCard extends StatelessWidget {
+  final GoalProgress daily;
+  final GoalProgress weekly;
+
+  const GoalCard({
+    super.key,
+    required this.daily,
+    required this.weekly,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E1E1E),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GoalProgressBar(progress: daily, label: 'Daily Goal'),
+          const SizedBox(height: 12),
+          GoalProgressBar(progress: weekly, label: 'Weekly Goal'),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show daily and weekly progress in `TrackProgressDashboardScreen`
- implement reusable `GoalProgressBar` and `GoalCard` widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfb766bd4832aad4df255b71bed1b