### PR TITLE
Implement LearningPathLibraryScreen

### DIFF
--- a/lib/repositories/learning_path_repository.dart
+++ b/lib/repositories/learning_path_repository.dart
@@ -1,0 +1,35 @@
+import 'package:collection/collection.dart';
+
+import '../models/learning_path_track_model.dart';
+import '../models/learning_path_template_v2.dart';
+import '../services/learning_path_registry_service.dart';
+import '../services/learning_path_track_library_service.dart';
+
+/// Provides helpers to load learning path tracks and their templates.
+class LearningPathRepository {
+  final LearningPathRegistryService registry;
+  final LearningPathTrackLibraryService tracks;
+
+  LearningPathRepository({
+    LearningPathRegistryService? registry,
+    LearningPathTrackLibraryService? trackLibrary,
+  })  : registry = registry ?? LearningPathRegistryService.instance,
+        tracks = trackLibrary ?? LearningPathTrackLibraryService.instance;
+
+  /// Loads all tracks and their learning paths.
+  Future<Map<LearningPathTrackModel, List<LearningPathTemplateV2>>>
+      loadAllTracksWithPaths() async {
+    await tracks.reload();
+    final templates = await registry.loadAll();
+    final result = <LearningPathTrackModel, List<LearningPathTemplateV2>>{};
+    for (final track in tracks.tracks) {
+      final list = <LearningPathTemplateV2>[];
+      for (final id in track.pathIds) {
+        final tpl = templates.firstWhereOrNull((t) => t.id == id);
+        if (tpl != null) list.add(tpl);
+      }
+      result[track] = list;
+    }
+    return result;
+  }
+}

--- a/lib/screens/learning_path_library_screen.dart
+++ b/lib/screens/learning_path_library_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../repositories/learning_path_repository.dart';
+import '../models/learning_path_track_model.dart';
+import '../models/learning_path_template_v2.dart';
+import '../widgets/track_section_widget.dart';
+
+/// Displays all available learning path tracks and their paths.
+class LearningPathLibraryScreen extends StatefulWidget {
+  const LearningPathLibraryScreen({super.key});
+
+  @override
+  State<LearningPathLibraryScreen> createState() => _LearningPathLibraryScreenState();
+}
+
+class _LearningPathLibraryScreenState extends State<LearningPathLibraryScreen> {
+  late Future<Map<LearningPathTrackModel, List<LearningPathTemplateV2>>> _future;
+  final _repo = LearningPathRepository();
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _repo.loadAllTracksWithPaths();
+  }
+
+  Future<void> _reload() async {
+    setState(() => _future = _repo.loadAllTracksWithPaths());
+    await _future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Map<LearningPathTrackModel, List<LearningPathTemplateV2>>>(
+      future: _future,
+      builder: (context, snapshot) {
+        final data = snapshot.data ?? const {};
+        return Scaffold(
+          appBar: AppBar(title: const Text('📚 Обучающие треки')),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : data.isEmpty
+                  ? const Center(child: Text('Нет доступных треков'))
+                  : RefreshIndicator(
+                      onRefresh: _reload,
+                      child: ListView(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        children: [
+                          for (final entry in data.entries)
+                            TrackSectionWidget(
+                              track: entry.key,
+                              paths: entry.value,
+                            ),
+                        ],
+                      ),
+                    ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LearningPathRepository` for combining track and template data
- add `LearningPathLibraryScreen` to display all tracks and paths with `TrackSectionWidget`

## Testing
- `flutter analyze` *(fails: `The name 'YamlEncoder' isn't a class` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687de0596260832aaed7f0639582eacb