### PR TITLE
Add goal insights screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
 import 'screens/goal_center_screen.dart';
 import 'screens/achievements_dashboard_screen.dart';
+import 'screens/goal_insights_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -327,6 +328,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               GoalCenterScreen.route: (_) => const GoalCenterScreen(),
               AchievementsDashboardScreen.route: (_) =>
                   const AchievementsDashboardScreen(),
+              GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -25,6 +25,7 @@ import 'services/demo_playback_controller.dart';
 import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
 import 'screens/goal_center_screen.dart';
+import 'screens/goal_insights_screen.dart';
 
 final GlobalKey analyzerKey = GlobalKey();
 
@@ -67,8 +68,9 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
       providers: [
         ChangeNotifierProvider(create: (_) => PlayerProfileService()),
         ChangeNotifierProvider(
-            create: (context) =>
-                PlayerManagerService(context.read<PlayerProfileService>())),
+          create: (context) =>
+              PlayerManagerService(context.read<PlayerProfileService>()),
+        ),
         ChangeNotifierProvider(create: (_) => AllInPlayersService()),
         ChangeNotifierProvider(create: (_) => FoldedPlayersService()),
         ChangeNotifierProvider(
@@ -83,7 +85,8 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
             final potSync = PotSyncService(historyService: history);
             final stackService = StackManagerService(
               Map<int, int>.from(
-                  context.read<PlayerManagerService>().initialStacks),
+                context.read<PlayerManagerService>().initialStacks,
+              ),
               potSync: potSync,
             );
             return PlaybackManagerService(
@@ -100,9 +103,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
           ),
         ),
         Provider(create: (_) => ActionHistoryService()),
-        ChangeNotifierProvider(
-          create: (_) => IgnoredMistakeService()..load(),
-        ),
+        ChangeNotifierProvider(create: (_) => IgnoredMistakeService()..load()),
         Provider(create: (_) => const TrainingImportExportService()),
       ],
       child: Builder(
@@ -137,8 +138,9 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
               Provider(
                 create: (_) => PlayerEditingService(
                   playerManager: context.read<PlayerManagerService>(),
-                  stackService:
-                      context.read<PlaybackManagerService>().stackService,
+                  stackService: context
+                      .read<PlaybackManagerService>()
+                      .stackService,
                   playbackManager: context.read<PlaybackManagerService>(),
                   profile: context.read<PlayerProfileService>(),
                 ),
@@ -147,85 +149,95 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                 create: (_) => DemoPlaybackController(
                   playbackManager: context.read<PlaybackManagerService>(),
                   boardManager: context.read<BoardManagerService>(),
-                  importExportService:
-                      context.read<TrainingImportExportService>(),
+                  importExportService: context
+                      .read<TrainingImportExportService>(),
                   potSync: context.read<PlaybackManagerService>().potSync,
                 ),
               ),
             ],
             child: DemoLauncher(
               child: MaterialApp(
-              title: 'Poker AI Analyzer Demo',
-              debugShowCheckedModeBanner: false,
-              theme: ThemeData.dark().copyWith(
-                colorScheme: ColorScheme.fromSeed(seedColor: Colors.greenAccent),
-                scaffoldBackgroundColor: Colors.black,
-                textTheme: ThemeData.dark().textTheme.apply(
-                      fontFamily: 'Roboto',
-                      bodyColor: Colors.white,
-                      displayColor: Colors.white,
-                    ),
-              ),
-              routes: {
-                WeaknessOverviewScreen.route: (_) => const WeaknessOverviewScreen(),
-                MasterModeScreen.route: (_) => const MasterModeScreen(),
-                GoalCenterScreen.route: (_) => const GoalCenterScreen(),
-              },
-              builder: (context, child) {
-                return Stack(
-                  children: [
-                    if (child != null) child,
-                    if (widget.demoMode)
-                      Positioned(
-                        bottom: MediaQuery.of(context).padding.bottom + 8,
-                        left: 8,
-                        child: FadeTransition(
-                          opacity: _labelController,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: Colors.white.withOpacity(0.2),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Text(
-                              'Demo Mode Active',
-                              style: TextStyle(
-                                color: Colors.white.withOpacity(0.8),
-                                fontSize: 12,
+                title: 'Poker AI Analyzer Demo',
+                debugShowCheckedModeBanner: false,
+                theme: ThemeData.dark().copyWith(
+                  colorScheme: ColorScheme.fromSeed(
+                    seedColor: Colors.greenAccent,
+                  ),
+                  scaffoldBackgroundColor: Colors.black,
+                  textTheme: ThemeData.dark().textTheme.apply(
+                    fontFamily: 'Roboto',
+                    bodyColor: Colors.white,
+                    displayColor: Colors.white,
+                  ),
+                ),
+                routes: {
+                  WeaknessOverviewScreen.route: (_) =>
+                      const WeaknessOverviewScreen(),
+                  MasterModeScreen.route: (_) => const MasterModeScreen(),
+                  GoalCenterScreen.route: (_) => const GoalCenterScreen(),
+                  GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
+                },
+                builder: (context, child) {
+                  return Stack(
+                    children: [
+                      if (child != null) child,
+                      if (widget.demoMode)
+                        Positioned(
+                          bottom: MediaQuery.of(context).padding.bottom + 8,
+                          left: 8,
+                          child: FadeTransition(
+                            opacity: _labelController,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.white.withOpacity(0.2),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                'Demo Mode Active',
+                                style: TextStyle(
+                                  color: Colors.white.withOpacity(0.8),
+                                  fontSize: 12,
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                  ],
-                );
-              },
-              home: PokerAnalyzerScreen(
-                actionSync: context.read<ActionSyncService>(),
-                foldedPlayersService: context.read<FoldedPlayersService>(),
-                allInPlayersService: context.read<AllInPlayersService>(),
-                handContext: CurrentHandContextService(),
-                playbackManager: context.read<PlaybackManagerService>(),
-                stackService:
-                    context.read<PlaybackManagerService>().stackService,
-                potSyncService: context.read<PlaybackManagerService>().potSync,
-                boardManager: context.read<BoardManagerService>(),
-                boardSync: context.read<BoardSyncService>(),
-                boardEditing: context.read<BoardEditingService>(),
-                playerEditing: context.read<PlayerEditingService>(),
-                playerManager: context.read<PlayerManagerService>(),
-                playerProfile: context.read<PlayerProfileService>(),
-                actionTagService:
-                    context.read<PlayerProfileService>().actionTagService,
-                boardReveal: boardReveal,
-                lockService: lockService,
-                actionHistory: context.read<ActionHistoryService>(),
-                demoMode: widget.demoMode,
-                key: analyzerKey,
+                    ],
+                  );
+                },
+                home: PokerAnalyzerScreen(
+                  actionSync: context.read<ActionSyncService>(),
+                  foldedPlayersService: context.read<FoldedPlayersService>(),
+                  allInPlayersService: context.read<AllInPlayersService>(),
+                  handContext: CurrentHandContextService(),
+                  playbackManager: context.read<PlaybackManagerService>(),
+                  stackService: context
+                      .read<PlaybackManagerService>()
+                      .stackService,
+                  potSyncService: context
+                      .read<PlaybackManagerService>()
+                      .potSync,
+                  boardManager: context.read<BoardManagerService>(),
+                  boardSync: context.read<BoardSyncService>(),
+                  boardEditing: context.read<BoardEditingService>(),
+                  playerEditing: context.read<PlayerEditingService>(),
+                  playerManager: context.read<PlayerManagerService>(),
+                  playerProfile: context.read<PlayerProfileService>(),
+                  actionTagService: context
+                      .read<PlayerProfileService>()
+                      .actionTagService,
+                  boardReveal: boardReveal,
+                  lockService: lockService,
+                  actionHistory: context.read<ActionHistoryService>(),
+                  demoMode: widget.demoMode,
+                  key: analyzerKey,
+                ),
               ),
             ),
-          ),
           );
         },
       ),

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -107,6 +107,7 @@ import 'tag_matrix_coverage_screen.dart';
 import 'skill_map_screen.dart';
 import 'goal_screen.dart';
 import 'goal_center_screen.dart';
+import 'goal_insights_screen.dart';
 import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
 import 'learning_path_intro_screen.dart';
@@ -2189,6 +2190,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                         builder: (_) => const AchievementsDashboardScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📈 Статистика целей'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const GoalInsightsScreen()),
                   );
                 },
               ),

--- a/lib/screens/goal_insights_screen.dart
+++ b/lib/screens/goal_insights_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../services/goal_engagement_tracker.dart';
+import '../helpers/date_utils.dart';
+
+class GoalInsightsScreen extends StatefulWidget {
+  static const route = '/goal_insights';
+  const GoalInsightsScreen({super.key});
+
+  @override
+  State<GoalInsightsScreen> createState() => _GoalInsightsScreenState();
+}
+
+class _GoalInsightsScreenState extends State<GoalInsightsScreen> {
+  bool _loading = true;
+  int _started = 0;
+  int _completed = 0;
+  int _skipped = 0;
+  DateTime? _lastActive;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final events = await GoalEngagementTracker.instance.getAll();
+    int started = 0;
+    int completed = 0;
+    int skipped = 0;
+    DateTime? last;
+    for (final e in events) {
+      switch (e.action) {
+        case 'start':
+          started++;
+          break;
+        case 'completed':
+          completed++;
+          break;
+        case 'dismiss':
+        case 'skip':
+          skipped++;
+          break;
+      }
+      if (last == null || e.timestamp.isAfter(last)) last = e.timestamp;
+    }
+    if (!mounted) return;
+    setState(() {
+      _started = started;
+      _completed = completed;
+      _skipped = skipped;
+      _lastActive = last;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Статистика целей'), centerTitle: true),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text('Всего начато целей: $_started'),
+                const SizedBox(height: 8),
+                Text('Завершено целей: $_completed'),
+                const SizedBox(height: 8),
+                Text('Пропущено/отклонено: $_skipped'),
+                const SizedBox(height: 8),
+                Text(
+                  'Последняя активность: ${_lastActive != null ? formatDate(_lastActive!) : 'нет'}',
+                ),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add GoalInsightsScreen showing counts of goals started, completed, skipped and last activity date
- wire up new route in main.dart and main_demo.dart
- expose screen from DevMenu for debugging

## Testing
- `dart format lib/screens/goal_insights_screen.dart`
- `flutter analyze` *(fails: Package file_picker references missing plugin implementation)*
- `flutter test` *(fails: Error: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6881c3464f1c832aa14ed03dcc3168b4