### PR TITLE
Enable training content validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # - name: Validate training content
-      #   run: dart tools/validate_training_content.dart --ci
+      - name: Validate training content
+        run: dart tools/validate_training_content.dart --ci
       # TODO: Re-enable after packs are fixed
 
       # Временно отключаем анализ, чтобы не мешал Codex


### PR DESCRIPTION
## Summary
- uncomment validation step in CI workflow

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688153ec8ee4832a8927e62519d44896