### PR TITLE
Implement missed +EV call classification

### DIFF
--- a/lib/models/mistake_tag.dart
+++ b/lib/models/mistake_tag.dart
@@ -2,6 +2,7 @@ enum MistakeTag {
   overfoldBtn('BTN Overfold'),
   looseCallBb('Loose Call BB'),
   missedEvPush('Missed +EV Push'),
+  missedEvCall('Missed +EV Call'),
   overpush('Overly Loose Push'),
   overfoldShortStack('Short Stack Overfold');
 

--- a/lib/services/mistake_tag_rules.dart
+++ b/lib/services/mistake_tag_rules.dart
@@ -33,6 +33,13 @@ final List<MistakeTagRule> mistakeTagRules = [
         a.evDiff > 0,
   ),
   MistakeTagRule(
+    MistakeTag.missedEvCall,
+    (a) =>
+        a.correctAction.toLowerCase() == 'call' &&
+        a.userAction.toLowerCase() != 'call' &&
+        a.evDiff > 0,
+  ),
+  MistakeTagRule(
     MistakeTag.overpush,
     (a) =>
         a.userAction.toLowerCase() == 'push' &&

--- a/test/auto_mistake_tagger_engine_test.dart
+++ b/test/auto_mistake_tagger_engine_test.dart
@@ -55,6 +55,12 @@ void main() {
     expect(tags, contains(MistakeTag.overpush));
   });
 
+  test('missed call classified', () {
+    final a = attempt(user: 'fold', correct: 'call', pos: HeroPosition.bb, ev: 1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.missedEvCall));
+  });
+
   test('short stack overfold classified', () {
     final a = attempt(user: 'fold', correct: 'push', pos: HeroPosition.sb, stack: 8, ev: 1);
     final tags = engine.tag(a);


### PR DESCRIPTION
## Summary
- extend `MistakeTag` with `missedEvCall`
- add new rule in `mistake_tag_rules.dart` to tag missed profitable calls
- test `AutoMistakeTaggerEngine` for the new classification

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/auto_mistake_tagger_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f58bad4c0832a91c3c228ab695802