### PR TITLE
Add BoosterSimilarityEngine

### DIFF
--- a/lib/models/spot_similarity_result.dart
+++ b/lib/models/spot_similarity_result.dart
@@ -1,0 +1,24 @@
+class SpotSimilarityResult {
+  final String idA;
+  final String idB;
+  final double similarity;
+
+  const SpotSimilarityResult({
+    required this.idA,
+    required this.idB,
+    required this.similarity,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'idA': idA,
+        'idB': idB,
+        'similarity': similarity,
+      };
+
+  factory SpotSimilarityResult.fromJson(Map<String, dynamic> json) =>
+      SpotSimilarityResult(
+        idA: json['idA'] as String? ?? '',
+        idB: json['idB'] as String? ?? '',
+        similarity: (json['similarity'] as num?)?.toDouble() ?? 0.0,
+      );
+}

--- a/lib/services/booster_similarity_engine.dart
+++ b/lib/services/booster_similarity_engine.dart
@@ -1,0 +1,85 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/spot_similarity_result.dart';
+import '../helpers/hand_utils.dart';
+
+/// Computes similarity between booster spots to detect duplicates.
+class BoosterSimilarityEngine {
+  const BoosterSimilarityEngine();
+
+  /// Returns pairs of spot ids with similarity above [threshold].
+  List<SpotSimilarityResult> analyzeSpots(
+    List<TrainingPackSpot> spots, {
+    double threshold = 0.85,
+  }) {
+    final results = <SpotSimilarityResult>[];
+    for (var i = 0; i < spots.length; i++) {
+      for (var j = i + 1; j < spots.length; j++) {
+        final sim = _similarity(spots[i], spots[j]);
+        if (sim > threshold) {
+          results.add(SpotSimilarityResult(
+            idA: spots[i].id,
+            idB: spots[j].id,
+            similarity: sim,
+          ));
+        }
+      }
+    }
+    results.sort((a, b) => b.similarity.compareTo(a.similarity));
+    return results;
+  }
+
+  /// Convenience wrapper to analyze all spots in [pack].
+  List<SpotSimilarityResult> analyzePack(
+    TrainingPackTemplateV2 pack, {
+    double threshold = 0.85,
+  }) =>
+      analyzeSpots(pack.spots, threshold: threshold);
+
+  double _similarity(TrainingPackSpot a, TrainingPackSpot b) {
+    final cardsA = _heroMask(a);
+    final cardsB = _heroMask(b);
+    final cardSim = (cardsA.isNotEmpty && cardsA == cardsB) ? 1.0 : 0.0;
+
+    final posSim = a.hand.position == b.hand.position ? 1.0 : 0.0;
+
+    final boardA = _normBoard(a.board.isNotEmpty ? a.board : a.hand.board);
+    final boardB = _normBoard(b.board.isNotEmpty ? b.board : b.hand.board);
+    final boardSim = (boardA.isNotEmpty && boardA == boardB) ? 1.0 : 0.0;
+
+    final evA = a.heroEv ?? a.heroIcmEv;
+    final evB = b.heroEv ?? b.heroIcmEv;
+    double evSim = 0.5;
+    if (evA != null && evB != null) {
+      final diff = (evA - evB).abs();
+      evSim = 1 - (diff.clamp(0, 1));
+    }
+
+    final lineA = _actionLine(a);
+    final lineB = _actionLine(b);
+    final actionSim = lineA.isNotEmpty && lineA == lineB ? 1.0 : 0.0;
+
+    return cardSim * 0.3 +
+        posSim * 0.2 +
+        boardSim * 0.2 +
+        evSim * 0.2 +
+        actionSim * 0.1;
+  }
+
+  String _heroMask(TrainingPackSpot s) {
+    final code = handCode(s.hand.heroCards);
+    return code ?? '';
+  }
+
+  String _normBoard(List<String> board) =>
+      board.map((c) => c.toUpperCase()).join(' ');
+
+  String _actionLine(TrainingPackSpot s) {
+    final actions = s.hand.actions.values.expand((e) => e).toList();
+    if (actions.isEmpty) return '';
+    return actions
+        .map((a) =>
+            '${a.playerIndex}:${a.action}${a.amount != null ? a.amount : ''}')
+        .join('|');
+  }
+}

--- a/test/booster_similarity_engine_test.dart
+++ b/test/booster_similarity_engine_test.dart
@@ -1,0 +1,39 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/booster_similarity_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+
+TrainingPackSpot _spot(
+  String id,
+  String cards,
+  HeroPosition pos, {
+  List<String>? board,
+  double? ev,
+}) {
+  final hand = HandData.fromSimpleInput(cards, pos, 10);
+  if (board != null) hand.board.addAll(board);
+  if (ev != null) {
+    final acts = hand.actions[0];
+    if (acts.isNotEmpty) acts.first.ev = ev;
+  }
+  return TrainingPackSpot(id: id, hand: hand);
+}
+
+void main() {
+  test('analyzeSpots detects similar pair', () {
+    final s1 = _spot('a', 'AhKh', HeroPosition.btn,
+        board: ['Kd', 'Qs', 'Js'], ev: 0.5);
+    final s2 = _spot('b', 'AhKh', HeroPosition.btn,
+        board: ['Kd', 'Qs', 'Js'], ev: 0.52);
+    final s3 = _spot('c', '9c8c', HeroPosition.sb,
+        board: ['2h', '3d', '4s'], ev: -0.3);
+
+    const engine = BoosterSimilarityEngine();
+    final res = engine.analyzeSpots([s1, s2, s3], threshold: 0.8);
+
+    expect(res.length, 1);
+    expect(res.first.idA, 'a');
+    expect(res.first.idB, 'b');
+  });
+}


### PR DESCRIPTION
## Summary
- create `BoosterSimilarityEngine` to compute similarity between training spots
- model `SpotSimilarityResult`
- add unit test for similarity engine

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884dbeb53dc832a9e1e7cb777300db0