### PR TITLE
Implement SkillLossFeedEngine

### DIFF
--- a/lib/services/skill_loss_feed_engine.dart
+++ b/lib/services/skill_loss_feed_engine.dart
@@ -1,0 +1,71 @@
+import 'skill_loss_detector.dart';
+import 'tag_goal_tracker_service.dart';
+import 'pack_library_service.dart';
+
+class SkillLossFeedItem {
+  final String tag;
+  final double urgencyScore;
+  final String trend;
+  final String? suggestedPackId;
+
+  const SkillLossFeedItem({
+    required this.tag,
+    required this.urgencyScore,
+    required this.trend,
+    this.suggestedPackId,
+  });
+}
+
+class SkillLossFeedEngine {
+  final TagGoalTrackerService _goals;
+  final PackLibraryService _library;
+
+  const SkillLossFeedEngine({
+    TagGoalTrackerService? goals,
+    PackLibraryService? library,
+  }) : _goals = goals ?? TagGoalTrackerService.instance,
+       _library = library ?? PackLibraryService.instance;
+
+  Future<List<SkillLossFeedItem>> buildFeed(
+    List<SkillLoss> losses, {
+    DateTime? now,
+    int maxItems = 3,
+  }) async {
+    if (losses.isEmpty) return [];
+    final current = now ?? DateTime.now();
+
+    final scored = <_ScoredItem>[];
+
+    for (final loss in losses) {
+      final progress = await _goals.getProgress(loss.tag);
+      final last = progress.lastTrainingDate;
+      final daysSince = last == null
+          ? 30
+          : current.difference(last).inDays.clamp(0, 30);
+      final recencyFactor = 1 + daysSince / 7;
+      final score = loss.drop * recencyFactor;
+
+      final pack = await _library.findByTag(loss.tag);
+      scored.add(
+        _ScoredItem(
+          item: SkillLossFeedItem(
+            tag: loss.tag,
+            urgencyScore: score,
+            trend: loss.trend,
+            suggestedPackId: pack?.id,
+          ),
+          score: score,
+        ),
+      );
+    }
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return scored.map((e) => e.item).take(maxItems).toList();
+  }
+}
+
+class _ScoredItem {
+  final SkillLossFeedItem item;
+  final double score;
+  const _ScoredItem({required this.item, required this.score});
+}

--- a/test/services/skill_loss_feed_engine_test.dart
+++ b/test/services/skill_loss_feed_engine_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/skill_loss_feed_engine.dart';
+import 'package:poker_analyzer/services/skill_loss_detector.dart';
+import 'package:poker_analyzer/services/tag_goal_tracker_service.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+
+class _FakeGoals implements TagGoalTrackerService {
+  final Map<String, DateTime?> map;
+  _FakeGoals(this.map);
+  @override
+  Future<TagGoalProgress> getProgress(String tagId) async {
+    return TagGoalProgress(
+      trainings: 0,
+      xp: 0,
+      streak: 0,
+      lastTrainingDate: map[tagId],
+    );
+  }
+
+  @override
+  Future<void> logTraining(String tagId) async {}
+}
+
+class _FakeLibrary implements PackLibraryService {
+  final Map<String, TrainingPackTemplateV2> byTag;
+  _FakeLibrary(this.byTag);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async => byTag.values
+      .firstWhere((p) => p.id == id, orElse: () => byTag.values.first);
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async => byTag[tag];
+}
+
+TrainingPackTemplateV2 _tpl(String id, String tag) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: [tag],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('buildFeed ranks losses by urgency', () async {
+    final goals = _FakeGoals({
+      'a': DateTime.now().subtract(const Duration(days: 10)),
+      'b': DateTime.now().subtract(const Duration(days: 1)),
+    });
+    final library = _FakeLibrary({'a': _tpl('pa', 'a'), 'b': _tpl('pb', 'b')});
+    final engine = SkillLossFeedEngine(goals: goals, library: library);
+    final losses = [
+      SkillLoss(tag: 'a', drop: 0.5, trend: ''),
+      SkillLoss(tag: 'b', drop: 0.6, trend: ''),
+    ];
+    final result = await engine.buildFeed(losses);
+    expect(result.length, 2);
+    expect(result.first.tag, 'a');
+    expect(result.first.suggestedPackId, 'pa');
+    expect(result.last.tag, 'b');
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillLossFeedEngine` service for ranking skill loss items
- add unit test for the feed engine

## Testing
- `flutter test` *(fails: various compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f3ac16c50832a8a541834649c8c8b