### PR TITLE
Implement SmartPathSeedGenerator

### DIFF
--- a/lib/core/training/generation/smart_path_seed_generator.dart
+++ b/lib/core/training/generation/smart_path_seed_generator.dart
@@ -1,0 +1,78 @@
+import 'learning_path_library_generator.dart';
+import 'learning_path_stage_template_generator.dart';
+
+/// Utility generating stage templates from simple string descriptions.
+class SmartPathSeedGenerator {
+  final int minHands;
+  final double requiredAccuracy;
+  final Map<String, String> packIdMap;
+
+  const SmartPathSeedGenerator({
+    this.minHands = 10,
+    this.requiredAccuracy = 80,
+    this.packIdMap = const {},
+  });
+
+  /// Parses [lines] into a list of [LearningPathStageTemplateInput].
+  /// Each line has format `stageId:A,B,C` where `A,B,C` are sub stages.
+  List<LearningPathStageTemplateInput> generateFromStringList(
+    List<String> lines,
+  ) {
+    final result = <LearningPathStageTemplateInput>[];
+    String? prevStageId;
+
+    for (final raw in lines) {
+      final line = raw.trim();
+      if (line.isEmpty) continue;
+
+      final parts = line.split(':');
+      final stageId = parts.first.trim();
+      final packId = packIdMap[stageId] ?? '${stageId}_main';
+      final subTokens = parts.length > 1
+          ? parts[1]
+              .split(',')
+              .map((e) => e.trim())
+              .where((e) => e.isNotEmpty)
+              .toList()
+          : <String>[];
+
+      final subStages = <SubStageTemplateInput>[];
+      String? prevSubId;
+      for (final token in subTokens) {
+        final subId = '${stageId}_$token';
+        final unlock = prevSubId == null
+            ? null
+            : UnlockConditionInput(dependsOn: prevSubId);
+        subStages.add(
+          SubStageTemplateInput(
+            id: subId,
+            packId: packId,
+            title: token,
+            minHands: minHands,
+            requiredAccuracy: requiredAccuracy,
+            unlockCondition: unlock,
+          ),
+        );
+        prevSubId = subId;
+      }
+
+      final stageUnlock = prevStageId == null
+          ? null
+          : UnlockConditionInput(dependsOn: prevStageId);
+      result.add(
+        LearningPathStageTemplateInput(
+          id: stageId,
+          title: stageId,
+          packId: packId,
+          minHands: minHands,
+          requiredAccuracy: requiredAccuracy,
+          subStages: subStages,
+          unlockCondition: stageUnlock,
+        ),
+      );
+      prevStageId = stageId;
+    }
+
+    return result;
+  }
+}

--- a/test/smart_path_seed_generator_test.dart
+++ b/test/smart_path_seed_generator_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/smart_path_seed_generator.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generateFromStringList builds stages with subStages and unlocks', () {
+    const generator = SmartPathSeedGenerator();
+    final stages = generator.generateFromStringList([
+      'bb10_UTG:A,B,C',
+      'bb10_CO:A,B',
+    ]);
+    expect(stages.length, 2);
+
+    final s1 = stages.first;
+    expect(s1.id, 'bb10_UTG');
+    expect(s1.packId, 'bb10_UTG_main');
+    expect(s1.subStages.length, 3);
+    expect(s1.subStages.first.id, 'bb10_UTG_A');
+    expect(s1.subStages[1].unlockCondition?.dependsOn, 'bb10_UTG_A');
+
+    final s2 = stages[1];
+    expect(s2.unlockCondition?.dependsOn, 'bb10_UTG');
+    expect(s2.subStages.first.id, 'bb10_CO_A');
+  });
+}


### PR DESCRIPTION
## Summary
- add SmartPathSeedGenerator for creating learning path stages from short strings
- test generation of stages with sub-stages and unlocks

## Testing
- `flutter analyze` *(fails: 14481 issues)*
- `flutter test test/smart_path_seed_generator_test.dart` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_688283684f24832a9368d713f6180b1c