### PR TITLE
Add tests for learning path sections

### DIFF
--- a/test/learning_path_registry_service_test.dart
+++ b/test/learning_path_registry_service_test.dart
@@ -11,5 +11,6 @@ void main() {
     final tpl = service.findById('sample');
     expect(tpl, isNotNull);
     expect(tpl!.title, 'Sample Learning Path');
+    expect(tpl.sections.isNotEmpty, true);
   });
 }

--- a/test/learning_path_template_builder_test.dart
+++ b/test/learning_path_template_builder_test.dart
@@ -17,6 +17,8 @@ void main() {
     );
     expect(tpl.id, 'sample');
     expect(tpl.stages.length, 2);
+    expect(tpl.sections.length, 2);
+    expect(tpl.sections.first.title, 'Push/Fold Basics');
   });
 
   test('checkForCycles detects simple loop', () {


### PR DESCRIPTION
## Summary
- test that learning path template builder parses section info from YAML
- validate that registry service returns templates with sections

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdc8a14ec832aaec1300bc2f88fa4