### PR TITLE
Add starter theory packs

### DIFF
--- a/lib/services/theory_pack_library_service.dart
+++ b/lib/services/theory_pack_library_service.dart
@@ -14,6 +14,62 @@ class TheoryPackLibraryService {
   /// Default directory with bundled theory packs.
   static const String _dir = 'assets/theory_packs/';
 
+  /// Embedded starter theory packs shipped with the app.
+  static const List<Map<String, dynamic>> _defaultPackData = [
+    {
+      'id': 'push_fold_basics',
+      'title': 'Push/Fold Basics',
+      'tags': ['starter'],
+      'sections': [
+        {
+          'title': 'When to push',
+          'text':
+              'Short stack play revolves around pushing all-in when under 15BBs.',
+          'type': 'info'
+        },
+        {
+          'title': 'Ranges',
+          'text': 'Push widest from BTN and SB, tighten in early positions.',
+          'type': 'tip'
+        },
+      ]
+    },
+    {
+      'id': 'icm_essentials',
+      'title': 'ICM Essentials',
+      'tags': ['starter', 'icm'],
+      'sections': [
+        {
+          'title': 'What is ICM',
+          'text': 'ICM evaluates chip value based on payout structure.',
+          'type': 'info'
+        },
+        {
+          'title': 'Bubble play',
+          'text': 'Near the money bubble tighten your calling ranges.',
+          'type': 'tip'
+        },
+      ]
+    },
+    {
+      'id': 'tournament_tips',
+      'title': 'Tournament Tips',
+      'tags': ['starter'],
+      'sections': [
+        {
+          'title': 'Before you play',
+          'text': 'Get rest, review ranges and plan your session.',
+          'type': 'info'
+        },
+        {
+          'title': 'During breaks',
+          'text': 'Check big hands quickly and stay hydrated.',
+          'type': 'tip'
+        },
+      ]
+    },
+  ];
+
   final List<TheoryPackModel> _packs = [];
   final Map<String, TheoryPackModel> _index = {};
 
@@ -33,6 +89,7 @@ class TheoryPackLibraryService {
   Future<void> loadAll() async {
     if (_packs.isNotEmpty) return;
     await reload();
+    await loadDefaultPacks();
   }
 
   /// Reloads theory packs from assets.
@@ -75,6 +132,18 @@ class TheoryPackLibraryService {
         _packs.add(pack);
         _index[id] = pack;
       } catch (_) {}
+    }
+    await loadDefaultPacks();
+  }
+
+  /// Adds embedded starter packs to the library if not already present.
+  Future<void> loadDefaultPacks() async {
+    for (final data in _defaultPackData) {
+      final id = data['id']?.toString() ?? '';
+      if (id.isEmpty || _index.containsKey(id)) continue;
+      final pack = TheoryPackModel.fromYaml(data);
+      _packs.add(pack);
+      _index[id] = pack;
     }
   }
 }

--- a/test/theory_pack_library_service_test.dart
+++ b/test/theory_pack_library_service_test.dart
@@ -12,4 +12,12 @@ void main() {
     expect(pack, isNotNull);
     expect(pack!.sections.length, 2);
   });
+
+  test('loadDefaultPacks adds starter content', () async {
+    final service = TheoryPackLibraryService.instance;
+    await service.reload();
+    final initialCount = service.all.length;
+    await service.loadDefaultPacks();
+    expect(service.all.length, greaterThan(initialCount));
+  });
 }


### PR DESCRIPTION
## Summary
- preload starter theory content in `TheoryPackLibraryService`
- add a few embedded theory packs and merge them on reload
- test that default packs load

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6885897f7f38832ab2bf6f5e314d4524