### PR TITLE
Add LearningPath celebration screen

### DIFF
--- a/lib/widgets/confetti_overlay.dart
+++ b/lib/widgets/confetti_overlay.dart
@@ -5,11 +5,13 @@ import 'package:confetti/confetti.dart';
 class ConfettiOverlay extends StatefulWidget {
   final Duration duration;
   final VoidCallback onCompleted;
+  final Path Function(Size size)? particlePath;
 
   const ConfettiOverlay({
     Key? key,
     this.duration = const Duration(seconds: 3),
     required this.onCompleted,
+    this.particlePath,
   }) : super(key: key);
 
   @override
@@ -42,6 +44,7 @@ class _ConfettiOverlayState extends State<ConfettiOverlay>
           confettiController: _controller,
           blastDirectionality: BlastDirectionality.explosive,
           shouldLoop: false,
+          createParticlePath: widget.particlePath,
         ),
       ),
     );
@@ -49,13 +52,15 @@ class _ConfettiOverlayState extends State<ConfettiOverlay>
 }
 
 /// Helper to display [ConfettiOverlay] above the current screen.
-void showConfettiOverlay(BuildContext context) {
+void showConfettiOverlay(BuildContext context,
+    {Path Function(Size size)? particlePath}) {
   final overlay = Overlay.of(context);
   if (overlay == null) return;
 
   late OverlayEntry entry;
   entry = OverlayEntry(
-    builder: (_) => ConfettiOverlay(onCompleted: () => entry.remove()),
+    builder: (_) =>
+        ConfettiOverlay(onCompleted: () => entry.remove(), particlePath: particlePath),
   );
   overlay.insert(entry);
 }


### PR DESCRIPTION
## Summary
- add customizable particle path for confetti overlay
- implement LearningPathCelebrationScreen with stats and share option
- launch celebration from LearningPathScreen when path is complete

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e32824df0832a9acf1c367c3c8ffe