### PR TITLE
Implement SmartPathPreviewLauncher

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -89,7 +89,7 @@ import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
 import '../services/learning_path_promoter.dart';
 import '../services/learning_path_library.dart';
-import '../services/learning_path_preview_launcher.dart';
+import '../services/smart_path_preview_launcher.dart';
 import '../services/learning_path_template_validator.dart';
 import '../services/learning_path_library_validator.dart';
 import 'booster_preview_screen.dart';
@@ -1458,7 +1458,14 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
     if (!mounted || id == null || id.isEmpty) return;
     setState(() => _previewPathLoading = true);
-    await const LearningPathPreviewLauncher().launch(context, id);
+    final tpl = LearningPathLibrary.staging.getById(id);
+    if (tpl != null) {
+      await const SmartPathPreviewLauncher().launch(context, tpl);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Path not found: $id')),
+      );
+    }
     if (mounted) setState(() => _previewPathLoading = false);
   }
 

--- a/lib/screens/smart_path_preview_screen.dart
+++ b/lib/screens/smart_path_preview_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../models/learning_path_stage_model.dart';
+import '../models/stage_type.dart';
+
+/// Lightweight preview showing key details of a learning path.
+class SmartPathPreviewScreen extends StatelessWidget {
+  final LearningPathTemplateV2 path;
+  const SmartPathPreviewScreen({super.key, required this.path});
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = <StageType, List<LearningPathStageModel>>{};
+    for (final stage in path.stages) {
+      groups.putIfAbsent(stage.type, () => []).add(stage);
+    }
+    return Scaffold(
+      appBar: AppBar(title: Text(path.title)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (path.description.isNotEmpty)
+            Text(
+              path.description,
+              style: const TextStyle(color: Colors.white70),
+            ),
+          const SizedBox(height: 12),
+          Text(
+            '${path.stages.length} стадий',
+            style: const TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 12),
+          for (final type in StageType.values)
+            if (groups[type]?.isNotEmpty ?? false)
+              _buildGroup(context, type, groups[type]!),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGroup(
+    BuildContext context,
+    StageType type,
+    List<LearningPathStageModel> stages,
+  ) {
+    final color = _colorFor(type, context);
+    final icon = _iconFor(type);
+    final label = _labelFor(type);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon, color: color),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        for (final stage in stages)
+          ListTile(
+            leading: Icon(icon, color: color),
+            title: Text(stage.title),
+            subtitle: Text(stage.packId),
+          ),
+        const SizedBox(height: 12),
+      ],
+    );
+  }
+
+  IconData _iconFor(StageType type) {
+    switch (type) {
+      case StageType.theory:
+        return Icons.menu_book;
+      case StageType.booster:
+        return Icons.bolt;
+      case StageType.practice:
+      default:
+        return Icons.fitness_center;
+    }
+  }
+
+  Color _colorFor(StageType type, BuildContext context) {
+    switch (type) {
+      case StageType.theory:
+        return Colors.blue;
+      case StageType.booster:
+        return Colors.orange;
+      case StageType.practice:
+      default:
+        return Theme.of(context).colorScheme.secondary;
+    }
+  }
+
+  String _labelFor(StageType type) {
+    switch (type) {
+      case StageType.theory:
+        return 'Теория';
+      case StageType.booster:
+        return 'Booster';
+      case StageType.practice:
+      default:
+        return 'Практика';
+    }
+  }
+}
+

--- a/lib/services/smart_path_preview_launcher.dart
+++ b/lib/services/smart_path_preview_launcher.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../screens/smart_path_preview_screen.dart';
+
+/// Launches a lightweight preview of the given [LearningPathTemplateV2].
+class SmartPathPreviewLauncher {
+  const SmartPathPreviewLauncher();
+
+  Future<void> launch(BuildContext context, LearningPathTemplateV2 path) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SmartPathPreviewScreen(path: path),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `SmartPathPreviewLauncher` service
- show preview screen with grouped stage details
- integrate preview launcher into DevMenu

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855775676c832abcddf4841e302485