### PR TITLE
Implement BoosterSmartSelector service with dev menu option

### DIFF
--- a/lib/services/booster_smart_selector.dart
+++ b/lib/services/booster_smart_selector.dart
@@ -1,0 +1,81 @@
+
+import '../helpers/hand_utils.dart';
+import '../models/v2/hero_position.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'booster_cluster_engine.dart';
+
+/// Selects a diverse subset of spots for booster packs.
+class BoosterSmartSelector {
+  const BoosterSmartSelector();
+
+  /// Returns a copy of [pack] containing at most [maxSpots] of the most
+  /// representative spots from [pack] and [clusters].
+  TrainingPackTemplateV2 selectBest(
+    TrainingPackTemplateV2 pack,
+    List<SpotCluster> clusters, {
+    int maxSpots = 30,
+  }) {
+    if (pack.spots.isEmpty) {
+      return TrainingPackTemplateV2.fromJson(pack.toJson());
+    }
+
+    final candidates = <TrainingPackSpot>[];
+    final idSet = <String>{};
+    for (final s in pack.spots) {
+      if (idSet.add(s.id)) candidates.add(s);
+    }
+    for (final c in clusters) {
+      for (final s in c.spots) {
+        if (idSet.add(s.id)) candidates.add(s);
+      }
+    }
+
+    final positions = <HeroPosition>{};
+    final hands = <String>{};
+    final boards = <String>{};
+    final actions = <String>{};
+
+    final selected = <TrainingPackSpot>[];
+    final remaining = List<TrainingPackSpot>.from(candidates);
+
+    String boardKey(TrainingPackSpot s) {
+      final b = s.board.isNotEmpty ? s.board : s.hand.board;
+      return b.join('/');
+    }
+
+    String actionKey(TrainingPackSpot s) {
+      return s.correctAction ?? s.type;
+    }
+
+    int score(TrainingPackSpot s) {
+      var sc = 0;
+      if (!positions.contains(s.hand.position)) sc++;
+      final code = handCode(s.hand.heroCards) ?? s.hand.heroCards;
+      if (!hands.contains(code)) sc++;
+      if (!boards.contains(boardKey(s))) sc++;
+      if (!actions.contains(actionKey(s))) sc++;
+      return sc;
+    }
+
+    while (remaining.isNotEmpty && selected.length < maxSpots) {
+      remaining.sort((a, b) => score(b).compareTo(score(a)));
+      final best = remaining.removeAt(0);
+      positions.add(best.hand.position);
+      final code = handCode(best.hand.heroCards) ?? best.hand.heroCards;
+      hands.add(code);
+      boards.add(boardKey(best));
+      actions.add(actionKey(best));
+      selected.add(best);
+    }
+
+    final map = pack.toJson();
+    map['spots'] = [for (final s in selected) s.toJson()];
+    map['spotCount'] = selected.length;
+    final result =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    result.isGeneratedPack = pack.isGeneratedPack;
+    result.isSampledPack = pack.isSampledPack;
+    return result;
+  }
+}

--- a/test/booster_smart_selector_test.dart
+++ b/test/booster_smart_selector_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_smart_selector.dart';
+import 'package:poker_analyzer/services/booster_cluster_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackSpot _spot(String id, String cards, HeroPosition pos) {
+  final hand = HandData.fromSimpleInput(cards, pos, 10);
+  return TrainingPackSpot(id: id, hand: hand);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('selectBest picks diverse spots', () {
+    final s1 = _spot('a', 'AhKh', HeroPosition.btn);
+    final s2 = _spot('b', 'AhKh', HeroPosition.btn);
+    final s3 = _spot('c', '9c8c', HeroPosition.sb);
+
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Test',
+      trainingType: TrainingType.pushFold,
+      spots: [s1, s2, s3],
+      spotCount: 3,
+    );
+
+    final clusters = const BoosterClusterEngine().analyzePack(pack);
+    final selector = BoosterSmartSelector();
+    final res = selector.selectBest(pack, clusters, maxSpots: 2);
+
+    expect(res.spots.length, 2);
+    final ids = res.spots.map((e) => e.id).toList();
+    expect(ids.contains('c'), true);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterSmartSelector service to pick diverse booster spots
- expose Smart booster selector in Dev Menu
- include basic unit test for new selector

## Testing
- `dart format lib/services/booster_smart_selector.dart lib/screens/dev_menu_screen.dart test/booster_smart_selector_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fb6415e8832a93d151684ff2d829