### PR TITLE
Implement training streak tracker

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -120,6 +120,7 @@ import 'mistake_insight_screen.dart';
 import 'cluster_mistake_dashboard_screen.dart';
 import '../services/lesson_path_reminder_scheduler.dart';
 import '../services/lesson_streak_engine.dart';
+import '../services/training_streak_tracker_service.dart';
 
 class DevMenuScreen extends StatefulWidget {
   const DevMenuScreen({super.key});
@@ -169,6 +170,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _reminderLoading = false;
   bool _progressExportLoading = false;
   bool _progressImportLoading = false;
+  bool _trainingStreakExportLoading = false;
   bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
@@ -1514,6 +1516,19 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _progressImportLoading = false);
   }
 
+  Future<void> _exportTrainingStreak() async {
+    if (_trainingStreakExportLoading || !kDebugMode) return;
+    setState(() => _trainingStreakExportLoading = true);
+    final data = await TrainingStreakTrackerService.instance.exportData();
+    await Clipboard.setData(ClipboardData(text: jsonEncode(data)));
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Training streak copied to clipboard')),
+      );
+    }
+    setState(() => _trainingStreakExportLoading = false);
+  }
+
   Future<void> _autoAdvancePack() async {
     if (_autoAdvanceLoading || !kDebugMode) return;
     setState(() => _autoAdvanceLoading = true);
@@ -2277,6 +2292,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📥 Импорт прогресса из буфера'),
                 onTap: _progressImportLoading ? null : _importLearningProgress,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📊 Export Training Streak'),
+                onTap: _trainingStreakExportLoading ? null : _exportTrainingStreak,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -19,6 +19,7 @@ import 'xp_reward_engine.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
 import 'streak_tracker_service.dart';
+import 'training_streak_tracker_service.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
@@ -504,6 +505,7 @@ class TrainingSessionService extends ChangeNotifier {
     for (final tag in _template!.tags) {
       unawaited(TagGoalTrackerService.instance.logTraining(tag));
     }
+    unawaited(TrainingStreakTrackerService.instance.markTrainingCompletedToday());
     unawaited(_clearIndex());
     final mastery = context.read<TagMasteryService>();
     final deltas = await mastery.updateWithSession(

--- a/lib/services/training_streak_tracker_service.dart
+++ b/lib/services/training_streak_tracker_service.dart
@@ -1,0 +1,82 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks days when the user completed at least one training session.
+/// Provides current and maximum streak information.
+class TrainingStreakTrackerService {
+  TrainingStreakTrackerService._();
+  static final TrainingStreakTrackerService instance =
+      TrainingStreakTrackerService._();
+
+  static const _datesKey = 'training_streak_days';
+
+  String _fmt(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  List<DateTime> _parseDates(List<String> list) {
+    return list
+        .map((e) => DateTime.tryParse(e))
+        .whereType<DateTime>()
+        .map((d) => DateTime(d.year, d.month, d.day))
+        .toList()
+      ..sort();
+  }
+
+  Future<void> markTrainingCompletedToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final days = prefs.getStringList(_datesKey) ?? <String>[];
+    final today = DateTime.now();
+    final todayStr = _fmt(today);
+    if (!days.contains(todayStr)) {
+      days.add(todayStr);
+      days.sort();
+      await prefs.setStringList(_datesKey, days);
+    }
+  }
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dates = _parseDates(prefs.getStringList(_datesKey) ?? <String>[]);
+    if (dates.isEmpty) return 0;
+    final set = dates.toSet();
+    var day = DateTime.now();
+    day = DateTime(day.year, day.month, day.day);
+    int streak = 0;
+    while (set.contains(day)) {
+      streak += 1;
+      day = day.subtract(const Duration(days: 1));
+    }
+    return streak;
+  }
+
+  Future<int> getMaxStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dates = _parseDates(prefs.getStringList(_datesKey) ?? <String>[]);
+    if (dates.isEmpty) return 0;
+    int best = 1;
+    int current = 1;
+    for (var i = 1; i < dates.length; i++) {
+      final diff = dates[i].difference(dates[i - 1]).inDays;
+      if (diff == 1) {
+        current += 1;
+      } else if (diff > 1) {
+        if (current > best) best = current;
+        current = 1;
+      }
+    }
+    if (current > best) best = current;
+    return best;
+  }
+
+  /// Returns a map with all stored dates and streak info for analytics.
+  Future<Map<String, dynamic>> exportData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final days = prefs.getStringList(_datesKey) ?? <String>[];
+    final current = await getCurrentStreak();
+    final max = await getMaxStreak();
+    return {
+      'days': days,
+      'currentStreak': current,
+      'maxStreak': max,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- track daily trainings via `TrainingStreakTrackerService`
- mark trainings as completed in `TrainingSessionService`
- allow exporting streak data from Dev menu

## Testing
- `dart analyze` *(fails: many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6881d580c744832a9c7be2c4c3eba72e