### PR TITLE
Add TheoryBoosterPackLinker service

### DIFF
--- a/lib/services/theory_booster_pack_linker.dart
+++ b/lib/services/theory_booster_pack_linker.dart
@@ -1,0 +1,66 @@
+import '../models/theory_pack_model.dart';
+import 'theory_pack_auto_tagger.dart';
+import 'theory_pack_auto_booster_suggester.dart';
+import 'theory_pack_review_status_engine.dart';
+
+/// Links booster theory packs to a given theory module.
+class TheoryBoosterPackLinker {
+  const TheoryBoosterPackLinker();
+
+  /// Returns up to 3 booster pack ids relevant to [theoryPack].
+  List<String> autoLinkBoosters(
+    TheoryPackModel theoryPack,
+    List<TheoryPackModel> allBoosters,
+  ) {
+    const tagger = TheoryPackAutoTagger();
+    const suggester = TheoryPackAutoBoosterSuggester();
+    const reviewEngine = TheoryPackReviewStatusEngine();
+
+    final baseTags =
+        tagger.autoTag(theoryPack).map((e) => e.toLowerCase().trim()).toSet();
+
+    final candidates = <TheoryPackModel>[];
+    for (final b in allBoosters) {
+      if (b.id == theoryPack.id) continue;
+      if (!_isBooster(b)) continue;
+      if (reviewEngine.getStatus(b) != ReviewStatus.approved) continue;
+      candidates.add(b);
+    }
+
+    final suggested = suggester.suggestBoosters(theoryPack, candidates, max: 5);
+
+    final scored = <(String, double)>[];
+    for (final id in suggested) {
+      final pack = candidates.firstWhere((e) => e.id == id);
+      final tags =
+          tagger.autoTag(pack).map((e) => e.toLowerCase().trim()).toSet();
+      final inter = tags.intersection(baseTags).length.toDouble();
+      final union = tags.union(baseTags).length.toDouble();
+      var score = union == 0 ? 0 : inter / union;
+      final wc = _wordCount(pack);
+      if (wc < 300) score += 0.05;
+      scored.add((pack.id, score));
+    }
+
+    scored.sort((a, b) => b.$2.compareTo(a.$2));
+    return [for (final s in scored.take(3)) s.$1];
+  }
+
+  bool _isBooster(TheoryPackModel pack) {
+    final id = pack.id.toLowerCase();
+    final title = pack.title.toLowerCase();
+    if (id.contains('booster') || title.contains('booster')) return true;
+    for (final s in pack.sections) {
+      if (s.type.toLowerCase().contains('booster')) return true;
+    }
+    return false;
+  }
+
+  int _wordCount(TheoryPackModel pack) {
+    return pack.sections.fold<int>(
+      0,
+      (sum, s) =>
+          sum + s.text.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).length,
+    );
+  }
+}

--- a/test/theory_booster_pack_linker_test.dart
+++ b/test/theory_booster_pack_linker_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+import 'package:poker_analyzer/services/theory_booster_pack_linker.dart';
+
+TheoryPackModel _pack(String id, String title, String text) {
+  return TheoryPackModel(
+    id: id,
+    title: title,
+    sections: [
+      TheorySectionModel(title: 's', text: text, type: 'tip'),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('autoLinkBoosters prefers matching short boosters', () {
+    final theory = _pack(
+      't',
+      'Shortstack Strategy',
+      List.filled(160, 'shortstack').join(' '),
+    );
+
+    final booster1 = _pack(
+      'b1',
+      'Shortstack Booster',
+      List.filled(160, 'shortstack push').join(' '),
+    );
+
+    final booster2 = _pack(
+      'b2',
+      'ICM Booster',
+      List.filled(320, 'icm postflop').join(' '),
+    );
+
+    const linker = TheoryBoosterPackLinker();
+    final result = linker.autoLinkBoosters(theory, [booster1, booster2]);
+
+    expect(result.length, 1);
+    expect(result.first, 'b1');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryBoosterPackLinker` for suggesting booster packs based on tags
- add unit test for the new service

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856d018f94832abc465fc14f427ebe