### PR TITLE
Implement SmartMistakeReviewStrategy

### DIFF
--- a/lib/services/smart_mistake_review_strategy.dart
+++ b/lib/services/smart_mistake_review_strategy.dart
@@ -1,0 +1,117 @@
+import '../models/mistake_insight.dart';
+import '../services/mistake_tag_insights_service.dart';
+import '../services/skill_loss_feed_engine.dart';
+import '../services/tag_insight_reminder_engine.dart';
+import '../services/tag_mastery_history_service.dart';
+import '../services/training_history_service_v2.dart';
+import '../models/training_history_entry_v2.dart';
+
+enum ReviewStrategyType { repeatSameSpots, trainTagPack, recoverCluster }
+
+class ReviewStrategyDecision {
+  final ReviewStrategyType type;
+  final String reason;
+  final String? targetTag;
+
+  const ReviewStrategyDecision({
+    required this.type,
+    required this.reason,
+    this.targetTag,
+  });
+}
+
+class SmartMistakeReviewStrategy {
+  final MistakeTagInsightsService insightsService;
+  final SkillLossFeedEngine skillLossEngine;
+  final TagInsightReminderEngine reminder;
+
+  const SmartMistakeReviewStrategy({
+    this.insightsService = const MistakeTagInsightsService(),
+    this.skillLossEngine = const SkillLossFeedEngine(),
+    TagInsightReminderEngine? reminder,
+  }) : reminder = reminder ??
+            TagInsightReminderEngine(history: TagMasteryHistoryService());
+
+  Future<List<SkillLossFeedItem>> _loadFeed() async {
+    final losses = await reminder.loadLosses();
+    return skillLossEngine.buildFeed(losses);
+  }
+
+  Future<ReviewStrategyDecision> decide({
+    List<MistakeInsight>? insights,
+    List<SkillLossFeedItem>? feed,
+    List<TrainingHistoryEntryV2>? history,
+  }) async {
+    final ins = insights ?? await insightsService.buildInsights();
+    final hist = history ?? await TrainingHistoryServiceV2.getHistory(limit: 20);
+    final skillFeed = feed ?? await _loadFeed();
+
+    final lastTrained = <String, DateTime>{};
+    for (final h in hist) {
+      for (final t in h.tags) {
+        final tag = t.trim().toLowerCase();
+        final prev = lastTrained[tag];
+        if (prev == null || h.timestamp.isAfter(prev)) {
+          lastTrained[tag] = h.timestamp;
+        }
+      }
+    }
+
+    bool recentlyTrained(String tag, {int days = 3}) {
+      final last = lastTrained[tag.trim().toLowerCase()];
+      if (last == null) return false;
+      return DateTime.now().difference(last).inDays < days;
+    }
+
+    // Check for repeated spots across insights
+    final spotCounts = <String, int>{};
+    for (final i in ins) {
+      for (final ex in i.examples) {
+        final id = ex.spot.id;
+        if (id.isEmpty) continue;
+        spotCounts.update(id, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    if (spotCounts.values.any((c) => c >= 2)) {
+      return const ReviewStrategyDecision(
+        type: ReviewStrategyType.repeatSameSpots,
+        reason: 'Repeated mistakes on same spots',
+      );
+    }
+
+    // Determine if a single tag dominates mistakes
+    if (ins.isNotEmpty) {
+      final total = ins.fold<int>(0, (a, b) => a + b.count);
+      final top = ins.first;
+      if (total > 0 &&
+          top.count / total >= 0.5 &&
+          !recentlyTrained(top.tag.label)) {
+        return ReviewStrategyDecision(
+          type: ReviewStrategyType.trainTagPack,
+          reason: 'Tag ${top.tag.label} dominates recent mistakes',
+          targetTag: top.tag.label,
+        );
+      }
+    }
+
+    // Skill loss urgent tag
+    if (skillFeed.isNotEmpty) {
+      skillFeed.sort((a, b) => b.urgencyScore.compareTo(a.urgencyScore));
+      final item = skillFeed.first;
+      if (item.urgencyScore >= 1.0 && !recentlyTrained(item.tag)) {
+        return ReviewStrategyDecision(
+          type: ReviewStrategyType.recoverCluster,
+          reason: 'Skill loss detected for ${item.tag}',
+          targetTag: item.tag,
+        );
+      }
+    }
+
+    // Fallback
+    return const ReviewStrategyDecision(
+      type: ReviewStrategyType.repeatSameSpots,
+      reason: 'Default repeat mistakes',
+    );
+  }
+}
+

--- a/lib/services/smart_review_service.dart
+++ b/lib/services/smart_review_service.dart
@@ -10,6 +10,7 @@ import '../screens/training_session_screen.dart';
 import '../models/training_pack_template.dart';
 import 'package:uuid/uuid.dart';
 import '../models/mistake_profile.dart';
+import 'smart_mistake_review_strategy.dart';
 
 /// Stores IDs of spots where the user made a mistake for future review.
 class SmartReviewService {
@@ -74,6 +75,18 @@ class SmartReviewService {
     for (final id in _ids) {
       final spot = map[id];
       if (spot != null) result.add(spot);
+    }
+
+    final strategy = const SmartMistakeReviewStrategy();
+    final decision = await strategy.decide();
+    if (decision.type != ReviewStrategyType.repeatSameSpots &&
+        decision.targetTag != null) {
+      final tag = decision.targetTag!.toLowerCase();
+      final filtered = [
+        for (final s in result)
+          if (s.tags.any((t) => t.toLowerCase() == tag)) s
+      ];
+      if (filtered.isNotEmpty) result = filtered;
     }
 
     if (context != null && result.length > 5) {

--- a/test/smart_mistake_review_strategy_test.dart
+++ b/test/smart_mistake_review_strategy_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/mistake_insight.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/training_spot_attempt.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/smart_mistake_review_strategy.dart';
+import 'package:poker_analyzer/services/skill_loss_feed_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingSpotAttempt attempt(String id) => TrainingSpotAttempt(
+        spot: TrainingPackSpot(id: id, hand: HandData()),
+        userAction: '',
+        correctAction: '',
+        evDiff: 0,
+      );
+
+  test('dominant tag triggers trainTagPack', () async {
+    final insights = [
+      MistakeInsight(
+        tag: MistakeTag.overfoldBtn,
+        count: 8,
+        evLoss: 0,
+        shortExplanation: '',
+        examples: const [],
+      ),
+      MistakeInsight(
+        tag: MistakeTag.looseCallBb,
+        count: 2,
+        evLoss: 0,
+        shortExplanation: '',
+        examples: const [],
+      ),
+    ];
+
+    const strategy = SmartMistakeReviewStrategy();
+    final decision = await strategy.decide(
+      insights: insights,
+      feed: const [],
+      history: const [],
+    );
+    expect(decision.type, ReviewStrategyType.trainTagPack);
+    expect(decision.targetTag, MistakeTag.overfoldBtn.label);
+  });
+
+  test('repeated spots trigger repeatSameSpots', () async {
+    final ex1 = attempt('s1');
+    final insights = [
+      MistakeInsight(
+        tag: MistakeTag.overfoldBtn,
+        count: 2,
+        evLoss: 0,
+        shortExplanation: '',
+        examples: [ex1, ex1],
+      ),
+    ];
+
+    const strategy = SmartMistakeReviewStrategy();
+    final decision = await strategy.decide(
+      insights: insights,
+      feed: const [],
+      history: const [],
+    );
+    expect(decision.type, ReviewStrategyType.repeatSameSpots);
+  });
+
+  test('skill loss triggers recoverCluster', () async {
+    final feed = [
+      const SkillLossFeedItem(tag: 'sb call', urgencyScore: 1.2, trend: ''),
+    ];
+
+    const strategy = SmartMistakeReviewStrategy();
+    final decision = await strategy.decide(
+      insights: const [],
+      feed: feed,
+      history: const [],
+    );
+    expect(decision.type, ReviewStrategyType.recoverCluster);
+    expect(decision.targetTag, 'sb call');
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartMistakeReviewStrategy` for selecting review mode
- integrate strategy into `SmartReviewService`
- cover behaviour with unit tests

## Testing
- `flutter test test/smart_mistake_review_strategy_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a264a88832aad0f205548593e27