### PR TITLE
Implement goal completion event tracking

### DIFF
--- a/lib/models/goal_completion_event.dart
+++ b/lib/models/goal_completion_event.dart
@@ -1,0 +1,18 @@
+class GoalCompletionEvent {
+  final String tag;
+  final DateTime timestamp;
+
+  const GoalCompletionEvent({required this.tag, required this.timestamp});
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory GoalCompletionEvent.fromJson(Map<String, dynamic> json) =>
+      GoalCompletionEvent(
+        tag: json['tag'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}

--- a/lib/screens/goal_center_screen.dart
+++ b/lib/screens/goal_center_screen.dart
@@ -10,6 +10,7 @@ import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/smart_goal_tracking_service.dart';
 import '../services/goal_completion_engine.dart';
+import '../services/goal_completion_event_service.dart';
 import '../widgets/training_goal_card.dart';
 
 class GoalCenterScreen extends StatefulWidget {
@@ -45,6 +46,7 @@ class _GoalCenterScreenState extends State<GoalCenterScreen> {
       final tag = g.tag;
       if (tag != null) {
         final prog = await tracker.getGoalProgress(tag);
+        await GoalCompletionEventService.instance.logIfNew(prog);
         map[tag] = prog;
         if (_completionEngine.showCompletedGoals ||
             !_completionEngine.isGoalCompleted(prog)) {


### PR DESCRIPTION
## Summary
- add `GoalCompletionEvent` model
- implement `GoalCompletionEventService` for persistent event logging
- hook logging into `GoalCenterScreen`

## Testing
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6881ad6ab254832aa84b4e92b8831992