### PR TITLE
Add streak analytics card with heatmap

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -55,6 +55,7 @@ import '../widgets/weak_spot_card.dart';
 import '../widgets/achievements_card.dart';
 import '../widgets/daily_spotlight_card.dart';
 import '../widgets/streak_banner_widget.dart';
+import '../widgets/streak_analytics_card.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -165,6 +166,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             const ProgressForecastCard(),
             const PlayerStyleCard(),
             const StreakChart(),
+            const StreakAnalyticsCard(),
             const DailyProgressRing(),
             const GoalsCard(),
             const GoalDashboardWidget(),

--- a/lib/services/streak_tracker_service.dart
+++ b/lib/services/streak_tracker_service.dart
@@ -7,6 +7,7 @@ class StreakTrackerService {
   static const String _lastKey = 'lastActiveDate';
   static const String _currentKey = 'currentStreak';
   static const String _bestKey = 'bestStreak';
+  static const String _daysKey = 'streakActiveDays';
   static const List<int> milestones = [3, 7, 14, 30, 60, 100];
 
   Future<bool> markActiveToday() async {
@@ -17,6 +18,10 @@ class StreakTrackerService {
     final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
     var current = prefs.getInt(_currentKey) ?? 0;
     var best = prefs.getInt(_bestKey) ?? current;
+    final list = prefs.getStringList(_daysKey) ?? <String>[];
+    final todayStr = today.toIso8601String().split('T').first;
+    final set = list.toSet();
+    set.add(todayStr);
 
     if (last != null) {
       final lastDay = DateTime(last.year, last.month, last.day);
@@ -35,6 +40,7 @@ class StreakTrackerService {
     await prefs.setString(_lastKey, today.toIso8601String());
     await prefs.setInt(_currentKey, current);
     await prefs.setInt(_bestKey, best);
+    await prefs.setStringList(_daysKey, set.toList());
 
     return milestones.contains(current);
   }
@@ -61,5 +67,24 @@ class StreakTrackerService {
   Future<int> getBestStreak() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_bestKey) ?? 0;
+  }
+
+  Future<Map<DateTime, bool>> getLast30DaysMap() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_daysKey) ?? <String>[];
+    final set = list
+        .map((e) => DateTime.tryParse(e))
+        .whereType<DateTime>()
+        .map((d) => DateTime(d.year, d.month, d.day))
+        .toSet();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final start = today.subtract(const Duration(days: 29));
+    final map = <DateTime, bool>{};
+    for (var i = 0; i < 30; i++) {
+      final d = start.add(Duration(days: i));
+      map[d] = set.contains(d);
+    }
+    return map;
   }
 }

--- a/lib/widgets/streak_analytics_card.dart
+++ b/lib/widgets/streak_analytics_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import '../services/streak_tracker_service.dart';
+
+class StreakAnalyticsCard extends StatelessWidget {
+  const StreakAnalyticsCard({super.key});
+
+  Future<_CardData> _load(BuildContext context) async {
+    final service = StreakTrackerService.instance;
+    final current = await service.getCurrentStreak();
+    final best = await service.getBestStreak();
+    final map = await service.getLast30DaysMap();
+    return _CardData(current, best, map);
+  }
+
+  Color _color(bool active) => active ? Colors.greenAccent : Colors.grey[800]!;
+
+  Widget _buildGrid(Map<DateTime, bool> map) {
+    final start = map.keys.first;
+    final days = List<DateTime>.from(map.keys);
+    days.sort();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: List.generate(5, (row) {
+        return Row(
+          children: List.generate(6, (col) {
+            final index = row * 6 + col;
+            if (index >= days.length) return const SizedBox(width: 12, height: 12);
+            final d = days[index];
+            final active = map[d] ?? false;
+            return Container(
+              width: 12,
+              height: 12,
+              margin: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: _color(active),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            );
+          }),
+        );
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<_CardData>(
+      future: _load(context),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+        final data = snapshot.data!;
+        return Container(
+          margin: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('🔥 ${data.current} days · 🏆 Record: ${data.best}',
+                  style: TextStyle(color: accent)),
+              const SizedBox(height: 12),
+              _buildGrid(data.map),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CardData {
+  final int current;
+  final int best;
+  final Map<DateTime, bool> map;
+  _CardData(this.current, this.best, this.map);
+}
+

--- a/test/services/streak_tracker_service_test.dart
+++ b/test/services/streak_tracker_service_test.dart
@@ -49,11 +49,33 @@ void main() {
     await prefs.setInt('currentStreak', 1);
     // Day 2
     await service.markActiveToday();
-    final twoDaysAgo = DateTime.now().subtract(const Duration(days: 2));
-    await prefs.setString('lastActiveDate', twoDaysAgo.toIso8601String());
+    final yesterday2 = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('lastActiveDate', yesterday2.toIso8601String());
     await prefs.setInt('currentStreak', 2);
     // Day 3 should hit milestone
     final milestone = await service.markActiveToday();
     expect(milestone, true);
+  });
+
+  test('last 30 days map returns correct activity', () async {
+    SharedPreferences.setMockInitialValues({
+      'streakActiveDays': [
+        DateTime.now().toIso8601String().split('T').first,
+        DateTime.now()
+            .subtract(const Duration(days: 3))
+            .toIso8601String()
+            .split('T')
+            .first,
+      ]
+    });
+    final service = StreakTrackerService.instance;
+    final map = await service.getLast30DaysMap();
+    final today = DateTime.now();
+    final threeAgo = today.subtract(const Duration(days: 3));
+    final todayKey = DateTime(today.year, today.month, today.day);
+    final threeKey = DateTime(threeAgo.year, threeAgo.month, threeAgo.day);
+    expect(map[todayKey], true);
+    expect(map[threeKey], true);
+    expect(map[todayKey.subtract(const Duration(days: 1))], false);
   });
 }


### PR DESCRIPTION
## Summary
- extend `StreakTrackerService` with active day tracking and expose `getLast30DaysMap`
- add new `StreakAnalyticsCard` widget that displays current/best streak and 30‑day heatmap
- show the analytics card on the training home screen
- update unit tests

## Testing
- `flutter analyze` *(fails: many issues)*
- `flutter test test/services/streak_tracker_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688042486248832ab40de5c5527522bc