### PR TITLE
Add SmartTheoryPackGenerator service

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -52,6 +52,7 @@ import '../services/training_pack_generator_v2.dart';
 import '../models/training_attempt.dart';
 import '../services/weakness_cluster_engine_v2.dart';
 import '../services/goal_completion_engine.dart';
+import '../services/smart_theory_pack_generator.dart';
 import '../services/pack_library_review_engine.dart';
 import '../services/yaml_pack_auto_fix_engine.dart';
 import '../services/pack_library_smart_validator.dart';
@@ -233,6 +234,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _jsonLibraryLoading = false;
   bool _smartValidateLoading = false;
   bool _weaknessYamlLoading = false;
+  bool _smartTheoryPackLoading = false;
   bool _templateStorageTestLoading = false;
   bool _packSearchLoading = false;
   bool _reminderLoading = false;
@@ -1592,6 +1594,42 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (!mounted) return;
     setState(() => _weaknessYamlLoading = false);
     await showTrainingPackYamlPreviewer(context, pack);
+  }
+
+  Future<void> _generateSmartTheoryYamlPack() async {
+    if (_smartTheoryPackLoading || !kDebugMode) return;
+    setState(() => _smartTheoryPackLoading = true);
+    final ctr = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('🧠 Generate theory YAML pack'),
+        content: TextField(
+          controller: ctr,
+          decoration: const InputDecoration(labelText: 'Tag'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && ctr.text.trim().isNotEmpty) {
+      final generator = const SmartTheoryPackGenerator();
+      final pack = await generator.generateTheoryPack(ctr.text.trim());
+      if (!mounted) return;
+      setState(() => _smartTheoryPackLoading = false);
+      await showTrainingPackYamlPreviewer(context, pack);
+    } else {
+      if (mounted) setState(() => _smartTheoryPackLoading = false);
+    }
   }
 
   Future<void> _checkTagHealth() async {
@@ -3213,6 +3251,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                 title: const Text('🔧 Generate weakness-based YAML pack'),
                 onTap:
                     _weaknessYamlLoading ? null : _generateWeaknessYamlPack,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧠 Generate theory YAML pack'),
+                onTap:
+                    _smartTheoryPackLoading ? null : _generateSmartTheoryYamlPack,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/smart_theory_pack_generator.dart
+++ b/lib/services/smart_theory_pack_generator.dart
@@ -1,0 +1,104 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hand_data.dart';
+import '../models/v2/hero_position.dart';
+import '../models/action_entry.dart';
+import '../models/game_type.dart';
+import '../models/pack_library.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+/// Auto-generates a simple theory pack for a given tag.
+class SmartTheoryPackGenerator {
+  const SmartTheoryPackGenerator();
+
+  List<TrainingPackSpot> _buildTemplate(String tag, String idPrefix) {
+    final explanation = 'This is a theory module about $tag';
+    return [
+      TrainingPackSpot(
+        id: '${idPrefix}_1',
+        type: 'theory',
+        title: 'A9o push',
+        explanation: explanation,
+        tags: [tag],
+        hand: HandData.fromSimpleInput('As 9d', HeroPosition.sb, 10),
+      ),
+      TrainingPackSpot(
+        id: '${idPrefix}_2',
+        type: 'theory',
+        title: 'Q6s fold',
+        explanation: explanation,
+        tags: [tag],
+        hand: HandData(
+          heroCards: 'Qs 6s',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: const {'0': 10, '1': 10},
+          actions: {
+            0: [ActionEntry(0, 0, 'fold')]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: '${idPrefix}_3',
+        type: 'theory',
+        title: '22 push call',
+        explanation: explanation,
+        tags: [tag],
+        hand: HandData(
+          heroCards: '2c 2d',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: const {'0': 10, '1': 10},
+          actions: {
+            0: [
+              ActionEntry(0, 0, 'push', amount: 10),
+              ActionEntry(0, 1, 'call', amount: 9.5),
+            ]
+          },
+        ),
+      ),
+      TrainingPackSpot(
+        id: '${idPrefix}_4',
+        type: 'theory',
+        title: 'J9s push',
+        explanation: explanation,
+        tags: [tag],
+        hand: HandData.fromSimpleInput('Jh 9h', HeroPosition.sb, 10),
+      ),
+      TrainingPackSpot(
+        id: '${idPrefix}_5',
+        type: 'theory',
+        title: 'KTo push',
+        explanation: explanation,
+        tags: [tag],
+        hand: HandData.fromSimpleInput('Kh Td', HeroPosition.sb, 10),
+      ),
+    ];
+  }
+
+  /// Builds a theory pack for [tag] unless it already exists in [PackLibrary].
+  Future<TrainingPackTemplateV2> generateTheoryPack(String tag) async {
+    final key = tag.trim().toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+    final id = 'theory_$key';
+    final existing =
+        PackLibrary.main.getById(id) ?? PackLibrary.staging.getById(id);
+    if (existing != null) return existing;
+
+    final spots = _buildTemplate(tag, id);
+    final tpl = TrainingPackTemplateV2(
+      id: id,
+      name: 'Теория: $tag',
+      trainingType: TrainingType.theory,
+      tags: [tag],
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      meta: const {'schemaVersion': '2.0.0'},
+    );
+    tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
+    return tpl;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `SmartTheoryPackGenerator` for auto creating theory packs
- wire up new dev menu option "🧠 Generate theory YAML pack"

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885327b9140832ab63fa99ac9dab72f