### PR TITLE
Implement LearningPathStatsService

### DIFF
--- a/lib/models/learning_path_progress_stats.dart
+++ b/lib/models/learning_path_progress_stats.dart
@@ -1,0 +1,33 @@
+class SectionStats {
+  final String id;
+  final String title;
+  final int completedStages;
+  final int totalStages;
+
+  const SectionStats({
+    required this.id,
+    required this.title,
+    required this.completedStages,
+    required this.totalStages,
+  });
+
+  double get completionPercent =>
+      totalStages == 0 ? 0.0 : completedStages / totalStages;
+}
+
+class LearningPathProgressStats {
+  final int totalStages;
+  final int completedStages;
+  final double completionPercent;
+  final List<SectionStats> sections;
+  final List<String> lockedStageIds;
+
+  const LearningPathProgressStats({
+    required this.totalStages,
+    required this.completedStages,
+    required this.completionPercent,
+    required this.sections,
+    required this.lockedStageIds,
+  });
+}
+

--- a/lib/services/learning_path_stats_service.dart
+++ b/lib/services/learning_path_stats_service.dart
@@ -1,0 +1,72 @@
+import '../models/learning_path_template_v2.dart';
+import '../models/learning_path_progress_stats.dart';
+import 'training_path_progress_service_v2.dart';
+
+/// Computes detailed progress stats for a learning path.
+class LearningPathStatsService {
+  final TrainingPathProgressServiceV2 progress;
+
+  const LearningPathStatsService({required this.progress});
+
+  /// Builds progress statistics for [path] using current user progress.
+  LearningPathProgressStats computeStats(LearningPathTemplateV2 path) {
+    final completed = <String>{};
+    for (final stage in path.stages) {
+      if (progress.getStageCompletion(stage.id)) {
+        completed.add(stage.id);
+      }
+    }
+
+    final sections = <SectionStats>[];
+    for (final section in path.sections) {
+      final total = section.stageIds.length;
+      final done = section.stageIds.where(completed.contains).length;
+      sections.add(SectionStats(
+        id: section.id,
+        title: section.title,
+        completedStages: done,
+        totalStages: total,
+      ));
+    }
+
+    final baseUnlocked = progress.unlockedStageIds().toSet();
+    final locked = <String>[];
+
+    bool _sectionReady(String stageId) {
+      if (path.sections.isEmpty) return true;
+      final idx =
+          path.sections.indexWhere((s) => s.stageIds.contains(stageId));
+      if (idx <= 0) return true;
+      final prev = path.sections[idx - 1];
+      return prev.stageIds.every(completed.contains);
+    }
+
+    for (final stage in path.stages) {
+      if (completed.contains(stage.id)) continue;
+      var unlocked = baseUnlocked.contains(stage.id);
+      if (unlocked &&
+          stage.unlockAfter.isNotEmpty &&
+          !stage.unlockAfter.every(completed.contains)) {
+        unlocked = false;
+      }
+      if (unlocked && !_sectionReady(stage.id)) {
+        unlocked = false;
+      }
+      if (!unlocked) locked.add(stage.id);
+    }
+
+    final totalStages = path.stages.length;
+    final finished = completed.length;
+    final percent =
+        totalStages == 0 ? 0.0 : finished / totalStages;
+
+    return LearningPathProgressStats(
+      totalStages: totalStages,
+      completedStages: finished,
+      completionPercent: percent,
+      sections: sections,
+      lockedStageIds: locked,
+    );
+  }
+}
+

--- a/test/services/learning_path_stats_service_test.dart
+++ b/test/services/learning_path_stats_service_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_stats_service.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/learning_path_registry_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await LearningPathRegistryService.instance.loadAll();
+  });
+
+  test('compute stats with section and unlockAfter rules', () async {
+    final logs = [
+      SessionLog(
+        sessionId: '1',
+        templateId: 'pack1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 1,
+        mistakeCount: 0,
+      ),
+    ];
+    final progress = TrainingPathProgressServiceV2(logs: _FakeLogService(logs));
+    await progress.loadProgress('unlock_after');
+
+    final template =
+        LearningPathRegistryService.instance.findById('unlock_after')!;
+    final svc = LearningPathStatsService(progress: progress);
+
+    var stats = svc.computeStats(template);
+    expect(stats.completedStages, 0);
+    expect(stats.lockedStageIds, containsAll(['ua2', 'ua3']));
+
+    await progress.markStageCompleted('ua1', 100);
+    stats = svc.computeStats(template);
+    expect(stats.completedStages, 1);
+    expect(stats.lockedStageIds, contains('ua3'));
+    expect(stats.lockedStageIds.contains('ua2'), isFalse);
+
+    await progress.markStageCompleted('ua2', 100);
+    stats = svc.computeStats(template);
+    expect(stats.completedStages, 2);
+    expect(stats.lockedStageIds, isEmpty);
+  });
+}
+
+


### PR DESCRIPTION
## Summary
- add `LearningPathProgressStats` and `SectionStats` models
- add `LearningPathStatsService` for progress aggregation
- test stats computation with section and unlockAfter gating

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800535c258832a952f9a8ecc736d5e