### PR TITLE
Implement StageProgressChip for learning path v2

### DIFF
--- a/lib/widgets/stage_progress_chip.dart
+++ b/lib/widgets/stage_progress_chip.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../models/session_log.dart';
+
+/// Small chip showing progress for a learning path stage.
+class StageProgressChip extends StatelessWidget {
+  final SessionLog? log;
+  final double requiredAccuracy;
+  final int minHands;
+
+  const StageProgressChip({
+    super.key,
+    required this.log,
+    required this.requiredAccuracy,
+    required this.minHands,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hands = (log?.correctCount ?? 0) + (log?.mistakeCount ?? 0);
+    final correct = log?.correctCount ?? 0;
+    final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
+    final completed = hands >= minHands && accuracy >= requiredAccuracy;
+
+    Color color;
+    if (completed) {
+      color = Colors.green;
+    } else if (hands > 0) {
+      color = Colors.yellow.shade700;
+    } else {
+      color = Colors.grey;
+    }
+
+    final text = '$hands/$minHands · ${accuracy.toStringAsFixed(0)}%';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            text,
+            style: const TextStyle(color: Colors.black, fontSize: 12),
+          ),
+          if (completed) ...[
+            const SizedBox(width: 4),
+            const Text('✅', style: TextStyle(fontSize: 12)),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `StageProgressChip` widget to visualize stage accuracy and hands played
- track aggregated logs in `LearningPathScreen` v2
- display `StageProgressChip` under each stage title

## Testing
- `flutter analyze` *(fails: 6695 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3f996bd0832ab8807135f1288cf1