### PR TITLE
Add unified goal dashboard widget

### DIFF
--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -13,11 +13,8 @@ import '../services/lesson_track_meta_service.dart';
 import '../services/learning_path_completion_service.dart';
 import '../models/mastery_level.dart';
 import '../services/mastery_level_engine.dart';
-import '../services/lesson_goal_engine.dart';
-import '../services/lesson_goal_streak_engine.dart';
-import '../widgets/goal_progress_bar.dart';
+import '../widgets/goal_dashboard_widget.dart';
 import '../widgets/xp_level_bar.dart';
-import '../widgets/streak_flame_widget.dart';
 import '../services/xp_reward_engine.dart';
 import 'master_mode_screen.dart';
 import 'lesson_step_screen.dart';
@@ -46,8 +43,6 @@ class _TrackProgressDashboardScreenState
 
   Future<Map<String, dynamic>> _load() async {
     final tracks = const LearningTrackEngine().getTracks();
-    final dailyGoal = await LessonGoalEngine.instance.getDailyGoal();
-    final weeklyGoal = await LessonGoalEngine.instance.getWeeklyGoal();
     final progress =
         await LessonPathProgressService.instance.computeTrackProgress();
     final completed =
@@ -76,9 +71,6 @@ class _TrackProgressDashboardScreenState
     final totalXp = await XPRewardEngine.instance.getTotalXp();
     final level = getLevel(totalXp);
     final levelXp = getXpForNextLevel(totalXp);
-    final currentStreak =
-        await LessonGoalStreakEngine.instance.getCurrentStreak();
-    final bestStreak = await LessonGoalStreakEngine.instance.getBestStreak();
     return {
       'tracks': tracks,
       'progress': progress,
@@ -86,13 +78,9 @@ class _TrackProgressDashboardScreenState
       'steps': steps,
       'meta': meta,
       'pathCompleted': pathCompleted,
-      'dailyGoal': dailyGoal,
-      'weeklyGoal': weeklyGoal,
       'totalXp': totalXp,
       'level': level,
       'levelXp': levelXp,
-      'currentStreak': currentStreak,
-      'bestStreak': bestStreak,
     };
   }
 
@@ -150,8 +138,6 @@ class _TrackProgressDashboardScreenState
         final steps = data?['steps'] as List<LessonStep>? ?? [];
         final meta = data?['meta'] as Map<String, TrackMeta?>? ?? {};
         final pathCompleted = data?['pathCompleted'] == true;
-        final dailyGoal = data?['dailyGoal'] as GoalProgress?;
-        final weeklyGoal = data?['weeklyGoal'] as GoalProgress?;
 
         if (pathCompleted && !_bannerShown) {
           _bannerShown = true;
@@ -189,16 +175,11 @@ class _TrackProgressDashboardScreenState
                     )
                   : Column(
                       children: [
-                        if (dailyGoal != null && weeklyGoal != null)
-                          GoalCard(daily: dailyGoal, weekly: weeklyGoal),
+                        const GoalDashboardWidget(),
                         XPLevelBar(
                           currentXp: data?['totalXp'] as int? ?? 0,
                           levelXp: data?['levelXp'] as int? ?? 0,
                           level: data?['level'] as int? ?? 1,
-                        ),
-                        StreakFlameWidget(
-                          currentStreak: data?['currentStreak'] as int? ?? 0,
-                          bestStreak: data?['bestStreak'] as int? ?? 0,
                         ),
                         FutureBuilder<MasteryLevel>(
                           future: _levelFuture,

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/streak_chart.dart';
 import '../widgets/daily_goals_card.dart';
 import '../widgets/daily_progress_ring.dart';
 import '../widgets/goals_card.dart';
+import '../widgets/goal_dashboard_widget.dart';
 import '../widgets/repeat_mistakes_card.dart';
 import '../widgets/weekly_challenge_card.dart';
 import '../widgets/daily_challenge_card.dart';
@@ -122,6 +123,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const ResumeTrainingCard(),
             const DailyProgressRing(),
             const GoalsCard(),
+            const GoalDashboardWidget(),
             const DailyGoalsCard(),
             const DailyChallengeCard(),
             const SpotOfTheDayCard(),
@@ -141,6 +143,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const StreakChart(),
             const DailyProgressRing(),
             const GoalsCard(),
+            const GoalDashboardWidget(),
             const DailyGoalsCard(),
             const DailyChallengeCard(),
             const WeeklyChallengeCard(),

--- a/lib/widgets/goal_dashboard_widget.dart
+++ b/lib/widgets/goal_dashboard_widget.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import '../services/lesson_goal_engine.dart';
+import '../services/lesson_goal_streak_engine.dart';
+import 'goal_progress_bar.dart';
+
+/// Compact dashboard widget showing today's and weekly goal progress
+/// together with current and best streak information.
+class GoalDashboardWidget extends StatelessWidget {
+  /// When true, uses preset mock values for easier UI testing.
+  final bool mock;
+
+  const GoalDashboardWidget({super.key, this.mock = false});
+
+  Future<Map<String, dynamic>> _load() async {
+    if (mock) {
+      return {
+        'daily': const GoalProgress(current: 3, target: 5, completed: false),
+        'weekly': const GoalProgress(current: 12, target: 25, completed: false),
+        'current': 3,
+        'best': 6,
+      };
+    }
+    final daily = await LessonGoalEngine.instance.getDailyGoal();
+    final weekly = await LessonGoalEngine.instance.getWeeklyGoal();
+    final current = await LessonGoalStreakEngine.instance.getCurrentStreak();
+    final best = await LessonGoalStreakEngine.instance.getBestStreak();
+    return {
+      'daily': daily,
+      'weekly': weekly,
+      'current': current,
+      'best': best,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final data = snapshot.data;
+        if (data == null) return const SizedBox.shrink();
+        final daily = data['daily'] as GoalProgress;
+        final weekly = data['weekly'] as GoalProgress;
+        final current = data['current'] as int;
+        final best = data['best'] as int;
+        final flames = current.clamp(0, 7);
+        return Container(
+          margin: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1E1E1E),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              GoalProgressBar(progress: daily, label: '🎯 Today'),
+              const SizedBox(height: 12),
+              GoalProgressBar(progress: weekly, label: '📆 Week'),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  for (var i = 0; i < flames; i++)
+                    Text('🔥', style: TextStyle(fontSize: 20, color: accent)),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text('🔥 $current-day streak',
+                  style: const TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              Text('🏆 Best: $best',
+                  style: const TextStyle(color: Colors.white70)),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GoalDashboardWidget` for a compact view of daily/weekly goal progress and streak info
- show `GoalDashboardWidget` in TrackProgressDashboardScreen
- add `GoalDashboardWidget` to TrainingHomeScreen

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d553397c4832aa2dc242a1e5b3257