### PR TITLE
Implement TrainingProgressService summary metrics

### DIFF
--- a/lib/services/training_progress_service.dart
+++ b/lib/services/training_progress_service.dart
@@ -1,5 +1,22 @@
+import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/training_attempt.dart';
+import '../models/v2/training_pack_template_v2.dart';
 import 'training_pack_template_service.dart';
+
+/// Summary of a player's overall training progress.
+class TrainingProgress {
+  final double completionRate;
+  final List<String> mostImprovedTags;
+  final int streakDays;
+
+  const TrainingProgress({
+    required this.completionRate,
+    required this.mostImprovedTags,
+    required this.streakDays,
+  });
+}
 
 class TrainingProgressService {
   TrainingProgressService._();
@@ -15,5 +32,117 @@ class TrainingProgressService {
     final count = tpl.spots.isNotEmpty ? tpl.spots.length : tpl.spotCount;
     if (count == 0) return 0.0;
     return ((idx + 1) / count).clamp(0.0, 1.0);
+  }
+
+  /// Computes high-level training stats from [attempts] and [allPacks].
+  ///
+  /// Packs with average accuracy of 90% or higher are considered completed.
+  /// Tag improvements are measured by comparing average tag accuracy of the
+  /// last 7 days versus all earlier attempts. Only the top three tags with
+  /// positive improvement are returned.
+  TrainingProgress computeOverallProgress({
+    required List<TrainingAttempt> attempts,
+    required List<TrainingPackTemplateV2> allPacks,
+  }) {
+    if (allPacks.isEmpty) {
+      return const TrainingProgress(
+        completionRate: 0,
+        mostImprovedTags: [],
+        streakDays: 0,
+      );
+    }
+
+    // Index tags by pack and spot for quick lookup.
+    final tagsByPack = <String, Map<String, List<String>>>{};
+    for (final p in allPacks) {
+      tagsByPack[p.id] = {
+        for (final s in p.spots)
+          s.id: [for (final t in s.tags) t.trim().toLowerCase()]
+      };
+    }
+
+    // Determine the latest attempt per pack/spot.
+    final latest = <String, Map<String, TrainingAttempt>>{};
+    for (final a in attempts) {
+      final bySpot = latest.putIfAbsent(a.packId, () => {});
+      final prev = bySpot[a.spotId];
+      if (prev == null || a.timestamp.isAfter(prev.timestamp)) {
+        bySpot[a.spotId] = a;
+      }
+    }
+
+    // Compute pack completion rate.
+    var completed = 0;
+    for (final p in allPacks) {
+      final map = latest[p.id];
+      final spotCount = p.spots.isNotEmpty ? p.spots.length : p.spotCount;
+      if (map == null || spotCount == 0) continue;
+      if (map.length < spotCount) continue;
+      final avg = map.values
+              .map((a) => a.accuracy)
+              .sum /
+          spotCount;
+      if (avg >= 0.9) completed += 1;
+    }
+    final completionRate = completed / allPacks.length;
+
+    final now = DateTime.now();
+    final cutoff = now.subtract(const Duration(days: 7));
+
+    final recent = <String, List<double>>{};
+    final earlier = <String, List<double>>{};
+
+    void collect(TrainingAttempt a, Map<String, List<double>> target) {
+      final tags = tagsByPack[a.packId]?[a.spotId];
+      if (tags == null) return;
+      for (final t in tags) {
+        if (t.isEmpty) continue;
+        target.putIfAbsent(t, () => []).add(a.accuracy);
+      }
+    }
+
+    for (final a in attempts) {
+      if (a.timestamp.isAfter(cutoff)) {
+        collect(a, recent);
+      } else {
+        collect(a, earlier);
+      }
+    }
+
+    double avg(List<double> l) => l.isNotEmpty ? l.sum / l.length : 0;
+
+    final improvements = <String, double>{};
+    final allTags = {...recent.keys, ...earlier.keys};
+    for (final t in allTags) {
+      final delta = avg(recent[t] ?? []) - avg(earlier[t] ?? []);
+      improvements[t] = delta;
+    }
+
+    final mostImprovedTags = improvements.entries
+        .where((e) => e.value > 0)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final improved = [for (final e in mostImprovedTags.take(3)) e.key];
+
+    // Compute streak based on attempts per day.
+    final days = attempts
+        .map((a) => DateTime(a.timestamp.year, a.timestamp.month, a.timestamp.day))
+        .toSet();
+    var streak = 0;
+    for (var i = 0; ; i++) {
+      final day = DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
+      if (days.contains(day)) {
+        streak += 1;
+      } else {
+        break;
+      }
+    }
+
+    return TrainingProgress(
+      completionRate: completionRate,
+      mostImprovedTags: improved,
+      streakDays: streak,
+    );
   }
 }

--- a/test/training_progress_service_test.dart
+++ b/test/training_progress_service_test.dart
@@ -1,0 +1,126 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_attempt.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_progress_service.dart';
+
+void main() {
+  test('computeOverallProgress calculates completion rate', () {
+    final now = DateTime.now();
+    final p1 = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack 1',
+      trainingType: TrainingType.pushFold,
+      spots: [
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['a']),
+        TrainingPackSpot(id: 's2', hand: HandData(), tags: ['a']),
+      ],
+    );
+    final p2 = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Pack 2',
+      trainingType: TrainingType.pushFold,
+      spots: [TrainingPackSpot(id: 's3', hand: HandData(), tags: ['b'])],
+    );
+    final attempts = [
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: now,
+        accuracy: 1,
+        ev: 0,
+        icm: 0,
+      ),
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's2',
+        timestamp: now,
+        accuracy: 1,
+        ev: 0,
+        icm: 0,
+      ),
+      TrainingAttempt(
+        packId: 'p2',
+        spotId: 's3',
+        timestamp: now,
+        accuracy: 0.8,
+        ev: 0,
+        icm: 0,
+      ),
+    ];
+
+    final service = TrainingProgressService.instance;
+    final progress = service.computeOverallProgress(
+      attempts: attempts,
+      allPacks: [p1, p2],
+    );
+
+    expect(progress.completionRate, closeTo(0.5, 0.0001));
+    expect(progress.streakDays, 1);
+  });
+
+  test('computeOverallProgress detects most improved tags', () {
+    final now = DateTime.now();
+    final p1 = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack 1',
+      trainingType: TrainingType.pushFold,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData(), tags: ['a'])],
+    );
+    final attempts = [
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: now.subtract(const Duration(days: 8)),
+        accuracy: 0.5,
+        ev: 0,
+        icm: 0,
+      ),
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: now.subtract(const Duration(days: 1)),
+        accuracy: 1,
+        ev: 0,
+        icm: 0,
+      ),
+    ];
+
+    final progress = TrainingProgressService.instance.computeOverallProgress(
+      attempts: attempts,
+      allPacks: [p1],
+    );
+
+    expect(progress.mostImprovedTags, contains('a'));
+  });
+
+  test('computeOverallProgress calculates streak', () {
+    final now = DateTime.now();
+    final p1 = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack 1',
+      trainingType: TrainingType.pushFold,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData(), tags: ['a'])],
+    );
+    final attempts = [
+      for (int i = 0; i < 3; i++)
+        TrainingAttempt(
+          packId: 'p1',
+          spotId: 's1',
+          timestamp: now.subtract(Duration(days: i)),
+          accuracy: 1,
+          ev: 0,
+          icm: 0,
+        ),
+    ];
+
+    final progress = TrainingProgressService.instance.computeOverallProgress(
+      attempts: attempts,
+      allPacks: [p1],
+    );
+
+    expect(progress.streakDays, greaterThanOrEqualTo(3));
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingProgress model and computation logic
- report pack completion, improved tags and streak
- cover new service with unit tests

## Testing
- `dart test test/training_progress_service_test.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed506b8a4832aa90861e4b6d5162f