### PR TITLE
Implement TrainingSessionRecommender

### DIFF
--- a/lib/models/training_recommendation.dart
+++ b/lib/models/training_recommendation.dart
@@ -5,11 +5,19 @@ class TrainingRecommendation {
   final TrainingRecommendationType type;
   final String? goalTag;
   final double score;
+  final String? packId;
+  final String? reason;
+  final double progress;
+  final bool isUrgent;
 
   const TrainingRecommendation({
     required this.title,
     required this.type,
     this.goalTag,
     required this.score,
+    this.packId,
+    this.reason,
+    this.progress = 0,
+    this.isUrgent = false,
   });
 }

--- a/lib/services/training_session_recommender.dart
+++ b/lib/services/training_session_recommender.dart
@@ -1,0 +1,66 @@
+import '../models/training_recommendation.dart';
+import '../models/track_play_history.dart';
+import 'adaptive_learning_flow_engine.dart';
+import '../models/training_track.dart';
+
+/// Suggests which training session to play next based on the current
+/// [AdaptiveLearningPlan] and past [TrackPlayHistory].
+class TrainingSessionRecommender {
+  const TrainingSessionRecommender();
+
+  List<TrainingRecommendation> recommend({
+    required AdaptiveLearningPlan plan,
+    required List<TrackPlayHistory> history,
+  }) {
+    double progressFor(String goalId) {
+      final count = history
+          .where((h) => h.goalId == goalId && h.completedAt != null)
+          .length;
+      return (count / 3).clamp(0.0, 1.0);
+    }
+
+    final recs = <TrainingRecommendation>[];
+
+    final mistakePack = plan.mistakeReplayPack;
+    if (mistakePack != null) {
+      recs.add(
+        TrainingRecommendation(
+          title: mistakePack.name,
+          type: TrainingRecommendationType.mistakeReplay,
+          score: 1000,
+          packId: mistakePack.id,
+          reason: 'mistake_replay',
+          progress: progressFor('mistake_replay'),
+          isUrgent: true,
+        ),
+      );
+    }
+
+    final trackEntries = <MapEntry<TrainingTrack, double>>[];
+    for (final t in plan.recommendedTracks) {
+      final p = progressFor(t.goalId);
+      if (p < 1.0) {
+        trackEntries.add(MapEntry(t, p));
+      }
+    }
+    trackEntries.sort((a, b) => a.value.compareTo(b.value));
+    for (final entry in trackEntries) {
+      final t = entry.key;
+      final p = entry.value;
+      recs.add(
+        TrainingRecommendation(
+          title: t.title,
+          type: TrainingRecommendationType.weaknessDrill,
+          goalTag: t.goalId,
+          score: 500 * (1 - p),
+          packId: t.id,
+          reason: 'goal_track',
+          progress: p,
+          isUrgent: p < 0.3,
+        ),
+      );
+    }
+
+    return recs;
+  }
+}

--- a/test/services/training_session_recommender_test.dart
+++ b/test/services/training_session_recommender_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/training_session_recommender.dart';
+import 'package:poker_analyzer/services/adaptive_learning_flow_engine.dart';
+import 'package:poker_analyzer/models/training_track.dart';
+import 'package:poker_analyzer/models/track_play_history.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingPackTemplateV2 pack(String id) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.pushFold,
+      spots: const [],
+    );
+  }
+
+  TrainingTrack track(String id, String goal) {
+    return TrainingTrack(id: id, title: id, goalId: goal, spots: const [], tags: const []);
+  }
+
+  test('prioritizes mistake replay over tracks', () {
+    final plan = AdaptiveLearningPlan(
+      recommendedTracks: [track('t1', 'g1'), track('t2', 'g2')],
+      goals: const [],
+      mistakeReplayPack: pack('m1'),
+    );
+
+    final history = [
+      TrackPlayHistory(
+        goalId: 'g1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+      ),
+    ];
+
+    final recs = const TrainingSessionRecommender().recommend(
+      plan: plan,
+      history: history,
+    );
+
+    expect(recs.first.packId, 'm1');
+    expect(recs.length, 3);
+    expect(recs[1].packId, 't2');
+    expect(recs[2].packId, 't1');
+  });
+}


### PR DESCRIPTION
## Summary
- extend `TrainingRecommendation` model with additional fields
- add new service `TrainingSessionRecommender`
- provide basic unit test for the service

## Testing
- `flutter test test/services/training_session_recommender_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da18af94c832a9b132284a9b29c83