### PR TITLE
Implement LearningPathAutoPackAssigner

### DIFF
--- a/lib/core/training/generation/learning_path_auto_pack_assigner.dart
+++ b/lib/core/training/generation/learning_path_auto_pack_assigner.dart
@@ -1,0 +1,70 @@
+import 'learning_path_stage_template_generator.dart';
+import 'learning_path_library_generator.dart';
+
+/// Strategy for assigning pack ids to sub stages.
+abstract class PackAssignStrategy {
+  String? resolve(String subStageId);
+}
+
+/// Assigns a constant [packId] when [subStageId] starts with [prefix].
+class ByPrefixStrategy implements PackAssignStrategy {
+  final String prefix;
+  final String packId;
+  const ByPrefixStrategy({required this.prefix, required this.packId});
+  @override
+  String? resolve(String subStageId) =>
+      subStageId.startsWith(prefix) ? packId : null;
+}
+
+/// Resolves pack ids using [mapping] of prefixes to ids.
+class ManualMapStrategy implements PackAssignStrategy {
+  final Map<String, String> mapping;
+  const ManualMapStrategy(this.mapping);
+  @override
+  String? resolve(String subStageId) {
+    for (final entry in mapping.entries) {
+      if (subStageId.startsWith(entry.key)) return entry.value;
+    }
+    return null;
+  }
+}
+
+/// Utility assigning pack ids for sub stages based on [strategy].
+class LearningPathAutoPackAssigner {
+  const LearningPathAutoPackAssigner();
+
+  List<LearningPathStageTemplateInput> assignPackIds(
+    List<LearningPathStageTemplateInput> stages,
+    PackAssignStrategy strategy,
+  ) {
+    final result = <LearningPathStageTemplateInput>[];
+    for (final stage in stages) {
+      final updatedSubs = <SubStageTemplateInput>[];
+      for (final sub in stage.subStages) {
+        final packId = sub.packId.isNotEmpty
+            ? sub.packId
+            : (strategy.resolve(sub.id) ?? sub.id);
+        updatedSubs.add(SubStageTemplateInput(
+          id: sub.id,
+          packId: packId,
+          title: sub.title,
+          minHands: sub.minHands,
+          requiredAccuracy: sub.requiredAccuracy,
+          unlockCondition: sub.unlockCondition,
+        ));
+      }
+      result.add(LearningPathStageTemplateInput(
+        id: stage.id,
+        title: stage.title,
+        packId: stage.packId,
+        description: stage.description,
+        requiredAccuracy: stage.requiredAccuracy,
+        minHands: stage.minHands,
+        subStages: updatedSubs,
+        unlockCondition: stage.unlockCondition,
+        tags: stage.tags,
+      ));
+    }
+    return result;
+  }
+}

--- a/lib/core/training/generation/learning_path_stage_template_generator.dart
+++ b/lib/core/training/generation/learning_path_stage_template_generator.dart
@@ -3,6 +3,7 @@ import 'package:json2yaml/json2yaml.dart';
 /// Input model for sub-stage generation.
 class SubStageTemplateInput {
   final String id;
+  final String packId;
   final String title;
   final int minHands;
   final double requiredAccuracy;
@@ -10,6 +11,7 @@ class SubStageTemplateInput {
 
   const SubStageTemplateInput({
     required this.id,
+    required this.packId,
     required this.title,
     this.minHands = 0,
     this.requiredAccuracy = 0,
@@ -18,6 +20,7 @@ class SubStageTemplateInput {
 
   Map<String, dynamic> toMap() => {
         'id': id,
+        'packId': packId,
         'title': title,
         if (minHands > 0) 'minHands': minHands,
         if (requiredAccuracy > 0) 'requiredAccuracy': requiredAccuracy,

--- a/lib/models/sub_stage_model.dart
+++ b/lib/models/sub_stage_model.dart
@@ -2,6 +2,7 @@ import 'unlock_condition.dart';
 
 class SubStageModel {
   final String id;
+  final String packId;
   final String title;
   final String description;
   final int minHands;
@@ -10,6 +11,7 @@ class SubStageModel {
 
   const SubStageModel({
     required this.id,
+    required this.packId,
     required this.title,
     this.description = '',
     this.minHands = 0,
@@ -20,6 +22,7 @@ class SubStageModel {
   factory SubStageModel.fromJson(Map<String, dynamic> json) {
     return SubStageModel(
       id: json['id'] as String? ?? '',
+      packId: json['packId'] as String? ?? json['id'] as String? ?? '',
       title: json['title'] as String? ?? '',
       description: json['description'] as String? ?? '',
       minHands: (json['minHands'] as num?)?.toInt() ?? 0,
@@ -33,6 +36,7 @@ class SubStageModel {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'packId': packId,
         'title': title,
         if (description.isNotEmpty) 'description': description,
         if (minHands > 0) 'minHands': minHands,

--- a/lib/services/learning_path_completion_engine.dart
+++ b/lib/services/learning_path_completion_engine.dart
@@ -24,7 +24,7 @@ class LearningPathCompletionEngine {
         if (accuracy < stage.requiredAccuracy) return false;
       } else {
         for (final sub in stage.subStages) {
-          final log = logsByPackId[sub.id];
+          final log = logsByPackId[sub.packId];
           final correct = log?.correctCount ?? 0;
           final mistakes = log?.mistakeCount ?? 0;
           final hands = correct + mistakes;

--- a/lib/services/learning_path_progress_tracker_service.dart
+++ b/lib/services/learning_path_progress_tracker_service.dart
@@ -57,7 +57,7 @@ class LearningPathProgressTrackerService {
         var minHands = 0;
         double accSum = 0;
         for (final sub in stage.subStages) {
-          final log = aggregated[sub.id];
+          final log = aggregated[sub.packId];
           final h = (log?.correctCount ?? 0) + (log?.mistakeCount ?? 0);
           final correct = log?.correctCount ?? 0;
           final acc = h == 0 ? 0.0 : correct / h * 100;
@@ -91,7 +91,7 @@ class LearningPathProgressTrackerService {
         if (accuracy < stage.requiredAccuracy) return false;
       } else {
         for (final sub in stage.subStages) {
-          final log = aggregatedLogs[sub.id];
+          final log = aggregatedLogs[sub.packId];
           final correct = log?.correctCount ?? 0;
           final mistakes = log?.mistakeCount ?? 0;
           final hands = correct + mistakes;

--- a/lib/services/learning_path_stage_completion_engine.dart
+++ b/lib/services/learning_path_stage_completion_engine.dart
@@ -21,7 +21,7 @@ class LearningPathStageCompletionEngine {
         if (!isStageComplete(stage, hands)) return false;
       } else {
         for (final sub in stage.subStages) {
-          final hands = handsPlayedByPackId[sub.id] ?? 0;
+          final hands = handsPlayedByPackId[sub.packId] ?? 0;
           if (hands < sub.minHands) return false;
         }
       }

--- a/lib/services/learning_path_stage_unlock_engine.dart
+++ b/lib/services/learning_path_stage_unlock_engine.dart
@@ -47,7 +47,7 @@ class LearningPathStageUnlockEngine {
       } else {
         done = true;
         for (final sub in stage.subStages) {
-          final log = aggregatedLogs[sub.id];
+          final log = aggregatedLogs[sub.packId];
           final correct = log?.correctCount ?? 0;
           final mistakes = log?.mistakeCount ?? 0;
           final hands = correct + mistakes;

--- a/lib/services/training_path_progress_service_v2.dart
+++ b/lib/services/training_path_progress_service_v2.dart
@@ -87,7 +87,7 @@ class TrainingPathProgressServiceV2 {
     } else {
       for (final sub in stage.subStages) {
         for (final log in logs.logs) {
-          if (log.templateId == sub.id) {
+          if (log.templateId == sub.packId) {
             hands += log.correctCount + log.mistakeCount;
             correct += log.correctCount;
           }
@@ -132,7 +132,7 @@ class TrainingPathProgressServiceV2 {
                   id: '',
                   title: '',
                   description: '',
-                  packId: sub.id,
+                  packId: sub.packId,
                   requiredAccuracy: sub.requiredAccuracy,
                   minHands: sub.minHands,
                 ));

--- a/lib/widgets/learning_stage_tile.dart
+++ b/lib/widgets/learning_stage_tile.dart
@@ -55,10 +55,10 @@ class _LearningStageTileState extends State<LearningStageTile> {
     _lastStartedId = null;
     for (final s in widget.stage.subStages) {
       final prog = await TrainingProgressService.instance
-          .getSubStageProgress(widget.stage.id, s.id);
-      _progress[s.id] = prog;
-      final stat = await TrainingPackStatsService.getStats(s.id);
-      _accuracy[s.id] = (stat?.accuracy ?? 0.0) * 100;
+          .getSubStageProgress(widget.stage.id, s.packId);
+      _progress[s.packId] = prog;
+      final stat = await TrainingPackStatsService.getStats(s.packId);
+      _accuracy[s.packId] = (stat?.accuracy ?? 0.0) * 100;
     }
     _lastStartedId = _computeLastStarted();
     if (mounted) setState(() => _loading = false);
@@ -151,9 +151,9 @@ class _LearningStageTileState extends State<LearningStageTile> {
   }
 
   Widget _buildSubStageTile(SubStageModel sub) {
-    final prog = _progress[sub.id] ?? 0.0;
+    final prog = _progress[sub.packId] ?? 0.0;
     final done = prog >= 1.0;
-    final highlight = sub.id == _lastStartedId;
+    final highlight = sub.packId == _lastStartedId;
     final unlocked =
         _evaluator.isUnlocked(sub.unlockCondition, _progress, _accuracy);
     final grey = unlocked ? null : Colors.white60;
@@ -177,8 +177,8 @@ class _LearningStageTileState extends State<LearningStageTile> {
       onTap: !unlocked
           ? null
           : () async {
-              final tplId = TrainingPackTemplateService.hasTemplate(sub.id)
-                  ? sub.id
+              final tplId = TrainingPackTemplateService.hasTemplate(sub.packId)
+                  ? sub.packId
                   : widget.stage.packId;
               final tpl = TrainingPackTemplateService.getById(tplId, context);
               if (tpl == null) return;
@@ -190,9 +190,9 @@ class _LearningStageTileState extends State<LearningStageTile> {
                 ),
               );
               final updated = await TrainingProgressService.instance
-                  .getSubStageProgress(widget.stage.id, sub.id);
+                  .getSubStageProgress(widget.stage.id, sub.packId);
               setState(() {
-                _progress[sub.id] = updated;
+                _progress[sub.packId] = updated;
                 _lastStartedId = _computeLastStarted();
               });
             },

--- a/test/learning_path_auto_pack_assigner_test.dart
+++ b/test/learning_path_auto_pack_assigner_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_auto_pack_assigner.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_stage_template_generator.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_library_generator.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const stages = [
+    LearningPathStageTemplateInput(
+      id: 's1',
+      title: 'Stage',
+      packId: 'main',
+      subStages: [
+        SubStageTemplateInput(id: 'bb10_UTG_push', packId: '', title: 'A'),
+        SubStageTemplateInput(id: 'other', packId: '', title: 'B'),
+      ],
+    ),
+  ];
+
+  test('byPrefix strategy assigns packId', () {
+    final assigner = LearningPathAutoPackAssigner();
+    final result = assigner.assignPackIds(
+      stages,
+      const ByPrefixStrategy(prefix: 'bb10_UTG_', packId: 'bb10_UTG_main'),
+    );
+    expect(result.first.subStages.first.packId, 'bb10_UTG_main');
+    expect(result.first.subStages.last.packId, 'other');
+  });
+
+  test('manualMap strategy assigns packId', () {
+    final assigner = LearningPathAutoPackAssigner();
+    final result = assigner.assignPackIds(
+      stages,
+      const ManualMapStrategy({'bb10_UTG_': 'bb10_UTG_main'}),
+    );
+    expect(result.first.subStages.first.packId, 'bb10_UTG_main');
+  });
+}

--- a/test/learning_path_stage_template_generator_test.dart
+++ b/test/learning_path_stage_template_generator_test.dart
@@ -13,9 +13,11 @@ void main() {
       title: 'Stage',
       packId: 'test_pack',
       subStages: const [
-        SubStageTemplateInput(id: 'a', title: 'A', minHands: 5, requiredAccuracy: 60),
+        SubStageTemplateInput(
+            id: 'a', packId: 'a', title: 'A', minHands: 5, requiredAccuracy: 60),
         SubStageTemplateInput(
           id: 'b',
+          packId: 'b',
           title: 'B',
           minHands: 5,
           requiredAccuracy: 70,
@@ -27,6 +29,7 @@ void main() {
     final stage = LearningPathStageModel.fromJson(Map<String, dynamic>.from(map));
     expect(stage.id, 's1');
     expect(stage.subStages.length, 2);
+    expect(stage.subStages.first.packId, 'a');
     expect(stage.subStages.last.unlockCondition?.dependsOn, 'a');
   });
 

--- a/test/models/learning_path_substage_test.dart
+++ b/test/models/learning_path_substage_test.dart
@@ -15,13 +15,14 @@ void main() {
       'subStages': [
         {
           'id': 'p1',
+          'packId': 'p1',
           'title': 'A',
           'description': 'first',
           'requiredAccuracy': 70,
           'minHands': 5,
           'unlockCondition': {'dependsOn': 'p0', 'minAccuracy': 60},
         },
-        {'id': 'p2', 'title': 'B'}
+        {'id': 'p2', 'packId': 'p2', 'title': 'B'}
       ]
     };
     final stage = LearningPathStageModel.fromJson(json);
@@ -30,6 +31,7 @@ void main() {
     expect(stage.subStages.first.title, 'A');
     expect(stage.subStages.first.description, 'first');
     expect(stage.subStages.first.requiredAccuracy, 70);
+    expect(stage.subStages.first.packId, 'p1');
     expect(stage.subStages.first.unlockCondition?.dependsOn, 'p0');
     expect(stage.subStages.first.unlockCondition?.minAccuracy, 60);
     expect(stage.subStages.last.minHands, 0);
@@ -45,6 +47,7 @@ requiredAccuracy: 80
 minHands: 10
 subStages:
   - id: p1
+    packId: p1
     title: A
     description: first
     requiredAccuracy: 70
@@ -53,6 +56,7 @@ subStages:
       dependsOn: p0
       minAccuracy: 60
   - id: p2
+    packId: p2
     title: B
 ''';
     final map = const YamlReader().read(yamlStr);
@@ -62,8 +66,10 @@ subStages:
     expect(stage.subStages.first.title, 'A');
     expect(stage.subStages.first.description, 'first');
     expect(stage.subStages.first.requiredAccuracy, 70);
+    expect(stage.subStages.first.packId, 'p1');
     expect(stage.subStages.first.unlockCondition?.dependsOn, 'p0');
     expect(stage.subStages.first.unlockCondition?.minAccuracy, 60);
     expect(stage.subStages.last.id, 'p2');
+    expect(stage.subStages.last.packId, 'p2');
   });
 }


### PR DESCRIPTION
## Summary
- add `LearningPathAutoPackAssigner` with prefix and manual strategies
- store `packId` in `SubStageModel`/`SubStageTemplateInput`
- update services and widgets to use `sub.packId`
- adjust learning path generator tests
- add unit tests for auto pack assigner

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688281246104832a8d77be636c1b3adb