### PR TITLE
Implement TheoryBoosterGenerator

### DIFF
--- a/lib/services/theory_booster_generator.dart
+++ b/lib/services/theory_booster_generator.dart
@@ -1,0 +1,55 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'theory_injection_engine.dart';
+
+/// Generates booster packs by injecting theory spots into a base pack.
+class TheoryBoosterGenerator {
+  final TheoryInjectionEngine _engine;
+  final Uuid _uuid;
+
+  const TheoryBoosterGenerator({
+    TheoryInjectionEngine engine = const TheoryInjectionEngine(),
+    Uuid uuid = const Uuid(),
+  })  : _engine = engine,
+        _uuid = uuid;
+
+  /// Returns a new training pack with theory inserted from the most relevant
+  /// theory pack in [allTheoryPacks]. Relevance is determined by tag overlap
+  /// with [basePack]. The result has a new id and `meta['booster'] = true`.
+  TrainingPackTemplateV2 generateBooster({
+    required TrainingPackTemplateV2 basePack,
+    required List<TrainingPackTemplateV2> allTheoryPacks,
+  }) {
+    final theory = _selectTheory(basePack, allTheoryPacks);
+    final mixed = _engine.injectTheory(basePack, theory, interval: 3);
+    final map = mixed.toJson();
+    map['id'] = _uuid.v4();
+    final meta = Map<String, dynamic>.from(map['meta'] ?? {});
+    meta['booster'] = true;
+    map['meta'] = meta;
+    final result =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    result.trainingType = basePack.trainingType;
+    return result;
+  }
+
+  TrainingPackTemplateV2 _selectTheory(
+    TrainingPackTemplateV2 base,
+    List<TrainingPackTemplateV2> theoryPacks,
+  ) {
+    if (theoryPacks.isEmpty) return base;
+    final baseTags = base.tags.map((e) => e.toLowerCase()).toSet();
+    TrainingPackTemplateV2? best;
+    var bestScore = -1;
+    for (final t in theoryPacks) {
+      final tags = t.tags.map((e) => e.toLowerCase()).toSet();
+      final score = tags.intersection(baseTags).length;
+      if (score > bestScore) {
+        best = t;
+        bestScore = score;
+      }
+    }
+    return best ?? theoryPacks.first;
+  }
+}

--- a/test/theory_booster_generator_test.dart
+++ b/test/theory_booster_generator_test.dart
@@ -1,0 +1,59 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/theory_booster_generator.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+
+TrainingPackSpot _spot(String id, {String type = 'quiz'}) {
+  return TrainingPackSpot(id: id, type: type, hand: HandData());
+}
+
+void main() {
+  const generator = TheoryBoosterGenerator();
+
+  test('generateBooster injects relevant theory and marks booster', () {
+    final baseSpots = [
+      _spot('a'),
+      _spot('b'),
+      _spot('c'),
+      _spot('d'),
+    ];
+    final base = TrainingPackTemplateV2(
+      id: 'base',
+      name: 'Base',
+      trainingType: TrainingType.pushFold,
+      tags: ['btnPush'],
+      spots: baseSpots,
+      spotCount: baseSpots.length,
+    );
+    final theory1Spots = [_spot('t1', type: 'theory'), _spot('t2', type: 'theory')];
+    final theory1 = TrainingPackTemplateV2(
+      id: 'th1',
+      name: 'Theory1',
+      trainingType: TrainingType.pushFold,
+      tags: ['btnPush'],
+      spots: theory1Spots,
+      spotCount: theory1Spots.length,
+    );
+    final theory2 = TrainingPackTemplateV2(
+      id: 'th2',
+      name: 'Theory2',
+      trainingType: TrainingType.pushFold,
+      tags: ['limped'],
+      spots: [_spot('x', type: 'theory')],
+      spotCount: 1,
+    );
+
+    final booster = generator.generateBooster(
+      basePack: base,
+      allTheoryPacks: [theory2, theory1],
+    );
+
+    expect(booster.trainingType, base.trainingType);
+    expect(booster.id, isNot(base.id));
+    expect(booster.meta['booster'], true);
+    expect(booster.spots.map((s) => s.id).toList(),
+        ['t1', 'a', 'b', 'c', 't2', 'd']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryBoosterGenerator` service for building theory-augmented boosters
- test for `TheoryBoosterGenerator`

## Testing
- `dart` and `flutter` commands were not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6883b4c96a8c832a878b90deeab5470e