### PR TITLE
Implement LearningPathWeekPlannerScreen

### DIFF
--- a/lib/screens/learning_path_week_planner_screen.dart
+++ b/lib/screens/learning_path_week_planner_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_stage_model.dart';
+import '../models/learning_path_template_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/theory_pack_model.dart';
+import '../services/learning_path_orchestrator.dart';
+import '../services/training_progress_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/theory_pack_library_service.dart';
+import '../widgets/learning_path_stage_progress_card.dart';
+import 'learning_path_stage_preview_screen.dart';
+
+class LearningPathWeekPlannerScreen extends StatefulWidget {
+  const LearningPathWeekPlannerScreen({super.key});
+
+  @override
+  State<LearningPathWeekPlannerScreen> createState() =>
+      _LearningPathWeekPlannerScreenState();
+}
+
+class _LearningPathWeekPlannerScreenState
+    extends State<LearningPathWeekPlannerScreen> {
+  bool _loading = true;
+  LearningPathTemplateV2? _path;
+  final List<_StageInfo> _stages = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final path = await LearningPathOrchestrator.instance.resolve();
+    await TheoryPackLibraryService.instance.loadAll();
+    final list = <_StageInfo>[];
+    for (final stage in path.stages) {
+      if (list.length >= 7) break;
+      final prog =
+          await TrainingProgressService.instance.getStageProgress(stage.id);
+      if (prog >= 1.0) continue;
+      final pack = await PackLibraryService.instance.getById(stage.packId);
+      final theory = stage.theoryPackId == null
+          ? null
+          : TheoryPackLibraryService.instance.getById(stage.theoryPackId!);
+      list.add(_StageInfo(stage, prog, pack, theory));
+    }
+    if (!mounted) return;
+    setState(() {
+      _path = path;
+      _stages
+        ..clear()
+        ..addAll(list);
+      _loading = false;
+    });
+  }
+
+  Future<void> _open(LearningPathStageModel stage) async {
+    final path = _path;
+    if (path == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LearningPathStagePreviewScreen(path: path, stage: stage),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('План на неделю')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                const Text(
+                  'План на неделю',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Вот этапы, которые стоит пройти в ближайшие дни.',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Удачи и приятных тренировок!',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                const SizedBox(height: 16),
+                for (final info in _stages)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: LearningPathStageProgressCard(
+                      stage: info.stage,
+                      progress: info.progress,
+                      pack: info.pack,
+                      theoryPack: info.theoryPack,
+                      onTap: () => _open(info.stage),
+                    ),
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+class _StageInfo {
+  final LearningPathStageModel stage;
+  final double progress;
+  final TrainingPackTemplateV2? pack;
+  final TheoryPackModel? theoryPack;
+  _StageInfo(this.stage, this.progress, this.pack, this.theoryPack);
+}


### PR DESCRIPTION
## Summary
- add new screen `LearningPathWeekPlannerScreen`
- expose `getStageProgress` in `TrainingProgressService`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688594f1a0b0832a89b7f5e4ba7fcdd5