### PR TITLE
Add StarterLearningPathSeeder

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -83,6 +83,7 @@ import '../services/learning_path_service.dart';
 import '../services/smart_spot_injector.dart';
 import '../services/learning_path_engine.dart';
 import '../services/learning_path_stage_seeder.dart';
+import '../services/starter_learning_path_seeder.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -187,6 +188,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _seedAdvancedLoading = false;
   bool _seedFullPathLoading = false;
   bool _seedIcmMultiwayLoading = false;
+  bool _generateBeginnerPathLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
   bool _injectWeakSpots = false;
@@ -1777,6 +1779,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _seedIcmMultiwayLoading = false);
   }
 
+  Future<void> _generateBeginnerPath() async {
+    if (_generateBeginnerPathLoading || !kDebugMode) return;
+    setState(() => _generateBeginnerPathLoading = true);
+    try {
+      await const StarterLearningPathSeeder().generateStarterPath();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Beginner path generated')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Generation failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _generateBeginnerPathLoading = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -2548,6 +2570,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Seed Beginner Path'),
                 onTap: _seedBeginnerLoading ? null : _seedBeginnerPath,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⚙️ Generate Beginner Path'),
+                onTap: _generateBeginnerPathLoading ? null : _generateBeginnerPath,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/starter_learning_path_seeder.dart
+++ b/lib/services/starter_learning_path_seeder.dart
@@ -1,0 +1,67 @@
+import '../asset_manifest.dart';
+import 'pack_library_index_loader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class StarterLearningPathSeeder {
+  const StarterLearningPathSeeder();
+
+  Future<void> generateStarterPath() async {
+    await PackLibraryIndexLoader.instance.load();
+    final manifest = await AssetManifest.instance;
+    final library = PackLibraryIndexLoader.instance.library;
+
+    final selected = _selectPacks(library);
+    final paths = <String>[];
+    for (final p in selected) {
+      final path = _findAssetPath(manifest, p.id);
+      if (path != null) paths.add(path);
+    }
+
+    final unique = <String>[];
+    final seen = <String>{};
+    for (final p in paths) {
+      if (seen.add(p)) unique.add(p);
+    }
+
+    const writer = YamlWriter();
+    await writer.write({'packs': unique},
+        'assets/learning_paths/beginner_path.yaml');
+  }
+
+  List<TrainingPackTemplateV2> _selectPacks(List<TrainingPackTemplateV2> packs) {
+    final list = <TrainingPackTemplateV2>[];
+    for (final p in packs) {
+      final aud = p.audience?.toLowerCase();
+      final tags = p.tags.map((t) => t.toLowerCase()).toList();
+      if (aud == 'beginner') list.add(p);
+      else if (tags.contains('beginner') || tags.contains('starter')) list.add(p);
+    }
+    list.sort((a, b) {
+      final cmp = _rank(a).compareTo(_rank(b));
+      if (cmp != 0) return cmp;
+      return a.spotCount.compareTo(b.spotCount);
+    });
+    return list;
+  }
+
+  int _rank(TrainingPackTemplateV2 p) {
+    final name = p.name.toLowerCase();
+    final tags = p.tags.map((t) => t.toLowerCase()).toList();
+    if (name.contains('push') || tags.contains('pushfold')) return 0;
+    if (name.contains('call') || tags.contains('call')) return 1;
+    if (name.contains('trap') || name.contains('slowplay')) return 2;
+    if (p.bb <= 10) return 3;
+    if (name.contains('steal') || tags.contains('steal')) return 4;
+    return 5;
+  }
+
+  String? _findAssetPath(Map<String, dynamic> manifest, String id) {
+    for (final entry in manifest.keys) {
+      if (entry.startsWith('assets/packs/') && entry.endsWith('$id.yaml')) {
+        return entry;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `StarterLearningPathSeeder` for auto-building beginner YAML path
- wire into dev menu with a new "Generate Beginner Path" action

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882282c0e2c832a81fe90e0e7713248