### PR TITLE
Implement TrackPlayRecorder service

### DIFF
--- a/lib/models/track_play_history.dart
+++ b/lib/models/track_play_history.dart
@@ -1,0 +1,33 @@
+class TrackPlayHistory {
+  final String goalId;
+  final DateTime startedAt;
+  final DateTime? completedAt;
+  final double? accuracy;
+  final int? mistakeCount;
+
+  const TrackPlayHistory({
+    required this.goalId,
+    required this.startedAt,
+    this.completedAt,
+    this.accuracy,
+    this.mistakeCount,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'goalId': goalId,
+        'startedAt': startedAt.toIso8601String(),
+        if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
+        if (accuracy != null) 'accuracy': accuracy,
+        if (mistakeCount != null) 'mistakeCount': mistakeCount,
+      };
+
+  factory TrackPlayHistory.fromJson(Map<String, dynamic> json) => TrackPlayHistory(
+        goalId: json['goalId'] as String? ?? '',
+        startedAt: DateTime.tryParse(json['startedAt'] as String? ?? '') ?? DateTime.now(),
+        completedAt: json['completedAt'] != null
+            ? DateTime.tryParse(json['completedAt'] as String)
+            : null,
+        accuracy: (json['accuracy'] as num?)?.toDouble(),
+        mistakeCount: (json['mistakeCount'] as num?)?.toInt(),
+      );
+}

--- a/lib/services/track_play_recorder.dart
+++ b/lib/services/track_play_recorder.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/track_play_history.dart';
+
+/// Records usage of generated training tracks for progress tracking.
+class TrackPlayRecorder {
+  TrackPlayRecorder._();
+  static final TrackPlayRecorder instance = TrackPlayRecorder._();
+
+  static const _prefsKey = 'track_play_history';
+
+  final List<TrackPlayHistory> _history = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is List) {
+          _history.addAll(data.whereType<Map>().map((e) =>
+              TrackPlayHistory.fromJson(Map<String, dynamic>.from(e as Map))));
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final h in _history) h.toJson()]),
+    );
+  }
+
+  /// Logs start of a track play session for [goalId].
+  Future<void> recordStart(String goalId) async {
+    await _load();
+    _history.insert(
+      0,
+      TrackPlayHistory(goalId: goalId, startedAt: DateTime.now()),
+    );
+    if (_history.length > 100) _history.removeRange(100, _history.length);
+    await _save();
+  }
+
+  /// Logs completion of a track play session for [goalId].
+  Future<void> recordCompletion(
+    String goalId, {
+    required double accuracy,
+    required int mistakes,
+  }) async {
+    await _load();
+    final index =
+        _history.indexWhere((e) => e.goalId == goalId && e.completedAt == null);
+    final now = DateTime.now();
+    if (index != -1) {
+      final entry = _history[index];
+      _history[index] = TrackPlayHistory(
+        goalId: entry.goalId,
+        startedAt: entry.startedAt,
+        completedAt: now,
+        accuracy: accuracy,
+        mistakeCount: mistakes,
+      );
+    } else {
+      _history.insert(
+        0,
+        TrackPlayHistory(
+          goalId: goalId,
+          startedAt: now,
+          completedAt: now,
+          accuracy: accuracy,
+          mistakeCount: mistakes,
+        ),
+      );
+    }
+    if (_history.length > 100) _history.removeRange(100, _history.length);
+    await _save();
+  }
+
+  /// Returns stored track play history, most recent first.
+  Future<List<TrackPlayHistory>> getHistory() async {
+    await _load();
+    return List<TrackPlayHistory>.unmodifiable(_history);
+  }
+}

--- a/test/services/track_play_recorder_test.dart
+++ b/test/services/track_play_recorder_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/track_play_recorder.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('record start and completion', () async {
+    SharedPreferences.setMockInitialValues({});
+    final recorder = TrackPlayRecorder.instance;
+
+    await recorder.recordStart('g1');
+    var history = await recorder.getHistory();
+    expect(history.length, 1);
+    expect(history.first.goalId, 'g1');
+    expect(history.first.completedAt, isNull);
+
+    await recorder.recordCompletion('g1', accuracy: 0.8, mistakes: 2);
+    history = await recorder.getHistory();
+    expect(history.length, 1);
+    expect(history.first.completedAt, isNotNull);
+    expect(history.first.accuracy, 0.8);
+    expect(history.first.mistakeCount, 2);
+  });
+
+  test('keeps max 100 entries', () async {
+    SharedPreferences.setMockInitialValues({});
+    final recorder = TrackPlayRecorder.instance;
+    for (var i = 0; i < 120; i++) {
+      await recorder.recordStart('g$i');
+    }
+    final history = await recorder.getHistory();
+    expect(history.length, 100);
+    expect(history.first.goalId, 'g119');
+    expect(history.last.goalId, 'g20');
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrackPlayHistory` model to track play sessions
- implement `TrackPlayRecorder` for logging track progress
- test history recording and list trimming

## Testing
- `flutter pub get`
- `flutter test --run-skipped` *(fails: numerous compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d86b209bc832aa2a24996b4d294fd