### PR TITLE
Add smart push reminder scheduler

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -105,6 +105,8 @@ import 'services/scheduled_training_queue_service.dart';
 import 'services/auto_recovery_trigger_service.dart';
 import 'services/scheduled_training_launcher.dart';
 import 'services/daily_training_reminder_service.dart';
+import 'services/goal_reengagement_service.dart';
+import 'services/smart_push_scheduler_service.dart';
 import 'services/lesson_progress_tracker_service.dart';
 import 'services/lesson_path_progress_service.dart';
 import 'services/training_path_progress_service.dart';
@@ -487,6 +489,17 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => const ScheduledTrainingLauncher()),
     Provider(create: (_) => DailyTrainingReminderService()),
+    Provider(
+      create: (context) => GoalReengagementService(
+        logs: context.read<SessionLogService>(),
+      ),
+    ),
+    Provider(
+      create: (context) => SmartPushSchedulerService(
+        reengagement: context.read<GoalReengagementService>(),
+        reminder: context.read<DailyTrainingReminderService>(),
+      ),
+    ),
     Provider(
       create: (context) => GoalSuggestionEngine(
         mastery: context.read<TagMasteryService>(),

--- a/lib/services/smart_push_scheduler_service.dart
+++ b/lib/services/smart_push_scheduler_service.dart
@@ -1,0 +1,39 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'goal_reengagement_service.dart';
+import 'daily_training_reminder_service.dart';
+import '../models/training_goal.dart';
+
+/// Schedules reminder push notifications for stale goals.
+class SmartPushSchedulerService {
+  final GoalReengagementService reengagement;
+  final DailyTrainingReminderService reminder;
+
+  SmartPushSchedulerService({
+    required this.reengagement,
+    required this.reminder,
+  });
+
+  /// Picks a stale goal and schedules a one-time push if allowed.
+  Future<void> maybeScheduleReminderPush() async {
+    final TrainingGoal? goal = await reengagement.pickReengagementGoal();
+    final tag = goal?.tag?.trim().toLowerCase();
+    if (tag == null || tag.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'push_last_shown:$tag';
+    final lastStr = prefs.getString(key);
+    if (lastStr != null) {
+      final last = DateTime.tryParse(lastStr);
+      if (last != null &&
+          DateTime.now().difference(last) < const Duration(hours: 48)) {
+        return;
+      }
+    }
+
+    final body = "Цель '$tag' ждёт вашего возвращения. Продолжим?";
+    await reminder.scheduleOneTimePush(body);
+    await prefs.setString(key, DateTime.now().toIso8601String());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `SmartPushSchedulerService` for scheduling push reminders on stale goals
- extend `DailyTrainingReminderService` with push scheduling capability
- register `SmartPushSchedulerService` and `GoalReengagementService` in providers

## Testing
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881cccfbbc4832ab505b13b51cfaa3d