### PR TITLE
Implement mistake replay pack generator

### DIFF
--- a/lib/services/mistake_replay_pack_generator.dart
+++ b/lib/services/mistake_replay_pack_generator.dart
@@ -1,0 +1,104 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/training_result.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+/// Generates a training pack replaying the user's own mistakes.
+class MistakeReplayPackGenerator {
+  const MistakeReplayPackGenerator();
+
+  /// Builds a pack containing up to [maxSpots] mistaken spots.
+  ///
+  /// [results] should contain recent training results with optional `spotId`,
+  /// `heroEv` and `isCorrect` fields. Spots with low EV (< 0.8) or incorrect
+  /// answers are selected. Spot data is pulled from [sourcePacks].
+  TrainingPackTemplateV2 generateMistakePack({
+    required List<TrainingResult> results,
+    required List<TrainingPackTemplateV2> sourcePacks,
+    int maxSpots = 15,
+  }) {
+    final mistakeIds = <String>{};
+
+    String? _spotId(dynamic r) {
+      try {
+        final id = r.spotId;
+        if (id is String && id.isNotEmpty) return id;
+      } catch (_) {}
+      return null;
+    }
+
+    bool _isCorrect(dynamic r) {
+      try {
+        final v = r.isCorrect;
+        if (v is bool) return v;
+      } catch (_) {}
+      try {
+        final v = r.correct;
+        if (v is bool) return v;
+      } catch (_) {}
+      return true;
+    }
+
+    double? _heroEv(dynamic r) {
+      try {
+        final v = r.heroEv;
+        if (v is num) return v.toDouble();
+      } catch (_) {}
+      return null;
+    }
+
+    for (final r in results) {
+      final id = _spotId(r);
+      if (id == null) continue;
+      final correct = !_isCorrect(r);
+      final ev = _heroEv(r);
+      if (correct || (ev != null && ev < 0.8)) {
+        mistakeIds.add(id);
+        if (mistakeIds.length >= maxSpots) break;
+      }
+    }
+
+    final spotMap = <String, TrainingPackSpot>{};
+    for (final p in sourcePacks) {
+      for (final s in p.spots) {
+        spotMap[s.id] = s;
+      }
+    }
+
+    final spots = <TrainingPackSpot>[];
+    for (final id in mistakeIds) {
+      final s = spotMap[id];
+      if (s != null) {
+        spots.add(TrainingPackSpot.fromJson(s.toJson()));
+        if (spots.length >= maxSpots) break;
+      }
+    }
+
+    final positions = <HeroPosition>{for (final s in spots) s.hand.position};
+    final trainingType = sourcePacks.isNotEmpty
+        ? sourcePacks.first.trainingType
+        : const TrainingTypeEngine().detectTrainingType(
+            TrainingPackTemplateV2(
+              id: '',
+              name: '',
+              trainingType: TrainingType.pushFold,
+            ),
+          );
+
+    return TrainingPackTemplateV2(
+      id: const Uuid().v4(),
+      name: 'Review Mistakes',
+      trainingType: trainingType,
+      tags: const [],
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      positions: [for (final p in positions) p.name],
+      meta: {'origin': 'mistake_replay'},
+    );
+  }
+}

--- a/test/services/mistake_replay_pack_generator_test.dart
+++ b/test/services/mistake_replay_pack_generator_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mistake_replay_pack_generator.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/training_result.dart';
+
+class _Result extends TrainingResult {
+  final String spotId;
+  final bool isCorrect;
+  final double heroEv;
+  _Result({required this.spotId, required this.isCorrect, required this.heroEv})
+      : super(
+          date: DateTime.now(),
+          total: 1,
+          correct: isCorrect ? 1 : 0,
+          accuracy: isCorrect ? 100 : 0,
+        );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generates pack with mistaken spots', () {
+    final spot1 = TrainingPackSpot(id: 'a', hand: HandData());
+    final spot2 = TrainingPackSpot(id: 'b', hand: HandData());
+    final tpl = TrainingPackTemplateV2(
+      id: 'p',
+      name: 'test',
+      trainingType: TrainingType.pushFold,
+      spots: [spot1, spot2],
+    );
+    final results = [
+      _Result(spotId: 'a', isCorrect: true, heroEv: 1.2),
+      _Result(spotId: 'b', isCorrect: false, heroEv: 0.5),
+    ];
+    final generator = const MistakeReplayPackGenerator();
+    final pack = generator.generateMistakePack(
+      results: results,
+      sourcePacks: [tpl],
+      maxSpots: 5,
+    );
+    expect(pack.spots.length, 1);
+    expect(pack.spots.first.id, 'b');
+    expect(pack.meta['origin'], 'mistake_replay');
+  });
+});


### PR DESCRIPTION
## Summary
- add `MistakeReplayPackGenerator` service
- provide unit test for generator

## Testing
- `flutter test test/services/mistake_replay_pack_generator_test.dart -r json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d7fb311ac832a9e84fbf8bb55b266