### PR TITLE
Implement BoosterPackClusterExporter

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -110,6 +110,7 @@ import '../services/booster_pack_diff_reporter.dart';
 import '../services/booster_snapshot_archiver.dart';
 import '../services/booster_pack_changelog_generator.dart';
 import '../services/booster_pack_linter_engine.dart';
+import '../services/booster_pack_cluster_exporter.dart';
 import '../services/booster_quick_tester_engine.dart';
 import '../services/booster_anomaly_detector.dart';
 import '../services/booster_similarity_pruner.dart';
@@ -230,6 +231,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _boosterClusterLoading = false;
   bool _boosterVariationLoading = false;
   bool _boosterSmartSelectLoading = false;
+  bool _boosterClusterExportLoading = false;
   bool _thematicTagLoading = false;
   bool _seedBeginnerLoading = false;
   bool _seedIntermediateLoading = false;
@@ -603,6 +605,16 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     }
     if (!mounted) return;
     setState(() => _tagTheoryExportLoading = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
+  }
+
+  Future<void> _exportBoosterClusters() async {
+    if (_boosterClusterExportLoading || !kDebugMode) return;
+    setState(() => _boosterClusterExportLoading = true);
+    final count = await const BoosterPackClusterExporter().export();
+    if (!mounted) return;
+    setState(() => _boosterClusterExportLoading = false);
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
   }
@@ -2906,6 +2918,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📤 Экспортировать теорию по тегам'),
                 onTap: _tagTheoryExportLoading ? null : _exportTheoryTags,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📦 Экспортировать по тематикам'),
+                onTap:
+                    _boosterClusterExportLoading ? null : _exportBoosterClusters,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/booster_pack_cluster_exporter.dart
+++ b/lib/services/booster_pack_cluster_exporter.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'booster_thematic_tagger.dart';
+
+/// Exports YAML booster packs into thematic clusters.
+class BoosterPackClusterExporter {
+  const BoosterPackClusterExporter();
+
+  /// Reads all YAML files from [src] (defaults to `/packs`),
+  /// detects thematic tags and copies packs into
+  /// `build/cluster_<tag>` directories under [dst].
+  Future<int> export({String src = '/packs', String dst = 'build'}) async {
+    if (!kDebugMode) return 0;
+    final directory = Directory(src);
+    if (!directory.existsSync()) return 0;
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+    var count = 0;
+    for (final file in files) {
+      try {
+        final yaml = await file.readAsString();
+        final pack = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final tags = const BoosterThematicTagger().suggestThematicTags(pack);
+        for (final tag in tags) {
+          final dir = Directory(p.join(dst, 'cluster_${_slug(tag)}'));
+          await dir.create(recursive: true);
+          await file.copy(p.join(dir.path, p.basename(file.path)));
+        }
+        count++;
+      } catch (_) {}
+    }
+    return count;
+  }
+
+  String _slug(String tag) =>
+      tag.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+}

--- a/test/booster_pack_cluster_exporter_test.dart
+++ b/test/booster_pack_cluster_exporter_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_pack_cluster_exporter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('export clusters copies packs', () async {
+    final dir = Directory.systemTemp.createTempSync();
+    final packsDir = Directory('${dir.path}/packs')..createSync();
+    final file = File('${packsDir.path}/p1.yaml');
+    await file.writeAsString('''
+id: p1
+name: Test Pack
+trainingType: tournament
+spots:
+  - id: s1
+    heroOptions: [open, fold]
+    villainAction: none
+    hand:
+      position: utg
+      heroIndex: 0
+      playerCount: 2
+      stacks:
+        '0': 20
+        '1': 20
+spotCount: 1
+meta:
+  schemaVersion: 2.0.0
+''');
+
+    final exporter = BoosterPackClusterExporter();
+    final count = await exporter.export(src: packsDir.path, dst: dir.path);
+    expect(count, 1);
+    final clusters = dir
+        .listSync()
+        .whereType<Directory>()
+        .where((d) => d.path.contains('cluster_'))
+        .toList();
+    expect(clusters.isNotEmpty, true);
+    final copied = clusters.first
+        .listSync()
+        .whereType<File>()
+        .any((f) => f.path.endsWith('p1.yaml'));
+    expect(copied, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterPackClusterExporter service to copy packs by thematic tags
- hook exporter into dev menu with a new button
- test BoosterPackClusterExporter cluster export logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688508b9f11c832abec54e6c2434f477