### PR TITLE
Add SmartSpotInjector

### DIFF
--- a/lib/repositories/training_pack_repository.dart
+++ b/lib/repositories/training_pack_repository.dart
@@ -1,0 +1,23 @@
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+
+/// Provides access to training spots stored in the built-in library.
+class TrainingPackRepository {
+  const TrainingPackRepository();
+
+  /// Returns all spots that contain [tag] in their tag list.
+  Future<List<TrainingPackSpot>> getSpotsByTag(String tag) async {
+    final lower = tag.trim().toLowerCase();
+    if (lower.isEmpty) return [];
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final result = <TrainingPackSpot>[];
+    for (final pack in TrainingPackLibraryV2.instance.packs) {
+      for (final s in pack.spots) {
+        if (s.tags.any((t) => t.toLowerCase() == lower)) {
+          result.add(TrainingPackSpot.fromJson(s.toJson()));
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -76,6 +76,7 @@ import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
 import '../services/smart_stage_unlock_engine.dart';
 import '../services/learning_path_service.dart';
+import '../services/smart_spot_injector.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -175,6 +176,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _autoAdvanceLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
+  bool _injectWeakSpots = false;
   bool _showCompletedGoals = false;
   bool _achievementsCheckLoading = false;
   int _lessonStreak = 0;
@@ -2256,6 +2258,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 onChanged: (v) {
                   setState(() => _smartMode = v ?? false);
                   LearningPathService.instance.smartMode = _smartMode;
+                },
+              ),
+            if (kDebugMode)
+              CheckboxListTile(
+                title:
+                    const Text('Inject weakness spots at start of training'),
+                value: _injectWeakSpots,
+                activeColor: Colors.greenAccent,
+                onChanged: (v) {
+                  setState(() => _injectWeakSpots = v ?? false);
+                  SmartSpotInjector.instance.enabled = _injectWeakSpots;
                 },
               ),
             if (kDebugMode)

--- a/lib/services/smart_spot_injector.dart
+++ b/lib/services/smart_spot_injector.dart
@@ -1,0 +1,62 @@
+import '../models/v2/training_pack_spot.dart';
+import 'weakness_cluster_engine.dart';
+import 'tag_mastery_service.dart';
+import 'session_log_service.dart';
+import '../repositories/training_pack_repository.dart';
+
+/// Injects targeted spots at the start of a training pack based on player's weaknesses.
+class SmartSpotInjector {
+  SmartSpotInjector({
+    this.clusterEngine = const WeaknessClusterEngine(),
+    this.repository = const TrainingPackRepository(),
+  });
+
+  static final SmartSpotInjector instance = SmartSpotInjector();
+
+  /// When disabled, [injectWeaknessSpots] returns [originalSpots] unchanged.
+  bool enabled = false;
+
+  final WeaknessClusterEngine clusterEngine;
+  final TrainingPackRepository repository;
+
+  /// Returns [originalSpots] prefixed with up to three weakness spots.
+  Future<List<TrainingPackSpot>> injectWeaknessSpots({
+    required List<TrainingPackSpot> originalSpots,
+    required SessionLogService logs,
+    required TagMasteryService mastery,
+    int maxSpots = 3,
+  }) async {
+    if (!enabled) return originalSpots;
+
+    await logs.load();
+    final progress = await logs.getUserProgress();
+    final masteryMap = await mastery.computeMastery();
+    final clusters = clusterEngine.detectWeaknesses(
+      results: progress.history,
+      tagMastery: masteryMap,
+    );
+
+    final weakTags = <String>[];
+    for (final c in clusters) {
+      final value = masteryMap[c.tag] ?? 1.0;
+      if (value < 0.5) weakTags.add(c.tag);
+      if (weakTags.length >= maxSpots) break;
+    }
+
+    final added = <TrainingPackSpot>[];
+    final used = <String>{};
+    for (final tag in weakTags) {
+      final spots = await repository.getSpotsByTag(tag);
+      for (final s in spots) {
+        if (used.add(s.id)) {
+          added.add(TrainingPackSpot.fromJson(s.toJson()));
+          if (added.length >= maxSpots) break;
+        }
+      }
+      if (added.length >= maxSpots) break;
+    }
+
+    if (added.isEmpty) return originalSpots;
+    return [...added, ...originalSpots];
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -31,6 +31,8 @@ import '../models/category_progress.dart';
 import 'daily_reminder_scheduler.dart';
 import 'training_reminder_push_service.dart';
 import 'tag_mastery_service.dart';
+import 'session_log_service.dart';
+import 'smart_spot_injector.dart';
 import 'gift_drop_service.dart';
 import 'session_streak_tracker_service.dart';
 
@@ -350,6 +352,17 @@ class TrainingSessionService extends ChangeNotifier {
     _preEvPct = total == 0 ? 0 : template.evCovered * 100 / total;
     _preIcmPct = total == 0 ? 0 : template.icmCovered * 100 / total;
     _spots = List<TrainingPackSpot>.from(template.spots);
+
+    if (SmartSpotInjector.instance.enabled) {
+      final logs = SessionLogService(sessions: this);
+      final mastery = TagMasteryService(logs: logs);
+      _spots = await SmartSpotInjector.instance.injectWeaknessSpots(
+        originalSpots: _spots,
+        logs: logs,
+        mastery: mastery,
+      );
+      logs.dispose();
+    }
     _evAverageAll = 0;
     _icmAverageAll = 0;
     if (_spots.isNotEmpty) {


### PR DESCRIPTION
## Summary
- inject weakness spots when starting training
- repository to pull spots by tag
- dev menu toggle for spot injection

## Testing
- `dart` and `flutter` commands were unavailable in the environment

------
https://chatgpt.com/codex/tasks/task_e_6881ef122d38832aad86fda5a5b435cc