### PR TITLE
Add Smart Booster Suggestion block

### DIFF
--- a/lib/screens/skill_map_screen.dart
+++ b/lib/screens/skill_map_screen.dart
@@ -16,6 +16,7 @@ import '../models/mistake_tag.dart';
 import '../models/v2/training_pack_template.dart';
 import '../widgets/skill_card.dart';
 import '../widgets/booster_packs_block.dart';
+import '../widgets/booster_suggestion_block.dart';
 import '../utils/responsive.dart';
 import 'library_screen.dart';
 import 'tag_insight_screen.dart';
@@ -231,6 +232,8 @@ class _SkillMapScreenState extends State<SkillMapScreen> {
                 ),
                 const SizedBox(height: 16),
                 for (final c in _clusters) _clusterTile(c),
+                const SizedBox(height: 16),
+                const BoosterSuggestionBlock(),
                 const SizedBox(height: 16),
                 const BoosterPacksBlock(),
               ],

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -17,6 +17,8 @@ import 'training_session_screen.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../services/daily_spotlight_service.dart';
 
+import '../widgets/booster_suggestion_block.dart';
+
 import '../services/spot_of_the_day_service.dart';
 import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/streak_chart.dart';
@@ -130,6 +132,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           ),
           const ProgressSummaryCard(),
           const TrainingProgressCard(),
+          const BoosterSuggestionBlock(),
           if (!tablet) const DailySpotlightCard(),
           if (narrow) ...[
             const QuickContinueCard(),

--- a/lib/widgets/booster_suggestion_block.dart
+++ b/lib/widgets/booster_suggestion_block.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:collection/collection.dart';
+
+import '../models/mistake_tag.dart';
+import '../models/mistake_tag_cluster.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/smart_booster_generator.dart';
+import '../services/tag_mastery_service.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+
+class BoosterSuggestionBlock extends StatefulWidget {
+  const BoosterSuggestionBlock({super.key});
+
+  @override
+  State<BoosterSuggestionBlock> createState() => _BoosterSuggestionBlockState();
+}
+
+class _BoosterSuggestionBlockState extends State<BoosterSuggestionBlock> {
+  static const _cacheKey = 'smart_booster_cache';
+  static const _cacheTimeKey = 'smart_booster_cache_time';
+
+  bool _loading = true;
+  List<TrainingPackTemplateV2> _packs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final cacheTimeStr = prefs.getString(_cacheTimeKey);
+    final cacheStr = prefs.getString(_cacheKey);
+    final now = DateTime.now();
+    if (cacheTimeStr != null && cacheStr != null) {
+      final ts = DateTime.tryParse(cacheTimeStr);
+      if (ts != null && now.difference(ts) < const Duration(hours: 24)) {
+        final list = jsonDecode(cacheStr);
+        if (list is List) {
+          setState(() {
+            _packs = [
+              for (final e in list)
+                if (e is Map)
+                  TrainingPackTemplateV2.fromJson(
+                      Map<String, dynamic>.from(e))
+            ];
+            _loading = false;
+          });
+          return;
+        }
+      }
+    }
+
+    final packs = await const SmartBoosterGenerator().generate();
+    await prefs.setString(
+        _cacheKey, jsonEncode([for (final p in packs) p.toJson()]));
+    await prefs.setString(_cacheTimeKey, now.toIso8601String());
+    if (!mounted) return;
+    setState(() {
+      _packs = packs;
+      _loading = false;
+    });
+  }
+
+  Future<void> _start(TrainingPackTemplateV2 tpl) async {
+    await context.read<TrainingSessionService>().startSession(tpl);
+    if (!context.mounted) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+
+  double _clusterMastery(
+    String label,
+    Map<String, double> masteryMap,
+  ) {
+    final cluster = MistakeTagCluster.values
+        .firstWhereOrNull((c) => c.label == label);
+    if (cluster == null) return 0;
+    final tags = _clusterTags[cluster] ?? const <MistakeTag>[];
+    var sum = 0.0;
+    var count = 0;
+    for (final t in tags) {
+      final m = masteryMap[t.name.toLowerCase()];
+      if (m != null) {
+        sum += m;
+        count++;
+      }
+    }
+    return count > 0 ? sum / count : 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_packs.isEmpty) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<Map<String, double>>(
+      future: context.read<TagMasteryService>().computeMastery(),
+      builder: (context, snapshot) {
+        final masteryMap = snapshot.data ?? {};
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '🚀 Smart Boosters',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 160,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: _packs.length,
+                  separatorBuilder: (_, __) => const SizedBox(width: 12),
+                  itemBuilder: (_, i) {
+                    final pack = _packs[i];
+                    final tag = pack.meta['tag'] as String?;
+                    final mastery = tag != null
+                        ? (_clusterMastery(tag, masteryMap) * 100).round()
+                        : null;
+                    return Container(
+                      width: 180,
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: Colors.grey[800],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(pack.name,
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.bold)),
+                          if (tag != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                '$tag${mastery != null ? ' • $mastery%' : ''}',
+                                style: const TextStyle(
+                                    color: Colors.white70, fontSize: 12),
+                              ),
+                            ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              '${pack.spotCount} spots',
+                              style: const TextStyle(
+                                  color: Colors.white70, fontSize: 12),
+                            ),
+                          ),
+                          const Spacer(),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: ElevatedButton(
+                              onPressed: () => _start(pack),
+                              style: ElevatedButton.styleFrom(
+                                  backgroundColor: accent),
+                              child: const Text('Start Training'),
+                            ),
+                          )
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+const Map<MistakeTagCluster, List<MistakeTag>> _clusterTags = {
+  MistakeTagCluster.tightPreflopBtn: [
+    MistakeTag.overfoldBtn,
+    MistakeTag.overfoldShortStack,
+  ],
+  MistakeTagCluster.looseCallBlind: [
+    MistakeTag.looseCallBb,
+    MistakeTag.looseCallSb,
+    MistakeTag.looseCallCo,
+  ],
+  MistakeTagCluster.missedEvOpportunities: [
+    MistakeTag.missedEvPush,
+    MistakeTag.missedEvCall,
+    MistakeTag.missedEvRaise,
+  ],
+  MistakeTagCluster.aggressiveMistakes: [
+    MistakeTag.overpush,
+  ],
+};


### PR DESCRIPTION
## Summary
- implement `BoosterSuggestionBlock` widget using `SmartBoosterGenerator`
- show suggested boosters on SkillMap and Training Home screens

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f95e28980832aa5a792bdba66041d