### PR TITLE
Add track lock overlay

### DIFF
--- a/lib/services/track_unlock_reason_service.dart
+++ b/lib/services/track_unlock_reason_service.dart
@@ -1,0 +1,12 @@
+import 'learning_path_unlock_engine.dart';
+
+/// Convenience service that delegates to [LearningPathUnlockEngine]
+/// to fetch textual explanations for locked tracks.
+class TrackUnlockReasonService {
+  TrackUnlockReasonService._();
+  static final instance = TrackUnlockReasonService._();
+
+  Future<String?> getReason(String trackId) {
+    return LearningPathUnlockEngine.instance.getUnlockReason(trackId);
+  }
+}

--- a/lib/widgets/track_lock_overlay.dart
+++ b/lib/widgets/track_lock_overlay.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+/// Displays a lock icon and optional unlock reason over [child] when [locked].
+class TrackLockOverlay extends StatelessWidget {
+  final bool locked;
+  final String? reason;
+  final Widget child;
+  final VoidCallback? onTap;
+
+  const TrackLockOverlay({
+    super.key,
+    required this.locked,
+    this.reason,
+    required this.child,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!locked) return child;
+
+    final overlay = Container(
+      color: Colors.black54,
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.lock, color: Colors.white, size: 40),
+          if (reason != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                reason!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ),
+        ],
+      ),
+    );
+
+    return Stack(
+      children: [
+        ColorFiltered(
+          colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.saturation),
+          child: IgnorePointer(child: child),
+        ),
+        Positioned.fill(
+          child: InkWell(
+            onTap: onTap,
+            child: overlay,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TrackLockOverlay widget for locked tracks
- add TrackUnlockReasonService to fetch explanations
- expose default instance and reason method in LearningPathUnlockEngine
- show lock overlay and reason in LessonTrackLibraryScreen

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 14076 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687d6ee101a8832ab6b366b354cfb21e