### PR TITLE
Add BTN vs LJ 3bet push training pack

### DIFF
--- a/assets/packs/v2/preflop/3bet_push_btn_vs_lj.yaml
+++ b/assets/packs/v2/preflop/3bet_push_btn_vs_lj.yaml
@@ -19,13 +19,53 @@ spots:
       playerCount: 6
       stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
   - id: tb_btn_lj_2
-    title: BTN shove 98s vs LJ open
+    title: BTN shove QTs vs LJ open
     villainAction: open 2.5
     heroOptions: [3betPush, fold]
     hand:
-      heroCards: '9h 8h'
+      heroCards: 'Qh Th'
       position: btn
       heroIndex: 0
       playerCount: 6
       stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
-spotCount: 2
+  - id: tb_btn_lj_3
+    title: BTN shove 88 vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '8c 8d'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_btn_lj_4
+    title: BTN shove A5s vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'As 5s'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_btn_lj_5
+    title: BTN shove KQo vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Kd Qh'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_btn_lj_6
+    title: BTN shove JTs vs LJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Jh Ts'
+      position: btn
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 6


### PR DESCRIPTION
## Summary
- expand BTN 3bet push coverage vs LJ open with 6 hands

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809c598d64832aae30351c8a18e58f