### PR TITLE
Add TheoryPackQuickView widget

### DIFF
--- a/lib/models/theory_pack_model.dart
+++ b/lib/models/theory_pack_model.dart
@@ -1,0 +1,23 @@
+class TheoryPackModel {
+  final String id;
+  final String title;
+  final List<TheorySectionModel> sections;
+
+  TheoryPackModel({
+    required this.id,
+    required this.title,
+    required this.sections,
+  });
+}
+
+class TheorySectionModel {
+  final String title;
+  final String text;
+  final String type;
+
+  TheorySectionModel({
+    required this.title,
+    required this.text,
+    required this.type,
+  });
+}

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -88,6 +88,8 @@ import 'booster_theory_preview_screen.dart';
 import 'theory_staging_preview_screen.dart';
 import '../services/theory_pack_promoter.dart';
 import '../services/learning_path_promoter.dart';
+import '../ui/tools/theory_pack_quick_view.dart';
+import '../models/theory_pack_model.dart';
 import '../services/learning_path_library.dart';
 import '../services/smart_path_preview_launcher.dart';
 import '../services/learning_path_template_validator.dart';
@@ -3688,6 +3690,34 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                       builder: (_) => const TheoryBoosterPreviewScreen(),
                     ),
                   );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📖 Quick Theory Preview'),
+                onTap: () {
+                  final pack = TheoryPackModel(
+                    id: 'demo_theory',
+                    title: 'Demo Theory Pack',
+                    sections: [
+                      TheorySectionModel(
+                        title: 'Введение',
+                        text: 'Краткое введение в модуль.',
+                        type: 'info',
+                      ),
+                      TheorySectionModel(
+                        title: 'Важно',
+                        text: 'Не забывайте про ICM и размеры стеков.',
+                        type: 'warning',
+                      ),
+                      TheorySectionModel(
+                        title: 'Совет',
+                        text: 'Тренируйтесь регулярно для лучшего результата.',
+                        type: 'tip',
+                      ),
+                    ],
+                  );
+                  TheoryPackQuickView.launch(context, pack);
                 },
               ),
             if (kDebugMode)

--- a/lib/ui/tools/theory_pack_quick_view.dart
+++ b/lib/ui/tools/theory_pack_quick_view.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../../models/theory_pack_model.dart';
+
+class TheoryPackQuickView extends StatelessWidget {
+  final TheoryPackModel pack;
+  const TheoryPackQuickView({super.key, required this.pack});
+
+  static Future<void> launch(BuildContext context, TheoryPackModel pack) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheoryPackQuickView(pack: pack),
+      ),
+    );
+  }
+
+  int _wordCount(String text) {
+    final words = text.split(RegExp(r'\s+')).where((w) => w.isNotEmpty);
+    return words.length;
+  }
+
+  String _estimateReadTime() {
+    const wpm = 150; // average words per minute
+    final words = pack.sections.fold<int>(0, (sum, s) => sum + _wordCount(s.text));
+    if (words == 0) return '1 мин';
+    final minutes = words / wpm;
+    final min = minutes.ceil();
+    final max = (minutes * 1.5).ceil();
+    return '$min–$max мин';
+  }
+
+  String _summary(String text) {
+    final firstLine = text.split('\n').first.trim();
+    if (firstLine.length <= 80) return firstLine;
+    return '${firstLine.substring(0, 77)}...';
+  }
+
+  String _iconFor(String type) {
+    switch (type) {
+      case 'warning':
+        return '⚠️';
+      case 'tip':
+        return '💡';
+      default:
+        return '📘';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final readTime = _estimateReadTime();
+    return Scaffold(
+      appBar: AppBar(title: Text(pack.title)),
+      backgroundColor: const Color(0xFF121212),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: pack.sections.length + 1,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (_, i) {
+          if (i == 0) {
+            return Text('⏱ $readTime', style: const TextStyle(color: Colors.white70));
+          }
+          final section = pack.sections[i - 1];
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(_iconFor(section.type)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      section.title,
+                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    if (section.text.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          _summary(section.text),
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryPackModel` and `TheorySectionModel`
- implement `TheoryPackQuickView` with launch helper
- integrate quick preview into the dev menu with a demo pack

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688559013dd8832a929eff1fd1740091