### PR TITLE
Add AdaptiveSchedulerService

### DIFF
--- a/lib/models/training_recommendation.dart
+++ b/lib/models/training_recommendation.dart
@@ -1,0 +1,15 @@
+enum TrainingRecommendationType { mistakeReplay, weaknessDrill, reinforce }
+
+class TrainingRecommendation {
+  final String title;
+  final TrainingRecommendationType type;
+  final String? goalTag;
+  final double score;
+
+  const TrainingRecommendation({
+    required this.title,
+    required this.type,
+    this.goalTag,
+    required this.score,
+  });
+}

--- a/lib/services/adaptive_scheduler_service.dart
+++ b/lib/services/adaptive_scheduler_service.dart
@@ -1,0 +1,58 @@
+import 'package:collection/collection.dart';
+
+import '../models/training_recommendation.dart';
+import 'weakness_cluster_engine.dart';
+import '../models/training_result.dart';
+
+class AdaptiveSchedulerService {
+  const AdaptiveSchedulerService();
+
+  List<TrainingRecommendation> getNextRecommendations({
+    required List<WeaknessCluster> clusters,
+    required List<TrainingResult> history,
+    required Map<String, double> tagMastery,
+  }) {
+    final List<TrainingRecommendation> recs = [];
+
+    final mistakeScore = history.fold<int>(0, (p, r) => p + (r.total - r.correct));
+    if (mistakeScore > 0) {
+      recs.add(
+        TrainingRecommendation(
+          title: '🔁 Повтор ошибок',
+          type: TrainingRecommendationType.mistakeReplay,
+          score: mistakeScore.toDouble(),
+        ),
+      );
+    }
+
+    final allTags = <String>{...tagMastery.keys, ...clusters.map((c) => c.tag)};
+    for (final tag in allTags) {
+      final mastery = tagMastery[tag] ?? 1.0;
+      final severity = clusters.firstWhereOrNull((c) => c.tag == tag)?.severity ?? 0.0;
+      if (mastery < 0.6) {
+        final score = (0.6 - mastery) + severity;
+        recs.add(
+          TrainingRecommendation(
+            title: '📊 Укрепить $tag',
+            type: TrainingRecommendationType.weaknessDrill,
+            goalTag: tag,
+            score: score,
+          ),
+        );
+      } else if (mastery < 0.8) {
+        final score = (0.8 - mastery) + severity;
+        recs.add(
+          TrainingRecommendation(
+            title: '📈 Закрепить $tag',
+            type: TrainingRecommendationType.reinforce,
+            goalTag: tag,
+            score: score,
+          ),
+        );
+      }
+    }
+
+    recs.sort((a, b) => b.score.compareTo(a.score));
+    return recs;
+  }
+}

--- a/test/services/adaptive_scheduler_service_test.dart
+++ b/test/services/adaptive_scheduler_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_result.dart';
+import 'package:poker_analyzer/services/weakness_cluster_engine.dart';
+import 'package:poker_analyzer/services/adaptive_scheduler_service.dart';
+import 'package:poker_analyzer/models/training_recommendation.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final service = const AdaptiveSchedulerService();
+
+  test('returns sorted recommendations based on mistakes and mastery', () {
+    final clusters = [
+      const WeaknessCluster(tag: 'btn push', reason: 'many mistakes', severity: 0.5),
+    ];
+    final history = [
+      TrainingResult(date: DateTime.now(), total: 10, correct: 7, accuracy: 70, tags: const ['btn push']),
+      TrainingResult(date: DateTime.now(), total: 8, correct: 8, accuracy: 100, tags: const ['sb vs bb']),
+    ];
+    final mastery = {'btn push': 0.4, 'sb vs bb': 0.7};
+
+    final list = service.getNextRecommendations(
+      clusters: clusters,
+      history: history,
+      tagMastery: mastery,
+    );
+
+    expect(list.length, 3);
+    expect(list.first.type, TrainingRecommendationType.mistakeReplay);
+    expect(list[1].type, TrainingRecommendationType.weaknessDrill);
+    expect(list[1].goalTag, 'btn push');
+    expect(list[2].type, TrainingRecommendationType.reinforce);
+    expect(list[2].goalTag, 'sb vs bb');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TrainingRecommendation` model
- add `AdaptiveSchedulerService` to rank next training actions
- test scheduler recommendations

## Testing
- `dart test test/services/adaptive_scheduler_service_test.dart` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_687d81f59f8c832a92dc75e0cba1134b