### PR TITLE
Add SB vs LJ 3bet push pack

### DIFF
--- a/assets/learning_paths/3bet_push_sb_vs_lj.yaml
+++ b/assets/learning_paths/3bet_push_sb_vs_lj.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_sb_vs_lj
+title: 3bet Push SB vs LJ
+description: SB 3bet shoves vs LJ opens at 25bb
+stages:
+  - id: 3bet_push_sb_vs_lj_stage
+    title: 3bet Push
+    description: SB shoves over LJ open
+    packId: 3bet_push_sb_vs_lj
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -388,6 +388,29 @@
       "recommended": true,
       "icon": "north"
     }
+  },
+  {
+    "id": "3bet_push_sb_vs_lj",
+    "name": "3bet Push SB vs LJ",
+    "description": "SB shoves 25bb over LJ open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 4,
+    "positions": [
+      "sb"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "sb",
+      "lj",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
   }
   , {
     "id": "3bet_push_bb_vs_btn",

--- a/assets/packs/v2/preflop/3bet_push_sb_vs_lj.yaml
+++ b/assets/packs/v2/preflop/3bet_push_sb_vs_lj.yaml
@@ -1,0 +1,51 @@
+id: 3bet_push_sb_vs_lj
+name: 3bet Push SB vs LJ
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [sb]
+tags: [level2, 3bet-push, sb, lj, mtt]
+spots:
+  - id: tb_sb_lj_1
+    title: SB shove AJs vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'As Js'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_lj_2
+    title: SB shove 66 vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '6h 6c'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_lj_3
+    title: SB shove QTs vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Qd Td'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_lj_4
+    title: SB shove KQo vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Kh Qc'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 4

--- a/lib/templates/stage_template_3betpush_sb_vs_lj_mtt.dart
+++ b/lib/templates/stage_template_3betpush_sb_vs_lj_mtt.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for SB 3bet push versus LJ opens at 25bb.
+const LearningPathStageModel threeBetPushSbVsLjMttStageTemplate =
+    LearningPathStageModel(
+  id: '3bet_push_sb_vs_lj_stage',
+  title: 'SB 3bet Push vs LJ 25bb',
+  description: 'Decide to shove or fold from SB facing a LJ open at 25bb',
+  packId: '3bet_push_sb_vs_lj',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['level2', '3bet-push', 'sb', 'lj', 'mtt'],
+);


### PR DESCRIPTION
## Summary
- add 3bet push pack for SB vs LJ at 25bb
- create learning path and stage template for the new pack
- register new pack in library index

## Testing
- `dart tools/validate_training_content.dart --ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880900b03d4832a9be41757234c1d2f