### PR TITLE
Add TagMasteryImporter for JSON restore

### DIFF
--- a/lib/services/tag_mastery_importer.dart
+++ b/lib/services/tag_mastery_importer.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+/// Restores tag mastery data from a JSON export.
+class TagMasteryImporter {
+  /// Parses [jsonString] exported by [MasteryExportService] and returns a
+  /// sanitized tag mastery map.
+  ///
+  /// Invalid or out-of-range entries are ignored and remaining values are
+  /// clamped to the [0.0, 1.0] range. If parsing fails an empty map is
+  /// returned.
+  Map<String, double> importFromJson(String jsonString) {
+    try {
+      final data = jsonDecode(jsonString);
+      if (data is! Map) return {};
+      final tags = data['tags'];
+      if (tags is! Map) return {};
+      final result = <String, double>{};
+      for (final entry in tags.entries) {
+        final key = entry.key.toString().trim().toLowerCase();
+        if (key.isEmpty) continue;
+        final value = entry.value;
+        double? v;
+        if (value is num) {
+          v = value.toDouble();
+        } else if (value is String) {
+          v = double.tryParse(value);
+        }
+        if (v == null || v.isNaN || v.isInfinite) continue;
+        result[key] = v.clamp(0.0, 1.0);
+      }
+      return result;
+    } catch (_) {
+      return {};
+    }
+  }
+}

--- a/test/services/tag_mastery_importer_test.dart
+++ b/test/services/tag_mastery_importer_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/tag_mastery_importer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('importFromJson normalizes and clamps values', () {
+    const jsonStr = '{"schemaVersion":"1.0","exportedAt":"2024-01-01T00:00:00Z","tags":{"A":0.8,"B":"1.2"," ":0.5,"c":-0.1}}';
+    final importer = TagMasteryImporter();
+    final map = importer.importFromJson(jsonStr);
+    expect(map, {'a': 0.8, 'b': 1.0, 'c': 0.0});
+  });
+
+  test('importFromJson returns empty map on malformed input', () {
+    const badJson = '{"tags": [1,2,3]}';
+    final importer = TagMasteryImporter();
+    final map = importer.importFromJson(badJson);
+    expect(map, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TagMasteryImporter` for reading mastery exports
- test `TagMasteryImporter` behavior

## Testing
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d981d9164832ab070c3b4ab9ca3f1