### PR TITLE
Add ScheduledTrainingLauncher

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -101,6 +101,7 @@ import 'services/tag_mastery_history_service.dart';
 import 'services/tag_insight_reminder_engine.dart';
 import 'services/scheduled_training_queue_service.dart';
 import 'services/auto_recovery_trigger_service.dart';
+import 'services/scheduled_training_launcher.dart';
 import 'services/daily_training_reminder_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
@@ -479,6 +480,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         queue: ScheduledTrainingQueueService.instance,
       )..run(),
     ),
+    Provider(create: (_) => const ScheduledTrainingLauncher()),
     Provider(create: (_) => DailyTrainingReminderService()),
     Provider(
       create: (context) => GoalSuggestionEngine(

--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -8,6 +8,7 @@ import '../services/training_pack_stats_service.dart';
 import '../services/learning_track_engine.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/training_session_launcher.dart';
+import '../services/scheduled_training_launcher.dart';
 import '../services/recommendation_feed_engine.dart';
 import 'package:collection/collection.dart';
 import '../services/weakness_review_engine.dart';
@@ -52,6 +53,9 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
   void initState() {
     super.initState();
     _future = _load();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ScheduledTrainingLauncher>().launchNext();
+    });
   }
 
   Future<_DashboardData> _load() async {

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -32,6 +32,7 @@ import '../widgets/streak_widget.dart';
 import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../services/daily_training_reminder_service.dart';
+import '../services/scheduled_training_launcher.dart';
 import '../theme/app_colors.dart';
 import 'plugin_manager_screen.dart';
 import 'online_plugin_catalog_screen.dart';
@@ -74,6 +75,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeShowOnboarding();
       _maybeShowTrainingReminder();
+      _maybeLaunchScheduledTraining();
     });
   }
 
@@ -102,6 +104,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
 
   Future<void> _maybeShowTrainingReminder() async {
     await context.read<DailyTrainingReminderService>().maybeShowReminder(context);
+  }
+
+  Future<void> _maybeLaunchScheduledTraining() async {
+    await context.read<ScheduledTrainingLauncher>().launchNext();
   }
 
   Future<void> _setDailyGoal() async {
@@ -155,6 +161,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       _maybeShowTrainingReminder();
+      _maybeLaunchScheduledTraining();
     }
   }
 

--- a/lib/services/scheduled_training_launcher.dart
+++ b/lib/services/scheduled_training_launcher.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import 'scheduled_training_queue_service.dart';
+import 'pack_library_service.dart';
+import 'training_session_launcher.dart';
+
+/// Automatically launches the first queued training pack if available.
+class ScheduledTrainingLauncher {
+  final ScheduledTrainingQueueService queue;
+  final PackLibraryService library;
+  final TrainingSessionLauncher launcher;
+
+  const ScheduledTrainingLauncher({
+    ScheduledTrainingQueueService? queue,
+    PackLibraryService? library,
+    this.launcher = const TrainingSessionLauncher(),
+  })  : queue = queue ?? ScheduledTrainingQueueService.instance,
+        library = library ?? PackLibraryService.instance;
+
+  /// Launches the next scheduled pack if one is queued.
+  Future<void> launchNext() async {
+    if (!queue.hasItems) return;
+    final id = await queue.pop();
+    if (id == null) return;
+    final pack = await library.getById(id);
+    if (pack == null) return;
+    final ctx = navigatorKey.currentContext;
+    if (ctx != null && pack.tags.isNotEmpty) {
+      await showDialog<void>(
+        context: ctx,
+        builder: (_) => AlertDialog(
+          content: Text('Auto-recovery in progress for ${pack.tags.first}'),
+        ),
+      );
+    }
+    await launcher.launch(pack);
+  }
+}

--- a/test/services/scheduled_training_launcher_test.dart
+++ b/test/services/scheduled_training_launcher_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/scheduled_training_launcher.dart';
+import 'package:poker_analyzer/services/scheduled_training_queue_service.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLibrary implements PackLibraryService {
+  final Map<String, TrainingPackTemplateV2> packs;
+  _FakeLibrary(this.packs);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async => packs[id];
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async => null;
+}
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  TrainingPackTemplateV2? launched;
+  _FakeLauncher() : super();
+  @override
+  Future<void> launch(TrainingPackTemplateV2 template) async {
+    launched = template;
+  }
+}
+
+TrainingPackTemplateV2 _tpl(String id) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: ['tag'],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('launchNext starts queued pack', (tester) async {
+    final queue = ScheduledTrainingQueueService.instance;
+    await queue.load();
+    await queue.add('p1');
+    final library = _FakeLibrary({'p1': _tpl('p1')});
+    final launcher = _FakeLauncher();
+    final service = ScheduledTrainingLauncher(
+      queue: queue,
+      library: library,
+      launcher: launcher,
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: Container(key: key))));
+    await service.launchNext();
+    expect(launcher.launched?.id, 'p1');
+    expect(queue.queue.isEmpty, true);
+  });
+}
+


### PR DESCRIPTION
## Summary
- auto-start next queued review pack via new `ScheduledTrainingLauncher`
- register launcher in providers
- trigger launcher on app resume and dashboard load
- cover scheduler logic with unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f300ead10832aae246069cf6e89da