### PR TITLE
Implement LearningPathProgressTracker

### DIFF
--- a/lib/services/learning_path_progress_tracker.dart
+++ b/lib/services/learning_path_progress_tracker.dart
@@ -1,0 +1,48 @@
+import '../models/learning_path_template_v2.dart';
+import 'learning_path_orchestrator.dart';
+import 'training_progress_service.dart';
+
+/// Tracks progress across the entire learning path.
+class LearningPathProgressTracker {
+  final Future<LearningPathTemplateV2> Function() _getPath;
+  final Future<double> Function(String) _stageProgress;
+
+  LearningPathProgressTracker({
+    Future<LearningPathTemplateV2> Function()? getPath,
+    Future<double> Function(String stageId)? getStageProgress,
+  })  : _getPath = getPath ?? LearningPathOrchestrator.instance.resolve,
+        _stageProgress =
+            getStageProgress ?? TrainingProgressService.instance.getStageProgress;
+
+  Map<String, double>? _cache;
+  DateTime _cacheTime = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Returns map of stage id to completion ratio (0.0 - 1.0).
+  Future<Map<String, double>> getStageProgressMap() async {
+    final now = DateTime.now();
+    if (_cache != null &&
+        now.difference(_cacheTime) < const Duration(minutes: 5)) {
+      return _cache!;
+    }
+    final path = await _getPath();
+    final result = <String, double>{};
+    for (final stage in path.stages) {
+      final p = await _stageProgress(stage.id);
+      result[stage.id] = p;
+    }
+    _cache = result;
+    _cacheTime = now;
+    return result;
+  }
+
+  /// Returns average progress across all stages (0.0 - 1.0).
+  Future<double> getOverallProgress() async {
+    final map = await getStageProgressMap();
+    if (map.isEmpty) return 0.0;
+    var sum = 0.0;
+    for (final v in map.values) {
+      sum += v;
+    }
+    return sum / map.length;
+  }
+}

--- a/test/services/learning_path_progress_tracker_test.dart
+++ b/test/services/learning_path_progress_tracker_test.dart
@@ -1,0 +1,58 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/learning_path_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_progress_tracker.dart';
+
+void main() {
+  final template = LearningPathTemplateV2(
+    id: 'p',
+    title: 'Path',
+    description: '',
+    stages: const [
+      LearningPathStageModel(
+        id: 's1',
+        title: 'S1',
+        description: '',
+        packId: 'starter_pushfold_10bb',
+        requiredAccuracy: 0,
+        minHands: 0,
+      ),
+      LearningPathStageModel(
+        id: 's2',
+        title: 'S2',
+        description: '',
+        packId: 'starter_pushfold_15bb',
+        requiredAccuracy: 0,
+        minHands: 0,
+      ),
+    ],
+  );
+
+  late Map<String, double> progress;
+  late LearningPathProgressTracker tracker;
+
+  setUp(() {
+    progress = {'s1': 0.5, 's2': 1.0};
+    tracker = LearningPathProgressTracker(
+      getPath: () async => template,
+      getStageProgress: (id) async => progress[id] ?? 0.0,
+    );
+  });
+
+  test('getStageProgressMap returns stage map', () async {
+    final map = await tracker.getStageProgressMap();
+    expect(map, progress);
+  });
+
+  test('getOverallProgress averages stages', () async {
+    final overall = await tracker.getOverallProgress();
+    expect(overall, closeTo(0.75, 0.0001));
+  });
+
+  test('results are cached for 5 minutes', () async {
+    final first = await tracker.getStageProgressMap();
+    progress['s1'] = 1.0;
+    final second = await tracker.getStageProgressMap();
+    expect(second['s1'], first['s1']);
+  });
+}


### PR DESCRIPTION
## Summary
- add new service `LearningPathProgressTracker`
- compute stage progress and overall progress with caching
- add unit tests for tracker

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6885a9a6ef28832ab51f19c6f461866f