### PR TITLE
Implement LearningPathStageUnlockEngine

### DIFF
--- a/lib/services/learning_path_stage_unlock_engine.dart
+++ b/lib/services/learning_path_stage_unlock_engine.dart
@@ -1,0 +1,22 @@
+import '../models/learning_path_template_v2.dart';
+
+/// Determines if a stage within a learning path is unlocked.
+class LearningPathStageUnlockEngine {
+  const LearningPathStageUnlockEngine();
+
+  /// Returns `true` if [stageId] is unlocked given the set of
+  /// [completedStageIds].
+  bool isStageUnlocked(
+    LearningPathTemplateV2 path,
+    String stageId,
+    Set<String> completedStageIds,
+  ) {
+    for (final stage in path.stages) {
+      if (stage.unlocks.contains(stageId) &&
+          !completedStageIds.contains(stage.id)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/test/learning_path_stage_unlock_engine_test.dart
+++ b/test/learning_path_stage_unlock_engine_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_stage_unlock_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const engine = LearningPathStageUnlockEngine();
+
+  LearningPathTemplateV2 _path() {
+    return LearningPathTemplateV2(
+      id: 'p',
+      title: 'Path',
+      description: '',
+      stages: [
+        const LearningPathStageModel(
+          id: 'a',
+          title: 'A',
+          description: '',
+          packId: 'pack1',
+          requiredAccuracy: 80,
+          minHands: 1,
+          unlocks: ['b'],
+        ),
+        const LearningPathStageModel(
+          id: 'b',
+          title: 'B',
+          description: '',
+          packId: 'pack2',
+          requiredAccuracy: 70,
+          minHands: 1,
+          unlocks: ['d'],
+        ),
+        const LearningPathStageModel(
+          id: 'c',
+          title: 'C',
+          description: '',
+          packId: 'pack3',
+          requiredAccuracy: 70,
+          minHands: 1,
+          unlocks: ['d'],
+        ),
+        const LearningPathStageModel(
+          id: 'd',
+          title: 'D',
+          description: '',
+          packId: 'pack4',
+          requiredAccuracy: 70,
+          minHands: 1,
+        ),
+      ],
+    );
+  }
+
+  test('root stage is unlocked', () {
+    final path = _path();
+    final ok = engine.isStageUnlocked(path, 'a', <String>{});
+    expect(ok, isTrue);
+  });
+
+  test('single unlock dependency', () {
+    final path = _path();
+    expect(engine.isStageUnlocked(path, 'b', <String>{}), isFalse);
+    expect(engine.isStageUnlocked(path, 'b', {'a'}), isTrue);
+  });
+
+  test('multiple unlock dependencies', () {
+    final path = _path();
+    expect(engine.isStageUnlocked(path, 'd', {'b'}), isFalse);
+    expect(engine.isStageUnlocked(path, 'd', {'c'}), isFalse);
+    expect(engine.isStageUnlocked(path, 'd', {'b', 'c'}), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add a stage-level unlock engine for learning paths
- test stage unlocking for root, single, and multiple dependencies

## Testing
- `flutter test test/learning_path_stage_unlock_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e179bff00832aa1c3074c5bf21af7