### PR TITLE
feat: show booster suggestions in learning path

### DIFF
--- a/lib/screens/learning_path_stage_list_screen.dart
+++ b/lib/screens/learning_path_stage_list_screen.dart
@@ -12,6 +12,8 @@ import '../services/session_log_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/learning_path_progress_tracker_service.dart';
+import '../services/skill_gap_booster_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
 import '../widgets/learning_stage_tile.dart';
 
 /// Displays stages of a learning path with progress indicators.
@@ -35,6 +37,7 @@ class _LearningPathStageListScreenState
   LearningTrackProgressModel _model =
       const LearningTrackProgressModel(stages: []);
   Map<String, String> _progressStrings = {};
+  final Map<String, List<TrainingPackTemplateV2>> _boosters = {};
   bool _loading = true;
   bool _initialized = false;
 
@@ -63,10 +66,26 @@ class _LearningPathStageListScreenState
     final model = await _service.build(widget.path.id);
     final progressStrings =
         _tracker.computeProgressStrings(widget.path, _logs.logs);
+    final masteryMap = await context.read<TagMasteryService>().computeMastery();
+    final boosterService = const SkillGapBoosterService();
+    final boosters = <String, List<TrainingPackTemplateV2>>{};
+    for (final stage in widget.path.stages) {
+      final status = model.statusFor(stage.id)?.status ?? StageStatus.locked;
+      if (status == StageStatus.completed) continue;
+      final packs = await boosterService.suggestBoosters(
+        requiredTags: stage.tags,
+        masteryMap: masteryMap,
+        count: 3,
+      );
+      if (packs.isNotEmpty) boosters[stage.id] = packs;
+    }
     if (!mounted) return;
     setState(() {
       _model = model;
       _progressStrings = progressStrings;
+      _boosters
+        ..clear()
+        ..addAll(boosters);
       _loading = false;
     });
   }
@@ -101,15 +120,77 @@ class _LearningPathStageListScreenState
                   final status =
                       _model.statusFor(stage.id)?.status ?? StageStatus.locked;
                   final progress = _progressStrings[stage.id] ?? '';
-                  return LearningStageTile(
-                    stage: stage,
-                    status: status,
-                    subtitle: progress,
-                    onTap: () => _startStage(stage),
+                  final boosters = _boosters[stage.id] ?? const [];
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      LearningStageTile(
+                        stage: stage,
+                        status: status,
+                        subtitle: progress,
+                        onTap: () => _startStage(stage),
+                      ),
+                      if (boosters.isNotEmpty)
+                        SizedBox(
+                          height: 160,
+                          child: ListView.separated(
+                            scrollDirection: Axis.horizontal,
+                            padding:
+                                const EdgeInsets.only(left: 16, top: 4, bottom: 8),
+                            itemBuilder: (context, i) =>
+                                _buildBoosterCard(boosters[i]),
+                            separatorBuilder: (_, __) => const SizedBox(width: 8),
+                            itemCount: boosters.length,
+                          ),
+                        ),
+                    ],
                   );
                 },
               ),
             ),
+    );
+  }
+
+  Widget _buildBoosterCard(TrainingPackTemplateV2 pack) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final desc = pack.goal.isNotEmpty ? pack.goal : pack.description;
+    return GestureDetector(
+      onTap: () => const TrainingSessionLauncher().launch(pack),
+      child: Container(
+        width: 160,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Colors.grey[800],
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: accent),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              pack.name,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            if (desc.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  desc,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+              ),
+            const Spacer(),
+            Text(
+              '${pack.spotCount} spots',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- integrate `SkillGapBoosterService` into `LearningPathStageListScreen`
- load booster packs per stage and display them under the stage tile
- tapping a booster card launches a training session

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 7091 issues)*
- `flutter test` *(failed to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_687fcc4dfdf4832aa38feb07846184b6