### PR TITLE
Add MasteryExportService

### DIFF
--- a/lib/services/mastery_export_service.dart
+++ b/lib/services/mastery_export_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+/// Converts tag mastery data into a portable JSON format.
+class MasteryExportService {
+  /// Returns a JSON string representing [tagMastery].
+  ///
+  /// - Entries are sorted alphabetically by tag.
+  /// - Values are rounded to 3 decimal places.
+  /// - Only entries within [0.0, 1.0] are included.
+  /// - Metadata fields `schemaVersion` and `exportedAt` are added.
+  String exportToJson(Map<String, double> tagMastery) {
+    final filtered = <String, double>{};
+    tagMastery.forEach((tag, value) {
+      if (value.isFinite && value >= 0.0 && value <= 1.0) {
+        final key = tag.trim();
+        if (key.isNotEmpty) {
+          final rounded = ((value * 1000).round() / 1000);
+          filtered[key] = rounded;
+        }
+      }
+    });
+
+    final sortedKeys = filtered.keys.toList()..sort();
+    final sortedMap = {for (final k in sortedKeys) k: filtered[k]};
+
+    final data = {
+      'schemaVersion': '1.0',
+      'exportedAt': DateTime.now().toIso8601String(),
+      'tags': sortedMap,
+    };
+
+    return const JsonEncoder.withIndent('  ').convert(data);
+  }
+}

--- a/test/services/mastery_export_service_test.dart
+++ b/test/services/mastery_export_service_test.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mastery_export_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exportToJson filters, rounds and sorts entries', () {
+    final service = MasteryExportService();
+    final jsonStr = service.exportToJson({
+      'b': 0.5555,
+      'a': 1.2,
+      'c': -0.1,
+      'a2': 0.12349,
+    });
+    final data = jsonDecode(jsonStr) as Map<String, dynamic>;
+    expect(data['schemaVersion'], '1.0');
+    expect(DateTime.tryParse(data['exportedAt'] as String), isNotNull);
+    final tags = data['tags'] as Map<String, dynamic>;
+    expect(tags.keys.toList(), ['a2', 'b']);
+    expect(tags['a2'], 0.123);
+    expect(tags['b'], 0.556);
+  });
+}


### PR DESCRIPTION
## Summary
- add `MasteryExportService` to convert tag mastery values into JSON
- test export behavior

## Testing
- `flutter analyze`
- `flutter test test/services/mastery_export_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_687d963fad48832abbcd5799ae4f9351