### PR TITLE
Add theory auto seeder

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -96,6 +96,7 @@ import '../services/learning_path_stage_seeder.dart';
 import '../services/starter_learning_path_seeder.dart';
 import '../services/intermediate_learning_path_seeder.dart';
 import '../services/theory_path_stage_seeder.dart';
+import '../services/learning_path_auto_seeder.dart';
 
 import '../services/icm_postflop_path_seeder.dart';
 import '../services/live_hud_pack_seeder.dart';
@@ -256,6 +257,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _seedFullPathLoading = false;
   bool _seedIcmMultiwayLoading = false;
   bool _seedTheoryStagesLoading = false;
+  bool _autoSeedTheoryPathLoading = false;
   bool _generateBeginnerPathLoading = false;
   bool _generateIntermediatePathLoading = false;
   bool _generateAdvancedPathLoading = false;
@@ -2701,6 +2703,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _seedTheoryStagesLoading = false);
   }
 
+  Future<void> _autoSeedTheoryPath() async {
+    if (_autoSeedTheoryPathLoading || !kDebugMode) return;
+    setState(() => _autoSeedTheoryPathLoading = true);
+    try {
+      await const LearningPathAutoSeeder().seed();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Theory path seeded')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Seed failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _autoSeedTheoryPathLoading = false);
+  }
+
   Future<void> _seedIcmMultiwayPath() async {
     if (_seedIcmMultiwayLoading || !kDebugMode) return;
     setState(() => _seedIcmMultiwayLoading = true);
@@ -3921,6 +3943,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📚 Seed theory stages'),
                 onTap: _seedTheoryStagesLoading ? null : _seedTheoryStages,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🪄 Seed теория → Learning Path'),
+                onTap:
+                    _autoSeedTheoryPathLoading ? null : _autoSeedTheoryPath,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/learning_path_auto_seeder.dart
+++ b/lib/services/learning_path_auto_seeder.dart
@@ -1,0 +1,69 @@
+import '../models/learning_path_stage_model.dart';
+import '../models/stage_type.dart';
+import '../models/sub_stage_model.dart';
+import '../models/pack_library.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'learning_path_stage_library.dart';
+
+/// Creates learning path stages from promoted theory packs.
+class LearningPathAutoSeeder {
+  const LearningPathAutoSeeder();
+
+  /// Generates stages from [PackLibrary.main] and stores them in
+  /// [LearningPathStageLibrary].
+  Future<void> seed() async {
+    final groups = <String, List<TrainingPackTemplateV2>>{};
+    for (final pack in PackLibrary.main.packs) {
+      final source = pack.meta['source']?.toString();
+      if (source != 'theory_promoted') continue;
+      final category = pack.meta['category']?.toString().toLowerCase();
+      if (category == null || category.isEmpty) continue;
+      groups.putIfAbsent(category, () => []).add(pack);
+    }
+
+    final library = LearningPathStageLibrary.instance;
+    library.clear();
+
+    const mapping = {
+      'starter': 'theory_intro',
+      'core': 'theory_core',
+      'advanced': 'theory_advanced',
+    };
+    const titles = {
+      'starter': 'Введение в теорию',
+      'core': 'Базовая теория',
+      'advanced': 'Продвинутая теория',
+    };
+
+    var order = 0;
+    for (final entry in mapping.entries) {
+      final packs = groups[entry.key];
+      if (packs == null || packs.isEmpty) continue;
+      final mainPack = packs.first;
+      final subStages = <SubStageModel>[];
+      for (final p in packs.skip(1)) {
+        subStages.add(
+          SubStageModel(
+            id: p.id,
+            packId: p.id,
+            title: p.name,
+            description: p.description,
+          ),
+        );
+      }
+
+      final stage = LearningPathStageModel(
+        id: entry.value,
+        title: titles[entry.key]!,
+        description: '',
+        packId: mainPack.id,
+        requiredAccuracy: 0,
+        minHands: 0,
+        type: StageType.theory,
+        subStages: subStages,
+        order: order++,
+      );
+      library.add(stage);
+    }
+  }
+}

--- a/test/learning_path_auto_seeder_test.dart
+++ b/test/learning_path_auto_seeder_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/pack_library.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/learning_path_auto_seeder.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('creates stages from promoted packs', () async {
+    PackLibrary.main.clear();
+
+    final p1 = TrainingPackTemplateV2(
+      id: 's1',
+      name: 'Starter',
+      trainingType: TrainingType.pushFold,
+      meta: {'source': 'theory_promoted', 'category': 'starter'},
+    );
+    final p2 = TrainingPackTemplateV2(
+      id: 'c1',
+      name: 'Core1',
+      trainingType: TrainingType.pushFold,
+      meta: {'source': 'theory_promoted', 'category': 'core'},
+    );
+    final p3 = TrainingPackTemplateV2(
+      id: 'c2',
+      name: 'Core2',
+      trainingType: TrainingType.pushFold,
+      meta: {'source': 'theory_promoted', 'category': 'core'},
+    );
+    final p4 = TrainingPackTemplateV2(
+      id: 'a1',
+      name: 'Adv',
+      trainingType: TrainingType.pushFold,
+      meta: {'source': 'theory_promoted', 'category': 'advanced'},
+    );
+
+    PackLibrary.main.addAll([p1, p2, p3, p4]);
+
+    await const LearningPathAutoSeeder().seed();
+
+    final stages = LearningPathStageLibrary.instance.stages;
+    expect(stages, hasLength(3));
+
+    final intro = stages.firstWhere((s) => s.id == 'theory_intro');
+    expect(intro.packId, 's1');
+
+    final core = stages.firstWhere((s) => s.id == 'theory_core');
+    expect(core.packId, 'c1');
+    expect(core.subStages, hasLength(1));
+    expect(core.subStages.first.packId, 'c2');
+
+    final adv = stages.firstWhere((s) => s.id == 'theory_advanced');
+    expect(adv.packId, 'a1');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathAutoSeeder` for generating learning stages from promoted theory packs
- hook auto seeding into DevMenu
- cover new service with unit test

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: Unable to locate package)*
- `apt-get install -y flutter` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68852918f504832aa24aa8b7f82b5de2