### PR TITLE
Implement TheoryPackReaderScreen with completion watcher

### DIFF
--- a/lib/screens/theory_pack_reader_screen.dart
+++ b/lib/screens/theory_pack_reader_screen.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_pack_model.dart';
+import '../services/theory_stage_completion_watcher.dart';
+import '../services/theory_stage_progress_tracker.dart';
+import '../theme/app_colors.dart';
+
+/// Displays the full contents of a theory pack.
+class TheoryPackReaderScreen extends StatefulWidget {
+  final TheoryPackModel pack;
+  final String stageId;
+  const TheoryPackReaderScreen({
+    super.key,
+    required this.pack,
+    required this.stageId,
+  });
+
+  @override
+  State<TheoryPackReaderScreen> createState() =>
+      _TheoryPackReaderScreenState();
+}
+
+class _TheoryPackReaderScreenState extends State<TheoryPackReaderScreen> {
+  late final ScrollController _controller;
+  late final TheoryStageCompletionWatcher _watcher;
+  late Future<bool> _completedFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ScrollController();
+    _watcher = TheoryStageCompletionWatcher();
+    _completedFuture =
+        TheoryStageProgressTracker.instance.isCompleted(widget.stageId);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _watcher.observe(
+        widget.stageId,
+        _controller,
+        context: context,
+        onCompleted: _onCompleted,
+      );
+    });
+  }
+
+  void _onCompleted() {
+    setState(() {
+      _completedFuture =
+          TheoryStageProgressTracker.instance.isCompleted(widget.stageId);
+    });
+  }
+
+  @override
+  void dispose() {
+    _watcher.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Widget _buildSection(TheorySectionModel section) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            section.title,
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Text(section.text),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: _completedFuture,
+      builder: (context, snapshot) {
+        final completed = snapshot.data ?? false;
+        return Scaffold(
+          appBar: AppBar(title: Text(widget.pack.title)),
+          backgroundColor: AppColors.background,
+          body: Stack(
+            children: [
+              ListView.builder(
+                controller: _controller,
+                padding: const EdgeInsets.all(16),
+                itemCount: widget.pack.sections.length,
+                itemBuilder: (_, i) => _buildSection(widget.pack.sections[i]),
+              ),
+              Positioned(
+                top: 16,
+                right: 16,
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 300),
+                  opacity: completed ? 1.0 : 0.0,
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: Colors.green,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Text(
+                      '✓ Completed',
+                      style: TextStyle(color: Colors.black),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/services/theory_stage_completion_watcher.dart
+++ b/lib/services/theory_stage_completion_watcher.dart
@@ -22,6 +22,7 @@ class TheoryStageCompletionWatcher {
   Timer? _timer;
   ScrollController? _controller;
   VoidCallback? _listener;
+  VoidCallback? _onCompleted;
   String? _stageId;
   bool _completed = false;
 
@@ -32,10 +33,12 @@ class TheoryStageCompletionWatcher {
     String stageId,
     ScrollController controller, {
     BuildContext? context,
+    VoidCallback? onCompleted,
   }) {
     dispose();
     _stageId = stageId;
     _controller = controller;
+    _onCompleted = onCompleted;
     _listener = () => _onScroll(context);
     controller.addListener(_listener!);
     _timer = Timer(autoCompleteDelay, () => _markCompleted(context));
@@ -58,6 +61,7 @@ class TheoryStageCompletionWatcher {
     if (id == null) return;
     _completed = true;
     tracker.markCompleted(id);
+    _onCompleted?.call();
     if (context != null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('✓ Completed')),
@@ -74,6 +78,7 @@ class TheoryStageCompletionWatcher {
     }
     _controller = null;
     _listener = null;
+    _onCompleted = null;
     _stageId = null;
     _completed = false;
   }


### PR DESCRIPTION
## Summary
- extend `TheoryStageCompletionWatcher` with optional `onCompleted` callback
- add `TheoryPackReaderScreen` for reading theory packs
  - integrates `TheoryStageCompletionWatcher`
  - displays a completion badge when stage is done

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857d9b563c832a848d4c6bef592f0d