### PR TITLE
Add LearningGoalEngine

### DIFF
--- a/lib/models/learning_goal.dart
+++ b/lib/models/learning_goal.dart
@@ -1,0 +1,15 @@
+class LearningGoal {
+  final String id;
+  final String title;
+  final String description;
+  final String tag;
+  final double priorityScore;
+
+  const LearningGoal({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.tag,
+    required this.priorityScore,
+  });
+}

--- a/lib/services/learning_goal_engine.dart
+++ b/lib/services/learning_goal_engine.dart
@@ -1,0 +1,70 @@
+import '../models/learning_goal.dart';
+import 'weakness_cluster_engine.dart';
+
+class LearningGoalEngine {
+  const LearningGoalEngine();
+
+  List<LearningGoal> generateGoals(List<WeaknessCluster> clusters) {
+    if (clusters.isEmpty) return const [];
+    final grouped = <String, List<WeaknessCluster>>{};
+    for (final c in clusters) {
+      final key = _groupKey(c.tag);
+      grouped.putIfAbsent(key, () => []).add(c);
+    }
+
+    final goals = <LearningGoal>[];
+    final now = DateTime.now().millisecondsSinceEpoch;
+    var index = 0;
+    for (final e in grouped.entries) {
+      final list = e.value;
+      list.sort((a, b) => b.severity.compareTo(a.severity));
+      final best = list.first;
+      final id = 'lg_${now}_${index++}';
+      final title = _titleFor(best);
+      final desc = _descFor(best);
+      goals.add(LearningGoal(
+        id: id,
+        title: title,
+        description: desc,
+        tag: e.key,
+        priorityScore: best.severity,
+      ));
+    }
+    goals.sort((a, b) => b.priorityScore.compareTo(a.priorityScore));
+    return goals;
+  }
+
+  String _groupKey(String tag) {
+    final parts = tag.toLowerCase().split(RegExp(r'[\s_/\\-]+'));
+    if (parts.length >= 2) {
+      return '${parts[0]} ${parts[1]}';
+    }
+    return parts.first;
+  }
+
+  String _titleFor(WeaknessCluster c) {
+    switch (c.reason) {
+      case 'many mistakes':
+        return 'Reduce mistakes in ${c.tag}';
+      case 'low EV':
+        return 'Improve EV in ${c.tag}';
+      case 'low mastery':
+        return 'Improve mastery for ${c.tag}';
+      default:
+        return 'Improve ${c.tag}';
+    }
+  }
+
+  String _descFor(WeaknessCluster c) {
+    switch (c.reason) {
+      case 'many mistakes':
+        return 'Focus on ${c.tag} spots to avoid common mistakes.';
+      case 'low EV':
+        return 'Work on ${c.tag} hands to increase expected value.';
+      case 'low mastery':
+        return 'Study ${c.tag} hands to raise mastery level.';
+      default:
+        return 'Practice ${c.tag} hands to improve.';
+    }
+  }
+}

--- a/test/services/learning_goal_engine_test.dart
+++ b/test/services/learning_goal_engine_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/learning_goal_engine.dart';
+import 'package:poker_analyzer/services/weakness_cluster_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generates goals sorted by severity', () {
+    const engine = LearningGoalEngine();
+    final clusters = [
+      const WeaknessCluster(tag: 'btn push', reason: 'low EV', severity: 0.3),
+      const WeaknessCluster(tag: 'sb vs bb', reason: 'many mistakes', severity: 0.7),
+    ];
+
+    final goals = engine.generateGoals(clusters);
+
+    expect(goals.length, 2);
+    expect(goals.first.priorityScore, greaterThan(goals.last.priorityScore));
+    expect(goals.first.title.isNotEmpty, true);
+    expect(goals.first.description.isNotEmpty, true);
+  });
+
+  test('groups similar tags', () {
+    const engine = LearningGoalEngine();
+    final clusters = [
+      const WeaknessCluster(tag: 'btn push 10bb', reason: 'low EV', severity: 0.4),
+      const WeaknessCluster(tag: 'btn push 12bb', reason: 'many mistakes', severity: 0.5),
+    ];
+
+    final goals = engine.generateGoals(clusters);
+
+    expect(goals.length, 1);
+    expect(goals.first.tag, 'btn push');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `LearningGoalEngine` service to convert weakness clusters into actionable learning goals
- define `LearningGoal` model
- add unit tests for the new engine

## Testing
- `flutter test test/services/learning_goal_engine_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d7ba28c80832a8007212b4d6a2870