### PR TITLE
Implement MistakeReviewScreen overview

### DIFF
--- a/lib/screens/mistake_review_screen.dart
+++ b/lib/screens/mistake_review_screen.dart
@@ -2,10 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
+import '../models/mistake_insight.dart';
+import '../models/mistake_tag_cluster.dart';
 import '../models/training_pack_template.dart';
+import '../services/mistake_tag_cluster_service.dart';
+import '../services/mistake_tag_insights_service.dart';
 import '../services/smart_review_service.dart';
 import '../services/template_storage_service.dart';
 import '../services/training_session_service.dart';
+import '../theme/app_colors.dart';
+import '../widgets/v2/training_pack_spot_preview_card.dart';
 import 'training_session_screen.dart';
 import 'v2/training_pack_play_screen.dart';
 
@@ -19,6 +25,7 @@ class MistakeReviewScreen extends StatefulWidget {
 
 class _MistakeReviewScreenState extends State<MistakeReviewScreen> {
   bool _loading = true;
+  final Map<MistakeTagCluster, List<MistakeInsight>> _clusters = {};
 
   @override
   void initState() {
@@ -31,50 +38,76 @@ class _MistakeReviewScreenState extends State<MistakeReviewScreen> {
       setState(() => _loading = false);
       return;
     }
+    final insights =
+        await const MistakeTagInsightsService(exampleCount: 2).buildInsights();
+    final clusterSvc = const MistakeTagClusterService();
+    for (final ins in insights) {
+      final c = clusterSvc.getClusterForTag(ins.tag);
+      _clusters.putIfAbsent(c, () => []).add(ins);
+    }
+    setState(() => _loading = false);
+  }
+
+  Future<void> _startReview() async {
     final templates = context.read<TemplateStorageService>();
     final spots = await SmartReviewService.instance
         .getMistakeSpots(templates, context: context);
+    if (!mounted || spots.isEmpty) return;
+    final tpl = TrainingPackTemplate(
+      id: const Uuid().v4(),
+      name: 'Повтор ошибок',
+      createdAt: DateTime.now(),
+      spots: spots,
+    );
+    await context.read<TrainingSessionService>().startSession(tpl);
     if (!mounted) return;
-    if (spots.isNotEmpty) {
-      final tpl = TrainingPackTemplate(
-        id: const Uuid().v4(),
-        name: 'Повтор ошибок',
-        createdAt: DateTime.now(),
-        spots: spots,
-      );
-      await context.read<TrainingSessionService>().startSession(tpl);
-      if (mounted) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
-        );
-      }
-      if (mounted) {
-        final clear = await showDialog<bool>(
-          context: context,
-          builder: (_) => AlertDialog(
-            backgroundColor: const Color(0xFF121212),
-            title: const Text('Очистить ошибки?'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context, false),
-                child: const Text('Нет'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(context, true),
-                child: const Text('Да'),
-              ),
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  Widget _clusterCard(MistakeTagCluster cluster, List<MistakeInsight> insights) {
+    final tags = insights.take(2).toList();
+    final count = insights.fold<int>(0, (a, b) => a + b.count);
+    final evLoss = insights.fold<double>(0, (a, b) => a + b.evLoss);
+    final example = tags.first.examples.isNotEmpty ? tags.first.examples.first : null;
+    return Card(
+      color: AppColors.cardBackground,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(cluster.label,
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            for (final t in tags)
+              Text('${t.tag.label}: ${t.shortExplanation}',
+                  style: const TextStyle(color: Colors.white70)),
+            const SizedBox(height: 8),
+            Text('Ошибок: $count',
+                style: const TextStyle(color: Colors.white70)),
+            if (evLoss > 0)
+              Text('Потеря EV: ${evLoss.toStringAsFixed(2)}',
+                  style: const TextStyle(color: Colors.white70)),
+            if (example != null) ...[
+              const SizedBox(height: 8),
+              TrainingPackSpotPreviewCard(spot: example.spot),
             ],
-          ),
-        );
-        if (clear == true) {
-          await SmartReviewService.instance.clearMistakes();
-        }
-      }
-      if (mounted) Navigator.pop(context);
-    } else {
-      setState(() => _loading = false);
-    }
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: _startReview,
+                child: const Text('Повторить ошибки'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
   }
 
   @override
@@ -89,9 +122,36 @@ class _MistakeReviewScreenState extends State<MistakeReviewScreen> {
         body: Center(child: CircularProgressIndicator()),
       );
     }
-    return const Scaffold(
-      backgroundColor: Color(0xFF121212),
-      body: Center(child: Text('Нет ошибок для повторения')),
+    if (_clusters.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Повтор ошибок')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Вы отлично справляетесь!',
+                  style: TextStyle(color: Colors.white70)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _startReview,
+                child: const Text('Повторить прошлые ошибки'),
+              )
+            ],
+          ),
+        ),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Повтор ошибок')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          for (final entry in _clusters.entries) ...[
+            _clusterCard(entry.key, entry.value),
+            const SizedBox(height: 16),
+          ]
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/sync_status_widget.dart';
 import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
 import '../utils/responsive.dart';
+import 'mistake_review_screen.dart';
 
 class ProgressDashboardScreen extends StatefulWidget {
   const ProgressDashboardScreen({super.key});
@@ -190,6 +191,17 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
           ),
           const SizedBox(height: 16),
           const DailyEvIcmChart(),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const MistakeReviewScreen()),
+              );
+            },
+            child: const Text('Повтор ошибок'),
+          ),
         ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add new MistakeReviewScreen to display mistake clusters
- show cluster cards with top tags, EV loss and example hand
- provide review entry point
- link MistakeReviewScreen from ProgressDashboard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f69d3f578832ab6389dba2f8c2974