### PR TITLE
Add achievements screen

### DIFF
--- a/lib/screens/basic_achievements_screen.dart
+++ b/lib/screens/basic_achievements_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+
+import '../services/achievements_engine.dart';
+import '../models/achievement_basic.dart';
+
+class AchievementsScreen extends StatelessWidget {
+  const AchievementsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final achievements = context.watch<AchievementsEngine>().achievements;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Достижения'),
+        centerTitle: true,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final compact = constraints.maxWidth < 360;
+          final count = compact ? 1 : 2;
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: achievements.length,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: count,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 1.2,
+            ),
+            itemBuilder: (context, index) {
+              final a = achievements[index];
+              return _AchievementCard(a);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AchievementCard extends StatelessWidget {
+  final AchievementBasic achievement;
+  const _AchievementCard(this.achievement);
+
+  @override
+  Widget build(BuildContext context) {
+    final unlocked = achievement.isUnlocked;
+    final date = achievement.unlockDate;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                unlocked ? Icons.check_circle : Icons.lock_outline,
+                color: unlocked ? Colors.green : Colors.white54,
+              ),
+              const Spacer(),
+              if (date != null)
+                Text(
+                  DateFormat('dd.MM.yyyy', Intl.getCurrentLocale()).format(date),
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            achievement.title,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            achievement.description,
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -115,6 +115,7 @@ import '../services/learning_path_progress_service.dart';
 import '../services/achievement_trigger_engine.dart';
 import 'achievement_dashboard_screen.dart';
 import 'achievements_dashboard_screen.dart';
+import 'basic_achievements_screen.dart';
 import 'mistake_review_screen.dart';
 import 'mistake_insight_screen.dart';
 import 'cluster_mistake_dashboard_screen.dart';
@@ -2194,6 +2195,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                         builder: (_) => const AchievementDashboardScreen()),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🎖 Basic Achievements'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const AchievementsScreen()),
                   );
                 },
               ),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -12,6 +12,7 @@ import '../services/training_pack_cloud_sync_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
+import 'basic_achievements_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -262,6 +263,16 @@ class _ProfileScreenState extends State<ProfileScreen> {
           ),
           const SizedBox(height: 16),
           _buildChart(),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const AchievementsScreen()),
+              );
+            },
+            child: const Text('Достижения'),
+          ),
           const SizedBox(height: 16),
           Consumer<AuthService>(
             builder: (context, auth, child) {


### PR DESCRIPTION
## Summary
- add new `AchievementsScreen` for basic achievements
- integrate it into Dev Menu and Profile screens

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e4f09b4c832aa5f58672226d369f