### PR TITLE
Implement SmartGoalBanner

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/feedback_banner.dart';
 import '../widgets/recent_unlocks_banner.dart';
 import '../widgets/today_progress_banner.dart';
 import '../widgets/pack_suggestion_banner.dart';
+import '../widgets/smart_goal_banner.dart';
 import '../widgets/ev_goal_banner.dart';
 import '../widgets/repeat_last_corrected_card.dart';
 import '../widgets/repeat_corrected_drill_card.dart';
@@ -102,12 +103,15 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
       MaterialPageRoute(builder: (_) => const OnboardingScreen()),
     );
     if (mounted) {
-      setState(() => _tutorialCompleted = UserPreferences.instance.tutorialCompleted);
+      setState(() =>
+          _tutorialCompleted = UserPreferences.instance.tutorialCompleted);
     }
   }
 
   Future<void> _maybeShowTrainingReminder() async {
-    await context.read<DailyTrainingReminderService>().maybeShowReminder(context);
+    await context
+        .read<DailyTrainingReminderService>()
+        .maybeShowReminder(context);
   }
 
   Future<void> _maybeLaunchScheduledTraining() async {
@@ -201,6 +205,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
             ? const ResumeTrainingCard()
             : const SizedBox.shrink(),
         const ContinueTrainingButton(),
+        const SmartGoalBanner(),
         const NextBestStepBanner(),
         const SpotOfTheDayCard(),
         const PackSuggestionBanner(),
@@ -368,9 +373,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
             },
             itemBuilder: (context) => const [
               PopupMenuItem(value: 'settings', child: Text('⚙️ Settings')),
-              PopupMenuItem(value: 'notifications', child: Text('🔔 Notifications')),
+              PopupMenuItem(
+                  value: 'notifications', child: Text('🔔 Notifications')),
               PopupMenuItem(value: 'plugins', child: Text('🧩 Plugins')),
-              PopupMenuItem(value: 'community_plugins', child: Text('🌐 Community')),
+              PopupMenuItem(
+                  value: 'community_plugins', child: Text('🌐 Community')),
               PopupMenuItem(value: 'onboarding', child: Text('📖 Обучение')),
               PopupMenuItem(value: 'evicm', child: Text('EV/ICM')),
               PopupMenuItem(value: 'evstats', child: Text('EV Stats')),
@@ -431,7 +438,8 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
                       icon: Icon(Icons.history),
                       label: 'История',
                     ),
-                    BottomNavigationBarItem(icon: Icon(Icons.flag), label: 'Goal'),
+                    BottomNavigationBarItem(
+                        icon: Icon(Icons.flag), label: 'Goal'),
                     BottomNavigationBarItem(
                       icon: Icon(Icons.backpack),
                       label: 'My Packs',

--- a/lib/widgets/smart_goal_banner.dart
+++ b/lib/widgets/smart_goal_banner.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/training_goal.dart';
+import '../services/goal_reminder_engine.dart';
+import '../services/goal_suggestion_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/session_log_service.dart';
+import '../services/tag_mastery_service.dart';
+import '../services/training_session_launcher.dart';
+
+class SmartGoalBanner extends StatefulWidget {
+  const SmartGoalBanner({super.key});
+
+  @override
+  State<SmartGoalBanner> createState() => _SmartGoalBannerState();
+}
+
+class _SmartGoalBannerState extends State<SmartGoalBanner> {
+  bool _loading = true;
+  TrainingGoal? _goal;
+  bool _hidden = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final engine = GoalReminderEngine(
+      suggestions: GoalSuggestionService(
+        mastery: context.read<TagMasteryService>(),
+      ),
+      logs: context.read<SessionLogService>(),
+    );
+    final goals = await engine.getStaleGoals();
+    if (!mounted) return;
+    setState(() {
+      _goal = goals.isNotEmpty ? goals.first : null;
+      _loading = false;
+    });
+  }
+
+  Future<void> _continue() async {
+    final g = _goal;
+    if (g == null || g.tag == null) return;
+    final pack = await PackLibraryService.instance.findByTag(g.tag!);
+    if (pack == null) return;
+    await const TrainingSessionLauncher().launch(pack);
+  }
+
+  void _dismiss() => setState(() => _hidden = true);
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _hidden || _goal == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final g = _goal!;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      g.title,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    if (g.description.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          g.description,
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _dismiss,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _continue,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Продолжить'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add SmartGoalBanner widget that prompts resuming a stale goal
- insert SmartGoalBanner on the main screen above training content

## Testing
- `flutter/bin/flutter test` *(fails: Dart SDK version too low)*

------
https://chatgpt.com/codex/tasks/task_e_6881bf827404832a86dd05ce1eff870f