### PR TITLE
Implement LearningPathConfigLoader

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -89,6 +89,7 @@ import '../services/intermediate_learning_path_seeder.dart';
 import '../services/icm_postflop_path_seeder.dart';
 import '../services/live_hud_pack_seeder.dart';
 import '../services/cash_path_seeder.dart';
+import '../services/learning_path_config_loader.dart';
 import 'pack_filter_debug_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
@@ -199,6 +200,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _generateIcmPostflopPathLoading = false;
   bool _generateLivePathLoading = false;
   bool _generateCashPathLoading = false;
+  bool _loadAllPathsLoading = false;
   bool _unlockStages = false;
   bool _smartMode = false;
   bool _injectWeakSpots = false;
@@ -1910,6 +1912,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _generateCashPathLoading = false);
   }
 
+  Future<void> _loadAllLearningPaths() async {
+    if (_loadAllPathsLoading || !kDebugMode) return;
+    setState(() => _loadAllPathsLoading = true);
+    try {
+      await LearningPathConfigLoader.instance.loadAllPaths();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Learning paths loaded')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Load failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _loadAllPathsLoading = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -2722,6 +2744,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Generate Cash Path'),
                 onTap: _generateCashPathLoading ? null : _generateCashPath,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⚙️ Load All Learning Paths'),
+                onTap: _loadAllPathsLoading ? null : _loadAllLearningPaths,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/learning_path_config_loader.dart
+++ b/lib/services/learning_path_config_loader.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:yaml/yaml.dart';
+
+import '../core/training/generation/yaml_reader.dart';
+import '../models/learning_path_stage_model.dart';
+import 'learning_path_stage_library.dart';
+
+/// Loads learning path configurations from YAML files and registers stages.
+class LearningPathConfigLoader {
+  LearningPathConfigLoader._();
+
+  static final instance = LearningPathConfigLoader._();
+
+  /// Loads stages from [yamlPath] and registers them in [LearningPathStageLibrary].
+  Future<void> loadPath(String yamlPath) async {
+    final library = LearningPathStageLibrary.instance;
+    try {
+      final raw = await rootBundle.loadString(yamlPath);
+      final yaml = loadYaml(raw);
+      if (yaml is! Map) return;
+      final packPaths = [for (final p in (yaml['packs'] as List? ?? [])) p.toString()];
+      final reader = const YamlReader();
+      for (final path in packPaths) {
+        try {
+          final tpl = await reader.loadTemplate(path);
+          final stage = LearningPathStageModel(
+            id: tpl.id,
+            title: tpl.name,
+            description: tpl.description,
+            packId: tpl.id,
+            requiredAccuracy: 80,
+            minHands: 10,
+            tags: tpl.tags,
+            order: library.stages.length,
+          );
+          library.add(stage);
+        } catch (_) {}
+      }
+    } catch (_) {}
+  }
+
+  /// Loads all default learning paths.
+  Future<void> loadAllPaths() async {
+    final library = LearningPathStageLibrary.instance;
+    library.clear();
+    const paths = [
+      'assets/learning_paths/beginner_path.yaml',
+      'assets/learning_paths/icm_postflop_path.yaml',
+      'assets/learning_paths/live_path.yaml',
+      'assets/learning_paths/cash_path.yaml',
+    ];
+    for (final p in paths) {
+      await loadPath(p);
+    }
+  }
+}
+

--- a/test/learning_path_config_loader_test.dart
+++ b/test/learning_path_config_loader_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/learning_path_config_loader.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+
+class _FakeBundle extends CachingAssetBundle {
+  final Map<String, String> data;
+  _FakeBundle(this.data);
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => data[key]!;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadPath registers stages from packs', () async {
+    final bundle = _FakeBundle({
+      'assets/learning_paths/beginner_path.yaml': 'packs:\n  - assets/p1.yaml\n  - assets/p2.yaml',
+      'assets/p1.yaml': 'id: pack1\nname: Pack 1\ntrainingType: mtt\npositions:\n  - bb',
+      'assets/p2.yaml': 'id: pack2\nname: Pack 2\ntrainingType: mtt\npositions:\n  - bb',
+    });
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decode(message.buffer.asUint8List());
+      final data = bundle.data[key];
+      if (data != null) {
+        return ByteData.view(Uint8List.fromList(utf8.encode(data)).buffer);
+      }
+      return null;
+    });
+
+    await LearningPathConfigLoader.instance.loadPath('assets/learning_paths/beginner_path.yaml');
+
+    final stages = LearningPathStageLibrary.instance.stages;
+    expect(stages, hasLength(2));
+    expect(stages.first.id, 'pack1');
+    expect(stages[1].id, 'pack2');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathConfigLoader` service for centralized YAML loading
- hook loader into dev menu with new option to load all learning paths
- test loader behavior in a unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823737de4c832ab95561ba7500f30f