### PR TITLE
Integrate mistake tag history

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -20,6 +20,7 @@ import 'services/progress_forecast_service.dart';
 import 'services/mistake_review_pack_service.dart';
 import 'services/dynamic_pack_adjustment_service.dart';
 import 'services/mistake_streak_service.dart';
+import 'services/mistake_tag_history_service.dart';
 import 'services/session_note_service.dart';
 import 'services/session_pin_service.dart';
 import 'services/training_pack_storage_service.dart';
@@ -199,6 +200,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     ChangeNotifierProvider(create: (_) => MistakeStreakService()..load()),
+    ChangeNotifierProvider(create: (_) => MistakeTagHistoryService()..load()),
     ChangeNotifierProvider(
       create: (context) =>
           SessionNoteService(cloud: context.read<CloudSyncService>())..load(),

--- a/lib/services/mistake_tag_history_service.dart
+++ b/lib/services/mistake_tag_history_service.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/mistake_tag.dart';
+
+class MistakeTagHistoryService extends ChangeNotifier {
+  static const _key = 'mistake_tag_counts';
+
+  final Map<MistakeTag, int> _counts = {};
+  Map<MistakeTag, int> get counts => Map.unmodifiable(_counts);
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          for (final entry in data.entries) {
+            for (final t in MistakeTag.values) {
+              if (t.name == entry.key) {
+                _counts[t] = (entry.value as num).toInt();
+                break;
+              }
+            }
+          }
+        }
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final map = {for (final e in _counts.entries) e.key.name: e.value};
+    await prefs.setString(_key, jsonEncode(map));
+  }
+
+  Future<void> addTags(List<MistakeTag> tags) async {
+    if (tags.isEmpty) return;
+    for (final t in tags) {
+      _counts[t] = (_counts[t] ?? 0) + 1;
+    }
+    await _save();
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- add `MistakeTagHistoryService` for persisting automatic tags
- track mistake tags when a training session completes
- register the new service in providers

## Testing
- `apt-get update`
- ❌ `dart format lib/services/mistake_tag_history_service.dart lib/services/training_session_service.dart` *(command failed: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e40ab68832aba2550195185abac