### PR TITLE
Add theory stage validator engine

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -98,6 +98,8 @@ import '../services/starter_learning_path_seeder.dart';
 import '../services/intermediate_learning_path_seeder.dart';
 import '../services/theory_path_stage_seeder.dart';
 import '../services/learning_path_auto_seeder.dart';
+import '../services/theory_stage_validator_engine.dart';
+import '../models/pack_library.dart';
 
 import '../services/icm_postflop_path_seeder.dart';
 import '../services/live_hud_pack_seeder.dart';
@@ -195,6 +197,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _yamlMergeLoading = false;
   bool _theoryValidateLoading = false;
   bool _theoryExportValidateLoading = false;
+  bool _theoryStageValidateLoading = false;
   bool _theoryStagingImportLoading = false;
   bool _theoryPromoteLoading = false;
   bool _refactorLoading = false;
@@ -1306,6 +1309,39 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
       debugPrint('${e.$1}: ${e.$2}');
     }
     final text = errors.map((e) => '${e.$1}: ${e.$2}').join('\n');
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        content: SingleChildScrollView(
+          child: Text(text, style: const TextStyle(color: Colors.white)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _validateTheoryStages() async {
+    if (_theoryStageValidateLoading || !kDebugMode) return;
+    setState(() => _theoryStageValidateLoading = true);
+    await PackLibraryLoaderService.instance.loadLibrary();
+    PackLibrary.main
+      ..clear()
+      ..addAll(PackLibraryLoaderService.instance.library);
+    final errors = const TheoryStageValidatorEngine().validate();
+    if (!mounted) return;
+    setState(() => _theoryStageValidateLoading = false);
+    if (errors.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Ошибок нет')));
+      return;
+    }
+    final text = errors.join('\n');
     await showDialog(
       context: context,
       builder: (_) => AlertDialog(
@@ -3211,6 +3247,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 title: const Text('✅ Проверка теории (yaml_out/theory)'),
                 onTap:
                     _theoryExportValidateLoading ? null : _validateTheoryExport,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧪 Проверка стадий теории'),
+                onTap:
+                    _theoryStageValidateLoading ? null : _validateTheoryStages,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/theory_stage_validator_engine.dart
+++ b/lib/services/theory_stage_validator_engine.dart
@@ -1,0 +1,44 @@
+import '../models/pack_library.dart';
+import '../models/stage_type.dart';
+import 'learning_path_stage_library.dart';
+
+/// Validates theory stages against the main pack library.
+class TheoryStageValidatorEngine {
+  const TheoryStageValidatorEngine();
+
+  /// Returns a list of validation errors.
+  List<String> validate() {
+    final errors = <String>[];
+    final library = LearningPathStageLibrary.instance;
+    final stageIds = <String>{};
+    for (final stage in library.stages) {
+      if (!stageIds.add(stage.id)) {
+        errors.add('duplicate_stage_id:${stage.id}');
+      }
+      if (stage.title.trim().isEmpty) {
+        errors.add('empty_title:${stage.id}');
+      }
+
+      // Check for duplicate pack IDs within the stage and missing packs
+      final packIds = <String>{};
+      void checkPack(String id) {
+        if (!packIds.add(id)) {
+          errors.add('duplicate_pack_id:${stage.id}:$id');
+        }
+        if (PackLibrary.main.getById(id) == null) {
+          errors.add('missing_pack:$id');
+        }
+      }
+
+      checkPack(stage.packId);
+      for (final sub in stage.subStages) {
+        checkPack(sub.packId);
+      }
+
+      if (stage.type == StageType.theory && stage.subStages.isEmpty) {
+        errors.add('no_sub_stages:${stage.id}');
+      }
+    }
+    return errors;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryStageValidatorEngine` to check stage data integrity
- expose theory stage check in DevMenu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852bfb89cc832a970e0a7488d9e2ce