### PR TITLE
Implement BoosterPackValidatorService

### DIFF
--- a/lib/models/booster_validation_report.dart
+++ b/lib/models/booster_validation_report.dart
@@ -1,0 +1,24 @@
+class BoosterValidationReport {
+  final List<String> errors;
+  final List<String> warnings;
+  final bool isValid;
+
+  const BoosterValidationReport({
+    this.errors = const [],
+    this.warnings = const [],
+    this.isValid = true,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'errors': errors,
+        'warnings': warnings,
+        'isValid': isValid,
+      };
+
+  factory BoosterValidationReport.fromJson(Map<String, dynamic> j) =>
+      BoosterValidationReport(
+        errors: [for (final e in j['errors'] as List? ?? []) e.toString()],
+        warnings: [for (final w in j['warnings'] as List? ?? []) w.toString()],
+        isValid: j['isValid'] == true,
+      );
+}

--- a/lib/services/booster_pack_validator_service.dart
+++ b/lib/services/booster_pack_validator_service.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/booster_validation_report.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+
+class BoosterPackValidatorService {
+  const BoosterPackValidatorService();
+
+  BoosterValidationReport validate(TrainingPackTemplateV2 pack) {
+    final errors = <String>[];
+    final warnings = <String>[];
+    final ids = <String>{};
+
+    if (pack.id.trim().isEmpty) errors.add('missing_pack_id');
+    if (pack.spots.isEmpty) errors.add('missing_spots');
+
+    for (final s in pack.spots) {
+      final id = s.id.trim();
+      if (id.isEmpty) {
+        errors.add('missing_id');
+        continue;
+      }
+      if (!ids.add(id)) errors.add('duplicate_id:$id');
+      final res = _validateSpot(s, pack.positions);
+      errors.addAll(res.errors);
+      warnings.addAll(res.warnings);
+    }
+
+    debugPrint(
+        'BoosterPackValidatorService: ${errors.length} errors, ${warnings.length} warnings');
+    for (final e in errors) debugPrint('Error: $e');
+    for (final w in warnings) debugPrint('Warning: $w');
+
+    return BoosterValidationReport(
+      errors: errors,
+      warnings: warnings,
+      isValid: errors.isEmpty,
+    );
+  }
+
+  BoosterValidationReport validateAll(List<TrainingPackSpot> spots) {
+    final template = TrainingPackTemplateV2(
+      id: 'tmp',
+      name: 'tmp',
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+    );
+    return validate(template);
+  }
+
+  BoosterValidationReport _validateSpot(
+      TrainingPackSpot spot, List<String> packPositions) {
+    final errors = <String>[];
+    final warnings = <String>[];
+
+    if (spot.hand.heroCards.trim().isEmpty) {
+      errors.add('empty_heroCards:${spot.id}');
+    }
+    if (spot.hand.position == HeroPosition.unknown) {
+      errors.add('bad_heroPosition:${spot.id}');
+    } else if (packPositions.isNotEmpty) {
+      final matches = packPositions
+          .map(parseHeroPosition)
+          .contains(spot.hand.position);
+      if (!matches) warnings.add('position_mismatch:${spot.id}');
+    }
+
+    final board = spot.board.isNotEmpty ? spot.board : spot.hand.board;
+    if (board.any((c) => c.trim().isEmpty) || board.length > 5) {
+      warnings.add('bad_board:${spot.id}');
+    } else if (board.toSet().length != board.length) {
+      warnings.add('duplicate_board:${spot.id}');
+    }
+
+    if (spot.tags.toSet().length != spot.tags.length) {
+      warnings.add('duplicate_tags:${spot.id}');
+    }
+
+    if (spot.explanation != null && spot.explanation!.trim().isEmpty) {
+      warnings.add('bad_explanation:${spot.id}');
+    }
+
+    return BoosterValidationReport(
+      errors: errors,
+      warnings: warnings,
+      isValid: errors.isEmpty,
+    );
+  }
+}

--- a/lib/services/booster_quick_tester_engine.dart
+++ b/lib/services/booster_quick_tester_engine.dart
@@ -1,5 +1,6 @@
 import '../models/v2/hero_position.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import 'booster_pack_validator_service.dart';
 
 class BoosterTestReport {
   final int totalSpots;
@@ -23,6 +24,8 @@ class BoosterQuickTesterEngine {
   const BoosterQuickTesterEngine();
 
   BoosterTestReport test(TrainingPackTemplateV2 pack) {
+    final validation =
+        const BoosterPackValidatorService().validate(pack);
     final total = pack.spots.length;
     int emptyExp = 0;
     int badPos = 0;
@@ -50,11 +53,13 @@ class BoosterQuickTesterEngine {
 
     final evAvg = evCount > 0 ? evSum / evCount : 0.0;
 
-    final issues = <String>[];
+    final issues = <String>[...validation.errors, ...validation.warnings];
     if (duplicates.isNotEmpty) issues.add('duplicate_ids');
     final emptyPct = total > 0 ? emptyExp / total : 0.0;
     final badPct = total > 0 ? badPos / total : 0.0;
-    final quality = _quality(emptyPct, badPct, duplicates.isNotEmpty);
+    final quality = validation.isValid
+        ? _quality(emptyPct, badPct, duplicates.isNotEmpty)
+        : 'fail';
 
     issues.add('empty_expl: ${(emptyPct * 100).toStringAsFixed(1)}%');
     issues.add('bad_pos: ${(badPct * 100).toStringAsFixed(1)}%');

--- a/test/services/booster_pack_validator_service_test.dart
+++ b/test/services/booster_pack_validator_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_pack_validator_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/game_type.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('validator detects issues', () {
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(heroCards: '', position: HeroPosition.unknown),
+    );
+    final pack = TrainingPackTemplateV2(
+      id: '',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      gameType: GameType.tournament,
+      spots: [spot],
+      spotCount: 1,
+      positions: const [],
+      meta: const {'type': 'booster'},
+    );
+
+    final report = const BoosterPackValidatorService().validate(pack);
+    expect(report.isValid, isFalse);
+    expect(report.errors, contains('missing_pack_id'));
+    expect(report.errors, contains('empty_heroCards:s1'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterValidationReport` model
- implement `BoosterPackValidatorService` with deep checks
- integrate validator into `BoosterQuickTesterEngine`
- cover validator with basic unit test

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884d2eb5538832a87afa026c312ea3c