### PR TITLE
Implement MistakeReplayPackGenerator

### DIFF
--- a/lib/models/play_result.dart
+++ b/lib/models/play_result.dart
@@ -1,0 +1,29 @@
+import 'v2/training_pack_spot.dart';
+class PlayResult {
+  final String spotId;
+  final bool isCorrect;
+  final double? evGain;
+  final TrainingPackSpot spot;
+
+  const PlayResult({
+    required this.spotId,
+    required this.spot,
+    required this.isCorrect,
+    this.evGain,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'spotId': spotId,
+        'isCorrect': isCorrect,
+        if (evGain != null) 'evGain': evGain,
+        'spot': spot.toJson(),
+      };
+
+  factory PlayResult.fromJson(Map<String, dynamic> json) => PlayResult(
+        spotId: json['spotId'] as String? ?? '',
+        spot: TrainingPackSpot.fromJson(
+            Map<String, dynamic>.from(json['spot'] as Map)),
+        isCorrect: json['isCorrect'] as bool? ?? false,
+        evGain: (json['evGain'] as num?)?.toDouble(),
+      );
+}

--- a/lib/models/track_play_history.dart
+++ b/lib/models/track_play_history.dart
@@ -1,9 +1,12 @@
+import 'play_result.dart';
+
 class TrackPlayHistory {
   final String goalId;
   final DateTime startedAt;
   final DateTime? completedAt;
   final double? accuracy;
   final int? mistakeCount;
+  final List<PlayResult> results;
 
   const TrackPlayHistory({
     required this.goalId,
@@ -11,7 +14,8 @@ class TrackPlayHistory {
     this.completedAt,
     this.accuracy,
     this.mistakeCount,
-  });
+    List<PlayResult>? results,
+  }) : results = results ?? const [];
 
   Map<String, dynamic> toJson() => {
         'goalId': goalId,
@@ -19,6 +23,7 @@ class TrackPlayHistory {
         if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
         if (accuracy != null) 'accuracy': accuracy,
         if (mistakeCount != null) 'mistakeCount': mistakeCount,
+        if (results.isNotEmpty) 'results': [for (final r in results) r.toJson()],
       };
 
   factory TrackPlayHistory.fromJson(Map<String, dynamic> json) => TrackPlayHistory(
@@ -29,5 +34,9 @@ class TrackPlayHistory {
             : null,
         accuracy: (json['accuracy'] as num?)?.toDouble(),
         mistakeCount: (json['mistakeCount'] as num?)?.toInt(),
+        results: [
+          for (final r in (json['results'] as List? ?? []))
+            PlayResult.fromJson(Map<String, dynamic>.from(r as Map))
+        ],
       );
 }

--- a/test/services/mistake_replay_pack_generator_history_test.dart
+++ b/test/services/mistake_replay_pack_generator_history_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mistake_replay_pack_generator.dart';
+import 'package:poker_analyzer/models/play_result.dart';
+import 'package:poker_analyzer/models/track_play_history.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generate builds pack from recent mistakes', () {
+    final spot1 = TrainingPackSpot(id: 'a', hand: HandData(position: HeroPosition.btn));
+    final spot2 = TrainingPackSpot(id: 'b', hand: HandData(position: HeroPosition.sb));
+    final history = [
+      TrackPlayHistory(
+        goalId: 'g',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        results: [
+          PlayResult(spotId: 'a', spot: spot1, isCorrect: true, evGain: 1.0),
+          PlayResult(spotId: 'b', spot: spot2, isCorrect: false, evGain: 0.5),
+        ],
+      ),
+    ];
+
+    final generator = const MistakeReplayPackGenerator();
+    final pack = generator.generate(history: history, evThreshold: 0.8);
+
+    expect(pack.spots.length, 1);
+    expect(pack.spots.first.id, 'b');
+    expect(pack.name, 'Ошибки последних тренировок');
+  });
+}


### PR DESCRIPTION
## Summary
- add `PlayResult` model storing per-hand results
- extend `TrackPlayHistory` with list of `PlayResult`
- enhance `MistakeReplayPackGenerator` with new `generate` method for history
- add unit test for history-based generator

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*


------
https://chatgpt.com/codex/tasks/task_e_687d9f968cd8832aa72db10b6f02f9c4