### PR TITLE
Implement AdaptiveLearningFlowEngine

### DIFF
--- a/lib/services/adaptive_learning_flow_engine.dart
+++ b/lib/services/adaptive_learning_flow_engine.dart
@@ -1,0 +1,70 @@
+import '../models/learning_goal.dart';
+import '../models/training_result.dart';
+import '../models/training_track.dart';
+import '../models/training_recommendation.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/weakness_cluster_engine.dart';
+import '../services/learning_goal_engine.dart';
+import '../services/dynamic_track_builder.dart';
+import '../services/adaptive_scheduler_service.dart';
+import '../services/mistake_replay_pack_generator.dart';
+
+class AdaptiveLearningPlan {
+  final List<TrainingTrack> recommendedTracks;
+  final List<LearningGoal> goals;
+  final TrainingPackTemplateV2? mistakeReplayPack;
+
+  const AdaptiveLearningPlan({
+    required this.recommendedTracks,
+    required this.goals,
+    this.mistakeReplayPack,
+  });
+}
+
+class AdaptiveLearningFlowEngine {
+  final WeaknessClusterEngine clusterEngine;
+  final LearningGoalEngine goalEngine;
+  final DynamicTrackBuilder trackBuilder;
+  final AdaptiveSchedulerService scheduler;
+  final MistakeReplayPackGenerator mistakeGenerator;
+
+  const AdaptiveLearningFlowEngine({
+    this.clusterEngine = const WeaknessClusterEngine(),
+    this.goalEngine = const LearningGoalEngine(),
+    this.trackBuilder = const DynamicTrackBuilder(),
+    this.scheduler = const AdaptiveSchedulerService(),
+    this.mistakeGenerator = const MistakeReplayPackGenerator(),
+  });
+
+  AdaptiveLearningPlan generate({
+    required List<TrainingResult> history,
+    required Map<String, double> tagMastery,
+    required List<TrainingPackTemplateV2> sourcePacks,
+  }) {
+    final clusters =
+        clusterEngine.detectWeaknesses(results: history, tagMastery: tagMastery);
+    final goals = goalEngine.generateGoals(clusters);
+    final tracks = trackBuilder.buildTracks(goals: goals, sourcePacks: sourcePacks);
+    final recs = scheduler.getNextRecommendations(
+      clusters: clusters,
+      history: history,
+      tagMastery: tagMastery,
+    );
+
+    TrainingPackTemplateV2? replayPack;
+    final needReplay = recs.any((r) => r.type == TrainingRecommendationType.mistakeReplay);
+    if (needReplay && history.isNotEmpty) {
+      replayPack = mistakeGenerator.generateMistakePack(
+        results: history,
+        sourcePacks: sourcePacks,
+      );
+    }
+
+    return AdaptiveLearningPlan(
+      recommendedTracks: tracks,
+      goals: goals,
+      mistakeReplayPack: replayPack,
+    );
+  }
+}
+

--- a/test/services/adaptive_learning_flow_engine_test.dart
+++ b/test/services/adaptive_learning_flow_engine_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/adaptive_learning_flow_engine.dart';
+import 'package:poker_analyzer/models/training_result.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _Result extends TrainingResult {
+  final String spotId;
+  final bool isCorrect;
+  final double heroEv;
+  _Result({required this.spotId, required this.isCorrect, required this.heroEv})
+      : super(
+          date: DateTime.now(),
+          total: 1,
+          correct: isCorrect ? 1 : 0,
+          accuracy: isCorrect ? 100 : 0,
+          tags: const ['cbet'],
+          evDiff: heroEv - 1,
+        );
+}
+
+TrainingPackSpot _spot(String id, String tag, double ev) {
+  final hand = HandData(
+    position: HeroPosition.btn,
+    heroIndex: 0,
+    playerCount: 2,
+    actions: {
+      0: [ActionEntry(0, 0, 'push', ev: ev)],
+    },
+  );
+  return TrainingPackSpot(id: id, tags: [tag], hand: hand);
+}
+
+TrainingPackTemplateV2 _pack(String id, List<TrainingPackSpot> spots) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    tags: const ['cbet'],
+    spots: spots,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generate creates full learning plan', () {
+    final engine = const AdaptiveLearningFlowEngine();
+    final history = [
+      _Result(spotId: 's1', isCorrect: false, heroEv: 0.5),
+      _Result(spotId: 's2', isCorrect: true, heroEv: 1.2),
+    ];
+    final mastery = {'cbet': 0.4};
+    final packs = [_pack('p', [_spot('s1', 'cbet', -0.5), _spot('s2', 'cbet', 0.2)])];
+
+    final plan = engine.generate(
+      history: history,
+      tagMastery: mastery,
+      sourcePacks: packs,
+    );
+
+    expect(plan.goals.isNotEmpty, true);
+    expect(plan.recommendedTracks.isNotEmpty, true);
+    expect(plan.mistakeReplayPack, isNotNull);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `AdaptiveLearningFlowEngine` which combines clustering, goal generation, track building and scheduling
- expose `AdaptiveLearningPlan` model
- test the new engine

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8997b090832ab92d8d7377b9ebd0