### PR TITLE
Add missed EV raise classification

### DIFF
--- a/lib/models/mistake_tag.dart
+++ b/lib/models/mistake_tag.dart
@@ -3,6 +3,7 @@ enum MistakeTag {
   looseCallBb('Loose Call BB'),
   missedEvPush('Missed +EV Push'),
   missedEvCall('Missed +EV Call'),
+  missedEvRaise('Missed +EV Raise'),
   overpush('Overly Loose Push'),
   overfoldShortStack('Short Stack Overfold');
 

--- a/lib/services/mistake_tag_rules.dart
+++ b/lib/services/mistake_tag_rules.dart
@@ -40,6 +40,13 @@ final List<MistakeTagRule> mistakeTagRules = [
         a.evDiff > 0,
   ),
   MistakeTagRule(
+    MistakeTag.missedEvRaise,
+    (a) =>
+        a.correctAction.toLowerCase() == 'raise' &&
+        a.userAction.toLowerCase() != 'raise' &&
+        a.evDiff > 0,
+  ),
+  MistakeTagRule(
     MistakeTag.overpush,
     (a) =>
         a.userAction.toLowerCase() == 'push' &&

--- a/test/auto_mistake_tagger_engine_test.dart
+++ b/test/auto_mistake_tagger_engine_test.dart
@@ -61,6 +61,12 @@ void main() {
     expect(tags, contains(MistakeTag.missedEvCall));
   });
 
+  test('missed raise classified', () {
+    final a = attempt(user: 'call', correct: 'raise', pos: HeroPosition.co, ev: 2);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.missedEvRaise));
+  });
+
   test('short stack overfold classified', () {
     final a = attempt(user: 'fold', correct: 'push', pos: HeroPosition.sb, stack: 8, ev: 1);
     final tags = engine.tag(a);


### PR DESCRIPTION
## Summary
- categorize missed +EV raises via new `MistakeTag`
- extend mistake tagging rules
- cover new classification in unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/auto_mistake_tagger_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f59ce4aa4832ab7ed4d6a466b39c1