### PR TITLE
Implement LearningTrackProgressModel for stage states

### DIFF
--- a/lib/models/learning_track_progress_model.dart
+++ b/lib/models/learning_track_progress_model.dart
@@ -1,0 +1,17 @@
+enum StageStatus { locked, unlocked, completed }
+
+class StageProgressStatus {
+  final String stageId;
+  final StageStatus status;
+
+  const StageProgressStatus({required this.stageId, required this.status});
+}
+
+class LearningTrackProgressModel {
+  final List<StageProgressStatus> stages;
+
+  const LearningTrackProgressModel({required this.stages});
+
+  StageProgressStatus? statusFor(String stageId) =>
+      stages.firstWhere((e) => e.stageId == stageId, orElse: () => null);
+}

--- a/lib/services/learning_track_progress_service.dart
+++ b/lib/services/learning_track_progress_service.dart
@@ -1,0 +1,39 @@
+import '../models/learning_track_progress_model.dart';
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_gatekeeper_service.dart';
+import 'learning_path_registry_service.dart';
+import 'training_path_progress_service_v2.dart';
+
+/// Builds [LearningTrackProgressModel] for a learning path.
+class LearningTrackProgressService {
+  final TrainingPathProgressServiceV2 progress;
+  final LearningPathGatekeeperService gatekeeper;
+  final LearningPathRegistryService registry;
+
+  const LearningTrackProgressService({
+    required this.progress,
+    required this.gatekeeper,
+    LearningPathRegistryService? registry,
+  }) : registry = registry ?? LearningPathRegistryService.instance;
+
+  Future<LearningTrackProgressModel> build(String pathId) async {
+    await progress.loadProgress(pathId);
+    await gatekeeper.updateStageUnlocks(pathId);
+    final template = registry.findById(pathId);
+    if (template == null) {
+      return const LearningTrackProgressModel(stages: []);
+    }
+    final unlocked = progress.unlockedStageIds().toSet();
+    final statuses = <StageProgressStatus>[];
+    for (final stage in template.stages) {
+      final completed = progress.getStageCompletion(stage.id);
+      final isUnlocked =
+          unlocked.contains(stage.id) && gatekeeper.isStageUnlocked(stage.id);
+      final status = completed
+          ? StageStatus.completed
+          : (isUnlocked ? StageStatus.unlocked : StageStatus.locked);
+      statuses.add(StageProgressStatus(stageId: stage.id, status: status));
+    }
+    return LearningTrackProgressModel(stages: statuses);
+  }
+}

--- a/test/learning_track_progress_model_test.dart
+++ b/test/learning_track_progress_model_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_gatekeeper_service.dart';
+import 'package:poker_analyzer/services/learning_track_progress_service.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/learning_path_registry_service.dart';
+import 'package:poker_analyzer/models/learning_track_progress_model.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+class _FakeMasteryService extends TagMasteryService {
+  final Map<String, double> _map;
+  _FakeMasteryService(this._map)
+    : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async =>
+      _map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await LearningPathRegistryService.instance.loadAll();
+  });
+
+  test('progress model marks completed and unlocked stages', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 10,
+        mistakeCount: 0,
+      ),
+    ];
+    final progress = TrainingPathProgressServiceV2(logs: _FakeLogService(logs));
+    await progress.loadProgress('sample');
+    await progress.markStageCompleted('s1', 100);
+
+    final gatekeeper = LearningPathGatekeeperService(
+      progress: progress,
+      mastery: _FakeMasteryService(const {}),
+    );
+    await gatekeeper.updateStageUnlocks('sample');
+
+    final svc = LearningTrackProgressService(
+      progress: progress,
+      gatekeeper: gatekeeper,
+    );
+    final model = await svc.build('sample');
+    expect(model.statusFor('s1')?.status, StageStatus.completed);
+    expect(model.statusFor('s2')?.status, StageStatus.unlocked);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningTrackProgressModel` and stage status enum
- expose `LearningTrackProgressService` to build progress per path
- provide `getStageCompletion` in progress service
- unit test verifying completed/unlocked states

## Testing
- `dart test` *(fails: Flutter SDK unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687fc3ba0104832ab6dc7eae3609bb4f