### PR TITLE
Implement WeeklyPlannerBoosterEngine

### DIFF
--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -28,4 +28,22 @@ class PackLibraryService {
     final list = TrainingPackLibraryV2.instance.filterBy(type: TrainingType.pushFold);
     return list.firstWhereOrNull((p) => p.tags.contains(tag));
   }
+
+  /// Returns ids of booster packs matching [tag].
+  Future<List<String>> findBoosterCandidates(String tag) async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final lc = tag.toLowerCase();
+    final list = TrainingPackLibraryV2.instance.filterBy(
+      type: TrainingType.pushFold,
+    );
+    final ids = <String>[];
+    for (final p in list) {
+      final meta = p.meta;
+      if (meta['type']?.toString().toLowerCase() == 'booster' &&
+          meta['tag']?.toString().toLowerCase() == lc) {
+        ids.add(p.id);
+      }
+    }
+    return ids;
+  }
 }

--- a/lib/services/weekly_planner_booster_engine.dart
+++ b/lib/services/weekly_planner_booster_engine.dart
@@ -1,0 +1,57 @@
+import 'package:collection/collection.dart';
+
+import '../models/learning_path_template_v2.dart';
+import '../services/learning_path_planner_engine.dart';
+import '../services/learning_path_orchestrator.dart';
+import '../services/theory_pack_library_service.dart';
+import '../services/pack_library_service.dart';
+import 'theory_pack_auto_tagger.dart';
+
+/// Suggests booster packs for stages returned by [LearningPathPlannerEngine].
+class WeeklyPlannerBoosterEngine {
+  final PackLibraryService _library;
+  final TheoryPackLibraryService _theoryLibrary;
+  final Future<List<String>> Function() _getStageIds;
+  final Future<LearningPathTemplateV2> Function() _getPath;
+
+  const WeeklyPlannerBoosterEngine({
+    PackLibraryService? library,
+    TheoryPackLibraryService? theoryLibrary,
+    Future<List<String>> Function()? getStageIds,
+    Future<LearningPathTemplateV2> Function()? getPath,
+  })  : _library = library ?? PackLibraryService.instance,
+        _theoryLibrary = theoryLibrary ?? TheoryPackLibraryService.instance,
+        _getStageIds =
+            getStageIds ?? LearningPathPlannerEngine.instance.getPlannedStageIds,
+        _getPath = getPath ?? LearningPathOrchestrator.instance.resolve;
+
+  /// Returns a map from stage id to recommended booster pack ids.
+  Future<Map<String, List<String>>> suggestBoostersForPlannedStages() async {
+    final ids = await _getStageIds();
+    if (ids.isEmpty) return {};
+    await _theoryLibrary.loadAll();
+    await _library.recommendedStarter();
+    final path = await _getPath();
+    const tagger = TheoryPackAutoTagger();
+    final result = <String, List<String>>{};
+
+    for (final id in ids) {
+      final stage = path.stages.firstWhereOrNull((s) => s.id == id);
+      if (stage == null) continue;
+      final theoryId = stage.theoryPackId;
+      if (theoryId == null) continue;
+      final pack = _theoryLibrary.getById(theoryId);
+      if (pack == null) continue;
+      final tags = tagger.autoTag(pack);
+      final boosterIds = <String>{};
+      for (final t in tags) {
+        final cands = await _library.findBoosterCandidates(t);
+        boosterIds.addAll(cands);
+      }
+      if (boosterIds.isNotEmpty) {
+        result[id] = boosterIds.toList();
+      }
+    }
+    return result;
+  }
+}

--- a/test/services/auto_recovery_trigger_service_test.dart
+++ b/test/services/auto_recovery_trigger_service_test.dart
@@ -45,6 +45,8 @@ class _FakeLibrary implements PackLibraryService {
       byTag.values.firstWhereOrNull((p) => p.id == id);
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async => byTag[tag];
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 TrainingPackTemplateV2 _tpl(String id, String tag) {

--- a/test/services/booster_pack_launcher_test.dart
+++ b/test/services/booster_pack_launcher_test.dart
@@ -33,6 +33,8 @@ class _FakeLibrary implements PackLibraryService {
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
       packs.firstWhereOrNull((p) => p.tags.contains(tag));
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 class _FakeLauncher extends TrainingSessionLauncher {

--- a/test/services/learning_path_launcher_service_test.dart
+++ b/test/services/learning_path_launcher_service_test.dart
@@ -39,6 +39,11 @@ class _FakeLibrary implements PackLibraryService {
   Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
   @override
   Future<TrainingPackTemplateV2?> getById(String id) async => packs[id];
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
+      packs.values.firstWhereOrNull((p) => p.tags.contains(tag));
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 class _FakeLauncher extends TrainingSessionLauncher {

--- a/test/services/learning_path_stage_launcher_test.dart
+++ b/test/services/learning_path_stage_launcher_test.dart
@@ -26,6 +26,8 @@ class _FakePackLibrary implements PackLibraryService {
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
       packs.values.firstWhereOrNull((p) => p.tags.contains(tag));
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 class _FakeLauncher extends TrainingSessionLauncher {

--- a/test/services/scheduled_training_launcher_test.dart
+++ b/test/services/scheduled_training_launcher_test.dart
@@ -18,6 +18,8 @@ class _FakeLibrary implements PackLibraryService {
   Future<TrainingPackTemplateV2?> getById(String id) async => packs[id];
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async => null;
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 class _FakeLauncher extends TrainingSessionLauncher {

--- a/test/services/scheduled_training_queue_service_test.dart
+++ b/test/services/scheduled_training_queue_service_test.dart
@@ -18,6 +18,8 @@ class _FakeLibrary implements PackLibraryService {
       byTag.values.firstWhere((p) => p.id == id, orElse: () => byTag.values.first);
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async => byTag[tag];
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 TrainingPackTemplateV2 _tpl(String id, String tag) {

--- a/test/services/skill_gap_booster_service_test.dart
+++ b/test/services/skill_gap_booster_service_test.dart
@@ -18,6 +18,8 @@ class _FakeLibrary implements PackLibraryService {
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async =>
       packs.firstWhereOrNull((p) => p.tags.contains(tag));
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 TrainingPackTemplateV2 tpl(String id, List<String> tags, int count) {

--- a/test/services/skill_loss_feed_engine_test.dart
+++ b/test/services/skill_loss_feed_engine_test.dart
@@ -35,6 +35,8 @@ class _FakeLibrary implements PackLibraryService {
       .firstWhere((p) => p.id == id, orElse: () => byTag.values.first);
   @override
   Future<TrainingPackTemplateV2?> findByTag(String tag) async => byTag[tag];
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
 }
 
 class _FakeReviews implements TagReviewHistoryService {

--- a/test/services/weekly_planner_booster_engine_test.dart
+++ b/test/services/weekly_planner_booster_engine_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/weekly_planner_booster_engine.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+import 'package:poker_analyzer/models/stage_type.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/services/theory_pack_library_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+
+class _FakeTheoryLibrary implements TheoryPackLibraryService {
+  final Map<String, TheoryPackModel> packs;
+  _FakeTheoryLibrary(this.packs);
+  @override
+  List<TheoryPackModel> get all => packs.values.toList();
+  @override
+  TheoryPackModel? getById(String id) => packs[id];
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+}
+
+class _FakePackLibrary implements PackLibraryService {
+  final Map<String, List<String>> byTag;
+  _FakePackLibrary(this.byTag);
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async => null;
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async => null;
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async =>
+      byTag[tag] ?? const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('returns booster ids for planned stages', () async {
+    final path = LearningPathTemplateV2(
+      id: 'p',
+      title: 'Path',
+      description: '',
+      stages: const [
+        LearningPathStageModel(
+          id: 's1',
+          title: 'S1',
+          description: '',
+          packId: 'p1',
+          theoryPackId: 't1',
+          requiredAccuracy: 0,
+          minHands: 0,
+          type: StageType.practice,
+        ),
+        LearningPathStageModel(
+          id: 's2',
+          title: 'S2',
+          description: '',
+          packId: 'p2',
+          requiredAccuracy: 0,
+          minHands: 0,
+          type: StageType.practice,
+        ),
+      ],
+      sections: const [],
+    );
+    final planner = () async => ['s1', 's2'];
+    final theoryLib = _FakeTheoryLibrary({
+      't1': TheoryPackModel(id: 't1', title: 'Bubble Play', sections: const [], tags: const []),
+    });
+    final packLib = _FakePackLibrary({'bubble': ['b1']});
+
+    final engine = WeeklyPlannerBoosterEngine(
+      library: packLib,
+      theoryLibrary: theoryLib,
+      getStageIds: planner,
+      getPath: () async => path,
+    );
+
+    final result = await engine.suggestBoostersForPlannedStages();
+    expect(result, {'s1': ['b1']});
+  });
+}


### PR DESCRIPTION
## Summary
- extend PackLibraryService with `findBoosterCandidates`
- add new `WeeklyPlannerBoosterEngine` service
- update test stubs for new interface
- cover booster planner with unit test

## Testing
- `flutter analyze` *(fails: many issues found)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_68859f935458832a9f9f2db73d29d3d4