### PR TITLE
Add LearningPathCompletionEngine

### DIFF
--- a/lib/services/learning_path_completion_engine.dart
+++ b/lib/services/learning_path_completion_engine.dart
@@ -1,0 +1,27 @@
+import '../models/learning_path_template_v2.dart';
+import '../models/session_log.dart';
+
+/// Checks if an entire learning path has been completed based on session logs.
+class LearningPathCompletionEngine {
+  const LearningPathCompletionEngine();
+
+  /// Returns `true` when every stage in [path] has at least the required number
+  /// of hands played with sufficient accuracy.
+  ///
+  /// [logsByPackId] should contain aggregated session data for each pack.
+  bool isCompleted(
+    LearningPathTemplateV2 path,
+    Map<String, SessionLog> logsByPackId,
+  ) {
+    for (final stage in path.stages) {
+      final log = logsByPackId[stage.packId];
+      final correct = log?.correctCount ?? 0;
+      final mistakes = log?.mistakeCount ?? 0;
+      final hands = correct + mistakes;
+      if (hands < stage.minHands) return false;
+      final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
+      if (accuracy < stage.requiredAccuracy) return false;
+    }
+    return true;
+  }
+}

--- a/test/services/learning_path_completion_engine_test.dart
+++ b/test/services/learning_path_completion_engine_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_completion_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const engine = LearningPathCompletionEngine();
+
+  LearningPathTemplateV2 _path() => LearningPathTemplateV2(
+        id: 'p',
+        title: 'Path',
+        description: '',
+        stages: const [
+          LearningPathStageModel(
+            id: 's1',
+            title: 'Stage 1',
+            description: '',
+            packId: 'pack1',
+            requiredAccuracy: 80,
+            minHands: 10,
+          ),
+          LearningPathStageModel(
+            id: 's2',
+            title: 'Stage 2',
+            description: '',
+            packId: 'pack2',
+            requiredAccuracy: 70,
+            minHands: 5,
+          ),
+        ],
+      );
+
+  Map<String, SessionLog> _logs(int c1, int m1, int c2, int m2) => {
+        'pack1': SessionLog(
+          sessionId: 'l1',
+          templateId: 'pack1',
+          startedAt: DateTime.now(),
+          completedAt: DateTime.now(),
+          correctCount: c1,
+          mistakeCount: m1,
+        ),
+        'pack2': SessionLog(
+          sessionId: 'l2',
+          templateId: 'pack2',
+          startedAt: DateTime.now(),
+          completedAt: DateTime.now(),
+          correctCount: c2,
+          mistakeCount: m2,
+        ),
+      };
+
+  test('isCompleted true when all stages meet requirements', () {
+    final path = _path();
+    final logs = _logs(8, 2, 4, 1);
+    final ok = engine.isCompleted(path, logs);
+    expect(ok, isTrue);
+  });
+
+  test('isCompleted false when hands below requirement', () {
+    final path = _path();
+    final logs = _logs(8, 2, 3, 1); // second stage only 4 hands
+    final ok = engine.isCompleted(path, logs);
+    expect(ok, isFalse);
+  });
+
+  test('isCompleted false when accuracy below requirement', () {
+    final path = _path();
+    final logs = _logs(5, 5, 4, 1); // first stage accuracy 50%
+    final ok = engine.isCompleted(path, logs);
+    expect(ok, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathCompletionEngine` to detect when an entire learning path is completed based on session logs
- cover the engine with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e22f67ba8832a9f6b8a60c74c3dbb