### PR TITLE
Add monthly streak freeze logic

### DIFF
--- a/lib/widgets/streak_saved_dialog.dart
+++ b/lib/widgets/streak_saved_dialog.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class StreakSavedDialog extends StatelessWidget {
+  const StreakSavedDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Стрик сохранён'),
+      content: const Text('Пропуск дня использован. Продолжай серию!'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Ок'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `StreakSavedDialog`
- extend `StreakTrackerService` with monthly freeze support
- record freezes under `usedFreezes`
- test freeze behaviour in `StreakTrackerService`

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688048073258832a944976e87373d2a0