### PR TITLE
Implement navigation for theory spots

### DIFF
--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -170,14 +170,19 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     }
     final ps = _packSpots[_index];
     if (ps.type == 'theory') {
-      await Navigator.push(
+      final last = await Navigator.push<int>(
         context,
         MaterialPageRoute(
-          builder: (_) => TheorySpotWidget(spot: ps),
+          builder: (_) => TheorySpotWidget(spots: _packSpots, index: _index),
         ),
       );
-      _results[ps.id] = true;
-      _index++;
+      final end = last ?? _index;
+      for (int i = _index; i <= end && i < _packSpots.length; i++) {
+        if (_packSpots[i].type == 'theory') {
+          _results[_packSpots[i].id] = true;
+        }
+      }
+      _index = end + 1;
       await _showSpot();
       return;
     }

--- a/lib/widgets/theory_spot_widget.dart
+++ b/lib/widgets/theory_spot_widget.dart
@@ -1,21 +1,84 @@
 import 'package:flutter/material.dart';
 import '../models/v2/training_pack_spot.dart';
 
+/// Displays theory content within a training session with optional
+/// navigation to adjacent theory spots.
 class TheorySpotWidget extends StatelessWidget {
-  final TrainingPackSpot spot;
-  const TheorySpotWidget({super.key, required this.spot});
+  /// All spots of the current training pack.
+  final List<TrainingPackSpot> spots;
+
+  /// Index of the spot to display.
+  final int index;
+
+  const TheorySpotWidget({
+    super.key,
+    required this.spots,
+    required this.index,
+  });
+
+  TrainingPackSpot get _spot => spots[index];
+
+  int? _previousIndex() {
+    for (int i = index - 1; i >= 0; i--) {
+      if (spots[i].type == 'theory') return i;
+    }
+    return null;
+  }
+
+  int? _nextIndex() {
+    for (int i = index + 1; i < spots.length; i++) {
+      if (spots[i].type == 'theory') return i;
+    }
+    return null;
+  }
+
+  void _openSpot(BuildContext context, int idx) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheorySpotWidget(spots: spots, index: idx),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    final prev = _previousIndex();
+    final next = _nextIndex();
     return Scaffold(
-      appBar: AppBar(title: Text(spot.title)),
+      appBar: AppBar(title: Text(_spot.title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(
           child: Text(
-            spot.explanation ?? '',
+            _spot.explanation ?? '',
             style: const TextStyle(fontSize: 16),
           ),
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            if (prev != null)
+              ElevatedButton(
+                onPressed: () => _openSpot(context, prev),
+                child: const Text('Назад'),
+              )
+            else
+              const SizedBox(width: 0, height: 0),
+            ElevatedButton(
+              onPressed: () {
+                if (next != null) {
+                  _openSpot(context, next);
+                } else {
+                  Navigator.pop(context, index);
+                }
+              },
+              child: Text(next != null ? 'Далее' : 'Закрыть'),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add previous/next navigation to `TheorySpotWidget`
- preserve session flow by returning the final theory index
- integrate with `TrainingSessionScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688342236944832a8902d2a6f15cd443