### PR TITLE
Implement learning track engine

### DIFF
--- a/lib/models/learning_track.dart
+++ b/lib/models/learning_track.dart
@@ -1,0 +1,11 @@
+import "v2/training_pack_template_v2.dart";
+
+class LearningTrack {
+  final List<TrainingPackTemplateV2> unlockedPacks;
+  final TrainingPackTemplateV2? nextUpPack;
+
+  const LearningTrack({
+    required this.unlockedPacks,
+    this.nextUpPack,
+  });
+}

--- a/test/services/learning_track_engine_test.dart
+++ b/test/services/learning_track_engine_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/learning_track_engine.dart';
+import 'package:poker_analyzer/services/training_pack_stats_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/unlock_rules.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackTemplateV2 tpl(String id, {UnlockRules? rules}) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    unlockRules: rules,
+    spots: const [],
+    spotCount: 0,
+  );
+}
+
+TrainingPackStat stat(double accuracy) => TrainingPackStat(
+      accuracy: accuracy,
+      last: DateTime.now(),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computeTrack returns unlocked packs and next up', () {
+    final packs = [
+      tpl('a'),
+      tpl('b', rules: const UnlockRules(requiredPacks: ['a'])),
+      tpl('c'),
+    ];
+    final stats = {
+      'a': stat(1.0),
+      'b': stat(0.95),
+      'c': stat(0.8),
+    };
+
+    final track = const LearningTrackEngine()
+        .computeTrack(allPacks: packs, stats: stats);
+
+    expect(track.unlockedPacks.map((p) => p.id), ['a', 'b', 'c']);
+    expect(track.nextUpPack?.id, 'c');
+  });
+
+  test('nextUpPack null when all completed', () {
+    final packs = [tpl('a'), tpl('b')];
+    final stats = {'a': stat(0.95), 'b': stat(0.92)};
+
+    final track = const LearningTrackEngine()
+        .computeTrack(allPacks: packs, stats: stats);
+
+    expect(track.unlockedPacks.length, 2);
+    expect(track.nextUpPack, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `LearningTrack` model
- expand `LearningTrackEngine` with `computeTrack` to build the list of unlocked packs and choose the next pack
- add unit tests for new learning track engine

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec0993964832ab94f8ad23073607b