### PR TITLE
Add sub-stage support

### DIFF
--- a/lib/models/learning_path_stage_model.dart
+++ b/lib/models/learning_path_stage_model.dart
@@ -1,4 +1,5 @@
 import 'unlock_condition.dart';
+import 'learning_path_sub_stage.dart';
 
 class LearningPathStageModel {
   final String id;
@@ -7,6 +8,7 @@ class LearningPathStageModel {
   final String packId;
   final double requiredAccuracy;
   final int minHands;
+  final List<LearningPathSubStage> subStages;
   final List<String> unlocks;
   final List<String> unlockAfter;
   final List<String> tags;
@@ -21,6 +23,7 @@ class LearningPathStageModel {
     required this.packId,
     required this.requiredAccuracy,
     required this.minHands,
+    List<LearningPathSubStage>? subStages,
     List<String>? unlocks,
     List<String>? tags,
     List<String>? unlockAfter,
@@ -29,7 +32,8 @@ class LearningPathStageModel {
     this.unlockCondition,
   })  : unlocks = unlocks ?? const [],
         unlockAfter = unlockAfter ?? const [],
-        tags = tags ?? const [];
+        tags = tags ?? const [],
+        subStages = subStages ?? const [];
 
   factory LearningPathStageModel.fromJson(Map<String, dynamic> json) {
     return LearningPathStageModel(
@@ -48,6 +52,10 @@ class LearningPathStageModel {
           ? UnlockCondition.fromJson(
               Map<String, dynamic>.from(json['unlockCondition'] as Map))
           : null,
+      subStages: [
+        for (final s in (json['subStages'] as List? ?? []))
+          LearningPathSubStage.fromJson(Map<String, dynamic>.from(s)),
+      ],
     );
   }
 
@@ -65,6 +73,8 @@ class LearningPathStageModel {
         if (isOptional) 'isOptional': true,
         if (unlockCondition != null)
           'unlockCondition': unlockCondition!.toJson(),
+        if (subStages.isNotEmpty)
+          'subStages': [for (final s in subStages) s.toJson()],
       };
 
   factory LearningPathStageModel.fromYaml(Map yaml) {

--- a/lib/models/learning_path_sub_stage.dart
+++ b/lib/models/learning_path_sub_stage.dart
@@ -1,0 +1,35 @@
+class LearningPathSubStage {
+  final String title;
+  final String packId;
+  final double? requiredAccuracy;
+  final int? minHands;
+
+  const LearningPathSubStage({
+    required this.title,
+    required this.packId,
+    this.requiredAccuracy,
+    this.minHands,
+  });
+
+  factory LearningPathSubStage.fromJson(Map<String, dynamic> json) {
+    return LearningPathSubStage(
+      title: json['title'] as String? ?? '',
+      packId: json['packId'] as String? ?? '',
+      requiredAccuracy: (json['requiredAccuracy'] as num?)?.toDouble(),
+      minHands: (json['minHands'] as num?)?.toInt(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'packId': packId,
+        if (requiredAccuracy != null) 'requiredAccuracy': requiredAccuracy,
+        if (minHands != null) 'minHands': minHands,
+      };
+
+  factory LearningPathSubStage.fromYaml(Map yaml) {
+    final map = <String, dynamic>{};
+    yaml.forEach((k, v) => map[k.toString()] = v);
+    return LearningPathSubStage.fromJson(map);
+  }
+}

--- a/lib/services/learning_path_completion_engine.dart
+++ b/lib/services/learning_path_completion_engine.dart
@@ -14,13 +14,26 @@ class LearningPathCompletionEngine {
     Map<String, SessionLog> logsByPackId,
   ) {
     for (final stage in path.stages) {
-      final log = logsByPackId[stage.packId];
-      final correct = log?.correctCount ?? 0;
-      final mistakes = log?.mistakeCount ?? 0;
-      final hands = correct + mistakes;
-      if (hands < stage.minHands) return false;
-      final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
-      if (accuracy < stage.requiredAccuracy) return false;
+      if (stage.subStages.isEmpty) {
+        final log = logsByPackId[stage.packId];
+        final correct = log?.correctCount ?? 0;
+        final mistakes = log?.mistakeCount ?? 0;
+        final hands = correct + mistakes;
+        if (hands < stage.minHands) return false;
+        final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
+        if (accuracy < stage.requiredAccuracy) return false;
+      } else {
+        for (final sub in stage.subStages) {
+          final log = logsByPackId[sub.packId];
+          final correct = log?.correctCount ?? 0;
+          final mistakes = log?.mistakeCount ?? 0;
+          final hands = correct + mistakes;
+          if (hands < (sub.minHands ?? 0)) return false;
+          final accuracy = hands == 0 ? 0.0 : correct / hands * 100;
+          if (sub.requiredAccuracy != null &&
+              accuracy < sub.requiredAccuracy!) return false;
+        }
+      }
     }
     return true;
   }

--- a/lib/services/learning_path_stage_completion_engine.dart
+++ b/lib/services/learning_path_stage_completion_engine.dart
@@ -16,8 +16,15 @@ class LearningPathStageCompletionEngine {
     Map<String, int> handsPlayedByPackId,
   ) {
     for (final stage in path.stages) {
-      final hands = handsPlayedByPackId[stage.packId] ?? 0;
-      if (!isStageComplete(stage, hands)) return false;
+      if (stage.subStages.isEmpty) {
+        final hands = handsPlayedByPackId[stage.packId] ?? 0;
+        if (!isStageComplete(stage, hands)) return false;
+      } else {
+        for (final sub in stage.subStages) {
+          final hands = handsPlayedByPackId[sub.packId] ?? 0;
+          if (hands < (sub.minHands ?? 0)) return false;
+        }
+      }
     }
     return true;
   }

--- a/lib/widgets/learning_stage_tile.dart
+++ b/lib/widgets/learning_stage_tile.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import '../models/learning_path_stage_model.dart';
 import '../models/learning_track_progress_model.dart';
+import '../services/training_progress_service.dart';
+import '../models/learning_path_sub_stage.dart';
 import 'tag_badge.dart';
 
 /// Tile representing a stage of a learning path.
-class LearningStageTile extends StatelessWidget {
+class LearningStageTile extends StatefulWidget {
   final LearningPathStageModel stage;
   final StageStatus status;
   final String subtitle;
@@ -20,9 +22,29 @@ class LearningStageTile extends StatelessWidget {
   });
 
   @override
+  State<LearningStageTile> createState() => _LearningStageTileState();
+}
+
+class _LearningStageTileState extends State<LearningStageTile> {
+  final Map<String, double> _progress = {};
+  bool _loading = false;
+
+  Future<void> _load() async {
+    if (_loading) return;
+    setState(() => _loading = true);
+    for (final s in widget.stage.subStages) {
+      final prog =
+          await TrainingProgressService.instance.getProgress(s.packId);
+      _progress[s.packId] = prog;
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final locked = status == StageStatus.locked;
-    final completed = status == StageStatus.completed;
+    final stage = widget.stage;
+    final locked = widget.status == StageStatus.locked;
+    final completed = widget.status == StageStatus.completed;
 
     Widget trailing;
     if (completed) {
@@ -31,37 +53,92 @@ class LearningStageTile extends StatelessWidget {
       trailing = const Icon(Icons.lock, color: Colors.grey);
     } else {
       trailing = ElevatedButton(
-        onPressed: onTap,
+        onPressed: widget.onTap,
         child: const Text('Начать'),
       );
     }
 
     final grey = locked ? Colors.white60 : null;
 
-    return Card(
-      color: locked ? Colors.grey.shade800 : null,
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-      child: ListTile(
-        title: Text(stage.title, style: TextStyle(color: grey)),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (stage.description.isNotEmpty)
-              Text(stage.description, style: TextStyle(color: grey)),
-            Text(subtitle, style: TextStyle(color: grey, fontSize: 12)),
-            if (stage.tags.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(top: 4),
-                child: Wrap(
-                  spacing: 4,
-                  runSpacing: -4,
-                  children: [for (final t in stage.tags.take(3)) TagBadge(t)],
+    if (stage.subStages.isEmpty) {
+      return Card(
+        color: locked ? Colors.grey.shade800 : null,
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        child: ListTile(
+          title: Text(stage.title, style: TextStyle(color: grey)),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (stage.description.isNotEmpty)
+                Text(stage.description, style: TextStyle(color: grey)),
+              Text(widget.subtitle, style: TextStyle(color: grey, fontSize: 12)),
+              if (stage.tags.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Wrap(
+                    spacing: 4,
+                    runSpacing: -4,
+                    children: [for (final t in stage.tags.take(3)) TagBadge(t)],
+                  ),
                 ),
-              ),
-          ],
+            ],
+          ),
+          trailing: trailing,
+          onTap: locked ? null : widget.onTap,
         ),
-        trailing: trailing,
-        onTap: locked ? null : onTap,
+      );
+    } else {
+      final avgProg = _progress.isEmpty
+          ? 0.0
+          : _progress.values.fold(0.0, (a, b) => a + b) /
+              stage.subStages.length;
+      final children = _loading
+          ? const [
+              Padding(
+                padding: EdgeInsets.all(16),
+                child: CircularProgressIndicator(),
+              )
+            ]
+          : [for (final s in stage.subStages) _buildSubStageTile(s)];
+      return Card(
+        color: locked ? Colors.grey.shade800 : null,
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        child: ExpansionTile(
+          initiallyExpanded: !completed,
+          onExpansionChanged: (v) {
+            if (v && _progress.isEmpty) _load();
+          },
+          title: Row(
+            children: [
+              Expanded(child: Text(stage.title, style: TextStyle(color: grey))),
+              SizedBox(
+                width: 80,
+                child: LinearProgressIndicator(value: avgProg),
+              ),
+            ],
+          ),
+          subtitle: stage.description.isNotEmpty
+              ? Text(stage.description, style: TextStyle(color: grey))
+              : null,
+          children: children,
+        ),
+      );
+    }
+  }
+
+  Widget _buildSubStageTile(LearningPathSubStage sub) {
+    final prog = _progress[sub.packId] ?? 0.0;
+    final percent = (prog * 100).round();
+    final buttonLabel = prog == 0
+        ? 'Начать'
+        : (prog >= 1.0 ? 'Повторить' : 'Продолжить');
+    return ListTile(
+      title: Text(sub.title),
+      subtitle: Text('$percent%'),
+      trailing: ElevatedButton(
+        onPressed:
+            widget.status == StageStatus.locked ? null : widget.onTap,
+        child: Text(buttonLabel),
       ),
     );
   }

--- a/test/models/learning_path_substage_test.dart
+++ b/test/models/learning_path_substage_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_sub_stage.dart';
+
+void main() {
+  test('parses subStages from json', () {
+    final json = {
+      'id': 's1',
+      'title': 'Stage',
+      'description': '',
+      'packId': 'main',
+      'requiredAccuracy': 80,
+      'minHands': 10,
+      'subStages': [
+        {
+          'title': 'A',
+          'packId': 'p1',
+          'requiredAccuracy': 70,
+          'minHands': 5,
+        },
+        {
+          'title': 'B',
+          'packId': 'p2'
+        }
+      ]
+    };
+    final stage = LearningPathStageModel.fromJson(json);
+    expect(stage.subStages.length, 2);
+    expect(stage.subStages.first.title, 'A');
+    expect(stage.subStages.first.requiredAccuracy, 70);
+    expect(stage.subStages.last.minHands, isNull);
+  });
+}

--- a/test/services/learning_path_progress_tracker_service_substage_test.dart
+++ b/test/services/learning_path_progress_tracker_service_substage_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/models/learning_path_sub_stage.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/learning_path_progress_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const tracker = LearningPathProgressTrackerService();
+
+  final template = LearningPathTemplateV2(
+    id: 'p',
+    title: 'Path',
+    description: '',
+    stages: [
+      LearningPathStageModel(
+        id: 's1',
+        title: 'Stage',
+        description: '',
+        packId: 'main',
+        requiredAccuracy: 0,
+        minHands: 0,
+        subStages: [
+          LearningPathSubStage(
+            title: 'A',
+            packId: 'p1',
+            requiredAccuracy: 80,
+            minHands: 5,
+          ),
+          LearningPathSubStage(
+            title: 'B',
+            packId: 'p2',
+            requiredAccuracy: 60,
+            minHands: 5,
+          ),
+        ],
+      )
+    ],
+  );
+
+  final logs = [
+    SessionLog(
+      sessionId: '1',
+      templateId: 'p1',
+      startedAt: DateTime.now(),
+      completedAt: DateTime.now(),
+      correctCount: 4,
+      mistakeCount: 1,
+    ),
+    SessionLog(
+      sessionId: '2',
+      templateId: 'p2',
+      startedAt: DateTime.now(),
+      completedAt: DateTime.now(),
+      correctCount: 3,
+      mistakeCount: 2,
+    ),
+  ];
+
+  test('computeProgressStrings aggregates subStages', () {
+    final progress = tracker.computeProgressStrings(template, logs);
+    expect(progress['s1'], '10 / 10 рук · 70%');
+  });
+
+  test('isPathCompleted true when all subStages complete', () {
+    final aggregated = tracker.aggregateLogsByPack(logs);
+    final done = tracker.isPathCompleted(template, aggregated);
+    expect(done, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `LearningPathSubStage`
- allow stages to contain `subStages`
- compute progress and completion for sub-stages
- expand `LearningStageTile` to show sub-stage progress
- add unit tests for new parsing and progress logic

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825e6f1648832a927454a6513eca00