### PR TITLE
Add training content validator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Validate training content
+        run: dart tools/validate_training_content.dart --ci
+
       # Временно отключаем анализ, чтобы не мешал Codex
       # - name: Analyze
       #   run: flutter analyze

--- a/README.md
+++ b/README.md
@@ -127,3 +127,14 @@ echo 'ref: refs/heads/main' > .git/HEAD
 ```
 
 This removes hidden characters and resolves the error.
+
+## Content Validation
+
+Run the training content validator to lint YAML packs and ensure schema
+correctness:
+
+```bash
+dart tools/validate_training_content.dart --fix
+```
+
+Use `--ci` to exit with a non-zero code on errors.

--- a/tools/validate_training_content.dart
+++ b/tools/validate_training_content.dart
@@ -1,0 +1,211 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+class _Issue {
+  _Issue(this.file, this.message, {this.error = false});
+  final String file;
+  final String message;
+  final bool error;
+
+  Map<String, dynamic> toJson() => {
+        'file': file,
+        'error': error,
+        'message': message,
+      };
+
+  @override
+  String toString() => '[${error ? 'ERROR' : 'WARN'}] $file: $message';
+}
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addFlag('fix', negatable: false)
+    ..addFlag('json', negatable: false)
+    ..addFlag('ci', negatable: false);
+  final results = parser.parse(args);
+  final fix = results['fix'] as bool;
+  final jsonOut = results['json'] as bool;
+  final ci = results['ci'] as bool;
+
+  final allowedTags = _loadAllowedTags();
+  final issues = <_Issue>[];
+  final globalSpotIds = <String, String>{};
+  final packIds = <String, String>{};
+
+  final dir = Directory('assets/packs/v2');
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: ${dir.path}');
+    exit(1);
+  }
+
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+
+  for (final file in files) {
+    issues.addAll(_validateFile(
+      file,
+      allowedTags,
+      globalSpotIds,
+      packIds,
+      fix: fix,
+    ));
+  }
+
+  if (jsonOut) {
+    stdout.writeln(jsonEncode({'issues': [for (final i in issues) i.toJson()]}));
+  } else {
+    for (final i in issues) {
+      stdout.writeln(i);
+    }
+    stdout.writeln('Checked ${files.length} files, found ${issues.length} issues');
+  }
+
+  if (ci && issues.any((e) => e.error)) exit(1);
+}
+
+Set<String> _loadAllowedTags() {
+  final file = File('assets/packs/v2/library_index.json');
+  if (!file.existsSync()) return <String>{};
+  try {
+    final data = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+    final set = <String>{};
+    for (final entry in data) {
+      for (final t in entry['tags'] as List? ?? []) {
+        set.add(t.toString().toLowerCase());
+      }
+    }
+    return set;
+  } catch (_) {
+    return <String>{};
+  }
+}
+
+List<_Issue> _validateFile(
+  File file,
+  Set<String> allowedTags,
+  Map<String, String> spotIds,
+  Map<String, String> packIds, {
+  bool fix = false,
+}) {
+  final issues = <_Issue>[];
+  Map<String, dynamic> map;
+  try {
+    map = const YamlReader().read(file.readAsStringSync());
+  } catch (e) {
+    issues.add(_Issue(file.path, 'Invalid YAML: $e', error: true));
+    return issues;
+  }
+
+  bool changed = false;
+  // Required fields
+  const requiredFields = ['id', 'name', 'tags', 'spots', 'bb', 'positions'];
+  for (final f in requiredFields) {
+    if (map[f] == null) {
+      issues.add(_Issue(file.path, 'Missing required field `$f`', error: true));
+    }
+  }
+
+  // unique pack id
+  final pid = map['id']?.toString();
+  if (pid != null && pid.isNotEmpty) {
+    final prev = packIds[pid];
+    if (prev != null && prev != file.path) {
+      issues.add(_Issue(file.path,
+          'Duplicate pack id `$pid` also in $prev',
+          error: true));
+    } else {
+      packIds[pid] = file.path;
+    }
+  }
+
+  // tags validation
+  final tags = [for (final t in (map['tags'] as List? ?? [])) t.toString()];
+  final newTags = <String>[];
+  for (final t in tags) {
+    final lower = t.toLowerCase();
+    if (t != lower) {
+      issues.add(_Issue(file.path, 'Tag `$t` should be lowercase'));
+      if (fix) changed = true;
+    }
+    if (allowedTags.isNotEmpty && !allowedTags.contains(lower)) {
+      issues.add(_Issue(file.path, 'Unknown tag `$t`'));
+    }
+    newTags.add(fix ? lower : t);
+  }
+  if (fix && newTags.isNotEmpty) map['tags'] = newTags;
+
+  // bb warning
+  const validBbs = [10, 20, 25, 40, 50];
+  final bbVal = (map['bb'] as num?)?.toInt();
+  if (bbVal != null && !validBbs.contains(bbVal)) {
+    issues.add(_Issue(file.path, 'Unrecognized bb value $bbVal'));
+  }
+
+  final spots = map['spots'] as List? ?? [];
+  final spotIdsLocal = <String>{};
+  for (final s in spots) {
+    if (s is! Map) continue;
+    final id = s['id']?.toString();
+    if (id == null || id.isEmpty) {
+      issues.add(_Issue(file.path, 'Spot missing id', error: true));
+    } else {
+      if (!spotIdsLocal.add(id)) {
+        issues.add(_Issue(file.path, 'Duplicate spot id `$id`', error: true));
+      }
+      final prev = spotIds[id];
+      if (prev != null && prev != file.path) {
+        issues.add(_Issue(file.path,
+            'Spot id `$id` also used in $prev',
+            error: true));
+      } else {
+        spotIds[id] = file.path;
+      }
+    }
+    final hand = s['hand'] as Map?;
+    if (hand == null) {
+      issues.add(_Issue(file.path, 'Spot `$id` missing hand', error: true));
+      continue;
+    }
+    if (hand['heroCards'] == null) {
+      issues.add(_Issue(file.path, 'Spot `$id` missing heroCards', error: true));
+    }
+    if (hand['position'] == null) {
+      issues.add(_Issue(file.path, 'Spot `$id` missing position', error: true));
+    }
+    if (hand['stacks'] == null) {
+      issues.add(_Issue(file.path, 'Spot `$id` missing stacks', error: true));
+    }
+    final heroOptions = s['heroOptions'] as List?;
+    if (heroOptions == null || heroOptions.isEmpty) {
+      issues.add(_Issue(file.path, 'Spot `$id` missing heroOptions', error: true));
+    }
+  }
+
+  final spotCount = map['spotCount'];
+  if (spotCount != null && spotCount != spots.length) {
+    issues.add(_Issue(file.path,
+        'spotCount $spotCount does not match spots length ${spots.length}',
+        error: true));
+    if (fix) {
+      map['spotCount'] = spots.length;
+      changed = true;
+    }
+  }
+
+  final gameType = map['gameType']?.toString();
+  if (gameType != null && gameType != 'cash' && gameType != 'tournament') {
+    issues.add(_Issue(file.path, 'Unknown gameType `$gameType`'));
+  }
+
+  if (fix && changed) {
+    final yaml = const YamlEncoder().convert(map);
+    file.writeAsStringSync(yaml + '\n');
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- implement `TrainingContentValidator` to lint YAML packs
- run validator in CI
- document the validator in README

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6880760f556c832ab4547013fcae1f29