### PR TITLE
Implement SmartMistakeBooster

### DIFF
--- a/lib/services/mistake_tag_classifier.dart
+++ b/lib/services/mistake_tag_classifier.dart
@@ -1,0 +1,33 @@
+import '../models/mistake_tag.dart';
+import '../models/training_spot_attempt.dart';
+import '../models/mistake.dart';
+import 'mistake_categorization_engine.dart';
+import 'auto_mistake_tagger_engine.dart';
+
+class MistakeTagClassification {
+  final MistakeTag tag;
+  final double severity;
+  const MistakeTagClassification({required this.tag, required this.severity});
+}
+
+/// Simple classifier for major mistakes.
+class MistakeTagClassifier {
+  const MistakeTagClassifier();
+
+  /// Returns [MistakeTagClassification] if the attempt can be tagged.
+  MistakeTagClassification? classify(TrainingSpotAttempt attempt) {
+    final tags = const AutoMistakeTaggerEngine().tag(attempt);
+    if (tags.isEmpty) return null;
+    final tag = tags.first;
+
+    // Estimate severity based on hand strength and EV difference.
+    const engine = MistakeCategorizationEngine();
+    final strength = engine.computeHandStrength(attempt.spot.hand.heroCards);
+    final diff = attempt.evDiff.abs().clamp(0, 5);
+    final severity = ((strength * 0.7) + (diff / 5 * 0.3))
+        .clamp(0, 1)
+        .toDouble();
+
+    return MistakeTagClassification(tag: tag, severity: severity);
+  }
+}

--- a/test/mistake_tag_classifier_test.dart
+++ b/test/mistake_tag_classifier_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/training_spot_attempt.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/services/mistake_tag_classifier.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TrainingSpotAttempt _attempt() {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(heroCards: 'As Ad', position: HeroPosition.btn),
+    );
+    return TrainingSpotAttempt(
+      spot: spot,
+      userAction: 'fold',
+      correctAction: 'push',
+      evDiff: -3,
+    );
+  }
+
+  test('classifies major overfold', () {
+    final cls = const MistakeTagClassifier().classify(_attempt());
+    expect(cls, isNotNull);
+    expect(cls!.tag, MistakeTag.overfoldBtn);
+    expect(cls.severity, greaterThan(0.8));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `MistakeTagClassifier` to gauge severity of mistakes
- show inline "Fix this leak" banner during training when a severe mistake is detected
- basic test for `MistakeTagClassifier`

## Testing
- `dart analyze lib/screens/v2/training_pack_play_screen.dart`
- `dart test test/mistake_tag_classifier_test.dart` *(failed: Flutter SDK is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882d193c08c832a8c48c948a29a271d