### PR TITLE
Implement substage progress tracking

### DIFF
--- a/lib/widgets/learning_stage_tile.dart
+++ b/lib/widgets/learning_stage_tile.dart
@@ -33,8 +33,8 @@ class _LearningStageTileState extends State<LearningStageTile> {
     if (_loading) return;
     setState(() => _loading = true);
     for (final s in widget.stage.subStages) {
-      final prog =
-          await TrainingProgressService.instance.getProgress(s.id);
+      final prog = await TrainingProgressService.instance
+          .getSubStageProgress(widget.stage.id, s.id);
       _progress[s.id] = prog;
     }
     if (mounted) setState(() => _loading = false);
@@ -128,14 +128,16 @@ class _LearningStageTileState extends State<LearningStageTile> {
 
   Widget _buildSubStageTile(SubStageModel sub) {
     final prog = _progress[sub.id] ?? 0.0;
+    final done = prog >= 1.0;
     return ListTile(
       title: Text(sub.title),
-      subtitle:
-          sub.description.isNotEmpty ? Text(sub.description) : null,
-      trailing: SizedBox(
-        width: 80,
-        child: LinearProgressIndicator(value: prog),
-      ),
+      subtitle: sub.description.isNotEmpty ? Text(sub.description) : null,
+      trailing: done
+          ? const Icon(Icons.check_circle, color: Colors.green)
+          : SizedBox(
+              width: 80,
+              child: LinearProgressIndicator(value: prog),
+            ),
     );
   }
 }

--- a/test/services/training_progress_substage_test.dart
+++ b/test/services/training_progress_substage_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/training_progress_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getSubStageProgress caches per stage', () async {
+    SharedPreferences.setMockInitialValues({'tpl_prog_starter_pushfold_10bb': 0});
+    final service = TrainingProgressService.instance;
+    service.subStageProgress.clear();
+    final first = await service.getSubStageProgress('stage1', 'starter_pushfold_10bb');
+    expect(service.subStageProgress['stage1']?['starter_pushfold_10bb'], first);
+    expect(first, greaterThan(0));
+    SharedPreferences.setMockInitialValues({'tpl_prog_starter_pushfold_10bb': 5});
+    final second = await service.getSubStageProgress('stage1', 'starter_pushfold_10bb');
+    expect(second, first);
+  });
+}


### PR DESCRIPTION
## Summary
- cache progress per substage in `TrainingProgressService`
- expose `getSubStageProgress()` for stage/substage pairs
- display checkmark when substage is complete
- test caching of substage progress

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test test/services/training_progress_substage_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688274bd9794832aaf0af80b6c63ebe4