### PR TITLE
Add SessionStreakTrackerService

### DIFF
--- a/lib/services/session_streak_tracker_service.dart
+++ b/lib/services/session_streak_tracker_service.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import 'coins_service.dart';
+import 'xp_reward_engine.dart';
+
+/// Tracks consecutive days with completed training sessions
+/// and triggers rewards at specific thresholds.
+class SessionStreakTrackerService {
+  SessionStreakTrackerService._();
+  static final SessionStreakTrackerService instance =
+      SessionStreakTrackerService._();
+
+  static const _lastDateKey = 'session_streak_last';
+  static const _countKey = 'session_streak_count';
+  static const _avatarBonusKey = 'session_streak_avatar_bonus';
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_countKey) ?? 0;
+  }
+
+  Future<void> markCompletedToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastDateKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    int streak = prefs.getInt(_countKey) ?? 0;
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 0) {
+        return;
+      } else if (diff == 1) {
+        streak += 1;
+      } else {
+        streak = 1;
+      }
+    } else {
+      streak = 1;
+    }
+    await prefs.setInt(_countKey, streak);
+    await prefs.setString(_lastDateKey, today.toIso8601String());
+  }
+
+  Future<void> checkAndTriggerRewards() async {
+    final prefs = await SharedPreferences.getInstance();
+    final ctx = navigatorKey.currentContext;
+    final streak = prefs.getInt(_countKey) ?? 0;
+    bool updated = false;
+    if (streak >= 3 && !(prefs.getBool('reward_3') ?? false)) {
+      await CoinsService.instance.addCoins(10);
+      if (ctx != null) {
+        ScaffoldMessenger.of(ctx)
+            .showSnackBar(const SnackBar(content: Text('+10 coins for 3-day streak!')));
+      }
+      await prefs.setBool('reward_3', true);
+      updated = true;
+    }
+    if (streak >= 5 && !(prefs.getBool('reward_5') ?? false)) {
+      await XPRewardEngine.instance.addXp(20);
+      if (ctx != null) {
+        ScaffoldMessenger.of(ctx)
+            .showSnackBar(const SnackBar(content: Text('+20 XP for 5-day streak!')));
+      }
+      await prefs.setBool('reward_5', true);
+      updated = true;
+    }
+    if (streak >= 10 && !(prefs.getBool('reward_10') ?? false)) {
+      await CoinsService.instance.addCoins(50);
+      await prefs.setBool(_avatarBonusKey, true);
+      if (ctx != null) {
+        ScaffoldMessenger.of(ctx).showSnackBar(const SnackBar(
+            content: Text('🔥 10-day streak! +50 coins and avatar bonus unlocked!')));
+      }
+      await prefs.setBool('reward_10', true);
+      updated = true;
+    }
+    if (updated) {
+      // Persisted via prefs already
+    }
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -32,6 +32,7 @@ import 'daily_reminder_scheduler.dart';
 import 'training_reminder_push_service.dart';
 import 'tag_mastery_service.dart';
 import 'gift_drop_service.dart';
+import 'session_streak_tracker_service.dart';
 
 class TrainingSessionService extends ChangeNotifier {
   Box<dynamic>? _box;
@@ -512,6 +513,8 @@ class TrainingSessionService extends ChangeNotifier {
     unawaited(context
         .read<GiftDropService>()
         .checkAndDropGift(context: context));
+    unawaited(SessionStreakTrackerService.instance.markCompletedToday());
+    unawaited(SessionStreakTrackerService.instance.checkAndTriggerRewards());
     unawaited(_clearIndex());
     final mastery = context.read<TagMasteryService>();
     final deltas = await mastery.updateWithSession(


### PR DESCRIPTION
## Summary
- implement `SessionStreakTrackerService` to track consecutive training days
- reward coins/XP and avatar bonus at streak milestones
- integrate new tracker in `TrainingSessionService`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ec39491c832a9f2144899a55ef61