### PR TITLE
Implement NextUpEngine for lesson recommendations

### DIFF
--- a/lib/models/v3/lesson_step_ref.dart
+++ b/lib/models/v3/lesson_step_ref.dart
@@ -1,0 +1,6 @@
+class LessonStepRef {
+  final String trackId;
+  final String stepId;
+
+  const LessonStepRef({required this.trackId, required this.stepId});
+}

--- a/lib/services/next_up_engine.dart
+++ b/lib/services/next_up_engine.dart
@@ -1,0 +1,97 @@
+import 'package:collection/collection.dart';
+
+import '../models/v3/lesson_track.dart';
+import '../models/v3/lesson_step_ref.dart';
+import '../models/v3/track_meta.dart';
+import 'learning_path_unlock_engine.dart';
+import 'track_mastery_service.dart';
+import 'lesson_progress_tracker_service.dart';
+import 'lesson_track_meta_service.dart';
+import 'learning_track_engine.dart';
+import 'yaml_lesson_track_loader.dart';
+
+class NextUpEngine {
+  final LearningPathUnlockEngine unlockEngine;
+  final TrackMasteryService masteryService;
+  final LessonProgressTrackerService progressService;
+  final LessonTrackMetaService metaService;
+  final LearningTrackEngine trackEngine;
+  final YamlLessonTrackLoader yamlLoader;
+
+  NextUpEngine({
+    LearningPathUnlockEngine? unlockEngine,
+    required this.masteryService,
+    LessonProgressTrackerService? progressService,
+    LessonTrackMetaService? metaService,
+    LearningTrackEngine trackEngine = const LearningTrackEngine(),
+    YamlLessonTrackLoader? yamlLoader,
+  })  : unlockEngine = unlockEngine ?? LearningPathUnlockEngine.instance,
+        progressService = progressService ?? LessonProgressTrackerService.instance,
+        metaService = metaService ?? LessonTrackMetaService.instance,
+        trackEngine = trackEngine,
+        yamlLoader = yamlLoader ?? YamlLessonTrackLoader.instance;
+
+  Future<List<LessonTrack>> _loadTracks() async {
+    final builtIn = trackEngine.getTracks();
+    final yaml = await yamlLoader.loadTracksFromAssets();
+    return [...builtIn, ...yaml];
+  }
+
+  DateTime _lastActivity(TrackMeta? meta) {
+    return meta?.completedAt ?? meta?.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+  }
+
+  Future<LessonStepRef?> getNextRecommendedStep() async {
+    final available = await unlockEngine.getUnlockableTracks();
+    if (available.isEmpty) return null;
+
+    final allTracks = await _loadTracks();
+    final progress = await progressService.getCompletedStepsFlat();
+    final mastery = await masteryService.computeTrackMastery();
+
+    final entries = <_TrackEntry>[];
+    for (final t in available) {
+      final track = allTracks.firstWhere((e) => e.id == t.id, orElse: () => t);
+      final ids = track.stepIds;
+      if (ids.every((id) => progress[id] == true)) {
+        continue; // skip completed tracks
+      }
+      final meta = await metaService.load(track.id);
+      entries.add(_TrackEntry(
+        track: track,
+        mastery: mastery[track.id] ?? 0.0,
+        lastActivity: _lastActivity(meta),
+      ));
+    }
+
+    if (entries.isEmpty) return null;
+
+    entries.sort((a, b) {
+      var cmp = a.mastery.compareTo(b.mastery);
+      if (cmp != 0) return cmp;
+      cmp = b.lastActivity.compareTo(a.lastActivity);
+      if (cmp != 0) return cmp;
+      return a.track.id.compareTo(b.track.id);
+    });
+
+    final best = entries.first;
+    final stepId = best.track.stepIds.firstWhere((id) => progress[id] != true,
+        orElse: () => best.track.stepIds.last);
+    return LessonStepRef(trackId: best.track.id, stepId: stepId);
+  }
+
+  Future<LessonTrack?> getNextTrackRecommendation() async {
+    final step = await getNextRecommendedStep();
+    if (step == null) return null;
+    final tracks = await _loadTracks();
+    return tracks.firstWhereOrNull((t) => t.id == step.trackId);
+  }
+}
+
+class _TrackEntry {
+  final LessonTrack track;
+  final double mastery;
+  final DateTime lastActivity;
+
+  _TrackEntry({required this.track, required this.mastery, required this.lastActivity});
+}

--- a/test/services/next_up_engine_test.dart
+++ b/test/services/next_up_engine_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/next_up_engine.dart';
+import 'package:poker_analyzer/services/learning_path_unlock_engine.dart';
+import 'package:poker_analyzer/services/lesson_progress_tracker_service.dart';
+import 'package:poker_analyzer/services/track_mastery_service.dart';
+import 'package:poker_analyzer/models/v3/lesson_track.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+
+class _FakeUnlockEngine extends LearningPathUnlockEngine {
+  final List<LessonTrack> tracks;
+  _FakeUnlockEngine(this.tracks)
+      : super(masteryService: TrackMasteryService(mastery: _DummyMasteryService()));
+
+  @override
+  Future<List<LessonTrack>> getUnlockableTracks() async => tracks;
+}
+
+class _DummyMasteryService extends TagMasteryService {
+  _DummyMasteryService() : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => {};
+}
+
+class _FakeTrackMasteryService extends TrackMasteryService {
+  final Map<String, double> map;
+  _FakeTrackMasteryService(this.map)
+      : super(mastery: _DummyMasteryService());
+
+  @override
+  Future<Map<String, double>> computeTrackMastery({bool force = false}) async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await LessonProgressTrackerService.instance.load();
+  });
+
+  test('prefers track with lower mastery', () async {
+    final tracks = [
+      const LessonTrack(id: 't1', title: 'T1', description: '', stepIds: ['s1']),
+      const LessonTrack(id: 't2', title: 'T2', description: '', stepIds: ['s2']),
+    ];
+    final unlock = _FakeUnlockEngine(tracks);
+    final mastery = _FakeTrackMasteryService({'t1': 0.8, 't2': 0.2});
+    final engine = NextUpEngine(
+      unlockEngine: unlock,
+      masteryService: mastery,
+    );
+    final next = await engine.getNextRecommendedStep();
+    expect(next?.trackId, 't2');
+    expect(next?.stepId, 's2');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LessonStepRef` model for referencing a lesson step within a track
- implement `NextUpEngine` service to recommend the next lesson step based on unlock state, mastery and activity
- unit test verifying the engine prefers the lowest mastery track

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d72c2c700832aa10c141ac9613ff9