### PR TITLE
Implement SmartRecoveryBanner

### DIFF
--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/next_up_banner.dart';
 import '../widgets/skill_loss_banner.dart';
 import '../widgets/tag_insight_reminder_card.dart';
 import '../widgets/review_path_card.dart';
+import '../widgets/smart_recovery_banner.dart';
 import '../models/training_attempt.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
@@ -239,6 +240,7 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
                 const NextUpBanner(),
                 const SizedBox(height: 12),
               ],
+              const SmartRecoveryBanner(),
               const ReviewPathCard(),
               const SizedBox(height: 12),
               _section('🎯 Completion', '$completion% complete'),

--- a/lib/widgets/smart_recovery_banner.dart
+++ b/lib/widgets/smart_recovery_banner.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/scheduled_training_queue_service.dart';
+import '../services/tag_insight_reminder_engine.dart';
+import '../services/session_log_service.dart';
+import '../services/pack_library_loader_service.dart';
+import '../services/weakness_cluster_engine_v2.dart';
+import '../services/tag_goal_tracker_service.dart';
+import '../models/training_attempt.dart';
+import '../services/review_path_recommender.dart';
+
+class SmartRecoveryBanner extends StatefulWidget {
+  const SmartRecoveryBanner({super.key});
+
+  @override
+  State<SmartRecoveryBanner> createState() => _SmartRecoveryBannerState();
+}
+
+class _SmartRecoveryBannerState extends State<SmartRecoveryBanner> {
+  late Future<bool> _future;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _check();
+  }
+
+  Future<bool> _check() async {
+    final queue = ScheduledTrainingQueueService.instance;
+    await queue.load();
+    return queue.queue.isEmpty;
+  }
+
+  Future<void> _generate() async {
+    setState(() => _busy = true);
+    final queue = ScheduledTrainingQueueService.instance;
+
+    final losses = await context.read<TagInsightReminderEngine>().loadLosses();
+
+    final logs = context.read<SessionLogService>();
+    await logs.load();
+    final attempts = [
+      for (final log in logs.logs)
+        TrainingAttempt(
+          packId: log.templateId,
+          spotId: log.templateId,
+          timestamp: log.completedAt,
+          accuracy: (log.correctCount + log.mistakeCount) == 0
+              ? 0
+              : log.correctCount / (log.correctCount + log.mistakeCount),
+          ev: 0,
+          icm: 0,
+        )
+    ];
+
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final packs = PackLibraryLoaderService.instance.library;
+
+    final clusters = const WeaknessClusterEngine()
+        .computeClusters(attempts: attempts, allPacks: packs)
+        .take(3)
+        .map((c) => MistakeCluster(tag: c.label, count: c.spotIds.length))
+        .toList();
+
+    final tracker = TagGoalTrackerService.instance;
+    final missRates = <String, double>{};
+    final tags = <String>{
+      for (final p in packs) ...p.tags.map((e) => e.trim().toLowerCase()),
+    };
+    for (final t in tags) {
+      final prog = await tracker.getProgress(t);
+      final rate = (1 - prog.trainings / 10).clamp(0.0, 1.0);
+      missRates[t] = rate;
+    }
+
+    await queue.autoSchedule(
+      losses: losses,
+      mistakeClusters: clusters,
+      goalMissRatesByTag: missRates,
+    );
+
+    setState(() {
+      _future = _check();
+      _busy = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<bool>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || !snapshot.data! || _busy) {
+          return const SizedBox.shrink();
+        }
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: accent),
+          ),
+          child: Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Нет запланированных тренировок. Сгенерировать план?',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+              ElevatedButton(
+                onPressed: _generate,
+                style: ElevatedButton.styleFrom(backgroundColor: accent),
+                child: const Text('🧠 Generate Recovery Plan'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `SmartRecoveryBanner` widget to generate recovery plans when no packs are queued
- display banner in the learning dashboard

## Testing
- `flutter analyze` *(fails: 7058 issues)*
- `flutter test` *(fails to run due to missing assets and plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f35b891d0832a9c54e9310f7c1d9d