### PR TITLE
Implement SmartGoalReminderEngine

### DIFF
--- a/lib/services/smart_goal_reminder_engine.dart
+++ b/lib/services/smart_goal_reminder_engine.dart
@@ -1,0 +1,49 @@
+import '../models/goal_progress.dart';
+import '../models/goal_engagement.dart';
+import 'goal_completion_engine.dart';
+
+/// Returns tags of goals that have not been interacted with for [staleDays].
+class SmartGoalReminderEngine {
+  const SmartGoalReminderEngine();
+
+  Future<List<String>> getStaleGoalTags({
+    int staleDays = 5,
+    required List<GoalProgress> allGoals,
+    required List<GoalEngagement> engagementLog,
+  }) async {
+    final cutoff = DateTime.now().subtract(Duration(days: staleDays));
+
+    // Determine last relevant engagement for each tag.
+    final lastActivity = <String, DateTime?>{};
+    for (final e in engagementLog) {
+      if (e.action != 'start' && e.action != 'dismiss') continue;
+      final tag = e.tag.trim().toLowerCase();
+      final existing = lastActivity[tag];
+      if (existing == null || e.timestamp.isAfter(existing)) {
+        lastActivity[tag] = e.timestamp;
+      }
+    }
+
+    final staleEntries = <MapEntry<String, DateTime?>>[];
+    for (final g in allGoals) {
+      final tag = g.tag.trim().toLowerCase();
+      if (GoalCompletionEngine.instance.isGoalCompleted(g)) continue;
+      final last = lastActivity[tag];
+      if (last == null || last.isBefore(cutoff)) {
+        staleEntries.add(MapEntry(tag, last));
+      }
+    }
+
+    staleEntries.sort((a, b) {
+      final ta = a.value;
+      final tb = b.value;
+      if (ta == null && tb == null) return 0;
+      if (ta == null) return -1;
+      if (tb == null) return 1;
+      return ta.compareTo(tb);
+    });
+
+    return [for (final e in staleEntries) e.key];
+  }
+}
+

--- a/test/services/smart_goal_reminder_engine_test.dart
+++ b/test/services/smart_goal_reminder_engine_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/goal_engagement.dart';
+import 'package:poker_analyzer/models/goal_progress.dart';
+import 'package:poker_analyzer/services/smart_goal_reminder_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('returns stale tags ordered by last activity', () async {
+    final now = DateTime.now();
+    final allGoals = const [
+      GoalProgress(tag: 'a', stagesCompleted: 1, averageAccuracy: 50),
+      GoalProgress(tag: 'b', stagesCompleted: 2, averageAccuracy: 70),
+      GoalProgress(tag: 'c', stagesCompleted: 0, averageAccuracy: 0),
+    ];
+    final log = [
+      GoalEngagement(tag: 'a', action: 'start', timestamp: now.subtract(const Duration(days: 7))),
+      GoalEngagement(tag: 'b', action: 'dismiss', timestamp: now.subtract(const Duration(days: 2))),
+    ];
+    const engine = SmartGoalReminderEngine();
+    final result = await engine.getStaleGoalTags(
+      staleDays: 5,
+      allGoals: allGoals,
+      engagementLog: log,
+    );
+    expect(result, ['c', 'a']);
+  });
+
+  test('ignores completed goals', () async {
+    final now = DateTime.now();
+    final allGoals = const [
+      GoalProgress(tag: 'done', stagesCompleted: 3, averageAccuracy: 80),
+      GoalProgress(tag: 'todo', stagesCompleted: 1, averageAccuracy: 50),
+    ];
+    final log = [
+      GoalEngagement(tag: 'done', action: 'start', timestamp: now.subtract(const Duration(days: 10))),
+    ];
+    const engine = SmartGoalReminderEngine();
+    final result = await engine.getStaleGoalTags(
+      staleDays: 5,
+      allGoals: allGoals,
+      engagementLog: log,
+    );
+    expect(result, ['todo']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartGoalReminderEngine` to detect inactive goals
- verify new reminder logic via unit tests

## Testing
- `flutter analyze`
- `flutter test test/services/smart_goal_reminder_engine_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6881c651e7e0832abe5a3d08ce387843