### PR TITLE
Add theory pack YAML export

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -36,6 +36,7 @@ import '../services/smart_pack_recommendation_engine.dart';
 import '../services/training_pack_suggestion_service.dart';
 import '../services/smart_suggestion_engine.dart';
 import '../services/yaml_pack_balance_analyzer.dart';
+import '../services/theory_pack_generator_service.dart';
 import '../services/pack_library_loader_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/training_goal_suggestion_engine.dart';
@@ -150,6 +151,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _libraryLoading = false;
   bool _importLoading = false;
   bool _exportLoading = false;
+  bool _tagTheoryExportLoading = false;
   bool _cleanLoading = false;
   bool _yamlDupeLoading = false;
   bool _yamlAssetsDupeLoading = false;
@@ -548,6 +550,21 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
+  }
+
+  Future<void> _exportTheoryTags() async {
+    if (_tagTheoryExportLoading || !kDebugMode) return;
+    setState(() => _tagTheoryExportLoading = true);
+    int count = 0;
+    const service = TheoryPackGeneratorService();
+    for (final tag in TheoryPackGeneratorService.tags) {
+      await service.exportYamlForTag(tag);
+      count++;
+    }
+    if (!mounted) return;
+    setState(() => _tagTheoryExportLoading = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
   }
 
   Future<void> _cleanDuplicates() async {
@@ -2090,6 +2107,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📤 Экспортировать библиотеку'),
                 onTap: _exportLoading ? null : _exportLibrary,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📤 Экспортировать теорию по тегам'),
+                onTap: _tagTheoryExportLoading ? null : _exportTheoryTags,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/theory_pack_generator_service.dart
+++ b/lib/services/theory_pack_generator_service.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hand_data.dart';
@@ -33,6 +36,12 @@ class TheoryPackGeneratorService {
     },
   };
 
+  /// List of all supported theory tags.
+  static List<String> get tags => {
+        ..._titles.keys,
+        ..._explanations.keys,
+      }.toSet().toList();
+
   TrainingPackTemplateV2 generateForTag(String tag, {String lang = 'en'}) {
     final titleMap = _titles[tag];
     final expMap = _explanations[tag];
@@ -59,5 +68,15 @@ class TheoryPackGeneratorService {
     );
     tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
     return tpl;
+  }
+
+  /// Generates a theory pack for [tag] and writes it to `yaml_out/{tag}_theory.yaml`.
+  Future<File> exportYamlForTag(String tag) async {
+    final tpl = generateForTag(tag);
+    final dir = Directory('yaml_out');
+    await dir.create(recursive: true);
+    final file = File(p.join(dir.path, '${tag}_theory.yaml'));
+    await file.writeAsString(tpl.toYamlString());
+    return file;
   }
 }


### PR DESCRIPTION
## Summary
- add exportYamlForTag to TheoryPackGeneratorService
- enable DevMenu action to export theory packs by tag

## Testing
- `dart format lib/services/theory_pack_generator_service.dart lib/screens/dev_menu_screen.dart` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68839c5fbf7c832aa198646c776bf101