### PR TITLE
Add workflow to auto-fix training packs

### DIFF
--- a/.github/workflows/fix_packs.yml
+++ b/.github/workflows/fix_packs.yml
@@ -1,0 +1,41 @@
+name: Fix Training Packs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fix_packs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run fixer
+        run: dart tools/fix_training_pack_errors.dart --apply
+
+      - name: Show fix log
+        run: |
+          if [ -f fix_log.txt ]; then
+            cat fix_log.txt
+          else
+            echo "No fixes"
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: fix training packs"
+          title: "Fix training packs"
+          body: |
+            Automated fix of training pack YAML files using fix_training_pack_errors.dart.
+            See fix_log.txt for details.
+          branch: fix-packs-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- add a manual workflow that runs `fix_training_pack_errors.dart` and opens a PR with the changes

## Testing
- `flutter pub get`
- `dart tools/validate_training_content.dart --ci` *(fails: meta.schemaVersion expected 2.0.0 but found null)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9282580832a86d5a0ea252a9d65