### PR TITLE
Implement BoosterPackLauncher service

### DIFF
--- a/lib/services/booster_pack_launcher.dart
+++ b/lib/services/booster_pack_launcher.dart
@@ -1,0 +1,44 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../core/training/library/training_pack_library_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_service.dart';
+import 'skill_map_booster_recommender.dart';
+import 'tag_mastery_service.dart';
+import 'training_session_launcher.dart';
+
+class BoosterPackLauncher {
+  final TagMasteryService mastery;
+  final PackLibraryService library;
+  final SkillMapBoosterRecommender recommender;
+  final TrainingSessionLauncher launcher;
+
+  const BoosterPackLauncher({
+    required this.mastery,
+    this.library = PackLibraryService.instance,
+    SkillMapBoosterRecommender? recommender,
+    this.launcher = const TrainingSessionLauncher(),
+  }) : recommender = recommender ?? SkillMapBoosterRecommender();
+
+  Future<void> launchBooster(BuildContext context) async {
+    final weakTags = await recommender.getWeakTags(mastery: mastery);
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final packs = TrainingPackLibraryV2.instance.filterBy(
+      type: TrainingType.pushFold,
+    );
+    TrainingPackTemplateV2? pack;
+    for (final tag in weakTags) {
+      pack = packs.firstWhereOrNull((p) => p.tags.contains(tag));
+      if (pack != null) break;
+    }
+    if (pack != null) {
+      await launcher.launch(pack);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Нет подходящих бустеров')),
+      );
+    }
+  }
+}

--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -1,6 +1,7 @@
 import '../core/training/library/training_pack_library_v2.dart';
 import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import 'package:collection/collection.dart';
 
 class PackLibraryService {
   PackLibraryService._();
@@ -19,5 +20,12 @@ class PackLibraryService {
   Future<TrainingPackTemplateV2?> getById(String id) async {
     await TrainingPackLibraryV2.instance.loadFromFolder();
     return TrainingPackLibraryV2.instance.getById(id);
+  }
+
+  /// Returns the first pack containing [tag] or `null` if none found.
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final list = TrainingPackLibraryV2.instance.filterBy(type: TrainingType.pushFold);
+    return list.firstWhereOrNull((p) => p.tags.contains(tag));
   }
 }

--- a/test/services/booster_pack_launcher_test.dart
+++ b/test/services/booster_pack_launcher_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_pack_launcher.dart';
+import 'package:poker_analyzer/services/skill_map_booster_recommender.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:collection/collection.dart';
+
+class _FakeMasteryService extends TagMasteryService {
+  final Map<String, double> _map;
+  _FakeMasteryService(this._map)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => _map;
+}
+
+class _FakeLibrary implements PackLibraryService {
+  final List<TrainingPackTemplateV2> packs;
+  _FakeLibrary(this.packs);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async =>
+      packs.firstWhereOrNull((p) => p.id == id);
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
+      packs.firstWhereOrNull((p) => p.tags.contains(tag));
+}
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  TrainingPackTemplateV2? launched;
+  _FakeLauncher() : super();
+  @override
+  Future<void> launch(TrainingPackTemplateV2 template) async {
+    launched = template;
+  }
+}
+
+TrainingPackTemplateV2 tpl({required String id, required List<String> tags}) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: tags,
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('launches first matching booster', (tester) async {
+    final mastery = _FakeMasteryService({'icm': 0.2});
+    final library = _FakeLibrary([
+      tpl(id: 'a', tags: ['icm']),
+      tpl(id: 'b', tags: ['cbet']),
+    ]);
+    final launcher = _FakeLauncher();
+    final service = BoosterPackLauncher(
+      mastery: mastery,
+      library: library,
+      launcher: launcher,
+      recommender: SkillMapBoosterRecommender(),
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: Container(key: key))));
+    await service.launchBooster(key.currentContext!);
+    expect(launcher.launched?.id, 'a');
+  });
+
+  testWidgets('shows snackbar when no pack', (tester) async {
+    final mastery = _FakeMasteryService({'icm': 0.2});
+    final library = _FakeLibrary([]);
+    final launcher = _FakeLauncher();
+    final service = BoosterPackLauncher(
+      mastery: mastery,
+      library: library,
+      launcher: launcher,
+      recommender: SkillMapBoosterRecommender(),
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: Container(key: key))));
+    await service.launchBooster(key.currentContext!);
+    await tester.pump();
+    expect(launcher.launched, isNull);
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `BoosterPackLauncher` for launching the first booster pack based on weak tags
- extend `PackLibraryService` with `findByTag`
- add tests for the new launcher service

## Testing
- `flutter analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4682f8b8832aa2833fe77d4eb5b1