### PR TITLE
Add advanced postflop jam packs

### DIFF
--- a/assets/learning_paths/advanced_path.yaml
+++ b/assets/learning_paths/advanced_path.yaml
@@ -1,0 +1,5 @@
+packs:
+  - assets/packs/advanced/flop_draw_shove_check.yaml
+  - assets/packs/advanced/overpair_vs_aggression.yaml
+  - assets/packs/advanced/double_barrel_jam.yaml
+  - assets/packs/advanced/delayed_shove_vs_missed_cbet.yaml

--- a/assets/packs/advanced/delayed_shove_vs_missed_cbet.yaml
+++ b/assets/packs/advanced/delayed_shove_vs_missed_cbet.yaml
@@ -1,0 +1,48 @@
+id: delayed_shove_vs_missed_cbet
+name: Delayed Shove vs Missed CBet
+audience: Advanced
+trainingType: postflop
+bb: 20
+gameType: tournament
+positions:
+  - sb
+  - bb
+tags:
+  - advanced
+  - postflop-jam
+  - tournament
+spots:
+  - id: dsvc_1
+    title: Turn shove after flop check-check
+    board: [8s,5h,3c,2s]
+    street: 2
+    villainAction: check
+    heroOptions:
+      - shove
+      - bet 4
+      - check
+    hand:
+      heroCards: As Qs
+      position: sb
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 20, '1': 20}
+      board: [8s,5h,3c,2s]
+  - id: dsvc_2
+    title: Flop shove vs missed cbet
+    board: [Kc,8d,4c]
+    street: 1
+    villainAction: check
+    heroOptions:
+      - shove
+      - check
+    hand:
+      heroCards: As 4d
+      position: sb
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 15, '1': 15}
+      board: [Kc,8d,4c]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/advanced/double_barrel_jam.yaml
+++ b/assets/packs/advanced/double_barrel_jam.yaml
@@ -1,0 +1,48 @@
+id: double_barrel_jam
+name: Turn Barrel Jam
+audience: Advanced
+trainingType: postflop
+bb: 25
+gameType: tournament
+positions:
+  - btn
+  - bb
+tags:
+  - advanced
+  - postflop-jam
+  - tournament
+spots:
+  - id: dbj_1
+    title: Jam turn after flop cbet with AK
+    board: [Qh,8d,2s,5h]
+    street: 2
+    villainAction: check
+    heroOptions:
+      - shove
+      - check
+    hand:
+      heroCards: Ah Kh
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+      board: [Qh,8d,2s,5h]
+  - id: dbj_2
+    title: Jam turn with pair+draw vs bet
+    board: [Jc,9c,4s,6d]
+    street: 2
+    villainAction: bet
+    heroOptions:
+      - shove
+      - call
+      - fold
+    hand:
+      heroCards: Tc 9d
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 30, '1': 30}
+      board: [Jc,9c,4s,6d]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/advanced/flop_draw_shove_check.yaml
+++ b/assets/packs/advanced/flop_draw_shove_check.yaml
@@ -1,0 +1,48 @@
+id: flop_draw_shove_check
+name: Flop Draw Shove or Check
+audience: Advanced
+trainingType: postflop
+bb: 25
+gameType: tournament
+positions:
+  - btn
+  - bb
+tags:
+  - advanced
+  - postflop-jam
+  - tournament
+spots:
+  - id: fdsc_1
+    title: Shove nut flush draw on flop after check
+    board: [Ah,7h,3c]
+    street: 1
+    villainAction: check
+    heroOptions:
+      - shove
+      - check
+    hand:
+      heroCards: Kh Th
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+      board: [Ah,7h,3c]
+  - id: fdsc_2
+    title: OESD vs flop bet
+    board: [9s,8d,2c]
+    street: 1
+    villainAction: bet
+    heroOptions:
+      - shove
+      - call
+      - fold
+    hand:
+      heroCards: 7h 6h
+      position: bb
+      heroIndex: 1
+      playerCount: 2
+      stacks: {'0': 20, '1': 20}
+      board: [9s,8d,2c]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/advanced/overpair_vs_aggression.yaml
+++ b/assets/packs/advanced/overpair_vs_aggression.yaml
@@ -1,0 +1,48 @@
+id: overpair_vs_aggression
+name: Overpair vs Aggression
+audience: Advanced
+trainingType: postflop
+bb: 30
+gameType: tournament
+positions:
+  - co
+  - bb
+tags:
+  - advanced
+  - postflop-jam
+  - tournament
+spots:
+  - id: ova_1
+    title: JJ facing raise on flop 25bb
+    board: [8c,5d,2s]
+    street: 1
+    villainAction: raise
+    heroOptions:
+      - shove
+      - call
+    hand:
+      heroCards: Jd Jc
+      position: co
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+      board: [8c,5d,2s]
+  - id: ova_2
+    title: QQ vs donk bet 30bb
+    board: [7h,6s,2d]
+    street: 1
+    villainAction: bet
+    heroOptions:
+      - shove
+      - raise
+      - call
+    hand:
+      heroCards: Qh Qc
+      position: co
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 30, '1': 30}
+      board: [7h,6s,2d]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -684,5 +684,50 @@
       "recommended": true,
       "icon": "north"
     }
+  },
+  {
+    "id": "flop_draw_shove_check",
+    "name": "Flop Draw Shove or Check",
+    "description": "Postflop jam decision with draws",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": ["btn", "bb"],
+    "tags": ["advanced", "postflop-jam", "tournament"]
+  },
+  {
+    "id": "overpair_vs_aggression",
+    "name": "Overpair vs Aggression",
+    "description": "Handle overpairs facing aggression",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 30,
+    "spotCount": 2,
+    "positions": ["co", "bb"],
+    "tags": ["advanced", "postflop-jam", "tournament"]
+  },
+  {
+    "id": "double_barrel_jam",
+    "name": "Turn Barrel Jam",
+    "description": "2-barrel shove after flop cbet",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 25,
+    "spotCount": 2,
+    "positions": ["btn", "bb"],
+    "tags": ["advanced", "postflop-jam", "tournament"]
+  },
+  {
+    "id": "delayed_shove_vs_missed_cbet",
+    "name": "Delayed Shove vs Missed CBet",
+    "description": "Jam after opponent skips c-bet",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 20,
+    "spotCount": 2,
+    "positions": ["sb", "bb"],
+    "tags": ["advanced", "postflop-jam", "tournament"]
   }
 ]
+

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -184,6 +184,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _autoAdvanceLoading = false;
   bool _seedBeginnerLoading = false;
   bool _seedIntermediateLoading = false;
+  bool _seedAdvancedLoading = false;
   bool _seedFullPathLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
@@ -1700,6 +1701,33 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _seedIntermediateLoading = false);
   }
 
+  Future<void> _seedAdvancedPath() async {
+    if (_seedAdvancedLoading || !kDebugMode) return;
+    setState(() => _seedAdvancedLoading = true);
+    try {
+      final raw =
+          await rootBundle.loadString('assets/learning_paths/advanced_path.yaml');
+      final map = const YamlReader().read(raw);
+      final paths = [for (final p in (map['packs'] as List? ?? [])) p.toString()];
+      await const LearningPathStageSeeder().seedStages(
+        paths,
+        audience: 'Advanced',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Advanced path seeded')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Seed failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _seedAdvancedLoading = false);
+  }
+
   Future<void> _seedFullPathFromConfig() async {
     if (_seedFullPathLoading || !kDebugMode) return;
     setState(() => _seedFullPathLoading = true);
@@ -2497,6 +2525,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Seed Intermediate Path'),
                 onTap: _seedIntermediateLoading ? null : _seedIntermediatePath,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⚙️ Seed Advanced Path'),
+                onTap: _seedAdvancedLoading ? null : _seedAdvancedPath,
               ),
             if (kDebugMode)
               ListTile(


### PR DESCRIPTION
## Summary
- add postflop jam YAML packs for Advanced players
- register new packs in library_index.json
- create advanced learning path
- add DevMenu option to seed the Advanced path

## Testing
- `jq . assets/packs/v2/library_index.json`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821cd20a48832a99fd37c52461c4ac