### PR TITLE
Implement SmartPathCompiler

### DIFF
--- a/lib/core/training/generation/smart_path_compiler.dart
+++ b/lib/core/training/generation/smart_path_compiler.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'learning_path_auto_pack_assigner.dart';
+import 'learning_path_library_generator.dart';
+import 'learning_path_pack_validator.dart';
+import 'smart_path_seed_generator.dart';
+
+/// Compiles a simple string description of a learning path into YAML.
+class SmartPathCompiler {
+  final SmartPathSeedGenerator seedGenerator;
+  final LearningPathAutoPackAssigner packAssigner;
+  final LearningPathPackValidator validator;
+  final LearningPathLibraryGenerator libraryGenerator;
+
+  const SmartPathCompiler({
+    SmartPathSeedGenerator? seedGenerator,
+    LearningPathAutoPackAssigner? packAssigner,
+    LearningPathPackValidator? validator,
+    LearningPathLibraryGenerator? libraryGenerator,
+  })  : seedGenerator = seedGenerator ?? const SmartPathSeedGenerator(),
+        packAssigner = packAssigner ?? const LearningPathAutoPackAssigner(),
+        validator = validator ?? const LearningPathPackValidator(),
+        libraryGenerator = libraryGenerator ?? const LearningPathLibraryGenerator();
+
+  /// Compiles [lines] into a YAML learning path using packs from [packsDir].
+  /// Throws [Exception] if any referenced packs are missing.
+  String compile(List<String> lines, Directory packsDir) {
+    final stages = seedGenerator.generateFromStringList(lines);
+
+    final mapping = <String, String>{
+      for (final s in stages) '${s.id}_': s.packId,
+    };
+
+    final withPacks =
+        packAssigner.assignPackIds(stages, ManualMapStrategy(mapping));
+
+    final errors = validator.validate(withPacks, packsDir);
+    if (errors.isNotEmpty) {
+      throw Exception(errors.join(', '));
+    }
+
+    return libraryGenerator.generatePathYaml(withPacks);
+  }
+}

--- a/test/smart_path_compiler_test.dart
+++ b/test/smart_path_compiler_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/generation/smart_path_compiler.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('compiler_test');
+  });
+
+  tearDown(() {
+    dir.deleteSync(recursive: true);
+  });
+
+  test('compile returns yaml for valid packs', () {
+    File('${dir.path}/s1_main.yaml').writeAsStringSync('');
+    File('${dir.path}/s2_main.yaml').writeAsStringSync('');
+
+    final compiler = SmartPathCompiler();
+    final yaml = compiler.compile(['s1:A,B', 's2:A'], dir);
+
+    final map = const YamlReader().read(yaml);
+    final stages = map['stages'] as List? ?? [];
+    expect(stages.length, 2);
+    expect(stages.first['id'], 's1');
+  });
+
+  test('compile throws when pack missing', () {
+    File('${dir.path}/s1_main.yaml').writeAsStringSync('');
+
+    final compiler = SmartPathCompiler();
+    expect(() => compiler.compile(['s1:A', 's2:A'], dir), throwsException);
+  });
+}


### PR DESCRIPTION
## Summary
- add SmartPathCompiler to combine seed generation, pack assignment, validation, and YAML generation
- cover SmartPathCompiler with end-to-end tests

## Testing
- `flutter test test/smart_path_compiler_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68828bde5f10832abfa4c5453428c062