### PR TITLE
Add booster pack auto uploader

### DIFF
--- a/lib/models/pack_library.dart
+++ b/lib/models/pack_library.dart
@@ -1,0 +1,33 @@
+import 'v2/training_pack_template_v2.dart';
+
+/// Simple in-memory library used for staging imported packs.
+class PackLibrary {
+  PackLibrary._();
+
+  static final PackLibrary staging = PackLibrary._();
+
+  final List<TrainingPackTemplateV2> _packs = [];
+  final Map<String, TrainingPackTemplateV2> _index = {};
+
+  List<TrainingPackTemplateV2> get packs => List.unmodifiable(_packs);
+
+  void clear() {
+    _packs.clear();
+    _index.clear();
+  }
+
+  void add(TrainingPackTemplateV2 pack) {
+    if (_index.containsKey(pack.id)) return;
+    _packs.add(pack);
+    _index[pack.id] = pack;
+  }
+
+  void addAll(Iterable<TrainingPackTemplateV2> list) {
+    for (final p in list) {
+      add(p);
+    }
+  }
+
+  TrainingPackTemplateV2? getById(String id) => _index[id];
+}
+

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -123,6 +123,7 @@ import '../services/booster_thematic_tagger.dart';
 import '../services/booster_theory_pack_batch_generator.dart';
 import '../services/booster_theory_export_engine.dart';
 import '../services/theory_export_validator.dart';
+import '../services/booster_pack_auto_uploader.dart';
 import '../services/booster_thematic_descriptions.dart';
 import '../models/booster_anomaly_report.dart';
 import 'pack_library_qa_screen.dart';
@@ -190,6 +191,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _yamlMergeLoading = false;
   bool _theoryValidateLoading = false;
   bool _theoryExportValidateLoading = false;
+  bool _theoryStagingImportLoading = false;
   bool _refactorLoading = false;
   bool _ratingLoading = false;
   bool _tagHealthLoading = false;
@@ -1312,6 +1314,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _importTheoryStaging() async {
+    if (_theoryStagingImportLoading || !kDebugMode) return;
+    setState(() => _theoryStagingImportLoading = true);
+    final count = await compute(_importTheoryStagingTask, '');
+    if (!mounted) return;
+    setState(() => _theoryStagingImportLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Imported: $count')),
     );
   }
 
@@ -3144,6 +3157,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
+                title: const Text('📥 Импортировать теорию в staging'),
+                onTap:
+                    _theoryStagingImportLoading ? null : _importTheoryStaging,
+              ),
+            if (kDebugMode)
+              ListTile(
                 title: const Text('🧹 Рефакторинг библиотеки'),
                 onTap: _refactorLoading ? null : _refactorLibrary,
               ),
@@ -3970,6 +3989,11 @@ Future<List<(String, String)>> _validateTheoryTask(String _) async {
 
 Future<List<(String, String)>> _validateTheoryExportTask(String _) async {
   return const TheoryExportValidator().validateAll();
+}
+
+Future<int> _importTheoryStagingTask(String _) async {
+  final uploaded = await const BoosterPackAutoUploader().uploadAll();
+  return uploaded.length;
 }
 
 Future<int> _rankTask(String _) async {

--- a/lib/services/booster_pack_auto_uploader.dart
+++ b/lib/services/booster_pack_auto_uploader.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import '../models/pack_library.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/generation/yaml_reader.dart';
+import 'pack_library_loader_service.dart';
+import 'theory_export_validator.dart';
+
+/// Automatically uploads validated theory packs into the staging library.
+class BoosterPackAutoUploader {
+  const BoosterPackAutoUploader();
+
+  /// Loads all theory YAML files from [dir], validates them and imports
+  /// valid packs into [PackLibrary.staging].
+  ///
+  /// Returns the list of imported templates.
+  Future<List<TrainingPackTemplateV2>> uploadAll({String dir = 'yaml_out/theory'}) async {
+    await PackLibraryLoaderService.instance.loadLibrary();
+    final directory = Directory(dir);
+    if (!directory.existsSync()) return <TrainingPackTemplateV2>[];
+
+    // Collect validation errors to know which files to skip.
+    final validation = await const TheoryExportValidator().validateAll(dir: dir);
+    final errorsByFile = <String, List<String>>{};
+    for (final e in validation) {
+      errorsByFile.putIfAbsent(e.$1, () => <String>[]).add(e.$2);
+    }
+    final skip = <String>{};
+    errorsByFile.forEach((path, errs) {
+      if (errs.contains('duplicate_id') ||
+          errs.contains('parse_error') ||
+          errs.any((e) => e.startsWith('bad_trainingType'))) {
+        skip.add(path);
+      }
+    });
+
+    const reader = YamlReader();
+    final imported = <TrainingPackTemplateV2>[];
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+
+    for (final file in files) {
+      if (skip.contains(file.path)) continue;
+      try {
+        final map = reader.read(await file.readAsString());
+        final tpl = TrainingPackTemplateV2.fromJson(
+          Map<String, dynamic>.from(map),
+        );
+        tpl.meta = Map<String, dynamic>.from(tpl.meta)
+          ..['source'] = 'auto_uploaded_theory';
+        PackLibrary.staging.add(tpl);
+        imported.add(tpl);
+      } catch (_) {}
+    }
+
+    return imported;
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce in-memory `PackLibrary.staging` for imported templates
- add `BoosterPackAutoUploader` to load validated theory packs
- hook a new dev menu action to import theory packs into staging

## Testing
- `dart format -o none lib/services/booster_pack_auto_uploader.dart lib/models/pack_library.dart`
- `flutter pub get` *(passed with warnings)*
- `flutter test` *(failed: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688521ded4e8832abd63616e940494da