### PR TITLE
Add BTN vs LJ 3bet push pack

### DIFF
--- a/assets/learning_paths/3bet_push_btn_vs_lj.yaml
+++ b/assets/learning_paths/3bet_push_btn_vs_lj.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_btn_vs_lj
+title: 3bet Push BTN vs LJ
+description: BTN 3bet shoves vs LJ opens at 25bb
+stages:
+  - id: 3bet_push_btn_vs_lj_stage
+    title: 3bet Push
+    description: BTN shoves over LJ open
+    packId: 3bet_push_btn_vs_lj
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -271,5 +271,28 @@
       "recommended": true,
       "icon": "north"
     }
+  },
+  {
+    "id": "3bet_push_btn_vs_lj",
+    "name": "3bet Push BTN vs LJ",
+    "description": "BTN shoves 25bb over LJ open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": [
+      "btn"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "btn",
+      "lj",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
   }
 ]

--- a/assets/packs/v2/preflop/3bet_push_btn_vs_lj.yaml
+++ b/assets/packs/v2/preflop/3bet_push_btn_vs_lj.yaml
@@ -1,0 +1,31 @@
+id: 3bet_push_btn_vs_lj
+name: 3bet Push BTN vs LJ
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [btn]
+tags: [level2, 3bet-push, btn, lj, mtt]
+spots:
+  - id: tb_btn_lj_1
+    title: BTN shove AJo vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ah Jd'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_btn_lj_2
+    title: BTN shove 98s vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '9h 8h'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 2

--- a/lib/templates/stage_template_3betpush_btn_vs_lj_mtt.dart
+++ b/lib/templates/stage_template_3betpush_btn_vs_lj_mtt.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for BTN 3bet push versus LJ opens at 25bb.
+const LearningPathStageModel threeBetPushBtnVsLjMttStageTemplate = LearningPathStageModel(
+  id: '3bet_push_btn_vs_lj_stage',
+  title: 'BTN 3bet Push vs LJ 25bb',
+  description: 'Decide to shove or fold from BTN facing a LJ open at 25bb',
+  packId: '3bet_push_btn_vs_lj',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['level2', '3bet-push', 'btn', 'lj'],
+);


### PR DESCRIPTION
## Summary
- create 3bet push BTN vs LJ YAML pack with example hands
- register pack in library index
- add stage template for the pack
- include learning path for BTN vs LJ

## Testing
- `apt-get update` *(fails to provide flutter or dart)*

------
https://chatgpt.com/codex/tasks/task_e_688065af479c832a9fe258542bb02e3d