### PR TITLE
Implement LearningPathPlannerEngine.getPlannedStageIds

### DIFF
--- a/lib/services/learning_path_planner_engine.dart
+++ b/lib/services/learning_path_planner_engine.dart
@@ -1,0 +1,36 @@
+import 'learning_path_orchestrator.dart';
+import 'training_progress_service.dart';
+
+/// Computes which learning path stages should be presented in the weekly planner.
+class LearningPathPlannerEngine {
+  LearningPathPlannerEngine._();
+
+  static final LearningPathPlannerEngine instance = LearningPathPlannerEngine._();
+
+  List<String>? _cache;
+  DateTime _cacheTime = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Returns up to seven stage ids that are not yet completed.
+  Future<List<String>> getPlannedStageIds() async {
+    final now = DateTime.now();
+    if (_cache != null &&
+        now.difference(_cacheTime) < const Duration(minutes: 5)) {
+      return _cache!;
+    }
+
+    final path = await LearningPathOrchestrator.instance.resolve();
+    final result = <String>[];
+    for (final stage in path.stages) {
+      if (result.length >= 7) break;
+      final progress =
+          await TrainingProgressService.instance.getStageProgress(stage.id);
+      if (progress < 1.0) {
+        result.add(stage.id);
+      }
+    }
+
+    _cache = result;
+    _cacheTime = now;
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- add `LearningPathPlannerEngine` service
- compute up to seven incomplete stage IDs for planner banner

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885991785c0832a9d17f7b510c2b25a