### PR TITLE
Implement detailed learning path screen

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -6,6 +6,8 @@ import '../models/learning_path_stage_model.dart';
 import '../services/pack_library_service.dart';
 import '../services/session_log_service.dart';
 import '../services/training_session_launcher.dart';
+import '../services/learning_path_stage_progress_engine.dart';
+import '../services/learning_path_stage_unlock_engine.dart';
 import '../widgets/learning_path_stage_widget.dart';
 
 /// Displays all stages of a learning path and allows launching each pack.
@@ -20,13 +22,20 @@ class LearningPathScreen extends StatefulWidget {
 
 class _LearningPathScreenState extends State<LearningPathScreen> {
   late SessionLogService _logs;
-  late Future<void> _future;
+  late LearningPathStageProgressEngine _progressEngine;
+  final _unlockEngine = const LearningPathStageUnlockEngine();
+
+  bool _loading = true;
+  Map<String, double> _progress = {};
+  Set<String> _unlocked = {};
+  Set<String> _completed = {};
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _logs = context.read<SessionLogService>();
-    _future = Future.value();
+    _progressEngine = LearningPathStageProgressEngine(logs: _logs);
+    _load();
   }
 
   int _handsPlayed(String packId) {
@@ -39,6 +48,47 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     return hands;
   }
 
+  double _accuracy(String packId) {
+    var hands = 0;
+    var correct = 0;
+    for (final log in _logs.logs) {
+      if (log.templateId == packId) {
+        hands += log.correctCount + log.mistakeCount;
+        correct += log.correctCount;
+      }
+    }
+    if (hands == 0) return 0.0;
+    return correct / hands * 100;
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final map = await _progressEngine.getStageProgress(widget.template);
+    final completed = <String>{};
+    for (final stage in widget.template.stages) {
+      final hands = _handsPlayed(stage.packId);
+      final acc = _accuracy(stage.packId);
+      if (hands >= stage.minHands && acc >= stage.requiredAccuracy) {
+        completed.add(stage.id);
+      }
+    }
+    final unlocked = <String>{};
+    for (final stage in widget.template.stages) {
+      if (_unlockEngine.isStageUnlocked(widget.template, stage.id, completed)) {
+        unlocked.add(stage.id);
+      }
+    }
+    setState(() {
+      _progress = {
+        for (final stage in widget.template.stages)
+          stage.id: map[stage.packId] ?? 0.0
+      };
+      _completed = completed;
+      _unlocked = unlocked;
+      _loading = false;
+    });
+  }
+
   Future<void> _startStage(LearningPathStageModel stage) async {
     final template = await PackLibraryService.instance.getById(stage.packId);
     if (template == null) {
@@ -49,15 +99,20 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
       return;
     }
     await const TrainingSessionLauncher().launch(template);
-    if (mounted) setState(() {});
+    if (mounted) _load();
   }
 
-  Widget _buildStageTile(LearningPathStageModel stage) {
+  Widget _buildStageTile(LearningPathStageModel stage, bool recommended) {
     final hands = _handsPlayed(stage.packId);
-    final ratio = stage.minHands == 0 ? 1.0 : hands / stage.minHands;
+    final ratio = _progress[stage.id] ??
+        (stage.minHands == 0 ? 1.0 : hands / stage.minHands);
+    final unlocked = _unlocked.contains(stage.id);
     return LearningPathStageWidget(
       stage: stage,
       progress: ratio.clamp(0.0, 1.0),
+      handsPlayed: hands,
+      unlocked: unlocked,
+      recommended: recommended,
       onPressed: () => _startStage(stage),
     );
   }
@@ -66,40 +121,46 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
   Widget build(BuildContext context) {
     final template = widget.template;
     final tags = template.tags;
-    return FutureBuilder(
-      future: _future,
-      builder: (context, snapshot) {
-        return Scaffold(
-          appBar: AppBar(title: Text(template.title)),
-          body: snapshot.connectionState != ConnectionState.done
-              ? const Center(child: CircularProgressIndicator())
-              : ListView(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  children: [
-                    if (template.description.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8),
-                        child: Text(
-                          template.description,
-                          style: const TextStyle(color: Colors.white70),
-                        ),
-                      ),
-                    for (final stage in template.stages) _buildStageTile(stage),
-                    if (tags.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Wrap(
-                          spacing: 8,
-                          children: [
-                            for (final t in tags) Chip(label: Text(t)),
-                          ],
-                        ),
-                      ),
-                  ],
-                ),
-        );
-      },
+    String? recommended;
+    for (final s in template.stages) {
+      if (_unlocked.contains(s.id) && !_completed.contains(s.id)) {
+        recommended = s.id;
+        break;
+      }
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(template.title),
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              children: [
+                if (template.description.isNotEmpty)
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Text(
+                      template.description,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ),
+                for (final stage in template.stages)
+                  _buildStageTile(stage, stage.id == recommended),
+                if (tags.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Wrap(
+                      spacing: 8,
+                      children: [
+                        for (final t in tags) Chip(label: Text(t)),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
     );
   }
 }

--- a/lib/widgets/learning_path_stage_widget.dart
+++ b/lib/widgets/learning_path_stage_widget.dart
@@ -7,16 +7,23 @@ import 'tag_badge.dart';
 class LearningPathStageWidget extends StatelessWidget {
   final LearningPathStageModel stage;
   final double progress;
+  final int handsPlayed;
+  final bool unlocked;
+  final bool recommended;
   final VoidCallback onPressed;
 
   const LearningPathStageWidget({
     super.key,
     required this.stage,
     required this.progress,
+    required this.handsPlayed,
+    required this.unlocked,
+    this.recommended = false,
     required this.onPressed,
   });
 
   String _ctaLabel() {
+    if (!unlocked) return 'Заблокировано';
     if (progress >= 1.0) return 'Завершено';
     if (progress > 0.0) return 'Продолжить';
     return 'Начать';
@@ -32,8 +39,15 @@ class LearningPathStageWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final pctText = '${(progress.clamp(0.0, 1.0) * 100).round()}%';
+    final accent = Theme.of(context).colorScheme.secondary;
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 16),
+      shape: recommended
+          ? RoundedRectangleBorder(
+              side: BorderSide(color: accent, width: 2),
+              borderRadius: BorderRadius.circular(4),
+            )
+          : null,
       child: Padding(
         padding: const EdgeInsets.all(12),
         child: Column(
@@ -64,7 +78,15 @@ class LearningPathStageWidget extends StatelessWidget {
                     ],
                   ),
                 ),
-                Text(pctText, style: const TextStyle(color: Colors.white70)),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text('$handsPlayed/${stage.minHands}',
+                        style: const TextStyle(color: Colors.white70)),
+                    Text(pctText,
+                        style: const TextStyle(color: Colors.white70)),
+                  ],
+                ),
               ],
             ),
             if (stage.tags.isNotEmpty)
@@ -93,7 +115,8 @@ class LearningPathStageWidget extends StatelessWidget {
             Align(
               alignment: Alignment.centerRight,
               child: ElevatedButton(
-                onPressed: progress >= 1.0 ? null : onPressed,
+                onPressed:
+                    !unlocked || progress >= 1.0 ? null : onPressed,
                 child: Text(_ctaLabel()),
               ),
             ),


### PR DESCRIPTION
## Summary
- enhance `LearningPathStageWidget` to show hands played, lock state and highlight
- upgrade `LearningPathScreen` to compute progress/unlocks using new engines and session logs

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1a622e88832ab966f4c5f3852023