### PR TITLE
Add LearningBranchNode model

### DIFF
--- a/lib/models/learning_branch_node.dart
+++ b/lib/models/learning_branch_node.dart
@@ -1,0 +1,49 @@
+import 'learning_path_node.dart';
+
+/// A branching decision in a learning path.
+class LearningBranchNode implements LearningPathNode {
+  @override
+  final String id;
+
+  /// Question shown to the user when choosing a branch.
+  final String prompt;
+
+  /// Maps branch labels to target node ids.
+  final Map<String, String> branches;
+
+  const LearningBranchNode({
+    required this.id,
+    required this.prompt,
+    Map<String, String>? branches,
+  }) : branches = branches ?? const {};
+
+  /// Returns the target node id for [choice] or `null` if not found.
+  String? targetFor(String choice) => branches[choice];
+
+  factory LearningBranchNode.fromJson(Map<String, dynamic> json) {
+    final map = <String, String>{};
+    final rawBranches = json['branches'];
+    if (rawBranches is Map) {
+      rawBranches.forEach((k, v) {
+        map[k.toString()] = v.toString();
+      });
+    }
+    return LearningBranchNode(
+      id: json['id']?.toString() ?? '',
+      prompt: json['prompt']?.toString() ?? '',
+      branches: map,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'prompt': prompt,
+        if (branches.isNotEmpty) 'branches': branches,
+      };
+
+  factory LearningBranchNode.fromYaml(Map yaml) {
+    final map = <String, dynamic>{};
+    yaml.forEach((k, v) => map[k.toString()] = v);
+    return LearningBranchNode.fromJson(map);
+  }
+}

--- a/lib/models/learning_path_node.dart
+++ b/lib/models/learning_path_node.dart
@@ -1,0 +1,4 @@
+/// Base class for nodes in a learning path graph.
+abstract class LearningPathNode {
+  String get id;
+}

--- a/test/models/learning_branch_node_test.dart
+++ b/test/models/learning_branch_node_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_branch_node.dart';
+import 'package:poker_analyzer/models/learning_path_node.dart';
+
+void main() {
+  test('targetFor returns mapped node id', () {
+    const node = LearningBranchNode(
+      id: 'b1',
+      prompt: 'Choose',
+      branches: {'Cash': 'cash_intro', 'MTT': 'mtt_intro'},
+    );
+    expect(node.targetFor('Cash'), 'cash_intro');
+    expect(node.targetFor('MTT'), 'mtt_intro');
+    expect(node.targetFor('Other'), isNull);
+  });
+
+  test('fromJson parses branches', () {
+    final json = {
+      'id': 'b2',
+      'prompt': 'Format?',
+      'branches': {'A': 'n1', 'B': 'n2'}
+    };
+    final node = LearningBranchNode.fromJson(json);
+    expect(node.id, 'b2');
+    expect(node.prompt, 'Format?');
+    expect(node.branches['A'], 'n1');
+    expect(node.branches['B'], 'n2');
+  });
+
+  test('toJson outputs branches', () {
+    const node = LearningBranchNode(
+      id: 'b3',
+      prompt: 'Example',
+      branches: {'X': 'x1'},
+    );
+    final map = node.toJson();
+    expect(map['id'], 'b3');
+    expect(map['prompt'], 'Example');
+    expect((map['branches'] as Map)['X'], 'x1');
+  });
+
+  test('fromYaml matches toJson round-trip', () {
+    const yamlMap = {
+      'id': 'b4',
+      'prompt': 'Way?',
+      'branches': {'Live': 'nLive', 'Online': 'nOnline'}
+    };
+    final node = LearningBranchNode.fromYaml(yamlMap);
+    expect(node.toJson(), yamlMap);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathNode` base class
- implement `LearningBranchNode` for branching decisions
- cover new class with unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/models/learning_branch_node_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688625b0d274832a8091a4a98a32d9e9