### PR TITLE
Add theory intro banner

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -17,6 +17,9 @@ import '../services/learning_path_personalization_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/learning_path_prefs.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/intro_seen_tracker.dart';
+import '../services/booster_thematic_descriptions.dart';
+import '../widgets/theory_intro_banner.dart';
 import 'learning_path_celebration_screen.dart';
 import '../widgets/next_steps_modal.dart';
 import '../widgets/stage_progress_chip.dart';
@@ -225,6 +228,24 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
         const SnackBar(content: Text('Theory pack not found')),
       );
       return;
+    }
+    final tag = stage.tags.isNotEmpty ? stage.tags.first : null;
+    if (tag != null) {
+      final tracker = const IntroSeenTracker();
+      final seen = await tracker.hasSeen(tag);
+      if (!seen && mounted) {
+        final desc = BoosterThematicDescriptions.get(tag) ?? '';
+        final ok = await showTheoryIntroBanner(
+          context,
+          title: stage.title,
+          description: desc,
+        );
+        if (ok == true) {
+          await tracker.markSeen(tag);
+        } else {
+          return;
+        }
+      }
     }
     await const TrainingSessionLauncher().launch(template);
     if (mounted) {

--- a/lib/services/booster_thematic_descriptions.dart
+++ b/lib/services/booster_thematic_descriptions.dart
@@ -1,0 +1,9 @@
+/// Provides short explanations for booster/theory tags.
+class BoosterThematicDescriptions {
+  static const Map<String, String> _data = {
+    'push_sb':
+        'Пуш с малого блайнда часто выгоден из-за отсутствия позиции.\nИзучите, когда лучше пушить против большого блайнда.',
+  };
+
+  static String? get(String tag) => _data[tag];
+}

--- a/lib/services/intro_seen_tracker.dart
+++ b/lib/services/intro_seen_tracker.dart
@@ -1,0 +1,18 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks which theory intros have been seen.
+class IntroSeenTracker {
+  static const _keyPrefix = 'theory_intro_seen_';
+
+  const IntroSeenTracker();
+
+  Future<bool> hasSeen(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('$_keyPrefix$tag') ?? false;
+  }
+
+  Future<void> markSeen(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('$_keyPrefix$tag', true);
+  }
+}

--- a/lib/widgets/theory_intro_banner.dart
+++ b/lib/widgets/theory_intro_banner.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+/// Banner shown before a theory pack to provide brief context.
+class TheoryIntroBanner extends StatelessWidget {
+  final String title;
+  final String description;
+  const TheoryIntroBanner({
+    super.key,
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E1E1E),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('\u{1F4D6}', style: TextStyle(fontSize: 48)),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: const TextStyle(fontSize: 20),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            description,
+            style: const TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Начать'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shows [TheoryIntroBanner] with a fade animation.
+Future<bool?> showTheoryIntroBanner(
+  BuildContext context, {
+  required String title,
+  required String description,
+}) {
+  return showGeneralDialog<bool>(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: 'Intro',
+    transitionDuration: const Duration(milliseconds: 300),
+    pageBuilder: (_, __, ___) => Center(
+      child: TheoryIntroBanner(title: title, description: description),
+    ),
+    transitionBuilder: (_, anim, __, child) =>
+        FadeTransition(opacity: anim, child: child),
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `IntroSeenTracker` to persist banner state
- add `BoosterThematicDescriptions` for intro text
- create `TheoryIntroBanner` widget with fade animation
- show intro banner before first theory pack

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850e46e2a4832ab64ed0e24cff8801