### PR TITLE
Add LearningHeatmapService

### DIFF
--- a/lib/models/heatmap_entry.dart
+++ b/lib/models/heatmap_entry.dart
@@ -1,0 +1,17 @@
+class HeatmapEntry {
+  final DateTime date;
+  final int count;
+
+  const HeatmapEntry({required this.date, required this.count});
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'count': count,
+      };
+
+  factory HeatmapEntry.fromJson(Map<String, dynamic> json) => HeatmapEntry(
+        date:
+            DateTime.tryParse(json['date'] as String? ?? '') ?? DateTime.now(),
+        count: (json['count'] as num?)?.toInt() ?? 0,
+      );
+}

--- a/lib/services/learning_heatmap_service.dart
+++ b/lib/services/learning_heatmap_service.dart
@@ -1,0 +1,32 @@
+import '../models/heatmap_entry.dart';
+import '../models/track_play_history.dart';
+
+class LearningHeatmapService {
+  const LearningHeatmapService();
+
+  /// Builds a tag -> daily activity heatmap from [history].
+  Map<String, List<HeatmapEntry>> buildHeatmap(List<TrackPlayHistory> history) {
+    final map = <String, Map<DateTime, int>>{};
+
+    for (final h in history) {
+      final completedAt = h.completedAt;
+      if (completedAt == null) continue;
+      final tag = h.goalId.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      final day =
+          DateTime(completedAt.year, completedAt.month, completedAt.day);
+      final tagMap = map.putIfAbsent(tag, () => <DateTime, int>{});
+      tagMap.update(day, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    final result = <String, List<HeatmapEntry>>{};
+    for (final entry in map.entries) {
+      final list = [
+        for (final e in entry.value.entries)
+          HeatmapEntry(date: e.key, count: e.value)
+      ]..sort((a, b) => a.date.compareTo(b.date));
+      result[entry.key] = list;
+    }
+    return result;
+  }
+}

--- a/test/learning_heatmap_service_test.dart
+++ b/test/learning_heatmap_service_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/track_play_history.dart';
+import 'package:poker_analyzer/services/learning_heatmap_service.dart';
+
+void main() {
+  const service = LearningHeatmapService();
+
+  test('aggregates completed tracks per tag and day', () {
+    final history = [
+      TrackPlayHistory(
+        goalId: 'push',
+        startedAt: DateTime(2023, 1, 1),
+        completedAt: DateTime(2023, 1, 1, 10),
+      ),
+      TrackPlayHistory(
+        goalId: 'push',
+        startedAt: DateTime(2023, 1, 1, 12),
+        completedAt: DateTime(2023, 1, 1, 15),
+      ),
+      TrackPlayHistory(
+        goalId: 'fold',
+        startedAt: DateTime(2023, 1, 2),
+        completedAt: DateTime(2023, 1, 2),
+      ),
+      TrackPlayHistory(
+        goalId: 'push',
+        startedAt: DateTime(2023, 1, 2),
+        completedAt: DateTime(2023, 1, 2),
+      ),
+      TrackPlayHistory(
+        goalId: 'push',
+        startedAt: DateTime(2023, 1, 3),
+      ),
+    ];
+
+    final result = service.buildHeatmap(history);
+
+    expect(result.keys.length, 2);
+    final push = result['push']!;
+    expect(push.length, 2);
+    expect(push[0].date, DateTime(2023, 1, 1));
+    expect(push[0].count, 2);
+    expect(push[1].date, DateTime(2023, 1, 2));
+    expect(push[1].count, 1);
+
+    final fold = result['fold']!;
+    expect(fold.length, 1);
+    expect(fold.first.count, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `HeatmapEntry` model
- implement `LearningHeatmapService` to aggregate tag activity per day
- test `LearningHeatmapService`

## Testing
- `flutter analyze --no-pub` *(fails: many existing warnings/errors)*
- `flutter test test/learning_heatmap_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687d9bde7b34832aada3faf441c42513