### PR TITLE
Implement theory pack promotion

### DIFF
--- a/lib/models/pack_library.dart
+++ b/lib/models/pack_library.dart
@@ -1,10 +1,11 @@
 import 'v2/training_pack_template_v2.dart';
 
-/// Simple in-memory library used for staging imported packs.
+/// Simple in-memory libraries used during development.
 class PackLibrary {
   PackLibrary._();
 
   static final PackLibrary staging = PackLibrary._();
+  static final PackLibrary main = PackLibrary._();
 
   final List<TrainingPackTemplateV2> _packs = [];
   final Map<String, TrainingPackTemplateV2> _index = {};

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -81,6 +81,7 @@ import 'yaml_pack_quick_preview_screen.dart';
 import 'yaml_pack_previewer_screen.dart';
 import 'theory_booster_preview_screen.dart';
 import 'theory_staging_preview_screen.dart';
+import '../services/theory_pack_promoter.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -193,6 +194,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _theoryValidateLoading = false;
   bool _theoryExportValidateLoading = false;
   bool _theoryStagingImportLoading = false;
+  bool _theoryPromoteLoading = false;
   bool _refactorLoading = false;
   bool _ratingLoading = false;
   bool _tagHealthLoading = false;
@@ -1326,6 +1328,37 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     setState(() => _theoryStagingImportLoading = false);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Imported: $count')),
+    );
+  }
+
+  Future<void> _promoteTheory() async {
+    if (_theoryPromoteLoading || !kDebugMode) return;
+    final ctr = TextEditingController();
+    final category = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Theory category'),
+        content: TextField(controller: ctr),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, ctr.text.trim()),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (category == null || category.isEmpty) return;
+    setState(() => _theoryPromoteLoading = true);
+    final count = const TheoryPackPromoter().promoteAll(category);
+    if (!mounted) return;
+    setState(() => _theoryPromoteLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Promoted: $count')),
     );
   }
 
@@ -3173,6 +3206,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     ),
                   );
                 },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📤 Promote теорию из staging → main'),
+                onTap: _theoryPromoteLoading ? null : _promoteTheory,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/theory_pack_promoter.dart
+++ b/lib/services/theory_pack_promoter.dart
@@ -1,0 +1,29 @@
+import '../models/pack_library.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Moves validated theory packs from [PackLibrary.staging] into
+/// [PackLibrary.main].
+class TheoryPackPromoter {
+  const TheoryPackPromoter();
+
+  /// Copies all packs from [PackLibrary.staging] to [PackLibrary.main].
+  /// Existing IDs in the main library are skipped. Each promoted pack gets
+  /// `meta['source'] = 'theory_promoted'` and `meta['category'] = [category]`.
+  /// The original entry is removed from the staging library.
+  int promoteAll(String category) {
+    final list = List<TrainingPackTemplateV2>.from(PackLibrary.staging.packs);
+    var count = 0;
+    for (final tpl in list) {
+      if (PackLibrary.main.getById(tpl.id) != null) {
+        continue;
+      }
+      tpl.meta = Map<String, dynamic>.from(tpl.meta)
+        ..['source'] = 'theory_promoted'
+        ..['category'] = category;
+      PackLibrary.main.add(tpl);
+      PackLibrary.staging.remove(tpl.id);
+      count++;
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary
- manage pack libraries with a new `main` store
- add `TheoryPackPromoter` to move packs from `staging` to `main`
- hook promotion into DevMenu with category input

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688527b06498832aa463f55d3a189ff7