### PR TITLE
Add progress tracking for learning paths

### DIFF
--- a/assets/learning_paths/sample_path.yaml
+++ b/assets/learning_paths/sample_path.yaml
@@ -11,3 +11,11 @@ stages:
     packId: pack1
     requiredAccuracy: 80
     minHands: 10
+    unlocks:
+      - s2
+  - id: s2
+    title: Stage Two
+    description: Second stage
+    packId: pack2
+    requiredAccuracy: 70
+    minHands: 5

--- a/lib/services/training_path_progress_service_v2.dart
+++ b/lib/services/training_path_progress_service_v2.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../models/learning_path_stage_model.dart';
+import 'learning_path_registry_service.dart';
+import 'session_log_service.dart';
+
+class TrainingPathProgressServiceV2 {
+  final SessionLogService logs;
+  final LearningPathRegistryService registry;
+
+  TrainingPathProgressServiceV2({
+    required this.logs,
+    LearningPathRegistryService? registry,
+  }) : registry = registry ?? LearningPathRegistryService.instance;
+
+  String? _pathId;
+  LearningPathTemplateV2? _template;
+  final Map<String, _StageProgress> _progress = {};
+  final Set<String> _unlocked = {};
+
+  Future<void> loadProgress(String pathId) async {
+    final templates = await registry.loadAll();
+    _template = templates.firstWhereOrNull((e) => e.id == pathId);
+    if (_template == null) return;
+    _pathId = pathId;
+    final prefs = await SharedPreferences.getInstance();
+    _progress.clear();
+    for (final stage in _template!.stages) {
+      final acc = prefs.getDouble(_accKey(stage.id)) ?? 0.0;
+      final hands = prefs.getInt(_handsKey(stage.id)) ?? 0;
+      _progress[stage.id] = _StageProgress(accuracy: acc, hands: hands);
+    }
+    _recomputeUnlocked();
+  }
+
+  Future<void> markStageCompleted(String stageId, double accuracy) async {
+    if (_pathId == null || _template == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    final stage =
+        _template!.stages.firstWhereOrNull((s) => s.id == stageId);
+    if (stage == null) return;
+    final stats = _computeStats(stage);
+    final acc = accuracy.isNaN ? stats.accuracy : accuracy;
+    final prog = _StageProgress(accuracy: acc, hands: stats.hands);
+    _progress[stageId] = prog;
+    await prefs.setDouble(_accKey(stageId), prog.accuracy);
+    await prefs.setInt(_handsKey(stageId), prog.hands);
+    _recomputeUnlocked();
+  }
+
+  bool isStageUnlocked(String stageId) => _unlocked.contains(stageId);
+
+  double getStageAccuracy(String stageId) =>
+      _progress[stageId]?.accuracy ?? 0.0;
+
+  List<String> unlockedStageIds() => List.unmodifiable(_unlocked);
+
+  // --- internal helpers ---
+
+  String _prefix(String stageId) => 'training_path_v2_${_pathId ?? ''}_$stageId';
+  String _accKey(String stageId) => '${_prefix(stageId)}_acc';
+  String _handsKey(String stageId) => '${_prefix(stageId)}_hands';
+
+  _StageProgress _computeStats(LearningPathStageModel stage) {
+    var hands = 0;
+    var correct = 0;
+    for (final log in logs.logs) {
+      if (log.templateId == stage.packId) {
+        hands += log.correctCount + log.mistakeCount;
+        correct += log.correctCount;
+      }
+    }
+    final acc = hands == 0 ? 0.0 : correct / hands * 100;
+    return _StageProgress(accuracy: acc, hands: hands);
+  }
+
+  void _recomputeUnlocked() {
+    _unlocked.clear();
+    if (_template == null) return;
+
+    final prereq = <String, Set<String>>{};
+    for (final s in _template!.stages) {
+      for (final u in s.unlocks) {
+        prereq.putIfAbsent(u, () => <String>{}).add(s.id);
+      }
+    }
+
+    final completed = <String>{};
+    final queue = <String>[for (final s in _template!.entryStages) s.id];
+
+    while (queue.isNotEmpty) {
+      final id = queue.removeAt(0);
+      if (_unlocked.contains(id)) continue;
+      _unlocked.add(id);
+      final stage = _template!.stages.firstWhere((e) => e.id == id);
+      final prog = _progress[id];
+      final done = prog != null &&
+          prog.hands >= stage.minHands &&
+          prog.accuracy >= stage.requiredAccuracy;
+      if (done) {
+        completed.add(id);
+        for (final next in stage.unlocks) {
+          final deps = prereq[next] ?? const <String>{};
+          if (deps.every(completed.contains)) {
+            queue.add(next);
+          }
+        }
+      }
+    }
+  }
+}
+
+class _StageProgress {
+  double accuracy;
+  int hands;
+  _StageProgress({this.accuracy = 0.0, this.hands = 0});
+}

--- a/test/services/training_path_progress_service_v2_test.dart
+++ b/test/services/training_path_progress_service_v2_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/learning_path_registry_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLogService extends SessionLogService {
+  List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+
+  @override
+  Future<void> load() async {}
+
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await LearningPathRegistryService.instance.loadAll();
+  });
+
+  test('stage unlocks after completion', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 8,
+        mistakeCount: 2,
+      ),
+    ];
+    final svc = TrainingPathProgressServiceV2(logs: _FakeLogService(logs));
+    await svc.loadProgress('sample');
+    expect(svc.isStageUnlocked('s1'), isTrue);
+    expect(svc.isStageUnlocked('s2'), isFalse);
+
+    await svc.markStageCompleted('s1', 80);
+    expect(svc.isStageUnlocked('s2'), isTrue);
+    expect(svc.getStageAccuracy('s1'), closeTo(80, 0.1));
+  });
+
+  test('stage remains locked when requirements unmet', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 4,
+        mistakeCount: 6,
+      ),
+    ];
+    final svc = TrainingPathProgressServiceV2(logs: _FakeLogService(logs));
+    await svc.loadProgress('sample');
+    await svc.markStageCompleted('s1', 40);
+    expect(svc.isStageUnlocked('s2'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- update `sample_path.yaml` with a second stage
- implement `TrainingPathProgressServiceV2` for path progress tracking
- test unlocking logic for the new service

## Testing
- `flutter test test/services/training_path_progress_service_v2_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dceb8f62c832aa746a0948a5cfe53