### PR TITLE
Implement section gating logic

### DIFF
--- a/assets/learning_paths/section_chain.yaml
+++ b/assets/learning_paths/section_chain.yaml
@@ -1,0 +1,36 @@
+id: section_chain
+title: Section Chain Path
+description: Path with unlock chain inside section
+stages:
+  - id: sc1
+    title: SC1
+    description: ''
+    packId: pack1
+    requiredAccuracy: 80
+    minHands: 1
+  - id: sc2
+    title: SC2
+    description: ''
+    packId: pack1
+    requiredAccuracy: 80
+    minHands: 1
+    unlocks:
+      - sc3
+  - id: sc3
+    title: SC3
+    description: ''
+    packId: pack1
+    requiredAccuracy: 80
+    minHands: 1
+sections:
+  - id: first
+    title: First Section
+    description: ''
+    stageIds:
+      - sc1
+  - id: second
+    title: Second Section
+    description: ''
+    stageIds:
+      - sc2
+      - sc3

--- a/lib/services/learning_path_gatekeeper_service.dart
+++ b/lib/services/learning_path_gatekeeper_service.dart
@@ -75,7 +75,6 @@ class LearningPathGatekeeperService {
         for (final id in section.stageIds) {
           final stage = stageById[id];
           if (stage == null) continue;
-          if (!base.contains(stage.id)) continue;
           if (!_meetsMastery(stage, masteryMap)) continue;
           if (_isBlocked(stage, blockedClusters)) continue;
           if (!_meetsSessionCount()) continue;

--- a/test/services/learning_path_gatekeeper_service_test.dart
+++ b/test/services/learning_path_gatekeeper_service_test.dart
@@ -117,4 +117,34 @@ void main() {
     await gatekeeper.updateStageUnlocks('no_sections');
     expect(gatekeeper.isStageUnlocked('ns2'), isTrue);
   });
+
+  test('ignores stage prerequisites within unlocked sections', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 0,
+        mistakeCount: 0,
+      ),
+    ];
+    final progress = TrainingPathProgressServiceV2(logs: _FakeLogService(logs));
+    await progress.loadProgress('section_chain');
+
+    final gatekeeper = LearningPathGatekeeperService(
+      progress: progress,
+      mastery: _FakeMasteryService(const {}),
+    );
+
+    await gatekeeper.updateStageUnlocks('section_chain');
+    expect(gatekeeper.isStageUnlocked('sc1'), isTrue);
+    expect(gatekeeper.isStageUnlocked('sc2'), isFalse);
+    expect(gatekeeper.isStageUnlocked('sc3'), isFalse);
+
+    await progress.markStageCompleted('sc1', 100);
+    await gatekeeper.updateStageUnlocks('section_chain');
+    expect(gatekeeper.isStageUnlocked('sc2'), isTrue);
+    expect(gatekeeper.isStageUnlocked('sc3'), isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- enable module-level gating in LearningPathGatekeeperService
- add sample path with chained unlock inside a section
- test that section gating ignores intra-section prerequisites

## Testing
- `apt-get update`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880010c9bf4832aa22cbda5d5674803