### PR TITLE
feat: promote staged learning paths

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -87,6 +87,7 @@ import 'theory_booster_preview_screen.dart';
 import 'booster_theory_preview_screen.dart';
 import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
+import '../services/staged_path_promoter.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -205,6 +206,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _theoryStageValidateLoading = false;
   bool _theoryStagingImportLoading = false;
   bool _theoryPromoteLoading = false;
+  bool _pathPromoteLoading = false;
   bool _refactorLoading = false;
   bool _ratingLoading = false;
   bool _tagHealthLoading = false;
@@ -1406,6 +1408,37 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     final count = const TheoryPackPromoter().promoteAll(category);
     if (!mounted) return;
     setState(() => _theoryPromoteLoading = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Promoted: $count')),
+    );
+  }
+
+  Future<void> _promotePaths() async {
+    if (_pathPromoteLoading || !kDebugMode) return;
+    final ctr = TextEditingController();
+    final prefix = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Path prefix (optional)'),
+        content: TextField(controller: ctr),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, ctr.text.trim()),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    setState(() => _pathPromoteLoading = true);
+    final count = const StagedPathPromoter().promoteAll(prefix: prefix?.isEmpty == true ? null : prefix);
+    if (!mounted) return;
+    setState(() => _pathPromoteLoading = false);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Promoted: $count')),
     );
@@ -4169,6 +4202,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Load All Learning Paths'),
                 onTap: _loadAllPathsLoading ? null : _loadAllLearningPaths,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('⬆️ Promote staged paths'),
+                onTap: _pathPromoteLoading ? null : _promotePaths,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/staged_path_promoter.dart
+++ b/lib/services/staged_path_promoter.dart
@@ -1,0 +1,31 @@
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_library.dart';
+
+/// Moves staged learning paths from [LearningPathLibrary.staging] into
+/// [LearningPathLibrary.main] so they are accessible in the app.
+class StagedPathPromoter {
+  const StagedPathPromoter();
+
+  /// Copies all templates from the staging library into the main library.
+  ///
+  /// When [prefix] is provided, only templates with IDs starting with
+  /// the prefix are promoted. Existing entries with the same `id`
+  /// are overwritten.
+  int promoteAll({String? prefix}) {
+    final staging = List<LearningPathTemplateV2>.from(
+      LearningPathLibrary.staging.paths,
+    );
+    final main = LearningPathLibrary.main;
+    main.clear();
+    var count = 0;
+    for (final tpl in staging) {
+      if (prefix != null && !tpl.id.startsWith(prefix)) {
+        continue;
+      }
+      main.remove(tpl.id);
+      main.add(tpl);
+      count++;
+    }
+    return count;
+  }
+}

--- a/test/staged_path_promoter_test.dart
+++ b/test/staged_path_promoter_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_library.dart';
+import 'package:poker_analyzer/services/staged_path_promoter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  LearningPathTemplateV2 tpl(String id) => LearningPathTemplateV2(
+        id: id,
+        title: id,
+        description: '',
+      );
+
+  test('promoteAll filters by prefix and overwrites', () {
+    final staging = LearningPathLibrary.staging;
+    final mainLib = LearningPathLibrary.main;
+    staging.clear();
+    mainLib.clear();
+
+    staging.addAll([
+      tpl('theory_path_one'),
+      tpl('booster_path_two'),
+      tpl('theory_path_three'),
+    ]);
+
+    final count = const StagedPathPromoter().promoteAll(prefix: 'theory_path_');
+
+    expect(count, 2);
+    expect(mainLib.paths.length, 2);
+    expect(mainLib.getById('theory_path_one'), isNotNull);
+    expect(mainLib.getById('theory_path_three'), isNotNull);
+    expect(mainLib.getById('booster_path_two'), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `StagedPathPromoter` to copy staged paths into the main library
- add DevMenu option "⬆️ Promote staged paths"
- cover promoter with a unit test

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853882c7e8832a8d8b00230378412c