### PR TITLE
Implement goal engagement tracker

### DIFF
--- a/lib/models/goal_engagement.dart
+++ b/lib/models/goal_engagement.dart
@@ -1,0 +1,25 @@
+class GoalEngagement {
+  final String tag;
+  final String action; // "start", "skip", "dismiss", "completed"
+  final DateTime timestamp;
+
+  const GoalEngagement({
+    required this.tag,
+    required this.action,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'action': action,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory GoalEngagement.fromJson(Map<String, dynamic> json) => GoalEngagement(
+        tag: json['tag'] as String? ?? '',
+        action: json['action'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}
+

--- a/lib/services/goal_completion_event_service.dart
+++ b/lib/services/goal_completion_event_service.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/goal_completion_event.dart';
 import '../models/goal_progress.dart';
 import 'goal_completion_engine.dart';
+import 'goal_engagement_tracker.dart';
+import '../models/goal_engagement.dart';
 
 class GoalCompletionEventService {
   GoalCompletionEventService._();
@@ -49,8 +51,12 @@ class GoalCompletionEventService {
     final tag = progress.tag.trim().toLowerCase();
     if (_events.containsKey(tag)) return;
     if (!GoalCompletionEngine.instance.isGoalCompleted(progress)) return;
-    _events[tag] = DateTime.now();
+    final now = DateTime.now();
+    _events[tag] = now;
     await _save();
+    await GoalEngagementTracker.instance.log(
+      GoalEngagement(tag: tag, action: 'completed', timestamp: now),
+    );
   }
 
   DateTime? completedAt(String tag) {

--- a/lib/services/goal_engagement_tracker.dart
+++ b/lib/services/goal_engagement_tracker.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/goal_engagement.dart';
+
+/// Tracks user interactions with training goals.
+class GoalEngagementTracker {
+  GoalEngagementTracker._();
+
+  /// Singleton instance.
+  static final GoalEngagementTracker instance = GoalEngagementTracker._();
+
+  static const String _prefsKey = 'goal_engagement_log';
+
+  final List<GoalEngagement> _events = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_prefsKey) ?? [];
+    _events
+      ..clear()
+      ..addAll(raw.map((e) =>
+          GoalEngagement.fromJson(jsonDecode(e) as Map<String, dynamic>)));
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      [for (final e in _events) jsonEncode(e.toJson())],
+    );
+  }
+
+  /// Log a goal engagement event.
+  Future<void> log(GoalEngagement event) async {
+    await _load();
+    _events.add(event);
+    await _save();
+  }
+
+  /// Returns all logged engagement events.
+  Future<List<GoalEngagement>> getAll() async {
+    await _load();
+    return List.unmodifiable(_events);
+  }
+}
+

--- a/lib/widgets/smart_goal_banner.dart
+++ b/lib/widgets/smart_goal_banner.dart
@@ -8,6 +8,8 @@ import '../services/pack_library_service.dart';
 import '../services/session_log_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/training_session_launcher.dart';
+import '../services/goal_engagement_tracker.dart';
+import '../models/goal_engagement.dart';
 
 class SmartGoalBanner extends StatefulWidget {
   const SmartGoalBanner({super.key});
@@ -47,10 +49,29 @@ class _SmartGoalBannerState extends State<SmartGoalBanner> {
     if (g == null || g.tag == null) return;
     final pack = await PackLibraryService.instance.findByTag(g.tag!);
     if (pack == null) return;
+    await GoalEngagementTracker.instance.log(
+      GoalEngagement(
+        tag: g.tag!,
+        action: 'start',
+        timestamp: DateTime.now(),
+      ),
+    );
     await const TrainingSessionLauncher().launch(pack);
   }
 
-  void _dismiss() => setState(() => _hidden = true);
+  void _dismiss() async {
+    final g = _goal;
+    if (g != null && g.tag != null) {
+      await GoalEngagementTracker.instance.log(
+        GoalEngagement(
+          tag: g.tag!,
+          action: 'dismiss',
+          timestamp: DateTime.now(),
+        ),
+      );
+    }
+    setState(() => _hidden = true);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/training_goal_card.dart
+++ b/lib/widgets/training_goal_card.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../models/training_goal.dart';
 import '../models/goal_progress.dart';
 import '../services/goal_completion_engine.dart';
+import '../services/goal_engagement_tracker.dart';
+import '../models/goal_engagement.dart';
 import '../utils/goal_status_utils.dart';
 
 class TrainingGoalCard extends StatelessWidget {
@@ -65,7 +67,19 @@ class TrainingGoalCard extends StatelessWidget {
           Align(
             alignment: Alignment.centerRight,
             child: ElevatedButton(
-              onPressed: onStart,
+              onPressed: () async {
+                final tag = goal.tag;
+                if (tag != null) {
+                  await GoalEngagementTracker.instance.log(
+                    GoalEngagement(
+                      tag: tag,
+                      action: 'start',
+                      timestamp: DateTime.now(),
+                    ),
+                  );
+                }
+                onStart?.call();
+              },
               style: ElevatedButton.styleFrom(backgroundColor: accent),
               child: const Text('Начать'),
             ),


### PR DESCRIPTION
## Summary
- add `GoalEngagement` model to record goal events
- implement `GoalEngagementTracker` with SharedPreferences storage
- record goal start from `TrainingGoalCard`
- log banner interactions in `SmartGoalBanner`
- mark completed goals in `GoalCompletionEventService`

## Testing
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_6881c21f37f4832aa1d8a3b32a6e2955