### PR TITLE
Implement TheoryPackSampler

### DIFF
--- a/bin/theory_pack_sampler.dart
+++ b/bin/theory_pack_sampler.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:poker_analyzer/core/training/generation/yaml_reader.dart';
+import 'package:poker_analyzer/core/training/export/training_pack_exporter_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/theory_pack_sampler.dart';
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()..addFlag('help', abbr: 'h', negatable: false);
+  final results = parser.parse(args);
+  if (results['help'] as bool || results.rest.isEmpty) {
+    stdout.writeln('Usage: dart bin/theory_pack_sampler.dart <pack.yaml>');
+    return;
+  }
+  final path = results.rest.first;
+  final file = File(path);
+  if (!file.existsSync()) {
+    stderr.writeln('File not found: $path');
+    exit(1);
+  }
+  final yaml = await file.readAsString();
+  final map = const YamlReader().read(yaml);
+  final pack = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+  final sampler = const TheoryPackSampler();
+  final theoryPack = sampler.sample(pack);
+  if (theoryPack == null) {
+    stderr.writeln('No theory spots found');
+    exit(2);
+  }
+  final outYaml = const TrainingPackExporterV2().exportYaml(theoryPack);
+  stdout.writeln(outYaml);
+}

--- a/lib/services/theory_pack_sampler.dart
+++ b/lib/services/theory_pack_sampler.dart
@@ -1,0 +1,24 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Extracts theory spots from a training pack template.
+class TheoryPackSampler {
+  const TheoryPackSampler();
+
+  /// Returns a new [TrainingPackTemplateV2] containing only spots
+  /// with `type == "theory"`. Returns `null` if no such spots exist.
+  TrainingPackTemplateV2? sample(TrainingPackTemplateV2 fullPack) {
+    final theorySpots =
+        fullPack.spots.where((s) => s.type == 'theory').toList();
+    if (theorySpots.isEmpty) return null;
+
+    final map = fullPack.toJson();
+    map['id'] = '${fullPack.id}-theory';
+    map['name'] = '📘 Теория: ${fullPack.name}';
+    map['spots'] = [for (final s in theorySpots) s.toJson()];
+    map['spotCount'] = theorySpots.length;
+    final result =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    result.isSampledPack = true;
+    return result;
+  }
+}

--- a/test/theory_pack_sampler_test.dart
+++ b/test/theory_pack_sampler_test.dart
@@ -1,0 +1,47 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/theory_pack_sampler.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackSpot _spot(String id, String type) {
+  return TrainingPackSpot(id: id, type: type, hand: HandData());
+}
+
+void main() {
+  test('sample returns null when no theory spots', () {
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      spots: [_spot('a', 'quiz')],
+      spotCount: 1,
+    );
+    const sampler = TheoryPackSampler();
+    final sample = sampler.sample(pack);
+    expect(sample, isNull);
+  });
+
+  test('sample extracts theory spots and updates metadata', () {
+    final spots = [
+      _spot('a', 'quiz'),
+      _spot('b', 'theory'),
+      _spot('c', 'theory'),
+    ];
+    final pack = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Full',
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+    );
+    const sampler = TheoryPackSampler();
+    final sample = sampler.sample(pack);
+    expect(sample, isNotNull);
+    expect(sample!.spots.length, 2);
+    expect(sample.id, 'p2-theory');
+    expect(sample.name.startsWith('📘 Теория:'), true);
+    expect(sample.isSampledPack, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryPackSampler` service for extracting theory spots
- provide CLI `theory_pack_sampler.dart` to build theory-only packs
- verify behavior with new test

## Testing
- `flutter analyze lib test` *(fails: 5827 issues due to plugin defaults)*
- `flutter test test/theory_pack_sampler_test.dart` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688367ef8b18832a97d51a8bbbefbcca