### PR TITLE
Implement TheoryPackAutoTagger

### DIFF
--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -8,6 +8,7 @@ import '../theme/app_colors.dart';
 import '../services/theory_pack_review_status_engine.dart';
 import '../services/theory_pack_completion_estimator.dart';
 import '../services/theory_pack_auto_fix_engine.dart';
+import '../services/theory_pack_auto_tagger.dart';
 
 /// Developer screen to browse and preview all bundled theory packs.
 class TheoryPackDebuggerScreen extends StatefulWidget {
@@ -23,6 +24,7 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
   List<TheoryPackModel> _packs = [];
   bool _loading = true;
   final _reviewEngine = const TheoryPackReviewStatusEngine();
+  final _tagger = const TheoryPackAutoTagger();
 
   @override
   void initState() {
@@ -52,7 +54,7 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
       for (final p in _packs)
         if (p.id.toLowerCase().contains(query) ||
             p.title.toLowerCase().contains(query))
-          p
+          p,
     ];
   }
 
@@ -73,8 +75,9 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
             padding: const EdgeInsets.all(8),
             child: TextField(
               controller: _searchController,
-              decoration:
-                  const InputDecoration(hintText: 'Search by ID or title'),
+              decoration: const InputDecoration(
+                hintText: 'Search by ID or title',
+              ),
               onChanged: (_) => setState(() {}),
             ),
           ),
@@ -90,8 +93,9 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
               itemBuilder: (_, i) {
                 final pack = _filtered[i];
                 final status = _reviewEngine.getStatus(pack);
-                final completion =
-                    const TheoryPackCompletionEstimator().estimate(pack);
+                final completion = const TheoryPackCompletionEstimator()
+                    .estimate(pack);
+                final tagText = _tagger.autoTag(pack).join(', ');
                 Widget icon;
                 switch (status) {
                   case ReviewStatus.approved:
@@ -105,10 +109,11 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                     break;
                 }
                 return ListTile(
-                  title:
-                      Text(pack.title.isNotEmpty ? pack.title : '(no title)'),
+                  title: Text(
+                    pack.title.isNotEmpty ? pack.title : '(no title)',
+                  ),
                   subtitle: Text(
-                    '${pack.id} • ${completion.wordCount}w • ${completion.estimatedMinutes}m',
+                    '${pack.id} • ${completion.wordCount}w • ${completion.estimatedMinutes}m\n$tagText',
                   ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -116,7 +121,8 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                       Text('${pack.sections.length}'),
                       const SizedBox(width: 8),
                       Text(
-                          '${(completion.completionRatio * 100).toStringAsFixed(0)}%'),
+                        '${(completion.completionRatio * 100).toStringAsFixed(0)}%',
+                      ),
                       const SizedBox(width: 8),
                       icon,
                       IconButton(

--- a/lib/services/theory_pack_auto_indexer_service.dart
+++ b/lib/services/theory_pack_auto_indexer_service.dart
@@ -4,6 +4,7 @@ import '../models/theory_pack_model.dart';
 import '../models/learning_path_template_v2.dart';
 import 'theory_pack_review_status_engine.dart';
 import 'theory_pack_completion_estimator.dart';
+import 'theory_pack_auto_tagger.dart';
 
 /// Builds YAML index of theory packs with usage metadata.
 class TheoryPackAutoIndexerService {
@@ -33,6 +34,7 @@ class TheoryPackAutoIndexerService {
 
     const reviewEngine = TheoryPackReviewStatusEngine();
     const estimator = TheoryPackCompletionEstimator();
+    const tagger = TheoryPackAutoTagger();
 
     final used = <Map<String, dynamic>>[];
     final unused = <Map<String, dynamic>>[];
@@ -47,6 +49,7 @@ class TheoryPackAutoIndexerService {
         'wordCount': comp.wordCount,
         'readTimeMinutes': comp.estimatedMinutes,
         'reviewStatus': reviewEngine.getStatus(pack).name,
+        'tags': tagger.autoTag(pack).toList(),
         'usedInPaths': pathsUsed,
       };
       if (pathsUsed.isNotEmpty) {

--- a/lib/services/theory_pack_auto_tagger.dart
+++ b/lib/services/theory_pack_auto_tagger.dart
@@ -1,0 +1,43 @@
+import '../models/theory_pack_model.dart';
+
+/// Generates automatic tags for a [TheoryPackModel].
+class TheoryPackAutoTagger {
+  const TheoryPackAutoTagger();
+
+  /// Returns a set of tags detected in [pack] using simple
+  /// keyword heuristics over all section titles and texts.
+  Set<String> autoTag(TheoryPackModel pack) {
+    final buffer = StringBuffer(pack.title.toLowerCase());
+    for (final s in pack.sections) {
+      buffer
+        ..write(' ')
+        ..write(s.title.toLowerCase())
+        ..write(' ')
+        ..write(s.text.toLowerCase());
+    }
+    final text = buffer.toString();
+    final tags = <String>{};
+
+    bool containsAny(List<String> words) {
+      for (final w in words) {
+        if (text.contains(w)) return true;
+      }
+      return false;
+    }
+
+    if (text.contains('bubble')) tags.add('bubble');
+    if (containsAny(['shortstack', 'short stack'])) tags.add('shortstack');
+    if (text.contains('icm')) tags.add('ICM');
+    if (containsAny(['deepstack', 'deep stack'])) tags.add('deepstack');
+    if (containsAny(['final table', 'final-table', 'finaltable'])) {
+      tags.add('final table');
+    }
+    if (text.contains('preflop')) tags.add('preflop');
+    if (containsAny(['postflop', 'flop', 'turn', 'river']))
+      tags.add('postflop');
+    if (text.contains('exploit')) tags.add('exploit');
+    if (text.contains('live')) tags.add('live');
+
+    return tags;
+  }
+}

--- a/test/theory_pack_auto_indexer_service_test.dart
+++ b/test/theory_pack_auto_indexer_service_test.dart
@@ -21,9 +21,13 @@ void main() {
   test('buildIndexYaml groups packs by usage', () {
     final longText = List.filled(150, 'word').join(' ');
     final packs = [
-      TheoryPackModel(id: 't1', title: 'A', sections: [
-        TheorySectionModel(title: 's', text: longText, type: 'info'),
-      ]),
+      TheoryPackModel(
+        id: 't1',
+        title: 'A',
+        sections: [
+          TheorySectionModel(title: 's', text: longText, type: 'info'),
+        ],
+      ),
       TheoryPackModel(id: 't2', title: 'B', sections: const []),
     ];
     final paths = [
@@ -31,12 +35,17 @@ void main() {
         id: 'path',
         title: 'Path',
         description: '',
-        stages: [_stage(theoryId: 't1'), _stage(id: 's2', theoryId: 't3')],
+        stages: [
+          _stage(theoryId: 't1'),
+          _stage(id: 's2', theoryId: 't3'),
+        ],
       ),
     ];
 
-    final yaml = const TheoryPackAutoIndexerService()
-        .buildIndexYaml(packs, paths);
+    final yaml = const TheoryPackAutoIndexerService().buildIndexYaml(
+      packs,
+      paths,
+    );
 
     final map = const YamlReader().read(yaml);
 
@@ -48,6 +57,7 @@ void main() {
     expect(map['used'][0]['reviewStatus'], 'approved');
     expect(map['used'][0]['wordCount'], 150);
     expect(map['used'][0]['readTimeMinutes'], 1);
+    expect(map['used'][0]['tags'], isList);
     expect(map['unused'][0]['id'], 't2');
     expect(map['unused'][0]['reviewStatus'], 'rewrite');
     expect(map['missing'][0]['id'], 't3');

--- a/test/theory_pack_auto_tagger_test.dart
+++ b/test/theory_pack_auto_tagger_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+import 'package:poker_analyzer/services/theory_pack_auto_tagger.dart';
+
+void main() {
+  test('autoTag detects keywords', () {
+    final pack = TheoryPackModel(
+      id: 'p',
+      title: 'ICM Bubble Play',
+      sections: [
+        TheorySectionModel(
+          title: 'Short Stack Strategy',
+          text: 'On the bubble you must play tight with a short stack.',
+          type: 'info',
+        ),
+      ],
+    );
+
+    final tags = const TheoryPackAutoTagger().autoTag(pack);
+    expect(tags, contains('ICM'));
+    expect(tags, contains('bubble'));
+    expect(tags, contains('shortstack'));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryPackAutoTagger` for heuristic tag generation
- include auto tags in `TheoryPackAutoIndexerService` output
- show generated tags in `TheoryPackDebuggerScreen`
- add unit tests for new tagger and updated indexer service

## Testing
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_688568a77a68832a99ada3f5c77b785e