### PR TITLE
Add PathLibraryScreen

### DIFF
--- a/lib/screens/path_library_screen.dart
+++ b/lib/screens/path_library_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../services/learning_path_registry_service.dart';
+import '../widgets/smart_path_preview_card.dart';
+
+/// Sorting options for [PathLibraryScreen].
+enum PathSort { name, length, date }
+
+/// Screen displaying all learning paths as [SmartPathPreviewCard] widgets.
+class PathLibraryScreen extends StatefulWidget {
+  const PathLibraryScreen({super.key});
+
+  @override
+  State<PathLibraryScreen> createState() => _PathLibraryScreenState();
+}
+
+class _PathLibraryScreenState extends State<PathLibraryScreen> {
+  late Future<List<LearningPathTemplateV2>> _future;
+  PathDifficulty? _filter;
+  PathSort _sort = PathSort.name;
+  bool _error = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<List<LearningPathTemplateV2>> _load() async {
+    try {
+      final list = await LearningPathRegistryService.instance.loadAll();
+      return list;
+    } catch (_) {
+      _error = true;
+      return [];
+    }
+  }
+
+  PathDifficulty _difficultyOf(LearningPathTemplateV2 tpl) {
+    final count = tpl.stages.length;
+    if (count <= 3) return PathDifficulty.easy;
+    if (count <= 6) return PathDifficulty.medium;
+    return PathDifficulty.hard;
+  }
+
+  List<LearningPathTemplateV2> _process(List<LearningPathTemplateV2> list) {
+    var result = List<LearningPathTemplateV2>.from(list);
+    if (_filter != null) {
+      result = result.where((p) => _difficultyOf(p) == _filter).toList();
+    }
+    switch (_sort) {
+      case PathSort.length:
+        result.sort((a, b) => a.stages.length.compareTo(b.stages.length));
+        break;
+      case PathSort.name:
+        result.sort((a, b) => a.title.compareTo(b.title));
+        break;
+      case PathSort.date:
+        result.sort((a, b) => a.id.compareTo(b.id));
+        break;
+    }
+    return result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Пути обучения')),
+      body: FutureBuilder<List<LearningPathTemplateV2>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (_error) {
+            return const Center(child: Text('Ошибка загрузки'));
+          }
+          final list = _process(snapshot.data ?? const []);
+          if (list.isEmpty) {
+            return const Center(child: Text('Нет доступных путей'));
+          }
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Row(
+                  children: [
+                    DropdownButton<PathDifficulty?>(
+                      value: _filter,
+                      hint: const Text('Сложность'),
+                      onChanged: (val) => setState(() => _filter = val),
+                      items: [
+                        const DropdownMenuItem<PathDifficulty?>(
+                          value: null,
+                          child: Text('Все'),
+                        ),
+                        DropdownMenuItem(
+                          value: PathDifficulty.easy,
+                          child: const Text('Легкие'),
+                        ),
+                        DropdownMenuItem(
+                          value: PathDifficulty.medium,
+                          child: const Text('Средние'),
+                        ),
+                        DropdownMenuItem(
+                          value: PathDifficulty.hard,
+                          child: const Text('Сложные'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(width: 16),
+                    DropdownButton<PathSort>(
+                      value: _sort,
+                      onChanged: (val) {
+                        if (val != null) setState(() => _sort = val);
+                      },
+                      items: const [
+                        DropdownMenuItem(
+                          value: PathSort.name,
+                          child: Text('По названию'),
+                        ),
+                        DropdownMenuItem(
+                          value: PathSort.length,
+                          child: Text('По длине'),
+                        ),
+                        DropdownMenuItem(
+                          value: PathSort.date,
+                          child: Text('По дате'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: GridView.builder(
+                  padding: const EdgeInsets.all(12),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    mainAxisSpacing: 12,
+                    crossAxisSpacing: 12,
+                    childAspectRatio: 0.8,
+                  ),
+                  itemCount: list.length,
+                  itemBuilder: (context, index) {
+                    final tpl = list[index];
+                    return SmartPathPreviewCard(
+                      pathId: tpl.id,
+                      pathTitle: tpl.title,
+                      pathDescription: tpl.description,
+                      stageCount: tpl.stages.length,
+                      packCount:
+                          tpl.stages.map((e) => e.packId).toSet().length,
+                      difficulty: _difficultyOf(tpl),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/learning_path_dashboard_block.dart
+++ b/lib/widgets/learning_path_dashboard_block.dart
@@ -5,7 +5,7 @@ import '../services/session_log_service.dart';
 import '../services/training_session_service.dart';
 import '../models/learning_path_track_model.dart';
 import '../models/learning_path_template_v2.dart';
-import '../screens/learning_path_library_screen.dart';
+import '../screens/path_library_screen.dart';
 
 /// Dashboard widget highlighting the next learning path to continue.
 class LearningPathDashboardBlock extends StatefulWidget {
@@ -53,7 +53,7 @@ class _LearningPathDashboardBlockState extends State<LearningPathDashboardBlock>
   void _openPath() {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => const LearningPathLibraryScreen()),
+      MaterialPageRoute(builder: (_) => const PathLibraryScreen()),
     );
   }
 


### PR DESCRIPTION
## Summary
- introduce `PathLibraryScreen` to display all learning paths
- support filtering by difficulty and sorting by name, length or date
- update dashboard block to navigate to the new screen

## Testing
- `flutter analyze` *(fails: 14492 issues)*
- `flutter test` *(fails to run due to missing files and plugin configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6882988d9234832aace602a2315e2e1b