### PR TITLE
Add tag insight reminder engine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -98,6 +98,7 @@ import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
 import 'services/tag_mastery_history_service.dart';
+import 'services/tag_insight_reminder_engine.dart';
 import 'services/daily_training_reminder_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
@@ -462,6 +463,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => TagCoverageService()),
     Provider(create: (_) => TagMasteryHistoryService()),
+    Provider(
+      create: (context) => TagInsightReminderEngine(
+        history: context.read<TagMasteryHistoryService>(),
+      ),
+    ),
     Provider(create: (_) => DailyTrainingReminderService()),
     Provider(
       create: (context) => GoalSuggestionEngine(

--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -11,8 +11,7 @@ import '../services/training_session_launcher.dart';
 import '../services/recommendation_feed_engine.dart';
 import 'package:collection/collection.dart';
 import '../services/weakness_review_engine.dart';
-import '../services/skill_loss_detector.dart';
-import '../services/progress_forecast_service.dart';
+import '../services/tag_insight_reminder_engine.dart';
 import '../widgets/weakness_review_section.dart';
 import '../widgets/feed_recommendation_widget.dart';
 import '../widgets/next_up_banner.dart';
@@ -113,12 +112,8 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
       allPacks: packs,
     );
 
-    final forecast = context.read<ProgressForecastService>();
-    final tagHistory = {
-      for (final tag in forecast.tags)
-        tag: [for (final e in forecast.tagSeries(tag)) e.accuracy]
-    };
-    final losses = const SkillLossDetector().detect(tagHistory);
+    final reminder = context.read<TagInsightReminderEngine>();
+    final losses = await reminder.loadLosses();
 
     return _DashboardData(
       progress: progress,

--- a/lib/services/tag_insight_reminder_engine.dart
+++ b/lib/services/tag_insight_reminder_engine.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'skill_loss_detector.dart';
+import 'tag_mastery_history_service.dart';
+
+/// Periodically checks for skill loss on tags and caches results.
+class TagInsightReminderEngine {
+  final TagMasteryHistoryService history;
+  TagInsightReminderEngine({required this.history});
+
+  static const _lastKey = 'tag_insight_reminder_last';
+  static const _dataKey = 'tag_insight_reminder_data';
+
+  Future<List<SkillLoss>> loadLosses({int days = 14}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null && now.difference(last) < const Duration(days: 1)) {
+      final raw = prefs.getString(_dataKey);
+      if (raw != null) {
+        try {
+          final list = jsonDecode(raw);
+          if (list is List) {
+            return [
+              for (final item in list)
+                if (item is Map)
+                  SkillLoss(
+                    tag: item['tag'] ?? '',
+                    drop: (item['drop'] as num?)?.toDouble() ?? 0,
+                    trend: item['trend'] ?? '',
+                  )
+            ];
+          }
+        } catch (_) {}
+      }
+    }
+
+    final hist = await history.getHistory();
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(Duration(days: days - 1));
+    final map = <String, List<double>>{};
+    for (final entry in hist.entries) {
+      final data = List<double>.filled(days, 0);
+      for (final e in entry.value) {
+        final d = DateTime(e.date.year, e.date.month, e.date.day);
+        if (d.isBefore(start) || d.isAfter(today)) continue;
+        final idx = d.difference(start).inDays;
+        if (idx >= 0 && idx < days) data[idx] += e.xp.toDouble();
+      }
+      map[entry.key] = data;
+    }
+    final losses = const SkillLossDetector().detect(map).take(2).toList();
+    final encoded = jsonEncode([
+      for (final l in losses)
+        {'tag': l.tag, 'drop': l.drop, 'trend': l.trend}
+    ]);
+    await prefs.setString(_lastKey, now.toIso8601String());
+    await prefs.setString(_dataKey, encoded);
+    return losses;
+  }
+}

--- a/test/services/tag_insight_reminder_engine_test.dart
+++ b/test/services/tag_insight_reminder_engine_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/tag_xp_history_entry.dart';
+import 'package:poker_analyzer/services/tag_insight_reminder_engine.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeHistoryService extends TagMasteryHistoryService {
+  final Map<String, List<TagXpHistoryEntry>> data;
+  _FakeHistoryService(this.data);
+  @override
+  Future<Map<String, List<TagXpHistoryEntry>>> getHistory() async => data;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadLosses caches results for a day', () async {
+    SharedPreferences.setMockInitialValues({});
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day - 2);
+    final hist = {
+      'a': [
+        TagXpHistoryEntry(date: start, xp: 10, source: ''),
+        TagXpHistoryEntry(date: start.add(const Duration(days: 1)), xp: 8, source: ''),
+        TagXpHistoryEntry(date: start.add(const Duration(days: 2)), xp: 4, source: ''),
+      ],
+      'b': [
+        TagXpHistoryEntry(date: start, xp: 5, source: ''),
+        TagXpHistoryEntry(date: start.add(const Duration(days: 1)), xp: 5, source: ''),
+        TagXpHistoryEntry(date: start.add(const Duration(days: 2)), xp: 5, source: ''),
+      ],
+    };
+    final engine = TagInsightReminderEngine(history: _FakeHistoryService(hist));
+    final first = await engine.loadLosses(days: 3);
+    expect(first.length, 1);
+    expect(first.first.tag, 'a');
+
+    // modify history but results should come from cache
+    final engine2 = TagInsightReminderEngine(history: _FakeHistoryService({}));
+    final second = await engine2.loadLosses(days: 3);
+    expect(second.first.tag, 'a');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TagInsightReminderEngine` for detecting decaying tags
- provide reminder results to dashboard
- register reminder engine in providers
- add service test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2a1e5f18832aa4f9c91849722d41