### PR TITLE
Add staged learning path preview

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -89,6 +89,7 @@ import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
 import '../services/learning_path_promoter.dart';
 import '../services/learning_path_library.dart';
+import '../services/learning_path_preview_launcher.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -209,6 +210,7 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
   bool _theoryStagingImportLoading = false;
   bool _theoryPromoteLoading = false;
   bool _pathPromoteLoading = false;
+  bool _previewPathLoading = false;
   bool _refactorLoading = false;
   bool _ratingLoading = false;
   bool _tagHealthLoading = false;
@@ -1427,6 +1429,33 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Promoted: $count')),
     );
+  }
+
+  Future<void> _previewStagedPath() async {
+    if (_previewPathLoading || !kDebugMode) return;
+    final ctr = TextEditingController();
+    final id = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Path ID'),
+        content: TextField(controller: ctr),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, ctr.text.trim()),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || id == null || id.isEmpty) return;
+    setState(() => _previewPathLoading = true);
+    await const LearningPathPreviewLauncher().launch(context, id);
+    if (mounted) setState(() => _previewPathLoading = false);
   }
 
   Future<void> _mergeLibraries() async {
@@ -4187,6 +4216,11 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ListTile(
                 title: const Text('⚙️ Load All Learning Paths'),
                 onTap: _loadAllPathsLoading ? null : _loadAllLearningPaths,
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('🔍 Preview staged path'),
+                onTap: _previewPathLoading ? null : _previewStagedPath,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/services/learning_path_preview_launcher.dart
+++ b/lib/services/learning_path_preview_launcher.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../screens/learning_path_screen_v2.dart';
+import 'learning_path_library.dart';
+
+/// Opens a staged learning path by [id] for preview.
+class LearningPathPreviewLauncher {
+  const LearningPathPreviewLauncher();
+
+  Future<void> launch(BuildContext context, String id) async {
+    final template = LearningPathLibrary.staging.getById(id);
+    if (template == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Path not found: $id')),
+      );
+      return;
+    }
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LearningPathScreen(template: template),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LearningPathPreviewLauncher` service
- allow devs to preview staged paths by ID via DevMenu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688552bb1f04832a8573d7ac3bde1450