### PR TITLE
Add goal progress to goal center

### DIFF
--- a/lib/screens/goal_center_screen.dart
+++ b/lib/screens/goal_center_screen.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/training_goal.dart';
+import '../models/goal_progress.dart';
 import '../services/goal_suggestion_service.dart';
 import '../services/session_log_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
+import '../services/smart_goal_tracking_service.dart';
 import '../widgets/training_goal_card.dart';
 
 class GoalCenterScreen extends StatefulWidget {
@@ -19,6 +21,7 @@ class GoalCenterScreen extends StatefulWidget {
 
 class _GoalCenterScreenState extends State<GoalCenterScreen> {
   List<TrainingGoal>? _goals;
+  final Map<String, GoalProgress> _progress = {};
 
   @override
   void initState() {
@@ -32,8 +35,22 @@ class _GoalCenterScreenState extends State<GoalCenterScreen> {
       mastery: context.read<TagMasteryService>(),
     );
     final goals = await service.suggestGoals(progress: progress);
+    final tracker =
+        SmartGoalTrackingService(logs: context.read<SessionLogService>());
+    final map = <String, GoalProgress>{};
+    for (final g in goals) {
+      final tag = g.tag;
+      if (tag != null) {
+        map[tag] = await tracker.getGoalProgress(tag);
+      }
+    }
     if (!mounted) return;
-    setState(() => _goals = goals);
+    setState(() {
+      _goals = goals;
+      _progress
+        ..clear()
+        ..addAll(map);
+    });
   }
 
   Future<void> _startGoal(TrainingGoal goal) async {
@@ -73,6 +90,7 @@ class _GoalCenterScreenState extends State<GoalCenterScreen> {
                     return TrainingGoalCard(
                       goal: g,
                       onStart: () => _startGoal(g),
+                      progress: g.tag != null ? _progress[g.tag] : null,
                     );
                   },
                 ),

--- a/lib/widgets/training_goal_card.dart
+++ b/lib/widgets/training_goal_card.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 
 import '../models/training_goal.dart';
+import '../models/goal_progress.dart';
 
 class TrainingGoalCard extends StatelessWidget {
   final TrainingGoal goal;
   final VoidCallback? onStart;
-  const TrainingGoalCard({super.key, required this.goal, this.onStart});
+  final GoalProgress? progress;
+  const TrainingGoalCard({
+    super.key,
+    required this.goal,
+    this.onStart,
+    this.progress,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +36,14 @@ class TrainingGoalCard extends StatelessWidget {
             Text(
               goal.description,
               style: const TextStyle(color: Colors.white70),
+            ),
+          ],
+          if (progress != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              'Пройдено: ${progress!.stagesCompleted} стадий · Средняя точность: '
+              '${progress!.averageAccuracy.toStringAsFixed(0)}%',
+              style: const TextStyle(color: Colors.white54, fontSize: 12),
             ),
           ],
           const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- extend `TrainingGoalCard` with optional progress
- show progress via `SmartGoalTrackingService` in `GoalCenterScreen`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881aa33183c832a9e43b1744711a9f3