### PR TITLE
Add Booster Library screen

### DIFF
--- a/lib/screens/booster_library_screen.dart
+++ b/lib/screens/booster_library_screen.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/training_pack_library_loader_service.dart';
+import '../services/training_session_launcher.dart';
+
+class BoosterLibraryScreen extends StatefulWidget {
+  const BoosterLibraryScreen({super.key});
+
+  @override
+  State<BoosterLibraryScreen> createState() => _BoosterLibraryScreenState();
+}
+
+class _BoosterLibraryScreenState extends State<BoosterLibraryScreen> {
+  bool _loading = true;
+  List<TrainingPackTemplateV2> _packs = [];
+  String _tagFilter = '';
+  int? _difficultyFilter;
+  bool _recommendedOnly = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await TrainingPackLibraryLoaderService.instance.preloadLibrary();
+    final all = TrainingPackLibraryLoaderService.instance.loadedTemplates;
+    final boosters = [
+      for (final p in all)
+        if (p.meta['type'] == 'booster') p
+    ];
+    setState(() {
+      _packs = boosters;
+      _loading = false;
+    });
+  }
+
+  List<String> get _tags {
+    final set = <String>{};
+    for (final p in _packs) {
+      final t = p.meta['tag']?.toString();
+      if (t != null && t.isNotEmpty) set.add(t);
+    }
+    final list = set.toList()..sort();
+    return list;
+  }
+
+  List<TrainingPackTemplateV2> get _filtered {
+    return [
+      for (final p in _packs)
+        if ((_tagFilter.isEmpty || p.meta['tag'] == _tagFilter) &&
+            (_difficultyFilter == null ||
+                (p.meta['difficulty'] as num?)?.toInt() == _difficultyFilter) &&
+            (!_recommendedOnly || p.recommended))
+          p
+    ];
+  }
+
+  String? _difficultyLabel(TrainingPackTemplateV2 p) {
+    final d = (p.meta['difficulty'] as num?)?.toInt() ?? 0;
+    if (d == 1) return 'Easy';
+    if (d == 2) return 'Medium';
+    if (d >= 3) return 'Hard';
+    return null;
+  }
+
+  Widget _buildCard(TrainingPackTemplateV2 p) {
+    final tag = p.meta['tag']?.toString();
+    final diff = _difficultyLabel(p);
+    return ListTile(
+      onTap: () => const TrainingSessionLauncher().launch(p),
+      title: Row(
+        children: [
+          Expanded(child: Text(p.name)),
+          if (p.recommended) const Text('🔥')
+        ],
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (p.description.isNotEmpty)
+            Text(p.description,
+                maxLines: 2, overflow: TextOverflow.ellipsis),
+          Wrap(
+            spacing: 4,
+            children: [
+              if (tag != null)
+                Chip(label: Text(tag), visualDensity: VisualDensity.compact),
+              if (diff != null)
+                Chip(label: Text(diff), visualDensity: VisualDensity.compact),
+            ],
+          )
+        ],
+      ),
+      trailing: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.grey[800],
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text('${p.spotCount}',
+            style: const TextStyle(color: Colors.white70)),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Booster Library')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      DropdownButton<String>(
+                        value: _tagFilter.isEmpty ? '' : _tagFilter,
+                        hint: const Text('Tag'),
+                        items: [
+                          const DropdownMenuItem(
+                              value: '', child: Text('All')),
+                          for (final t in _tags)
+                            DropdownMenuItem(value: t, child: Text(t)),
+                        ],
+                        onChanged: (v) => setState(() => _tagFilter = v ?? ''),
+                      ),
+                      const SizedBox(height: 8),
+                      DropdownButton<int>(
+                        value: _difficultyFilter ?? 0,
+                        items: const [
+                          DropdownMenuItem(value: 0, child: Text('Any')),
+                          DropdownMenuItem(value: 1, child: Text('Easy')),
+                          DropdownMenuItem(value: 2, child: Text('Medium')),
+                          DropdownMenuItem(value: 3, child: Text('Hard')),
+                        ],
+                        onChanged: (v) => setState(() {
+                          _difficultyFilter = v == null || v == 0 ? null : v;
+                        }),
+                      ),
+                      CheckboxListTile(
+                        value: _recommendedOnly,
+                        onChanged: (v) =>
+                            setState(() => _recommendedOnly = v ?? false),
+                        title: const Text('Recommended only'),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: _filtered.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) => _buildCard(_filtered[index]),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -13,6 +13,7 @@ import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
 import 'basic_achievements_screen.dart';
+import 'booster_library_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -272,6 +273,16 @@ class _ProfileScreenState extends State<ProfileScreen> {
               );
             },
             child: const Text('Достижения'),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const BoosterLibraryScreen()),
+              );
+            },
+            child: const Text('Booster Library'),
           ),
           const SizedBox(height: 16),
           Consumer<AuthService>(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -54,6 +54,7 @@ import '../widgets/achievements_card.dart';
 import '../widgets/daily_spotlight_card.dart';
 import '../widgets/streak_banner_widget.dart';
 import '../widgets/streak_analytics_card.dart';
+import 'booster_library_screen.dart';
 import 'training_progress_analytics_screen.dart';
 import 'training_recommendation_screen.dart';
 import '../helpers/training_onboarding.dart';
@@ -110,6 +111,17 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
                 context,
                 MaterialPageRoute(
                   builder: (_) => const TrainingRecommendationScreen(),
+                ),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.local_fire_department),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const BoosterLibraryScreen(),
                 ),
               );
             },


### PR DESCRIPTION
## Summary
- add new `BoosterLibraryScreen`
- hook Booster library from training and profile pages

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6882c31ce4f4832ab4e15202a901f610