### PR TITLE
Finalize TrainingPackTemplateV2 migration

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -8,6 +8,7 @@ import '../../core/training/engine/training_type_engine.dart';
 import 'training_pack_spot.dart';
 import 'spot_template.dart';
 import 'unlock_rules.dart';
+import 'hero_position.dart';
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -180,6 +181,27 @@ class TrainingPackTemplateV2 {
 
   // Backwards compatible alias used across the code base.
   String toYaml() => toYamlString();
+
+  /// Removes all spots from this template.
+  void clear() => spots.clear();
+
+  /// Appends [newSpots] to the existing list of spots.
+  void addAll(List<SpotTemplate> newSpots) => spots.addAll(newSpots);
+
+  /// Primary hero position inferred from [positions].
+  HeroPosition get heroPos =>
+      positions.isNotEmpty ? parseHeroPosition(positions.first) : HeroPosition.unknown;
+
+  /// Hero stack size in big blinds. Backwards compatible alias for [bb].
+  int get heroBbStack => bb;
+
+  /// Difficulty level read from [meta] map.
+  int get difficultyLevel {
+    final diff = meta['difficulty'];
+    if (diff is int) return diff;
+    if (diff is String) return int.tryParse(diff) ?? 0;
+    return 0;
+  }
 
   factory TrainingPackTemplateV2.fromTemplate(
     TrainingPackTemplate template, {

--- a/lib/services/daily_pack_service.dart
+++ b/lib/services/daily_pack_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
 import 'template_storage_service.dart';
 import 'training_pack_stats_service.dart';
 
@@ -11,13 +11,13 @@ class DailyPackService extends ChangeNotifier {
   static const _dateKey = 'daily_pack_date';
 
   final TemplateStorageService templates;
-  TrainingPackTemplate? _template;
+  TrainingPackTemplateV2? _template;
   DateTime? _date;
   Timer? _timer;
 
   DailyPackService({required this.templates});
 
-  TrainingPackTemplate? get template => _template;
+  TrainingPackTemplateV2? get template => _template;
 
   bool _sameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
@@ -42,8 +42,8 @@ class DailyPackService extends ChangeNotifier {
       _schedule();
       return;
     }
-    final preferred = <TrainingPackTemplate>[];
-    final others = <TrainingPackTemplate>[];
+    final preferred = <TrainingPackTemplateV2>[];
+    final others = <TrainingPackTemplateV2>[];
     for (final t in templates.templates) {
       final stat = await TrainingPackStatsService.getStats(t.id);
       final ev = stat == null ? 0.0 : (stat.postEvPct > 0 ? stat.postEvPct : stat.preEvPct);
@@ -51,7 +51,7 @@ class DailyPackService extends ChangeNotifier {
       final completed = stat != null && stat.accuracy >= .9 && ev >= 80 && icm >= 80;
       if (completed || (ev >= 90 && icm >= 90)) continue;
       final target = (t.recommended || t.tags.contains('starter') ||
-          now.difference(t.createdAt).inDays < 7)
+          now.difference(t.created).inDays < 7)
           ? preferred
           : others;
       target.add(t);

--- a/lib/utils/template_coverage_utils.dart
+++ b/lib/utils/template_coverage_utils.dart
@@ -1,8 +1,8 @@
-import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
 
 class TemplateCoverageUtils {
-  static void recountAll(TrainingPackTemplate template) {
+  static void recountAll(TrainingPackTemplateV2 template) {
     final List<TrainingPackSpot> list = template.spots;
     int ev = 0;
     int icm = 0;

--- a/lib/utils/template_difficulty.dart
+++ b/lib/utils/template_difficulty.dart
@@ -1,13 +1,20 @@
 import '../models/training_pack_template_model.dart';
-import '../models/v2/training_pack_template.dart' as v2;
+import '../models/v2/training_pack_template.dart' as legacy;
+import '../models/v2/training_pack_template_v2.dart' as v2;
 
 extension TemplateDifficulty on Object {
   int get difficultyLevel {
     if (this is TrainingPackTemplateModel) {
       return (this as TrainingPackTemplateModel).difficulty;
     }
-    if (this is v2.TrainingPackTemplate) {
-      return int.tryParse((this as v2.TrainingPackTemplate).difficulty ?? '') ?? 0;
+    if (this is legacy.TrainingPackTemplate) {
+      return int.tryParse((this as legacy.TrainingPackTemplate).difficulty ?? '') ?? 0;
+    }
+    if (this is v2.TrainingPackTemplateV2) {
+      final diff = (this as v2.TrainingPackTemplateV2).meta['difficulty'];
+      if (diff is int) return diff;
+      if (diff is String) return int.tryParse(diff) ?? 0;
+      return 0;
     }
     return 0;
   }

--- a/lib/utils/template_priority.dart
+++ b/lib/utils/template_priority.dart
@@ -1,9 +1,9 @@
-import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
 
 const kTplPriority = ['Push/Fold', 'ICM', 'Postflop', '3-бет'];
 
-extension SortedByPriority on Iterable<TrainingPackTemplate> {
-  List<TrainingPackTemplate> sortedByPriority() {
+extension SortedByPriority on Iterable<TrainingPackTemplateV2> {
+  List<TrainingPackTemplateV2> sortedByPriority() {
     final map = {
       for (var i = 0; i < kTplPriority.length; i++) kTplPriority[i]: i
     };


### PR DESCRIPTION
## Summary
- extend `TrainingPackTemplateV2` with helpers and compatibility getters
- migrate daily pack service to use `TrainingPackTemplateV2`
- update template utilities to rely on the V2 model

## Testing
- `flutter analyze --no-pub` *(fails: 15610 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb66cf5a4832aa5a590d8a5dd9f54