### PR TITLE
Add validator for learning path packs

### DIFF
--- a/lib/core/training/generation/learning_path_pack_validator.dart
+++ b/lib/core/training/generation/learning_path_pack_validator.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'learning_path_library_generator.dart';
+
+class LearningPathPackValidator {
+  const LearningPathPackValidator();
+
+  List<String> validate(
+    List<LearningPathStageTemplateInput> stages,
+    Directory packsDir,
+  ) {
+    final files = packsDir.listSync(recursive: true);
+    final names = <String>{};
+    for (final f in files) {
+      if (f is File && f.path.toLowerCase().endsWith('.yaml')) {
+        names.add(p.basenameWithoutExtension(f.path));
+      }
+    }
+
+    final errors = <String>[];
+    for (final stage in stages) {
+      if (!names.contains(stage.packId)) {
+        errors.add('Missing pack: ${stage.packId}');
+      }
+      for (final sub in stage.subStages) {
+        if (!names.contains(sub.packId)) {
+          errors.add('Missing subStage pack: ${sub.packId}');
+        }
+      }
+    }
+    return errors;
+  }
+}

--- a/test/learning_path_pack_validator_test.dart
+++ b/test/learning_path_pack_validator_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_pack_validator.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_library_generator.dart';
+import 'package:poker_analyzer/core/training/generation/learning_path_stage_template_generator.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('packs');
+  });
+
+  tearDown(() {
+    dir.deleteSync(recursive: true);
+  });
+
+  test('validate passes when packs exist', () {
+    File('${dir.path}/main.yaml').writeAsStringSync('');
+    File('${dir.path}/sub.yaml').writeAsStringSync('');
+    const stages = [
+      LearningPathStageTemplateInput(
+        id: 's1',
+        title: 'Stage',
+        packId: 'main',
+        subStages: [
+          SubStageTemplateInput(id: 'sub1', packId: 'sub', title: 'Sub'),
+        ],
+      ),
+    ];
+    final validator = LearningPathPackValidator();
+    final result = validator.validate(stages, dir);
+    expect(result, isEmpty);
+  });
+
+  test('validate reports missing stage pack', () {
+    final validator = LearningPathPackValidator();
+    const stages = [
+      LearningPathStageTemplateInput(
+        id: 's1',
+        title: 'Stage',
+        packId: 'missing',
+      ),
+    ];
+    final result = validator.validate(stages, dir);
+    expect(result, contains('Missing pack: missing'));
+  });
+
+  test('validate reports missing subStage pack', () {
+    File('${dir.path}/main.yaml').writeAsStringSync('');
+    const stages = [
+      LearningPathStageTemplateInput(
+        id: 's1',
+        title: 'Stage',
+        packId: 'main',
+        subStages: [
+          SubStageTemplateInput(id: 'sub1', packId: 'other', title: 'Sub'),
+        ],
+      ),
+    ];
+    final validator = LearningPathPackValidator();
+    final result = validator.validate(stages, dir);
+    expect(result, contains('Missing subStage pack: other'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathPackValidator` to ensure pack IDs exist
- check subStage packs as well
- cover validator with tests

## Testing
- `dart run test test/learning_path_pack_validator_test.dart` *(fails: Flutter SDK not available)*
- `flutter pub get` *(fails: Dart SDK version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688287a75560832a891835b35079a950