### PR TITLE
Implement TrainingReminderPushService for stale goal pushes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,8 @@ import 'services/cloud_sync_service.dart';
 import 'services/auth_service.dart';
 import 'services/connectivity_sync_controller.dart';
 import 'services/training_session_service.dart';
+import 'services/training_reminder_push_service.dart';
+import 'services/goal_reengagement_service.dart';
 import 'services/personal_recommendation_service.dart';
 import 'services/notification_service.dart';
 import 'services/daily_challenge_notification_service.dart';
@@ -226,6 +228,10 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     NotificationService.startRecommendedPackTask(context);
     unawaited(context.read<LearningPathSummaryCache>().refresh());
     unawaited(context.read<DailyAppCheckService>().run(context));
+    unawaited(TrainingReminderPushService.instance.reschedule(
+      reengagement: context.read<GoalReengagementService>(),
+      sessions: context.read<TrainingSessionService>(),
+    ));
     unawaited(context.read<SkillLossOverlayPromptService>().run(context));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeStartPinnedTraining();

--- a/lib/services/training_reminder_push_service.dart
+++ b/lib/services/training_reminder_push_service.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'app_settings_service.dart';
+import 'goal_reengagement_service.dart';
+import 'training_session_service.dart';
+
+/// Schedules reminder pushes for stale training goals.
+class TrainingReminderPushService {
+  TrainingReminderPushService._();
+  static final TrainingReminderPushService instance =
+      TrainingReminderPushService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+
+  static const _lastKey = 'training_goal_push_last';
+  static const _id = 308;
+
+  Future<void> _init() async {
+    if (_initialized) return;
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    await _plugin.initialize(const InitializationSettings(android: android, iOS: ios));
+    tz.initializeTimeZones();
+    _initialized = true;
+  }
+
+  /// Cancels any scheduled reminder.
+  Future<void> cancelAll() async {
+    await _init();
+    await _plugin.cancel(_id);
+  }
+
+  /// Reschedules the next reminder push if conditions allow.
+  Future<void> reschedule({
+    required GoalReengagementService reengagement,
+    required TrainingSessionService sessions,
+  }) async {
+    await _init();
+    await AppSettingsService.instance.load();
+    if (!AppSettingsService.instance.notificationsEnabled) return;
+
+    await _plugin.cancel(_id);
+
+    if (sessions.currentSession != null && !sessions.isCompleted) return;
+
+    final goal = await reengagement.pickReengagementGoal();
+    final tag = goal?.tag?.trim().toLowerCase();
+    if (tag == null || tag.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastKey);
+    if (lastStr != null) {
+      final last = DateTime.tryParse(lastStr);
+      if (last != null && DateTime.now().difference(last).inHours < 24) {
+        return;
+      }
+    }
+
+    final now = tz.TZDateTime.now(tz.local);
+    var when = tz.TZDateTime(tz.local, now.year, now.month, now.day, 11);
+    if (!when.isAfter(now)) {
+      when = when.add(const Duration(days: 1));
+    }
+
+    final body = '⏱️ Продолжите цель: $tag';
+    await _plugin.zonedSchedule(
+      _id,
+      'Poker Analyzer',
+      body,
+      when,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('training_goal_reminder', 'Training Goal Reminder'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+
+    await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+  }
+}
+

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -27,6 +27,7 @@ import '../models/v2/training_action.dart';
 import '../models/v2/focus_goal.dart';
 import '../models/category_progress.dart';
 import 'daily_reminder_scheduler.dart';
+import 'training_reminder_push_service.dart';
 import 'tag_mastery_service.dart';
 
 class TrainingSessionService extends ChangeNotifier {
@@ -336,6 +337,7 @@ class TrainingSessionService extends ChangeNotifier {
   }) async {
     if (persist) await _openBox();
     unawaited(DailyReminderScheduler.instance.cancelAll());
+    unawaited(TrainingReminderPushService.instance.cancelAll());
     if (template.tags.contains('customPath')) {
       unawaited(LearningPathProgressService.instance.markCustomPathStarted());
     }


### PR DESCRIPTION
## Summary
- add `TrainingReminderPushService` to schedule daily goal reminder notifications
- invoke the new service on app start and when starting a training session

## Testing
- `flutter analyze` *(fails: 5769 issues reported)*

------
https://chatgpt.com/codex/tasks/task_e_6881d22fd79c832a8eb979273cffe01c