### PR TITLE
Add smart stage recommender

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -74,6 +74,7 @@ import 'yaml_pack_editor_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
 import '../services/smart_stage_unlock_engine.dart';
+import '../services/learning_path_service.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -166,6 +167,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _progressImportLoading = false;
   bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
+  bool _smartMode = false;
   bool _achievementsCheckLoading = false;
   int _lessonStreak = 0;
   StreamSubscription<int>? _lessonSub;
@@ -2180,6 +2182,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                   setState(() => _unlockStages = v ?? false);
                   LearningPathProgressService.instance.unlockAllStages =
                       _unlockStages;
+                },
+              ),
+            if (kDebugMode)
+              CheckboxListTile(
+                title: const Text('🤖 Smart Mode'),
+                value: _smartMode,
+                activeColor: Colors.greenAccent,
+                onChanged: (v) {
+                  setState(() => _smartMode = v ?? false);
+                  LearningPathService.instance.smartMode = _smartMode;
                 },
               ),
             if (kDebugMode)

--- a/lib/services/smart_recommender_engine.dart
+++ b/lib/services/smart_recommender_engine.dart
@@ -1,0 +1,57 @@
+import '../models/training_result.dart';
+import '../models/learning_path_stage_model.dart';
+import 'weakness_cluster_engine.dart';
+import 'tag_mastery_service.dart';
+
+/// Lightweight identifier for a learning stage with associated tags.
+class StageID {
+  final String id;
+  final List<String> tags;
+
+  const StageID(this.id, {this.tags = const []});
+}
+
+/// Container for user progress data required by [SmartRecommenderEngine].
+class UserProgress {
+  final List<TrainingResult> history;
+
+  const UserProgress({required this.history});
+}
+
+/// Suggests the next best stage based on user's weaknesses and mastery.
+class SmartRecommenderEngine {
+  final WeaknessClusterEngine clusterEngine;
+  final TagMasteryService masteryService;
+
+  const SmartRecommenderEngine({
+    this.clusterEngine = const WeaknessClusterEngine(),
+    required this.masteryService,
+  });
+
+  Future<StageID?> suggestNextStage({
+    required UserProgress progress,
+    required List<StageID> availableStages,
+    double masteryThreshold = 0.7,
+  }) async {
+    if (availableStages.isEmpty) return null;
+
+    final mastery = await masteryService.computeMastery();
+    final clusters = clusterEngine.detectWeaknesses(
+      results: progress.history,
+      tagMastery: mastery,
+    );
+    final weakTags = <String>{
+      for (final c in clusters) c.tag.toLowerCase(),
+      for (final e in mastery.entries)
+        if (e.value < masteryThreshold) e.key.toLowerCase(),
+    };
+
+    for (final stage in availableStages) {
+      final tags = stage.tags.map((e) => e.toLowerCase());
+      if (tags.any(weakTags.contains)) {
+        return stage;
+      }
+    }
+    return availableStages.first;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `SmartRecommenderEngine` for personalized stage suggestions
- expose `smartMode` option in `LearningPathService`
- provide `getNextStage` method using the new engine
- add debug toggle for Smart Mode in Dev menu

## Testing
- `flutter analyze` *(fails: requires Dart SDK >=3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_688191e0747c832aa1e0bdabb3408883