### PR TITLE
Implement TheoryPackLibraryService

### DIFF
--- a/assets/theory_packs/sample_theory.yaml
+++ b/assets/theory_packs/sample_theory.yaml
@@ -1,0 +1,9 @@
+id: sample_theory
+title: 'Sample Theory Pack'
+sections:
+  - title: 'Intro'
+    text: 'Basic intro.'
+    type: info
+  - title: 'Tip'
+    text: 'Remember to fold more.'
+    type: tip

--- a/lib/models/theory_pack_model.dart
+++ b/lib/models/theory_pack_model.dart
@@ -8,6 +8,23 @@ class TheoryPackModel {
     required this.title,
     required this.sections,
   });
+
+  factory TheoryPackModel.fromYaml(Map yaml) {
+    final id = yaml['id']?.toString() ?? '';
+    final title = yaml['title']?.toString() ?? '';
+    final secYaml = yaml['sections'];
+    final sections = <TheorySectionModel>[];
+    if (secYaml is List) {
+      for (final s in secYaml) {
+        if (s is Map) {
+          sections.add(
+            TheorySectionModel.fromYaml(Map<String, dynamic>.from(s)),
+          );
+        }
+      }
+    }
+    return TheoryPackModel(id: id, title: title, sections: sections);
+  }
 }
 
 class TheorySectionModel {
@@ -20,4 +37,12 @@ class TheorySectionModel {
     required this.text,
     required this.type,
   });
+
+  factory TheorySectionModel.fromYaml(Map yaml) {
+    return TheorySectionModel(
+      title: yaml['title']?.toString() ?? '',
+      text: yaml['text']?.toString() ?? '',
+      type: yaml['type']?.toString() ?? '',
+    );
+  }
 }

--- a/lib/services/theory_pack_library_service.dart
+++ b/lib/services/theory_pack_library_service.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/theory_pack_model.dart';
+
+/// Loads and indexes theory packs stored as YAML files.
+class TheoryPackLibraryService {
+  TheoryPackLibraryService._();
+
+  /// Singleton instance of this service.
+  static final TheoryPackLibraryService instance = TheoryPackLibraryService._();
+
+  /// Default directory with bundled theory packs.
+  static const String _dir = 'assets/theory_packs/';
+
+  final List<TheoryPackModel> _packs = [];
+  final Map<String, TheoryPackModel> _index = {};
+
+  /// Unmodifiable list of all loaded packs.
+  List<TheoryPackModel> get all => List.unmodifiable(_packs);
+
+  /// Returns a pack with [id] if loaded.
+  TheoryPackModel? getById(String id) => _index[id];
+
+  /// Clears current state.
+  void _clear() {
+    _packs.clear();
+    _index.clear();
+  }
+
+  /// Loads all theory packs from assets.
+  Future<void> loadAll() async {
+    if (_packs.isNotEmpty) return;
+    await reload();
+  }
+
+  /// Reloads theory packs from assets.
+  Future<void> reload() async {
+    _clear();
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        var id = map['id']?.toString() ?? '';
+        if (id.isEmpty) {
+          final name = path.split('/').last;
+          id = name.replaceAll('.yaml', '');
+        }
+        final title = map['title']?.toString() ?? '';
+        final secYaml = map['sections'];
+        final sections = <TheorySectionModel>[];
+        if (secYaml is List) {
+          for (final s in secYaml) {
+            if (s is Map) {
+              sections.add(
+                TheorySectionModel.fromYaml(Map<String, dynamic>.from(s)),
+              );
+            }
+          }
+        }
+        final pack = TheoryPackModel(id: id, title: title, sections: sections);
+        _packs.add(pack);
+        _index[id] = pack;
+      } catch (_) {}
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,6 +106,7 @@ flutter:
     - assets/packs/v2/
     - assets/packs/v2/library_index.json
     - assets/built_in_packs.yaml
+    - assets/theory_packs/
     - assets/lessons/
     - assets/lesson_tracks/
       - assets/pack_matrix.json

--- a/test/theory_pack_library_service_test.dart
+++ b/test/theory_pack_library_service_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_pack_library_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadAll loads sample theory pack', () async {
+    final service = TheoryPackLibraryService.instance;
+    await service.reload();
+    expect(service.all.isNotEmpty, true);
+    final pack = service.getById('sample_theory');
+    expect(pack, isNotNull);
+    expect(pack!.sections.length, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `TheoryPackLibraryService` for loading YAML theory packs
- add YAML parsing factories to `TheoryPackModel`
- register `assets/theory_packs/` in `pubspec.yaml`
- provide a sample theory pack asset
- test loading of theory packs

## Testing
- `dart test test/theory_pack_library_service_test.dart` *(fails: `/workspace/Poker_Analyzer/dart-sdk/dart-sdk/bin/dart: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68855a6b6dac832a887422e8f5515014