### PR TITLE
Add analytics logging on review CTA taps

### DIFF
--- a/lib/services/engagement_analytics_service.dart
+++ b/lib/services/engagement_analytics_service.dart
@@ -1,0 +1,23 @@
+import 'user_action_logger.dart';
+
+class EngagementAnalyticsService {
+  EngagementAnalyticsService._();
+
+  static final instance = EngagementAnalyticsService._();
+
+  Future<void> logEvent(
+    String event, {
+    required String source,
+    String? tag,
+    String? packId,
+  }) async {
+    final data = <String, dynamic>{
+      'event': event,
+      'source': source,
+      if (tag != null) 'tag': tag,
+      if (packId != null) 'packId': packId,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    await UserActionLogger.instance.logEvent(data);
+  }
+}

--- a/lib/widgets/mistake_review_button.dart
+++ b/lib/widgets/mistake_review_button.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
@@ -10,6 +12,7 @@ import '../services/tag_mastery_service.dart';
 import '../services/training_pack_stats_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/weakness_review_engine.dart';
+import '../services/engagement_analytics_service.dart';
 
 class MistakeReviewButton extends StatefulWidget {
   final TrainingSession session;
@@ -97,7 +100,20 @@ class _MistakeReviewButtonState extends State<MistakeReviewButton> {
     return Padding(
       padding: const EdgeInsets.only(bottom: 16),
       child: ElevatedButton(
-        onPressed: _startPack,
+        onPressed: () {
+          final item = _item;
+          if (item != null) {
+            unawaited(
+              EngagementAnalyticsService.instance.logEvent(
+                'review_cta.tap',
+                source: 'MistakeReviewButton',
+                tag: item.tag,
+                packId: item.packId,
+              ),
+            );
+          }
+          _startPack();
+        },
         child: const Text('🔁 Review Related Spots'),
       ),
     );

--- a/lib/widgets/review_path_card.dart
+++ b/lib/widgets/review_path_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
@@ -8,6 +10,7 @@ import '../services/tag_insight_reminder_engine.dart';
 import '../services/training_session_launcher.dart';
 import '../services/skill_loss_detector.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../services/engagement_analytics_service.dart';
 
 /// Card showing the top scheduled recovery pack.
 class ReviewPathCard extends StatefulWidget {
@@ -112,6 +115,14 @@ class _ReviewPathCardState extends State<ReviewPathCard> {
               ElevatedButton(
                 onPressed: () {
                   final d = data;
+                  unawaited(
+                    EngagementAnalyticsService.instance.logEvent(
+                      'review_cta.tap',
+                      source: 'ReviewPathCard',
+                      tag: d.tag,
+                      packId: d.pack.id,
+                    ),
+                  );
                   _startRecovery(d);
                 },
                 style: ElevatedButton.styleFrom(backgroundColor: accent),

--- a/lib/widgets/skill_loss_banner_v2.dart
+++ b/lib/widgets/skill_loss_banner_v2.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -5,6 +7,7 @@ import '../services/skill_loss_feed_engine.dart';
 import '../services/tag_insight_reminder_engine.dart';
 import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
+import '../services/engagement_analytics_service.dart';
 
 /// Compact banner showing top skill losses as review chips.
 class SkillLossBannerV2 extends StatefulWidget {
@@ -63,7 +66,17 @@ class _SkillLossBannerV2State extends State<SkillLossBannerV2> {
             children: [
               for (final item in display)
                 ActionChip(
-                  onPressed: () => _review(item),
+                  onPressed: () {
+                    unawaited(
+                      EngagementAnalyticsService.instance.logEvent(
+                        'review_cta.tap',
+                        source: 'SkillLossBannerV2',
+                        tag: item.tag,
+                        packId: item.suggestedPackId,
+                      ),
+                    );
+                    _review(item);
+                  },
                   backgroundColor: Colors.grey[700],
                   label: Row(
                     mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- track engagement by adding `EngagementAnalyticsService`
- log review CTA taps from SkillLossBannerV2
- log review CTA taps from ReviewPathCard
- log review CTA taps from MistakeReviewButton

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f45d5d124832a820f531336505b9b