### PR TITLE
Fix YAML validator with json2yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,8 @@ dev_dependencies:
   fake_cloud_firestore: ^3.1.0
   firebase_auth_mocks: ^0.14.0
   mocktail: ^1.0.4
+  json2yaml: ^3.0.0
+  yaml: ^3.1.1
 
 flutter:
 

--- a/tools/validate_training_content.dart
+++ b/tools/validate_training_content.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 
 import 'package:args/args.dart';
 import 'package:yaml/yaml.dart';
-import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+import 'package:json2yaml/json2yaml.dart';
 
 class _Issue {
   _Issue(this.file, this.message, {this.error = false});
@@ -96,7 +96,8 @@ List<_Issue> _validateFile(
   final issues = <_Issue>[];
   Map<String, dynamic> map;
   try {
-    map = const YamlReader().read(file.readAsStringSync());
+    final yamlMap = loadYaml(file.readAsStringSync()) as YamlMap;
+    map = jsonDecode(jsonEncode(yamlMap)) as Map<String, dynamic>;
   } catch (e) {
     issues.add(_Issue(file.path, 'Invalid YAML: $e', error: true));
     return issues;
@@ -204,8 +205,8 @@ List<_Issue> _validateFile(
   }
 
   if (fix && changed) {
-    final yaml = const YamlEncoder().convert(map);
-    file.writeAsStringSync(yaml + '\n');
+    final yamlOut = json2yaml(map);
+    file.writeAsStringSync(yamlOut + '\n');
   }
 
   return issues;


### PR DESCRIPTION
## Summary
- replace outdated `YamlReader` and `YamlEncoder` usage in `tools/validate_training_content.dart`
- add `json2yaml` and `yaml` to dev dependencies

## Testing
- `flutter pub get`
- `flutter test` *(fails: various compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880c6addf24832ab41dd123aef75489