### PR TITLE
Implement LearningPathProgressEngine

### DIFF
--- a/lib/services/learning_path_progress_engine.dart
+++ b/lib/services/learning_path_progress_engine.dart
@@ -1,0 +1,117 @@
+import 'dart:math';
+import 'package:collection/collection.dart';
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_registry_service.dart';
+import 'learning_path_track_library_service.dart';
+import 'pack_library_service.dart';
+import 'session_log_service.dart';
+
+/// Callback for resolving training pack spot count.
+typedef PackSizeLoader = Future<int?> Function(String packId);
+
+/// Computes user progress across learning paths.
+class LearningPathProgressEngine {
+  final SessionLogService logs;
+  final LearningPathRegistryService registry;
+  final LearningPathTrackLibraryService tracks;
+  final PackSizeLoader _packSize;
+
+  LearningPathProgressEngine({
+    required this.logs,
+    LearningPathRegistryService? registry,
+    LearningPathTrackLibraryService? trackLibrary,
+    PackSizeLoader? packSizeLoader,
+  })  : registry = registry ?? LearningPathRegistryService.instance,
+        tracks = trackLibrary ?? LearningPathTrackLibraryService.instance,
+        _packSize = packSizeLoader ?? _defaultPackSize;
+
+  static Future<int?> _defaultPackSize(String id) async {
+    final tpl = await PackLibraryService.instance.getById(id);
+    if (tpl == null) return null;
+    return tpl.spots.isNotEmpty ? tpl.spots.length : tpl.spotCount;
+  }
+
+  Map<String, double> _pathProgress = {};
+  DateTime _lastComputed = DateTime.fromMillisecondsSinceEpoch(0);
+  Future<void>? _loading;
+
+  Future<void> _ensureData() async {
+    if (_loading != null) {
+      await _loading;
+      return;
+    }
+    if (_pathProgress.isNotEmpty &&
+        DateTime.now().difference(_lastComputed) <
+            const Duration(minutes: 5)) {
+      return;
+    }
+    final future = _compute();
+    _loading = future;
+    await future;
+    _loading = null;
+  }
+
+  Future<void> _compute() async {
+    await logs.load();
+    final handsByPack = <String, int>{};
+    for (final l in logs.logs) {
+      final count = l.correctCount + l.mistakeCount;
+      handsByPack.update(l.templateId, (v) => v + count, ifAbsent: () => count);
+    }
+
+    final templates = await registry.loadAll();
+    _pathProgress.clear();
+    for (final t in templates) {
+      final progress = await _computePath(t, handsByPack);
+      _pathProgress[t.id] = progress;
+    }
+    _lastComputed = DateTime.now();
+  }
+
+  Future<double> _computePath(
+    LearningPathTemplateV2 template,
+    Map<String, int> handsByPack,
+  ) async {
+    var played = 0;
+    var total = 0;
+    for (final stage in template.stages) {
+      final size = await _packSize(stage.packId) ?? 0;
+      if (size <= 0) continue;
+      final hands = handsByPack[stage.packId] ?? 0;
+      played += min(hands, size);
+      total += size;
+    }
+    if (total == 0) return 0.0;
+    return played / total;
+  }
+
+  /// Returns completion ratio for [pathId].
+  Future<double> getPathProgress(String pathId) async {
+    await _ensureData();
+    return _pathProgress[pathId] ?? 0.0;
+  }
+
+  /// Returns average progress across all paths in [trackId].
+  Future<double> getTrackProgress(String trackId) async {
+    await _ensureData();
+    await tracks.reload();
+    final track = tracks.getById(trackId);
+    if (track == null || track.pathIds.isEmpty) return 0.0;
+    final values = track.pathIds
+        .map((id) => _pathProgress[id])
+        .whereNotNull()
+        .toList();
+    if (values.isEmpty) return 0.0;
+    final sum = values.reduce((a, b) => a + b);
+    return sum / values.length;
+  }
+
+  /// Returns progress for all loaded learning paths.
+  Future<Map<String, double>> getAllPathProgress() async {
+    await _ensureData();
+    return Map.unmodifiable(_pathProgress);
+  }
+
+  /// Clears cached results forcing recomputation on next call.
+  void clearCache() => _pathProgress.clear();
+}

--- a/test/services/learning_path_progress_engine_test.dart
+++ b/test/services/learning_path_progress_engine_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_progress_engine.dart';
+import 'package:poker_analyzer/services/learning_path_registry_service.dart';
+import 'package:poker_analyzer/services/learning_path_track_library_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await LearningPathRegistryService.instance.loadAll();
+    await LearningPathTrackLibraryService.instance.reload();
+  });
+
+  test('computes path and track progress', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 10,
+        mistakeCount: 0,
+      ),
+      SessionLog(
+        sessionId: '2',
+        templateId: 'pack2',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 5,
+        mistakeCount: 0,
+      ),
+    ];
+
+    final engine = LearningPathProgressEngine(
+      logs: _FakeLogService(logs),
+      packSizeLoader: (id) async => id == 'pack1' ? 10 : 20,
+    );
+
+    final pathProg = await engine.getPathProgress('sample');
+    expect(pathProg, closeTo(0.5, 0.01));
+
+    final trackProg = await engine.getTrackProgress('fundamentals');
+    expect(trackProg, closeTo(0.5, 0.01));
+
+    final all = await engine.getAllPathProgress();
+    expect(all['sample'], closeTo(0.5, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathProgressEngine` service for computing learning path and track completion
- cover new engine with unit test

## Testing
- `flutter analyze` *(fails: The project has many existing issues)*
- `flutter test test/services/learning_path_progress_engine_test.dart` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687de2ef562c832ab5c97b3faa6b7dc9