### PR TITLE
Add theory booster preview screen

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -78,6 +78,7 @@ import 'pack_matrix_config_editor_screen.dart';
 import 'yaml_library_preview_screen.dart';
 import 'yaml_pack_quick_preview_screen.dart';
 import 'yaml_pack_previewer_screen.dart';
+import 'theory_booster_preview_screen.dart';
 import 'yaml_pack_editor_screen.dart';
 import 'pack_library_health_screen.dart';
 import 'pack_library_stats_screen.dart';
@@ -2253,6 +2254,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const YamlPackQuickPreviewScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📖 Просмотр теории'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const TheoryBoosterPreviewScreen(),
                     ),
                   );
                 },

--- a/lib/screens/theory_booster_preview_screen.dart
+++ b/lib/screens/theory_booster_preview_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/theory_yaml_importer.dart';
+import '../theme/app_colors.dart';
+import 'training_pack_preview_screen.dart';
+
+class TheoryBoosterPreviewScreen extends StatefulWidget {
+  const TheoryBoosterPreviewScreen({super.key});
+
+  @override
+  State<TheoryBoosterPreviewScreen> createState() =>
+      _TheoryBoosterPreviewScreenState();
+}
+
+class _TheoryBoosterPreviewScreenState
+    extends State<TheoryBoosterPreviewScreen> {
+  final List<TrainingPackTemplateV2> _packs = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    const importer = TheoryYamlImporter();
+    final list = await importer.importFromDirectory('yaml_out/boosters');
+    if (!mounted) return;
+    setState(() {
+      _packs
+        ..clear()
+        ..addAll(list);
+      _loading = false;
+    });
+  }
+
+  void _open(TrainingPackTemplateV2 tpl) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackPreviewScreen(template: tpl),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Theory Preview')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: _packs.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, i) {
+                final tpl = _packs[i];
+                final type = tpl.meta['booster'] == true ? 'booster' : 'theory';
+                final count = tpl.spotCount;
+                return ListTile(
+                  title: Text(tpl.name),
+                  subtitle: Text('Spots: $count • $type'),
+                  onTap: () => _open(tpl),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- enable TheoryBoosterPreviewScreen to list generated theory and booster YAML packs
- wire up the screen from DevMenu

## Testing
- `flutter analyze` *(fails: undefined_getter depend_on_referenced_packages)*
- `flutter test` *(fails: Couldn't resolve the package 'flutter_gen')*

------
https://chatgpt.com/codex/tasks/task_e_6883bfb0e254832a828fd5075a31821a