### PR TITLE
Implement PackSearchEngine

### DIFF
--- a/lib/services/pack_search_engine.dart
+++ b/lib/services/pack_search_engine.dart
@@ -1,0 +1,55 @@
+import 'dart:math';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_index_loader.dart';
+
+/// Provides fuzzy search over training pack titles and tags.
+class PackSearchEngine {
+  const PackSearchEngine({List<TrainingPackTemplateV2>? library})
+      : _library = library;
+
+  final List<TrainingPackTemplateV2>? _library;
+
+  List<TrainingPackTemplateV2> search(String query, {int limit = 5}) {
+    final library = _library ?? PackLibraryIndexLoader.instance.library;
+    final q = query.trim().toLowerCase();
+    if (library.isEmpty) return const [];
+    if (q.isEmpty) return library.take(limit).toList();
+
+    final scored = <(TrainingPackTemplateV2, double)>[];
+    for (final tpl in library) {
+      final title = tpl.name.toLowerCase();
+      final tagScores = [
+        for (final t in tpl.tags) _similarity(q, t.toLowerCase())
+      ];
+      final tagScore = tagScores.isEmpty ? 0.0 : tagScores.reduce(max);
+      final score = _similarity(q, title) * 0.7 + tagScore * 0.3;
+      if (score > 0) scored.add((tpl, score));
+    }
+    if (scored.isEmpty) return library.take(limit).toList();
+    scored.sort((a, b) => b.$2.compareTo(a.$2));
+    return [for (final s in scored.take(limit)) s.$1];
+  }
+
+  double _similarity(String a, String b) {
+    final ta = _trigrams(a);
+    final tb = _trigrams(b);
+    if (ta.isEmpty || tb.isEmpty) return 0;
+    final inter = ta.intersection(tb).length.toDouble();
+    final union = ta.union(tb).length.toDouble();
+    return union == 0 ? 0 : inter / union;
+  }
+
+  Set<String> _trigrams(String s) {
+    final clean = s.replaceAll(RegExp(r'[^a-z0-9]'), '');
+    final set = <String>{};
+    if (clean.length <= 3) {
+      if (clean.isNotEmpty) set.add(clean);
+      return set;
+    }
+    for (var i = 0; i <= clean.length - 3; i++) {
+      set.add(clean.substring(i, i + 3));
+    }
+    return set;
+  }
+}

--- a/test/pack_search_engine_test.dart
+++ b/test/pack_search_engine_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/pack_search_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  test('fuzzy search by title and tags', () {
+    final t1 = TrainingPackTemplateV2(
+      id: '1',
+      name: 'Aggressive Push',
+      trainingType: TrainingType.pushFold,
+      tags: ['push', 'aggression'],
+    );
+    final t2 = TrainingPackTemplateV2(
+      id: '2',
+      name: 'ICM Defense',
+      trainingType: TrainingType.icm,
+      tags: ['icm', 'call'],
+    );
+
+    final engine = PackSearchEngine(library: [t1, t2]);
+    final res1 = engine.search('agr push');
+    expect(res1.first, t1);
+    final res2 = engine.search('icm');
+    expect(res2, contains(t2));
+  });
+}


### PR DESCRIPTION
## Summary
- add a fuzzy text search engine for training pack titles and tags
- expose the search engine in the dev menu for quick testing
- add unit test for PackSearchEngine

## Testing
- `dart format lib/services/pack_search_engine.dart lib/screens/dev_menu_screen.dart test/pack_search_engine_test.dart`
- `dart analyze lib/services/pack_search_engine.dart lib/screens/dev_menu_screen.dart test/pack_search_engine_test.dart` *(fails: numerous unrelated analysis errors)*
- `flutter test` *(fails: project build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687efefeea44832a870fee62486e3241