### PR TITLE
Add GoalProgressBadge to goal cards

### DIFF
--- a/lib/utils/goal_status_utils.dart
+++ b/lib/utils/goal_status_utils.dart
@@ -1,0 +1,11 @@
+import '../models/goal_progress.dart';
+import '../services/goal_completion_engine.dart';
+
+/// Returns a human readable status string for a goal.
+String getGoalStatus(GoalProgress progress) {
+  if (GoalCompletionEngine.instance.isGoalCompleted(progress)) {
+    return '✔ Завершено';
+  }
+  final accuracy = progress.averageAccuracy.toStringAsFixed(0);
+  return 'Пройдено: ${progress.stagesCompleted}/3 · Точность: $accuracy%';
+}

--- a/lib/widgets/training_goal_card.dart
+++ b/lib/widgets/training_goal_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../models/training_goal.dart';
 import '../models/goal_progress.dart';
+import '../services/goal_completion_engine.dart';
+import '../utils/goal_status_utils.dart';
 
 class TrainingGoalCard extends StatelessWidget {
   final TrainingGoal goal;
@@ -17,19 +19,33 @@ class TrainingGoalCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
-    return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.grey[850],
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            goal.title,
-            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+    final prog = progress;
+    final completed =
+        prog != null && GoalCompletionEngine.instance.isGoalCompleted(prog);
+    return Opacity(
+      opacity: completed ? 0.6 : 1,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  goal.title,
+                  style: const TextStyle(
+                      fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+              ),
+              if (prog != null) _GoalProgressBadge(progress: prog),
+            ],
           ),
           if (goal.description.isNotEmpty) ...[
             const SizedBox(height: 4),
@@ -38,11 +54,10 @@ class TrainingGoalCard extends StatelessWidget {
               style: const TextStyle(color: Colors.white70),
             ),
           ],
-          if (progress != null) ...[
+          if (prog != null) ...[
             const SizedBox(height: 4),
             Text(
-              'Пройдено: ${progress!.stagesCompleted} стадий · Средняя точность: '
-              '${progress!.averageAccuracy.toStringAsFixed(0)}%',
+              getGoalStatus(prog),
               style: const TextStyle(color: Colors.white54, fontSize: 12),
             ),
           ],
@@ -56,6 +71,31 @@ class TrainingGoalCard extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    ),
+    );
+  }
+}
+
+class _GoalProgressBadge extends StatelessWidget {
+  final GoalProgress progress;
+  const _GoalProgressBadge({required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final completed =
+        GoalCompletionEngine.instance.isGoalCompleted(progress);
+    final color = completed ? Colors.green[700] : Colors.grey[700];
+    return Container(
+      margin: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        getGoalStatus(progress),
+        style: const TextStyle(color: Colors.white, fontSize: 11),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- display goal status string via `getGoalStatus`
- show `_GoalProgressBadge` on each goal card with color based on completion
- fade completed goal cards

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6881ac616a38832a9b4a4db53b3f7cc0