### PR TITLE
Add BoosterPack linter and dev option

### DIFF
--- a/lib/services/booster_pack_linter_engine.dart
+++ b/lib/services/booster_pack_linter_engine.dart
@@ -1,0 +1,40 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/hero_position.dart';
+
+/// Lints booster packs and returns list of formatted error messages.
+class BoosterPackLinterEngine {
+  const BoosterPackLinterEngine();
+
+  /// Returns list of errors in "- [id] Ошибка: ..." format.
+  List<String> lint(TrainingPackTemplateV2 pack) {
+    final errs = <String>[];
+    final ids = <String>{};
+    for (final s in pack.spots) {
+      if (!ids.add(s.id)) {
+        errs.add('- [${s.id}] Ошибка: duplicate_id');
+      }
+      if (s.explanation == null || s.explanation!.trim().isEmpty) {
+        errs.add('- [${s.id}] Ошибка: empty_explanation');
+      }
+      if (s.hand.heroCards.trim().isEmpty) {
+        errs.add('- [${s.id}] Ошибка: empty_heroCards');
+      }
+      final hasActions = s.hand.actions.values.any((l) => l.isNotEmpty);
+      if (!hasActions) {
+        errs.add('- [${s.id}] Ошибка: empty_actions');
+      }
+      if (s.hand.position == HeroPosition.unknown) {
+        errs.add('- [${s.id}] Ошибка: bad_heroPosition');
+      }
+      if (s.tags.isEmpty) {
+        errs.add('- [${s.id}] Ошибка: missing_tags');
+      }
+      final ev = s.heroEv;
+      final icm = s.heroIcmEv;
+      if ((ev != null && ev == 0) || (icm != null && icm == 0)) {
+        errs.add('- [${s.id}] Ошибка: zero_ev');
+      }
+    }
+    return errs;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `BoosterPackLinterEngine` for validating booster packs
- add a dev menu option to lint a booster YAML file

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cd098740832aa4a03a6258b3a31b