### PR TITLE
Add LearningPathStageWidget

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -6,6 +6,7 @@ import '../models/learning_path_stage_model.dart';
 import '../services/pack_library_service.dart';
 import '../services/session_log_service.dart';
 import '../services/training_session_launcher.dart';
+import '../widgets/learning_path_stage_widget.dart';
 
 /// Displays all stages of a learning path and allows launching each pack.
 class LearningPathScreen extends StatefulWidget {
@@ -53,28 +54,11 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
 
   Widget _buildStageTile(LearningPathStageModel stage) {
     final hands = _handsPlayed(stage.packId);
-    final progress = '$hands/${stage.minHands} hands';
-    final label = hands == 0 ? 'Начать' : 'Продолжить';
-
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 16),
-      child: ListTile(
-        title: Text(stage.title),
-        subtitle: stage.description.isNotEmpty
-            ? Text(stage.description)
-            : null,
-        trailing: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(progress),
-            const SizedBox(height: 4),
-            ElevatedButton(
-              onPressed: () => _startStage(stage),
-              child: Text(label),
-            ),
-          ],
-        ),
-      ),
+    final ratio = stage.minHands == 0 ? 1.0 : hands / stage.minHands;
+    return LearningPathStageWidget(
+      stage: stage,
+      progress: ratio.clamp(0.0, 1.0),
+      onPressed: () => _startStage(stage),
     );
   }
 

--- a/lib/widgets/learning_path_stage_widget.dart
+++ b/lib/widgets/learning_path_stage_widget.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_stage_model.dart';
+import 'tag_badge.dart';
+
+/// Reusable widget displaying a single stage of a learning path.
+class LearningPathStageWidget extends StatelessWidget {
+  final LearningPathStageModel stage;
+  final double progress;
+  final VoidCallback onPressed;
+
+  const LearningPathStageWidget({
+    super.key,
+    required this.stage,
+    required this.progress,
+    required this.onPressed,
+  });
+
+  String _ctaLabel() {
+    if (progress >= 1.0) return 'Завершено';
+    if (progress > 0.0) return 'Продолжить';
+    return 'Начать';
+  }
+
+  Color _progressColor(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    if (progress >= 1.0) return Colors.green;
+    if (progress > 0.0) return accent;
+    return Colors.grey;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pctText = '${(progress.clamp(0.0, 1.0) * 100).round()}%';
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        stage.title,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (stage.description.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            stage.description,
+                            style:
+                                const TextStyle(color: Colors.white70, fontSize: 12),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                Text(pctText, style: const TextStyle(color: Colors.white70)),
+              ],
+            ),
+            if (stage.tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Wrap(
+                  spacing: 4,
+                  runSpacing: -4,
+                  children: [for (final t in stage.tags) TagBadge(t)],
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: progress.clamp(0.0, 1.0),
+                  backgroundColor: Colors.white24,
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(_progressColor(context)),
+                  minHeight: 6,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: progress >= 1.0 ? null : onPressed,
+                child: Text(_ctaLabel()),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/tag_badge.dart
+++ b/lib/widgets/tag_badge.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Simple visual badge for displaying a training tag.
+class TagBadge extends StatelessWidget {
+  final String tag;
+  const TagBadge(this.tag, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text(
+        tag,
+        style: const TextStyle(color: Colors.white, fontSize: 11),
+      ),
+      backgroundColor: const Color(0xFF3A3B3E),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TagBadge` for rendering tag labels consistently
- add `LearningPathStageWidget` to display stage info with progress and CTA
- use the new widget in `LearningPathScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de8eec5b8832a94d1bb76e3cc517d