### PR TITLE
Add booster theory pack auto-fix

### DIFF
--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -8,6 +8,7 @@ import '../theme/app_colors.dart';
 import '../services/theory_pack_review_status_engine.dart';
 import '../services/theory_pack_completion_estimator.dart';
 import '../services/theory_pack_auto_fix_engine.dart';
+import '../services/booster_pack_auto_fix_engine.dart';
 import '../services/theory_pack_auto_tagger.dart';
 import '../services/theory_pack_auto_booster_suggester.dart';
 
@@ -62,6 +63,11 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
 
   void _autoFix(TheoryPackModel pack) {
     final fixed = const TheoryPackAutoFixEngine().autoFix(pack);
+    TheoryPackQuickView.launch(context, fixed);
+  }
+
+  void _autoFixBooster(TheoryPackModel pack) {
+    final fixed = const BoosterPackAutoFixEngine().autoFix(pack);
     TheoryPackQuickView.launch(context, fixed);
   }
 
@@ -134,6 +140,10 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
                       IconButton(
                         icon: const Icon(Icons.build),
                         onPressed: () => _autoFix(pack),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.flash_on),
+                        onPressed: () => _autoFixBooster(pack),
                       ),
                       IconButton(
                         icon: const Icon(Icons.visibility),

--- a/lib/services/booster_pack_auto_fix_engine.dart
+++ b/lib/services/booster_pack_auto_fix_engine.dart
@@ -1,0 +1,38 @@
+import '../models/theory_pack_model.dart';
+import 'theory_pack_auto_fix_engine.dart';
+
+/// Performs cleanup and auto-fixes on booster theory packs.
+class BoosterPackAutoFixEngine extends TheoryPackAutoFixEngine {
+  const BoosterPackAutoFixEngine();
+
+  @override
+  TheoryPackModel autoFix(TheoryPackModel pack) {
+    final fixed = super.autoFix(pack);
+
+    String clean(String v) => v.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+    final sections = <TheorySectionModel>[];
+    for (final s in fixed.sections) {
+      final type = clean(s.type).toLowerCase();
+      if (type == 'info') continue; // info sections are not allowed in boosters
+      sections.add(
+        TheorySectionModel(
+          title: clean(s.title),
+          text: clean(s.text),
+          type: type,
+        ),
+      );
+    }
+    if (sections.isEmpty) {
+      sections.add(
+        const TheorySectionModel(
+          title: 'Placeholder',
+          text: 'TODO: Add content',
+          type: 'tip',
+        ),
+      );
+    }
+
+    return TheoryPackModel(id: fixed.id, title: fixed.title, sections: sections);
+  }
+}

--- a/test/services/booster_pack_auto_fix_engine_test.dart
+++ b/test/services/booster_pack_auto_fix_engine_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_pack_auto_fix_engine.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const engine = BoosterPackAutoFixEngine();
+
+  test('autoFix cleans booster pack sections', () {
+    final pack = TheoryPackModel(
+      id: ' b1 ',
+      title: '  Booster  ',
+      sections: [
+        TheorySectionModel(title: '  ', text: 'x', type: 'info'),
+        TheorySectionModel(title: 'Good', text: 'Word ' * 10, type: 'info'),
+        TheorySectionModel(title: 'Tip', text: 'Many words here ' * 5, type: 'tip'),
+      ],
+    );
+
+    final fixed = engine.autoFix(pack);
+
+    expect(fixed.id, 'b1');
+    expect(fixed.title, 'Booster');
+    // info sections should be removed
+    expect(fixed.sections.length, 1);
+    expect(fixed.sections.first.title, 'Tip');
+    expect(fixed.sections.first.type, 'tip');
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterPackAutoFixEngine` for cleaning booster theory packs
- expose booster fix in debugger for quick QA
- test booster auto fix logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856bc38494832a923b41df08a9b139