### PR TITLE
Implement stage UI status engine

### DIFF
--- a/lib/services/learning_path_stage_ui_status_engine.dart
+++ b/lib/services/learning_path_stage_ui_status_engine.dart
@@ -1,0 +1,29 @@
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_stage_unlock_engine.dart';
+
+enum LearningStageUIState { locked, active, done }
+
+class LearningPathStageUIStatusEngine {
+  final LearningPathStageUnlockEngine unlockEngine;
+
+  const LearningPathStageUIStatusEngine({
+    LearningPathStageUnlockEngine? unlockEngine,
+  }) : unlockEngine = unlockEngine ?? const LearningPathStageUnlockEngine();
+
+  Map<String, LearningStageUIState> computeStageUIStates(
+    LearningPathTemplateV2 path,
+    Set<String> completedStageIds,
+  ) {
+    final states = <String, LearningStageUIState>{};
+    for (final stage in path.stages) {
+      if (completedStageIds.contains(stage.id)) {
+        states[stage.id] = LearningStageUIState.done;
+      } else if (unlockEngine.isStageUnlocked(path, stage.id, completedStageIds)) {
+        states[stage.id] = LearningStageUIState.active;
+      } else {
+        states[stage.id] = LearningStageUIState.locked;
+      }
+    }
+    return states;
+  }
+}

--- a/test/services/learning_path_stage_ui_status_engine_test.dart
+++ b/test/services/learning_path_stage_ui_status_engine_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_stage_ui_status_engine.dart';
+import 'package:poker_analyzer/services/learning_path_stage_unlock_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const unlockEngine = LearningPathStageUnlockEngine();
+  final uiEngine = LearningPathStageUIStatusEngine(unlockEngine: unlockEngine);
+
+  LearningPathTemplateV2 _path() => LearningPathTemplateV2(
+        id: 'p',
+        title: 'Path',
+        description: '',
+        stages: const [
+          LearningPathStageModel(
+            id: 'a',
+            title: 'A',
+            description: '',
+            packId: 'pack1',
+            requiredAccuracy: 80,
+            minHands: 1,
+            unlocks: ['b'],
+          ),
+          LearningPathStageModel(
+            id: 'b',
+            title: 'B',
+            description: '',
+            packId: 'pack2',
+            requiredAccuracy: 70,
+            minHands: 1,
+          ),
+        ],
+      );
+
+  test('computeStageUIStates returns locked, active, done', () {
+    final path = _path();
+    final result1 = uiEngine.computeStageUIStates(path, const {});
+    expect(result1['a'], LearningStageUIState.active);
+    expect(result1['b'], LearningStageUIState.locked);
+
+    final result2 = uiEngine.computeStageUIStates(path, const {'a'});
+    expect(result2['a'], LearningStageUIState.done);
+    expect(result2['b'], LearningStageUIState.active);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathStageUIStatusEngine` to evaluate UI states per stage
- test active/locked/done cases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2006fcc8832a8a0932b2547cfb14