### PR TITLE
Add LevelBadgeWidget to dashboard

### DIFF
--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/review_path_card.dart';
 import '../widgets/smart_recovery_banner.dart';
 import '../widgets/streak_recovery_block.dart';
 import '../widgets/training_streak_indicator.dart';
+import '../widgets/level_badge_widget.dart';
 import '../models/training_attempt.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
@@ -226,6 +227,8 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
             padding: const EdgeInsets.all(16),
             children: [
               const TrainingStreakIndicator(),
+              const SizedBox(height: 12),
+              const LevelBadgeWidget(),
               const SizedBox(height: 12),
               const StreakRecoveryBlock(),
               if (data.reviews.isNotEmpty) ...[

--- a/lib/widgets/level_badge_widget.dart
+++ b/lib/widgets/level_badge_widget.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/xp_tracker_service.dart';
+
+/// Displays the current level and progress toward the next level.
+class LevelBadgeWidget extends StatelessWidget {
+  const LevelBadgeWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final xp = context.watch<XPTrackerService>();
+    final level = xp.level;
+    final progress = xp.progress.clamp(0.0, 1.0);
+    final currentXp = xp.xp;
+    final nextXp = xp.nextLevelXp;
+    final accent = Theme.of(context).colorScheme.secondary;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: accent,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '$level',
+              style: const TextStyle(
+                color: Colors.black,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Уровень $level',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation(accent),
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '$currentXp / $nextXp XP',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show current level progress with a new `LevelBadgeWidget`
- add the widget below `TrainingStreakIndicator` on the dashboard

## Testing
- `flutter analyze` *(fails: multiple lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6881ddcff9f4832abb0a6dea8f93e6e2