### PR TITLE
Fix analyzer imports

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -53,6 +53,8 @@ import 'services/all_in_players_service.dart';
 import 'services/folded_players_service.dart';
 import 'services/action_sync_service.dart';
 import 'services/user_preferences_service.dart';
+import 'services/goal_progress_cloud_service.dart';
+import 'user_preferences.dart';
 import 'services/tag_service.dart';
 import 'services/tag_cache_service.dart';
 import 'services/training_pack_tag_analytics_service.dart';
@@ -340,6 +342,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         weak: context.read<WeakSpotRecommendationService>(),
         style: context.read<PlayerStyleService>(),
         forecast: context.read<PlayerStyleForecastService>(),
+        progress: context.read<ProgressForecastService>(),
       ),
     ),
     ChangeNotifierProvider(
@@ -469,9 +472,9 @@ List<SingleChildWidget> buildTrainingProviders() {
         logs: context.read<SessionLogService>(),
       ),
     ),
-    Provider(create: (_) => LessonProgressTrackerService()..load()),
-    Provider(create: (_) => LessonPathProgressService()),
-    Provider(create: (_) => TrainingPathProgressService()),
+    Provider(create: (_) => LessonProgressTrackerService.instance..load()),
+    Provider(create: (_) => LessonPathProgressService.instance),
+    Provider(create: (_) => TrainingPathProgressService.instance),
     Provider<LearningPathRegistryService>.value(
       value: LearningPathRegistryService.instance,
     ),

--- a/lib/core/training/bootstrap/built_in_pack_seeder.dart
+++ b/lib/core/training/bootstrap/built_in_pack_seeder.dart
@@ -24,6 +24,6 @@ class BuiltInPackSeeder {
       templates.add(t);
     }
     if (templates.isEmpty) return [];
-    return const PackLibraryGenerator().generateFromTemplates(templates);
+    return PackLibraryGenerator().generateFromTemplates(templates);
   }
 }

--- a/lib/core/training/generation/gpt_pack_template_generator.dart
+++ b/lib/core/training/generation/gpt_pack_template_generator.dart
@@ -13,7 +13,7 @@ class GptPackTemplateGenerator {
     required this.apiKey,
     http.Client? client,
     YamlReader? yamlReader,
-  })  : client = client ?? const http.Client(),
+  })  : client = client ?? http.Client(),
         reader = yamlReader ?? const YamlReader();
 
   Future<String> generateYamlTemplate(String prompt) async {

--- a/lib/core/training/generation/pack_library_generator.dart
+++ b/lib/core/training/generation/pack_library_generator.dart
@@ -8,6 +8,7 @@ import '../../../models/v2/training_pack_template_v2.dart';
 import '../../../models/v2/training_pack_v2.dart';
 import '../../../models/v2/training_pack_spot.dart';
 import '../../../models/v2/hero_position.dart';
+import '../../../models/game_type.dart';
 import '../engine/training_type_engine.dart';
 
 class PackLibraryGenerator {

--- a/lib/helpers/pack_spot_utils.dart
+++ b/lib/helpers/pack_spot_utils.dart
@@ -2,6 +2,7 @@ import '../models/saved_hand.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/card_model.dart';
 import '../models/action_entry.dart';
+import '../models/v2/hero_position.dart';
 
 SavedHand handFromPackSpot(TrainingPackSpot spot, {int anteBb = 0}) {
   final parts = spot.hand.heroCards

--- a/lib/helpers/push_fold_helper.dart
+++ b/lib/helpers/push_fold_helper.dart
@@ -1,4 +1,4 @@
-const Map<String, int> kPushFoldThresholds = _buildPushFoldThresholds();
+final Map<String, int> kPushFoldThresholds = _buildPushFoldThresholds();
 
 Map<String, int> _buildPushFoldThresholds() {
   const ranks = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A'];

--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -24,7 +24,7 @@ class TrainingPackStorage {
     if (raw == null || raw.isEmpty) {
       final generated = [
         for (final id in _presetIds)
-          TrainingPackAuthorService.generateFromPreset(id)
+          TrainingPackAuthorService().generateFromPreset(id)
       ];
       await save(generated);
       return generated;
@@ -33,7 +33,7 @@ class TrainingPackStorage {
     if (list.isEmpty) {
       final generated = [
         for (final id in _presetIds)
-          TrainingPackAuthorService.generateFromPreset(id)
+          TrainingPackAuthorService().generateFromPreset(id)
       ];
       await save(generated);
       return generated;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,7 +93,7 @@ import 'screens/onboarding_screen.dart';
 import 'onboarding/onboarding_flow_manager.dart';
 import 'app_bootstrap.dart';
 import 'app_providers.dart';
-import 'l10n/app_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   path_provider: ^2.0.15
   path: ^1.8.3
   open_filex: ^4.7.0
+  collection: ^1.18.0
   file_picker: ^6.2.1
   desktop_drop: ^0.6.0
   fl_chart: ^0.66.0
@@ -36,6 +37,7 @@ dependencies:
   sticky_headers: ^0.3.0+2
   archive: ^4.0.0
   share_plus: ^7.0.0
+  http: ^1.1.0
   uuid: ^4.0.0
   synchronized: ^3.0.0
   yaml: ^3.1.1


### PR DESCRIPTION
## Summary
- add missing service imports
- fix PersonalRecommendationService constructor usage
- refer to singleton instances for learning path services
- clean up generator constructors
- add http and collection packages

## Testing
- `flutter pub get`
- `flutter analyze --no-pub` *(fails: 6779 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea04bb194832aa281fdc5a6364fd3