### PR TITLE
Add BoosterTheoryExportEngine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -121,6 +121,7 @@ import '../services/booster_smart_selector.dart';
 import '../services/booster_pack_similarity_reporter.dart';
 import '../services/booster_thematic_tagger.dart';
 import '../services/booster_theory_pack_batch_generator.dart';
+import '../services/booster_theory_export_engine.dart';
 import '../services/booster_thematic_descriptions.dart';
 import '../models/booster_anomaly_report.dart';
 import 'pack_library_qa_screen.dart';
@@ -607,16 +608,13 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   Future<void> _exportTheoryTags() async {
     if (_tagTheoryExportLoading || !kDebugMode) return;
     setState(() => _tagTheoryExportLoading = true);
-    int count = 0;
-    const service = TheoryPackGeneratorService();
-    for (final tag in TheoryPackGeneratorService.tags) {
-      await service.exportYamlForTag(tag);
-      count++;
-    }
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final library = PackLibraryLoaderService.instance.library;
+    final paths = await const BoosterTheoryExportEngine().export(library);
     if (!mounted) return;
     setState(() => _tagTheoryExportLoading = false);
     ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Экспортировано: $count')));
+        .showSnackBar(SnackBar(content: Text('Экспортировано: ${paths.length}')));
   }
 
   Future<void> _exportBoosterClusters() async {

--- a/lib/services/booster_theory_export_engine.dart
+++ b/lib/services/booster_theory_export_engine.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:json2yaml/json2yaml.dart';
+import 'package:path/path.dart' as p;
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+/// Exports theory packs from a library into YAML files.
+class BoosterTheoryExportEngine {
+  const BoosterTheoryExportEngine();
+
+  /// Writes every theory pack from [library] into [dir].
+  ///
+  /// Returns paths of the exported files.
+  Future<List<String>> export(
+    List<TrainingPackTemplateV2> library, {
+    String dir = 'yaml_out/theory',
+  }) async {
+    if (!kDebugMode) return [];
+    final directory = Directory(dir);
+    await directory.create(recursive: true);
+    final paths = <String>[];
+    for (final pack in library) {
+      if (pack.trainingType != TrainingType.theory) continue;
+      final yaml = _encodeYaml(pack.toJson());
+      final file = File(p.join(directory.path, '${pack.id}.yaml'));
+      await file.writeAsString('$yaml\n');
+      paths.add(file.path);
+    }
+    return paths;
+  }
+
+  String _encodeYaml(Map<String, dynamic> map) =>
+      json2yaml(map, yamlStyle: YamlStyle.pubspecYaml);
+}


### PR DESCRIPTION
## Summary
- implement `BoosterTheoryExportEngine` to export theory packs to YAML
- hook engine into dev menu for easy exporting

## Testing
- `flutter analyze` *(fails: 6092 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68851dc76494832a9e742922f0f03cb5