### PR TITLE
Add TagProgressCard widget

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -55,6 +55,7 @@ import '../helpers/training_onboarding.dart';
 import '../widgets/sync_status_widget.dart';
 import '../tutorial/tutorial_flow.dart';
 import '../widgets/suggestion_card_weak_spots.dart';
+import '../widgets/tag_progress_card.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
   final TutorialFlow? tutorial;
@@ -138,6 +139,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const ProgressSummaryBox(),
             const XPProgressBar(),
             const SuggestionCardWeakSpots(),
+            const TagProgressCard(),
           ] else ...[
             const QuickContinueCard(),
             const ResumeTrainingCard(),
@@ -157,6 +159,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const WeeklyChallengeCard(),
             const XPProgressBar(),
             const SuggestionCardWeakSpots(),
+            const TagProgressCard(),
             const AchievementsCard(),
             const WeakSpotCard(),
             const ReviewPastMistakesCard(),
@@ -206,9 +209,8 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final service = context.read<AdaptiveTrainingService>();
     await service.refresh();
     final list = service.recommended.toList();
-    final weak = await context
-        .read<WeakSpotRecommendationService>()
-        .buildPack();
+    final weak =
+        await context.read<WeakSpotRecommendationService>().buildPack();
     if (weak != null) list.insert(0, weak);
     final review = await MistakeReviewPackService.latestTemplate(context);
     if (review != null) list.insert(0, review);
@@ -217,8 +219,7 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final delta = <String, double?>{};
     final adjusted = <TrainingPackTemplate>[];
     for (final t in list) {
-      stats[t.id] =
-          service.statFor(t.id) ??
+      stats[t.id] = service.statFor(t.id) ??
           await TrainingPackStatsService.getStats(t.id);
       final hist = await TrainingPackStatsService.history(t.id);
       if (hist.length >= 2) {
@@ -359,14 +360,14 @@ class _PackCard extends StatelessWidget {
     final label = completed
         ? 'Пройдено'
         : progress > 0
-        ? 'Продолжить'
-        : 'Начать';
+            ? 'Продолжить'
+            : 'Начать';
     final color = completed ? Colors.green : Colors.orange;
-    final spotlight = context.watch<DailySpotlightService>().template?.id ==
-        template.id;
+    final spotlight =
+        context.watch<DailySpotlightService>().template?.id == template.id;
     final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(
-      template.id,
-    );
+          template.id,
+        );
     final ev = stat?.postEvPct ?? 0;
     final icm = stat?.postIcmPct ?? 0;
     final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
@@ -452,8 +453,8 @@ class _PackCard extends StatelessWidget {
                 ? null
                 : () async {
                     await context.read<TrainingSessionService>().startSession(
-                      template,
-                    );
+                          template,
+                        );
                     if (context.mounted) {
                       await Navigator.push(
                         context,
@@ -479,8 +480,8 @@ class _PackCard extends StatelessWidget {
                     .review(context, template.id);
                 if (review != null && context.mounted) {
                   await context.read<TrainingSessionService>().startSession(
-                    review,
-                  );
+                        review,
+                      );
                   if (context.mounted) {
                     await Navigator.push(
                       context,

--- a/lib/widgets/tag_progress_card.dart
+++ b/lib/widgets/tag_progress_card.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_mastery_service.dart';
+import '../screens/skill_map_screen.dart';
+import '../screens/tag_skill_detail_screen.dart';
+
+class TagProgressCard extends StatelessWidget {
+  const TagProgressCard({super.key});
+
+  String _capitalize(String s) =>
+      s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
+
+  Future<List<MapEntry<String, double>>> _load(BuildContext context) async {
+    final map = await context.read<TagMasteryService>().computeMastery();
+    final list = map.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+    return list.take(3).toList();
+  }
+
+  void _openTag(BuildContext context, String tag) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TagSkillDetailScreen(tag: tag)),
+    );
+  }
+
+  void _openSkillMap(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SkillMapScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<MapEntry<String, double>>>(
+      future: _load(context),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+        final list = snapshot.data!;
+        if (list.isEmpty) return const SizedBox.shrink();
+
+        Widget row(MapEntry<String, double> e) {
+          final value = e.value.clamp(0.0, 1.0);
+          final color =
+              Color.lerp(Colors.red, Colors.green, value) ?? Colors.red;
+          final icon = value < 0.3 ? ' ⚠️' : '';
+          final name = _capitalize(e.key);
+          return GestureDetector(
+            onTap: () => _openTag(context, e.key),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '$name$icon',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  const SizedBox(height: 2),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: value,
+                      backgroundColor: Colors.white24,
+                      valueColor: AlwaysStoppedAnimation<Color>(color),
+                      minHeight: 6,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${(value * 100).toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return GestureDetector(
+          onTap: () => _openSkillMap(context),
+          child: Container(
+            margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Row(
+                  children: [
+                    Icon(Icons.flag, color: Colors.amberAccent),
+                    SizedBox(width: 8),
+                    Text(
+                      'Слабые навыки',
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                for (final e in list) row(e),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TagProgressCard` widget to visualize weakest tags
- show weakest tags on dashboard

## Testing
- `dart format lib/widgets/tag_progress_card.dart lib/screens/training_home_screen.dart`
- `flutter analyze` *(fails: many existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_687da6d90db8832a9c609cf71114585e