### PR TITLE
Add session streak overlay prompt

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -118,6 +118,7 @@ import 'services/learning_path_reminder_engine.dart';
 import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/gift_drop_service.dart';
+import 'services/session_streak_overlay_prompt_service.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -559,6 +560,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       ),
     ),
     Provider(create: (_) => GiftDropService()),
+    Provider(create: (_) => SessionStreakOverlayPromptService()),
   ];
 }
 

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -56,6 +56,7 @@ import 'learning_path_screen_v2.dart';
 import '../widgets/sync_status_widget.dart';
 import '../user_preferences.dart';
 import '../services/gift_drop_service.dart';
+import '../services/session_streak_overlay_prompt_service.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -85,6 +86,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
       _maybeLaunchScheduledTraining();
       _handleDeepLink();
       context.read<GiftDropService>().checkAndDropGift(context: context);
+      context.read<SessionStreakOverlayPromptService>().run(context);
     });
   }
 

--- a/lib/services/session_streak_overlay_prompt_service.dart
+++ b/lib/services/session_streak_overlay_prompt_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../widgets/session_streak_overlay.dart';
+import 'session_streak_tracker_service.dart';
+
+/// Shows a temporary overlay banner with the current training session streak.
+class SessionStreakOverlayPromptService {
+  Future<void> run(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    final streak = await SessionStreakTrackerService.instance.getCurrentStreak();
+    if (streak <= 0) return;
+    if (prefs.getBool('reward_10') ?? false) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+
+    late OverlayEntry entry;
+    void close() => entry.remove();
+    entry = OverlayEntry(
+      builder: (_) => SessionStreakOverlay(streak: streak, onDismiss: close),
+    );
+    overlay.insert(entry);
+  }
+}

--- a/lib/widgets/session_streak_overlay.dart
+++ b/lib/widgets/session_streak_overlay.dart
@@ -1,0 +1,80 @@
+
+import 'package:flutter/material.dart';
+
+class SessionStreakOverlay extends StatefulWidget {
+  final int streak;
+  final VoidCallback onDismiss;
+
+  const SessionStreakOverlay({super.key, required this.streak, required this.onDismiss});
+
+  @override
+  State<SessionStreakOverlay> createState() => _SessionStreakOverlayState();
+}
+
+class _SessionStreakOverlayState extends State<SessionStreakOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+    Future.delayed(const Duration(seconds: 3), _dismiss);
+  }
+
+  Future<void> _dismiss() async {
+    await _controller.reverse();
+    if (mounted) widget.onDismiss();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Positioned(
+      top: 20,
+      left: 0,
+      right: 0,
+      child: SafeArea(
+        child: GestureDetector(
+          onTap: _dismiss,
+          child: FadeTransition(
+            opacity: _controller,
+            child: Material(
+              color: Colors.transparent,
+              child: Center(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  margin: const EdgeInsets.symmetric(horizontal: 16),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[850],
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.local_fire_department, color: accent),
+                      const SizedBox(width: 8),
+                      Text(
+                        '🔥 \u0421\u0435\u0440\u0438\u044f: ${widget.streak} \u0434\u043d\u0435\u0439',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- display temporary overlay about active training session streak
- provide `SessionStreakOverlayPromptService`
- show overlay in `MainNavigationScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ed628408832aa0b60555db409730