### PR TITLE
Implement stage completion skill boost

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -25,6 +25,7 @@ import '../helpers/poker_street_helper.dart';
 import '../services/session_log_service.dart';
 import '../services/training_path_progress_service_v2.dart';
 import '../services/learning_path_registry_service.dart';
+import '../services/tag_mastery_service.dart';
 import 'stage_completed_screen.dart';
 import 'package:collection/collection.dart';
 import '../widgets/spot_viewer_dialog.dart';
@@ -97,6 +98,15 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       await progress.markStageCompleted(stage.id, stats.accuracy);
       final after = progress.getStageCompletion(stage.id);
       if (!before && after) {
+        final mastery = context.read<TagMasteryService>();
+        await mastery.updateWithSession(
+          template: widget.template,
+          results: widget.session.results,
+          dryRun: false,
+          applyCompletionBonus: true,
+          requiredHands: stage.minHands,
+          requiredAccuracy: stage.requiredAccuracy,
+        );
         if (!mounted) return;
         Navigator.pushReplacement(
           context,


### PR DESCRIPTION
## Summary
- bump `TagMasteryService.updateWithSession` to support an optional completion bonus
- when a learning stage is newly completed, boost mastery for pack tags

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68803524c4ec832aaaaa2c63b628d90e