### PR TITLE
Add ReviewPathRecommender service

### DIFF
--- a/lib/services/review_path_recommender.dart
+++ b/lib/services/review_path_recommender.dart
@@ -1,0 +1,76 @@
+import 'package:collection/collection.dart';
+
+import 'skill_loss_detector.dart';
+
+class MistakeCluster {
+  final String tag;
+  final int count;
+
+  const MistakeCluster({required this.tag, required this.count});
+}
+
+class RecoveryPath {
+  final String tag;
+  final double urgencyScore;
+  final String reason;
+
+  const RecoveryPath({
+    required this.tag,
+    required this.urgencyScore,
+    required this.reason,
+  });
+}
+
+class ReviewPathRecommender {
+  const ReviewPathRecommender();
+
+  List<RecoveryPath> suggestRecoveryPath({
+    required List<SkillLoss> losses,
+    required List<MistakeCluster> mistakeClusters,
+    required Map<String, double> goalMissRatesByTag,
+  }) {
+    final tags = <String>{
+      ...losses.map((e) => e.tag),
+      ...mistakeClusters.map((e) => e.tag),
+      ...goalMissRatesByTag.keys,
+    };
+
+    final List<RecoveryPath> results = [];
+
+    for (final tag in tags) {
+      double score = 0;
+      final reasons = <String>[];
+
+      final loss = losses.firstWhereOrNull((l) => l.tag == tag);
+      if (loss != null && loss.drop > 0.15) {
+        score += 1.0;
+        reasons.add('skill drop');
+      }
+
+      final cluster = mistakeClusters.firstWhereOrNull((c) => c.tag == tag);
+      if (cluster != null && cluster.count >= 3) {
+        score += 0.8;
+        reasons.add('many mistakes');
+      }
+
+      final missRate = goalMissRatesByTag[tag];
+      if (missRate != null && missRate > 0.4) {
+        score += 0.5;
+        reasons.add('missed goals');
+      }
+
+      if (score > 0) {
+        results.add(
+          RecoveryPath(
+            tag: tag,
+            urgencyScore: score,
+            reason: reasons.join(', '),
+          ),
+        );
+      }
+    }
+
+    results.sort((a, b) => b.urgencyScore.compareTo(a.urgencyScore));
+    return results;
+  }
+}

--- a/test/review_path_recommender_test.dart
+++ b/test/review_path_recommender_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/review_path_recommender.dart';
+import 'package:poker_analyzer/services/skill_loss_detector.dart';
+
+void main() {
+
+  test('suggestRecoveryPath ranks tags by urgency', () {
+    final losses = [
+      SkillLoss(tag: 'a', drop: 0.2, trend: ''),
+      SkillLoss(tag: 'b', drop: 0.1, trend: ''),
+    ];
+    final clusters = [
+      const MistakeCluster(tag: 'a', count: 4),
+      const MistakeCluster(tag: 'c', count: 2),
+    ];
+    final missRates = {'a': 0.5, 'c': 0.6, 'b': 0.2};
+
+    const recommender = ReviewPathRecommender();
+    final result = recommender.suggestRecoveryPath(
+      losses: losses,
+      mistakeClusters: clusters,
+      goalMissRatesByTag: missRates,
+    );
+
+    expect(result.length, 2);
+    expect(result.first.tag, 'a');
+    expect(result.first.urgencyScore, closeTo(2.3, 0.001));
+    expect(result.last.tag, 'c');
+    expect(result.last.urgencyScore, closeTo(0.5, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `ReviewPathRecommender` service with scoring logic
- include minimal `MistakeCluster` model
- add unit test for the recommender

## Testing
- `dart pub get` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_687f316fbdd8832a984bb092a75d61e1