### PR TITLE
Implement MasteryPersistenceService

### DIFF
--- a/lib/services/mastery_persistence_service.dart
+++ b/lib/services/mastery_persistence_service.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists tag mastery values between app sessions.
+class MasteryPersistenceService {
+  static const _key = 'tag_mastery';
+
+  /// Saves the provided [tagMastery] map to local storage.
+  Future<void> save(Map<String, double> tagMastery) async {
+    final prefs = await SharedPreferences.getInstance();
+    final sanitized = <String, double>{};
+    tagMastery.forEach((tag, value) {
+      final key = tag.trim().toLowerCase();
+      if (key.isEmpty) return;
+      if (value.isNaN || value.isInfinite) return;
+      sanitized[key] = value.clamp(0.0, 1.0);
+    });
+    await prefs.setString(_key, jsonEncode(sanitized));
+  }
+
+  /// Loads the persisted tag mastery map.
+  Future<Map<String, double>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return {};
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        final result = <String, double>{};
+        for (final entry in data.entries) {
+          final key = entry.key.toString().trim().toLowerCase();
+          if (key.isEmpty) continue;
+          final value = entry.value;
+          double? v;
+          if (value is num) {
+            v = value.toDouble();
+          } else if (value is String) {
+            v = double.tryParse(value);
+          }
+          if (v != null && v.isFinite) {
+            result[key] = v.clamp(0.0, 1.0);
+          }
+        }
+        return result;
+      }
+    } catch (_) {}
+    return {};
+  }
+}

--- a/test/services/mastery_persistence_service_test.dart
+++ b/test/services/mastery_persistence_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/mastery_persistence_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('save and load roundtrip', () async {
+    final service = MasteryPersistenceService();
+    await service.save({'A': 0.8, 'B ': 1.2});
+    final map = await service.load();
+    expect(map['a'], closeTo(0.8, 0.0001));
+    expect(map['b'], 1.0);
+  });
+
+  test('load handles malformed data', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('tag_mastery', '{"x": "bad", "y": 0.5, "z": null}');
+    final service = MasteryPersistenceService();
+    final map = await service.load();
+    expect(map, {'y': 0.5});
+  });
+}


### PR DESCRIPTION
## Summary
- add `MasteryPersistenceService` for saving/loading tag mastery
- test persistence roundtrip and malformed data handling

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --run-skipped` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8f118c04832a9ee15b0c56ab05ab