### PR TITLE
Add learning path celebration screen

### DIFF
--- a/lib/screens/learning_path_celebration_screen.dart
+++ b/lib/screens/learning_path_celebration_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../widgets/confetti_overlay.dart';
+import '../services/path_suggestion_service.dart';
+import 'learning_path_screen.dart';
+import 'skill_map_screen.dart';
+
+class LearningPathCelebrationScreen extends StatefulWidget {
+  final LearningPathTemplateV2 path;
+  const LearningPathCelebrationScreen({super.key, required this.path});
+
+  @override
+  State<LearningPathCelebrationScreen> createState() =>
+      _LearningPathCelebrationScreenState();
+}
+
+class _LearningPathCelebrationScreenState
+    extends State<LearningPathCelebrationScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+  }
+
+  void _repeat() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const LearningPathScreen()),
+    );
+  }
+
+  Future<void> _nextPath() async {
+    final next = await PathSuggestionService.instance.nextPath();
+    if (!mounted) return;
+    if (next == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Next path coming soon')),
+      );
+      return;
+    }
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LearningPathCelebrationScreen(path: next),
+      ),
+    );
+  }
+
+  void _skills() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const SkillMapScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.emoji_events, color: Colors.amber, size: 80),
+              const SizedBox(height: 24),
+              const Text(
+                'Поздравляем!',
+                style: TextStyle(fontSize: 28),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Вы завершили путь "${widget.path.title}"',
+                style: const TextStyle(fontSize: 20),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton.icon(
+                onPressed: _repeat,
+                icon: const Text('🔁'),
+                label: const Text('Повторить'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton.icon(
+                onPressed: _nextPath,
+                icon: const Text('➡️'),
+                label: const Text('Следующий путь'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton.icon(
+                onPressed: _skills,
+                icon: const Icon(Icons.bar_chart),
+                label: const Text('Мои навыки'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -10,6 +10,8 @@ import '../widgets/learning_path_recommendation_banner.dart';
 import '../widgets/daily_learning_goal_banner.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_path_completion_screen.dart';
+import 'learning_path_celebration_screen.dart';
+import '../services/learning_path_registry_service.dart';
 import 'learning_progress_stats_screen.dart';
 
 class LearningPathScreen extends StatefulWidget {
@@ -42,14 +44,30 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
         final stages = snapshot.data ?? [];
 
         if (snapshot.connectionState == ConnectionState.done) {
-          LearningPathProgressService.instance.isAllStagesCompleted().then((done) {
+          LearningPathProgressService.instance
+              .isAllStagesCompleted()
+              .then((done) async {
             if (done && context.mounted) {
-              Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const LearningPathCompletionScreen(),
-                ),
-              );
+              final templates =
+                  await LearningPathRegistryService.instance.loadAll();
+              final path = templates.isNotEmpty ? templates.first : null;
+              if (!context.mounted) return;
+              if (path != null) {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        LearningPathCelebrationScreen(path: path),
+                  ),
+                );
+              } else {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const LearningPathCompletionScreen(),
+                  ),
+                );
+              }
             }
           });
         }

--- a/lib/services/path_suggestion_service.dart
+++ b/lib/services/path_suggestion_service.dart
@@ -1,0 +1,16 @@
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_registry_service.dart';
+
+/// Stub service that will later suggest the next learning path.
+class PathSuggestionService {
+  PathSuggestionService._();
+  static final instance = PathSuggestionService._();
+
+  /// Returns next recommended [LearningPathTemplateV2] or `null` if none.
+  Future<LearningPathTemplateV2?> nextPath() async {
+    // TODO: implement actual suggestion logic
+    final templates = await LearningPathRegistryService.instance.loadAll();
+    if (templates.length < 2) return null;
+    return templates[1];
+  }
+}


### PR DESCRIPTION
## Summary
- show a celebration when finishing all learning path stages
- stub out a path suggestion service
- push celebration screen after path completion

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e23e8dc88832aa7c8cb663f042240