### PR TITLE
Implement theory spot support

### DIFF
--- a/lib/core/training/factory/theory_spot_factory.dart
+++ b/lib/core/training/factory/theory_spot_factory.dart
@@ -1,0 +1,15 @@
+import '../../models/v2/training_pack_spot.dart';
+
+class TheorySpotFactory {
+  const TheorySpotFactory();
+
+  TrainingPackSpot fromYaml(Map yaml) {
+    return TrainingPackSpot(
+      id: yaml['id']?.toString() ?? '',
+      type: 'theory',
+      title: yaml['title']?.toString() ?? '',
+      explanation: yaml['explanation']?.toString() ?? '',
+      tags: [for (final t in (yaml['tags'] as List? ?? [])) t.toString()],
+    );
+  }
+}

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -4,6 +4,7 @@ import '../evaluation_result.dart';
 
 class TrainingPackSpot {
   final String id;
+  String type;
   String title;
   String note;
   HandData hand;
@@ -32,6 +33,7 @@ class TrainingPackSpot {
 
   TrainingPackSpot({
     required this.id,
+    this.type = 'quiz',
     this.title = '',
     this.note = '',
     HandData? hand,
@@ -64,6 +66,7 @@ class TrainingPackSpot {
 
   TrainingPackSpot copyWith({
     String? id,
+    String? type,
     String? title,
     String? note,
     HandData? hand,
@@ -87,6 +90,7 @@ class TrainingPackSpot {
   }) =>
       TrainingPackSpot(
         id: id ?? this.id,
+        type: type ?? this.type,
         title: title ?? this.title,
         note: note ?? this.note,
         hand: hand ?? this.hand,
@@ -111,6 +115,7 @@ class TrainingPackSpot {
 
   factory TrainingPackSpot.fromJson(Map<String, dynamic> j) => TrainingPackSpot(
         id: j['id'] as String? ?? '',
+        type: j['type'] as String? ?? 'quiz',
         title: j['title'] as String? ?? '',
         note: j['note'] as String? ?? '',
         hand: j['hand'] != null
@@ -146,6 +151,7 @@ class TrainingPackSpot {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'type': type,
         'title': title,
         'note': note,
         'hand': hand.toJson(),
@@ -178,6 +184,8 @@ class TrainingPackSpot {
   factory TrainingPackSpot.fromYaml(Map yaml) {
     final map = <String, dynamic>{};
     yaml.forEach((k, v) => map[k.toString()] = v);
+
+    map['type'] = yaml['type']?.toString() ?? 'quiz';
 
     final board = <String>[for (final c in (yaml['board'] as List? ?? [])) c.toString()];
     if (board.length >= 3 && board.length <= 5) map['board'] = board;
@@ -218,6 +226,7 @@ class TrainingPackSpot {
       other is TrainingPackSpot &&
           runtimeType == other.runtimeType &&
           id == other.id &&
+          type == other.type &&
           title == other.title &&
           note == other.note &&
           hand == other.hand &&
@@ -239,6 +248,7 @@ class TrainingPackSpot {
   @override
   int get hashCode => Object.hash(
         id,
+        type,
         title,
         note,
         hand,

--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -6,6 +6,7 @@ import '../../models/card_model.dart';
 import '../../models/action_entry.dart';
 import '../../models/player_model.dart';
 import '../spot_solve_screen.dart';
+import '../../widgets/theory_spot_widget.dart';
 import '../../theme/app_colors.dart';
 import '../../helpers/training_pack_storage.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -167,12 +168,25 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       }
       return;
     }
+    final ps = _packSpots[_index];
+    if (ps.type == 'theory') {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TheorySpotWidget(spot: ps),
+        ),
+      );
+      _results[ps.id] = true;
+      _index++;
+      await _showSpot();
+      return;
+    }
     final solved = await Navigator.push<bool>(
       context,
       MaterialPageRoute(
         builder: (_) => SpotSolveScreen(
           spot: _spots[_index],
-          packSpot: _packSpots[_index],
+          packSpot: ps,
           template: widget.template,
         ),
       ),

--- a/lib/widgets/theory_spot_widget.dart
+++ b/lib/widgets/theory_spot_widget.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class TheorySpotWidget extends StatelessWidget {
+  final TrainingPackSpot spot;
+  const TheorySpotWidget({super.key, required this.spot});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(spot.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Text(
+            spot.explanation ?? '',
+            style: const TextStyle(fontSize: 16),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/training_pack_spot_yaml_test.dart
+++ b/test/training_pack_spot_yaml_test.dart
@@ -48,4 +48,17 @@ title: Test
     expect(spot.villainAction, isNull);
     expect(spot.heroOptions, isEmpty);
   });
+
+  test('fromYaml parses theory spot type', () {
+    const yamlStr = '''
+id: t1
+type: theory
+title: Intro
+explanation: Hello
+''';
+    final map = const YamlReader().read(yamlStr);
+    final spot = TrainingPackSpot.fromYaml(map);
+    expect(spot.type, 'theory');
+    expect(spot.explanation, 'Hello');
+  });
 }

--- a/tools/validate_training_content.dart
+++ b/tools/validate_training_content.dart
@@ -173,23 +173,27 @@ List<_Issue> _validateFile(
         spotIds[id] = file.path;
       }
     }
+    final type = s['type']?.toString();
+    final isTheory = type == 'theory';
     final hand = s['hand'] as Map?;
-    if (hand == null) {
-      issues.add(_Issue(file.path, 'Spot `$id` missing hand', error: true));
-      continue;
-    }
-    if (hand['heroCards'] == null) {
-      issues.add(_Issue(file.path, 'Spot `$id` missing heroCards', error: true));
-    }
-    if (hand['position'] == null) {
-      issues.add(_Issue(file.path, 'Spot `$id` missing position', error: true));
-    }
-    if (hand['stacks'] == null) {
-      issues.add(_Issue(file.path, 'Spot `$id` missing stacks', error: true));
-    }
-    final heroOptions = s['heroOptions'] as List?;
-    if (heroOptions == null || heroOptions.isEmpty) {
-      issues.add(_Issue(file.path, 'Spot `$id` missing heroOptions', error: true));
+    if (!isTheory) {
+      if (hand == null) {
+        issues.add(_Issue(file.path, 'Spot `$id` missing hand', error: true));
+        continue;
+      }
+      if (hand['heroCards'] == null) {
+        issues.add(_Issue(file.path, 'Spot `$id` missing heroCards', error: true));
+      }
+      if (hand['position'] == null) {
+        issues.add(_Issue(file.path, 'Spot `$id` missing position', error: true));
+      }
+      if (hand['stacks'] == null) {
+        issues.add(_Issue(file.path, 'Spot `$id` missing stacks', error: true));
+      }
+      final heroOptions = s['heroOptions'] as List?;
+      if (heroOptions == null || heroOptions.isEmpty) {
+        issues.add(_Issue(file.path, 'Spot `$id` missing heroOptions', error: true));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add `type` field to `TrainingPackSpot`
- parse theory spots with a new `TheorySpotFactory`
- render explanations in `TrainingSessionScreen` via `TheorySpotWidget`
- adjust validation script for theory spots
- extend unit tests for YAML theory spots

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882da744fcc832a901b3820918aa94f