### PR TITLE
Add theory template index generator

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -38,6 +38,7 @@ import '../services/smart_suggestion_engine.dart';
 import '../services/yaml_pack_balance_analyzer.dart';
 import '../services/theory_pack_generator_service.dart';
 import '../services/theory_validation_engine.dart';
+import '../services/theory_template_index.dart';
 import '../services/pack_library_loader_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/training_goal_suggestion_engine.dart';
@@ -164,6 +165,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _tagHealthLoading = false;
   bool _normalizeYamlLoading = false;
   bool _tagIndexLoading = false;
+  bool _theoryIndexLoading = false;
   bool _tagSuggestLoading = false;
   bool _yamlTagSuggestLoading = false;
   bool _templateTagSuggestLoading = false;
@@ -844,6 +846,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Индекс: $count')));
+  }
+
+  Future<void> _generateTheoryIndex() async {
+    if (_theoryIndexLoading || !kDebugMode) return;
+    setState(() => _theoryIndexLoading = true);
+    final count = await compute(_theoryIndexTask, '');
+    if (!mounted) return;
+    setState(() => _theoryIndexLoading = false);
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Indexed: $count')));
   }
 
   Future<void> _suggestTags() async {
@@ -2376,6 +2389,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
+                title: const Text('📦 Сгенерировать index теории'),
+                onTap: _theoryIndexLoading ? null : _generateTheoryIndex,
+              ),
+            if (kDebugMode)
+              ListTile(
                 title: const Text('📦 Pack Tag Analyzer'),
                 onTap: () {
                   Navigator.push(
@@ -2950,6 +2968,10 @@ Future<bool> _tagHealthTask(String _) async {
 
 Future<int> _tagIndexTask(String _) async {
   return const PackTagIndexService().buildIndex();
+}
+
+Future<int> _theoryIndexTask(String _) async {
+  return const TheoryTemplateIndex().generateJsonIndex();
 }
 
 Future<List<String>> _suggestTagsTask(String path) async {

--- a/lib/services/theory_template_index.dart
+++ b/lib/services/theory_template_index.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Generates a JSON index for theory YAML packs in `yaml_out/`.
+class TheoryTemplateIndex {
+  const TheoryTemplateIndex();
+
+  /// Scans [dir] for theory YAML packs and writes `theory_index.json`.
+  /// Returns the number of indexed files.
+  Future<int> generateJsonIndex({String dir = 'yaml_out'}) async {
+    final directory = Directory(dir);
+    if (!directory.existsSync()) return 0;
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'))
+        .toList();
+    final list = <Map<String, dynamic>>[];
+    for (final file in files) {
+      try {
+        final yaml = await file.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        list.add({
+          'id': tpl.id,
+          'tags': tpl.tags,
+          'title': tpl.name,
+          'lang': tpl.meta['lang'] ?? 'en',
+          'filename': p.basename(file.path),
+        });
+      } catch (_) {}
+    }
+    final outFile = File(p.join(directory.path, 'theory_index.json'))
+      ..createSync(recursive: true);
+    await outFile.writeAsString(jsonEncode(list), flush: true);
+    return list.length;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TheoryTemplateIndex` service
- hook generator into DevMenu

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a43512b4832abcd6885d857e122c