### PR TITLE
Implement LearningPlanCache

### DIFF
--- a/lib/services/learning_plan_cache.dart
+++ b/lib/services/learning_plan_cache.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/learning_goal.dart';
+import '../models/training_track.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'adaptive_learning_flow_engine.dart';
+
+/// Persists the last generated [AdaptiveLearningPlan] to allow instant resume
+/// after app restart.
+class LearningPlanCache {
+  static const _key = 'learning_plan_cache';
+
+  const LearningPlanCache();
+
+  /// Saves [plan] to local storage.
+  Future<void> save(AdaptiveLearningPlan plan) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = _planToJson(plan);
+    await prefs.setString(_key, jsonEncode(data));
+  }
+
+  /// Loads cached plan if available. Returns `null` if the cache is missing
+  /// or corrupted.
+  Future<AdaptiveLearningPlan?> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map<String, dynamic>) {
+        return _planFromJson(Map<String, dynamic>.from(data));
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Map<String, dynamic> _planToJson(AdaptiveLearningPlan plan) => {
+        'goals': [for (final g in plan.goals) _goalToJson(g)],
+        'tracks': [for (final t in plan.recommendedTracks) _trackToJson(t)],
+        if (plan.mistakeReplayPack != null)
+          'mistakePack': plan.mistakeReplayPack!.toJson(),
+      };
+
+  Map<String, dynamic> _goalToJson(LearningGoal g) => {
+        'id': g.id,
+        'title': g.title,
+        'description': g.description,
+        'tag': g.tag,
+        'priority': g.priorityScore,
+      };
+
+  Map<String, dynamic> _trackToJson(TrainingTrack t) => {
+        'id': t.id,
+        'title': t.title,
+        'goalId': t.goalId,
+        'tags': t.tags,
+        'spots': [for (final s in t.spots) s.toJson()],
+      };
+
+  AdaptiveLearningPlan? _planFromJson(Map<String, dynamic> j) {
+    final goalsRaw = j['goals'];
+    final tracksRaw = j['tracks'];
+    if (goalsRaw is! List || tracksRaw is! List) return null;
+
+    final goals = <LearningGoal>[];
+    for (final g in goalsRaw) {
+      if (g is! Map) return null;
+      goals.add(LearningGoal(
+        id: g['id'] as String? ?? '',
+        title: g['title'] as String? ?? '',
+        description: g['description'] as String? ?? '',
+        tag: g['tag'] as String? ?? '',
+        priorityScore: (g['priority'] as num?)?.toDouble() ?? 0.0,
+      ));
+    }
+
+    final tracks = <TrainingTrack>[];
+    for (final t in tracksRaw) {
+      if (t is! Map) return null;
+      final spotsRaw = t['spots'];
+      if (spotsRaw is! List) return null;
+      final spots = <TrainingPackSpot>[];
+      for (final s in spotsRaw) {
+        if (s is! Map) return null;
+        spots.add(
+            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s)));
+      }
+      tracks.add(TrainingTrack(
+        id: t['id'] as String? ?? '',
+        title: t['title'] as String? ?? '',
+        goalId: t['goalId'] as String? ?? '',
+        spots: spots,
+        tags: [for (final tag in (t['tags'] as List? ?? [])) tag.toString()],
+      ));
+    }
+
+    TrainingPackTemplateV2? replayPack;
+    final mp = j['mistakePack'];
+    if (mp is Map) {
+      try {
+        replayPack =
+            TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(mp));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    return AdaptiveLearningPlan(
+      recommendedTracks: tracks,
+      goals: goals,
+      mistakeReplayPack: replayPack,
+    );
+  }
+}
+

--- a/test/services/learning_plan_cache_test.dart
+++ b/test/services/learning_plan_cache_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/adaptive_learning_flow_engine.dart';
+import 'package:poker_analyzer/services/learning_plan_cache.dart';
+import 'package:poker_analyzer/models/learning_goal.dart';
+import 'package:poker_analyzer/models/training_track.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('save and load roundtrip', () async {
+    final cache = const LearningPlanCache();
+
+    final spot = TrainingPackSpot(
+      id: 's1',
+      title: 'Spot',
+      hand: HandData(
+        position: HeroPosition.btn,
+        heroIndex: 0,
+        playerCount: 2,
+        actions: {
+          0: [ActionEntry(0, 0, 'push', ev: 1.0)],
+        },
+      ),
+    );
+    final track = TrainingTrack(
+      id: 't1',
+      title: 'Track',
+      goalId: 'g1',
+      spots: [spot],
+      tags: const ['push'],
+    );
+    final goal = const LearningGoal(
+      id: 'g1',
+      title: 'Goal',
+      description: 'desc',
+      tag: 'push',
+      priorityScore: 1.0,
+    );
+    final replay = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Replay',
+      trainingType: TrainingType.pushFold,
+      tags: const [],
+      spots: const [],
+      spotCount: 0,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      positions: const [],
+    );
+    final plan = AdaptiveLearningPlan(
+      recommendedTracks: [track],
+      goals: [goal],
+      mistakeReplayPack: replay,
+    );
+
+    await cache.save(plan);
+
+    final loaded = await cache.load();
+    expect(loaded, isNotNull);
+    expect(loaded!.goals.first.id, 'g1');
+    expect(loaded.recommendedTracks.first.id, 't1');
+    expect(loaded.mistakeReplayPack?.id, 'p1');
+  });
+
+  test('invalid data returns null', () async {
+    SharedPreferences.setMockInitialValues({
+      'learning_plan_cache': 'oops'
+    });
+    final cache = const LearningPlanCache();
+    final result = await cache.load();
+    expect(result, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add LearningPlanCache for persisting the last generated AdaptiveLearningPlan
- test round‑trip cache load and invalid data handling

## Testing
- `flutter test test/services/learning_plan_cache_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d9532f1e8832ab120a8b63a46cde9