### PR TITLE
Implement YAML pack auto-tag engine

### DIFF
--- a/lib/services/yaml_pack_auto_tag_engine.dart
+++ b/lib/services/yaml_pack_auto_tag_engine.dart
@@ -1,0 +1,90 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/hero_position.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/game_type.dart';
+
+/// Generates tags for YAML packs based on simple heuristics.
+class YamlPackAutoTagEngine {
+  const YamlPackAutoTagEngine();
+
+  /// Returns a sorted list of unique tags inferred from [pack]. Existing
+  /// tags in the pack are preserved.
+  List<String> autoTag(TrainingPackTemplateV2 pack) {
+    final tags = <String>{...pack.tags};
+
+    _detectPushFold(pack, tags);
+    _detectIcm(pack, tags);
+    _detectGameType(pack, tags);
+    _detectHeroPosition(pack, tags);
+    _detect3Bet(pack, tags);
+
+    final list = tags.toList()..sort();
+    return list;
+  }
+
+  void _detectPushFold(TrainingPackTemplateV2 pack, Set<String> tags) {
+    if (pack.spots.isEmpty) return;
+    var shortCount = 0;
+    for (final s in pack.spots) {
+      final heroStack = s.hand.stacks['${s.hand.heroIndex}'];
+      if (heroStack != null && heroStack <= 15) shortCount++;
+    }
+    if (shortCount >= (pack.spots.length / 2)) {
+      tags.add('pushfold');
+    }
+  }
+
+  void _detectIcm(TrainingPackTemplateV2 pack, Set<String> tags) {
+    if (pack.meta['icm'] == true) tags.add('icm');
+  }
+
+  void _detectGameType(TrainingPackTemplateV2 pack, Set<String> tags) {
+    if (pack.gameType == GameType.cash) tags.add('cash');
+  }
+
+  void _detectHeroPosition(TrainingPackTemplateV2 pack, Set<String> tags) {
+    final counts = <HeroPosition, int>{};
+    for (final p in pack.positions) {
+      final pos = parseHeroPosition(p);
+      counts[pos] = (counts[pos] ?? 0) + 1;
+    }
+    for (final s in pack.spots) {
+      final pos = s.hand.position;
+      counts[pos] = (counts[pos] ?? 0) + 1;
+    }
+    var total = 0;
+    counts.forEach((_, v) => total += v);
+    if (total == 0) return;
+    final maxEntry = counts.entries
+        .reduce((a, b) => a.value >= b.value ? a : b);
+    if (maxEntry.value >= total / 2 && maxEntry.key != HeroPosition.unknown) {
+      final label = maxEntry.key.name.toUpperCase();
+      tags.add('hero$label');
+    }
+  }
+
+  void _detect3Bet(TrainingPackTemplateV2 pack, Set<String> tags) {
+    bool found = false;
+    for (final s in pack.spots) {
+      if (_spotContains3Bet(s)) {
+        found = true;
+        break;
+      }
+    }
+    if (found) tags.add('3bet');
+  }
+
+  bool _spotContains3Bet(TrainingPackSpot s) {
+    for (final o in s.heroOptions) {
+      if (o.toLowerCase().contains('3bet')) return true;
+    }
+    final villain = s.villainAction?.toLowerCase();
+    if (villain != null && villain.contains('3bet')) return true;
+    for (final list in s.hand.actions.values) {
+      for (final a in list) {
+        if (a.action.toLowerCase().contains('3bet')) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/test/yaml_pack_auto_tag_engine_test.dart
+++ b/test/yaml_pack_auto_tag_engine_test.dart
@@ -1,0 +1,66 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/yaml_pack_auto_tag_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  TrainingPackSpot spot({required HeroPosition pos, required double stack, List<String> heroOpts = const ['push']}) {
+    return TrainingPackSpot(
+      id: 's${pos.name}-$stack',
+      hand: HandData(
+        position: pos,
+        heroIndex: 0,
+        stacks: {'0': stack},
+        actions: {0: [ActionEntry(0, 0, heroOpts.first)]},
+      ),
+      heroOptions: heroOpts,
+    );
+  }
+
+  test('detects pushfold and hero position', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Test',
+      trainingType: TrainingType.pushFold,
+      gameType: GameType.tournament,
+      spots: [
+        spot(pos: HeroPosition.btn, stack: 10),
+        spot(pos: HeroPosition.btn, stack: 12),
+      ],
+    );
+    final tags = const YamlPackAutoTagEngine().autoTag(tpl);
+    expect(tags, contains('pushfold'));
+    expect(tags, contains('heroBTN'));
+  });
+
+  test('detects icm and cash', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Test',
+      meta: {'icm': true},
+      gameType: GameType.cash,
+      trainingType: TrainingType.pushFold,
+    );
+    final tags = const YamlPackAutoTagEngine().autoTag(tpl);
+    expect(tags, contains('icm'));
+    expect(tags, contains('cash'));
+  });
+
+  test('detects 3bet action', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 'p3',
+      name: 'T',
+      trainingType: TrainingType.pushFold,
+      spots: [
+        spot(pos: HeroPosition.sb, stack: 20, heroOpts: ['3betPush', 'fold']),
+      ],
+    );
+    final tags = const YamlPackAutoTagEngine().autoTag(tpl);
+    expect(tags, contains('3bet'));
+  });
+}


### PR DESCRIPTION
## Summary
- add a `YamlPackAutoTagEngine` service to infer tags like `pushfold`, `3bet`, `icm`, `cash`, and hero position
- provide unit tests for the new engine

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818bf40880832a81881abcbe2c57d9