### PR TITLE
Implement TheoryYamlImporter

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -148,6 +148,9 @@ class TrainingPackTemplateV2 {
     return TrainingPackTemplateV2.fromJson(map);
   }
 
+  factory TrainingPackTemplateV2.fromYamlString(String source) =>
+      TrainingPackTemplateV2.fromYaml(source);
+
   factory TrainingPackTemplateV2.fromYamlAuto(String source) {
     final map = const YamlReader().read(source);
     final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));

--- a/lib/services/theory_yaml_importer.dart
+++ b/lib/services/theory_yaml_importer.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import '../core/error_logger.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TheoryYamlImporter {
+  const TheoryYamlImporter({ErrorLogger? logger}) : _logger = logger ?? ErrorLogger.instance;
+
+  final ErrorLogger _logger;
+
+  Future<List<TrainingPackTemplateV2>> importFromDirectory(String dirPath) async {
+    final dir = Directory(dirPath);
+    if (!dir.existsSync()) return <TrainingPackTemplateV2>[];
+
+    const reader = YamlReader();
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+
+    final templates = <TrainingPackTemplateV2>[];
+
+    for (final file in files) {
+      try {
+        final yaml = await file.readAsString();
+        final map = reader.read(yaml);
+        final meta = map['meta'];
+        final isTheory = map['type']?.toString().toLowerCase() == 'theory';
+        final isBooster = meta is Map && meta['booster'] == true;
+        if (!isTheory && !isBooster) continue;
+        templates.add(TrainingPackTemplateV2.fromYamlString(yaml));
+      } catch (e, st) {
+        _logger.logError('Failed to load ${file.path}', e, st);
+      }
+    }
+
+    return templates;
+  }
+}


### PR DESCRIPTION
## Summary
- add a `TheoryYamlImporter` service for scanning theory and booster YAML packs
- extend `TrainingPackTemplateV2` with a `fromYamlString` factory

## Testing
- ❌ `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883bdb73080832a8a12bc47995ee7e7