### PR TITLE
Add streak milestone celebration queue

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -40,6 +40,7 @@ import 'weakness_overview_screen.dart';
 import 'next_step_suggestion_dialog.dart';
 import '../widgets/mistake_review_button.dart';
 import '../services/streak_tracker_service.dart';
+import '../services/streak_milestone_queue_service.dart';
 import '../widgets/confetti_overlay.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
@@ -139,6 +140,8 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       final s = context.read<NextStepEngine>().suggestion;
       if (s != null) _showNextStep(s);
       await NextStepSuggestionDialog.show(context);
+      await StreakMilestoneQueueService.instance
+          .showNextMilestoneCelebrationIfAny(context);
     });
     _loadWeakPack();
   }

--- a/lib/services/streak_milestone_queue_service.dart
+++ b/lib/services/streak_milestone_queue_service.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/streak_milestone_celebration_overlay.dart';
+
+/// Queues streak milestone celebrations to avoid overlapping animations.
+class StreakMilestoneQueueService {
+  StreakMilestoneQueueService._();
+
+  /// Singleton instance.
+  static final StreakMilestoneQueueService instance =
+      StreakMilestoneQueueService._();
+
+  final List<int> _queue = [];
+  bool _showing = false;
+
+  /// Add a milestone [streakDays] to the celebration queue.
+  void addMilestoneToQueue(int streakDays) {
+    _queue.add(streakDays);
+  }
+
+  /// Displays the next milestone celebration if any are queued.
+  Future<void> showNextMilestoneCelebrationIfAny(BuildContext context) async {
+    if (_showing || _queue.isEmpty || !context.mounted) return;
+    _showing = true;
+    final days = _queue.removeAt(0);
+    final msg = '🔥 Поздравляем! Ты достиг $days-дневного стрика! 🎉';
+    await showCelebrationOverlay(context, msg);
+    _showing = false;
+    if (_queue.isNotEmpty) {
+      await showNextMilestoneCelebrationIfAny(context);
+    }
+  }
+}

--- a/lib/services/streak_tracker_service.dart
+++ b/lib/services/streak_tracker_service.dart
@@ -3,7 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../widgets/streak_lost_dialog.dart';
 import '../widgets/streak_saved_dialog.dart';
-import '../widgets/streak_milestone_celebration_overlay.dart';
+import 'streak_milestone_queue_service.dart';
 
 class StreakTrackerService {
   StreakTrackerService._();
@@ -54,8 +54,7 @@ class StreakTrackerService {
 
     final milestone = milestones.contains(current);
     if (milestone && context.mounted) {
-      showCelebrationOverlay(
-          context, '🔥 Ты достиг $current-дневного стрика!');
+      StreakMilestoneQueueService.instance.addMilestoneToQueue(current);
     }
     return milestone;
   }

--- a/lib/widgets/streak_milestone_celebration_overlay.dart
+++ b/lib/widgets/streak_milestone_celebration_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
 import 'confetti_overlay.dart';
 
 /// Overlay shown when user hits a streak milestone.
@@ -51,8 +52,11 @@ class _StreakMilestoneCelebrationOverlayState
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(Icons.local_fire_department,
-                    color: Colors.orange, size: 120),
+                Lottie.asset(
+                  'assets/animations/congrats.json',
+                  width: 160,
+                  repeat: false,
+                ),
                 const SizedBox(height: 16),
                 Text(
                   widget.message,


### PR DESCRIPTION
## Summary
- queue streak milestone celebrations via new `StreakMilestoneQueueService`
- enqueue milestone when marking activity
- show queued celebrations on the summary screen after other dialogs
- add animation to the milestone overlay using Lottie

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880539f3c80832a83e8583c1b942ac6