### PR TITLE
Implement streak milestones

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -39,6 +39,8 @@ import 'spot_of_the_day_screen.dart';
 import 'weakness_overview_screen.dart';
 import 'next_step_suggestion_dialog.dart';
 import '../widgets/mistake_review_button.dart';
+import '../services/streak_tracker_service.dart';
+import '../widgets/confetti_overlay.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -131,6 +133,10 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final milestone = await StreakTrackerService.instance.markActiveToday();
+      if (milestone && mounted) {
+        showConfettiOverlay(context);
+      }
       final s = context.read<NextStepEngine>().suggestion;
       if (s != null) _showNextStep(s);
       await NextStepSuggestionDialog.show(context);

--- a/lib/services/streak_tracker_service.dart
+++ b/lib/services/streak_tracker_service.dart
@@ -7,8 +7,9 @@ class StreakTrackerService {
   static const String _lastKey = 'lastActiveDate';
   static const String _currentKey = 'currentStreak';
   static const String _bestKey = 'bestStreak';
+  static const List<int> milestones = [3, 7, 14, 30, 60, 100];
 
-  Future<void> markActiveToday() async {
+  Future<bool> markActiveToday() async {
     final prefs = await SharedPreferences.getInstance();
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -34,6 +35,8 @@ class StreakTrackerService {
     await prefs.setString(_lastKey, today.toIso8601String());
     await prefs.setInt(_currentKey, current);
     await prefs.setInt(_bestKey, best);
+
+    return milestones.contains(current);
   }
 
   Future<int> getCurrentStreak() async {

--- a/test/services/streak_tracker_service_test.dart
+++ b/test/services/streak_tracker_service_test.dart
@@ -8,11 +8,12 @@ void main() {
   test('streak increments on consecutive days', () async {
     SharedPreferences.setMockInitialValues({});
     final service = StreakTrackerService.instance;
-    await service.markActiveToday();
+    final milestone1 = await service.markActiveToday();
     var current = await service.getCurrentStreak();
     var best = await service.getBestStreak();
     expect(current, 1);
     expect(best, 1);
+    expect(milestone1, false);
 
     final prefs = await SharedPreferences.getInstance();
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
@@ -20,11 +21,12 @@ void main() {
     await prefs.setInt('currentStreak', 1);
     await prefs.setInt('bestStreak', 3);
 
-    await service.markActiveToday();
+    final milestone2 = await service.markActiveToday();
     current = await service.getCurrentStreak();
     best = await service.getBestStreak();
     expect(current, 2);
     expect(best, 3);
+    expect(milestone2, false);
 
     final old = DateTime.now().subtract(const Duration(days: 3));
     await prefs.setString('lastActiveDate', old.toIso8601String());
@@ -34,5 +36,24 @@ void main() {
     best = await service.getBestStreak();
     expect(current, 0);
     expect(best, 3);
+  });
+
+  test('milestone detected correctly', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = StreakTrackerService.instance;
+    // Day 1
+    await service.markActiveToday();
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('lastActiveDate', yesterday.toIso8601String());
+    await prefs.setInt('currentStreak', 1);
+    // Day 2
+    await service.markActiveToday();
+    final twoDaysAgo = DateTime.now().subtract(const Duration(days: 2));
+    await prefs.setString('lastActiveDate', twoDaysAgo.toIso8601String());
+    await prefs.setInt('currentStreak', 2);
+    // Day 3 should hit milestone
+    final milestone = await service.markActiveToday();
+    expect(milestone, true);
   });
 }


### PR DESCRIPTION
## Summary
- add milestone logic to `StreakTrackerService`
- fire streak celebration confetti in `TrainingSessionSummaryScreen`
- test streak milestone detection

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688040ac9e40832a87eb73987e385920