### PR TITLE
Add TheoryStagingPreviewScreen

### DIFF
--- a/lib/models/pack_library.dart
+++ b/lib/models/pack_library.dart
@@ -28,6 +28,11 @@ class PackLibrary {
     }
   }
 
+  /// Removes a template with the given [id] from the library.
+  void remove(String id) {
+    final tpl = _index.remove(id);
+    if (tpl != null) _packs.remove(tpl);
+  }
+
   TrainingPackTemplateV2? getById(String id) => _index[id];
 }
-

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -80,6 +80,7 @@ import 'yaml_library_preview_screen.dart';
 import 'yaml_pack_quick_preview_screen.dart';
 import 'yaml_pack_previewer_screen.dart';
 import 'theory_booster_preview_screen.dart';
+import 'theory_staging_preview_screen.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -3160,6 +3161,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 title: const Text('📥 Импортировать теорию в staging'),
                 onTap:
                     _theoryStagingImportLoading ? null : _importTheoryStaging,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📦 Теория: предпросмотр staging'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const TheoryStagingPreviewScreen(),
+                    ),
+                  );
+                },
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/screens/theory_staging_preview_screen.dart
+++ b/lib/screens/theory_staging_preview_screen.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../models/pack_library.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_v2.dart';
+import '../theme/app_colors.dart';
+import 'training_session_screen.dart';
+
+class TheoryStagingPreviewScreen extends StatefulWidget {
+  const TheoryStagingPreviewScreen({super.key});
+
+  @override
+  State<TheoryStagingPreviewScreen> createState() =>
+      _TheoryStagingPreviewScreenState();
+}
+
+class _TheoryStagingPreviewScreenState
+    extends State<TheoryStagingPreviewScreen> {
+  final List<TrainingPackTemplateV2> _packs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  void _load() {
+    setState(() {
+      _packs
+        ..clear()
+        ..addAll(PackLibrary.staging.packs);
+    });
+  }
+
+  void _preview(TrainingPackTemplateV2 tpl) {
+    final pack = TrainingPackV2.fromTemplate(tpl, tpl.id);
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => TrainingSessionScreen(pack: pack)),
+    );
+  }
+
+  void _delete(TrainingPackTemplateV2 tpl) {
+    PackLibrary.staging.remove(tpl.id);
+    setState(() => _packs.removeWhere((p) => p.id == tpl.id));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Staging Theory')),
+      backgroundColor: AppColors.background,
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: _packs.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (_, i) {
+          final tpl = _packs[i];
+          return ListTile(
+            title: Text(tpl.name),
+            subtitle: Text(
+                '${tpl.trainingType.name} • ${tpl.id}\n${tpl.tags.join(', ')}'),
+            isThreeLine: true,
+            trailing: Wrap(
+              spacing: 8,
+              children: [
+                ElevatedButton(
+                  onPressed: () => _preview(tpl),
+                  child: const Text('👁 Предпросмотр'),
+                ),
+                ElevatedButton(
+                  onPressed: () => _delete(tpl),
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                  child: const Text('🗑 Удалить'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add remove method for `PackLibrary`
- create a theory staging preview screen for DevMenu
- link preview screen from DevMenu

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 5988 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6885255e6874832a868310ff11c4e391