### PR TITLE
Add SB vs CO 3bet push pack

### DIFF
--- a/assets/learning_paths/3bet_push_sb_vs_co.yaml
+++ b/assets/learning_paths/3bet_push_sb_vs_co.yaml
@@ -1,0 +1,10 @@
+id: 3bet_push_sb_vs_co
+title: 3bet Push SB vs CO
+description: SB 3bet shoves vs CO opens at 25bb
+stages:
+  - id: 3bet_push_sb_vs_co_stage
+    title: 3bet Push
+    description: SB shoves over CO open
+    packId: 3bet_push_sb_vs_co
+    requiredAccuracy: 80
+    minHands: 10

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -413,6 +413,29 @@
     }
   },
   {
+    "id": "3bet_push_sb_vs_co",
+    "name": "3bet Push SB vs CO",
+    "description": "SB shoves 25bb over CO open",
+    "type": "mtt",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 6,
+    "positions": [
+      "sb"
+    ],
+    "tags": [
+      "level2",
+      "3bet-push",
+      "sb",
+      "co",
+      "mtt"
+    ],
+    "meta": {
+      "recommended": true,
+      "icon": "north"
+    }
+  },
+  {
     "id": "3bet_push_sb_vs_lj",
     "name": "3bet Push SB vs LJ",
     "description": "SB shoves 25bb over LJ open",

--- a/assets/packs/v2/preflop/3bet_push_sb_vs_co.yaml
+++ b/assets/packs/v2/preflop/3bet_push_sb_vs_co.yaml
@@ -1,0 +1,71 @@
+id: 3bet_push_sb_vs_co
+name: 3bet Push SB vs CO
+trainingType: mtt
+recommended: true
+icon: north
+bb: 25
+gameType: tournament
+positions: [sb]
+tags: [level2, 3bet-push, sb, co, mtt]
+spots:
+  - id: tb_sb_co_1
+    title: SB shove A9s vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'As 9s'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_co_2
+    title: SB shove 66 vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: '6h 6d'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_co_3
+    title: SB shove KTs vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Kh Th'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_co_4
+    title: SB shove A5s vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Ac 5c'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_co_5
+    title: SB shove QJo vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Qd Jc'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+  - id: tb_sb_co_6
+    title: SB shove T9s vs CO open
+    villainAction: open 2.5
+    heroOptions: [3betPush, fold]
+    hand:
+      heroCards: 'Td 9d'
+      position: sb
+      heroIndex: 0
+      playerCount: 6
+      stacks: {'0': 25, '1': 25, '2': 25, '3': 25, '4': 25, '5': 25}
+spotCount: 6

--- a/lib/templates/stage_template_3betpush_sb_vs_co_mtt.dart
+++ b/lib/templates/stage_template_3betpush_sb_vs_co_mtt.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for SB 3bet push versus CO opens at 25bb.
+const LearningPathStageModel threeBetPushSbVsCoMttStageTemplate =
+    LearningPathStageModel(
+  id: '3bet_push_sb_vs_co_stage',
+  title: 'SB 3bet Push vs CO 25bb',
+  description: 'Decide to shove or fold from SB facing a CO open at 25bb',
+  packId: '3bet_push_sb_vs_co',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['level2', '3bet-push', 'sb', 'co', 'mtt'],
+);


### PR DESCRIPTION
## Summary
- add SB vs CO 3bet push MTT pack and learning path
- register the pack in the library index
- provide stage template for SB 3bet push vs CO

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ab578ff8832ab01836c5e7179df9