### PR TITLE
Implement CashPathSeeder and dev menu trigger

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -88,6 +88,7 @@ import '../services/intermediate_learning_path_seeder.dart';
 
 import '../services/icm_postflop_path_seeder.dart';
 import '../services/live_hud_pack_seeder.dart';
+import '../services/cash_path_seeder.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -197,6 +198,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _generateAdvancedPathLoading = false;
   bool _generateIcmPostflopPathLoading = false;
   bool _generateLivePathLoading = false;
+  bool _generateCashPathLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
   bool _injectWeakSpots = false;
@@ -1888,6 +1890,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _generateLivePathLoading = false);
   }
 
+  Future<void> _generateCashPath() async {
+    if (_generateCashPathLoading || !kDebugMode) return;
+    setState(() => _generateCashPathLoading = true);
+    try {
+      await const CashPathSeeder().generateCashPath();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Cash path generated')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Generation failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _generateCashPathLoading = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -2695,6 +2717,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Generate Live Path'),
                 onTap: _generateLivePathLoading ? null : _generateLivePath,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⚙️ Generate Cash Path'),
+                onTap: _generateCashPathLoading ? null : _generateCashPath,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/cash_path_seeder.dart
+++ b/lib/services/cash_path_seeder.dart
@@ -1,0 +1,80 @@
+import '../asset_manifest.dart';
+import 'pack_library_index_loader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class CashPathSeeder {
+  const CashPathSeeder();
+
+  Future<void> generateCashPath() async {
+    await PackLibraryIndexLoader.instance.load();
+    final manifest = await AssetManifest.instance;
+    final library = PackLibraryIndexLoader.instance.library;
+
+    final selected = _selectPacks(library);
+    final paths = <String>[];
+    for (final p in selected) {
+      final path = _findAssetPath(manifest, p.id);
+      if (path != null) paths.add(path);
+    }
+
+    final unique = <String>[];
+    final seen = <String>{};
+    for (final p in paths) {
+      if (seen.add(p)) unique.add(p);
+    }
+
+    const writer = YamlWriter();
+    await writer.write({
+      'packs': unique,
+    }, 'assets/learning_paths/cash_path.yaml');
+  }
+
+  List<TrainingPackTemplateV2> _selectPacks(
+    List<TrainingPackTemplateV2> packs,
+  ) {
+    const tagsFilter = {
+      'cash',
+      'deepstack',
+      '100bb+',
+      'isoraise',
+      'nonicm',
+      'postflop-deep',
+      'light3bet',
+    };
+    final list = <TrainingPackTemplateV2>[];
+    for (final p in packs) {
+      final tags = p.tags.map((t) => t.toLowerCase()).toList();
+      if (p.spotCount < 2) continue;
+      if (tags.any(tagsFilter.contains)) {
+        list.add(p);
+      }
+    }
+    list.sort((a, b) {
+      final cmp = _rank(a).compareTo(_rank(b));
+      if (cmp != 0) return cmp;
+      return a.spotCount.compareTo(b.spotCount);
+    });
+    return list;
+  }
+
+  int _rank(TrainingPackTemplateV2 p) {
+    final tags = p.tags.map((t) => t.toLowerCase()).toList();
+    if (tags.contains('deepstack') || tags.contains('postflop-deep')) return 0;
+    if (tags.contains('100bb+') ||
+        tags.contains('isoraise') ||
+        tags.contains('light3bet'))
+      return 1;
+    if (tags.contains('cash') || tags.contains('nonicm')) return 2;
+    return 3;
+  }
+
+  String? _findAssetPath(Map<String, dynamic> manifest, String id) {
+    for (final entry in manifest.keys) {
+      if (entry.startsWith('assets/packs/') && entry.endsWith('$id.yaml')) {
+        return entry;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `CashPathSeeder` to generate a learning path for cash-game training packs
- expose "⚙️ Generate Cash Path" option in Dev Menu

## Testing
- `flutter analyze` *(fails: 14470 issues)*

------
https://chatgpt.com/codex/tasks/task_e_688233a43784832ab6954371faa4ba12