### PR TITLE
Implement AutoMistakeTaggerEngine

### DIFF
--- a/lib/models/mistake_tag.dart
+++ b/lib/models/mistake_tag.dart
@@ -1,0 +1,13 @@
+enum MistakeTag {
+  overfoldBtn('BTN Overfold'),
+  looseCallBb('Loose Call BB'),
+  missedEvPush('Missed +EV Push'),
+  overpush('Overly Loose Push');
+
+  final String label;
+  const MistakeTag(this.label);
+
+  @override
+  String toString() => label;
+}
+

--- a/lib/models/training_spot_attempt.dart
+++ b/lib/models/training_spot_attempt.dart
@@ -1,0 +1,15 @@
+import "v2/training_pack_spot.dart";
+
+class TrainingSpotAttempt {
+  final TrainingPackSpot spot;
+  final String userAction;
+  final String correctAction;
+  final double evDiff;
+
+  TrainingSpotAttempt({
+    required this.spot,
+    required this.userAction,
+    required this.correctAction,
+    required this.evDiff,
+  });
+}

--- a/lib/services/auto_mistake_tagger_engine.dart
+++ b/lib/services/auto_mistake_tagger_engine.dart
@@ -1,0 +1,16 @@
+import '../models/mistake_tag.dart';
+import '../models/training_spot_attempt.dart';
+import 'mistake_tag_rules.dart';
+
+class AutoMistakeTaggerEngine {
+  const AutoMistakeTaggerEngine();
+
+  List<MistakeTag> tag(TrainingSpotAttempt attempt) {
+    final tags = <MistakeTag>[];
+    for (final rule in mistakeTagRules) {
+      if (rule.predicate(attempt)) tags.add(rule.tag);
+    }
+    return tags;
+  }
+}
+

--- a/lib/services/mistake_tag_rules.dart
+++ b/lib/services/mistake_tag_rules.dart
@@ -1,0 +1,42 @@
+import '../models/mistake_tag.dart';
+import '../models/training_spot_attempt.dart';
+import '../models/v2/hero_position.dart';
+
+typedef MistakeTagPredicate = bool Function(TrainingSpotAttempt attempt);
+
+class MistakeTagRule {
+  final MistakeTag tag;
+  final MistakeTagPredicate predicate;
+  const MistakeTagRule(this.tag, this.predicate);
+}
+
+final List<MistakeTagRule> mistakeTagRules = [
+  MistakeTagRule(
+    MistakeTag.overfoldBtn,
+    (a) =>
+        a.spot.hand.position == HeroPosition.btn &&
+        a.userAction.toLowerCase() == 'fold' &&
+        a.correctAction.toLowerCase() != 'fold',
+  ),
+  MistakeTagRule(
+    MistakeTag.looseCallBb,
+    (a) =>
+        a.spot.hand.position == HeroPosition.bb &&
+        a.userAction.toLowerCase() == 'call' &&
+        a.correctAction.toLowerCase() == 'fold',
+  ),
+  MistakeTagRule(
+    MistakeTag.missedEvPush,
+    (a) =>
+        a.correctAction.toLowerCase() == 'push' &&
+        a.userAction.toLowerCase() != 'push' &&
+        a.evDiff > 0,
+  ),
+  MistakeTagRule(
+    MistakeTag.overpush,
+    (a) =>
+        a.userAction.toLowerCase() == 'push' &&
+        a.correctAction.toLowerCase() == 'fold' &&
+        a.evDiff < 0,
+  ),
+];

--- a/test/auto_mistake_tagger_engine_test.dart
+++ b/test/auto_mistake_tagger_engine_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/models/training_spot_attempt.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/auto_mistake_tagger_engine.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const engine = AutoMistakeTaggerEngine();
+
+  TrainingSpotAttempt attempt({
+    required String user,
+    required String correct,
+    double ev = 1.0,
+    HeroPosition pos = HeroPosition.btn,
+  }) {
+    final spot = TrainingPackSpot(
+      id: 's',
+      hand: HandData(position: pos),
+      evalResult: EvaluationResult(
+        correct: false,
+        expectedAction: correct,
+        userEquity: 0,
+        expectedEquity: 0,
+      ),
+    );
+    return TrainingSpotAttempt(
+      spot: spot,
+      userAction: user,
+      correctAction: correct,
+      evDiff: ev,
+    );
+  }
+
+  test('btn overfold classified', () {
+    final a = attempt(user: 'fold', correct: 'push', pos: HeroPosition.btn, ev: 1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.overfoldBtn));
+    expect(tags, contains(MistakeTag.missedEvPush));
+  });
+
+  test('loose call bb classified', () {
+    final a = attempt(user: 'call', correct: 'fold', pos: HeroPosition.bb, ev: -1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.looseCallBb));
+  });
+
+  test('overpush classified', () {
+    final a = attempt(user: 'push', correct: 'fold', pos: HeroPosition.utg, ev: -1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.overpush));
+  });
+}
+


### PR DESCRIPTION
## Summary
- add model for TrainingSpotAttempt
- add MistakeTag enum for interpretable labels
- implement mistake tag rules in a separate file
- implement AutoMistakeTaggerEngine using the rules
- test AutoMistakeTaggerEngine logic

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f543e3420832a82d016bb9bfcb47e