### PR TITLE
Add TrackSectionWidget and LearningPathCard

### DIFF
--- a/lib/widgets/learning_path_card.dart
+++ b/lib/widgets/learning_path_card.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../theme/app_colors.dart';
+
+class LearningPathCard extends StatelessWidget {
+  final LearningPathTemplateV2 template;
+  final VoidCallback? onTap;
+
+  const LearningPathCard({
+    super.key,
+    required this.template,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              template.title,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            if (template.description.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  template.description,
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ),
+            if (template.recommendedFor != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  template.recommendedFor!,
+                  style: const TextStyle(color: Colors.orange, fontSize: 12),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/track_section_widget.dart
+++ b/lib/widgets/track_section_widget.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_track_model.dart';
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_card.dart';
+
+class TrackSectionWidget extends StatelessWidget {
+  final LearningPathTrackModel track;
+  final List<LearningPathTemplateV2> paths;
+
+  const TrackSectionWidget({
+    super.key,
+    required this.track,
+    required this.paths,
+  });
+
+  int _orderOf(LearningPathTemplateV2 p) {
+    try {
+      final value = (p as dynamic).order;
+      if (value is int) return value;
+    } catch (_) {}
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final list = List<LearningPathTemplateV2>.from(paths)
+      ..sort((a, b) => _orderOf(a).compareTo(_orderOf(b)));
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              track.title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+          ),
+          if (track.description.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Text(
+                track.description,
+                style: const TextStyle(color: Colors.white70),
+              ),
+            ),
+          if (track.recommendedFor != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Text(
+                track.recommendedFor!,
+                style: TextStyle(color: accent, fontSize: 12),
+              ),
+            ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                for (final p in list)
+                  SizedBox(
+                    width: 180,
+                    child: LearningPathCard(template: p),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `LearningPathCard` for showing basic path info
- implement `TrackSectionWidget` which groups multiple `LearningPathCard` entries under a track header

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd91b0860832abf9c54d016398d47