### PR TITLE
Implement theory pack auto-fixer

### DIFF
--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -7,13 +7,15 @@ import '../ui/tools/theory_pack_quick_view.dart';
 import '../theme/app_colors.dart';
 import '../services/theory_pack_review_status_engine.dart';
 import '../services/theory_pack_completion_estimator.dart';
+import '../services/theory_pack_auto_fix_engine.dart';
 
 /// Developer screen to browse and preview all bundled theory packs.
 class TheoryPackDebuggerScreen extends StatefulWidget {
   const TheoryPackDebuggerScreen({super.key});
 
   @override
-  State<TheoryPackDebuggerScreen> createState() => _TheoryPackDebuggerScreenState();
+  State<TheoryPackDebuggerScreen> createState() =>
+      _TheoryPackDebuggerScreenState();
 }
 
 class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
@@ -54,6 +56,11 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
     ];
   }
 
+  void _autoFix(TheoryPackModel pack) {
+    final fixed = const TheoryPackAutoFixEngine().autoFix(pack);
+    TheoryPackQuickView.launch(context, fixed);
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!kDebugMode) return const SizedBox.shrink();
@@ -66,7 +73,8 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
             padding: const EdgeInsets.all(8),
             child: TextField(
               controller: _searchController,
-              decoration: const InputDecoration(hintText: 'Search by ID or title'),
+              decoration:
+                  const InputDecoration(hintText: 'Search by ID or title'),
               onChanged: (_) => setState(() {}),
             ),
           ),
@@ -82,8 +90,8 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
               itemBuilder: (_, i) {
                 final pack = _filtered[i];
                 final status = _reviewEngine.getStatus(pack);
-                final completion = const TheoryPackCompletionEstimator()
-                    .estimate(pack);
+                final completion =
+                    const TheoryPackCompletionEstimator().estimate(pack);
                 Widget icon;
                 switch (status) {
                   case ReviewStatus.approved:
@@ -97,7 +105,8 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                     break;
                 }
                 return ListTile(
-                  title: Text(pack.title.isNotEmpty ? pack.title : '(no title)'),
+                  title:
+                      Text(pack.title.isNotEmpty ? pack.title : '(no title)'),
                   subtitle: Text(
                     '${pack.id} • ${completion.wordCount}w • ${completion.estimatedMinutes}m',
                   ),
@@ -106,12 +115,18 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                     children: [
                       Text('${pack.sections.length}'),
                       const SizedBox(width: 8),
-                      Text('${(completion.completionRatio * 100).toStringAsFixed(0)}%'),
+                      Text(
+                          '${(completion.completionRatio * 100).toStringAsFixed(0)}%'),
                       const SizedBox(width: 8),
                       icon,
                       IconButton(
+                        icon: const Icon(Icons.build),
+                        onPressed: () => _autoFix(pack),
+                      ),
+                      IconButton(
                         icon: const Icon(Icons.visibility),
-                        onPressed: () => TheoryPackQuickView.launch(context, pack),
+                        onPressed: () =>
+                            TheoryPackQuickView.launch(context, pack),
                       ),
                     ],
                   ),
@@ -121,4 +136,3 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
     );
   }
 }
-

--- a/lib/services/theory_pack_auto_fix_engine.dart
+++ b/lib/services/theory_pack_auto_fix_engine.dart
@@ -1,0 +1,32 @@
+import '../models/theory_pack_model.dart';
+
+class TheoryPackAutoFixEngine {
+  const TheoryPackAutoFixEngine();
+
+  TheoryPackModel autoFix(TheoryPackModel pack) {
+    String clean(String v) => v.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+    final title = pack.title.trim().isEmpty ? '(untitled)' : clean(pack.title);
+    final sections = <TheorySectionModel>[];
+    for (final s in pack.sections) {
+      final secTitle = clean(s.title);
+      final text = clean(s.text);
+      if (secTitle.isEmpty) continue;
+      if (text.split(' ').where((w) => w.isNotEmpty).length < 10) continue;
+      sections.add(
+        TheorySectionModel(title: secTitle, text: text, type: clean(s.type)),
+      );
+    }
+    if (sections.isEmpty) {
+      sections.add(
+        TheorySectionModel(
+          title: 'Placeholder',
+          text: 'TODO: Add content',
+          type: 'info',
+        ),
+      );
+    }
+    return TheoryPackModel(
+        id: pack.id.trim(), title: title, sections: sections);
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryPackAutoFixEngine` to clean up theory pack data
- integrate auto-fix button in `TheoryPackDebuggerScreen`

## Testing
- `flutter pub get`
- `flutter test` *(fails: numerous compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885665a76b4832aacb70e95f22f50d9