### PR TITLE
Add XP level progress bar

### DIFF
--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -15,6 +15,8 @@ import '../models/mastery_level.dart';
 import '../services/mastery_level_engine.dart';
 import '../services/lesson_goal_engine.dart';
 import '../widgets/goal_progress_bar.dart';
+import '../widgets/xp_level_bar.dart';
+import '../services/xp_reward_engine.dart';
 import 'master_mode_screen.dart';
 import 'lesson_step_screen.dart';
 import 'lesson_step_recap_screen.dart';
@@ -69,6 +71,9 @@ class _TrackProgressDashboardScreenState
     }
     final pathCompleted =
         await LearningPathCompletionService.instance.isPathCompleted();
+    final totalXp = await XPRewardEngine.instance.getTotalXp();
+    final level = getLevel(totalXp);
+    final levelXp = getXpForNextLevel(totalXp);
     return {
       'tracks': tracks,
       'progress': progress,
@@ -78,6 +83,9 @@ class _TrackProgressDashboardScreenState
       'pathCompleted': pathCompleted,
       'dailyGoal': dailyGoal,
       'weeklyGoal': weeklyGoal,
+      'totalXp': totalXp,
+      'level': level,
+      'levelXp': levelXp,
     };
   }
 
@@ -176,6 +184,11 @@ class _TrackProgressDashboardScreenState
                       children: [
                         if (dailyGoal != null && weeklyGoal != null)
                           GoalCard(daily: dailyGoal, weekly: weeklyGoal),
+                        XPLevelBar(
+                          currentXp: data?['totalXp'] as int? ?? 0,
+                          levelXp: data?['levelXp'] as int? ?? 0,
+                          level: data?['level'] as int? ?? 1,
+                        ),
                         FutureBuilder<MasteryLevel>(
                           future: _levelFuture,
                           builder: (context, levelSnap) {

--- a/lib/services/xp_reward_engine.dart
+++ b/lib/services/xp_reward_engine.dart
@@ -4,6 +4,8 @@ class XPRewardEngine {
   XPRewardEngine._();
   static final XPRewardEngine instance = XPRewardEngine._();
 
+  static const int levelStep = 500;
+
   static const String _xpKey = 'xp_total';
 
   Future<void> addXp(int amount) async {
@@ -16,4 +18,11 @@ class XPRewardEngine {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_xpKey) ?? 0;
   }
+}
+
+int getLevel(int totalXp) => (totalXp ~/ XPRewardEngine.levelStep) + 1;
+
+int getXpForNextLevel(int currentXp) {
+  final level = getLevel(currentXp);
+  return level * XPRewardEngine.levelStep;
 }

--- a/lib/widgets/xp_level_bar.dart
+++ b/lib/widgets/xp_level_bar.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class XPLevelBar extends StatelessWidget {
+  final int currentXp;
+  final int levelXp;
+  final int level;
+
+  const XPLevelBar({
+    super.key,
+    required this.currentXp,
+    required this.levelXp,
+    required this.level,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final pct = levelXp > 0 ? (currentXp / levelXp).clamp(0.0, 1.0) : 0.0;
+    final barColor = currentXp >= levelXp ? Colors.greenAccent : accent;
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E1E1E),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text('Level $level',
+                  style: const TextStyle(
+                      color: Colors.white, fontWeight: FontWeight.bold)),
+              const Spacer(),
+              Text('$currentXp / $levelXp XP',
+                  style: const TextStyle(color: Colors.white70)),
+            ],
+          ),
+          const SizedBox(height: 4),
+          TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 0, end: pct),
+            duration: const Duration(milliseconds: 300),
+            builder: (context, value, _) {
+              return ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: value,
+                  backgroundColor: Colors.white24,
+                  valueColor: AlwaysStoppedAnimation(barColor),
+                  minHeight: 6,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/xp_reward_engine_test.dart
+++ b/test/services/xp_reward_engine_test.dart
@@ -13,4 +13,11 @@ void main() {
     final total = await engine.getTotalXp();
     expect(total, 15);
   });
+
+  test('level calculations', () async {
+    expect(getLevel(0), 1);
+    expect(getLevel(499), 1);
+    expect(getLevel(500), 2);
+    expect(getXpForNextLevel(780), 1000);
+  });
 }


### PR DESCRIPTION
## Summary
- compute XP levels in XPRewardEngine
- display new XPLevelBar widget in track progress dashboard
- include level calculation tests

## Testing
- `flutter test test/services/xp_reward_engine_test.dart` *(fails: Flutter not fully configured)*

------
https://chatgpt.com/codex/tasks/task_e_687cfc9a54f8832a81606335654002b0