### PR TITLE
Add weakness review section

### DIFF
--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -10,6 +10,8 @@ import '../services/tag_mastery_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/recommendation_feed_engine.dart';
 import 'package:collection/collection.dart';
+import '../services/weakness_review_engine.dart';
+import '../widgets/weakness_review_section.dart';
 import '../widgets/feed_recommendation_widget.dart';
 import '../models/training_attempt.dart';
 import '../models/v2/training_pack_template_v2.dart';
@@ -26,10 +28,12 @@ class _DashboardData {
   final TrainingProgress progress;
   final TrainingPackTemplateV2? nextPack;
   final Map<String, double> improvements;
+  final List<WeaknessReviewItem> reviews;
   const _DashboardData({
     required this.progress,
     required this.nextPack,
     required this.improvements,
+    required this.reviews,
   });
 }
 
@@ -96,10 +100,18 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
       for (final e in top.take(3)) e.key: e.value,
     };
 
+    final reviewItems = const WeaknessReviewEngine().analyze(
+      attempts: attempts,
+      stats: stats,
+      tagDeltas: deltas,
+      allPacks: packs,
+    );
+
     return _DashboardData(
       progress: progress,
       nextPack: track.nextUpPack,
       improvements: improvements,
+      reviews: reviewItems,
     );
   }
 
@@ -192,6 +204,11 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
               _section('🎯 Completion', '$completion% complete'),
               const SizedBox(height: 12),
               _improvements(data.improvements),
+              const SizedBox(height: 12),
+              WeaknessReviewSection(
+                items: data.reviews,
+                onTap: _handlePackLaunch,
+              ),
               const SizedBox(height: 12),
               _section('🔥 Streak', '${streak}-day streak'),
               const SizedBox(height: 12),

--- a/lib/widgets/weakness_review_section.dart
+++ b/lib/widgets/weakness_review_section.dart
@@ -1,0 +1,68 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../services/pack_library_loader_service.dart';
+import '../services/weakness_review_engine.dart';
+
+class WeaknessReviewSection extends StatelessWidget {
+  final List<WeaknessReviewItem> items;
+  final void Function(String packId) onTap;
+
+  const WeaknessReviewSection({
+    super.key,
+    required this.items,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final packs = PackLibraryLoaderService.instance.library;
+    final display = items.take(3).toList();
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const ClampingScrollPhysics(),
+      padding: const EdgeInsets.all(16),
+      itemCount: display.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (_, i) {
+        final item = display[i];
+        final pack = packs.firstWhereOrNull((p) => p.id == item.packId);
+        final title = pack?.name ?? item.packId;
+        return Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                item.tag,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(title, style: const TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              Text(item.reason, style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: () => onTap(item.packId),
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  child: const Text('Review'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `WeaknessReviewSection` widget to show packs that regressed
- compute weakness review items in `LearningDashboardScreen`
- display the section on the learning dashboard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eef1916f8832aab7872009288948e