### PR TITLE
Add substage display and generation support

### DIFF
--- a/assets/learning_paths/sample_path.yaml
+++ b/assets/learning_paths/sample_path.yaml
@@ -12,6 +12,19 @@ stages:
     packId: pack1
     requiredAccuracy: 80
     minHands: 10
+    subStages:
+      - id: s1a
+        packId: pack1
+        title: Part A
+        description: Intro task
+        requiredAccuracy: 80
+        minHands: 5
+      - id: s1b
+        packId: pack1
+        title: Part B
+        description: Final task
+        requiredAccuracy: 80
+        minHands: 5
     objectives:
       - Push decisions
     unlocks:

--- a/lib/core/training/generation/learning_path_auto_pack_assigner.dart
+++ b/lib/core/training/generation/learning_path_auto_pack_assigner.dart
@@ -48,6 +48,7 @@ class LearningPathAutoPackAssigner {
           id: sub.id,
           packId: packId,
           title: sub.title,
+          description: sub.description,
           minHands: sub.minHands,
           requiredAccuracy: sub.requiredAccuracy,
           unlockCondition: sub.unlockCondition,

--- a/lib/core/training/generation/learning_path_stage_template_generator.dart
+++ b/lib/core/training/generation/learning_path_stage_template_generator.dart
@@ -5,6 +5,7 @@ class SubStageTemplateInput {
   final String id;
   final String packId;
   final String title;
+  final String description;
   final int minHands;
   final double requiredAccuracy;
   final UnlockConditionInput? unlockCondition;
@@ -13,6 +14,7 @@ class SubStageTemplateInput {
     required this.id,
     required this.packId,
     required this.title,
+    this.description = '',
     this.minHands = 0,
     this.requiredAccuracy = 0,
     this.unlockCondition,
@@ -22,6 +24,7 @@ class SubStageTemplateInput {
         'id': id,
         'packId': packId,
         'title': title,
+        if (description.isNotEmpty) 'description': description,
         if (minHands > 0) 'minHands': minHands,
         if (requiredAccuracy > 0) 'requiredAccuracy': requiredAccuracy,
         if (unlockCondition != null)

--- a/lib/core/training/generation/smart_path_seed_generator.dart
+++ b/lib/core/training/generation/smart_path_seed_generator.dart
@@ -48,6 +48,7 @@ class SmartPathSeedGenerator {
             id: subId,
             packId: packId,
             title: token,
+            description: '',
             minHands: minHands,
             requiredAccuracy: requiredAccuracy,
             unlockCondition: unlock,

--- a/lib/screens/learning_path_stage_preview_screen.dart
+++ b/lib/screens/learning_path_stage_preview_screen.dart
@@ -191,6 +191,46 @@ class _LearningPathStagePreviewScreenState
                     widget.stage.description,
                     style: const TextStyle(color: Colors.white70),
                   ),
+                if (widget.stage.subStages.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Подэтапы',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final sub in widget.stage.subStages)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  sub.title,
+                                  style:
+                                      const TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                                if (sub.description.isNotEmpty)
+                                  Text(
+                                    sub.description,
+                                    style:
+                                        const TextStyle(color: Colors.white70),
+                                  ),
+                              ],
+                            ),
+                          ),
+                          Text(
+                            '${sub.minHands} рук · ${sub.requiredAccuracy.toStringAsFixed(0)}%',
+                            style:
+                                const TextStyle(color: Colors.white70, fontSize: 12),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
                 if (widget.stage.objectives.isNotEmpty) ...[
                   const SizedBox(height: 16),
                   const Text(

--- a/test/learning_path_auto_pack_assigner_test.dart
+++ b/test/learning_path_auto_pack_assigner_test.dart
@@ -12,8 +12,18 @@ void main() {
       title: 'Stage',
       packId: 'main',
       subStages: [
-        SubStageTemplateInput(id: 'bb10_UTG_push', packId: '', title: 'A'),
-        SubStageTemplateInput(id: 'other', packId: '', title: 'B'),
+        SubStageTemplateInput(
+          id: 'bb10_UTG_push',
+          packId: '',
+          title: 'A',
+          description: '',
+        ),
+        SubStageTemplateInput(
+          id: 'other',
+          packId: '',
+          title: 'B',
+          description: '',
+        ),
       ],
     ),
   ];

--- a/test/learning_path_pack_validator_test.dart
+++ b/test/learning_path_pack_validator_test.dart
@@ -26,7 +26,12 @@ void main() {
         title: 'Stage',
         packId: 'main',
         subStages: [
-          SubStageTemplateInput(id: 'sub1', packId: 'sub', title: 'Sub'),
+          SubStageTemplateInput(
+            id: 'sub1',
+            packId: 'sub',
+            title: 'Sub',
+            description: '',
+          ),
         ],
       ),
     ];
@@ -56,7 +61,12 @@ void main() {
         title: 'Stage',
         packId: 'main',
         subStages: [
-          SubStageTemplateInput(id: 'sub1', packId: 'other', title: 'Sub'),
+          SubStageTemplateInput(
+            id: 'sub1',
+            packId: 'other',
+            title: 'Sub',
+            description: '',
+          ),
         ],
       ),
     ];

--- a/test/learning_path_stage_template_generator_test.dart
+++ b/test/learning_path_stage_template_generator_test.dart
@@ -14,11 +14,17 @@ void main() {
       packId: 'test_pack',
       subStages: const [
         SubStageTemplateInput(
-            id: 'a', packId: 'a', title: 'A', minHands: 5, requiredAccuracy: 60),
+            id: 'a',
+            packId: 'a',
+            title: 'A',
+            description: 'desc A',
+            minHands: 5,
+            requiredAccuracy: 60),
         SubStageTemplateInput(
           id: 'b',
           packId: 'b',
           title: 'B',
+          description: 'desc B',
           minHands: 5,
           requiredAccuracy: 70,
           unlockCondition: UnlockConditionInput(dependsOn: 'a'),


### PR DESCRIPTION
## Summary
- support description field in `SubStageTemplateInput`
- propagate description in auto pack assigner and seed generator
- show substage list on stage preview screen
- extend sample learning path with substage data
- update tests for new `SubStageTemplateInput` API

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b7bf0ba0832a9680b086b3d8bf4a