### PR TITLE
Add TrainingStatsScreenV2

### DIFF
--- a/lib/models/training_stats_v2.dart
+++ b/lib/models/training_stats_v2.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'session_log.dart';
+import 'v2/training_pack_template_v2.dart';
+import 'v2/hero_position.dart';
+
+class TrainingStatsV2Model {
+  final int totalHands;
+  final double accuracy;
+  final Map<HeroPosition, int> handsByPosition;
+  final Map<HeroPosition, double> accuracyByPosition;
+  final Map<int, int> handsByStack;
+  final Map<int, double> accuracyByStack;
+  final Map<String, double> accuracyByTag;
+
+  TrainingStatsV2Model({
+    required this.totalHands,
+    required this.accuracy,
+    required this.handsByPosition,
+    required this.accuracyByPosition,
+    required this.handsByStack,
+    required this.accuracyByStack,
+    required this.accuracyByTag,
+  });
+
+  static TrainingStatsV2Model compute({
+    required List<SessionLog> logs,
+    required List<TrainingPackTemplateV2> library,
+    DateTimeRange? range,
+    HeroPosition? position,
+    int? stack,
+    String? tag,
+  }) {
+    final byId = {for (final t in library) t.id: t};
+    int totalHands = 0;
+    int totalCorrect = 0;
+    final posHands = <HeroPosition, int>{};
+    final posCorrect = <HeroPosition, int>{};
+    final stackHands = <int, int>{};
+    final stackCorrect = <int, int>{};
+    final tagHands = <String, int>{};
+    final tagCorrect = <String, int>{};
+    for (final log in logs) {
+      if (range != null) {
+        if (log.completedAt.isBefore(range.start) ||
+            log.completedAt.isAfter(range.end)) {
+          continue;
+        }
+      }
+      final tpl = byId[log.templateId];
+      if (tpl == null) continue;
+      final positions = tpl.positions.isNotEmpty
+          ? tpl.positions.map(parseHeroPosition).toList()
+          : [HeroPosition.unknown];
+      final bb = tpl.bb;
+      final tags = [for (final t in tpl.tags) t.toLowerCase()];
+      if (position != null && !positions.contains(position)) continue;
+      if (stack != null && bb != stack) continue;
+      if (tag != null && !tags.contains(tag.toLowerCase())) continue;
+      final hands = log.correctCount + log.mistakeCount;
+      final correct = log.correctCount;
+      totalHands += hands;
+      totalCorrect += correct;
+      for (final p in positions) {
+        posHands[p] = (posHands[p] ?? 0) + hands;
+        posCorrect[p] = (posCorrect[p] ?? 0) + correct;
+      }
+      stackHands[bb] = (stackHands[bb] ?? 0) + hands;
+      stackCorrect[bb] = (stackCorrect[bb] ?? 0) + correct;
+      for (final tg in tags) {
+        tagHands[tg] = (tagHands[tg] ?? 0) + hands;
+        tagCorrect[tg] = (tagCorrect[tg] ?? 0) + correct;
+      }
+    }
+    double calc(int c, int h) => h > 0 ? c / h : 0.0;
+    final accByPos = {
+      for (final p in posHands.keys) p: calc(posCorrect[p] ?? 0, posHands[p]!)
+    };
+    final accByStack = {
+      for (final s in stackHands.keys)
+        s: calc(stackCorrect[s] ?? 0, stackHands[s]!)
+    };
+    final accByTag = {
+      for (final t in tagHands.keys) t: calc(tagCorrect[t] ?? 0, tagHands[t]!)
+    };
+    final overall = calc(totalCorrect, totalHands);
+    return TrainingStatsV2Model(
+      totalHands: totalHands,
+      accuracy: overall,
+      handsByPosition: posHands,
+      accuracyByPosition: accByPos,
+      handsByStack: stackHands,
+      accuracyByStack: accByStack,
+      accuracyByTag: accByTag,
+    );
+  }
+}

--- a/lib/screens/training_stats_screen_v2.dart
+++ b/lib/screens/training_stats_screen_v2.dart
@@ -1,0 +1,283 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../models/training_stats_v2.dart';
+import '../models/v2/hero_position.dart';
+import '../services/session_log_service.dart';
+import '../services/pack_library_loader_service.dart';
+
+enum StatsRange { today, week, month, all }
+
+class TrainingStatsScreenV2 extends StatefulWidget {
+  const TrainingStatsScreenV2({super.key});
+
+  @override
+  State<TrainingStatsScreenV2> createState() => _TrainingStatsScreenV2State();
+}
+
+class _TrainingStatsScreenV2State extends State<TrainingStatsScreenV2> {
+  StatsRange _range = StatsRange.all;
+  HeroPosition? _position;
+  int? _stack;
+  String? _tag;
+  TrainingStatsV2Model? _stats;
+  bool _loading = true;
+  List<int> _allStacks = [];
+  List<String> _allTags = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  DateTimeRange? _rangeToDates() {
+    final now = DateTime.now();
+    switch (_range) {
+      case StatsRange.today:
+        final start = DateTime(now.year, now.month, now.day);
+        return DateTimeRange(start: start, end: now);
+      case StatsRange.week:
+        final start = DateTime(now.year, now.month, now.day)
+            .subtract(const Duration(days: 6));
+        return DateTimeRange(start: start, end: now);
+      case StatsRange.month:
+        final start = DateTime(now.year, now.month, now.day)
+            .subtract(const Duration(days: 29));
+        return DateTimeRange(start: start, end: now);
+      case StatsRange.all:
+        return null;
+    }
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final logService = context.read<SessionLogService>();
+    await logService.load();
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = PackLibraryLoaderService.instance.library;
+    _allStacks = {for (final t in library) t.bb}.toList()..sort();
+    _allTags = {
+      for (final t in library)
+        for (final tag in t.tags) tag.toLowerCase()
+    }.toList()
+      ..sort();
+    final stats = TrainingStatsV2Model.compute(
+      logs: logService.logs,
+      library: library,
+      range: _rangeToDates(),
+      position: _position,
+      stack: _stack,
+      tag: _tag,
+    );
+    setState(() {
+      _stats = stats;
+      _loading = false;
+    });
+  }
+
+  Color _tagColor(double v) {
+    return Color.lerp(Colors.red, Colors.green, v) ?? Colors.green;
+  }
+
+  Widget _buildTagHeatmap(TrainingStatsV2Model stats) {
+    if (stats.accuracyByTag.isEmpty) return const SizedBox();
+    final maxVal = stats.accuracyByTag.values.reduce(math.max);
+    final items = stats.accuracyByTag.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return Wrap(
+      spacing: 4,
+      runSpacing: 4,
+      children: [
+        for (final e in items)
+          Container(
+            padding: const EdgeInsets.all(4),
+            color: _tagColor(maxVal == 0 ? 0 : e.value / maxVal),
+            child: Text('${e.key} ${(e.value * 100).toStringAsFixed(0)}%',
+                style: const TextStyle(color: Colors.white, fontSize: 10)),
+          )
+      ],
+    );
+  }
+
+  Widget _buildStackChart(TrainingStatsV2Model stats) {
+    if (stats.accuracyByStack.isEmpty) return const SizedBox(height: 160);
+    final stacks = stats.accuracyByStack.keys.toList()..sort();
+    final groups = <BarChartGroupData>[];
+    double maxY = 0;
+    for (var i = 0; i < stacks.length; i++) {
+      final s = stacks[i];
+      final acc = stats.accuracyByStack[s]! * 100;
+      if (acc > maxY) maxY = acc;
+      groups.add(BarChartGroupData(x: i, barRods: [
+        BarChartRodData(
+            toY: acc,
+            width: 8,
+            borderRadius: BorderRadius.circular(2),
+            color: Colors.blueAccent),
+      ]));
+    }
+    return SizedBox(
+      height: 160,
+      child: BarChart(
+        BarChartData(
+          maxY: maxY <= 0 ? 1 : maxY,
+          minY: 0,
+          barGroups: groups,
+          titlesData: FlTitlesData(
+            leftTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  final idx = value.toInt();
+                  if (idx < 0 || idx >= stacks.length) return const SizedBox();
+                  return Text('${stacks[idx]}bb',
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 10));
+                },
+              ),
+            ),
+          ),
+          gridData: const FlGridData(show: false),
+          borderData: FlBorderData(show: false),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPositionPie(TrainingStatsV2Model stats) {
+    if (stats.handsByPosition.isEmpty) return const SizedBox(height: 160);
+    final entries = stats.handsByPosition.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final total = stats.totalHands;
+    final sections = <PieChartSectionData>[];
+    for (final e in entries) {
+      final pct = total > 0 ? e.value * 100 / total : 0;
+      sections.add(PieChartSectionData(
+        value: e.value.toDouble(),
+        title: '${e.key.label} ${pct.toStringAsFixed(0)}%',
+        radius: 40,
+        titleStyle: const TextStyle(color: Colors.white, fontSize: 10),
+      ));
+    }
+    return SizedBox(
+      height: 160,
+      child: PieChart(PieChartData(sectionsSpace: 2, sections: sections)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = _stats;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Training Stats'),
+      ),
+      body: _loading || stats == null
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Row(
+                  children: [
+                    DropdownButton<StatsRange>(
+                      value: _range,
+                      dropdownColor: Colors.grey[900],
+                      items: const [
+                        DropdownMenuItem(
+                            value: StatsRange.today, child: Text('Today')),
+                        DropdownMenuItem(
+                            value: StatsRange.week, child: Text('7d')),
+                        DropdownMenuItem(
+                            value: StatsRange.month, child: Text('30d')),
+                        DropdownMenuItem(
+                            value: StatsRange.all, child: Text('All')),
+                      ],
+                      onChanged: (v) {
+                        if (v != null) setState(() => _range = v);
+                        _load();
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    DropdownButton<HeroPosition?>(
+                      value: _position,
+                      hint: const Text('Pos',
+                          style: TextStyle(color: Colors.white70)),
+                      dropdownColor: Colors.grey[900],
+                      items: [
+                        const DropdownMenuItem(value: null, child: Text('All')),
+                        for (final p in kPositionOrder)
+                          DropdownMenuItem(value: p, child: Text(p.label)),
+                      ],
+                      onChanged: (v) {
+                        setState(() => _position = v);
+                        _load();
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    DropdownButton<int?>(
+                      value: _stack,
+                      hint: const Text('Stack',
+                          style: TextStyle(color: Colors.white70)),
+                      dropdownColor: Colors.grey[900],
+                      items: [
+                        const DropdownMenuItem(value: null, child: Text('All')),
+                        for (final s in _allStacks)
+                          DropdownMenuItem(value: s, child: Text('${s}bb')),
+                      ],
+                      onChanged: (v) {
+                        setState(() => _stack = v);
+                        _load();
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    DropdownButton<String?>(
+                      value: _tag,
+                      hint: const Text('Tag',
+                          style: TextStyle(color: Colors.white70)),
+                      dropdownColor: Colors.grey[900],
+                      items: [
+                        const DropdownMenuItem(value: null, child: Text('All')),
+                        for (final t in _allTags)
+                          DropdownMenuItem(value: t, child: Text(t)),
+                      ],
+                      onChanged: (v) {
+                        setState(() => _tag = v);
+                        _load();
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Text('Total hands: ${stats.totalHands}',
+                    style: const TextStyle(color: Colors.white)),
+                Text('Accuracy: ${(stats.accuracy * 100).toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 16),
+                const Text('Accuracy by Tag',
+                    style: TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                _buildTagHeatmap(stats),
+                const SizedBox(height: 16),
+                const Text('Accuracy by Stack',
+                    style: TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                _buildStackChart(stats),
+                const SizedBox(height: 16),
+                const Text('Hands by Position',
+                    style: TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                _buildPositionPie(stats),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingStatsV2Model` for aggregating session logs
- implement `TrainingStatsScreenV2` with filters and charts

## Testing
- `flutter analyze` *(fails: 6642 issues found)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687dad16cf40832a9b80c2e7a5cba222