### PR TITLE
Implement daily training reminders

### DIFF
--- a/lib/services/training_reminder_engine.dart
+++ b/lib/services/training_reminder_engine.dart
@@ -1,4 +1,7 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 import 'session_log_service.dart';
 import 'smart_pack_recommendation_engine.dart' show UserProfile;
@@ -6,7 +9,21 @@ import 'smart_pack_recommendation_engine.dart' show UserProfile;
 class TrainingReminderEngine {
   final SessionLogService logs;
 
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+  static bool _initialized = false;
+
   TrainingReminderEngine({required this.logs});
+
+  Future<void> _init() async {
+    if (_initialized) return;
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(
+        const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+    _initialized = true;
+  }
 
   static const _checkKey = 'lastReminderCheck';
 
@@ -28,5 +45,46 @@ class TrainingReminderEngine {
     }
     if (last == null) return true;
     return now.difference(last) > const Duration(days: 3);
+  }
+
+  /// Schedule a local notification encouraging training if the user
+  /// hasn't trained today. The notification fires at 20:00 local time.
+  Future<void> scheduleDailyReminder({
+    required DateTime lastTrainingTime,
+    required int streakDays,
+  }) async {
+    await _init();
+    final now = tz.TZDateTime.now(tz.local);
+    final today = tz.TZDateTime(tz.local, now.year, now.month, now.day);
+    final lastDay = tz.TZDateTime(
+        tz.local, lastTrainingTime.year, lastTrainingTime.month, lastTrainingTime.day);
+    if (lastDay.isAtSameMomentAs(today)) return;
+
+    var when = tz.TZDateTime(tz.local, today.year, today.month, today.day, 20);
+    if (!when.isAfter(now)) {
+      when = when.add(const Duration(days: 1));
+    }
+
+    final body = streakDays >= 3
+        ? '🔥 Keep your streak alive! Jump into training.'
+        : '🏋️ Ready to improve today? Your next pack awaits.';
+
+    await _plugin.zonedSchedule(
+      131,
+      'Poker Analyzer',
+      body,
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'training_reminder',
+          'Training Reminder',
+        ),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- introduce notification scheduling to `TrainingReminderEngine`
- send 20:00 reminder if user missed a day, with streak-aware message

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed8834844832abbe8819a11a020d5