### PR TITLE
Add SB 3bet push vs BTN pack

### DIFF
--- a/assets/learning_paths/3bet_push_sb_vs_btn.yaml
+++ b/assets/learning_paths/3bet_push_sb_vs_btn.yaml
@@ -1,0 +1,11 @@
+id: 3bet_push_sb_vs_btn
+title: 3bet Push SB vs BTN
+description: SB 3bet shoves vs BTN opens at 25bb
+stages:
+  - id: 3bet_push_sb_vs_btn_stage
+    title: 3bet Push
+    description: SB shoves over BTN open
+    packId: 3bet_push_sb_vs_btn
+    requiredAccuracy: 80
+    minHands: 10
+

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -365,6 +365,29 @@
       "recommended": true,
       "icon": "north"
     }
+  },
+  {
+    "id": "3bet_push_sb_vs_btn",
+    "name": "3bet Push SB vs BTN",
+    "description": "SB shoves 25bb over BTN open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": [
+      "sb"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "sb",
+      "btn",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
   }
 
 ]

--- a/assets/packs/v2/preflop/3bet_push_sb_vs_btn.yaml
+++ b/assets/packs/v2/preflop/3bet_push_sb_vs_btn.yaml
@@ -1,0 +1,32 @@
+id: 3bet_push_sb_vs_btn
+name: 3bet Push SB vs BTN
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [sb]
+tags: [level2, 3bet-push, sb, btn, mtt]
+spots:
+  - id: tb_sb_btn_1
+    title: SB shove A5s vs BTN open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'As 5s'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_btn_2
+    title: SB shove QJo vs BTN open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Qh Jd'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 2
+

--- a/lib/templates/stage_template_3betpush_sb_vs_btn_mtt.dart
+++ b/lib/templates/stage_template_3betpush_sb_vs_btn_mtt.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for SB 3bet push versus BTN opens at 25bb.
+const LearningPathStageModel threeBetPushSbVsBtnMttStageTemplate =
+    LearningPathStageModel(
+  id: '3bet_push_sb_vs_btn_stage',
+  title: 'SB 3bet Push vs BTN 25bb',
+  description: 'Decide to shove or fold from SB facing a BTN open at 25bb',
+  packId: '3bet_push_sb_vs_btn',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['level2', '3bet-push', 'sb', 'btn', 'mtt'],
+);


### PR DESCRIPTION
## Summary
- add preflop pack for SB shoving over BTN open
- register the pack in the library index
- add learning path entry and stage template

## Testing
- `flutter analyze` *(fails: 7098 issues)*
- `dart tools/validate_training_content.dart --fix` *(fails: couldn't find constructor 'YamlReader')*

------
https://chatgpt.com/codex/tasks/task_e_68807a7d4238832a9dbdb22d4e4df855