### PR TITLE
Add GoalCenterScreen with smart goal suggestions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/plugin_runtime.dart';
 import 'screens/main_navigation_screen.dart';
 import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
+import 'screens/goal_center_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -322,6 +323,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               WeaknessOverviewScreen.route: (_) =>
                   const WeaknessOverviewScreen(),
               MasterModeScreen.route: (_) => const MasterModeScreen(),
+              GoalCenterScreen.route: (_) => const GoalCenterScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -24,6 +24,7 @@ import 'services/training_import_export_service.dart';
 import 'services/demo_playback_controller.dart';
 import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
+import 'screens/goal_center_screen.dart';
 
 final GlobalKey analyzerKey = GlobalKey();
 
@@ -168,6 +169,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
               routes: {
                 WeaknessOverviewScreen.route: (_) => const WeaknessOverviewScreen(),
                 MasterModeScreen.route: (_) => const MasterModeScreen(),
+                GoalCenterScreen.route: (_) => const GoalCenterScreen(),
               },
               builder: (context, child) {
                 return Stack(

--- a/lib/models/training_goal.dart
+++ b/lib/models/training_goal.dart
@@ -1,9 +1,11 @@
 class TrainingGoal {
   final String title;
   final String description;
+  final String? tag;
 
   const TrainingGoal(
     this.title, {
     this.description = '',
+    this.tag,
   });
 }

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -105,6 +105,7 @@ import 'tools/spot_duplication_wizard.dart';
 import 'tag_matrix_coverage_screen.dart';
 import 'skill_map_screen.dart';
 import 'goal_screen.dart';
+import 'goal_center_screen.dart';
 import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
 import 'learning_path_intro_screen.dart';
@@ -2103,6 +2104,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const GoalScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🎯 Goal Center'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const GoalCenterScreen()),
                   );
                 },
               ),

--- a/lib/screens/goal_center_screen.dart
+++ b/lib/screens/goal_center_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_goal.dart';
+import '../services/goal_suggestion_service.dart';
+import '../services/session_log_service.dart';
+import '../services/tag_mastery_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/training_session_launcher.dart';
+import '../widgets/training_goal_card.dart';
+
+class GoalCenterScreen extends StatefulWidget {
+  static const route = '/goals';
+  const GoalCenterScreen({super.key});
+
+  @override
+  State<GoalCenterScreen> createState() => _GoalCenterScreenState();
+}
+
+class _GoalCenterScreenState extends State<GoalCenterScreen> {
+  List<TrainingGoal>? _goals;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final progress = await context.read<SessionLogService>().getUserProgress();
+    final service = GoalSuggestionService(
+      mastery: context.read<TagMasteryService>(),
+    );
+    final goals = await service.suggestGoals(progress: progress);
+    if (!mounted) return;
+    setState(() => _goals = goals);
+  }
+
+  Future<void> _startGoal(TrainingGoal goal) async {
+    if (goal.tag == null) return;
+    final pack = await PackLibraryService.instance.findByTag(goal.tag!);
+    if (pack == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Тренировка не найдена')),
+      );
+      return;
+    }
+    await const TrainingSessionLauncher().launch(pack);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final goals = _goals;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Центр целей'),
+      ),
+      body: goals == null
+          ? const Center(child: CircularProgressIndicator())
+          : goals.isEmpty
+              ? const Center(
+                  child: Text(
+                    'Нет персональных целей',
+                    style: TextStyle(color: Colors.white70),
+                  ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: goals.length,
+                  itemBuilder: (context, index) {
+                    final g = goals[index];
+                    return TrainingGoalCard(
+                      goal: g,
+                      onStart: () => _startGoal(g),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/services/goal_suggestion_service.dart
+++ b/lib/services/goal_suggestion_service.dart
@@ -31,7 +31,7 @@ class GoalSuggestionService {
       final title = mapping?['title'] ?? 'Улучшить игру $tag';
       final desc = mapping?['description'] ??
           'Закрой хотя бы 3 стадии с этим тегом';
-      goals.add(TrainingGoal(title, description: desc));
+      goals.add(TrainingGoal(title, description: desc, tag: tag));
       if (goals.length >= 3) break;
     }
 

--- a/lib/widgets/training_goal_card.dart
+++ b/lib/widgets/training_goal_card.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_goal.dart';
+
+class TrainingGoalCard extends StatelessWidget {
+  final TrainingGoal goal;
+  final VoidCallback? onStart;
+  const TrainingGoalCard({super.key, required this.goal, this.onStart});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            goal.title,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          if (goal.description.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              goal.description,
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: onStart,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Начать'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `GoalCenterScreen` to display personalized goals
- create `TrainingGoalCard` widget
- extend `TrainingGoal` model with optional `tag`
- return tags in `GoalSuggestionService`
- expose `getUserProgress` in `SessionLogService`
- register new route and dev menu entry

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819dec4638832aa6198c324bbe7a9d