### PR TITLE
Reload learning path after training sessions

### DIFF
--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -217,7 +217,11 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
                 itemBuilder: (context, index) {
                   final stage = _stages[index];
                   final status = _stageStatus[stage.id] ?? StageStatus.locked;
-                  return _DynamicStageTile(stage: stage, status: status);
+                  return _DynamicStageTile(
+                    stage: stage,
+                    status: status,
+                    onReturn: _loadCurrent,
+                  );
                 },
               ),
             ),
@@ -230,7 +234,13 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
 class _DynamicStageTile extends StatelessWidget {
   final LearningPathStageModel stage;
   final StageStatus status;
-  const _DynamicStageTile({required this.stage, required this.status});
+  final Future<void> Function()? onReturn;
+
+  const _DynamicStageTile({
+    required this.stage,
+    required this.status,
+    this.onReturn,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -286,25 +296,26 @@ class _DynamicStageTile extends StatelessWidget {
             trailing: ElevatedButton(
               onPressed: status == StageStatus.locked
                   ? null
-                  : () {
-                final tpl = TrainingPackTemplateService.getById(
-                  stage.packId,
-                  context,
-                );
-                if (tpl == null) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Template not found')),
-                  );
-                  return;
-                }
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) =>
-                        TrainingPackPlayScreen(template: tpl, original: tpl),
-                  ),
-                );
-              },
+                  : () async {
+                      final tpl = TrainingPackTemplateService.getById(
+                        stage.packId,
+                        context,
+                      );
+                      if (tpl == null) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Template not found')),
+                        );
+                        return;
+                      }
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              TrainingPackPlayScreen(template: tpl, original: tpl),
+                        ),
+                      );
+                      if (onReturn != null) await onReturn!();
+                    },
               child: Text(buttonLabel),
             ),
           ),


### PR DESCRIPTION
## Summary
- automatically reload `LearningPathScreen` when returning from a training pack
- pass reload callback to stage tiles
- await navigation to training screen and refresh on return

## Testing
- `flutter pub get`
- `flutter analyze --no-pub` *(fails: 14468 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68824d7c4d4c832a8b0def7f5da6dc9e