### PR TITLE
Add postflop bluffcatch packs

### DIFF
--- a/assets/learning_paths/advanced_path.yaml
+++ b/assets/learning_paths/advanced_path.yaml
@@ -6,6 +6,9 @@ packs:
   - assets/packs/advanced/draw_or_shove_flop.yaml
   - assets/packs/advanced/overpair_vs_late_aggression.yaml
   - assets/packs/advanced/barrel_jam_drawy.yaml
+  - assets/packs/advanced/river_bluffcatch_overbet.yaml
+  - assets/packs/advanced/turn_xcall_vs_barrel.yaml
+  - assets/packs/advanced/marginal_bluffcatch_shove.yaml
   - assets/packs/advanced_icm/btn_open_bb_call_sb_shove.yaml
   - assets/packs/advanced_icm/limp_limp_hero_bb.yaml
   - assets/packs/advanced_icm/icm_final6_sb_vs_bb_reshove.yaml

--- a/assets/packs/advanced/marginal_bluffcatch_shove.yaml
+++ b/assets/packs/advanced/marginal_bluffcatch_shove.yaml
@@ -1,0 +1,48 @@
+id: marginal_bluffcatch_shove
+name: Facing Shove with Marginal Bluffcatcher
+audience: Advanced
+trainingType: postflop
+bb: 20
+gameType: tournament
+positions:
+  - btn
+  - bb
+tags:
+  - bluffcatch
+  - hero-call
+  - advanced
+  - tournament
+spots:
+  - id: mbs_1
+    title: Hero call river shove with weak top pair
+    board: [Qc,7s,5d,5c,2h]
+    street: 3
+    villainAction: shove
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: Qh Jd
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 20, '1': 20}
+      board: [Qc,7s,5d,5c,2h]
+  - id: mbs_2
+    title: Call or fold with pocket fours on blank river
+    board: [8h,6d,2c,9s,Kh]
+    street: 3
+    villainAction: shove
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: 4s 4d
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+      board: [8h,6d,2c,9s,Kh]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/advanced/river_bluffcatch_overbet.yaml
+++ b/assets/packs/advanced/river_bluffcatch_overbet.yaml
@@ -1,0 +1,48 @@
+id: river_bluffcatch_overbet
+name: River Bluffcatch vs Overbet
+audience: Advanced
+trainingType: postflop
+bb: 40
+gameType: tournament
+positions:
+  - co
+  - btn
+tags:
+  - bluffcatch
+  - hero-call
+  - advanced
+  - tournament
+spots:
+  - id: rbo_1
+    title: Call with top pair vs river overbet shove
+    board: [Kd,7c,4h,2s,2d]
+    street: 3
+    villainAction: overbet-shove
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: Kh Qh
+      position: co
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 40, '1': 40}
+      board: [Kd,7c,4h,2s,2d]
+  - id: rbo_2
+    title: Hero call second pair vs river pot overbet
+    board: [9h,9d,5s,4c,3d]
+    street: 3
+    villainAction: overbet
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: 5h 5d
+      position: co
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 30, '1': 30}
+      board: [9h,9d,5s,4c,3d]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/advanced/turn_xcall_vs_barrel.yaml
+++ b/assets/packs/advanced/turn_xcall_vs_barrel.yaml
@@ -1,0 +1,48 @@
+id: turn_xcall_vs_barrel
+name: Turn X-Call vs Barrel
+audience: Advanced
+trainingType: postflop
+bb: 30
+gameType: tournament
+positions:
+  - bb
+  - btn
+tags:
+  - bluffcatch
+  - hero-call
+  - advanced
+  - tournament
+spots:
+  - id: txb_1
+    title: Call turn barrel with mid pair
+    board: [Jh,8s,4d,2c]
+    street: 2
+    villainAction: bet
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: 8c 8d
+      position: bb
+      heroIndex: 1
+      playerCount: 2
+      stacks: {'0': 30, '1': 30}
+      board: [Jh,8s,4d,2c]
+  - id: txb_2
+    title: Float turn with ace high after flop check
+    board: [Td,6h,3s,9c]
+    street: 2
+    villainAction: bet
+    heroOptions:
+      - call
+      - fold
+    hand:
+      heroCards: As Qs
+      position: bb
+      heroIndex: 1
+      playerCount: 2
+      stacks: {'0': 25, '1': 25}
+      board: [Td,6h,3s,9c]
+spotCount: 2
+meta:
+  schemaVersion: 2.0.0

--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -897,4 +897,37 @@
     "positions": ["bb", "btn"],
     "tags": ["advanced", "icm", "multiway", "tournament"]
   }
+  {
+    "id": "river_bluffcatch_overbet",
+    "name": "River Bluffcatch vs Overbet",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 40,
+    "spotCount": 2,
+    "positions": ["co", "btn"],
+    "tags": ["bluffcatch", "hero-call", "advanced", "tournament"]
+  },
+  {
+    "id": "turn_xcall_vs_barrel",
+    "name": "Turn X-Call vs Barrel",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 30,
+    "spotCount": 2,
+    "positions": ["bb", "btn"],
+    "tags": ["bluffcatch", "hero-call", "advanced", "tournament"]
+  },
+  {
+    "id": "marginal_bluffcatch_shove",
+    "name": "Facing Shove with Marginal Bluffcatcher",
+    "description": "Postflop training pack",
+    "type": "postflop",
+    "gameType": "tournament",
+    "bb": 20,
+    "spotCount": 2,
+    "positions": ["btn", "bb"],
+    "tags": ["bluffcatch", "hero-call", "advanced", "tournament"]
+  }
 ]


### PR DESCRIPTION
## Summary
- add bluffcatch training packs for river overbets, turn barrels, and marginal shove calls
- register new packs in Advanced learning path
- list packs in library index

## Testing
- `flutter --version` *(fails: dart SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68822db976bc832aa09efea200328a12