### PR TITLE
Implement theory path auto seeder

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -102,6 +102,7 @@ import '../services/starter_learning_path_seeder.dart';
 import '../services/intermediate_learning_path_seeder.dart';
 import '../services/theory_path_stage_seeder.dart';
 import '../services/learning_path_auto_seeder.dart';
+import '../services/theory_stage_auto_seeder.dart';
 import '../services/theory_stage_validator_engine.dart';
 import '../models/pack_library.dart';
 
@@ -269,6 +270,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _seedIcmMultiwayLoading = false;
   bool _seedTheoryStagesLoading = false;
   bool _autoSeedTheoryPathLoading = false;
+  bool _seedTheoryPathFromYamlLoading = false;
   bool _autoTheorySeedLoading = false;
   bool _generateBeginnerPathLoading = false;
   bool _generateIntermediatePathLoading = false;
@@ -2900,6 +2902,26 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     if (mounted) setState(() => _autoSeedTheoryPathLoading = false);
   }
 
+  Future<void> _seedTheoryPathFromYaml() async {
+    if (_seedTheoryPathFromYamlLoading || !kDebugMode) return;
+    setState(() => _seedTheoryPathFromYamlLoading = true);
+    try {
+      await const TheoryStageAutoSeeder().seed();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Theory path seeded')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Seed failed')),
+        );
+      }
+    }
+    if (mounted) setState(() => _seedTheoryPathFromYamlLoading = false);
+  }
+
   Future<void> _seedIcmMultiwayPath() async {
     if (_seedIcmMultiwayLoading || !kDebugMode) return;
     setState(() => _seedIcmMultiwayLoading = true);
@@ -4162,6 +4184,12 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('📚 Seed theory stages'),
                 onTap: _seedTheoryStagesLoading ? null : _seedTheoryStages,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧠 Seed theory path from YAML'),
+                onTap:
+                    _seedTheoryPathFromYamlLoading ? null : _seedTheoryPathFromYaml,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/learning_path_library.dart
+++ b/lib/services/learning_path_library.dart
@@ -1,0 +1,47 @@
+import '../models/learning_path_template_v2.dart';
+
+/// In-memory library for learning path templates.
+class LearningPathLibrary {
+  LearningPathLibrary._();
+
+  /// Staging library used during development.
+  static final LearningPathLibrary staging = LearningPathLibrary._();
+
+  /// Main library for promoted paths.
+  static final LearningPathLibrary main = LearningPathLibrary._();
+
+  final List<LearningPathTemplateV2> _paths = [];
+  final Map<String, LearningPathTemplateV2> _index = {};
+
+  /// Unmodifiable view of stored templates.
+  List<LearningPathTemplateV2> get paths => List.unmodifiable(_paths);
+
+  /// Clears all templates from this library.
+  void clear() {
+    _paths.clear();
+    _index.clear();
+  }
+
+  /// Adds [template] if its id is not already present.
+  void add(LearningPathTemplateV2 template) {
+    if (_index.containsKey(template.id)) return;
+    _paths.add(template);
+    _index[template.id] = template;
+  }
+
+  /// Adds all templates from [list].
+  void addAll(Iterable<LearningPathTemplateV2> list) {
+    for (final tpl in list) {
+      add(tpl);
+    }
+  }
+
+  /// Removes template with [id] if present.
+  void remove(String id) {
+    final tpl = _index.remove(id);
+    if (tpl != null) _paths.remove(tpl);
+  }
+
+  /// Returns template with [id] if stored.
+  LearningPathTemplateV2? getById(String id) => _index[id];
+}

--- a/lib/services/theory_stage_auto_seeder.dart
+++ b/lib/services/theory_stage_auto_seeder.dart
@@ -1,0 +1,71 @@
+import '../models/learning_path_stage_model.dart';
+import '../models/learning_path_template_v2.dart';
+import '../models/stage_type.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'learning_path_library.dart';
+import 'theory_yaml_importer.dart';
+
+/// Builds theory-only learning paths from YAML packs.
+class TheoryStageAutoSeeder {
+  final TheoryYamlImporter importer;
+  final String dir;
+  final int maxStages;
+
+  const TheoryStageAutoSeeder({
+    TheoryYamlImporter? importer,
+    this.dir = 'yaml_out/theory',
+    this.maxStages = 12,
+  }) : importer = importer ?? const TheoryYamlImporter();
+
+  /// Loads theory packs from [dir], groups them by tag and saves generated
+  /// paths into [LearningPathLibrary.staging].
+  Future<List<LearningPathTemplateV2>> seed() async {
+    final templates = await importer.importFromDirectory(dir);
+    final groups = <String, List<TrainingPackTemplateV2>>{};
+    for (final tpl in templates) {
+      if (tpl.trainingType != TrainingType.theory) continue;
+      if (tpl.id.trim().isEmpty) continue;
+      if (tpl.tags.isEmpty) continue;
+      final tag = tpl.tags.first.trim().toLowerCase();
+      groups.putIfAbsent(tag, () => []).add(tpl);
+    }
+
+    final library = LearningPathLibrary.staging;
+    library.clear();
+
+    final result = <LearningPathTemplateV2>[];
+    for (final entry in groups.entries) {
+      final tag = entry.key;
+      final sanitized = tag.replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+      final packs = entry.value..sort((a, b) => a.name.compareTo(b.name));
+      var order = 0;
+      final stages = <LearningPathStageModel>[];
+      for (final p in packs.take(maxStages)) {
+        stages.add(
+          LearningPathStageModel(
+            id: p.id,
+            title: p.name,
+            description: p.description,
+            packId: p.id,
+            type: StageType.theory,
+            requiredAccuracy: 0,
+            minHands: 0,
+            tags: p.tags,
+            order: order++,
+          ),
+        );
+      }
+      final tpl = LearningPathTemplateV2(
+        id: 'theory_path_$sanitized',
+        title: 'Theory: $tag',
+        description: '',
+        stages: stages,
+        tags: [tag],
+      );
+      library.add(tpl);
+      result.add(tpl);
+    }
+    return result;
+  }
+}

--- a/test/theory_stage_auto_seeder_test.dart
+++ b/test/theory_stage_auto_seeder_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_stage_auto_seeder.dart';
+import 'package:poker_analyzer/services/learning_path_library.dart';
+import 'package:poker_analyzer/services/theory_yaml_importer.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _FakeImporter extends TheoryYamlImporter {
+  final List<TrainingPackTemplateV2> list;
+  const _FakeImporter(this.list);
+  @override
+  Future<List<TrainingPackTemplateV2>> importFromDirectory(String dirPath) async => list;
+}
+
+TrainingPackTemplateV2 _tpl(String id, String tag) => TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.theory,
+      tags: [tag],
+      spots: [TrainingPackSpot(id: 's', type: 'theory', hand: HandData())],
+      spotCount: 1,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('seed builds paths grouped by tag', () async {
+    final importer = _FakeImporter([
+      _tpl('p1', 'pushfold'),
+      _tpl('p2', 'pushfold'),
+      _tpl('c1', 'call'),
+    ]);
+    final seeder = TheoryStageAutoSeeder(importer: importer);
+    final paths = await seeder.seed();
+
+    expect(paths, hasLength(2));
+    final lib = LearningPathLibrary.staging.paths;
+    expect(lib, hasLength(2));
+
+    final push = lib.firstWhere((e) => e.id == 'theory_path_pushfold');
+    expect(push.stages, hasLength(2));
+    expect(push.stages.first.packId, 'p1');
+  });
+}


### PR DESCRIPTION
## Summary
- support storing learning path templates with `LearningPathLibrary`
- seed theory-only learning paths with new `TheoryStageAutoSeeder`
- expose YAML-based theory path seeding in the Dev Menu
- add basic unit test for the new seeder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885364a4574832a9bf5496de8a05400