### PR TITLE
Implement WeaknessReviewEngine

### DIFF
--- a/lib/services/weakness_review_engine.dart
+++ b/lib/services/weakness_review_engine.dart
@@ -1,0 +1,103 @@
+import '../models/training_attempt.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_pack_stats_service.dart';
+
+class WeaknessReviewItem {
+  final String packId;
+  final String tag;
+  final String reason;
+
+  const WeaknessReviewItem({
+    required this.packId,
+    required this.tag,
+    required this.reason,
+  });
+}
+
+class WeaknessReviewEngine {
+  const WeaknessReviewEngine();
+
+  List<WeaknessReviewItem> analyze({
+    required List<TrainingAttempt> attempts,
+    required Map<String, TrainingPackStat> stats,
+    required Map<String, double> tagDeltas,
+    required List<TrainingPackTemplateV2> allPacks,
+    DateTime? now,
+  }) {
+    if (allPacks.isEmpty || tagDeltas.isEmpty) return [];
+    final current = now ?? DateTime.now();
+    const deltaThreshold = -0.3;
+    const lookback = Duration(days: 14);
+    final recentCutoff = current.subtract(lookback);
+
+    final weakTags = <String, double>{};
+    tagDeltas.forEach((tag, delta) {
+      if (delta <= deltaThreshold) {
+        weakTags[tag.trim().toLowerCase()] = delta;
+      }
+    });
+    if (weakTags.isEmpty) return [];
+
+    final attemptsByPack = <String, List<TrainingAttempt>>{};
+    for (final a in attempts) {
+      if (a.timestamp.isBefore(recentCutoff)) continue;
+      attemptsByPack.putIfAbsent(a.packId, () => []).add(a);
+    }
+
+    final scored = <_ScoredItem>[];
+
+    double avgAcc(List<TrainingAttempt> list) {
+      if (list.isEmpty) return 1.0;
+      var sum = 0.0;
+      for (final a in list) sum += a.accuracy;
+      return sum / list.length;
+    }
+
+    for (final p in allPacks) {
+      final stat = stats[p.id];
+      if (stat == null) continue;
+      if (stat.accuracy >= 0.6) continue;
+      if (current.difference(stat.last) > lookback) continue;
+
+      final packTags = [for (final t in p.tags) t.trim().toLowerCase()];
+      String? matchedTag;
+      double? delta;
+      for (final tag in packTags) {
+        final d = weakTags[tag];
+        if (d != null) {
+          matchedTag = tag;
+          delta = d;
+          break;
+        }
+      }
+      if (matchedTag == null) continue;
+
+      final recentAttempts = attemptsByPack[p.id] ?? [];
+      final recAcc = recentAttempts.isNotEmpty
+          ? avgAcc(recentAttempts)
+          : stat.accuracy;
+      if (recAcc >= 0.6) continue;
+
+      final score = (-delta!) + (0.6 - recAcc);
+      scored.add(
+        _ScoredItem(
+          item: WeaknessReviewItem(
+            packId: p.id,
+            tag: matchedTag,
+            reason: 'weakness in $matchedTag',
+          ),
+          score: score,
+        ),
+      );
+    }
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return [for (final e in scored) e.item];
+  }
+}
+
+class _ScoredItem {
+  final WeaknessReviewItem item;
+  final double score;
+  const _ScoredItem({required this.item, required this.score});
+}

--- a/test/weakness_review_engine_test.dart
+++ b/test/weakness_review_engine_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/weakness_review_engine.dart';
+import 'package:poker_analyzer/models/training_attempt.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_pack_stats_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('analyze picks packs with negative tag deltas', () {
+    final now = DateTime(2024, 1, 10);
+    final packs = [
+      TrainingPackTemplateV2(
+        id: 'p1',
+        name: 'P1',
+        trainingType: TrainingType.pushFold,
+        tags: const ['btn push'],
+        spots: const [],
+      ),
+      TrainingPackTemplateV2(
+        id: 'p2',
+        name: 'P2',
+        trainingType: TrainingType.pushFold,
+        tags: const ['sb call'],
+        spots: const [],
+      ),
+    ];
+
+    final stats = {
+      'p1': TrainingPackStat(
+        accuracy: 0.5,
+        last: now.subtract(const Duration(days: 1)),
+      ),
+      'p2': TrainingPackStat(
+        accuracy: 0.55,
+        last: now.subtract(const Duration(days: 1)),
+      ),
+    };
+
+    final attempts = [
+      TrainingAttempt(
+        packId: 'p1',
+        spotId: 's1',
+        timestamp: now.subtract(const Duration(days: 1)),
+        accuracy: 0.5,
+        ev: 0,
+        icm: 0,
+      ),
+      TrainingAttempt(
+        packId: 'p2',
+        spotId: 's1',
+        timestamp: now.subtract(const Duration(days: 1)),
+        accuracy: 0.55,
+        ev: 0,
+        icm: 0,
+      ),
+    ];
+
+    final tagDeltas = {'btn push': -0.4, 'sb call': -0.1};
+
+    const engine = WeaknessReviewEngine();
+    final list = engine.analyze(
+      attempts: attempts,
+      stats: stats,
+      tagDeltas: tagDeltas,
+      allPacks: packs,
+      now: now,
+    );
+
+    expect(list.length, 1);
+    expect(list.first.packId, 'p1');
+    expect(list.first.tag, 'btn push');
+  });
+}


### PR DESCRIPTION
## Summary
- add `WeaknessReviewEngine` to recommend review packs for weak tags
- unit test covering core logic

## Testing
- `dart test test/weakness_review_engine_test.dart` *(fails: Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_687eed832384832ab60aef46387d4aa7