### PR TITLE
Add 3bet Push BB vs BTN pack

### DIFF
--- a/assets/learning_paths/3bet_push_bb_vs_btn.yaml
+++ b/assets/learning_paths/3bet_push_bb_vs_btn.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_bb_vs_btn
+title: 3bet Push BB vs BTN
+description: BB 3bet shoves vs BTN opens at 25bb
+stages:
+  - id: 3bet_push_bb_vs_btn_stage
+    title: 3bet Push
+    description: BB shoves over BTN open
+    packId: 3bet_push_bb_vs_btn
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -389,5 +389,28 @@
       "icon": "north"
     }
   }
+  , {
+    "id": "3bet_push_bb_vs_btn",
+    "name": "3bet Push BB vs BTN",
+    "description": "BB shoves 25bb over BTN open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": [
+      "bb"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "bb",
+      "btn",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
+  }
 
 ]

--- a/assets/packs/v2/preflop/3bet_push_bb_vs_btn.yaml
+++ b/assets/packs/v2/preflop/3bet_push_bb_vs_btn.yaml
@@ -1,0 +1,31 @@
+id: 3bet_push_bb_vs_btn
+name: 3bet Push BB vs BTN
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [bb]
+tags: [level2, 3bet-push, bb, btn, mtt]
+spots:
+  - id: tb_bb_btn_1
+    title: BB shove AJo vs BTN open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ad Jc'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_btn_2
+    title: BB shove 76s vs BTN open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '7s 6s'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 2

--- a/lib/templates/stage_template_3betpush_bb_vs_btn_mtt.dart
+++ b/lib/templates/stage_template_3betpush_bb_vs_btn_mtt.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for BB 3bet push versus BTN opens at 25bb.
+const LearningPathStageModel threeBetPushBbVsBtnMttStageTemplate =
+    LearningPathStageModel(
+      id: '3bet_push_bb_vs_btn_stage',
+      title: 'BB 3bet Push vs BTN 25bb',
+      description: 'Decide to shove or fold from BB facing a BTN open at 25bb',
+      packId: '3bet_push_bb_vs_btn',
+      requiredAccuracy: 80,
+      minHands: 10,
+      tags: ['level2', '3bet-push', 'bb', 'btn', 'mtt'],
+    );


### PR DESCRIPTION
## Summary
- add new preflop pack `3bet Push BB vs BTN`
- add learning path stage template for BB vs BTN 3bet push
- register the pack in the library index
- add learning path for the new pack

## Testing
- `dart format lib/templates/stage_template_3betpush_bb_vs_btn_mtt.dart`
- `dart tools/validate_training_content.dart --ci` *(fails: Couldn't resolve the package 'args')*

------
https://chatgpt.com/codex/tasks/task_e_68807d9a0f94832abcb20cd5fe719779