### PR TITLE
Add stage objectives display

### DIFF
--- a/assets/learning_paths/sample_path.yaml
+++ b/assets/learning_paths/sample_path.yaml
@@ -12,6 +12,8 @@ stages:
     packId: pack1
     requiredAccuracy: 80
     minHands: 10
+    objectives:
+      - Push decisions
     unlocks:
       - s2
   - id: s2
@@ -20,6 +22,8 @@ stages:
     packId: pack2
     requiredAccuracy: 70
     minHands: 5
+    objectives:
+      - Postflop calls
     unlockCondition:
       dependsOn: s1
       minAccuracy: 75

--- a/lib/core/training/generation/learning_path_library_generator.dart
+++ b/lib/core/training/generation/learning_path_library_generator.dart
@@ -14,6 +14,7 @@ class LearningPathStageTemplateInput {
   final List<SubStageTemplateInput> subStages;
   final UnlockConditionInput? unlockCondition;
   final List<String>? tags;
+  final List<String>? objectives;
 
   const LearningPathStageTemplateInput({
     required this.id,
@@ -25,13 +26,15 @@ class LearningPathStageTemplateInput {
     this.subStages = const [],
     this.unlockCondition,
     this.tags,
+    this.objectives,
   });
 }
 
 /// Generates a learning path YAML file from stage templates.
 class LearningPathLibraryGenerator {
   final LearningPathStageTemplateGenerator stageGenerator;
-  const LearningPathLibraryGenerator({LearningPathStageTemplateGenerator? stageGenerator})
+  const LearningPathLibraryGenerator(
+      {LearningPathStageTemplateGenerator? stageGenerator})
       : stageGenerator = stageGenerator ?? LearningPathStageTemplateGenerator();
 
   /// Generates YAML for a complete learning path based on [stages].
@@ -48,6 +51,7 @@ class LearningPathLibraryGenerator {
         minHands: s.minHands,
         subStages: s.subStages,
         unlockCondition: s.unlockCondition,
+        objectives: s.objectives,
         tags: s.tags,
       );
       final map = const YamlReader().read(yaml);
@@ -65,4 +69,3 @@ class LearningPathLibraryGenerator {
     return json2yaml(pathMap, yamlStyle: YamlStyle.pubspecYaml);
   }
 }
-

--- a/lib/core/training/generation/learning_path_stage_template_generator.dart
+++ b/lib/core/training/generation/learning_path_stage_template_generator.dart
@@ -68,6 +68,7 @@ class LearningPathStageTemplateGenerator {
     int minHands = 10,
     List<SubStageTemplateInput> subStages = const [],
     UnlockConditionInput? unlockCondition,
+    List<String>? objectives,
     List<String>? tags,
   }) {
     _order += 1;
@@ -87,6 +88,9 @@ class LearningPathStageTemplateGenerator {
     }
     if (unlockCondition != null) {
       map['unlockCondition'] = unlockCondition.toMap();
+    }
+    if (objectives != null && objectives.isNotEmpty) {
+      map['objectives'] = objectives;
     }
     if (subStages.isNotEmpty) {
       map['subStages'] = [for (final s in subStages) s.toMap()];

--- a/lib/models/learning_path_stage_model.dart
+++ b/lib/models/learning_path_stage_model.dart
@@ -14,6 +14,7 @@ class LearningPathStageModel {
   final List<String> unlocks;
   final List<String> unlockAfter;
   final List<String> tags;
+  final List<String> objectives;
   final int order;
   final bool isOptional;
   final UnlockCondition? unlockCondition;
@@ -29,12 +30,14 @@ class LearningPathStageModel {
     List<String>? unlocks,
     List<String>? tags,
     List<String>? unlockAfter,
+    List<String>? objectives,
     this.order = 0,
     this.isOptional = false,
     this.unlockCondition,
   })  : unlocks = unlocks ?? const [],
         unlockAfter = unlockAfter ?? const [],
         tags = tags ?? const [],
+        objectives = objectives ?? const [],
         subStages = subStages ?? const [];
 
   factory LearningPathStageModel.fromJson(Map<String, dynamic> json) {
@@ -50,6 +53,9 @@ class LearningPathStageModel {
         for (final u in (json['unlockAfter'] as List? ?? [])) u.toString(),
       ],
       tags: [for (final t in (json['tags'] as List? ?? [])) t.toString()],
+      objectives: [
+        for (final o in (json['objectives'] as List? ?? [])) o.toString()
+      ],
       order: (json['order'] as num?)?.toInt() ?? 0,
       isOptional: json['isOptional'] as bool? ?? false,
       unlockCondition: json['unlockCondition'] is Map
@@ -74,6 +80,7 @@ class LearningPathStageModel {
         if (unlocks.isNotEmpty) 'unlocks': unlocks,
         if (unlockAfter.isNotEmpty) 'unlockAfter': unlockAfter,
         if (tags.isNotEmpty) 'tags': tags,
+        if (objectives.isNotEmpty) 'objectives': objectives,
         'order': order,
         if (isOptional) 'isOptional': true,
         if (unlockCondition != null)

--- a/lib/screens/learning_path_stage_preview_screen.dart
+++ b/lib/screens/learning_path_stage_preview_screen.dart
@@ -18,7 +18,6 @@ import '../models/mistake_tag_cluster.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../widgets/skill_card.dart';
 
-
 class LearningPathStagePreviewScreen extends StatefulWidget {
   final LearningPathTemplateV2 path;
   final LearningPathStageModel stage;
@@ -81,7 +80,8 @@ class _LearningPathStagePreviewScreenState
       count: 3,
     );
     final model = await _service.build(widget.path.id);
-    final status = model.statusFor(widget.stage.id)?.status ?? StageStatus.locked;
+    final status =
+        model.statusFor(widget.stage.id)?.status ?? StageStatus.locked;
     final reasons = <String>[];
     if (status == StageStatus.locked) {
       final threshold = _gatekeeper.masteryThreshold;
@@ -121,7 +121,8 @@ class _LearningPathStagePreviewScreenState
   }
 
   Future<void> _start() async {
-    final template = await PackLibraryService.instance.getById(widget.stage.packId);
+    final template =
+        await PackLibraryService.instance.getById(widget.stage.packId);
     if (template == null) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -190,10 +191,26 @@ class _LearningPathStagePreviewScreenState
                     widget.stage.description,
                     style: const TextStyle(color: Colors.white70),
                   ),
-                if (widget.stage.tags.isNotEmpty) ...[
+                if (widget.stage.objectives.isNotEmpty) ...[
                   const SizedBox(height: 16),
                   const Text(
                     'Навыки',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 4,
+                    runSpacing: -4,
+                    children: [
+                      for (final o in widget.stage.objectives)
+                        Chip(label: Text(o)),
+                    ],
+                  ),
+                ],
+                if (widget.stage.tags.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Теги',
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 8),
@@ -238,7 +255,8 @@ class _LearningPathStagePreviewScreenState
                     height: 160,
                     child: ListView.separated(
                       scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, i) => _buildBoosterCard(_boosters[i]),
+                      itemBuilder: (context, i) =>
+                          _buildBoosterCard(_boosters[i]),
                       separatorBuilder: (_, __) => const SizedBox(width: 8),
                       itemCount: _boosters.length,
                     ),
@@ -248,8 +266,7 @@ class _LearningPathStagePreviewScreenState
                 Align(
                   alignment: Alignment.centerRight,
                   child: ElevatedButton(
-                    onPressed:
-                        _status == StageStatus.unlocked ? _start : null,
+                    onPressed: _status == StageStatus.unlocked ? _start : null,
                     child: const Text('Начать тренировку'),
                   ),
                 ),
@@ -258,4 +275,3 @@ class _LearningPathStagePreviewScreenState
     );
   }
 }
-

--- a/lib/screens/path_overview_screen.dart
+++ b/lib/screens/path_overview_screen.dart
@@ -147,7 +147,8 @@ class _PathOverviewScreenState extends State<PathOverviewScreen> {
                       alignment: Alignment.center,
                       child: ElevatedButton(
                         onPressed: _startLearning,
-                        child: Text(_progress > 0 ? 'Продолжить обучение' : 'Начать'),
+                        child: Text(
+                            _progress > 0 ? 'Продолжить обучение' : 'Начать'),
                       ),
                     ),
                   ],
@@ -173,9 +174,21 @@ class _PathOverviewScreenState extends State<PathOverviewScreen> {
     return ListTile(
       leading: Icon(icon, color: color),
       title: Text('${index}. ${stage.title}'),
-      subtitle: stage.description.isNotEmpty ? Text(stage.description) : null,
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (stage.description.isNotEmpty) Text(stage.description),
+          if (stage.objectives.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                'Навыки: ${stage.objectives.join(', ')}',
+                style: const TextStyle(fontSize: 12, color: Colors.white70),
+              ),
+            ),
+        ],
+      ),
       trailing: Text('$hands / ${stage.minHands}'),
     );
   }
 }
-

--- a/lib/widgets/stage_preview_dialog.dart
+++ b/lib/widgets/stage_preview_dialog.dart
@@ -27,22 +27,22 @@ class _StagePreviewDialogState extends State<StagePreviewDialog> {
     final p = await PackLibraryService.instance.getById(widget.stage.packId);
     if (mounted) {
       setState(() {
-      _pack = p;
-      _loading = false;
-    });
+        _pack = p;
+        _loading = false;
+      });
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final pack = _pack;
-    final estMinutes =
-        pack == null ? null : (pack.spotCount / 2).ceil();
+    final estMinutes = pack == null ? null : (pack.spotCount / 2).ceil();
     return AlertDialog(
       backgroundColor: const Color(0xFF1E1E1E),
       title: Text(widget.stage.title),
       content: _loading
-          ? const SizedBox(height: 100, child: Center(child: CircularProgressIndicator()))
+          ? const SizedBox(
+              height: 100, child: Center(child: CircularProgressIndicator()))
           : Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -58,13 +58,22 @@ class _StagePreviewDialogState extends State<StagePreviewDialog> {
                     Text('Estimated time: ${estMinutes}m',
                         style: const TextStyle(color: Colors.white70)),
                 ],
+                if (widget.stage.objectives.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 4,
+                    children: [
+                      for (final o in widget.stage.objectives)
+                        Chip(label: Text(o)),
+                    ],
+                  ),
+                ],
                 if (widget.stage.tags.isNotEmpty) ...[
                   const SizedBox(height: 8),
                   Wrap(
                     spacing: 4,
                     children: [
-                      for (final t in widget.stage.tags)
-                        Chip(label: Text(t)),
+                      for (final t in widget.stage.tags) Chip(label: Text(t)),
                     ],
                   ),
                 ],


### PR DESCRIPTION
## Summary
- extend `LearningPathStageModel` with `objectives` field
- display stage objectives on overview and preview screens
- show objectives in stage preview dialog
- support `objectives` in path generation tools
- update sample learning path with objectives

## Testing
- `mise exec flutter@3.32.7 -- flutter analyze`
- `mise exec flutter@3.32.7 -- flutter test` *(fails: unable to build project)*

------
https://chatgpt.com/codex/tasks/task_e_6882b46f78e0832a9355626da30ad048