### PR TITLE
Extend auto mistake tagging

### DIFF
--- a/lib/models/mistake_tag.dart
+++ b/lib/models/mistake_tag.dart
@@ -2,7 +2,8 @@ enum MistakeTag {
   overfoldBtn('BTN Overfold'),
   looseCallBb('Loose Call BB'),
   missedEvPush('Missed +EV Push'),
-  overpush('Overly Loose Push');
+  overpush('Overly Loose Push'),
+  overfoldShortStack('Short Stack Overfold');
 
   final String label;
   const MistakeTag(this.label);

--- a/lib/services/mistake_tag_rules.dart
+++ b/lib/services/mistake_tag_rules.dart
@@ -39,4 +39,14 @@ final List<MistakeTagRule> mistakeTagRules = [
         a.correctAction.toLowerCase() == 'fold' &&
         a.evDiff < 0,
   ),
+  MistakeTagRule(
+    MistakeTag.overfoldShortStack,
+    (a) {
+      final heroIndex = a.spot.hand.heroIndex;
+      final stack = a.spot.hand.stacks['$heroIndex'] ?? 0;
+      return stack <= 10 &&
+          a.userAction.toLowerCase() == 'fold' &&
+          a.correctAction.toLowerCase() != 'fold';
+    },
+  ),
 ];

--- a/test/auto_mistake_tagger_engine_test.dart
+++ b/test/auto_mistake_tagger_engine_test.dart
@@ -16,10 +16,11 @@ void main() {
     required String correct,
     double ev = 1.0,
     HeroPosition pos = HeroPosition.btn,
+    int stack = 15,
   }) {
     final spot = TrainingPackSpot(
       id: 's',
-      hand: HandData(position: pos),
+      hand: HandData(position: pos, stacks: {'0': stack.toDouble()}),
       evalResult: EvaluationResult(
         correct: false,
         expectedAction: correct,
@@ -52,6 +53,12 @@ void main() {
     final a = attempt(user: 'push', correct: 'fold', pos: HeroPosition.utg, ev: -1);
     final tags = engine.tag(a);
     expect(tags, contains(MistakeTag.overpush));
+  });
+
+  test('short stack overfold classified', () {
+    final a = attempt(user: 'fold', correct: 'push', pos: HeroPosition.sb, stack: 8, ev: 1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.overfoldShortStack));
   });
 }
 


### PR DESCRIPTION
## Summary
- classify short stack overfold spots via new rule
- support new `overfoldShortStack` MistakeTag
- test coverage for the short stack rule

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f557fdcec832aa863b21fe046ca11