### PR TITLE
Add LearningTrackRecommendationEngine

### DIFF
--- a/lib/services/learning_track_recommendation_engine.dart
+++ b/lib/services/learning_track_recommendation_engine.dart
@@ -1,0 +1,53 @@
+import '../models/v3/lesson_track.dart';
+import 'learning_track_engine.dart';
+import 'track_mastery_service.dart';
+import 'yaml_lesson_track_loader.dart';
+import 'lesson_track_meta_service.dart';
+
+/// Recommends lesson tracks based on mastery levels.
+class LearningTrackRecommendationEngine {
+  final TrackMasteryService masteryService;
+  final LessonTrackMetaService metaService;
+  final LearningTrackEngine trackEngine;
+  final YamlLessonTrackLoader yamlLoader;
+
+  const LearningTrackRecommendationEngine({
+    required this.masteryService,
+    LessonTrackMetaService? metaService,
+    LearningTrackEngine trackEngine = const LearningTrackEngine(),
+    YamlLessonTrackLoader? yamlLoader,
+  })  : metaService = metaService ?? LessonTrackMetaService.instance,
+        trackEngine = trackEngine,
+        yamlLoader = yamlLoader ?? YamlLessonTrackLoader.instance;
+
+  /// Returns up to [limit] recommended tracks sorted by lowest mastery.
+  Future<List<LessonTrack>> getRecommendedTracks({int limit = 3}) async {
+    final builtIn = trackEngine.getTracks();
+    final yaml = await yamlLoader.loadTracksFromAssets();
+    final tracks = <LessonTrack>[...builtIn, ...yaml];
+
+    final mastery = await masteryService.computeTrackMastery();
+    final entries = <MapEntry<LessonTrack, double>>[];
+    for (final t in tracks) {
+      entries.add(MapEntry(t, mastery[t.id] ?? 0.0));
+    }
+    entries.sort((a, b) => a.value.compareTo(b.value));
+
+    final result = <LessonTrack>[];
+    for (final e in entries) {
+      final meta = await metaService.load(e.key.id);
+      if (meta?.completedAt != null) continue;
+      result.add(e.key);
+      if (result.length >= limit) break;
+    }
+    return result;
+  }
+
+  /// Returns textual explanation for a recommendation.
+  Future<String> getRecommendationReason(LessonTrack track) async {
+    final mastery = await masteryService.computeTrackMastery();
+    final value = mastery[track.id] ?? 0.0;
+    final pct = (value * 100).round();
+    return 'Mastery $pct%';
+  }
+}

--- a/test/services/learning_track_recommendation_engine_test.dart
+++ b/test/services/learning_track_recommendation_engine_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/v3/track_meta.dart';
+import 'package:poker_analyzer/services/learning_track_recommendation_engine.dart';
+import 'package:poker_analyzer/services/track_mastery_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class FakeTagMasteryService extends TagMasteryService {
+  final Map<String, double> _map;
+  FakeTagMasteryService(this._map)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => _map;
+}
+
+class FakeTrackMasteryService extends TrackMasteryService {
+  final Map<String, double> _map;
+  FakeTrackMasteryService(this._map)
+      : super(mastery: FakeTagMasteryService(const {}));
+
+  @override
+  Future<Map<String, double>> computeTrackMastery({bool force = false}) async => _map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getRecommendedTracks sorts by mastery and filters completed', () async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_track_meta_leak_fixer': jsonEncode(
+        TrackMeta(completedAt: DateTime.now()).toJson(),
+      ),
+    });
+
+    final mastery = FakeTrackMasteryService({
+      'mtt_pro': 0.2,
+      'live_exploit': 0.8,
+      'leak_fixer': 0.1,
+      'yaml_sample': 0.5,
+    });
+
+    final engine = LearningTrackRecommendationEngine(masteryService: mastery);
+    final list = await engine.getRecommendedTracks();
+    expect(list.map((e) => e.id).toList(), ['mtt_pro', 'yaml_sample', 'live_exploit']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `LearningTrackRecommendationEngine` for track suggestions
- include unit test for basic recommendation logic

## Testing
- `flutter test test/services/learning_track_recommendation_engine_test.dart` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d5e372ffc832aa720cc00ffcd6478