### PR TITLE
Implement LearningPathPromoter service

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -87,7 +87,8 @@ import 'theory_booster_preview_screen.dart';
 import 'booster_theory_preview_screen.dart';
 import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
-import '../services/staged_path_promoter.dart';
+import '../services/learning_path_promoter.dart';
+import '../services/learning_path_library.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -1416,28 +1417,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
 
   Future<void> _promotePaths() async {
     if (_pathPromoteLoading || !kDebugMode) return;
-    final ctr = TextEditingController();
-    final prefix = await showDialog<String>(
-      context: context,
-      builder: (_) => AlertDialog(
-        backgroundColor: const Color(0xFF121212),
-        title: const Text('Path prefix (optional)'),
-        content: TextField(controller: ctr),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, ctr.text.trim()),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
-    if (!mounted) return;
     setState(() => _pathPromoteLoading = true);
-    final count = const StagedPathPromoter().promoteAll(prefix: prefix?.isEmpty == true ? null : prefix);
+    final count = const LearningPathPromoter().promoteStaged(
+      staged: LearningPathLibrary.staging,
+      target: LearningPathLibrary.main,
+    );
     if (!mounted) return;
     setState(() => _pathPromoteLoading = false);
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/services/learning_path_library.dart
+++ b/lib/services/learning_path_library.dart
@@ -8,7 +8,7 @@ class LearningPathLibrary {
   static final LearningPathLibrary staging = LearningPathLibrary._();
 
   /// Main library for promoted paths.
-  static final LearningPathLibrary main = LearningPathLibrary._();
+  static LearningPathLibrary main = LearningPathLibrary._();
 
   final List<LearningPathTemplateV2> _paths = [];
   final Map<String, LearningPathTemplateV2> _index = {};

--- a/lib/services/learning_path_promoter.dart
+++ b/lib/services/learning_path_promoter.dart
@@ -1,0 +1,25 @@
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_library.dart';
+
+/// Updates [target] library with paths from [staged] when IDs match.
+class LearningPathPromoter {
+  const LearningPathPromoter();
+
+  /// Replaces entries in [target] with staged versions that share the same id.
+  /// Returns the number of paths that were updated.
+  int promoteStaged({
+    required LearningPathLibrary staged,
+    required LearningPathLibrary target,
+  }) {
+    var count = 0;
+    for (final tpl in staged.paths) {
+      if (target.getById(tpl.id) != null) {
+        target.remove(tpl.id);
+        target.add(tpl);
+        count++;
+      }
+    }
+    LearningPathLibrary.main = target;
+    return count;
+  }
+}

--- a/test/learning_path_promoter_test.dart
+++ b/test/learning_path_promoter_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_library.dart';
+import 'package:poker_analyzer/services/learning_path_promoter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  LearningPathTemplateV2 tpl(String id) => LearningPathTemplateV2(
+        id: id,
+        title: id,
+        description: '',
+      );
+
+  test('promoteStaged overwrites matching ids only', () {
+    final staging = LearningPathLibrary.staging;
+    final target = LearningPathLibrary.main;
+    staging.clear();
+    target.clear();
+
+    staging.addAll([tpl('path_one'), tpl('path_two')]);
+    target.addAll([tpl('path_one'), tpl('path_three')]);
+
+    final count = const LearningPathPromoter().promoteStaged(
+      staged: staging,
+      target: target,
+    );
+
+    expect(count, 1);
+    expect(target.paths.length, 2);
+    expect(target.getById('path_one'), isNotNull);
+    expect(target.getById('path_two'), isNull);
+    expect(target.getById('path_three'), isNotNull);
+    expect(identical(LearningPathLibrary.main, target), isTrue);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `LearningPathPromoter` that updates existing paths by id
- expose mutable `LearningPathLibrary.main`
- wire dev menu to run the promoter
- test promoter logic

## Testing
- `flutter analyze` *(fails: Dart SDK version 3.6 required)*
- `flutter test test/learning_path_promoter_test.dart` *(fails: Dart SDK version 3.6 required)*

------
https://chatgpt.com/codex/tasks/task_e_688550e2e1cc832aab083c2af5752108