### PR TITLE
Add SmartPathValidator and validation UI

### DIFF
--- a/lib/models/path_validation_issue.dart
+++ b/lib/models/path_validation_issue.dart
@@ -1,0 +1,36 @@
+enum PathIssueType { missingPack, invalidStageOrder, duplicateId, unlinkedStage }
+
+class PathValidationIssue {
+  final String pathId;
+  final String? stageId;
+  final String? subStageId;
+  final PathIssueType issueType;
+  final String message;
+
+  const PathValidationIssue({
+    required this.pathId,
+    this.stageId,
+    this.subStageId,
+    required this.issueType,
+    required this.message,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'pathId': pathId,
+        if (stageId != null) 'stageId': stageId,
+        if (subStageId != null) 'subStageId': subStageId,
+        'issueType': issueType.name,
+        'message': message,
+      };
+
+  factory PathValidationIssue.fromJson(Map<String, dynamic> json) => PathValidationIssue(
+        pathId: json['pathId']?.toString() ?? '',
+        stageId: json['stageId'] as String?,
+        subStageId: json['subStageId'] as String?,
+        issueType: PathIssueType.values.firstWhere(
+          (e) => e.name == json['issueType'],
+          orElse: () => PathIssueType.missingPack,
+        ),
+        message: json['message']?.toString() ?? '',
+      );
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -169,6 +169,7 @@ import 'goal_insights_screen.dart';
 import 'lesson_path_screen.dart';
 import 'learning_path_screen.dart';
 import 'learning_path_intro_screen.dart';
+import 'learning_path_validation_screen.dart';
 import 'path_map_screen.dart';
 import '../services/learning_path_progress_service.dart';
 import '../services/achievement_trigger_engine.dart';
@@ -4207,6 +4208,17 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⬆️ Promote staged paths'),
                 onTap: _pathPromoteLoading ? null : _promotePaths,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🧪 Validate learning paths'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const LearningPathValidationScreen()),
+                  );
+                },
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/screens/learning_path_validation_screen.dart
+++ b/lib/screens/learning_path_validation_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../services/learning_path_library.dart';
+import '../services/smart_path_validator.dart';
+import '../models/path_validation_issue.dart';
+import '../models/learning_path_template_v2.dart';
+import '../theme/app_colors.dart';
+
+class LearningPathValidationScreen extends StatefulWidget {
+  const LearningPathValidationScreen({super.key});
+
+  @override
+  State<LearningPathValidationScreen> createState() => _LearningPathValidationScreenState();
+}
+
+class _LearningPathValidationScreenState extends State<LearningPathValidationScreen> {
+  bool _loading = true;
+  final List<PathValidationIssue> _issues = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final json = [for (final p in LearningPathLibrary.main.paths) p.toJson()];
+    final data = await compute(_validateTask, json);
+    if (!mounted) return;
+    setState(() {
+      _issues
+        ..clear()
+        ..addAll(data.map((e) => PathValidationIssue.fromJson(e)));
+      _loading = false;
+    });
+  }
+
+  Map<String, List<PathValidationIssue>> _grouped() {
+    final map = <String, List<PathValidationIssue>>{};
+    for (final i in _issues) {
+      map.putIfAbsent(i.pathId, () => []).add(i);
+    }
+    return map;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Learning Path Validation'),
+        actions: [IconButton(onPressed: _load, icon: const Icon(Icons.refresh))],
+      ),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text('Total issues: ${_issues.length}'),
+                const SizedBox(height: 16),
+                for (final entry in _grouped().entries)
+                  Card(
+                    color: AppColors.cardBackground,
+                    child: ExpansionTile(
+                      title: Text(entry.key),
+                      subtitle: Text('Issues: ${entry.value.length}'),
+                      children: [
+                        for (final i in entry.value)
+                          ListTile(
+                            title: Text('${i.issueType.name}: ${i.message}'),
+                            subtitle: i.stageId != null
+                                ? Text('stage: ${i.stageId}${i.subStageId != null ? ' / ${i.subStageId}' : ''}')
+                                : null,
+                          ),
+                      ],
+                    ),
+                  ),
+                if (_issues.isEmpty) const Center(child: Text('No issues found')),
+              ],
+            ),
+    );
+  }
+}
+
+Future<List<Map<String, dynamic>>> _validateTask(List<Map<String, dynamic>> json) async {
+  final paths = [for (final m in json) LearningPathTemplateV2.fromJson(m)];
+  final issues = const SmartPathValidator().validateAll(paths);
+  return [for (final i in issues) i.toJson()];
+}

--- a/lib/services/smart_path_validator.dart
+++ b/lib/services/smart_path_validator.dart
@@ -1,0 +1,136 @@
+import '../models/learning_path_template_v2.dart';
+import '../models/path_validation_issue.dart';
+
+class SmartPathValidator {
+  const SmartPathValidator();
+
+  List<PathValidationIssue> validateAll(List<LearningPathTemplateV2> paths) {
+    final issues = <PathValidationIssue>[];
+    for (final path in paths) {
+      final stageIds = <String>{};
+      final subStageIds = <String>{};
+      final orders = <int>[];
+      final sectionStages = <String>{
+        for (final s in path.sections) ...s.stageIds
+      };
+
+      for (final stage in path.stages) {
+        if (!stageIds.add(stage.id)) {
+          issues.add(
+            PathValidationIssue(
+              pathId: path.id,
+              stageId: stage.id,
+              issueType: PathIssueType.duplicateId,
+              message: 'duplicate stage id',
+            ),
+          );
+        }
+        if (stage.packId.trim().isEmpty) {
+          issues.add(
+            PathValidationIssue(
+              pathId: path.id,
+              stageId: stage.id,
+              issueType: PathIssueType.missingPack,
+              message: 'missing packId',
+            ),
+          );
+        }
+        if (stage.title.trim().isEmpty) {
+          issues.add(
+            PathValidationIssue(
+              pathId: path.id,
+              stageId: stage.id,
+              issueType: PathIssueType.unlinkedStage,
+              message: 'missing title',
+            ),
+          );
+        }
+        orders.add(stage.order);
+        final cond = stage.unlockCondition;
+        if (cond?.dependsOn != null) {
+          final dep = cond!.dependsOn!;
+          if (!stageIds.contains(dep) && !subStageIds.contains(dep)) {
+            issues.add(
+              PathValidationIssue(
+                pathId: path.id,
+                stageId: stage.id,
+                issueType: PathIssueType.unlinkedStage,
+                message: 'bad unlock reference: $dep',
+              ),
+            );
+          }
+        }
+        for (final sub in stage.subStages) {
+          if (!subStageIds.add(sub.id)) {
+            issues.add(
+              PathValidationIssue(
+                pathId: path.id,
+                stageId: stage.id,
+                subStageId: sub.id,
+                issueType: PathIssueType.duplicateId,
+                message: 'duplicate subStage id',
+              ),
+            );
+          }
+          if (sub.packId.trim().isEmpty) {
+            issues.add(
+              PathValidationIssue(
+                pathId: path.id,
+                stageId: stage.id,
+                subStageId: sub.id,
+                issueType: PathIssueType.missingPack,
+                message: 'missing packId',
+              ),
+            );
+          }
+          final sc = sub.unlockCondition;
+          if (sc?.dependsOn != null) {
+            final dep = sc!.dependsOn!;
+            if (!stageIds.contains(dep) && !subStageIds.contains(dep)) {
+              issues.add(
+                PathValidationIssue(
+                  pathId: path.id,
+                  stageId: stage.id,
+                  subStageId: sub.id,
+                  issueType: PathIssueType.unlinkedStage,
+                  message: 'bad unlock reference: $dep',
+                ),
+              );
+            }
+          }
+        }
+      }
+
+      if (orders.isNotEmpty) {
+        final sorted = List<int>.from(orders)..sort();
+        for (var i = 0; i < sorted.length; i++) {
+          final expected = sorted.first + i;
+          if (sorted[i] != expected) {
+            issues.add(
+              PathValidationIssue(
+                pathId: path.id,
+                issueType: PathIssueType.invalidStageOrder,
+                message: 'order values should be sequential',
+              ),
+            );
+            break;
+          }
+        }
+      }
+
+      for (final id in stageIds) {
+        if (!sectionStages.contains(id)) {
+          issues.add(
+            PathValidationIssue(
+              pathId: path.id,
+              stageId: id,
+              issueType: PathIssueType.unlinkedStage,
+              message: 'stage not in any section',
+            ),
+          );
+        }
+      }
+    }
+    return issues;
+  }
+}


### PR DESCRIPTION
## Summary
- add model `PathValidationIssue`
- implement `SmartPathValidator` for structural checks
- add `LearningPathValidationScreen` and expose in DevMenu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854f2ea6a0832ab76b90d2d6a0f422