### PR TITLE
Implement MistakeTag clustering

### DIFF
--- a/lib/models/mistake_tag_cluster.dart
+++ b/lib/models/mistake_tag_cluster.dart
@@ -1,0 +1,12 @@
+enum MistakeTagCluster {
+  tightPreflopBtn('Too tight from BTN'),
+  looseCallBlind('Leaky blind defense'),
+  missedEvOpportunities('Missed EV opportunities'),
+  aggressiveMistakes('Overly aggressive plays');
+
+  final String label;
+  const MistakeTagCluster(this.label);
+
+  @override
+  String toString() => label;
+}

--- a/lib/services/mistake_tag_cluster_service.dart
+++ b/lib/services/mistake_tag_cluster_service.dart
@@ -1,0 +1,22 @@
+import '../models/mistake_tag.dart';
+import '../models/mistake_tag_cluster.dart';
+
+final Map<MistakeTag, MistakeTagCluster> _clusterMap = {
+  MistakeTag.overfoldBtn: MistakeTagCluster.tightPreflopBtn,
+  MistakeTag.looseCallBb: MistakeTagCluster.looseCallBlind,
+  MistakeTag.looseCallSb: MistakeTagCluster.looseCallBlind,
+  MistakeTag.looseCallCo: MistakeTagCluster.looseCallBlind,
+  MistakeTag.missedEvPush: MistakeTagCluster.missedEvOpportunities,
+  MistakeTag.missedEvCall: MistakeTagCluster.missedEvOpportunities,
+  MistakeTag.missedEvRaise: MistakeTagCluster.missedEvOpportunities,
+  MistakeTag.overpush: MistakeTagCluster.aggressiveMistakes,
+  MistakeTag.overfoldShortStack: MistakeTagCluster.tightPreflopBtn,
+};
+
+class MistakeTagClusterService {
+  const MistakeTagClusterService();
+
+  MistakeTagCluster getClusterForTag(MistakeTag tag) {
+    return _clusterMap[tag] ?? MistakeTagCluster.aggressiveMistakes;
+  }
+}

--- a/test/mistake_tag_cluster_service_test.dart
+++ b/test/mistake_tag_cluster_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mistake_tag_cluster_service.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/mistake_tag_cluster.dart';
+
+void main() {
+  const service = MistakeTagClusterService();
+
+  test('maps tags to clusters correctly', () {
+    expect(
+      service.getClusterForTag(MistakeTag.overfoldBtn),
+      MistakeTagCluster.tightPreflopBtn,
+    );
+    expect(
+      service.getClusterForTag(MistakeTag.looseCallBb),
+      MistakeTagCluster.looseCallBlind,
+    );
+    expect(
+      service.getClusterForTag(MistakeTag.missedEvPush),
+      MistakeTagCluster.missedEvOpportunities,
+    );
+    expect(
+      service.getClusterForTag(MistakeTag.overpush),
+      MistakeTagCluster.aggressiveMistakes,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add `MistakeTagCluster` enum to categorize tags
- provide `MistakeTagClusterService` with tag→cluster mapping
- test mapping logic

## Testing
- `dart format lib/models/mistake_tag_cluster.dart lib/services/mistake_tag_cluster_service.dart test/mistake_tag_cluster_service_test.dart`
- `flutter pub get` *(fails: file_picker default plugin warnings)*
- `flutter test` *(fails: unresolved assets and compilation issues)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e701394832a8f95ec9431886910