### PR TITLE
Implement AutoRecoveryTriggerService

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -99,6 +99,8 @@ import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
 import 'services/tag_mastery_history_service.dart';
 import 'services/tag_insight_reminder_engine.dart';
+import 'services/scheduled_training_queue_service.dart';
+import 'services/auto_recovery_trigger_service.dart';
 import 'services/daily_training_reminder_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
@@ -467,6 +469,15 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => TagInsightReminderEngine(
         history: context.read<TagMasteryHistoryService>(),
       ),
+    ),
+    ChangeNotifierProvider<ScheduledTrainingQueueService>.value(
+      value: ScheduledTrainingQueueService.instance..load(),
+    ),
+    Provider(
+      create: (context) => AutoRecoveryTriggerService(
+        reminder: context.read<TagInsightReminderEngine>(),
+        queue: ScheduledTrainingQueueService.instance,
+      )..run(),
     ),
     Provider(create: (_) => DailyTrainingReminderService()),
     Provider(

--- a/lib/services/auto_recovery_trigger_service.dart
+++ b/lib/services/auto_recovery_trigger_service.dart
@@ -1,0 +1,48 @@
+import '../main.dart';
+import 'notification_service.dart';
+import 'tag_insight_reminder_engine.dart';
+import 'tag_goal_tracker_service.dart';
+import 'pack_library_service.dart';
+import 'scheduled_training_queue_service.dart';
+import 'skill_loss_detector.dart';
+
+/// Automatically queues recovery drills when skill loss is detected.
+class AutoRecoveryTriggerService {
+  final TagInsightReminderEngine reminder;
+  final TagGoalTrackerService goals;
+  final PackLibraryService library;
+  final ScheduledTrainingQueueService queue;
+
+  AutoRecoveryTriggerService({
+    required this.reminder,
+    required this.queue,
+    TagGoalTrackerService? goals,
+    PackLibraryService? library,
+  })  : goals = goals ?? TagGoalTrackerService.instance,
+        library = library ?? PackLibraryService.instance;
+
+  /// Checks for skill losses and schedules review packs if needed.
+  Future<void> run() async {
+    final losses = await reminder.loadLosses();
+    bool anyQueued = false;
+    for (final loss in losses) {
+      final progress = await goals.getProgress(loss.tag);
+      final last = progress.lastTrainingDate;
+      if (last != null &&
+          DateTime.now().difference(last) < const Duration(days: 3)) {
+        continue;
+      }
+      final tpl = await library.findByTag(loss.tag);
+      if (tpl != null) {
+        await queue.add(tpl.id);
+        anyQueued = true;
+      }
+    }
+    if (anyQueued) {
+      final ctx = navigatorKey.currentContext;
+      if (ctx != null) {
+        await NotificationService.scheduleDailyReminder(ctx);
+      }
+    }
+  }
+}

--- a/test/services/auto_recovery_trigger_service_test.dart
+++ b/test/services/auto_recovery_trigger_service_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/auto_recovery_trigger_service.dart';
+import 'package:poker_analyzer/services/scheduled_training_queue_service.dart';
+import 'package:poker_analyzer/services/tag_goal_tracker_service.dart';
+import 'package:poker_analyzer/services/tag_insight_reminder_engine.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/services/skill_loss_detector.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:collection/collection.dart';
+
+class _FakeReminder extends TagInsightReminderEngine {
+  final List<SkillLoss> _losses;
+  _FakeReminder(this._losses) : super(history: TagMasteryHistoryService());
+  @override
+  Future<List<SkillLoss>> loadLosses({int days = 14}) async => _losses;
+}
+
+class _FakeTracker implements TagGoalTrackerService {
+  final Map<String, DateTime?> map;
+  _FakeTracker(this.map);
+  @override
+  Future<TagGoalProgress> getProgress(String tagId) async {
+    return TagGoalProgress(
+      trainings: 0,
+      xp: 0,
+      streak: 0,
+      lastTrainingDate: map[tagId],
+    );
+  }
+
+  @override
+  Future<void> logTraining(String tagId) async {}
+}
+
+class _FakeLibrary implements PackLibraryService {
+  final Map<String, TrainingPackTemplateV2> byTag;
+  _FakeLibrary(this.byTag);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async =>
+      byTag.values.firstWhereOrNull((p) => p.id == id);
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async => byTag[tag];
+}
+
+TrainingPackTemplateV2 _tpl(String id, String tag) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: [tag],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('queues pack when tag not trained recently', () async {
+    final reminder = _FakeReminder([SkillLoss(tag: 'icm', drop: 0.5, trend: '')]);
+    final tracker = _FakeTracker({'icm': DateTime.now().subtract(const Duration(days: 4))});
+    final library = _FakeLibrary({'icm': _tpl('a', 'icm')});
+    final queue = ScheduledTrainingQueueService();
+    await queue.load();
+    final service = AutoRecoveryTriggerService(
+      reminder: reminder,
+      queue: queue,
+      goals: tracker,
+      library: library,
+    );
+    await service.run();
+    expect(queue.queue, ['a']);
+  });
+
+  test('does not queue when recently trained', () async {
+    final reminder = _FakeReminder([SkillLoss(tag: 'cbet', drop: 0.5, trend: '')]);
+    final tracker = _FakeTracker({'cbet': DateTime.now().subtract(const Duration(days: 1))});
+    final library = _FakeLibrary({'cbet': _tpl('b', 'cbet')});
+    final queue = ScheduledTrainingQueueService();
+    await queue.load();
+    final service = AutoRecoveryTriggerService(
+      reminder: reminder,
+      queue: queue,
+      goals: tracker,
+      library: library,
+    );
+    await service.run();
+    expect(queue.queue.isEmpty, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `ScheduledTrainingQueueService` for persisting scheduled packs
- implement `AutoRecoveryTriggerService` to queue reviews when skill loss detected
- register new services in `app_providers`
- add unit tests for scheduling logic

## Testing
- `flutter analyze` *(fails: Dart SDK 3.1.2 < 3.6.0)*
- `flutter test test/services/auto_recovery_trigger_service_test.dart` *(fails: Dart SDK 3.1.2 < 3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_687f2cce42bc832ab0ff1fdc8a2a02c5