### PR TITLE
ci: validate packs on push/PR

### DIFF
--- a/.github/workflows/validate_packs.yml
+++ b/.github/workflows/validate_packs.yml
@@ -1,0 +1,17 @@
+name: Validate Training Packs
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Validate packs
+        run: dart tools/validate_training_content.dart --ci


### PR DESCRIPTION
## Summary
- add workflow to run validation of training packs on every push and pull request

## Testing
- `dart --version`
- `apt-get install -y dart`
- `dart pub get` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6880db23ef50832abd44e3143b08c9d2