### PR TITLE
Add BTN vs SB 3bet push pack

### DIFF
--- a/assets/learning_paths/3bet_push_btn_vs_sb.yaml
+++ b/assets/learning_paths/3bet_push_btn_vs_sb.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_btn_vs_sb
+title: 3bet Push BTN vs SB
+description: BTN 3bet shoves vs SB opens at 25bb
+stages:
+  - id: 3bet_push_btn_vs_sb_stage
+    title: 3bet Push
+    description: BTN shoves over SB open
+    packId: 3bet_push_btn_vs_sb
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -318,5 +318,28 @@
       "recommended": true,
       "icon": "north"
     }
+  },
+  {
+    "id": "3bet_push_btn_vs_sb",
+    "name": "3bet Push BTN vs SB",
+    "description": "BTN shoves 25bb over SB open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": [
+      "btn"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "btn",
+      "sb",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
   }
 ]

--- a/assets/packs/v2/preflop/3bet_push_btn_vs_sb.yaml
+++ b/assets/packs/v2/preflop/3bet_push_btn_vs_sb.yaml
@@ -1,0 +1,31 @@
+id: 3bet_push_btn_vs_sb
+name: 3bet Push BTN vs SB
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [btn]
+tags: [level2, 3bet-push, btn, sb, mtt]
+spots:
+  - id: tb_btn_sb_1
+    title: BTN shove A8s vs SB open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'As 8s'
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+  - id: tb_btn_sb_2
+    title: BTN shove J9s vs SB open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Js 9s'
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+spotCount: 2

--- a/lib/templates/stage_template_3betpush_btn_vs_sb_mtt.dart
+++ b/lib/templates/stage_template_3betpush_btn_vs_sb_mtt.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for BTN 3bet push versus SB opens at 25bb.
+const LearningPathStageModel threeBetPushBtnVsSbMttStageTemplate = LearningPathStageModel(
+  id: '3bet_push_btn_vs_sb_stage',
+  title: 'BTN 3bet Push vs SB 25bb',
+  description: 'Decide to shove or fold from BTN facing a SB open at 25bb',
+  packId: '3bet_push_btn_vs_sb',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['level2', '3bet-push', 'btn', 'sb', 'mtt'],
+);


### PR DESCRIPTION
## Summary
- add BTN vs SB 3bet push preflop pack with A8s and J9s spots
- provide stage template for the new BTN vs SB pack
- register the pack in library index
- expose new learning path for BTN vs SB 3bet push scenario

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688068fb7a3c832a94a1ca0f150571c5