### PR TITLE
Add lesson path reminder notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,7 +110,7 @@ import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
 import 'services/app_init_service.dart';
 import 'services/suggested_pack_push_service.dart';
-import 'services/lesson_reminder_scheduler.dart';
+import 'services/lesson_path_reminder_scheduler.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -270,9 +270,9 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     }());
     unawaited(NotificationService.scheduleDailyProgress(context));
     unawaited(() async {
-      final t = await LessonReminderScheduler.instance.getScheduledTime();
+      final t = await LessonPathReminderScheduler.instance.getScheduledTime();
       if (t != null) {
-        await LessonReminderScheduler.instance.scheduleReminder(time: t);
+        await LessonPathReminderScheduler.instance.scheduleReminder(time: t);
       }
     }());
     NotificationService.startRecommendedPackTask(context);

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -108,6 +108,7 @@ import '../services/achievement_trigger_engine.dart';
 import 'achievement_dashboard_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_insight_screen.dart';
+import '../services/lesson_path_reminder_scheduler.dart';
 import '../services/lesson_streak_engine.dart';
 
 class DevMenuScreen extends StatefulWidget {
@@ -1373,6 +1374,15 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
   }
 
+  Future<void> _sendTestLessonPathReminder() async {
+    await LessonPathReminderScheduler.instance.sendTestReminder();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Reminder sent')),
+      );
+    }
+  }
+
   Future<void> _exportLearningProgress() async {
     if (_progressExportLoading || !kDebugMode) return;
     setState(() => _progressExportLoading = true);
@@ -2117,6 +2127,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🔔 Проверить напоминание'),
                 onTap: _reminderLoading ? null : _checkTrainingReminder,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('Send test reminder now'),
+                onTap: _sendTestLessonPathReminder,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -17,7 +17,7 @@ import '../widgets/goal_dashboard_widget.dart';
 import '../widgets/xp_level_bar.dart';
 import '../widgets/next_up_widget.dart';
 import '../services/xp_reward_engine.dart';
-import '../services/lesson_reminder_scheduler.dart';
+import '../services/lesson_path_reminder_scheduler.dart';
 import 'master_mode_screen.dart';
 import 'lesson_step_screen.dart';
 import 'lesson_step_recap_screen.dart';
@@ -43,7 +43,7 @@ class _TrackProgressDashboardScreenState
     super.initState();
     _future = _load();
     _levelFuture = MasteryLevelEngine().computeUserLevel();
-    LessonReminderScheduler.instance.getScheduledTime().then((t) {
+    LessonPathReminderScheduler.instance.getScheduledTime().then((t) {
       if (!mounted) return;
       if (t != null) {
         setState(() {
@@ -141,9 +141,9 @@ class _TrackProgressDashboardScreenState
 
   Future<void> _toggleReminder(bool value) async {
     if (value) {
-      await LessonReminderScheduler.instance.scheduleReminder(time: _reminderTime);
+      await LessonPathReminderScheduler.instance.scheduleReminder(time: _reminderTime);
     } else {
-      await LessonReminderScheduler.instance.cancelReminder();
+      await LessonPathReminderScheduler.instance.cancelReminder();
     }
     if (mounted) {
       setState(() => _reminderEnabled = value);
@@ -156,7 +156,7 @@ class _TrackProgressDashboardScreenState
       initialTime: _reminderTime,
     );
     if (picked != null) {
-      await LessonReminderScheduler.instance.scheduleReminder(time: picked);
+      await LessonPathReminderScheduler.instance.scheduleReminder(time: picked);
       if (mounted) {
         setState(() {
           _reminderEnabled = true;

--- a/lib/services/lesson_path_reminder_scheduler.dart
+++ b/lib/services/lesson_path_reminder_scheduler.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class LessonPathReminderScheduler {
+  LessonPathReminderScheduler._();
+  static final LessonPathReminderScheduler instance = LessonPathReminderScheduler._();
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+
+  static const _hourKey = 'lesson_path_reminder_hour';
+  static const _minuteKey = 'lesson_path_reminder_minute';
+  static const _enabledKey = 'lesson_path_reminder_enabled';
+  static const _id = 222;
+
+  Future<void> _init() async {
+    if (_initialized) return;
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+    _initialized = true;
+  }
+
+  Future<TimeOfDay?> getScheduledTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    final enabled = prefs.getBool(_enabledKey) ?? false;
+    if (!enabled) return null;
+    final hour = prefs.getInt(_hourKey) ?? 19;
+    final minute = prefs.getInt(_minuteKey) ?? 0;
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  Future<void> scheduleReminder({required TimeOfDay time}) async {
+    await _init();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_hourKey, time.hour);
+    await prefs.setInt(_minuteKey, time.minute);
+    await prefs.setBool(_enabledKey, true);
+
+    final now = tz.TZDateTime.now(tz.local);
+    var when = tz.TZDateTime(tz.local, now.year, now.month, now.day, time.hour, time.minute);
+    if (!when.isAfter(now)) {
+      when = when.add(const Duration(days: 1));
+    }
+
+    await _plugin.zonedSchedule(
+      _id,
+      'Poker Analyzer',
+      '🧠 Не забудьте пройти шаг обучения сегодня!',
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('lesson_path_reminder', 'Lesson Path Reminder'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<void> sendTestReminder() async {
+    await _init();
+    await _plugin.show(
+      _id,
+      'Poker Analyzer',
+      '🧠 Не забудьте пройти шаг обучения сегодня!',
+      const NotificationDetails(
+        android: AndroidNotificationDetails('lesson_path_reminder', 'Lesson Path Reminder'),
+        iOS: DarwinNotificationDetails(),
+      ),
+    );
+  }
+
+  Future<void> cancelReminder() async {
+    await _init();
+    await _plugin.cancel(_id);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, false);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `LessonPathReminderScheduler` with daily local notification support
- hook scheduler into `TrackProgressDashboardScreen`
- initialise lesson path reminders on app start
- expose a dev menu action to trigger a test reminder

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*

------
https://chatgpt.com/codex/tasks/task_e_687d632462fc832abbd9efb2d0a267fd