### PR TITLE
Add level up celebration engine

### DIFF
--- a/lib/services/level_up_celebration_engine.dart
+++ b/lib/services/level_up_celebration_engine.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../widgets/confetti_overlay.dart';
+import 'xp_level_engine.dart';
+import 'xp_reward_engine.dart';
+import '../main.dart';
+
+/// Triggers a celebration animation when the user levels up.
+class LevelUpCelebrationEngine {
+  LevelUpCelebrationEngine._();
+
+  /// Singleton instance.
+  static final LevelUpCelebrationEngine instance = LevelUpCelebrationEngine._();
+
+  static const _prefsKey = 'level_up_last';
+  static const int _bonusXp = 25;
+
+  /// Checks if XP increased enough to reach a new level and shows celebration.
+  Future<void> checkAndCelebrate(int oldXp, int newXp) async {
+    final oldLevel = XPLevelEngine.instance.getLevel(oldXp);
+    final newLevel = XPLevelEngine.instance.getLevel(newXp);
+    if (newLevel <= oldLevel) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getInt(_prefsKey) ?? 0;
+    if (newLevel <= last) return;
+
+    await prefs.setInt(_prefsKey, newLevel);
+    unawaited(XPRewardEngine.instance.addXp(_bonusXp));
+    final ctx = navigatorKey.currentContext;
+    if (ctx != null) {
+      showConfettiOverlay(ctx);
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(content: Text('🎉 Уровень $newLevel! +$_bonusXp XP')),
+      );
+      unawaited(SystemSound.play(SystemSoundType.alert));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `LevelUpCelebrationEngine` to play celebration animation when a new level is reached
- trigger this engine from `XPTrackerService.add`
- reward extra XP and show confetti/snackbar at level-up

## Testing
- `dart format lib/services/level_up_celebration_engine.dart lib/services/xp_tracker_service.dart`
- `flutter analyze` *(fails: 5774 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6881df552528832a8e90d6f1363c1fde