### PR TITLE
Implement LearningPathStageTemplateGenerator

### DIFF
--- a/lib/core/training/generation/learning_path_stage_template_generator.dart
+++ b/lib/core/training/generation/learning_path_stage_template_generator.dart
@@ -1,0 +1,96 @@
+import 'package:json2yaml/json2yaml.dart';
+
+/// Input model for sub-stage generation.
+class SubStageTemplateInput {
+  final String id;
+  final String title;
+  final int minHands;
+  final double requiredAccuracy;
+  final UnlockConditionInput? unlockCondition;
+
+  const SubStageTemplateInput({
+    required this.id,
+    required this.title,
+    this.minHands = 0,
+    this.requiredAccuracy = 0,
+    this.unlockCondition,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'title': title,
+        if (minHands > 0) 'minHands': minHands,
+        if (requiredAccuracy > 0) 'requiredAccuracy': requiredAccuracy,
+        if (unlockCondition != null)
+          'unlockCondition': unlockCondition!.toMap(),
+      };
+}
+
+/// Input model for unlock conditions.
+class UnlockConditionInput {
+  final String? dependsOn;
+  final int? minAccuracy;
+
+  const UnlockConditionInput({this.dependsOn, this.minAccuracy});
+
+  Map<String, dynamic> toMap() => {
+        if (dependsOn != null) 'dependsOn': dependsOn,
+        if (minAccuracy != null) 'minAccuracy': minAccuracy,
+      };
+}
+
+/// Generates YAML for [LearningPathStageModel] templates.
+class LearningPathStageTemplateGenerator {
+  int _order = 0;
+  String? _lastId;
+
+  /// Resets internal counters.
+  void reset() {
+    _order = 0;
+    _lastId = null;
+  }
+
+  List<String> _autoTags(String packId) {
+    final tokens = packId.split(RegExp(r'[\-_]'));
+    return tokens.toSet().toList();
+  }
+
+  /// Generates YAML for a single stage.
+  String generateStageYaml({
+    required String id,
+    required String title,
+    required String packId,
+    String description = '',
+    double requiredAccuracy = 80,
+    int minHands = 10,
+    List<SubStageTemplateInput> subStages = const [],
+    UnlockConditionInput? unlockCondition,
+    List<String>? tags,
+  }) {
+    _order += 1;
+    final map = <String, dynamic>{
+      'id': id,
+      'title': title,
+      if (description.isNotEmpty) 'description': description,
+      'packId': packId,
+      'requiredAccuracy': requiredAccuracy,
+      'minHands': minHands,
+      'order': _order,
+    };
+
+    map['tags'] = tags == null || tags.isEmpty ? _autoTags(packId) : tags;
+    if (_lastId != null) {
+      map['unlockAfter'] = [_lastId];
+    }
+    if (unlockCondition != null) {
+      map['unlockCondition'] = unlockCondition.toMap();
+    }
+    if (subStages.isNotEmpty) {
+      map['subStages'] = [for (final s in subStages) s.toMap()];
+    }
+
+    final yamlOut = json2yaml(map, yamlStyle: YamlStyle.pubspecYaml);
+    _lastId = id;
+    return yamlOut;
+  }
+}

--- a/test/learning_path_stage_template_generator_test.dart
+++ b/test/learning_path_stage_template_generator_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_stage_template_generator.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generate stage with subStages', () {
+    final generator = LearningPathStageTemplateGenerator();
+    final yaml = generator.generateStageYaml(
+      id: 's1',
+      title: 'Stage',
+      packId: 'test_pack',
+      subStages: const [
+        SubStageTemplateInput(id: 'a', title: 'A', minHands: 5, requiredAccuracy: 60),
+        SubStageTemplateInput(
+          id: 'b',
+          title: 'B',
+          minHands: 5,
+          requiredAccuracy: 70,
+          unlockCondition: UnlockConditionInput(dependsOn: 'a'),
+        ),
+      ],
+    );
+    final map = const YamlReader().read(yaml);
+    final stage = LearningPathStageModel.fromJson(Map<String, dynamic>.from(map));
+    expect(stage.id, 's1');
+    expect(stage.subStages.length, 2);
+    expect(stage.subStages.last.unlockCondition?.dependsOn, 'a');
+  });
+
+  test('order and unlockAfter auto increment', () {
+    final generator = LearningPathStageTemplateGenerator();
+    final first = generator.generateStageYaml(
+      id: 'first',
+      title: 'First',
+      packId: 'pack1',
+    );
+    final second = generator.generateStageYaml(
+      id: 'second',
+      title: 'Second',
+      packId: 'pack1',
+    );
+    final mapFirst = const YamlReader().read(first);
+    final stageFirst =
+        LearningPathStageModel.fromJson(Map<String, dynamic>.from(mapFirst));
+    final mapSecond = const YamlReader().read(second);
+    final stageSecond =
+        LearningPathStageModel.fromJson(Map<String, dynamic>.from(mapSecond));
+    expect(stageFirst.order, 1);
+    expect(stageSecond.order, 2);
+    expect(stageSecond.unlockAfter, contains('first'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathStageTemplateGenerator` for easier stage YAML generation
- support subStage inputs and unlock conditions
- include unit tests for YAML generation

## Testing
- `flutter test test/learning_path_stage_template_generator_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827d59a810832a9ea235a87f5d6134