### PR TITLE
Add stage tag heatmap

### DIFF
--- a/lib/screens/learning_path_week_planner_screen.dart
+++ b/lib/screens/learning_path_week_planner_screen.dart
@@ -34,6 +34,7 @@ class _LearningPathWeekPlannerScreenState
   int _remaining = 0;
   final WeeklyPlannerBoosterFeed _boosterFeed = WeeklyPlannerBoosterFeed();
   final ValueNotifier<double> _overallProgress = ValueNotifier<double>(0.0);
+  Map<String, Map<String, double>>? _tagProgress;
 
   @override
   void initState() {
@@ -42,6 +43,7 @@ class _LearningPathWeekPlannerScreenState
     _loadBadge();
     _boosterFeed.refresh();
     _loadOverallProgress();
+    _loadTagProgress();
   }
 
   Future<void> _load() async {
@@ -100,6 +102,13 @@ class _LearningPathWeekPlannerScreenState
     if (mounted) _overallProgress.value = value;
   }
 
+  Future<void> _loadTagProgress() async {
+    final tracker = LearningPathProgressTracker();
+    final map = await tracker.getTagProgressPerStage();
+    if (!mounted) return;
+    setState(() => _tagProgress = map);
+  }
+
   Future<void> _open(LearningPathStageModel stage) async {
     final path = _path;
     if (path == null) return;
@@ -112,6 +121,7 @@ class _LearningPathWeekPlannerScreenState
     await _load();
     await _loadBadge();
     await _loadOverallProgress();
+    await _loadTagProgress();
   }
 
   Future<void> _openBooster(String packId) async {
@@ -210,6 +220,7 @@ class _LearningPathWeekPlannerScreenState
                           progress: info.progress,
                           pack: info.pack,
                           theoryPack: info.theoryPack,
+                          tagProgress: _tagProgress?[info.stage.id],
                           onTap: () => _open(info.stage),
                         ),
                         ValueListenableBuilder<Map<String, List<BoosterSuggestion>>>(

--- a/lib/widgets/learning_path_stage_progress_card.dart
+++ b/lib/widgets/learning_path_stage_progress_card.dart
@@ -5,6 +5,7 @@ import '../models/theory_pack_model.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
 import 'tag_badge.dart';
+import 'tag_progress_chip.dart';
 
 /// Compact card showing progress for a single learning path stage.
 class LearningPathStageProgressCard extends StatelessWidget {
@@ -26,6 +27,9 @@ class LearningPathStageProgressCard extends StatelessWidget {
   /// Whether to use a compact layout with max height of 140.
   final bool compact;
 
+  /// Per-tag progress values for this stage.
+  final Map<String, double>? tagProgress;
+
   const LearningPathStageProgressCard({
     super.key,
     required this.stage,
@@ -34,6 +38,7 @@ class LearningPathStageProgressCard extends StatelessWidget {
     this.theoryPack,
     this.onTap,
     this.compact = false,
+    this.tagProgress,
   });
 
   String _infoLabel() {
@@ -101,7 +106,19 @@ class LearningPathStageProgressCard extends StatelessWidget {
                 ),
               ],
             ),
-            if (stage.tags.isNotEmpty)
+            if (tagProgress != null && tagProgress!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Wrap(
+                  spacing: 4,
+                  runSpacing: -4,
+                  children: [
+                    for (final e in tagProgress!.entries.take(6))
+                      TagProgressChip(tag: e.key, progress: e.value),
+                  ],
+                ),
+              )
+            else if (stage.tags.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.only(top: 6),
                 child: Wrap(

--- a/lib/widgets/tag_progress_chip.dart
+++ b/lib/widgets/tag_progress_chip.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../screens/tag_insight_screen.dart';
+
+/// Chip displaying tag progress as a colored pill.
+class TagProgressChip extends StatelessWidget {
+  final String tag;
+  final double progress; // 0.0 - 1.0
+  final VoidCallback? onTap;
+
+  const TagProgressChip({
+    super.key,
+    required this.tag,
+    required this.progress,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final value = progress.clamp(0.0, 1.0);
+    final color = Color.lerp(Colors.red, Colors.green, value) ?? Colors.red;
+    final pct = (value * 100).round();
+    return GestureDetector(
+      onTap: onTap ??
+          () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => TagInsightScreen(tag: tag)),
+              ),
+      child: Chip(
+        label: Text(
+          '$tag $pct%',
+          style: const TextStyle(color: Colors.white, fontSize: 11),
+        ),
+        backgroundColor: color,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show mastery color-coded `TagProgressChip`
- preload per-stage tag progress and pass into stage cards
- update weekly planner progress card to show a tag heatmap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886017b8df8832a98015168803f61ea