### PR TITLE
Add stage preview dialog

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -15,6 +15,7 @@ import '../services/smart_stage_unlock_service.dart';
 import '../services/learning_path_personalization_service.dart';
 import 'learning_path_celebration_screen.dart';
 import '../widgets/stage_progress_chip.dart';
+import '../widgets/stage_preview_dialog.dart';
 
 /// Displays all stages of a learning path and allows launching each pack.
 class LearningPathScreen extends StatefulWidget {
@@ -216,6 +217,20 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
                 child: Icon(Icons.star, color: Colors.orange),
               ),
             if (_reinforced.contains(stage.id)) const SizedBox(width: 4),
+            if (state == LearningStageUIState.active)
+              IconButton(
+                icon: const Icon(Icons.visibility),
+                tooltip: 'Preview',
+                color: Colors.white70,
+                onPressed: () async {
+                  final start = await showDialog<bool>(
+                    context: context,
+                    builder: (_) => StagePreviewDialog(stage: stage),
+                  );
+                  if (start == true) _startStage(stage);
+                },
+              ),
+            if (state == LearningStageUIState.active) const SizedBox(width: 4),
             Icon(icon, color: color),
             const SizedBox(width: 4),
             Text(label, style: TextStyle(color: color)),

--- a/lib/widgets/stage_preview_dialog.dart
+++ b/lib/widgets/stage_preview_dialog.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_stage_model.dart';
+import '../services/pack_library_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Dialog showing brief information about a learning path stage.
+class StagePreviewDialog extends StatefulWidget {
+  final LearningPathStageModel stage;
+  const StagePreviewDialog({super.key, required this.stage});
+
+  @override
+  State<StagePreviewDialog> createState() => _StagePreviewDialogState();
+}
+
+class _StagePreviewDialogState extends State<StagePreviewDialog> {
+  TrainingPackTemplateV2? _pack;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final p = await PackLibraryService.instance.getById(widget.stage.packId);
+    if (mounted) setState(() {
+      _pack = p;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pack = _pack;
+    final estMinutes =
+        pack == null ? null : (pack.spotCount / 2).ceil();
+    return AlertDialog(
+      backgroundColor: const Color(0xFF1E1E1E),
+      title: Text(widget.stage.title),
+      content: _loading
+          ? const SizedBox(height: 100, child: Center(child: CircularProgressIndicator()))
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (widget.stage.description.isNotEmpty)
+                  Text(widget.stage.description,
+                      style: const TextStyle(color: Colors.white70)),
+                if (pack != null) ...[
+                  const SizedBox(height: 8),
+                  Text('Spots: ${pack.spotCount}',
+                      style: const TextStyle(color: Colors.white70)),
+                  if (estMinutes != null)
+                    Text('Estimated time: ${estMinutes}m',
+                        style: const TextStyle(color: Colors.white70)),
+                ],
+                if (widget.stage.tags.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 4,
+                    children: [
+                      for (final t in widget.stage.tags)
+                        Chip(label: Text(t)),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Закрыть'),
+        ),
+        ElevatedButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Начать тренировку'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `StagePreviewDialog` to preview stage info
- show preview icon on active stages in `LearningPathScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801c8acf10832a948dbae7edf17ed9