### PR TITLE
Implement LearningPathLibraryGenerator

### DIFF
--- a/lib/core/training/generation/learning_path_library_generator.dart
+++ b/lib/core/training/generation/learning_path_library_generator.dart
@@ -1,0 +1,68 @@
+import 'package:json2yaml/json2yaml.dart';
+
+import 'learning_path_stage_template_generator.dart';
+import 'yaml_reader.dart';
+
+/// Input model for a learning path stage.
+class LearningPathStageTemplateInput {
+  final String id;
+  final String title;
+  final String packId;
+  final String description;
+  final double requiredAccuracy;
+  final int minHands;
+  final List<SubStageTemplateInput> subStages;
+  final UnlockConditionInput? unlockCondition;
+  final List<String>? tags;
+
+  const LearningPathStageTemplateInput({
+    required this.id,
+    required this.title,
+    required this.packId,
+    this.description = '',
+    this.requiredAccuracy = 80,
+    this.minHands = 10,
+    this.subStages = const [],
+    this.unlockCondition,
+    this.tags,
+  });
+}
+
+/// Generates a learning path YAML file from stage templates.
+class LearningPathLibraryGenerator {
+  final LearningPathStageTemplateGenerator stageGenerator;
+  const LearningPathLibraryGenerator({LearningPathStageTemplateGenerator? stageGenerator})
+      : stageGenerator = stageGenerator ?? LearningPathStageTemplateGenerator();
+
+  /// Generates YAML for a complete learning path based on [stages].
+  String generatePathYaml(List<LearningPathStageTemplateInput> stages) {
+    stageGenerator.reset();
+    final stageMaps = <Map<String, dynamic>>[];
+    for (final s in stages) {
+      final yaml = stageGenerator.generateStageYaml(
+        id: s.id,
+        title: s.title,
+        packId: s.packId,
+        description: s.description,
+        requiredAccuracy: s.requiredAccuracy,
+        minHands: s.minHands,
+        subStages: s.subStages,
+        unlockCondition: s.unlockCondition,
+        tags: s.tags,
+      );
+      final map = const YamlReader().read(yaml);
+      stageMaps.add(Map<String, dynamic>.from(map));
+    }
+    final tags = <String>{};
+    for (final m in stageMaps) {
+      for (final t in (m['tags'] as List? ?? [])) {
+        final tag = t.toString().trim();
+        if (tag.isNotEmpty) tags.add(tag);
+      }
+    }
+    final pathMap = <String, dynamic>{'stages': stageMaps};
+    if (tags.isNotEmpty) pathMap['tags'] = tags.toList()..sort();
+    return json2yaml(pathMap, yamlStyle: YamlStyle.pubspecYaml);
+  }
+}
+

--- a/test/learning_path_library_generator_test.dart
+++ b/test/learning_path_library_generator_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_library_generator.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generatePathYaml builds stages with unlockAfter', () {
+    final generator = LearningPathLibraryGenerator();
+    final yaml = generator.generatePathYaml([
+      const LearningPathStageTemplateInput(
+        id: 's1',
+        title: 'Stage 1',
+        packId: 'pack1',
+        tags: ['a'],
+      ),
+      const LearningPathStageTemplateInput(
+        id: 's2',
+        title: 'Stage 2',
+        packId: 'pack2',
+        tags: ['b'],
+      ),
+    ]);
+    final map = const YamlReader().read(yaml);
+    final stages = [
+      for (final m in (map['stages'] as List? ?? []))
+        LearningPathStageModel.fromJson(Map<String, dynamic>.from(m))
+    ];
+    expect(stages.length, 2);
+    expect(stages.first.order, 1);
+    expect(stages[1].order, 2);
+    expect(stages[1].unlockAfter, contains('s1'));
+    final tags = List<String>.from(map['tags'] as List);
+    expect(tags.contains('a'), true);
+    expect(tags.contains('b'), true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathLibraryGenerator` to build a path YAML from stage templates
- create `LearningPathStageTemplateInput` to hold stage data
- add unit test for path generation

## Testing
- `flutter test test/learning_path_library_generator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827ede71b8832a9e1ed6a0fa9828b9