### PR TITLE
Add loose call SB mistake tag

### DIFF
--- a/lib/models/mistake_tag.dart
+++ b/lib/models/mistake_tag.dart
@@ -1,6 +1,7 @@
 enum MistakeTag {
   overfoldBtn('BTN Overfold'),
   looseCallBb('Loose Call BB'),
+  looseCallSb('Loose Call SB'),
   missedEvPush('Missed +EV Push'),
   missedEvCall('Missed +EV Call'),
   missedEvRaise('Missed +EV Raise'),

--- a/lib/services/mistake_tag_rules.dart
+++ b/lib/services/mistake_tag_rules.dart
@@ -26,6 +26,13 @@ final List<MistakeTagRule> mistakeTagRules = [
         a.correctAction.toLowerCase() == 'fold',
   ),
   MistakeTagRule(
+    MistakeTag.looseCallSb,
+    (a) =>
+        a.spot.hand.position == HeroPosition.sb &&
+        a.userAction.toLowerCase() == 'call' &&
+        a.correctAction.toLowerCase() == 'fold',
+  ),
+  MistakeTagRule(
     MistakeTag.missedEvPush,
     (a) =>
         a.correctAction.toLowerCase() == 'push' &&

--- a/test/auto_mistake_tagger_engine_test.dart
+++ b/test/auto_mistake_tagger_engine_test.dart
@@ -49,6 +49,12 @@ void main() {
     expect(tags, contains(MistakeTag.looseCallBb));
   });
 
+  test('loose call sb classified', () {
+    final a = attempt(user: 'call', correct: 'fold', pos: HeroPosition.sb, ev: -1);
+    final tags = engine.tag(a);
+    expect(tags, contains(MistakeTag.looseCallSb));
+  });
+
   test('overpush classified', () {
     final a = attempt(user: 'push', correct: 'fold', pos: HeroPosition.utg, ev: -1);
     final tags = engine.tag(a);


### PR DESCRIPTION
## Summary
- expand `MistakeTag` with `looseCallSb`
- tag loose calls from SB in `mistake_tag_rules.dart`
- test new SB rule in the mistake tagger tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/auto_mistake_tagger_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5ae59c2c832ab7adabc6c15eff1f