### PR TITLE
Implement stage preview deep link

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -55,6 +55,8 @@ import '../utils/route_link.dart';
 import '../services/learning_path_registry_service.dart';
 import '../services/learning_path_orchestrator.dart';
 import '../services/theory_pack_library_service.dart';
+import 'learning_path_stage_preview_screen.dart';
+import 'package:collection/collection.dart';
 import 'learning_path_screen_v2.dart';
 import '../widgets/sync_status_widget.dart';
 import '../user_preferences.dart';
@@ -135,6 +137,27 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
     await LearningPathRegistryService.instance.loadAll();
     final template = LearningPathRegistryService.instance.findById(link.pathId);
     if (template == null) return;
+    // New deep link to a specific stage preview.
+    final segments = Uri.base.pathSegments;
+    if (segments.length >= 4 &&
+        segments.first == 'path' &&
+        segments[2] == 'stage' &&
+        link.stageId != null) {
+      await TheoryPackLibraryService.instance.loadAll();
+      final stage =
+          template.stages.firstWhereOrNull((s) => s.id == link.stageId);
+      if (stage == null || !mounted) return;
+      await UserActionLogger.instance.log('deeplink_stage_preview');
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) =>
+              LearningPathStagePreviewScreen(path: template, stage: stage),
+        ),
+      );
+      return;
+    }
+
     if (!mounted) return;
     await Navigator.push(
       context,

--- a/lib/utils/route_link.dart
+++ b/lib/utils/route_link.dart
@@ -4,13 +4,30 @@ class RouteLink {
 
   const RouteLink({required this.pathId, this.stageId});
 
-  /// Parses [uri] and returns a [RouteLink] if it matches `/learn`.
-  /// Expected format: `/learn?path=VALUE&stage=VALUE`.
+  /// Parses [uri] and returns a [RouteLink] if it matches one of the supported
+  /// formats:
+  ///
+  /// - `/learn?path=VALUE&stage=VALUE`
+  /// - `/path/{pathId}/stage/{stageId}`
   static RouteLink? tryParse(Uri uri) {
-    if (uri.path != '/learn') return null;
-    final path = uri.queryParameters['path'];
-    if (path == null || path.isEmpty) return null;
-    final stage = uri.queryParameters['stage'];
-    return RouteLink(pathId: path, stageId: stage);
+    // Legacy query parameter based format.
+    if (uri.path == '/learn') {
+      final path = uri.queryParameters['path'];
+      if (path == null || path.isEmpty) return null;
+      final stage = uri.queryParameters['stage'];
+      return RouteLink(pathId: path, stageId: stage);
+    }
+
+    // New deep link format with path segments.
+    final segments = uri.pathSegments;
+    if (segments.length >= 4 &&
+        segments[0] == 'path' &&
+        segments[2] == 'stage') {
+      final pathId = segments[1];
+      final stageId = segments[3];
+      if (pathId.isEmpty) return null;
+      return RouteLink(pathId: pathId, stageId: stageId);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- support `/path/{pathId}/stage/{stageId}` in `RouteLink`
- add new handler in `MainNavigationScreen` to open `LearningPathStagePreviewScreen`
- log `deeplink_stage_preview`

## Testing
- `apt-get update` *(passed)*
- `apt-get install -y dart` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688590bd1200832a879307a9e4ada0e2