### PR TITLE
Add learning path stage completion engine

### DIFF
--- a/lib/services/learning_path_stage_completion_engine.dart
+++ b/lib/services/learning_path_stage_completion_engine.dart
@@ -1,0 +1,24 @@
+import '../models/learning_path_stage_model.dart';
+import '../models/learning_path_template_v2.dart';
+
+/// Determines completion status for learning path stages and entire paths.
+class LearningPathStageCompletionEngine {
+  const LearningPathStageCompletionEngine();
+
+  /// Returns `true` if [handsPlayed] meets or exceeds [stage.minHands].
+  bool isStageComplete(LearningPathStageModel stage, int handsPlayed) {
+    return handsPlayed >= stage.minHands;
+  }
+
+  /// Returns `true` if all stages in [path] are complete.
+  bool isPathComplete(
+    LearningPathTemplateV2 path,
+    Map<String, int> handsPlayedByPackId,
+  ) {
+    for (final stage in path.stages) {
+      final hands = handsPlayedByPackId[stage.packId] ?? 0;
+      if (!isStageComplete(stage, hands)) return false;
+    }
+    return true;
+  }
+}

--- a/test/services/learning_path_stage_completion_engine_test.dart
+++ b/test/services/learning_path_stage_completion_engine_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_stage_completion_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final engine = const LearningPathStageCompletionEngine();
+
+  LearningPathTemplateV2 _samplePath() => LearningPathTemplateV2(
+        id: 'p',
+        title: 'Path',
+        description: '',
+        stages: [
+          const LearningPathStageModel(
+            id: 's1',
+            title: 'Stage 1',
+            description: '',
+            packId: 'pack1',
+            requiredAccuracy: 0,
+            minHands: 10,
+          ),
+          const LearningPathStageModel(
+            id: 's2',
+            title: 'Stage 2',
+            description: '',
+            packId: 'pack2',
+            requiredAccuracy: 0,
+            minHands: 5,
+          ),
+        ],
+      );
+
+  test('isStageComplete checks minHands', () {
+    final stage = _samplePath().stages.first;
+    expect(engine.isStageComplete(stage, 9), isFalse);
+    expect(engine.isStageComplete(stage, 10), isTrue);
+  });
+
+  test('isPathComplete true when all stages complete', () {
+    final path = _samplePath();
+    final done = engine.isPathComplete(path, {'pack1': 10, 'pack2': 5});
+    expect(done, isTrue);
+  });
+
+  test('isPathComplete false when any stage incomplete', () {
+    final path = _samplePath();
+    final done = engine.isPathComplete(path, {'pack1': 10, 'pack2': 4});
+    expect(done, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathStageCompletionEngine` to check stage/path completion
- add unit tests for completion logic

## Testing
- `flutter analyze` *(fails: 6671 issues found)*
- `flutter test` *(fails to compile due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687deaf0e468832aaa885a1b62ed265c