### PR TITLE
Add LearningPathStageLauncher

### DIFF
--- a/lib/screens/theory_pack_reader_screen.dart
+++ b/lib/screens/theory_pack_reader_screen.dart
@@ -7,6 +7,7 @@ import '../theme/app_colors.dart';
 
 /// Displays the full contents of a theory pack.
 class TheoryPackReaderScreen extends StatefulWidget {
+  static const route = '/theory_reader';
   final TheoryPackModel pack;
   final String stageId;
   const TheoryPackReaderScreen({

--- a/lib/services/learning_path_stage_launcher.dart
+++ b/lib/services/learning_path_stage_launcher.dart
@@ -1,0 +1,97 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_stage_model.dart';
+import '../models/stage_type.dart';
+import '../models/theory_pack_model.dart';
+import '../services/theory_pack_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/training_session_launcher.dart';
+import '../screens/theory_pack_reader_screen.dart';
+import 'user_action_logger.dart';
+
+/// Helper to open a learning path stage.
+class LearningPathStageLauncher {
+  final PackLibraryService _library;
+  final TheoryPackLibraryService _theoryLibrary;
+  final TrainingSessionLauncher _launcher;
+
+  const LearningPathStageLauncher({
+    PackLibraryService? library,
+    TheoryPackLibraryService? theoryLibrary,
+    TrainingSessionLauncher launcher = const TrainingSessionLauncher(),
+  })  : _library = library ?? PackLibraryService.instance,
+        _theoryLibrary = theoryLibrary ?? TheoryPackLibraryService.instance,
+        _launcher = launcher;
+
+  Future<void> launch(BuildContext context, LearningPathStageModel stage) async {
+    await UserActionLogger.instance.logEvent({
+      'event': 'stage_opened',
+      'type': stage.type.name,
+      'id': stage.id,
+      if (stage.tags.isNotEmpty) 'tags': stage.tags,
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+
+    switch (stage.type) {
+      case StageType.theory:
+        final id = stage.theoryPackId;
+        if (id == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Theory pack not found')),
+          );
+          return;
+        }
+        await _theoryLibrary.loadAll();
+        final pack = _theoryLibrary.getById(id);
+        if (pack == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Theory pack not found')),
+          );
+          return;
+        }
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            settings: const RouteSettings(name: TheoryPackReaderScreen.route),
+            builder: (_) => TheoryPackReaderScreen(pack: pack, stageId: stage.id),
+          ),
+        );
+        break;
+      case StageType.practice:
+        final tpl = await _library.getById(stage.packId);
+        if (tpl == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Training pack not found')),
+          );
+          return;
+        }
+        await _launcher.launch(tpl);
+        break;
+      case StageType.booster:
+        TheoryPackModel? booster;
+        await _theoryLibrary.loadAll();
+        if (stage.boosterTheoryPackIds != null &&
+            stage.boosterTheoryPackIds!.isNotEmpty) {
+          booster = _theoryLibrary.getById(stage.boosterTheoryPackIds!.first);
+        }
+        booster ??= _theoryLibrary.all.firstWhereOrNull(
+          (p) => stage.tags.any((t) => p.tags.contains(t)),
+        );
+        if (booster == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Booster not found')),
+          );
+          return;
+        }
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            settings: const RouteSettings(name: TheoryPackReaderScreen.route),
+            builder: (_) => TheoryPackReaderScreen(pack: booster!, stageId: stage.id),
+          ),
+        );
+        break;
+    }
+  }
+}

--- a/test/services/learning_path_stage_launcher_test.dart
+++ b/test/services/learning_path_stage_launcher_test.dart
@@ -1,0 +1,146 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/stage_type.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_stage_launcher.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/services/theory_pack_library_service.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/screens/theory_pack_reader_screen.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakePackLibrary implements PackLibraryService {
+  final Map<String, TrainingPackTemplateV2> packs;
+  _FakePackLibrary(this.packs);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async => packs[id];
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
+      packs.values.firstWhereOrNull((p) => p.tags.contains(tag));
+}
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  TrainingPackTemplateV2? launched;
+  _FakeLauncher() : super();
+  @override
+  Future<void> launch(TrainingPackTemplateV2 template, {int startIndex = 0}) async {
+    launched = template;
+  }
+}
+
+class _FakeTheoryLibrary implements TheoryPackLibraryService {
+  final Map<String, TheoryPackModel> packs;
+  _FakeTheoryLibrary(this.packs);
+  @override
+  List<TheoryPackModel> get all => packs.values.toList();
+  @override
+  TheoryPackModel? getById(String id) => packs[id];
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+}
+
+TrainingPackTemplateV2 _tpl(String id) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    spots: const [TrainingPackSpot(id: 's')],
+    spotCount: 1,
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+TheoryPackModel _theory(String id) {
+  return TheoryPackModel(id: id, title: id, sections: const [], tags: const []);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('launch practice stage starts session', (tester) async {
+    final library = _FakePackLibrary({'p1': _tpl('p1')});
+    final launcher = _FakeLauncher();
+    final service = LearningPathStageLauncher(
+      library: library,
+      theoryLibrary: _FakeTheoryLibrary(const {}),
+      launcher: launcher,
+    );
+    const stage = LearningPathStageModel(
+      id: 's',
+      title: 'S',
+      description: '',
+      packId: 'p1',
+      requiredAccuracy: 0,
+      minHands: 0,
+      type: StageType.practice,
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: Container(key: key))));
+    await service.launch(key.currentContext!, stage);
+    expect(launcher.launched?.id, 'p1');
+    expect(UserActionLogger.instance.events.last['event'], 'stage_opened');
+  });
+
+  testWidgets('launch theory stage opens reader', (tester) async {
+    final theory = _theory('t1');
+    final service = LearningPathStageLauncher(
+      library: _FakePackLibrary(const {}),
+      theoryLibrary: _FakeTheoryLibrary({'t1': theory}),
+    );
+    const stage = LearningPathStageModel(
+      id: 's',
+      title: 'S',
+      description: '',
+      packId: 'p',
+      theoryPackId: 't1',
+      requiredAccuracy: 0,
+      minHands: 0,
+      type: StageType.theory,
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(navigatorKey: GlobalKey(), home: Scaffold(body: Container(key: key))));
+    await service.launch(key.currentContext!, stage);
+    await tester.pumpAndSettle();
+    expect(find.byType(TheoryPackReaderScreen), findsOneWidget);
+  });
+
+  testWidgets('launch booster stage uses booster id', (tester) async {
+    final booster = _theory('b1');
+    final service = LearningPathStageLauncher(
+      library: _FakePackLibrary(const {}),
+      theoryLibrary: _FakeTheoryLibrary({'b1': booster}),
+    );
+    const stage = LearningPathStageModel(
+      id: 's',
+      title: 'S',
+      description: '',
+      packId: 'p',
+      boosterTheoryPackIds: ['b1'],
+      requiredAccuracy: 0,
+      minHands: 0,
+      type: StageType.booster,
+    );
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(navigatorKey: GlobalKey(), home: Scaffold(body: Container(key: key))));
+    await service.launch(key.currentContext!, stage);
+    await tester.pumpAndSettle();
+    expect(find.byType(TheoryPackReaderScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add route constant for TheoryPackReaderScreen
- create LearningPathStageLauncher to open theory, practice, or booster stages
- log analytics events and support deep linking
- add basic tests for the new launcher

## Testing
- `flutter analyze` *(fails: Package file_picker missing inline implementations)*
- `flutter test test/services/learning_path_stage_launcher_test.dart` *(fails: analysis errors)*

------
https://chatgpt.com/codex/tasks/task_e_68857ed09a38832a9acf968ccbbb2965