### PR TITLE
Implement booster tag stats

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -99,6 +99,7 @@ import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
 import 'yaml_coverage_stats_screen.dart';
 import 'pack_coverage_stats_screen.dart';
+import '../services/booster_tag_coverage_stats.dart';
 import 'pack_library_qa_screen.dart';
 import 'pack_conflict_analysis_screen.dart';
 import 'pack_merge_duplicates_screen.dart';
@@ -196,6 +197,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _progressImportLoading = false;
   bool _trainingStreakExportLoading = false;
   bool _autoAdvanceLoading = false;
+  bool _boosterTagCoverageLoading = false;
   bool _seedBeginnerLoading = false;
   bool _seedIntermediateLoading = false;
   bool _seedAdvancedLoading = false;
@@ -570,6 +572,28 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     setState(() => _tagTheoryExportLoading = false);
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
+  }
+
+  Future<void> _showBoosterTagCoverageStats() async {
+    if (_boosterTagCoverageLoading || !kDebugMode) return;
+    setState(() => _boosterTagCoverageLoading = true);
+    final text = await const BoosterTagCoverageStats().buildReport();
+    if (!mounted) return;
+    setState(() => _boosterTagCoverageLoading = false);
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Booster Tag Stats'),
+        content: SingleChildScrollView(child: Text(text)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _cleanDuplicates() async {
@@ -2087,6 +2111,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     ),
                   );
                 },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📊 Статистика тэгов booster\'ов'),
+                onTap: _boosterTagCoverageLoading ? null : _showBoosterTagCoverageStats,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/booster_tag_coverage_stats.dart
+++ b/lib/services/booster_tag_coverage_stats.dart
@@ -1,0 +1,38 @@
+import 'theory_yaml_importer.dart';
+
+class BoosterTagCoverageStats {
+  const BoosterTagCoverageStats();
+
+  Future<Map<String, int>> loadCoverage({String dir = 'yaml_out/boosters'}) async {
+    const importer = TheoryYamlImporter();
+    final packs = await importer.importFromDirectory(dir);
+    final Map<String, int> counts = {};
+    for (final p in packs) {
+      if (p.meta['booster'] != true) continue;
+      for (final t in p.tags) {
+        final tag = t.trim();
+        if (tag.isEmpty) continue;
+        counts[tag] = (counts[tag] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+
+  Future<String> buildReport({String dir = 'yaml_out/boosters'}) async {
+    final counts = await loadCoverage(dir: dir);
+    if (counts.isEmpty) return 'No booster packs found';
+    final entries = counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final top = entries.take(10).toList();
+    final bottom = entries.reversed.take(10).toList();
+    final buffer = StringBuffer('Top 10 tags:\n');
+    for (final e in top) {
+      buffer.writeln('${e.key}: ${e.value}');
+    }
+    buffer.writeln('\nBottom 10 tags:');
+    for (final e in bottom) {
+      buffer.writeln('${e.key}: ${e.value}');
+    }
+    return buffer.toString();
+  }
+}


### PR DESCRIPTION
## Summary
- create `BoosterTagCoverageStats` service
- allow checking booster tag coverage from DevMenu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68847c842c20832a911c0dde33050594