### PR TITLE
Add spot type classification

### DIFF
--- a/lib/models/spot_type.dart
+++ b/lib/models/spot_type.dart
@@ -1,0 +1,11 @@
+enum SpotType {
+  pushfold,
+  isoPush,
+  threeBet,
+  flatCall,
+  limp,
+  postflopJam,
+  multiway,
+  icm,
+  unknown,
+}

--- a/lib/services/training_spot_type_classifier.dart
+++ b/lib/services/training_spot_type_classifier.dart
@@ -1,0 +1,62 @@
+import '../models/spot_type.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class TrainingSpotTypeClassifier {
+  const TrainingSpotTypeClassifier();
+
+  SpotType classify(TrainingPackSpot spot) {
+    final heroStack = spot.hand.stacks['${spot.hand.heroIndex}'] ?? 0.0;
+
+    String heroAction = '';
+    if (spot.correctAction != null && spot.correctAction!.isNotEmpty) {
+      heroAction = spot.correctAction!.toLowerCase();
+    } else if (spot.heroOptions.isNotEmpty) {
+      heroAction = spot.heroOptions.first.toLowerCase();
+    } else if (spot.evalResult?.expectedAction.isNotEmpty == true) {
+      heroAction = spot.evalResult!.expectedAction.toLowerCase();
+    } else {
+      final acts = spot.hand.actions[0] ?? [];
+      for (final a in acts) {
+        if (a.playerIndex == spot.hand.heroIndex) {
+          heroAction = a.action.toLowerCase();
+          break;
+        }
+      }
+    }
+
+    final preflopActs = spot.hand.actions[0] ?? [];
+    bool openBeforeHero = false;
+    for (final a in preflopActs) {
+      if (a.playerIndex == spot.hand.heroIndex) break;
+      final act = a.action.toLowerCase();
+      if (act == 'open' || act == 'raise' || act == 'bet' || act == 'push') {
+        openBeforeHero = true;
+      }
+    }
+
+    if (heroStack <= 15 && heroAction == 'push' && !openBeforeHero) {
+      return SpotType.pushfold;
+    }
+
+    if (heroAction == 'push' && openBeforeHero) {
+      return SpotType.isoPush;
+    }
+
+    if ((heroAction == '3bet' || heroAction == '3betpush') && heroStack > 20) {
+      return SpotType.threeBet;
+    }
+
+    if (spot.hand.board.isNotEmpty) {
+      return SpotType.postflopJam;
+    }
+
+    if (spot.hand.playerCount - 1 > 2) {
+      return SpotType.multiway;
+    }
+
+    final tags = {for (final t in spot.tags) t.toLowerCase()};
+    if (tags.contains('icm')) return SpotType.icm;
+
+    return SpotType.unknown;
+  }
+}


### PR DESCRIPTION
## Summary
- define `SpotType` enum
- implement `TrainingSpotTypeClassifier` with basic heuristics

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818c61f97c832a902f8c82988ac234