### PR TITLE
Add training streak indicator

### DIFF
--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -21,6 +21,7 @@ import '../widgets/tag_insight_reminder_card.dart';
 import '../widgets/review_path_card.dart';
 import '../widgets/smart_recovery_banner.dart';
 import '../widgets/streak_recovery_block.dart';
+import '../widgets/training_streak_indicator.dart';
 import '../models/training_attempt.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
@@ -29,7 +30,8 @@ class LearningDashboardScreen extends StatefulWidget {
   const LearningDashboardScreen({super.key});
 
   @override
-  State<LearningDashboardScreen> createState() => _LearningDashboardScreenState();
+  State<LearningDashboardScreen> createState() =>
+      _LearningDashboardScreenState();
 }
 
 class _DashboardData {
@@ -105,9 +107,7 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
     );
 
     final deltas = await context.read<TagMasteryService>().computeDelta();
-    final top = deltas.entries
-        .where((e) => e.value > 0)
-        .toList()
+    final top = deltas.entries.where((e) => e.value > 0).toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     final improvements = {
       for (final e in top.take(3)) e.key: e.value,
@@ -170,7 +170,9 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
           const SizedBox(height: 4),
           Text(value,
               style: const TextStyle(
-                  color: Colors.white, fontWeight: FontWeight.bold, fontSize: 20)),
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 20)),
         ],
       ),
     );
@@ -216,13 +218,15 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
           );
         }
         final data = snapshot.data!;
-        final completion = (data.progress.completionRate * 100).toStringAsFixed(0);
-        final streak = data.progress.streakDays;
+        final completion =
+            (data.progress.completionRate * 100).toStringAsFixed(0);
         return Scaffold(
           appBar: AppBar(title: const Text('Learning Dashboard')),
           body: ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              const TrainingStreakIndicator(),
+              const SizedBox(height: 12),
               const StreakRecoveryBlock(),
               if (data.reviews.isNotEmpty) ...[
                 WeaknessReviewSection(
@@ -230,15 +234,13 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
                   onTap: _handlePackLaunch,
                 ),
                 const SizedBox(height: 12),
-              ]
-              else if (_recommendationCards.isNotEmpty) ...[
+              ] else if (_recommendationCards.isNotEmpty) ...[
                 FeedRecommendationWidget(
                   cards: _recommendationCards,
                   onTap: _handlePackLaunch,
                 ),
                 const SizedBox(height: 12),
-              ]
-              else if (data.nextPack != null) ...[
+              ] else if (data.nextPack != null) ...[
                 const NextUpBanner(),
                 const SizedBox(height: 12),
               ],
@@ -248,8 +250,6 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
               _section('🎯 Completion', '$completion% complete'),
               const SizedBox(height: 12),
               _improvements(data.improvements),
-              const SizedBox(height: 12),
-              _section('🔥 Streak', '$streak-day streak'),
               const SizedBox(height: 12),
               const TagInsightReminderCard(),
               const SizedBox(height: 12),

--- a/lib/widgets/training_streak_indicator.dart
+++ b/lib/widgets/training_streak_indicator.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import '../services/training_streak_tracker_service.dart';
+
+/// Displays current and maximum training streak.
+class TrainingStreakIndicator extends StatefulWidget {
+  const TrainingStreakIndicator({super.key});
+
+  @override
+  State<TrainingStreakIndicator> createState() =>
+      _TrainingStreakIndicatorState();
+}
+
+class _TrainingStreakIndicatorState extends State<TrainingStreakIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fade;
+  int? _current;
+  int _max = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _fade = Tween(begin: 1.0, end: 0.2).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    final current =
+        await TrainingStreakTrackerService.instance.getCurrentStreak();
+    final max = await TrainingStreakTrackerService.instance.getMaxStreak();
+    if (!mounted) return;
+    setState(() {
+      _current = current;
+      _max = max;
+    });
+    if (current >= 1) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = _current;
+    if (current == null || current < 1) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FadeTransition(
+            opacity: _fade,
+            child: Text('🔥', style: TextStyle(color: accent, fontSize: 20)),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            '$current-day streak',
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            '🔥 Max: $_max',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show TrainingStreakIndicator on LearningDashboardScreen
- implement TrainingStreakIndicator widget with blinking flame icon

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6881daa2f174832aae57341316cdeab2