### PR TITLE
Implement streak reward engine

### DIFF
--- a/lib/services/streak_reward_engine.dart
+++ b/lib/services/streak_reward_engine.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../widgets/confetti_overlay.dart';
+import 'dev_console_log_service.dart';
+import 'training_streak_tracker_service.dart';
+import 'xp_reward_engine.dart';
+import '../main.dart';
+
+/// Rewards users for reaching training streak milestones.
+class StreakRewardEngine {
+  StreakRewardEngine._();
+  static final StreakRewardEngine instance = StreakRewardEngine._();
+
+  static const _rewardKey = 'streak_reward_levels';
+  static const Map<int, int> _rewards = {
+    3: 25,
+    7: 50,
+    14: 75,
+    30: 100,
+    60: 150,
+    100: 200,
+  };
+
+  Future<void> checkAndTriggerRewards() async {
+    final prefs = await SharedPreferences.getInstance();
+    final unlocked = prefs.getStringList(_rewardKey) ?? <String>[];
+    final current = await TrainingStreakTrackerService.instance.getCurrentStreak();
+    bool updated = false;
+    for (final entry in _rewards.entries) {
+      final level = entry.key;
+      if (current >= level && !unlocked.contains(level.toString())) {
+        final xp = entry.value;
+        unlocked.add(level.toString());
+        updated = true;
+        DevConsoleLogService.instance.log('Streak reward unlocked: $level days');
+        await XPRewardEngine.instance.addXp(xp);
+        final ctx = navigatorKey.currentContext;
+        if (ctx != null) {
+          showConfettiOverlay(ctx);
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            SnackBar(content: Text('🔥 $level-day streak! +$xp XP')),
+          );
+        }
+      }
+    }
+    if (updated) {
+      await prefs.setStringList(_rewardKey, unlocked);
+    }
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -16,6 +16,7 @@ import 'learning_path_personalization_service.dart';
 import 'xp_tracker_service.dart';
 import 'tag_goal_tracker_service.dart';
 import 'xp_reward_engine.dart';
+import 'streak_reward_engine.dart';
 import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
 import 'streak_tracker_service.dart';
@@ -506,6 +507,7 @@ class TrainingSessionService extends ChangeNotifier {
       unawaited(TagGoalTrackerService.instance.logTraining(tag));
     }
     unawaited(TrainingStreakTrackerService.instance.markTrainingCompletedToday());
+    unawaited(StreakRewardEngine.instance.checkAndTriggerRewards());
     unawaited(_clearIndex());
     final mastery = context.read<TagMasteryService>();
     final deltas = await mastery.updateWithSession(


### PR DESCRIPTION
## Summary
- reward users for training streaks in `StreakRewardEngine`
- trigger streak rewards when completing a training session

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d984d898832aa78bd9f6a7584a5a