### PR TITLE
Add BB vs HJ 3bet push pack

### DIFF
--- a/assets/learning_paths/3bet_push_bb_vs_hj.yaml
+++ b/assets/learning_paths/3bet_push_bb_vs_hj.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_bb_vs_hj
+title: 3bet Push BB vs HJ
+description: BB 3bet shoves vs HJ opens at 25bb
+stages:
+  - id: 3bet_push_bb_vs_hj_stage
+    title: 3bet Push
+    description: BB shoves over HJ open
+    packId: 3bet_push_bb_vs_hj
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -502,5 +502,27 @@
       "recommended": true,
       "icon": "north"
     }
+  }, {
+    "id": "3bet_push_bb_vs_hj",
+    "name": "3bet Push BB vs HJ",
+    "description": "BB shoves 25bb over HJ open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 6,
+    "positions": [
+      "bb"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "bb",
+      "hj",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
   }
 ]

--- a/assets/packs/v2/preflop/3bet_push_bb_vs_hj.yaml
+++ b/assets/packs/v2/preflop/3bet_push_bb_vs_hj.yaml
@@ -1,0 +1,71 @@
+id: 3bet_push_bb_vs_hj
+name: 3bet Push BB vs HJ
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [bb]
+tags: [level2, 3bet-push, bb, hj, mtt]
+spots:
+  - id: tb_bb_hj_1
+    title: BB shove AJo vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ad Jh'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_hj_2
+    title: BB shove 66 vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '6s 6c'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_hj_3
+    title: BB shove KJs vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ks Js'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_hj_4
+    title: BB shove A5s vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ac 5c'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_hj_5
+    title: BB shove QJs vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Qd Jd'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_bb_hj_6
+    title: BB shove JTs vs HJ open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Jh Th'
+      position: bb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 6

--- a/lib/templates/stage_template_3betpush_bb_vs_hj_mtt.dart
+++ b/lib/templates/stage_template_3betpush_bb_vs_hj_mtt.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for BB 3bet push versus HJ opens at 25bb.
+const LearningPathStageModel threeBetPushBbVsHjMttStageTemplate =
+    LearningPathStageModel(
+      id: '3bet_push_bb_vs_hj_stage',
+      title: 'BB 3bet Push vs HJ 25bb',
+      description: 'Decide to shove or fold from BB facing a HJ open at 25bb',
+      packId: '3bet_push_bb_vs_hj',
+      requiredAccuracy: 80,
+      minHands: 10,
+      tags: ['level2', '3bet-push', 'bb', 'hj', 'mtt'],
+    );


### PR DESCRIPTION
## Summary
- add a new training pack `3bet_push_bb_vs_hj` with 6 spots
- register pack in the library index
- provide matching learning path file
- add stage template for BB vs HJ scenario

## Testing
- `dart tools/validate_training_content.dart --fix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880aa368008832aae911e4517a9682b