### PR TITLE
Show progress in learning path library

### DIFF
--- a/lib/models/learning_path_progress.dart
+++ b/lib/models/learning_path_progress.dart
@@ -1,0 +1,13 @@
+class LearningPathProgress {
+  final int completedStages;
+  final int totalStages;
+  final double percentComplete;
+
+  const LearningPathProgress({
+    required this.completedStages,
+    required this.totalStages,
+    required this.percentComplete,
+  });
+
+  bool get finished => totalStages > 0 && completedStages >= totalStages;
+}

--- a/lib/screens/learning_path_library_screen.dart
+++ b/lib/screens/learning_path_library_screen.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 import '../repositories/learning_path_repository.dart';
 import '../models/learning_path_track_model.dart';
 import '../models/learning_path_template_v2.dart';
+import '../models/learning_path_progress.dart';
 import '../widgets/track_section_widget.dart';
+import '../services/learning_path_stage_progress_engine.dart';
+import '../services/learning_path_stage_unlock_engine.dart';
+import '../services/session_log_service.dart';
+import 'package:provider/provider.dart';
 
 /// Displays all available learning path tracks and their paths.
 class LearningPathLibraryScreen extends StatefulWidget {
@@ -16,15 +21,77 @@ class LearningPathLibraryScreen extends StatefulWidget {
 class _LearningPathLibraryScreenState extends State<LearningPathLibraryScreen> {
   late Future<Map<LearningPathTrackModel, List<LearningPathTemplateV2>>> _future;
   final _repo = LearningPathRepository();
+  late SessionLogService _logs;
+  late LearningPathStageProgressEngine _progressEngine;
+  final _unlockEngine = const LearningPathStageUnlockEngine();
+  Map<String, LearningPathProgress> _progress = {};
+  bool _initialized = false;
 
   @override
   void initState() {
     super.initState();
-    _future = _repo.loadAllTracksWithPaths();
+    // will load in didChangeDependencies
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_initialized) {
+      _logs = context.read<SessionLogService>();
+      _progressEngine = LearningPathStageProgressEngine(logs: _logs);
+      _future = _load();
+      _initialized = true;
+    }
+  }
+
+  Future<Map<LearningPathTrackModel, List<LearningPathTemplateV2>>> _load() async {
+    final map = await _repo.loadAllTracksWithPaths();
+    await _computeProgress(map.values.expand((e) => e));
+    return map;
+  }
+
+  Future<void> _computeProgress(Iterable<LearningPathTemplateV2> paths) async {
+    final hands = <String, int>{};
+    final correct = <String, int>{};
+    for (final log in _logs.logs) {
+      final count = log.correctCount + log.mistakeCount;
+      hands.update(log.templateId, (v) => v + count, ifAbsent: () => count);
+      correct.update(log.templateId, (v) => v + log.correctCount,
+          ifAbsent: () => log.correctCount);
+    }
+    final result = <String, LearningPathProgress>{};
+    for (final path in paths) {
+      final map = await _progressEngine.getStageProgress(path);
+      final completed = <String>{};
+      final unlocked = <String>{};
+      for (final stage in path.stages) {
+        final ratio = map[stage.packId] ?? 0.0;
+        final played = hands[stage.packId] ?? 0;
+        final corr = correct[stage.packId] ?? 0;
+        final acc = played == 0 ? 0.0 : corr / played * 100;
+        if (played >= stage.minHands && acc >= stage.requiredAccuracy && ratio >= 1.0) {
+          completed.add(stage.id);
+        }
+      }
+      for (final stage in path.stages) {
+        if (_unlockEngine.isStageUnlocked(path, stage.id, completed)) {
+          unlocked.add(stage.id);
+        }
+      }
+      final percent = path.stages.isEmpty
+          ? 0.0
+          : completed.length / path.stages.length;
+      result[path.id] = LearningPathProgress(
+        completedStages: completed.length,
+        totalStages: path.stages.length,
+        percentComplete: percent,
+      );
+    }
+    setState(() => _progress = result);
   }
 
   Future<void> _reload() async {
-    setState(() => _future = _repo.loadAllTracksWithPaths());
+    setState(() => _future = _load());
     await _future;
   }
 
@@ -46,10 +113,11 @@ class _LearningPathLibraryScreenState extends State<LearningPathLibraryScreen> {
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         children: [
                           for (final entry in data.entries)
-                            TrackSectionWidget(
-                              track: entry.key,
-                              paths: entry.value,
-                            ),
+                          TrackSectionWidget(
+                            track: entry.key,
+                            paths: entry.value,
+                            progress: _progress,
+                          ),
                         ],
                       ),
                     ),

--- a/lib/widgets/learning_path_card.dart
+++ b/lib/widgets/learning_path_card.dart
@@ -3,13 +3,17 @@ import 'package:flutter/material.dart';
 import '../models/learning_path_template_v2.dart';
 import '../theme/app_colors.dart';
 
+import '../models/learning_path_progress.dart';
+
 class LearningPathCard extends StatelessWidget {
   final LearningPathTemplateV2 template;
+  final LearningPathProgress? progress;
   final VoidCallback? onTap;
 
   const LearningPathCard({
     super.key,
     required this.template,
+    this.progress,
     this.onTap,
   });
 
@@ -22,6 +26,9 @@ class LearningPathCard extends StatelessWidget {
         decoration: BoxDecoration(
           color: AppColors.cardBackground,
           borderRadius: BorderRadius.circular(8),
+          border: progress != null && progress!.finished
+              ? Border.all(color: Colors.greenAccent)
+              : null,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -47,6 +54,50 @@ class LearningPathCard extends StatelessWidget {
                 child: Text(
                   template.recommendedFor!,
                   style: const TextStyle(color: Colors.orange, fontSize: 12),
+                ),
+              ),
+            if (progress != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: progress!.percentComplete.clamp(0.0, 1.0),
+                        backgroundColor: Colors.white24,
+                        valueColor: const AlwaysStoppedAnimation<Color>(
+                            Colors.greenAccent),
+                        minHeight: 6,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            progress!.finished
+                                ? 'Завершено'
+                                : '${progress!.completedStages} из ${progress!.totalStages} этапов',
+                            style: const TextStyle(
+                                color: Colors.white70, fontSize: 12),
+                          ),
+                        ),
+                        Text(
+                          '${(progress!.percentComplete * 100).round()}%',
+                          style:
+                              const TextStyle(color: Colors.white70, fontSize: 12),
+                        ),
+                        if (progress!.finished)
+                          const Padding(
+                            padding: EdgeInsets.only(left: 4),
+                            child: Icon(Icons.check_circle,
+                                color: Colors.green, size: 16),
+                          ),
+                      ],
+                    ),
+                  ],
                 ),
               ),
           ],

--- a/lib/widgets/track_section_widget.dart
+++ b/lib/widgets/track_section_widget.dart
@@ -5,14 +5,18 @@ import '../models/learning_path_template_v2.dart';
 import 'learning_path_card.dart';
 import '../screens/learning_path_screen_v2.dart';
 
+import '../models/learning_path_progress.dart';
+
 class TrackSectionWidget extends StatelessWidget {
   final LearningPathTrackModel track;
   final List<LearningPathTemplateV2> paths;
+  final Map<String, LearningPathProgress> progress;
 
   const TrackSectionWidget({
     super.key,
     required this.track,
     required this.paths,
+    required this.progress,
   });
 
   int _orderOf(LearningPathTemplateV2 p) {
@@ -69,6 +73,7 @@ class TrackSectionWidget extends StatelessWidget {
                     width: 180,
                     child: LearningPathCard(
                       template: p,
+                      progress: progress[p.id],
                       onTap: () {
                         Navigator.push(
                           context,


### PR DESCRIPTION
## Summary
- compute path progress using session logs
- show progress bar and completed stage count on each path card
- highlight fully completed paths

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687e1e37300c832aadc6f4e6832cf12c