### PR TITLE
Implement DynamicTrackBuilder

### DIFF
--- a/lib/models/training_track.dart
+++ b/lib/models/training_track.dart
@@ -1,0 +1,17 @@
+import 'v2/training_pack_spot.dart';
+
+class TrainingTrack {
+  final String id;
+  final String title;
+  final String goalId;
+  final List<TrainingPackSpot> spots;
+  final List<String> tags;
+
+  const TrainingTrack({
+    required this.id,
+    required this.title,
+    required this.goalId,
+    required this.spots,
+    required this.tags,
+  });
+}

--- a/lib/services/dynamic_track_builder.dart
+++ b/lib/services/dynamic_track_builder.dart
@@ -1,0 +1,61 @@
+import '../models/learning_goal.dart';
+import '../models/training_track.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class DynamicTrackBuilder {
+  const DynamicTrackBuilder();
+
+  List<TrainingTrack> buildTracks({
+    required List<LearningGoal> goals,
+    required List<TrainingPackTemplateV2> sourcePacks,
+    int spotsPerTrack = 8,
+  }) {
+    final tracks = <TrainingTrack>[];
+    var index = 0;
+    for (final goal in goals) {
+      final tag = goal.tag.toLowerCase();
+      final spots = <TrainingPackSpot>[];
+      for (final pack in sourcePacks) {
+        for (final spot in pack.spots) {
+          final spotTags = <String>{
+            ...pack.tags.map((e) => e.toLowerCase()),
+            ...spot.tags.map((e) => e.toLowerCase()),
+            ...spot.categories.map((e) => e.toLowerCase()),
+          }..removeWhere((e) => e.isEmpty);
+          if (spotTags.contains(tag)) {
+            spots.add(spot);
+          }
+        }
+      }
+      if (spots.isEmpty) continue;
+      spots.sort((a, b) {
+        final evA = a.heroEv ?? 0;
+        final evB = b.heroEv ?? 0;
+        return evA.compareTo(evB);
+      });
+      final selected = spots.take(spotsPerTrack).toList();
+      final title = _titleFor(goal);
+      tracks.add(
+        TrainingTrack(
+          id: 'track_${goal.id}_$index',
+          title: title,
+          goalId: goal.id,
+          spots: selected,
+          tags: [goal.tag],
+        ),
+      );
+      index++;
+    }
+    return tracks;
+  }
+
+  String _titleFor(LearningGoal goal) {
+    if (goal.title.isNotEmpty) return goal.title;
+    final words = goal.tag
+        .split(RegExp(r'[\s_-]+'))
+        .map((w) => w.isEmpty ? w : '${w[0].toUpperCase()}${w.substring(1)}')
+        .toList();
+    return 'Fix ${words.join(' ')} Mistakes';
+  }
+}

--- a/test/services/dynamic_track_builder_test.dart
+++ b/test/services/dynamic_track_builder_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/dynamic_track_builder.dart';
+import 'package:poker_analyzer/models/learning_goal.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingPackSpot spot(String id, String tag, double ev) {
+    final hand = HandData(
+      position: HeroPosition.btn,
+      heroIndex: 0,
+      playerCount: 2,
+      actions: {
+        0: [ActionEntry(0, 0, 'push', ev: ev)],
+      },
+    );
+    return TrainingPackSpot(id: id, tags: [tag], hand: hand);
+  }
+
+  TrainingPackTemplateV2 pack(String id, List<TrainingPackSpot> spots) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.pushFold,
+      tags: const ['cbet'],
+      spots: spots,
+    );
+  }
+
+  test('builds track with sorted spots', () {
+    final builder = const DynamicTrackBuilder();
+    final goal = LearningGoal(
+      id: 'g1',
+      title: '',
+      description: '',
+      tag: 'cbet',
+      priorityScore: 1,
+    );
+    final p1 = pack('p1', [spot('s1', 'cbet', -0.5), spot('s2', 'cbet', 0.2)]);
+    final p2 = pack('p2', [spot('s3', 'cbet', -1.0)]);
+
+    final tracks = builder.buildTracks(goals: [goal], sourcePacks: [p1, p2]);
+
+    expect(tracks.length, 1);
+    final t = tracks.first;
+    expect(t.goalId, 'g1');
+    expect(t.spots.map((s) => s.id).toList(), ['s3', 's1', 's2']);
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple `TrainingTrack` model
- implement `DynamicTrackBuilder` service for creating tracks from learning goals and pack templates
- cover basic functionality with unit test

## Testing
- `dart test test/services/dynamic_track_builder_test.dart` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_687d7ddf6bb0832aad6629aaaecc62a8