### PR TITLE
Add TheoryPathStageSeeder

### DIFF
--- a/lib/models/learning_path_stage_model.dart
+++ b/lib/models/learning_path_stage_model.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 
 import 'unlock_condition.dart';
 import 'sub_stage_model.dart';
+import 'stage_type.dart';
 
 class LearningPathStageModel {
   final String id;
   final String title;
   final String description;
+  final StageType type;
   final String packId;
   final String? theoryPackId;
   final List<String>? boosterTheoryPackIds;
@@ -38,6 +40,7 @@ class LearningPathStageModel {
     this.order = 0,
     this.isOptional = false,
     this.unlockCondition,
+    this.type = StageType.practice,
   })  : unlocks = unlocks ?? const [],
         unlockAfter = unlockAfter ?? const [],
         tags = tags ?? const [],
@@ -50,6 +53,7 @@ class LearningPathStageModel {
       title: json['title'] as String? ?? '',
       description: json['description'] as String? ?? '',
       packId: json['packId'] as String? ?? '',
+      type: _parseType(json['type']),
       theoryPackId: json['theoryPackId'] as String?,
       boosterTheoryPackIds: [
         for (final b in (json['boosterTheoryPackIds'] as List? ?? []))
@@ -79,11 +83,23 @@ class LearningPathStageModel {
     );
   }
 
+  static StageType _parseType(dynamic value) {
+    final s = value?.toString();
+    switch (s) {
+      case 'theory':
+        return StageType.theory;
+      case 'booster':
+        return StageType.booster;
+    }
+    return StageType.practice;
+  }
+
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'description': description,
         'packId': packId,
+        'type': type.name,
         if (theoryPackId != null) 'theoryPackId': theoryPackId,
         if (boosterTheoryPackIds != null && boosterTheoryPackIds!.isNotEmpty)
           'boosterTheoryPackIds': boosterTheoryPackIds,

--- a/lib/models/stage_type.dart
+++ b/lib/models/stage_type.dart
@@ -1,0 +1,2 @@
+enum StageType { practice, theory, booster }
+

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -92,6 +92,7 @@ import '../services/learning_path_engine.dart';
 import '../services/learning_path_stage_seeder.dart';
 import '../services/starter_learning_path_seeder.dart';
 import '../services/intermediate_learning_path_seeder.dart';
+import '../services/theory_path_stage_seeder.dart';
 
 import '../services/icm_postflop_path_seeder.dart';
 import '../services/live_hud_pack_seeder.dart';
@@ -238,6 +239,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _seedAdvancedLoading = false;
   bool _seedFullPathLoading = false;
   bool _seedIcmMultiwayLoading = false;
+  bool _seedTheoryStagesLoading = false;
   bool _generateBeginnerPathLoading = false;
   bool _generateIntermediatePathLoading = false;
   bool _generateAdvancedPathLoading = false;
@@ -2475,6 +2477,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _seedFullPathLoading = false);
   }
 
+  Future<void> _seedTheoryStages() async {
+    if (_seedTheoryStagesLoading || !kDebugMode) return;
+    setState(() => _seedTheoryStagesLoading = true);
+    try {
+      await const TheoryPathStageSeeder().seedAll();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Theory stages seeded')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Seed failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _seedTheoryStagesLoading = false);
+  }
+
   Future<void> _seedIcmMultiwayPath() async {
     if (_seedIcmMultiwayLoading || !kDebugMode) return;
     setState(() => _seedIcmMultiwayLoading = true);
@@ -3640,6 +3662,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Seed Full Path from Config'),
                 onTap: _seedFullPathLoading ? null : _seedFullPathFromConfig,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📚 Seed theory stages'),
+                onTap: _seedTheoryStagesLoading ? null : _seedTheoryStages,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/theory_path_stage_seeder.dart
+++ b/lib/services/theory_path_stage_seeder.dart
@@ -1,0 +1,41 @@
+import '../models/learning_path_stage_model.dart';
+import '../models/stage_type.dart';
+import 'booster_thematic_tagger.dart';
+import 'theory_pack_generator_service.dart';
+import 'training_path_storage_service.dart';
+
+/// Generates basic theory stages for key tags and saves them to storage.
+class TheoryPathStageSeeder {
+  final BoosterThematicTagger tagger;
+  final TheoryPackGeneratorService generator;
+  final TrainingPathStorageService storage;
+
+  const TheoryPathStageSeeder({
+    this.tagger = const BoosterThematicTagger(),
+    this.generator = const TheoryPackGeneratorService(),
+    this.storage = const TrainingPathStorageService(),
+  });
+
+  Future<void> seedAll() async {
+    final tags = TheoryPackGeneratorService.tags;
+    final stages = <LearningPathStageModel>[];
+    var order = 0;
+    for (final tag in tags) {
+      final tpl = generator.generateForTag(tag);
+      stages.add(
+        LearningPathStageModel(
+          id: 'theory_$tag',
+          title: '📘 ${tpl.name}',
+          description: tpl.description,
+          packId: tpl.id,
+          type: StageType.theory,
+          requiredAccuracy: 0,
+          minHands: 0,
+          tags: [tag],
+          order: order++,
+        ),
+      );
+    }
+    await storage.save('core_path', stages);
+  }
+}

--- a/lib/services/training_path_storage_service.dart
+++ b/lib/services/training_path_storage_service.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/learning_path_stage_model.dart';
+
+class TrainingPathStorageService {
+  static const _key = 'training_paths_v2';
+
+  const TrainingPathStorageService();
+
+  Future<Map<String, List<LearningPathStageModel>>> _loadAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return {};
+    try {
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return map.map((k, v) {
+        final list = (v as List?) ?? [];
+        return MapEntry(
+          k,
+          [
+            for (final e in list)
+              LearningPathStageModel.fromJson(
+                Map<String, dynamic>.from(e as Map),
+              )
+          ],
+        );
+      });
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<void> save(String pathId, List<LearningPathStageModel> stages) async {
+    final all = await _loadAll();
+    all[pathId] = stages;
+    final prefs = await SharedPreferences.getInstance();
+    final map = all.map((k, v) => MapEntry(k, [for (final s in v) s.toJson()]));
+    await prefs.setString(_key, jsonEncode(map));
+  }
+}


### PR DESCRIPTION
## Summary
- add StageType enum and extend `LearningPathStageModel`
- add local storage service for training path templates
- implement `TheoryPathStageSeeder`
- expose seeder in dev menu

## Testing
- `flutter analyze` *(fails: 6081 issues)*
- `flutter test` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68850a4997e0832a9699f7d5a10e8058