### PR TITLE
Add SmartPath compiler CLI

### DIFF
--- a/test/tools/compile_path_test.dart
+++ b/test/tools/compile_path_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('compile path cli', () async {
+    final packs = await Directory.systemTemp.createTemp('compile_path_packs');
+    try {
+      // create sample pack files
+      for (final stage in ['bb10_UTG', 'bb10_CO', 'bb10_BTN']) {
+        await File(p.join(packs.path, '${stage}_main.yaml')).writeAsString('');
+      }
+      final txtFile = File(p.join(packs.path, 'bb10.txt'));
+      await txtFile.writeAsString('bb10_UTG:A\nbb10_CO:A\nbb10_BTN:A\n');
+
+      final res = await Process.run('dart', [
+        'run',
+        'tools/compile_path.dart',
+        txtFile.path,
+        packs.path,
+      ]);
+      expect(
+        res.exitCode,
+        0,
+        reason: 'stdout: ${res.stdout}\nstderr: ${res.stderr}',
+      );
+      final outFile = File('compiled/path.yaml');
+      expect(outFile.existsSync(), isTrue);
+      final content = outFile.readAsStringSync();
+      expect(content.trim().isNotEmpty, isTrue);
+    } finally {
+      await Directory('compiled').delete(recursive: true);
+      await packs.delete(recursive: true);
+    }
+  });
+}

--- a/tools/compile_path.dart
+++ b/tools/compile_path.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/core/error_logger.dart';
+import 'package:poker_analyzer/core/training/generation/smart_path_compiler.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.length < 2) {
+    ErrorLogger.instance.logError(
+      'Usage: dart run tools/compile_path.dart <spec.txt> <packs_dir>',
+    );
+    exit(1);
+  }
+
+  final specFile = File(args[0]);
+  final packsDir = Directory(args[1]);
+
+  if (!specFile.existsSync()) {
+    ErrorLogger.instance.logError('File not found: ${specFile.path}');
+    exit(1);
+  }
+
+  if (!packsDir.existsSync()) {
+    ErrorLogger.instance.logError('Directory not found: ${packsDir.path}');
+    exit(1);
+  }
+
+  final lines = specFile.readAsLinesSync();
+  final compiler = SmartPathCompiler();
+  late String yaml;
+  try {
+    yaml = compiler.compile(lines, packsDir);
+  } catch (e) {
+    final msg = e.toString();
+    for (final line in msg.split(',')) {
+      ErrorLogger.instance.logError(line.trim());
+    }
+    exit(1);
+  }
+
+  final outDir = Directory('compiled');
+  await outDir.create(recursive: true);
+  final outFile = File(p.join(outDir.path, 'path.yaml'));
+  outFile.writeAsStringSync('$yaml\n');
+  ErrorLogger.instance.logError('Wrote ${outFile.path}');
+}


### PR DESCRIPTION
## Summary
- add CLI to compile learning path YAML from text specs
- test compile_path command

## Testing
- `flutter pub run tools/compile_path.dart /tmp/packs/bb10.txt /tmp/packs` *(fails: Offset not defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68828cbfb148832aaedaf27470de1694