### PR TITLE
Add basic shop screen

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -48,6 +48,7 @@ import 'weakness_overview_screen.dart';
 import 'learning_dashboard_screen.dart';
 import 'notification_settings_screen.dart';
 import 'dev_menu_screen.dart';
+import 'shop_screen.dart';
 import 'package:provider/provider.dart';
 import '../utils/route_link.dart';
 import '../services/learning_path_registry_service.dart';
@@ -368,6 +369,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
                     ),
                   );
                   break;
+                case 'shop':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ShopScreen()),
+                  );
+                  break;
                 case 'about':
                   showAboutDialog(context: context);
                   break;
@@ -387,6 +394,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
               PopupMenuItem(value: 'tracks', child: Text('🎓 Треки')),
               PopupMenuItem(value: 'dashboard', child: Text('📈 Dashboard')),
               PopupMenuItem(value: 'dev', child: Text('Dev Menu')),
+              PopupMenuItem(value: 'shop', child: Text('🛒 Shop')),
               PopupMenuItem(value: 'about', child: Text('About')),
             ],
           ),

--- a/lib/screens/shop_screen.dart
+++ b/lib/screens/shop_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/coins_service.dart';
+import '../shop/shop_items.dart';
+import '../shop/shop_item.dart';
+
+class ShopScreen extends StatelessWidget {
+  const ShopScreen({super.key});
+
+  Future<void> _buy(BuildContext context, ShopItem item) async {
+    final coins = context.read<CoinsService>();
+    if (coins.coins < item.price) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Недостаточно монет')),
+      );
+      return;
+    }
+    final ok = await coins.spendCoins(item.price);
+    if (!ok) return;
+    await item.onPurchase(context);
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Куплено: ${item.name}')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final balance = context.watch<CoinsService>().coins;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Shop'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Монеты: $balance',
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 16),
+          for (final item in shopItems)
+            Card(
+              color: Colors.grey[850],
+              child: ListTile(
+                leading: Icon(item.icon, color: Colors.orange),
+                title: Text(item.name),
+                subtitle: Text('${item.description}\nЦена: ${item.price}'),
+                isThreeLine: true,
+                onTap: () => _buy(context, item),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/coins_service.dart
+++ b/lib/services/coins_service.dart
@@ -31,4 +31,13 @@ class CoinsService extends ChangeNotifier {
     await _save();
     notifyListeners();
   }
+
+  Future<bool> spendCoins(int amount) async {
+    if (amount <= 0) return true;
+    if (_coins < amount) return false;
+    _coins -= amount;
+    await _save();
+    notifyListeners();
+    return true;
+  }
 }

--- a/lib/shop/shop_item.dart
+++ b/lib/shop/shop_item.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class ShopItem {
+  final String id;
+  final String name;
+  final String description;
+  final int price;
+  final IconData icon;
+  final Future<void> Function(BuildContext context) onPurchase;
+
+  const ShopItem({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.price,
+    required this.icon,
+    required this.onPurchase,
+  });
+}

--- a/lib/shop/shop_items.dart
+++ b/lib/shop/shop_items.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/xp_tracker_service.dart';
+import '../services/theme_service.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../services/training_session_service.dart';
+import '../screens/training_session_screen.dart';
+import 'shop_item.dart';
+
+final List<ShopItem> shopItems = [
+  ShopItem(
+    id: 'xp_booster',
+    name: 'Бустер XP',
+    description: '+100 XP',
+    price: 50,
+    icon: Icons.flash_on,
+    onPurchase: (context) async {
+      await context.read<XPTrackerService>().add(xp: 100, source: 'shop');
+    },
+  ),
+  ShopItem(
+    id: 'avatar_color',
+    name: 'Цвет аватара',
+    description: 'Изменить цвет профиля',
+    price: 30,
+    icon: Icons.brush,
+    onPurchase: (context) async {
+      final colors = [Colors.orange, Colors.pinkAccent, Colors.lightBlueAccent];
+      final color = colors[Random().nextInt(colors.length)];
+      await context.read<ThemeService>().setAccentColor(color);
+    },
+  ),
+  ShopItem(
+    id: 'bonus_pack',
+    name: 'Бонусный пак',
+    description: 'Случайный YAML',
+    price: 40,
+    icon: Icons.card_giftcard,
+    onPurchase: (context) async {
+      await TrainingPackLibraryV2.instance.loadFromFolder();
+      final packs = TrainingPackLibraryV2.instance.packs;
+      if (packs.isEmpty) return;
+      final pack = packs[Random().nextInt(packs.length)];
+      await context.read<TrainingSessionService>().startSession(pack);
+      if (!context.mounted) return;
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+      );
+    },
+  ),
+];


### PR DESCRIPTION
## Summary
- enable spending coins in `CoinsService`
- list purchasable items in new `shop` directory
- allow buying XP, color customization, or a random pack
- add `ShopScreen` and open it from main menu

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e8504a4c832aa3e8fc6c72fc9879