### PR TITLE
Add GameModeProfileEngine

### DIFF
--- a/lib/services/game_mode_profile_engine.dart
+++ b/lib/services/game_mode_profile_engine.dart
@@ -1,0 +1,46 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Available learning track profiles for players.
+enum GameModeProfile { cashOnline, cashLive, mttOnline, mttLive }
+
+/// Provides access to the current [GameModeProfile] and persists it across app launches.
+class GameModeProfileEngine {
+  GameModeProfileEngine._();
+
+  static final GameModeProfileEngine instance = GameModeProfileEngine._();
+
+  static const _prefsKey = 'active_game_mode_profile';
+
+  GameModeProfile _active = GameModeProfile.cashOnline;
+  bool _loaded = false;
+
+  /// Loads the active profile from persistent storage.
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final idx = prefs.getInt(_prefsKey);
+    if (idx != null && idx >= 0 && idx < GameModeProfile.values.length) {
+      _active = GameModeProfile.values[idx];
+    }
+    _loaded = true;
+  }
+
+  /// Returns the current active profile.
+  GameModeProfile getActiveProfile() {
+    if (!_loaded) {
+      throw StateError('GameModeProfileEngine not loaded');
+    }
+    return _active;
+  }
+
+  /// Sets [profile] as the active profile and persists it.
+  Future<void> setActiveProfile(GameModeProfile profile) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_prefsKey, profile.index);
+    _active = profile;
+  }
+
+  /// Returns all profiles currently available to the user.
+  List<GameModeProfile> getAvailableProfiles() =>
+      List.unmodifiable(GameModeProfile.values);
+}
+

--- a/test/game_mode_profile_engine_test.dart
+++ b/test/game_mode_profile_engine_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/game_mode_profile_engine.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('defaults to cashOnline when no value stored', () async {
+    SharedPreferences.setMockInitialValues({});
+    await GameModeProfileEngine.instance.load();
+    expect(GameModeProfileEngine.instance.getActiveProfile(),
+        GameModeProfile.cashOnline);
+  });
+
+  test('setActiveProfile stores and returns value', () async {
+    SharedPreferences.setMockInitialValues({});
+    await GameModeProfileEngine.instance.load();
+    await GameModeProfileEngine.instance
+        .setActiveProfile(GameModeProfile.mttLive);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getInt('active_game_mode_profile'),
+        GameModeProfile.mttLive.index);
+    expect(GameModeProfileEngine.instance.getActiveProfile(),
+        GameModeProfile.mttLive);
+  });
+}


### PR DESCRIPTION
## Summary
- implement a new service `GameModeProfileEngine`
- allow persisting and switching between cash and MTT profiles
- add unit tests

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68861d4319fc832abc1a20b8501f6845