### PR TITLE
Implement mastery sync service

### DIFF
--- a/lib/services/mastery_sync_service.dart
+++ b/lib/services/mastery_sync_service.dart
@@ -1,0 +1,25 @@
+/// Merges two tag mastery maps using weighted interpolation.
+class MasterySyncService {
+  /// Returns a new mastery map by blending [incoming] into [current].
+  ///
+  /// [incomingWeight] determines how much influence the incoming values have.
+  /// Values are clamped to the `[0.0, 1.0]` range.
+  Map<String, double> merge({
+    required Map<String, double> current,
+    required Map<String, double> incoming,
+    double incomingWeight = 0.5,
+  }) {
+    final weight = incomingWeight.clamp(0.0, 1.0);
+    final result = Map<String, double>.from(current);
+    for (final entry in incoming.entries) {
+      final tag = entry.key.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      final inc = entry.value;
+      if (inc.isNaN || inc.isInfinite) continue;
+      final old = result[tag] ?? 0.5;
+      final blended = old * (1 - weight) + inc * weight;
+      result[tag] = blended.clamp(0.0, 1.0);
+    }
+    return result;
+  }
+}

--- a/test/services/mastery_sync_service_test.dart
+++ b/test/services/mastery_sync_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mastery_sync_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('merge blends values with weight', () {
+    final service = MasterySyncService();
+    final result = service.merge(
+      current: {'a': 0.6},
+      incoming: {'a': 1.0},
+      incomingWeight: 0.5,
+    );
+    expect(result['a']!, closeTo(0.8, 0.0001));
+  });
+
+  test('missing current tag starts at 0.5', () {
+    final service = MasterySyncService();
+    final result = service.merge(
+      current: const {},
+      incoming: {'b': 0.2},
+      incomingWeight: 0.5,
+    );
+    expect(result['b']!, closeTo(0.35, 0.0001));
+  });
+
+  test('missing incoming tag is untouched', () {
+    final service = MasterySyncService();
+    final result = service.merge(
+      current: {'c': 0.3},
+      incoming: const {},
+      incomingWeight: 0.5,
+    );
+    expect(result['c'], 0.3);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `MasterySyncService` for merging mastery maps
- test weighted interpolation logic

## Testing
- `flutter test test/services/mastery_sync_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687d9941c76c832a823b7b3ef37ae137