### PR TITLE
Add SmartWeaknessBooster support

### DIFF
--- a/lib/core/training/generation/learning_path_stage_template_generator.dart
+++ b/lib/core/training/generation/learning_path_stage_template_generator.dart
@@ -8,6 +8,7 @@ class SubStageTemplateInput {
   final String description;
   final int minHands;
   final double requiredAccuracy;
+  final List<String> objectives;
   final UnlockConditionInput? unlockCondition;
 
   const SubStageTemplateInput({
@@ -17,6 +18,7 @@ class SubStageTemplateInput {
     this.description = '',
     this.minHands = 0,
     this.requiredAccuracy = 0,
+    this.objectives = const [],
     this.unlockCondition,
   });
 
@@ -27,6 +29,7 @@ class SubStageTemplateInput {
         if (description.isNotEmpty) 'description': description,
         if (minHands > 0) 'minHands': minHands,
         if (requiredAccuracy > 0) 'requiredAccuracy': requiredAccuracy,
+        if (objectives.isNotEmpty) 'objectives': objectives,
         if (unlockCondition != null)
           'unlockCondition': unlockCondition!.toMap(),
       };

--- a/lib/models/sub_stage_model.dart
+++ b/lib/models/sub_stage_model.dart
@@ -7,6 +7,7 @@ class SubStageModel {
   final String description;
   final int minHands;
   final double requiredAccuracy;
+  final List<String> objectives;
   final UnlockCondition? unlockCondition;
 
   const SubStageModel({
@@ -16,6 +17,7 @@ class SubStageModel {
     this.description = '',
     this.minHands = 0,
     this.requiredAccuracy = 0,
+    this.objectives = const [],
     this.unlockCondition,
   });
 
@@ -27,6 +29,9 @@ class SubStageModel {
       description: json['description'] as String? ?? '',
       minHands: (json['minHands'] as num?)?.toInt() ?? 0,
       requiredAccuracy: (json['requiredAccuracy'] as num?)?.toDouble() ?? 0.0,
+      objectives: [
+        for (final o in (json['objectives'] as List? ?? [])) o.toString()
+      ],
       unlockCondition: json['unlockCondition'] is Map
           ? UnlockCondition.fromJson(
               Map<String, dynamic>.from(json['unlockCondition'] as Map))
@@ -41,6 +46,7 @@ class SubStageModel {
         if (description.isNotEmpty) 'description': description,
         if (minHands > 0) 'minHands': minHands,
         if (requiredAccuracy > 0) 'requiredAccuracy': requiredAccuracy,
+        if (objectives.isNotEmpty) 'objectives': objectives,
         if (unlockCondition != null)
           'unlockCondition': unlockCondition!.toJson(),
       };

--- a/test/models/learning_path_substage_test.dart
+++ b/test/models/learning_path_substage_test.dart
@@ -34,6 +34,7 @@ void main() {
     expect(stage.subStages.first.packId, 'p1');
     expect(stage.subStages.first.unlockCondition?.dependsOn, 'p0');
     expect(stage.subStages.first.unlockCondition?.minAccuracy, 60);
+    expect(stage.subStages.first.objectives, isEmpty);
     expect(stage.subStages.last.minHands, 0);
   });
 
@@ -69,6 +70,7 @@ subStages:
     expect(stage.subStages.first.packId, 'p1');
     expect(stage.subStages.first.unlockCondition?.dependsOn, 'p0');
     expect(stage.subStages.first.unlockCondition?.minAccuracy, 60);
+    expect(stage.subStages.first.objectives, isEmpty);
     expect(stage.subStages.last.id, 'p2');
     expect(stage.subStages.last.packId, 'p2');
   });


### PR DESCRIPTION
## Summary
- add objectives field to SubStageModel
- compute substage accuracy and booster recommendations in stage preview
- display "Усилить 🔥" button with booster name when accuracy is low
- support objectives in template generator
- update substage model tests

## Testing
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_6882badf35e4832a86c96219dc5ecfb0