### PR TITLE
Implement MistakeTagInsightsService

### DIFF
--- a/lib/models/mistake_insight.dart
+++ b/lib/models/mistake_insight.dart
@@ -1,0 +1,16 @@
+import 'mistake_tag.dart';
+import 'training_spot_attempt.dart';
+
+class MistakeInsight {
+  final MistakeTag tag;
+  final int count;
+  final String shortExplanation;
+  final List<TrainingSpotAttempt> examples;
+
+  const MistakeInsight({
+    required this.tag,
+    required this.count,
+    required this.shortExplanation,
+    required this.examples,
+  });
+}

--- a/lib/models/training_spot_attempt.dart
+++ b/lib/models/training_spot_attempt.dart
@@ -12,4 +12,20 @@ class TrainingSpotAttempt {
     required this.correctAction,
     required this.evDiff,
   });
+
+  Map<String, dynamic> toJson() => {
+        'spot': spot.toJson(),
+        'userAction': userAction,
+        'correctAction': correctAction,
+        'evDiff': evDiff,
+      };
+
+  factory TrainingSpotAttempt.fromJson(Map<String, dynamic> json) =>
+      TrainingSpotAttempt(
+        spot: TrainingPackSpot.fromJson(
+            Map<String, dynamic>.from(json['spot'] as Map)),
+        userAction: json['userAction'] as String? ?? '',
+        correctAction: json['correctAction'] as String? ?? '',
+        evDiff: (json['evDiff'] as num?)?.toDouble() ?? 0.0,
+      );
 }

--- a/lib/services/mistake_tag_history_service.dart
+++ b/lib/services/mistake_tag_history_service.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/mistake_tag.dart';
+import '../models/training_spot_attempt.dart';
+
+class MistakeTagHistoryService {
+  static const _prefsKey = 'mistake_tag_history';
+
+  final Map<String, _TagRecord> _history = {};
+
+  Map<String, _TagRecord> get history =>
+      {for (final e in _history.entries) e.key: e.value.copy()};
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        _history.clear();
+        data.forEach((key, value) {
+          if (value is Map) {
+            _history[key.toString()] =
+                _TagRecord.fromJson(Map<String, dynamic>.from(value));
+          }
+        });
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        _prefsKey,
+        jsonEncode(
+            {for (final e in _history.entries) e.key: e.value.toJson()}));
+  }
+
+  Future<void> record(
+      List<MistakeTag> tags, TrainingSpotAttempt attempt) async {
+    for (final t in tags) {
+      final key = t.name;
+      final rec = _history.putIfAbsent(key, () => _TagRecord());
+      rec.count += 1;
+      if (rec.examples.length < 5) {
+        rec.examples.add(attempt);
+      }
+    }
+    await _save();
+  }
+
+  Future<void> clear() async {
+    _history.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+  }
+}
+
+class _TagRecord {
+  int count;
+  final List<TrainingSpotAttempt> examples;
+  _TagRecord({this.count = 0, List<TrainingSpotAttempt>? examples})
+      : examples = examples ?? [];
+
+  Map<String, dynamic> toJson() => {
+        'count': count,
+        if (examples.isNotEmpty)
+          'examples': [for (final e in examples) e.toJson()],
+      };
+
+  _TagRecord copy() => _TagRecord(
+      count: count, examples: List<TrainingSpotAttempt>.from(examples));
+
+  factory _TagRecord.fromJson(Map<String, dynamic> json) => _TagRecord(
+        count: (json['count'] as num?)?.toInt() ?? 0,
+        examples: [
+          for (final e in (json['examples'] as List? ?? []))
+            TrainingSpotAttempt.fromJson(Map<String, dynamic>.from(e as Map))
+        ],
+      );
+}

--- a/lib/services/mistake_tag_insights_service.dart
+++ b/lib/services/mistake_tag_insights_service.dart
@@ -1,0 +1,63 @@
+import 'package:collection/collection.dart';
+
+import '../models/mistake_insight.dart';
+import '../models/mistake_tag.dart';
+import '../models/training_spot_attempt.dart';
+import 'mistake_tag_history_service.dart';
+
+class MistakeTagInsightsService {
+  final MistakeTagHistoryService history;
+  MistakeTagInsightsService({required this.history});
+
+  static const Map<MistakeTag, String> _explanations = {
+    MistakeTag.overfoldBtn: 'Too tight on BTN, folding +EV hands',
+    MistakeTag.looseCallBb: 'Calling too wide from BB',
+    MistakeTag.looseCallSb: 'Calling too loose from SB',
+    MistakeTag.looseCallCo: 'Calling too loose from CO',
+    MistakeTag.missedEvPush: 'Missed profitable shove',
+    MistakeTag.missedEvCall: 'Missed profitable call',
+    MistakeTag.missedEvRaise: 'Missed profitable raise',
+    MistakeTag.overpush: 'Jamming too wide',
+    MistakeTag.overfoldShortStack: 'Overfolding short stack',
+  };
+
+  Future<List<MistakeInsight>> generate({bool sortByEvLoss = false}) async {
+    final data = history.history;
+    final insights = <_InsightWrap>[];
+
+    for (final entry in data.entries) {
+      final tag =
+          MistakeTag.values.firstWhereOrNull((t) => t.name == entry.key);
+      if (tag == null) continue;
+      final examples = entry.value.examples;
+      final evLoss =
+          examples.fold<double>(0, (prev, a) => prev + a.evDiff.abs());
+      insights.add(
+        _InsightWrap(
+          insight: MistakeInsight(
+            tag: tag,
+            count: entry.value.count,
+            shortExplanation: _explanations[tag] ?? '',
+            examples: List<TrainingSpotAttempt>.from(examples),
+          ),
+          evLoss: evLoss,
+        ),
+      );
+    }
+
+    insights.sort((a, b) {
+      if (sortByEvLoss) {
+        return b.evLoss.compareTo(a.evLoss);
+      }
+      return b.insight.count.compareTo(a.insight.count);
+    });
+
+    return [for (final w in insights) w.insight];
+  }
+}
+
+class _InsightWrap {
+  final MistakeInsight insight;
+  final double evLoss;
+  _InsightWrap({required this.insight, required this.evLoss});
+}

--- a/test/mistake_tag_insights_service_test.dart
+++ b/test/mistake_tag_insights_service_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/training_spot_attempt.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/mistake_tag_history_service.dart';
+import 'package:poker_analyzer/services/mistake_tag_insights_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingSpotAttempt attempt({
+    required String user,
+    required String correct,
+    double ev = 1.0,
+    HeroPosition pos = HeroPosition.btn,
+  }) {
+    final spot = TrainingPackSpot(
+      id: 's',
+      hand: HandData(position: pos, stacks: {'0': 15}),
+      evalResult: EvaluationResult(
+        correct: false,
+        expectedAction: correct,
+        userEquity: 0,
+        expectedEquity: 0,
+      ),
+    );
+    return TrainingSpotAttempt(
+      spot: spot,
+      userAction: user,
+      correctAction: correct,
+      evDiff: ev,
+    );
+  }
+
+  test('insights sorted by frequency', () async {
+    SharedPreferences.setMockInitialValues({});
+    final history = MistakeTagHistoryService();
+    await history.load();
+    await history.record([
+      MistakeTag.overfoldBtn,
+    ], attempt(user: 'fold', correct: 'push', ev: 2));
+    await history.record([
+      MistakeTag.overfoldBtn,
+    ], attempt(user: 'fold', correct: 'push', ev: 1));
+    await history.record([
+      MistakeTag.looseCallBb,
+    ], attempt(user: 'call', correct: 'fold', ev: -1));
+
+    final service = MistakeTagInsightsService(history: history);
+    final result = await service.generate();
+    expect(result.first.tag, MistakeTag.overfoldBtn);
+    expect(result.first.count, 2);
+  });
+
+  test('insights sorted by ev loss', () async {
+    SharedPreferences.setMockInitialValues({});
+    final history = MistakeTagHistoryService();
+    await history.load();
+    await history.record([
+      MistakeTag.overfoldBtn,
+    ], attempt(user: 'fold', correct: 'push', ev: 1));
+    await history.record([
+      MistakeTag.looseCallBb,
+    ], attempt(user: 'call', correct: 'fold', ev: -5));
+
+    final service = MistakeTagInsightsService(history: history);
+    final result = await service.generate(sortByEvLoss: true);
+    expect(result.first.tag, MistakeTag.looseCallBb);
+  });
+}


### PR DESCRIPTION
## Summary
- add JSON helpers for `TrainingSpotAttempt`
- define `MistakeInsight` model
- implement `MistakeTagHistoryService` to store tag counts and sample hands
- implement `MistakeTagInsightsService` to summarize mistake tags
- add unit tests for insights service

## Testing
- `dart format lib/models/training_spot_attempt.dart lib/models/mistake_insight.dart lib/services/mistake_tag_history_service.dart lib/services/mistake_tag_insights_service.dart test/mistake_tag_insights_service_test.dart`
- `flutter test test/mistake_tag_insights_service_test.dart` *(fails: Dart SDK version 3.0.6 < 3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e5a94d8832aa5f1c316f67adcf9