### PR TITLE
Add GoalSuggestionService

### DIFF
--- a/lib/models/training_goal.dart
+++ b/lib/models/training_goal.dart
@@ -1,4 +1,9 @@
 class TrainingGoal {
   final String title;
-  const TrainingGoal(this.title);
+  final String description;
+
+  const TrainingGoal(
+    this.title, {
+    this.description = '',
+  });
 }

--- a/lib/services/goal_suggestion_service.dart
+++ b/lib/services/goal_suggestion_service.dart
@@ -1,0 +1,51 @@
+import '../models/training_goal.dart';
+import 'smart_recommender_engine.dart';
+import 'tag_mastery_service.dart';
+
+/// Suggests short-term training goals based on user's weaknesses.
+class GoalSuggestionService {
+  final SmartRecommenderEngine engine;
+  final TagMasteryService mastery;
+
+  GoalSuggestionService({
+    SmartRecommenderEngine? engine,
+    required this.mastery,
+  }) : engine = engine ?? SmartRecommenderEngine(masteryService: mastery);
+
+  /// Returns a list of up to three high-impact goals sorted by weakness severity.
+  Future<List<TrainingGoal>> suggestGoals({required UserProgress progress}) async {
+    final masteryMap = await mastery.computeMastery();
+    final clusters = engine.clusterEngine.detectWeaknesses(
+      results: progress.history,
+      tagMastery: masteryMap,
+    );
+
+    final goals = <TrainingGoal>[];
+    final used = <String>{};
+
+    for (final c in clusters) {
+      final tag = c.tag.toLowerCase();
+      if (masteryMap[tag] != null && masteryMap[tag]! >= 0.85) continue;
+      if (!used.add(tag)) continue;
+      final mapping = _tagGoals[tag];
+      final title = mapping?['title'] ?? 'Улучшить игру $tag';
+      final desc = mapping?['description'] ??
+          'Закрой хотя бы 3 стадии с этим тегом';
+      goals.add(TrainingGoal(title, description: desc));
+      if (goals.length >= 3) break;
+    }
+
+    return goals;
+  }
+
+  static const Map<String, Map<String, String>> _tagGoals = {
+    'sbvsbb': {
+      'title': 'Улучшить игру SB vs BB',
+      'description': 'Закрой хотя бы 3 стадии с этим тегом',
+    },
+    'openfold': {
+      'title': 'Отработать open/fold',
+      'description': 'Закрой хотя бы 3 стадии с этим тегом',
+    },
+  };
+}

--- a/test/services/goal_suggestion_service_test.dart
+++ b/test/services/goal_suggestion_service_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_result.dart';
+import 'package:poker_analyzer/services/goal_suggestion_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+
+class _FakeLogService extends SessionLogService {
+  _FakeLogService() : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => const [];
+}
+
+class _FakeMasteryService extends TagMasteryService {
+  final Map<String, double> map;
+  _FakeMasteryService(this.map)
+      : super(logs: _FakeLogService());
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('suggestGoals returns prioritized goals', () async {
+    final progress = UserProgress(history: [
+      TrainingResult(
+        date: DateTime.now(),
+        total: 10,
+        correct: 5,
+        accuracy: 50,
+        tags: const ['sbvsbb'],
+      ),
+      TrainingResult(
+        date: DateTime.now(),
+        total: 8,
+        correct: 6,
+        accuracy: 75,
+        tags: const ['openfold'],
+      ),
+      TrainingResult(
+        date: DateTime.now(),
+        total: 5,
+        correct: 5,
+        accuracy: 100,
+        tags: const ['strong'],
+      ),
+    ]);
+
+    final mastery = _FakeMasteryService({
+      'sbvsbb': 0.3,
+      'openfold': 0.6,
+      'strong': 0.9,
+    });
+
+    final service = GoalSuggestionService(mastery: mastery);
+    final goals = await service.suggestGoals(progress: progress);
+
+    expect(goals.length, 2);
+    expect(goals.first.title, contains('SB vs BB'));
+    expect(goals.last.title, contains('open/fold'));
+  });
+}


### PR DESCRIPTION
## Summary
- extend `TrainingGoal` model with a description
- implement `GoalSuggestionService` to recommend goals via `SmartRecommenderEngine`
- add unit test for new service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688197c89a24832a96d506e9b03a8708