### PR TITLE
Implement WeaknessClusterEngine

### DIFF
--- a/lib/services/weakness_cluster_engine.dart
+++ b/lib/services/weakness_cluster_engine.dart
@@ -1,0 +1,100 @@
+import '../models/training_result.dart';
+
+class WeaknessCluster {
+  final String tag;
+  final String reason;
+  final double severity;
+
+  const WeaknessCluster({
+    required this.tag,
+    required this.reason,
+    required this.severity,
+  });
+}
+
+class WeaknessClusterEngine {
+  const WeaknessClusterEngine();
+
+  List<WeaknessCluster> detectWeaknesses({
+    required List<TrainingResult> results,
+    required Map<String, double> tagMastery,
+  }) {
+    final attempts = <String, int>{};
+    final mistakes = <String, int>{};
+    final evSum = <String, double>{};
+    final evCount = <String, int>{};
+
+    for (final r in results) {
+      final miss = r.total - r.correct;
+      for (final t in r.tags) {
+        final tag = t.trim().toLowerCase();
+        if (tag.isEmpty) continue;
+        attempts.update(tag, (v) => v + r.total, ifAbsent: () => r.total);
+        mistakes.update(tag, (v) => v + miss, ifAbsent: () => miss);
+        if (r.evDiff != null) {
+          evSum.update(tag, (v) => v + r.evDiff!, ifAbsent: () => r.evDiff!);
+          evCount.update(tag, (v) => v + 1, ifAbsent: () => 1);
+        }
+      }
+    }
+
+    final tags = <String>{...attempts.keys, ...tagMastery.keys};
+    final clusters = <WeaknessCluster>[];
+
+    for (final tag in tags) {
+      final plays = attempts[tag] ?? 0;
+      final miss = mistakes[tag] ?? 0;
+      final acc = plays > 0 ? (plays - miss) / plays : 1.0;
+      final avgEv = evCount.containsKey(tag)
+          ? evSum[tag]! / evCount[tag]!
+          : null;
+      final mastery = tagMastery[tag] ?? 1.0;
+
+      double bestScore = 0;
+      String? reason;
+
+      if (plays >= 5 && miss > 0) {
+        final rate = miss / plays;
+        if (rate > bestScore) {
+          bestScore = rate;
+          reason = 'many mistakes';
+        }
+      }
+
+      if (avgEv != null && avgEv < 0) {
+        final score = -avgEv; // higher loss -> higher severity
+        if (score > bestScore) {
+          bestScore = score;
+          reason = 'low EV';
+        }
+      }
+
+      if (mastery < 0.6) {
+        final score = 0.6 - mastery;
+        if (score > bestScore) {
+          bestScore = score;
+          reason = 'low mastery';
+        }
+      }
+
+      if (reason != null && bestScore > 0) {
+        clusters.add(
+          WeaknessCluster(tag: tag, reason: reason, severity: bestScore),
+        );
+      }
+    }
+
+    clusters.sort((a, b) => b.severity.compareTo(a.severity));
+    return clusters;
+  }
+
+  List<WeaknessCluster> topWeaknesses({
+    required List<TrainingResult> results,
+    required Map<String, double> tagMastery,
+    int count = 3,
+  }) {
+    final all = detectWeaknesses(results: results, tagMastery: tagMastery);
+    return all.take(count).toList();
+  }
+}
+

--- a/test/weakness_cluster_engine_test.dart
+++ b/test/weakness_cluster_engine_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_result.dart';
+import 'package:poker_analyzer/services/weakness_cluster_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('detects weakest tags', () {
+    final results = [
+      TrainingResult(date: DateTime.now(), total: 10, correct: 6, accuracy: 60, tags: const ['a'], evDiff: -1),
+      TrainingResult(date: DateTime.now(), total: 8, correct: 8, accuracy: 100, tags: const ['b'], evDiff: 0.2),
+      TrainingResult(date: DateTime.now(), total: 5, correct: 3, accuracy: 60, tags: const ['a'], evDiff: -0.5),
+    ];
+
+    final mastery = {'a': 0.5, 'b': 0.9};
+
+    final engine = const WeaknessClusterEngine();
+    final clusters = engine.detectWeaknesses(results: results, tagMastery: mastery);
+
+    expect(clusters.first.tag, 'a');
+    expect(clusters.first.reason.isNotEmpty, true);
+    expect(clusters.first.severity, greaterThan(0));
+    final top = engine.topWeaknesses(results: results, tagMastery: mastery, count: 1);
+    expect(top.length, 1);
+    expect(top.first.tag, 'a');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `WeaknessClusterEngine` to analyze weak tags
- expose clustering logic and helper to fetch top weaknesses
- add unit test for weakness detection

## Testing
- `flutter test test/training_result_test.dart -r compact` *(fails: type 'Null' is not a subtype of type 'String')*

------
https://chatgpt.com/codex/tasks/task_e_687d79662418832aa1213acc1adfdf5f