### PR TITLE
Implement PackCompletionStatsService

### DIFF
--- a/lib/models/training_attempt.dart
+++ b/lib/models/training_attempt.dart
@@ -1,0 +1,36 @@
+class TrainingAttempt {
+  final String packId;
+  final String spotId;
+  final DateTime timestamp;
+  final double accuracy;
+  final double ev;
+  final double icm;
+
+  TrainingAttempt({
+    required this.packId,
+    required this.spotId,
+    required this.timestamp,
+    required this.accuracy,
+    required this.ev,
+    required this.icm,
+  });
+
+  factory TrainingAttempt.fromJson(Map<String, dynamic> j) => TrainingAttempt(
+        packId: j['packId'] as String? ?? '',
+        spotId: j['spotId'] as String? ?? '',
+        timestamp:
+            DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
+        accuracy: (j['accuracy'] as num?)?.toDouble() ?? 0,
+        ev: (j['ev'] as num?)?.toDouble() ?? 0,
+        icm: (j['icm'] as num?)?.toDouble() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'packId': packId,
+        'spotId': spotId,
+        'timestamp': timestamp.toIso8601String(),
+        'accuracy': accuracy,
+        'ev': ev,
+        'icm': icm,
+      };
+}

--- a/lib/services/pack_completion_stats_service.dart
+++ b/lib/services/pack_completion_stats_service.dart
@@ -1,0 +1,53 @@
+import '../models/training_attempt.dart';
+
+class TrainingPackStat {
+  final double accuracy;
+  final double ev;
+  final double icm;
+  final int attempts;
+
+  const TrainingPackStat({
+    required this.accuracy,
+    required this.ev,
+    required this.icm,
+    required this.attempts,
+  });
+}
+
+class PackCompletionStatsService {
+  const PackCompletionStatsService();
+
+  Map<String, TrainingPackStat> computeStats(List<TrainingAttempt> attempts) {
+    final Map<String, Map<String, TrainingAttempt>> latest = {};
+    for (final a in attempts) {
+      final pack = latest.putIfAbsent(a.packId, () => {});
+      final prev = pack[a.spotId];
+      if (prev == null || a.timestamp.isAfter(prev.timestamp)) {
+        pack[a.spotId] = a;
+      }
+    }
+
+    final Map<String, TrainingPackStat> result = {};
+    for (final entry in latest.entries) {
+      final values = entry.value.values.toList();
+      if (values.isEmpty) continue;
+      double acc = 0;
+      double ev = 0;
+      double icm = 0;
+      for (final v in values) {
+        acc += v.accuracy;
+        ev += v.ev;
+        icm += v.icm;
+      }
+      final count = values.length;
+      result[entry.key] = TrainingPackStat(
+        accuracy: acc / count,
+        ev: ev / count,
+        icm: icm / count,
+        attempts: count,
+      );
+    }
+
+    return result;
+  }
+}

--- a/test/pack_completion_stats_service_test.dart
+++ b/test/pack_completion_stats_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_attempt.dart';
+import 'package:poker_analyzer/services/pack_completion_stats_service.dart';
+
+void main() {
+  test('computeStats aggregates per pack using latest attempts', () {
+    final attempts = [
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: DateTime(2024, 1, 1),
+        accuracy: 1,
+        ev: 0.5,
+        icm: 0.3,
+      ),
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: DateTime(2024, 1, 2),
+        accuracy: 0,
+        ev: -0.1,
+        icm: -0.2,
+      ),
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's2',
+        timestamp: DateTime(2024, 1, 2),
+        accuracy: 0.5,
+        ev: 0.2,
+        icm: 0.1,
+      ),
+      TrainingAttempt(
+        packId: 'p2',
+        spotId: 'x',
+        timestamp: DateTime(2024, 1, 3),
+        accuracy: 0.7,
+        ev: 0.4,
+        icm: 0.2,
+      ),
+    ];
+
+    const service = PackCompletionStatsService();
+    final stats = service.computeStats(attempts);
+
+    expect(stats.length, 2);
+    final p1 = stats['p1']!;
+    expect(p1.attempts, 2);
+    expect(p1.accuracy, closeTo(0.25, 0.0001));
+    expect(p1.ev, closeTo(0.05, 0.0001));
+    expect(p1.icm, closeTo(-0.05, 0.0001));
+
+    final p2 = stats['p2']!;
+    expect(p2.attempts, 1);
+    expect(p2.accuracy, 0.7);
+    expect(p2.ev, 0.4);
+    expect(p2.icm, 0.2);
+  });
+}


### PR DESCRIPTION
## Summary
- add model for training attempts
- implement PackCompletionStatsService to aggregate per-pack stats
- test pack stat computation logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec5a1c3bc832aaf71bba6ae1f7a59