### PR TITLE
Add StreakTrackerService for training streaks

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -59,6 +59,7 @@ import 'services/training_pack_tag_analytics_service.dart';
 import 'services/ignored_mistake_service.dart';
 import 'services/goals_service.dart';
 import 'services/streak_service.dart';
+import 'services/streak_tracker_service.dart';
 import 'services/achievement_service.dart';
 import 'services/achievement_engine.dart';
 import 'services/user_goal_engine.dart';
@@ -316,6 +317,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         xp: context.read<XPTrackerService>(),
       )..load(),
     ),
+    Provider(create: (_) => StreakTrackerService()),
     ChangeNotifierProvider(
       create: (context) => AchievementService(
         stats: context.read<TrainingStatsService>(),

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -24,6 +24,7 @@ import '../../widgets/common/explanation_text.dart';
 import '../../widgets/dynamic_progress_row.dart';
 import '../../theme/app_colors.dart';
 import '../../services/streak_service.dart';
+import '../../services/streak_tracker_service.dart';
 import '../../services/notification_service.dart';
 import '../../services/mistake_review_pack_service.dart';
 import 'training_pack_result_screen_v2.dart';
@@ -563,6 +564,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
       _index = _spots.length - 1;
       _save();
       await context.read<StreakService>().onFinish();
+      await context.read<StreakTrackerService>().markActiveToday();
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
       final prefs = await SharedPreferences.getInstance();

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -24,6 +24,7 @@ import '../../widgets/common/explanation_text.dart';
 import '../../widgets/dynamic_progress_row.dart';
 import '../../theme/app_colors.dart';
 import '../../services/streak_service.dart';
+import '../../services/streak_tracker_service.dart';
 import '../../services/notification_service.dart';
 import '../../services/mistake_review_pack_service.dart';
 import 'training_pack_result_screen_v2.dart';
@@ -583,6 +584,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
       _index = _spots.length - 1;
       _save();
       await context.read<StreakService>().onFinish();
+      await context.read<StreakTrackerService>().markActiveToday();
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
       final prefs = await SharedPreferences.getInstance();

--- a/lib/services/streak_tracker_service.dart
+++ b/lib/services/streak_tracker_service.dart
@@ -1,0 +1,62 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StreakTrackerService {
+  StreakTrackerService._();
+  static final StreakTrackerService instance = StreakTrackerService._();
+
+  static const String _lastKey = 'lastActiveDate';
+  static const String _currentKey = 'currentStreak';
+  static const String _bestKey = 'bestStreak';
+
+  Future<void> markActiveToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    var current = prefs.getInt(_currentKey) ?? 0;
+    var best = prefs.getInt(_bestKey) ?? current;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 1) {
+        current += 1;
+      } else if (diff > 1) {
+        current = 1;
+      }
+    } else {
+      current = 1;
+    }
+
+    if (current > best) best = current;
+
+    await prefs.setString(_lastKey, today.toIso8601String());
+    await prefs.setInt(_currentKey, current);
+    await prefs.setInt(_bestKey, best);
+  }
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    var current = prefs.getInt(_currentKey) ?? 0;
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = DateTime.now().difference(lastDay).inDays;
+      if (diff > 1) {
+        current = 0;
+        await prefs.setInt(_currentKey, 0);
+      }
+    } else if (current != 0) {
+      current = 0;
+      await prefs.setInt(_currentKey, 0);
+    }
+    return current;
+  }
+
+  Future<int> getBestStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_bestKey) ?? 0;
+  }
+}

--- a/lib/widgets/goal_dashboard_widget.dart
+++ b/lib/widgets/goal_dashboard_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../services/lesson_goal_engine.dart';
-import '../services/lesson_goal_streak_engine.dart';
+import '../services/streak_tracker_service.dart';
 import 'goal_progress_bar.dart';
 
 /// Compact dashboard widget showing today's and weekly goal progress
@@ -23,8 +23,8 @@ class GoalDashboardWidget extends StatelessWidget {
     }
     final daily = await LessonGoalEngine.instance.getDailyGoal();
     final weekly = await LessonGoalEngine.instance.getWeeklyGoal();
-    final current = await LessonGoalStreakEngine.instance.getCurrentStreak();
-    final best = await LessonGoalStreakEngine.instance.getBestStreak();
+    final current = await StreakTrackerService.instance.getCurrentStreak();
+    final best = await StreakTrackerService.instance.getBestStreak();
     return {
       'daily': daily,
       'weekly': weekly,
@@ -70,7 +70,7 @@ class GoalDashboardWidget extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 8),
-              Text('🔥 $current-day streak',
+              Text('🔥 \u0421\u0442\u0440\u0438\u043A: $current \u0434\u043D\u044F \u043F\u043E\u0434\u0440\u044F\u0434',
                   style: const TextStyle(color: Colors.white)),
               const SizedBox(height: 4),
               Text('🏆 Best: $best',

--- a/test/services/streak_tracker_service_test.dart
+++ b/test/services/streak_tracker_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/streak_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('streak increments on consecutive days', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = StreakTrackerService.instance;
+    await service.markActiveToday();
+    var current = await service.getCurrentStreak();
+    var best = await service.getBestStreak();
+    expect(current, 1);
+    expect(best, 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('lastActiveDate', yesterday.toIso8601String());
+    await prefs.setInt('currentStreak', 1);
+    await prefs.setInt('bestStreak', 3);
+
+    await service.markActiveToday();
+    current = await service.getCurrentStreak();
+    best = await service.getBestStreak();
+    expect(current, 2);
+    expect(best, 3);
+
+    final old = DateTime.now().subtract(const Duration(days: 3));
+    await prefs.setString('lastActiveDate', old.toIso8601String());
+    await prefs.setInt('currentStreak', 2);
+
+    current = await service.getCurrentStreak();
+    best = await service.getBestStreak();
+    expect(current, 0);
+    expect(best, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `StreakTrackerService` to track consecutive training days
- integrate tracker with training sessions
- expose tracker on goal dashboard
- provide provider wiring
- add unit tests

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803a8bc744832a95c58b0b8e7b4e83