### PR TITLE
Enable deep tag exploration

### DIFF
--- a/lib/screens/accuracy_mistake_overview_screen.dart
+++ b/lib/screens/accuracy_mistake_overview_screen.dart
@@ -5,6 +5,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../helpers/poker_street_helper.dart';
 import '../widgets/sync_status_widget.dart';
+import 'tag_insight_screen.dart';
 
 /// Shows accuracy percentages grouped by tag, street and hero position.
 ///
@@ -87,6 +88,13 @@ class AccuracyMistakeOverviewScreen extends StatelessWidget {
                 title: Text(e.key, style: const TextStyle(color: Colors.white)),
                 trailing: Text('${e.value.toStringAsFixed(1)}%',
                     style: const TextStyle(color: Colors.white)),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => TagInsightScreen(tag: e.key)),
+                  );
+                },
               ),
             const SizedBox(height: 16),
           ],

--- a/lib/screens/lesson_tag_heatmap_screen.dart
+++ b/lib/screens/lesson_tag_heatmap_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/tag_coverage_service.dart';
 import '../utils/responsive.dart';
 import '../widgets/tag_coverage_tile.dart';
+import 'tag_insight_screen.dart';
 
 class LessonTagHeatmapScreen extends StatefulWidget {
   const LessonTagHeatmapScreen({super.key});
@@ -87,7 +88,13 @@ class _LessonTagHeatmapScreenState extends State<LessonTagHeatmapScreen> {
                   tag: entry.key,
                   count: entry.value,
                   max: maxCount,
-                  onTap: () {},
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => TagInsightScreen(tag: entry.key)),
+                    );
+                  },
                 );
               },
             ),

--- a/lib/screens/skill_map_screen.dart
+++ b/lib/screens/skill_map_screen.dart
@@ -7,7 +7,7 @@ import '../widgets/skill_card.dart';
 import '../widgets/booster_packs_block.dart';
 import '../utils/responsive.dart';
 import 'library_screen.dart';
-import 'tag_skill_detail_screen.dart';
+import 'tag_insight_screen.dart';
 
 class SkillMapScreen extends StatefulWidget {
   const SkillMapScreen({super.key});
@@ -61,7 +61,7 @@ class _SkillMapScreenState extends State<SkillMapScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => TagSkillDetailScreen(tag: tag),
+        builder: (_) => TagInsightScreen(tag: tag),
       ),
     );
   }

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -18,6 +18,7 @@ import '../services/saved_hand_manager_service.dart';
 import '../services/evaluation_executor_service.dart';
 import '../models/mistake_severity.dart';
 import '../models/mistake_sort_option.dart';
+import 'tag_insight_screen.dart';
 import '../theme/app_colors.dart';
 import '../services/ignored_mistake_service.dart';
 import '../services/tag_service.dart';
@@ -1008,12 +1009,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => _TagMistakeHandsScreen(
-                            tag: e.key,
-                            dateFilter: widget.dateFilter,
-                            dateRange: _range,
-                          ),
-                        ),
+                            builder: (_) => TagInsightScreen(tag: e.key)),
                       );
                     },
                   );

--- a/lib/widgets/skill_loss_banner.dart
+++ b/lib/widgets/skill_loss_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../services/skill_loss_detector.dart';
+import '../screens/tag_insight_screen.dart';
 
 class SkillLossBanner extends StatelessWidget {
   final List<SkillLoss> losses;
@@ -38,9 +39,16 @@ class SkillLossBanner extends StatelessWidget {
               child: Row(
                 children: [
                   Expanded(
-                    child: Text(
-                      '${loss.tag} — ${loss.trend}',
-                      style: const TextStyle(color: Colors.white),
+                    child: GestureDetector(
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => TagInsightScreen(tag: loss.tag)),
+                      ),
+                      child: Text(
+                        '${loss.tag} — ${loss.trend}',
+                        style: const TextStyle(color: Colors.white),
+                      ),
                     ),
                   ),
                   ElevatedButton(

--- a/lib/widgets/tag_badge.dart
+++ b/lib/widgets/tag_badge.dart
@@ -1,20 +1,31 @@
 import 'package:flutter/material.dart';
 
+import '../screens/tag_insight_screen.dart';
+
 /// Simple visual badge for displaying a training tag.
 class TagBadge extends StatelessWidget {
   final String tag;
-  const TagBadge(this.tag, {super.key});
+  final VoidCallback? onTap;
+  const TagBadge(this.tag, {super.key, this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    return Chip(
-      label: Text(
-        tag,
-        style: const TextStyle(color: Colors.white, fontSize: 11),
+    return GestureDetector(
+      onTap: onTap ??
+          () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => TagInsightScreen(tag: tag)),
+              ),
+      child: Chip(
+        label: Text(
+          tag,
+          style: const TextStyle(color: Colors.white, fontSize: 11),
+        ),
+        backgroundColor: const Color(0xFF3A3B3E),
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
       ),
-      backgroundColor: const Color(0xFF3A3B3E),
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
     );
   }
 }

--- a/lib/widgets/tag_coverage_tile.dart
+++ b/lib/widgets/tag_coverage_tile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../screens/tag_insight_screen.dart';
+
 class TagCoverageTile extends StatelessWidget {
   final String tag;
   final int count;
@@ -20,7 +22,12 @@ class TagCoverageTile extends StatelessWidget {
     final color =
         Color.lerp(const Color(0xFF444444), const Color(0xFFFFA500), t)!;
     return GestureDetector(
-      onTap: onTap,
+      onTap: onTap ??
+          () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => TagInsightScreen(tag: tag)),
+              ),
       child: Container(
         decoration: BoxDecoration(
           color: color,

--- a/lib/widgets/tag_progress_card.dart
+++ b/lib/widgets/tag_progress_card.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/tag_mastery_service.dart';
 import '../screens/skill_map_screen.dart';
-import '../screens/tag_skill_detail_screen.dart';
+import '../screens/tag_insight_screen.dart';
 
 class TagProgressCard extends StatelessWidget {
   const TagProgressCard({super.key});
@@ -21,7 +21,7 @@ class TagProgressCard extends StatelessWidget {
   void _openTag(BuildContext context, String tag) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => TagSkillDetailScreen(tag: tag)),
+      MaterialPageRoute(builder: (_) => TagInsightScreen(tag: tag)),
     );
   }
 

--- a/lib/widgets/tag_skill_tile.dart
+++ b/lib/widgets/tag_skill_tile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../screens/tag_insight_screen.dart';
+
 class TagSkillTile extends StatelessWidget {
   final String tag;
   final double value;
@@ -16,7 +18,12 @@ class TagSkillTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = Color.lerp(Colors.red, Colors.green, value) ?? Colors.red;
     return GestureDetector(
-      onTap: onTap,
+      onTap: onTap ??
+          () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => TagInsightScreen(tag: tag)),
+              ),
       child: Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- tap any tag to open `TagInsightScreen`
- update Skill Map, banners and overviews to link into insights
- make tag badges and tiles clickable by default

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef9b06cd8832aafdb7aabb4a900c2