### PR TITLE
Implement BoosterSimilarityPruner

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -110,6 +110,7 @@ import '../services/booster_pack_changelog_generator.dart';
 import '../services/booster_pack_linter_engine.dart';
 import '../services/booster_quick_tester_engine.dart';
 import '../services/booster_anomaly_detector.dart';
+import '../services/booster_similarity_pruner.dart';
 import '../models/booster_anomaly_report.dart';
 import 'pack_library_qa_screen.dart';
 import 'pack_conflict_analysis_screen.dart';
@@ -217,6 +218,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _boosterArchiveLoading = false;
   bool _boosterChangelogLoading = false;
   bool _boosterLintLoading = false;
+  bool _boosterPruneLoading = false;
   bool _seedBeginnerLoading = false;
   bool _seedIntermediateLoading = false;
   bool _seedAdvancedLoading = false;
@@ -778,6 +780,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
         ],
       ),
     );
+  }
+
+  Future<void> _pruneBoosterDuplicates() async {
+    if (_boosterPruneLoading || !kDebugMode) return;
+    setState(() => _boosterPruneLoading = true);
+    final count = await const BoosterSimilarityPruner().pruneAndSaveAll();
+    if (!mounted) return;
+    setState(() => _boosterPruneLoading = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Обновлено: $count')));
   }
 
   Future<void> _quickTestBoosterYaml() async {
@@ -2466,6 +2478,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('🛠 Улучшить booster паки'),
                 onTap: _boosterRefineLoading ? null : _refineBoosters,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧹 Удалить дубликаты в booster паках'),
+                onTap: _boosterPruneLoading ? null : _pruneBoosterDuplicates,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/booster_similarity_pruner.dart
+++ b/lib/services/booster_similarity_pruner.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'booster_similarity_engine.dart';
+
+/// Removes highly similar spots from booster packs.
+class BoosterSimilarityPruner {
+  final BoosterSimilarityEngine _engine;
+  final double _threshold;
+
+  const BoosterSimilarityPruner({BoosterSimilarityEngine? engine, double threshold = 0.85})
+      : _engine = engine ?? const BoosterSimilarityEngine(),
+        _threshold = threshold;
+
+  /// Returns a copy of [pack] with similar spots removed.
+  TrainingPackTemplateV2 prune(TrainingPackTemplateV2 pack, {double? threshold}) {
+    final thr = threshold ?? _threshold;
+    final results = _engine.analyzePack(pack, threshold: thr);
+    if (results.isEmpty) return TrainingPackTemplateV2.fromJson(pack.toJson());
+
+    final idPos = <String, int>{};
+    for (var i = 0; i < pack.spots.length; i++) {
+      idPos[pack.spots[i].id] = i;
+    }
+
+    final toRemove = <String>{};
+    for (final r in results) {
+      if (r.similarity < thr) break;
+      final idA = r.idA;
+      final idB = r.idB;
+      if (toRemove.contains(idA) || toRemove.contains(idB)) continue;
+      final posA = idPos[idA] ?? 0;
+      final posB = idPos[idB] ?? 0;
+      if (posA <= posB) {
+        toRemove.add(idB);
+      } else {
+        toRemove.add(idA);
+      }
+    }
+
+    if (toRemove.isEmpty) return TrainingPackTemplateV2.fromJson(pack.toJson());
+
+    final spots = [for (final s in pack.spots) if (!toRemove.contains(s.id)) s];
+    final copy = TrainingPackTemplateV2.fromJson(pack.toJson());
+    copy.spots
+      ..clear()
+      ..addAll(spots);
+    copy.spotCount = spots.length;
+    return copy;
+  }
+
+  /// Scans [dir] for YAML booster packs, prunes duplicates and saves files.
+  /// Returns the number of updated files.
+  Future<int> pruneAndSaveAll({String dir = 'yaml_out/boosters'}) async {
+    final directory = Directory(dir);
+    if (!directory.existsSync()) return 0;
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+    var count = 0;
+    for (final file in files) {
+      try {
+        final yaml = await file.readAsString();
+        final tpl = TrainingPackTemplateV2.fromYamlString(yaml);
+        final pruned = prune(tpl);
+        if (pruned.spots.length != tpl.spots.length) {
+          await file.writeAsString(pruned.toYamlString());
+          count++;
+        }
+      } catch (_) {}
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary
- create `BoosterSimilarityPruner` for removing near-duplicate booster spots
- expose cleanup action in DevMenu

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884dd88b09c832a98ce4e6f3aff2248