### PR TITLE
Add skill loss overlay reactivation prompt

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -110,6 +110,7 @@ import 'services/learning_path_registry_service.dart';
 import 'services/learning_path_summary_cache.dart';
 import 'services/learning_path_reminder_engine.dart';
 import 'services/daily_app_check_service.dart';
+import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -522,6 +523,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(
       create: (context) => DailyAppCheckService(
         reminder: context.read<LearningPathReminderEngine>(),
+      ),
+    ),
+    Provider(
+      create: (context) => SkillLossOverlayPromptService(
+        logs: context.read<SessionLogService>(),
       ),
     ),
   ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -106,6 +106,7 @@ import 'services/training_pack_stats_service.dart';
 import 'services/learning_path_summary_cache.dart';
 import 'services/learning_path_reminder_engine.dart';
 import 'services/daily_app_check_service.dart';
+import 'services/skill_loss_overlay_prompt_service.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
 import 'services/app_init_service.dart';
@@ -278,6 +279,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     NotificationService.startRecommendedPackTask(context);
     unawaited(context.read<LearningPathSummaryCache>().refresh());
     unawaited(context.read<DailyAppCheckService>().run(context));
+    unawaited(context.read<SkillLossOverlayPromptService>().run(context));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeStartPinnedTraining();
       _maybeResumeTraining();

--- a/lib/services/skill_loss_overlay_prompt_service.dart
+++ b/lib/services/skill_loss_overlay_prompt_service.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/session_log_service.dart';
+import '../widgets/skill_loss_overlay_prompt.dart';
+
+/// Checks inactivity and performance to occasionally show [SkillLossOverlayPrompt].
+class SkillLossOverlayPromptService {
+  SkillLossOverlayPromptService({required this.logs});
+
+  final SessionLogService logs;
+
+  static const _lastKey = 'skill_loss_overlay_prompt_last';
+  static const _gap = Duration(days: 5);
+
+  Future<void> run(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null && now.difference(last) < const Duration(days: 1)) {
+      return;
+    }
+
+    await logs.load();
+    DateTime? lastTraining;
+    if (logs.logs.isNotEmpty) {
+      lastTraining = logs.logs.first.completedAt;
+    }
+
+    var show = false;
+    if (lastTraining == null || now.difference(lastTraining) > _gap) {
+      show = true;
+    } else {
+      final recent = logs.logs.take(3).toList();
+      if (recent.length >= 3) {
+        var correct = 0;
+        var total = 0;
+        for (final l in recent) {
+          correct += l.correctCount;
+          total += l.correctCount + l.mistakeCount;
+        }
+        if (total >= 3 && correct / total < 0.5) {
+          show = true;
+        }
+      }
+    }
+
+    if (!show) return;
+    await prefs.setString(_lastKey, now.toIso8601String());
+    if (context.mounted) {
+      await SkillLossOverlayPrompt.show(context);
+    }
+  }
+}

--- a/lib/widgets/skill_loss_overlay_prompt.dart
+++ b/lib/widgets/skill_loss_overlay_prompt.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_insight_reminder_engine.dart';
+import '../services/skill_loss_feed_engine.dart';
+import '../services/pack_library_service.dart';
+import '../services/training_session_launcher.dart';
+
+/// Full screen modal urging the user to review fading skills.
+class SkillLossOverlayPrompt extends StatefulWidget {
+  const SkillLossOverlayPrompt({super.key});
+
+  /// Displays the prompt modally.
+  static Future<void> show(BuildContext context) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const SkillLossOverlayPrompt(),
+    );
+  }
+
+  @override
+  State<SkillLossOverlayPrompt> createState() => _SkillLossOverlayPromptState();
+}
+
+class _SkillLossOverlayPromptState extends State<SkillLossOverlayPrompt>
+    with SingleTickerProviderStateMixin {
+  late Future<SkillLossFeedItem?> _future;
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(seconds: 2))
+          ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<SkillLossFeedItem?> _load() async {
+    final reminder = context.read<TagInsightReminderEngine>();
+    final losses = await reminder.loadLosses();
+    final feed = await const SkillLossFeedEngine().buildFeed(losses);
+    return feed.isEmpty ? null : feed.first;
+  }
+
+  Future<void> _review(SkillLossFeedItem item) async {
+    final id = item.suggestedPackId;
+    if (id == null) return;
+    final pack = await PackLibraryService.instance.getById(id);
+    if (pack != null) {
+      await const TrainingSessionLauncher().launch(pack);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      backgroundColor: Colors.black87,
+      body: Center(
+        child: FutureBuilder<SkillLossFeedItem?>(
+          future: _future,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const CircularProgressIndicator();
+            }
+            final item = snapshot.data;
+            if (item == null) {
+              Navigator.pop(context);
+              return const SizedBox.shrink();
+            }
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AnimatedBuilder(
+                  animation: _controller,
+                  builder: (_, child) => Container(
+                    padding: const EdgeInsets.all(24),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color:
+                            accent.withOpacity(0.5 + 0.5 * _controller.value),
+                        width: 8,
+                      ),
+                    ),
+                    child: child,
+                  ),
+                  child: const Icon(Icons.warning,
+                      color: Colors.white, size: 48),
+                ),
+                const SizedBox(height: 24),
+                const Text(
+                  'Your skills are fading',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  item.tag,
+                  style: const TextStyle(color: Colors.white70, fontSize: 16),
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: () {
+                    _review(item);
+                    Navigator.pop(context);
+                  },
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  child: const Text('Review now'),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `SkillLossOverlayPrompt` fullscreen modal
- add `SkillLossOverlayPromptService` to trigger the modal
- register new service in providers and run on startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f4939e9d0832a80408f5dec80534d