### PR TITLE
Implement weakness booster overlay

### DIFF
--- a/lib/services/tag_mastery_service.dart
+++ b/lib/services/tag_mastery_service.dart
@@ -94,23 +94,23 @@ class TagMasteryService {
 
   Future<List<String>> topWeakTags(int count) async {
     final map = await computeMastery();
-    final list = map.entries.toList()
-      ..sort((a, b) => a.value.compareTo(b.value));
+    final list =
+        map.entries.toList()..sort((a, b) => a.value.compareTo(b.value));
     return [for (final e in list.take(count)) e.key];
   }
 
   Future<List<String>> topStrongTags(int count) async {
     final map = await computeMastery();
-    final list = map.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+    final list =
+        map.entries.toList()..sort((a, b) => b.value.compareTo(a.value));
     return [for (final e in list.take(count)) e.key];
   }
 
   /// Returns the weakest [count] tags sorted by mastery ascending.
   Future<List<String>> bottomWeakTags(int count) async {
     final map = await computeMastery();
-    final list = map.entries.toList()
-      ..sort((a, b) => a.value.compareTo(b.value));
+    final list =
+        map.entries.toList()..sort((a, b) => a.value.compareTo(b.value));
     return [for (final e in list.take(count)) e.key];
   }
 
@@ -119,8 +119,18 @@ class TagMasteryService {
     final map = await computeMastery();
     return [
       for (final e in map.entries)
-        if (e.value < threshold) e.key
+        if (e.value < threshold) e.key,
     ];
+  }
+
+  /// Returns all tags with mastery below [threshold], sorted ascending.
+  Future<List<String>> findWeakTags({double threshold = 0.7}) async {
+    final map = await computeMastery();
+    final list = [
+      for (final e in map.entries)
+        if (e.value < threshold) MapEntry(e.key, e.value),
+    ]..sort((a, b) => a.value.compareTo(b.value));
+    return [for (final e in list) e.key];
   }
 
   /// Computes mastery deltas for a completed training [session]. When
@@ -139,10 +149,8 @@ class TagMasteryService {
     for (final entry in results.entries) {
       final spot = spotsById[entry.key];
       if (spot == null) continue;
-      final tags = <String>{
-        ...spot.tags,
-        ...spot.categories,
-      }..removeWhere((t) => t.trim().isEmpty);
+      final tags = <String>{...spot.tags, ...spot.categories}
+        ..removeWhere((t) => t.trim().isEmpty);
       for (final t in tags) {
         final key = t.trim().toLowerCase();
         totals.update(key, (v) => v + 1, ifAbsent: () => 1);
@@ -177,13 +185,18 @@ class TagMasteryService {
   Future<Map<String, double>> computeDelta({bool fromLastWeek = false}) async {
     await logs.load();
     final now = DateTime.now();
-    final thisWeekStart = DateTime(now.year, now.month, now.day)
-        .subtract(Duration(days: now.weekday - 1));
+    final thisWeekStart = DateTime(
+      now.year,
+      now.month,
+      now.day,
+    ).subtract(Duration(days: now.weekday - 1));
     final lastWeekStart = thisWeekStart.subtract(const Duration(days: 7));
     final thisWeekLogs = logs.filter(range: DateTimeRange(thisWeekStart, now));
     final lastWeekLogs = logs.filter(
       range: DateTimeRange(
-          lastWeekStart, thisWeekStart.subtract(const Duration(seconds: 1))),
+        lastWeekStart,
+        thisWeekStart.subtract(const Duration(seconds: 1)),
+      ),
     );
 
     final current = await _computeForLogs(thisWeekLogs);

--- a/lib/widgets/weakness_booster_overlay.dart
+++ b/lib/widgets/weakness_booster_overlay.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+class WeaknessBoosterOverlay extends StatelessWidget {
+  final List<String> tags;
+  final VoidCallback onStart;
+  final VoidCallback onDismiss;
+  const WeaknessBoosterOverlay({
+    super.key,
+    required this.tags,
+    required this.onStart,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final list = tags.take(2).join(', ');
+    return Scaffold(
+      backgroundColor: Colors.black87,
+      body: Center(
+        child: Container(
+          margin: const EdgeInsets.all(24),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Усилить слабую зону?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'У тебя просадка в $list — хочешь отработать сейчас?',
+                style: const TextStyle(color: Colors.white70),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: onStart,
+                style: ElevatedButton.styleFrom(backgroundColor: accent),
+                child: const Text('Да, начать тренировку'),
+              ),
+              TextButton(
+                onPressed: onDismiss,
+                child: const Text(
+                  'Позже',
+                  style: TextStyle(color: Colors.white70),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showWeaknessBoosterOverlay(
+  BuildContext context, {
+  required List<String> tags,
+  required VoidCallback onStart,
+}) async {
+  await showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder:
+        (_) => WeaknessBoosterOverlay(
+          tags: tags,
+          onStart: () {
+            Navigator.pop(context);
+            onStart();
+          },
+          onDismiss: () {
+            Navigator.pop(context);
+          },
+        ),
+  );
+}


### PR DESCRIPTION
## Summary
- add `WeaknessBoosterOverlay` widget
- expose `findWeakTags` helper on `TagMasteryService`
- show booster overlay on `StageCompletedScreen`

## Testing
- `dart format lib/screens/stage_completed_screen.dart lib/services/tag_mastery_service.dart lib/widgets/weakness_booster_overlay.dart`
- `flutter analyze` *(fails: The current Dart SDK version is 3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68802783760c832a86d0bac514fbff11