### PR TITLE
Add TheoryInjectionEngine

### DIFF
--- a/lib/services/theory_injection_engine.dart
+++ b/lib/services/theory_injection_engine.dart
@@ -1,0 +1,50 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+
+/// Injects theory spots into a base training pack at a fixed interval.
+class TheoryInjectionEngine {
+  const TheoryInjectionEngine();
+
+  /// Returns [basePack] with theory spots from [theoryPack] inserted.
+  ///
+  /// The first theory spot is placed at the beginning, then after every
+  /// [interval] practice spots from [basePack]. Remaining theory spots are
+  /// ignored when the list is exhausted.
+  TrainingPackTemplateV2 injectTheory(
+    TrainingPackTemplateV2 basePack,
+    TrainingPackTemplateV2 theoryPack, {
+    int interval = 5,
+  }) {
+    if (interval <= 0) interval = 1;
+    final baseSpots = basePack.spots;
+    final theorySpots = theoryPack.spots;
+    final merged = <TrainingPackSpot>[];
+    var theoryIndex = 0;
+
+    // Start with a theory spot if available.
+    if (theorySpots.isNotEmpty) {
+      merged.add(theorySpots[theoryIndex]);
+      theoryIndex++;
+    }
+
+    var count = 0;
+    for (final spot in baseSpots) {
+      merged.add(spot);
+      count++;
+      if (count % interval == 0 && theoryIndex < theorySpots.length) {
+        merged.add(theorySpots[theoryIndex]);
+        theoryIndex++;
+      }
+    }
+
+    final map = basePack.toJson();
+    map['spots'] = [for (final s in merged) s.toJson()];
+    map['spotCount'] = merged.length;
+
+    final result =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    result.isGeneratedPack = basePack.isGeneratedPack;
+    result.isSampledPack = basePack.isSampledPack;
+    return result;
+  }
+}

--- a/test/theory_injection_engine_test.dart
+++ b/test/theory_injection_engine_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/theory_injection_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackSpot _spot(String id) {
+  return TrainingPackSpot(id: id, hand: HandData());
+}
+
+TrainingPackSpot _theory(String id) {
+  return TrainingPackSpot(id: id, type: 'theory', hand: HandData());
+}
+
+void main() {
+  const engine = TheoryInjectionEngine();
+
+  test('injectTheory mixes theory spots at interval', () {
+    final baseSpots = [_spot('a'), _spot('b'), _spot('c'), _spot('d')];
+    final theorySpots = [_theory('t1'), _theory('t2')];
+    final base = TrainingPackTemplateV2(
+      id: 'b',
+      name: 'Base',
+      trainingType: TrainingType.pushFold,
+      spots: baseSpots,
+      spotCount: baseSpots.length,
+    );
+    final theory = TrainingPackTemplateV2(
+      id: 't',
+      name: 'Theory',
+      trainingType: TrainingType.pushFold,
+      spots: theorySpots,
+      spotCount: theorySpots.length,
+    );
+
+    final res = engine.injectTheory(base, theory, interval: 2);
+    expect(res.spotCount, 6);
+    expect(res.id, base.id);
+    expect(res.trainingType, base.trainingType);
+    expect(res.spots.map((s) => s.id).toList(), ['t1', 'a', 'b', 't2', 'c', 'd']);
+  });
+
+  test('interval 1 alternates theory and practice', () {
+    final baseSpots = [_spot('x'), _spot('y')];
+    final theorySpots = [_theory('t1'), _theory('t2')];
+    final base = TrainingPackTemplateV2(
+      id: 'b2',
+      name: 'Base2',
+      trainingType: TrainingType.pushFold,
+      spots: baseSpots,
+      spotCount: baseSpots.length,
+    );
+    final theory = TrainingPackTemplateV2(
+      id: 't2',
+      name: 'Theory2',
+      trainingType: TrainingType.pushFold,
+      spots: theorySpots,
+      spotCount: theorySpots.length,
+    );
+
+    final res = engine.injectTheory(base, theory, interval: 1);
+    expect(res.spots.map((s) => s.id).toList(), ['t1', 'x', 't2', 'y']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryInjectionEngine` service for mixing theory spots into training packs
- test theory spot injection logic

## Testing
- `dart test test/theory_injection_engine_test.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883af04a7cc832aa75a119d9af7397d