### PR TITLE
Implement training pack loader for stage seeding

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -1,5 +1,9 @@
 import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:yaml/yaml.dart';
+
+import '../../models/v2/training_pack_template_v2.dart';
 
 class YamlReader {
   const YamlReader();
@@ -7,5 +11,14 @@ class YamlReader {
   Map<String, dynamic> read(String source) {
     final doc = loadYaml(source);
     return jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
+  }
+
+  /// Loads a training pack template from [path]. The path can point to an asset
+  /// (starting with `assets/`) or to a file on disk.
+  Future<TrainingPackTemplateV2> loadTemplate(String path) async {
+    final source = path.startsWith('assets/')
+        ? await rootBundle.loadString(path)
+        : await File(path).readAsString();
+    return TrainingPackTemplateV2.fromYamlAuto(source);
   }
 }

--- a/lib/services/learning_path_stage_seeder.dart
+++ b/lib/services/learning_path_stage_seeder.dart
@@ -1,9 +1,5 @@
-import 'dart:io';
-import 'package:flutter/services.dart' show rootBundle;
-
 import '../core/training/generation/yaml_reader.dart';
 import '../models/learning_path_stage_model.dart';
-import '../models/v2/training_pack_template_v2.dart';
 import 'learning_path_stage_library.dart';
 
 class LearningPathStageSeeder {
@@ -16,10 +12,7 @@ class LearningPathStageSeeder {
     var order = 0;
     for (final path in yamlPaths) {
       try {
-        final source = path.startsWith('assets/')
-            ? await rootBundle.loadString(path)
-            : await File(path).readAsString();
-        final tpl = TrainingPackTemplateV2.fromYamlAuto(source);
+        final tpl = await reader.loadTemplate(path);
         if (tpl.audience != null && tpl.audience!.isNotEmpty && tpl.audience != audience) {
           continue;
         }


### PR DESCRIPTION
## Summary
- add `YamlReader.loadTemplate` for reading pack YAML files from disk or assets
- refactor `LearningPathStageSeeder` to use the new method

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688210ee9c18832a8f3c4a9f6e17e82b