### PR TITLE
Add StageShareButton

### DIFF
--- a/lib/screens/learning_path_stage_preview_screen.dart
+++ b/lib/screens/learning_path_stage_preview_screen.dart
@@ -8,6 +8,7 @@ import '../services/learning_path_stage_launcher.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/theory_pack_model.dart';
 import '../screens/theory_pack_reader_screen.dart';
+import '../widgets/stage_share_button.dart';
 
 /// Simple preview page for a learning path stage.
 class LearningPathStagePreviewScreen extends StatefulWidget {
@@ -79,7 +80,10 @@ class _LearningPathStagePreviewScreenState
     final estMinutes = pack == null ? null : (pack.spotCount / 2).ceil();
     final progressPct = (_progress.clamp(0.0, 1.0) * 100).round();
     return Scaffold(
-      appBar: AppBar(title: Text(widget.stage.title)),
+      appBar: AppBar(
+        title: Text(widget.stage.title),
+        actions: [StageShareButton(path: widget.path, stage: widget.stage)],
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : ListView(

--- a/lib/widgets/stage_share_button.dart
+++ b/lib/widgets/stage_share_button.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../models/learning_path_stage_model.dart';
+
+/// Button for copying or sharing a direct link to a learning path stage preview.
+class StageShareButton extends StatelessWidget {
+  final LearningPathTemplateV2 path;
+  final LearningPathStageModel stage;
+
+  const StageShareButton({
+    super.key,
+    required this.path,
+    required this.stage,
+  });
+
+  String get _link =>
+      'https://pokeranalyzer.app/path/${path.id}/stage/${stage.id}';
+
+  Future<void> _share(BuildContext context) async {
+    await Clipboard.setData(ClipboardData(text: _link));
+    await Share.share(_link);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          Localizations.localeOf(context).languageCode == 'ru'
+              ? 'Ссылка скопирована'
+              : 'Link copied',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.link),
+      tooltip: Localizations.localeOf(context).languageCode == 'ru'
+          ? 'Копировать ссылку'
+          : 'Copy link',
+      onPressed: () => _share(context),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add StageShareButton widget for copying/sharing stage link
- use StageShareButton on the LearningPathStagePreviewScreen app bar

## Testing
- `apt-get update`
- ❌ `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688591c7a508832a87b3391a002103a5