### PR TITLE
Implement streak milestone celebration overlay

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -135,10 +135,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final milestone = await StreakTrackerService.instance.markActiveToday();
-      if (milestone && mounted) {
-        showConfettiOverlay(context);
-      }
+      await StreakTrackerService.instance.markActiveToday(context);
       final s = context.read<NextStepEngine>().suggestion;
       if (s != null) _showNextStep(s);
       await NextStepSuggestionDialog.show(context);

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -564,7 +564,9 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
       _index = _spots.length - 1;
       _save();
       await context.read<StreakService>().onFinish();
-      await context.read<StreakTrackerService>().markActiveToday();
+      await context
+          .read<StreakTrackerService>()
+          .markActiveToday(context);
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
       final prefs = await SharedPreferences.getInstance();

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -584,7 +584,9 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
       _index = _spots.length - 1;
       _save();
       await context.read<StreakService>().onFinish();
-      await context.read<StreakTrackerService>().markActiveToday();
+      await context
+          .read<StreakTrackerService>()
+          .markActiveToday(context);
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
       final prefs = await SharedPreferences.getInstance();

--- a/lib/services/streak_tracker_service.dart
+++ b/lib/services/streak_tracker_service.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../widgets/streak_lost_dialog.dart';
 import '../widgets/streak_saved_dialog.dart';
+import '../widgets/streak_milestone_celebration_overlay.dart';
 
 class StreakTrackerService {
   StreakTrackerService._();
@@ -19,7 +20,7 @@ class StreakTrackerService {
   bool _sameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
-  Future<bool> markActiveToday() async {
+  Future<bool> markActiveToday(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -51,7 +52,12 @@ class StreakTrackerService {
     await prefs.setInt(_bestKey, best);
     await prefs.setStringList(_daysKey, set.toList());
 
-    return milestones.contains(current);
+    final milestone = milestones.contains(current);
+    if (milestone && context.mounted) {
+      showCelebrationOverlay(
+          context, '🔥 Ты достиг $current-дневного стрика!');
+    }
+    return milestone;
   }
 
   Future<int> getCurrentStreak() async {

--- a/lib/widgets/streak_milestone_celebration_overlay.dart
+++ b/lib/widgets/streak_milestone_celebration_overlay.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'confetti_overlay.dart';
+
+/// Overlay shown when user hits a streak milestone.
+class StreakMilestoneCelebrationOverlay extends StatefulWidget {
+  final String message;
+  final VoidCallback onClose;
+  const StreakMilestoneCelebrationOverlay({
+    super.key,
+    required this.message,
+    required this.onClose,
+  });
+
+  @override
+  State<StreakMilestoneCelebrationOverlay> createState() =>
+      _StreakMilestoneCelebrationOverlayState();
+}
+
+class _StreakMilestoneCelebrationOverlayState
+    extends State<StreakMilestoneCelebrationOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black87,
+      body: Center(
+        child: FadeTransition(
+          opacity: CurvedAnimation(parent: _anim, curve: Curves.easeIn),
+          child: ScaleTransition(
+            scale: CurvedAnimation(parent: _anim, curve: Curves.elasticOut),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.local_fire_department,
+                    color: Colors.orange, size: 120),
+                const SizedBox(height: 16),
+                Text(
+                  widget.message,
+                  style: const TextStyle(color: Colors.white, fontSize: 24),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: widget.onClose,
+                  child: const Text('Продолжай в том же духе'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Display [StreakMilestoneCelebrationOverlay] above current screen.
+Future<void> showCelebrationOverlay(
+    BuildContext context, String message) async {
+  await showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => StreakMilestoneCelebrationOverlay(
+      message: message,
+      onClose: () => Navigator.pop(context),
+    ),
+  );
+}

--- a/test/services/streak_tracker_service_test.dart
+++ b/test/services/streak_tracker_service_test.dart
@@ -8,7 +8,8 @@ void main() {
   test('streak increments on consecutive days', () async {
     SharedPreferences.setMockInitialValues({});
     final service = StreakTrackerService.instance;
-    final milestone1 = await service.markActiveToday();
+    final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
+    final milestone1 = await service.markActiveToday(ctx);
     var current = await service.getCurrentStreak();
     var best = await service.getBestStreak();
     expect(current, 1);
@@ -21,7 +22,7 @@ void main() {
     await prefs.setInt('currentStreak', 1);
     await prefs.setInt('bestStreak', 3);
 
-    final milestone2 = await service.markActiveToday();
+    final milestone2 = await service.markActiveToday(ctx);
     current = await service.getCurrentStreak();
     best = await service.getBestStreak();
     expect(current, 2);
@@ -42,18 +43,19 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final service = StreakTrackerService.instance;
     // Day 1
-    await service.markActiveToday();
+    final ctx = TestWidgetsFlutterBinding.instance.renderViewElement!;
+    await service.markActiveToday(ctx);
     final prefs = await SharedPreferences.getInstance();
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
     await prefs.setString('lastActiveDate', yesterday.toIso8601String());
     await prefs.setInt('currentStreak', 1);
     // Day 2
-    await service.markActiveToday();
+    await service.markActiveToday(ctx);
     final yesterday2 = DateTime.now().subtract(const Duration(days: 1));
     await prefs.setString('lastActiveDate', yesterday2.toIso8601String());
     await prefs.setInt('currentStreak', 2);
     // Day 3 should hit milestone
-    final milestone = await service.markActiveToday();
+    final milestone = await service.markActiveToday(ctx);
     expect(milestone, true);
   });
 
@@ -85,7 +87,7 @@ void main() {
     await tester.pumpWidget(Container());
     final ctx = tester.element(find.byType(Container));
 
-    await service.markActiveToday();
+    await service.markActiveToday(ctx);
     final prefs = await SharedPreferences.getInstance();
     final twoAgo = DateTime.now().subtract(const Duration(days: 2));
     await prefs.setString('lastActiveDate', twoAgo.toIso8601String());
@@ -100,7 +102,7 @@ void main() {
     expect(DateTime.parse(lastStr!).day, yesterday.day);
     expect((prefs.getStringList('usedFreezes') ?? []).isNotEmpty, isTrue);
 
-    await service.markActiveToday();
+    await service.markActiveToday(ctx);
     final current = await service.getCurrentStreak();
     expect(current, 4);
   });


### PR DESCRIPTION
## Summary
- add `StreakMilestoneCelebrationOverlay` widget and `showCelebrationOverlay`
- trigger celebration overlay from `StreakTrackerService` when hitting a milestone
- update training screens to supply context to the service
- adjust tests for new API

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804e23c388832aa919391275e6d780