### PR TITLE
Add smart recovery stage generator

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -80,6 +80,7 @@ import 'pack_library_stats_screen.dart';
 import '../services/smart_stage_unlock_engine.dart';
 import '../services/learning_path_service.dart';
 import '../services/smart_spot_injector.dart';
+import '../services/learning_path_engine.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -181,6 +182,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _unlockStages = false;
   bool _smartMode = false;
   bool _injectWeakSpots = false;
+  bool _smartRecoveryStage = false;
   bool _showCompletedGoals = false;
   bool _achievementsCheckLoading = false;
   int _lessonStreak = 0;
@@ -2321,6 +2323,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 onChanged: (v) {
                   setState(() => _injectWeakSpots = v ?? false);
                   SmartSpotInjector.instance.enabled = _injectWeakSpots;
+                },
+              ),
+            if (kDebugMode)
+              CheckboxListTile(
+                title: const Text('🧠 Enable smart recovery stage'),
+                value: _smartRecoveryStage,
+                activeColor: Colors.greenAccent,
+                onChanged: (v) {
+                  setState(() => _smartRecoveryStage = v ?? false);
+                  LearningPathEngine.smartRecoveryEnabled = _smartRecoveryStage;
                 },
               ),
             if (kDebugMode)

--- a/lib/services/learning_path_engine.dart
+++ b/lib/services/learning_path_engine.dart
@@ -1,0 +1,61 @@
+import 'package:collection/collection.dart';
+
+import '../models/learning_path_stage_model.dart';
+import '../models/training_attempt.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'tag_mastery_service.dart';
+import 'weakness_cluster_engine_v2.dart';
+import 'training_pack_generator_v2.dart';
+
+/// Engine driving adaptive learning path stages.
+class LearningPathEngine {
+  /// Global toggle controlling smart recovery behavior.
+  static bool smartRecoveryEnabled = false;
+
+  final WeaknessClusterEngine clusterEngine;
+  final TagMasteryService masteryService;
+  final TrainingPackGeneratorV2 generator;
+
+  LearningPathEngine({
+    this.clusterEngine = const WeaknessClusterEngine(),
+    required this.masteryService,
+    TrainingPackGeneratorV2? generator,
+  }) : generator = generator ?? const TrainingPackGeneratorV2();
+
+  /// Returns the next training pack for [stage].
+  ///
+  /// When [smartRecoveryEnabled] is true and player's mastery over
+  /// [stage.tags] falls below 0.6, a custom recovery pack targeting the
+  /// weakest cluster is generated and returned.
+  Future<TrainingPackTemplateV2?> nextStage({
+    required LearningPathStageModel stage,
+    required List<TrainingPackTemplateV2> allPacks,
+    required List<TrainingAttempt> attempts,
+  }) async {
+    final defaultPack =
+        allPacks.firstWhereOrNull((p) => p.id == stage.packId);
+    if (!smartRecoveryEnabled) return defaultPack;
+
+    final masteryMap = await masteryService.computeMastery();
+    final tags = [for (final t in stage.tags) t.toLowerCase()];
+    if (tags.isNotEmpty) {
+      final values = [for (final t in tags) masteryMap[t] ?? 1.0];
+      final avg = values.reduce((a, b) => a + b) / values.length;
+      if (avg < 0.6) {
+        final clusters = clusterEngine.computeClusters(
+          attempts: attempts,
+          allPacks: allPacks,
+        );
+        if (clusters.isNotEmpty) {
+          final pack = await generator.generateFromWeakness(
+            cluster: clusters.first,
+            mastery: masteryMap,
+          );
+          pack.meta['isAdaptive'] = true;
+          return pack;
+        }
+      }
+    }
+    return defaultPack;
+  }
+}


### PR DESCRIPTION
## Summary
- create `LearningPathEngine` for adaptive stage selection
- add smart recovery toggle in dev menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f40a0cfc832aab228a4bc369375b