### PR TITLE
Implement basic learning path unlock logic

### DIFF
--- a/assets/learning_paths/sample_path.yaml
+++ b/assets/learning_paths/sample_path.yaml
@@ -4,6 +4,7 @@ description: Sample learning path for tests.
 tags:
   - sample
   - test
+prerequisitePathIds: []
 stages:
   - id: s1
     title: Stage One

--- a/lib/models/learning_path_template_v2.dart
+++ b/lib/models/learning_path_template_v2.dart
@@ -6,6 +6,7 @@ class LearningPathTemplateV2 {
   final List<LearningPathStageModel> stages;
   final List<String> tags;
   final String? recommendedFor;
+  final List<String> prerequisitePathIds;
 
   const LearningPathTemplateV2({
     required this.id,
@@ -14,8 +15,10 @@ class LearningPathTemplateV2 {
     List<LearningPathStageModel>? stages,
     List<String>? tags,
     this.recommendedFor,
+    List<String>? prerequisitePathIds,
   })  : stages = stages ?? const [],
-        tags = tags ?? const [];
+        tags = tags ?? const [],
+        prerequisitePathIds = prerequisitePathIds ?? const [];
 
   List<LearningPathStageModel> get entryStages {
     final unlockedIds = <String>{};
@@ -36,6 +39,10 @@ class LearningPathTemplateV2 {
       ],
       tags: [for (final t in (json['tags'] as List? ?? [])) t.toString()],
       recommendedFor: json['recommendedFor'] as String?,
+      prerequisitePathIds: [
+        for (final id in (json['prerequisitePathIds'] as List? ?? []))
+          id.toString()
+      ],
     );
   }
 
@@ -46,6 +53,8 @@ class LearningPathTemplateV2 {
         if (stages.isNotEmpty) 'stages': [for (final s in stages) s.toJson()],
         if (tags.isNotEmpty) 'tags': tags,
         if (recommendedFor != null) 'recommendedFor': recommendedFor,
+        if (prerequisitePathIds.isNotEmpty)
+          'prerequisitePathIds': prerequisitePathIds,
       };
 
   factory LearningPathTemplateV2.fromYaml(Map yaml) {

--- a/lib/services/learning_path_unlock_engine.dart
+++ b/lib/services/learning_path_unlock_engine.dart
@@ -1,4 +1,5 @@
 import '../models/v3/lesson_track.dart';
+import '../models/learning_path_template_v2.dart';
 import 'learning_track_engine.dart';
 import 'yaml_lesson_track_loader.dart';
 import 'track_mastery_service.dart';
@@ -217,6 +218,19 @@ class LearningPathUnlockEngine {
     }
 
     return null;
+  }
+
+  /// Returns `true` if [path] has no prerequisites or all of them
+  /// are contained in [completedPathIds].
+  bool isPathUnlocked(
+    LearningPathTemplateV2 path,
+    Set<String> completedPathIds,
+  ) {
+    if (path.prerequisitePathIds.isEmpty) return true;
+    for (final id in path.prerequisitePathIds) {
+      if (!completedPathIds.contains(id)) return false;
+    }
+    return true;
   }
 }
 

--- a/test/learning_path_unlock_engine_path_test.dart
+++ b/test/learning_path_unlock_engine_path_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_unlock_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final engine = LearningPathUnlockEngine.instance;
+
+  LearningPathTemplateV2 _path({List<String>? prereq}) => LearningPathTemplateV2(
+        id: 'p',
+        title: 'Path',
+        description: '',
+        prerequisitePathIds: prereq,
+      );
+
+  test('unlocked when no prerequisites', () {
+    final path = _path();
+    final ok = engine.isPathUnlocked(path, {'a'});
+    expect(ok, isTrue);
+  });
+
+  test('unlocked when all prerequisites completed', () {
+    final path = _path(prereq: ['a', 'b']);
+    final ok = engine.isPathUnlocked(path, {'a', 'b', 'x'});
+    expect(ok, isTrue);
+  });
+
+  test('locked when any prerequisite missing', () {
+    final path = _path(prereq: ['a', 'b']);
+    final ok = engine.isPathUnlocked(path, {'a'});
+    expect(ok, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- support `prerequisitePathIds` in `LearningPathTemplateV2`
- expose `isPathUnlocked` method from `LearningPathUnlockEngine`
- update sample learning path data
- test unlocking rules

## Testing
- `flutter analyze`
- `flutter test test/learning_path_unlock_engine_path_test.dart` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e1334b3c8832a97ef7d5b2e8ca9f9