### PR TITLE
Implement sequential stage unlocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 flutter/
 flutter.tar.xz
+flutter-sdk/

--- a/lib/services/learning_path_stage_unlock_engine.dart
+++ b/lib/services/learning_path_stage_unlock_engine.dart
@@ -1,4 +1,6 @@
 import '../models/learning_path_template_v2.dart';
+import '../models/session_log.dart';
+import 'learning_path_stage_ui_status_engine.dart';
 
 /// Determines if a stage within a learning path is unlocked.
 class LearningPathStageUnlockEngine {
@@ -18,5 +20,40 @@ class LearningPathStageUnlockEngine {
       }
     }
     return true;
+  }
+
+  /// Computes UI states for stages based on aggregated session logs.
+  ///
+  /// The first stage is always active. A stage is marked as [LearningStageUIState.done]
+  /// when both [LearningPathStageModel.minHands] and [LearningPathStageModel.requiredAccuracy]
+  /// requirements are met in [aggregatedLogs]. Only the immediate next stage after
+  /// the last completed one is set to [LearningStageUIState.active]; all subsequent
+  /// stages are [LearningStageUIState.locked].
+  Map<String, LearningStageUIState> computeStageUIStates(
+    LearningPathTemplateV2 path,
+    Map<String, SessionLog> aggregatedLogs,
+  ) {
+    final states = <String, LearningStageUIState>{};
+    var foundActive = false;
+    for (final stage in path.stages) {
+      final log = aggregatedLogs[stage.packId];
+      final correct = log?.correctCount ?? 0;
+      final mistakes = log?.mistakeCount ?? 0;
+      final hands = correct + mistakes;
+      final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
+      final done =
+          hands >= stage.minHands && accuracy >= stage.requiredAccuracy;
+      if (done) {
+        states[stage.id] = LearningStageUIState.done;
+        continue;
+      }
+      if (!foundActive) {
+        states[stage.id] = LearningStageUIState.active;
+        foundActive = true;
+      } else {
+        states[stage.id] = LearningStageUIState.locked;
+      }
+    }
+    return states;
   }
 }

--- a/test/learning_path_stage_unlock_engine_v2_test.dart
+++ b/test/learning_path_stage_unlock_engine_v2_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_stage_unlock_engine.dart';
+import 'package:poker_analyzer/services/learning_path_stage_ui_status_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const engine = LearningPathStageUnlockEngine();
+
+  LearningPathTemplateV2 _path() => LearningPathTemplateV2(
+    id: 'p',
+    title: 'Path',
+    description: '',
+    stages: const [
+      LearningPathStageModel(
+        id: 's1',
+        title: 'S1',
+        description: '',
+        packId: 'pack1',
+        requiredAccuracy: 80,
+        minHands: 2,
+      ),
+      LearningPathStageModel(
+        id: 's2',
+        title: 'S2',
+        description: '',
+        packId: 'pack2',
+        requiredAccuracy: 70,
+        minHands: 1,
+      ),
+      LearningPathStageModel(
+        id: 's3',
+        title: 'S3',
+        description: '',
+        packId: 'pack3',
+        requiredAccuracy: 70,
+        minHands: 1,
+      ),
+    ],
+  );
+
+  SessionLog _log(String id, int correct, int mistakes) => SessionLog(
+    sessionId: '1',
+    templateId: id,
+    startedAt: DateTime.now(),
+    completedAt: DateTime.now(),
+    correctCount: correct,
+    mistakeCount: mistakes,
+  );
+
+  test('only next stage active after completion', () {
+    final path = _path();
+    final logs = {'pack1': _log('pack1', 2, 0)};
+    final states = engine.computeStageUIStates(path, logs);
+    expect(states['s1'], LearningStageUIState.done);
+    expect(states['s2'], LearningStageUIState.active);
+    expect(states['s3'], LearningStageUIState.locked);
+  });
+
+  test('first stage active when none completed', () {
+    final path = _path();
+    final states = engine.computeStageUIStates(path, const {});
+    expect(states['s1'], LearningStageUIState.active);
+    expect(states['s2'], LearningStageUIState.locked);
+    expect(states['s3'], LearningStageUIState.locked);
+  });
+}


### PR DESCRIPTION
## Summary
- add computeStageUIStates to LearningPathStageUnlockEngine
- test stage unlock sequencing logic
- ignore local flutter SDK in git

## Testing
- `flutter test` *(fails: Compilation failed for test files)*

------
https://chatgpt.com/codex/tasks/task_e_687e3aeda5c0832a8de4cc5702f15aaa