### PR TITLE
Add BoosterTheoryPreviewScreen to DevMenu

### DIFF
--- a/lib/screens/booster_theory_preview_screen.dart
+++ b/lib/screens/booster_theory_preview_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../services/learning_path_stage_library.dart';
+import '../models/learning_path_stage_model.dart';
+import '../models/stage_type.dart';
+import '../theme/app_colors.dart';
+
+class BoosterTheoryPreviewScreen extends StatelessWidget {
+  const BoosterTheoryPreviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    final stages = LearningPathStageLibrary.instance.stages
+        .where((s) => s.type == StageType.theory)
+        .toList()
+      ..sort((a, b) => a.order.compareTo(b.order));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Theory Stages Preview')),
+      backgroundColor: AppColors.background,
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: stages.length,
+        itemBuilder: (_, i) {
+          final stage = stages[i];
+          return ExpansionTile(
+            title: Text(stage.title),
+            subtitle: Text(stage.packId),
+            trailing: Text('${stage.subStages.length} саб-стадии'),
+            childrenPadding: const EdgeInsets.only(left: 16, bottom: 8),
+            children: [
+              for (final sub in stage.subStages)
+                ListTile(
+                  dense: true,
+                  title: Text(sub.title),
+                  subtitle: Text(sub.packId),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -80,6 +80,7 @@ import 'yaml_library_preview_screen.dart';
 import 'yaml_pack_quick_preview_screen.dart';
 import 'yaml_pack_previewer_screen.dart';
 import 'theory_booster_preview_screen.dart';
+import 'booster_theory_preview_screen.dart';
 import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
 import 'booster_preview_screen.dart';
@@ -3320,6 +3321,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const TheoryBoosterPreviewScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📖 Просмотр стадий теории'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const BoosterTheoryPreviewScreen(),
                     ),
                   );
                 },


### PR DESCRIPTION
## Summary
- add a BoosterTheoryPreviewScreen for QA of theory stages
- link the new screen from the DevMenu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852b0c0c1c832a84a6a1410621c479