### PR TITLE
Add achievements dashboard

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'screens/main_navigation_screen.dart';
 import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
 import 'screens/goal_center_screen.dart';
+import 'screens/achievements_dashboard_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -324,6 +325,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
                   const WeaknessOverviewScreen(),
               MasterModeScreen.route: (_) => const MasterModeScreen(),
               GoalCenterScreen.route: (_) => const GoalCenterScreen(),
+              AchievementsDashboardScreen.route: (_) =>
+                  const AchievementsDashboardScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/screens/achievements_dashboard_screen.dart
+++ b/lib/screens/achievements_dashboard_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/goal_completion_event.dart';
+import '../services/goal_completion_event_service.dart';
+
+class AchievementsDashboardScreen extends StatefulWidget {
+  static const route = '/achievements';
+  const AchievementsDashboardScreen({super.key});
+
+  @override
+  State<AchievementsDashboardScreen> createState() =>
+      _AchievementsDashboardScreenState();
+}
+
+class _AchievementsDashboardScreenState
+    extends State<AchievementsDashboardScreen> {
+  late Future<List<GoalCompletionEvent>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = GoalCompletionEventService.instance.getAllEvents();
+  }
+
+  String _format(DateTime d) {
+    final day = d.day.toString().padLeft(2, '0');
+    final mon = d.month.toString().padLeft(2, '0');
+    return '$day.$mon.${d.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('История достижений'),
+        centerTitle: true,
+      ),
+      body: FutureBuilder<List<GoalCompletionEvent>>( 
+        future: _future,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final events = snapshot.data!;
+          if (events.isEmpty) {
+            return const Center(child: Text('Нет данных'));
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: events.length,
+            itemBuilder: (context, index) {
+              final e = events[index];
+              return _AchievementTile(event: e, dateFormatter: _format);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AchievementTile extends StatelessWidget {
+  final GoalCompletionEvent event;
+  final String Function(DateTime) dateFormatter;
+  const _AchievementTile({
+    required this.event,
+    required this.dateFormatter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Цель завершена: ${event.tag}',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Дата: ${dateFormatter(event.timestamp)}',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -113,6 +113,7 @@ import 'learning_path_intro_screen.dart';
 import '../services/learning_path_progress_service.dart';
 import '../services/achievement_trigger_engine.dart';
 import 'achievement_dashboard_screen.dart';
+import 'achievements_dashboard_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_insight_screen.dart';
 import 'cluster_mistake_dashboard_screen.dart';
@@ -2177,6 +2178,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                         builder: (_) => const AchievementDashboardScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🏅 История достижений'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const AchievementsDashboardScreen()),
                   );
                 },
               ),

--- a/lib/services/goal_completion_event_service.dart
+++ b/lib/services/goal_completion_event_service.dart
@@ -57,4 +57,14 @@ class GoalCompletionEventService {
     final key = tag.trim().toLowerCase();
     return _events[key];
   }
+
+  Future<List<GoalCompletionEvent>> getAllEvents() async {
+    await _load();
+    final list = [
+      for (final e in _events.entries)
+        GoalCompletionEvent(tag: e.key, timestamp: e.value)
+    ]
+      ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    return list;
+  }
 }


### PR DESCRIPTION
## Summary
- implement `AchievementsDashboardScreen` showing completed goals chronologically
- expose completed events via `GoalCompletionEventService.getAllEvents`
- wire new screen into routes and dev menu

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b0946d70832aafe0fe0c9aa13196