### PR TITLE
Update Flutter CI to stable 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.16.0'
           channel: stable
+      - name: Repair pub cache
+        run: flutter pub cache repair
       - name: Install dependencies
         run: flutter pub get
       - name: Verify pubspec.lock

--- a/.github/workflows/ci_lint_agent.yaml
+++ b/.github/workflows/ci_lint_agent.yaml
@@ -14,7 +14,11 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.16.0'
+          channel: stable
+
+      - name: Repair pub cache
+        run: flutter pub cache repair
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/demo_build.yml
+++ b/.github/workflows/demo_build.yml
@@ -14,7 +14,11 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.16.0'
+          channel: stable
+
+      - name: Repair pub cache
+        run: flutter pub cache repair
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.16.0'
+          channel: stable
+
+      - name: Repair pub cache
+        run: flutter pub cache repair
 
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
## Summary
- update all workflow files to use Flutter 3.16.0
- ensure stable channel is used and clean pub cache before installing deps

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4dac7340832aa28044f7c2a1d531