### PR TITLE
Implement theory stage auto completion

### DIFF
--- a/lib/services/theory_stage_completion_watcher.dart
+++ b/lib/services/theory_stage_completion_watcher.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import 'theory_stage_progress_tracker.dart';
+
+/// Watches scroll position and time spent on a theory stage
+/// to automatically mark it as completed.
+class TheoryStageCompletionWatcher {
+  /// Creates a watcher.
+  TheoryStageCompletionWatcher({
+    TheoryStageProgressTracker? tracker,
+    this.autoCompleteDelay = const Duration(seconds: 45),
+  }) : tracker = tracker ?? TheoryStageProgressTracker.instance;
+
+  /// Progress tracker used to mark completion.
+  final TheoryStageProgressTracker tracker;
+
+  /// Duration after which the stage is automatically marked
+  /// completed if the user stays on the screen.
+  final Duration autoCompleteDelay;
+
+  Timer? _timer;
+  ScrollController? _controller;
+  VoidCallback? _listener;
+  String? _stageId;
+  bool _completed = false;
+
+  /// Starts observing [controller] for [stageId].
+  ///
+  /// Optionally provide [context] to show a completion toast.
+  void observe(
+    String stageId,
+    ScrollController controller, {
+    BuildContext? context,
+  }) {
+    dispose();
+    _stageId = stageId;
+    _controller = controller;
+    _listener = () => _onScroll(context);
+    controller.addListener(_listener!);
+    _timer = Timer(autoCompleteDelay, () => _markCompleted(context));
+  }
+
+  void _onScroll(BuildContext? context) {
+    if (_completed) return;
+    final c = _controller;
+    if (c == null || !c.hasClients) return;
+    final pos = c.position;
+    if (!pos.hasContentDimensions) return;
+    if (pos.pixels >= pos.maxScrollExtent) {
+      _markCompleted(context);
+    }
+  }
+
+  void _markCompleted(BuildContext? context) {
+    if (_completed) return;
+    final id = _stageId;
+    if (id == null) return;
+    _completed = true;
+    tracker.markCompleted(id);
+    if (context != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('✓ Completed')),
+      );
+    }
+  }
+
+  /// Stops watching and cleans up listeners.
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    if (_controller != null && _listener != null) {
+      _controller!.removeListener(_listener!);
+    }
+    _controller = null;
+    _listener = null;
+    _stageId = null;
+    _completed = false;
+  }
+}
+

--- a/test/services/theory_stage_completion_watcher_test.dart
+++ b/test/services/theory_stage_completion_watcher_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_stage_completion_watcher.dart';
+import 'package:poker_analyzer/services/theory_stage_progress_tracker.dart';
+
+class _TestWidget extends StatefulWidget {
+  final ScrollController controller;
+  final TheoryStageCompletionWatcher watcher;
+  const _TestWidget({required this.controller, required this.watcher});
+
+  @override
+  State<_TestWidget> createState() => _TestWidgetState();
+}
+
+class _TestWidgetState extends State<_TestWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.watcher.observe('stage1', widget.controller);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: ListView.builder(
+        controller: widget.controller,
+        itemCount: 30,
+        itemBuilder: (_, i) => SizedBox(height: 40, child: Text('Item \$i')),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    widget.watcher.dispose();
+    super.dispose();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('marks completed when scrolled to bottom', (tester) async {
+    final controller = ScrollController();
+    final watcher = TheoryStageCompletionWatcher(
+      autoCompleteDelay: const Duration(seconds: 5),
+    );
+    await tester.pumpWidget(_TestWidget(controller: controller, watcher: watcher));
+    await tester.pump();
+
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pump();
+    expect(await TheoryStageProgressTracker.instance.isCompleted('stage1'), isTrue);
+  });
+
+  testWidgets('marks completed after delay', (tester) async {
+    final controller = ScrollController();
+    final watcher = TheoryStageCompletionWatcher(
+      autoCompleteDelay: const Duration(milliseconds: 500),
+    );
+    await tester.pumpWidget(_TestWidget(controller: controller, watcher: watcher));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(await TheoryStageProgressTracker.instance.isCompleted('stage1'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryStageCompletionWatcher` for automatic theory stage completion
- test marking on scroll and after a delay

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857be593f8832ab4156af1f45e5792