### PR TITLE
Add booster suggestions for theory packs

### DIFF
--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -9,6 +9,7 @@ import '../services/theory_pack_review_status_engine.dart';
 import '../services/theory_pack_completion_estimator.dart';
 import '../services/theory_pack_auto_fix_engine.dart';
 import '../services/theory_pack_auto_tagger.dart';
+import '../services/theory_pack_auto_booster_suggester.dart';
 
 /// Developer screen to browse and preview all bundled theory packs.
 class TheoryPackDebuggerScreen extends StatefulWidget {
@@ -25,6 +26,7 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
   bool _loading = true;
   final _reviewEngine = const TheoryPackReviewStatusEngine();
   final _tagger = const TheoryPackAutoTagger();
+  final _suggester = const TheoryPackAutoBoosterSuggester();
 
   @override
   void initState() {
@@ -96,6 +98,10 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                 final completion = const TheoryPackCompletionEstimator()
                     .estimate(pack);
                 final tagText = _tagger.autoTag(pack).join(', ');
+                final boosterList =
+                    _suggester.suggestBoosters(pack, _packs).join(', ');
+                final boosters =
+                    boosterList.isNotEmpty ? 'Boosters: $boosterList' : '';
                 Widget icon;
                 switch (status) {
                   case ReviewStatus.approved:
@@ -113,7 +119,7 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                     pack.title.isNotEmpty ? pack.title : '(no title)',
                   ),
                   subtitle: Text(
-                    '${pack.id} • ${completion.wordCount}w • ${completion.estimatedMinutes}m\n$tagText',
+                    '${pack.id} • ${completion.wordCount}w • ${completion.estimatedMinutes}m\n$tagText${boosters.isNotEmpty ? '\n$boosters' : ''}',
                   ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/services/theory_pack_auto_booster_suggester.dart
+++ b/lib/services/theory_pack_auto_booster_suggester.dart
@@ -1,0 +1,60 @@
+import '../models/theory_pack_model.dart';
+import 'theory_pack_auto_tagger.dart';
+import 'theory_pack_review_status_engine.dart';
+
+/// Suggests booster theory packs related to a given pack.
+class TheoryPackAutoBoosterSuggester {
+  const TheoryPackAutoBoosterSuggester();
+
+  /// Returns up to [max] booster pack ids ranked by relevance.
+  List<String> suggestBoosters(
+    TheoryPackModel pack,
+    List<TheoryPackModel> all, {
+    int max = 5,
+  }) {
+    const tagger = TheoryPackAutoTagger();
+    const reviewEngine = TheoryPackReviewStatusEngine();
+    final baseTags =
+        tagger.autoTag(pack).map((e) => e.toLowerCase().trim()).toSet();
+    final baseWords = _keywords(pack);
+
+    final scored = <(String, double)>[];
+    for (final other in all) {
+      if (other.id == pack.id) continue;
+      if (reviewEngine.getStatus(other) != ReviewStatus.approved) continue;
+      final tags =
+          tagger.autoTag(other).map((e) => e.toLowerCase().trim()).toSet();
+      final words = _keywords(other);
+
+      final tagInter = tags.intersection(baseTags).length.toDouble();
+      final tagUnion = tags.union(baseTags).length.toDouble();
+      final tagScore = tagUnion == 0 ? 0 : tagInter / tagUnion;
+
+      final wordInter = words.intersection(baseWords).length.toDouble();
+      final wordUnion = words.union(baseWords).length.toDouble();
+      final wordScore = wordUnion == 0 ? 0 : wordInter / wordUnion;
+
+      final score = tagScore * 0.6 + wordScore * 0.4;
+      if (score > 0) scored.add((other.id, score));
+    }
+
+    scored.sort((a, b) => b.$2.compareTo(a.$2));
+    return [for (final s in scored.take(max)) s.$1];
+  }
+
+  Set<String> _keywords(TheoryPackModel pack) {
+    final buffer = StringBuffer(pack.title.toLowerCase());
+    for (final s in pack.sections) {
+      buffer
+        ..write(' ')
+        ..write(s.title.toLowerCase())
+        ..write(' ')
+        ..write(s.text.toLowerCase());
+    }
+    final words = buffer.toString().split(RegExp(r'\W+'));
+    return {
+      for (final w in words)
+        if (w.isNotEmpty && w.length > 3) w,
+    };
+  }
+}

--- a/lib/services/theory_pack_auto_indexer_service.dart
+++ b/lib/services/theory_pack_auto_indexer_service.dart
@@ -5,6 +5,7 @@ import '../models/learning_path_template_v2.dart';
 import 'theory_pack_review_status_engine.dart';
 import 'theory_pack_completion_estimator.dart';
 import 'theory_pack_auto_tagger.dart';
+import 'theory_pack_auto_booster_suggester.dart';
 
 /// Builds YAML index of theory packs with usage metadata.
 class TheoryPackAutoIndexerService {
@@ -35,6 +36,7 @@ class TheoryPackAutoIndexerService {
     const reviewEngine = TheoryPackReviewStatusEngine();
     const estimator = TheoryPackCompletionEstimator();
     const tagger = TheoryPackAutoTagger();
+    const suggester = TheoryPackAutoBoosterSuggester();
 
     final used = <Map<String, dynamic>>[];
     final unused = <Map<String, dynamic>>[];
@@ -50,6 +52,7 @@ class TheoryPackAutoIndexerService {
         'readTimeMinutes': comp.estimatedMinutes,
         'reviewStatus': reviewEngine.getStatus(pack).name,
         'tags': tagger.autoTag(pack).toList(),
+        'boosters': suggester.suggestBoosters(pack, packs),
         'usedInPaths': pathsUsed,
       };
       if (pathsUsed.isNotEmpty) {


### PR DESCRIPTION
## Summary
- implement `TheoryPackAutoBoosterSuggester` to recommend booster packs based on tag and keyword similarity
- expose booster suggestions in the theory index YAML via `TheoryPackAutoIndexerService`
- display recommended boosters in `TheoryPackDebuggerScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856ab188e8832a8afa223c854a83ec