### PR TITLE
Add tag persistence

### DIFF
--- a/lib/models/theory_pack_model.dart
+++ b/lib/models/theory_pack_model.dart
@@ -2,12 +2,14 @@ class TheoryPackModel {
   final String id;
   final String title;
   final List<TheorySectionModel> sections;
+  final List<String> tags;
 
   TheoryPackModel({
     required this.id,
     required this.title,
     required this.sections,
-  });
+    List<String>? tags,
+  }) : tags = tags ?? const [];
 
   factory TheoryPackModel.fromYaml(Map yaml) {
     final id = yaml['id']?.toString() ?? '';
@@ -23,7 +25,15 @@ class TheoryPackModel {
         }
       }
     }
-    return TheoryPackModel(id: id, title: title, sections: sections);
+    final tagYaml = yaml['tags'];
+    final tags = <String>[];
+    if (tagYaml is List) {
+      for (final t in tagYaml) {
+        tags.add(t.toString());
+      }
+    }
+    return TheoryPackModel(
+        id: id, title: title, sections: sections, tags: tags);
   }
 }
 

--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -101,9 +101,12 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
               itemBuilder: (_, i) {
                 final pack = _filtered[i];
                 final status = _reviewEngine.getStatus(pack);
-                final completion = const TheoryPackCompletionEstimator()
-                    .estimate(pack);
-                final tagText = _tagger.autoTag(pack).join(', ');
+                final completion =
+                    const TheoryPackCompletionEstimator().estimate(pack);
+                final tags = pack.tags.isNotEmpty
+                    ? pack.tags
+                    : _tagger.autoTag(pack).toList();
+                final tagText = tags.join(', ');
                 final boosterList =
                     _suggester.suggestBoosters(pack, _packs).join(', ');
                 final boosters =

--- a/lib/services/theory_pack_auto_tagger.dart
+++ b/lib/services/theory_pack_auto_tagger.dart
@@ -40,4 +40,32 @@ class TheoryPackAutoTagger {
 
     return tags;
   }
+
+  /// Returns a copy of [pack] with detected tags written to [TheoryPackModel.tags].
+  /// Existing tags are preserved unless [overwrite] is true.
+  TheoryPackModel persistTags(
+    TheoryPackModel pack, {
+    bool overwrite = false,
+  }) {
+    if (pack.tags.isNotEmpty && !overwrite) {
+      final normalized = {for (final t in pack.tags) t.toLowerCase().trim()}
+        ..removeWhere((e) => e.isEmpty);
+      final sorted = normalized.toList()..sort();
+      return TheoryPackModel(
+        id: pack.id,
+        title: pack.title,
+        sections: pack.sections,
+        tags: sorted,
+      );
+    }
+
+    final tags = autoTag(pack).map((e) => e.toLowerCase().trim()).toSet();
+    final list = tags.toList()..sort();
+    return TheoryPackModel(
+      id: pack.id,
+      title: pack.title,
+      sections: pack.sections,
+      tags: list,
+    );
+  }
 }

--- a/lib/services/theory_pack_library_service.dart
+++ b/lib/services/theory_pack_library_service.dart
@@ -63,7 +63,15 @@ class TheoryPackLibraryService {
             }
           }
         }
-        final pack = TheoryPackModel(id: id, title: title, sections: sections);
+        final tagYaml = map['tags'];
+        final tags = <String>[];
+        if (tagYaml is List) {
+          for (final t in tagYaml) {
+            tags.add(t.toString());
+          }
+        }
+        final pack = TheoryPackModel(
+            id: id, title: title, sections: sections, tags: tags);
         _packs.add(pack);
         _index[id] = pack;
       } catch (_) {}

--- a/test/theory_pack_auto_tagger_test.dart
+++ b/test/theory_pack_auto_tagger_test.dart
@@ -21,4 +21,41 @@ void main() {
     expect(tags, contains('bubble'));
     expect(tags, contains('shortstack'));
   });
+
+  test('persistTags saves computed tags', () {
+    final pack = TheoryPackModel(
+      id: 'p',
+      title: 'ICM Bubble Play',
+      sections: [
+        TheorySectionModel(
+          title: 'Short Stack Strategy',
+          text: 'On the bubble you must play tight with a short stack.',
+          type: 'info',
+        ),
+      ],
+    );
+
+    final updated = const TheoryPackAutoTagger().persistTags(pack);
+    expect(updated.tags, contains('icm'));
+    expect(updated.tags, contains('bubble'));
+    expect(updated.tags, contains('shortstack'));
+    expect(pack.tags, isEmpty);
+  });
+
+  test('persistTags respects overwrite flag', () {
+    final pack = TheoryPackModel(
+      id: 'p',
+      title: 'ICM',
+      sections: const [],
+      tags: const ['Custom'],
+    );
+
+    final res1 = const TheoryPackAutoTagger().persistTags(pack);
+    expect(res1.tags, ['custom']);
+
+    final res2 =
+        const TheoryPackAutoTagger().persistTags(pack, overwrite: true);
+    expect(res2.tags, isNot(contains('custom')));
+    expect(res2.tags, contains('icm'));
+  });
 }


### PR DESCRIPTION
## Summary
- extend `TheoryPackModel` with a `tags` field
- load tags from YAML in `TheoryPackLibraryService`
- add `TheoryPackAutoTagger.persistTags` to store detected tags
- display stored tags in `TheoryPackDebuggerScreen`
- test tag persistence logic

## Testing
- `flutter pub get`
- `flutter test test/theory_pack_auto_tagger_test.dart`
- `flutter analyze` *(fails: 15152 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68856efb5b80832aaa2704f8a62379ea