### PR TITLE
Add TagMasteryUpdater

### DIFF
--- a/lib/services/tag_mastery_updater.dart
+++ b/lib/services/tag_mastery_updater.dart
@@ -1,0 +1,26 @@
+import '../models/training_track_summary.dart';
+
+/// Updates tag mastery values based on a completed training track summary.
+class TagMasteryUpdater {
+  const TagMasteryUpdater();
+
+  /// Returns an updated copy of [current] with mastery adjusted using
+  /// [summary]. The update moves mastery towards the observed accuracy
+  /// by a fraction controlled by [learningRate].
+  Map<String, double> updateMastery({
+    required Map<String, double> current,
+    required TrainingTrackSummary summary,
+    double learningRate = 0.15,
+  }) {
+    final result = Map<String, double>.from(current);
+    for (final entry in summary.tagBreakdown.entries) {
+      final tag = entry.key.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      final old = result[tag] ?? 0.5;
+      final acc = (entry.value.accuracy / 100).clamp(0.0, 1.0);
+      final updated = (old + (acc - old) * learningRate).clamp(0.0, 1.0);
+      result[tag] = updated;
+    }
+    return result;
+  }
+}

--- a/test/services/tag_mastery_updater_test.dart
+++ b/test/services/tag_mastery_updater_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_track_summary.dart';
+import 'package:poker_analyzer/services/tag_mastery_updater.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('updateMastery moves value towards accuracy', () {
+    final updater = const TagMasteryUpdater();
+    final current = {'a': 0.4};
+    final summary = TrainingTrackSummary(
+      goalId: 'g1',
+      accuracy: 80,
+      mistakeCount: 2,
+      tagBreakdown: {
+        'a': const TagSummary(total: 10, correct: 8, accuracy: 80),
+      },
+    );
+
+    final updated = updater.updateMastery(current: current, summary: summary);
+    // Expected new value = 0.4 + (0.8 - 0.4) * 0.15 = 0.46
+    expect(updated['a']!, closeTo(0.46, 0.0001));
+  });
+
+  test('new tags start at 0.5', () {
+    final updater = const TagMasteryUpdater();
+    final summary = TrainingTrackSummary(
+      goalId: 'g1',
+      accuracy: 50,
+      mistakeCount: 5,
+      tagBreakdown: {
+        'b': const TagSummary(total: 4, correct: 2, accuracy: 50),
+      },
+    );
+    final updated = updater.updateMastery(current: const {}, summary: summary);
+    // old default 0.5 -> new = 0.5 + (0.5 - 0.5)*0.15 = 0.5
+    expect(updated['b'], 0.5);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TagMasteryUpdater` service with `updateMastery` method
- test mastery updates with weighted average formula

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8e11e1cc832a8c86dcc3ba484b78