### PR TITLE
Implement GraphPathTemplateParser

### DIFF
--- a/lib/services/graph_path_template_parser.dart
+++ b/lib/services/graph_path_template_parser.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:yaml/yaml.dart';
+
+import '../models/learning_branch_node.dart';
+import '../models/learning_path_node.dart';
+import '../models/stage_type.dart';
+import 'path_map_engine.dart';
+
+class GraphPathTemplateParser {
+  final List<String> warnings = [];
+
+  Future<List<LearningPathNode>> parseFromYaml(String yamlText) async {
+    final doc = loadYaml(yamlText);
+    final map = doc is Map
+        ? Map<String, dynamic>.from(jsonDecode(jsonEncode(doc)))
+        : <String, dynamic>{};
+    final nodesRaw = map['nodes'] as List? ?? [];
+
+    final ids = <String>{};
+    final rawItems = <Map<String, dynamic>>[];
+    for (final n in nodesRaw) {
+      if (n is Map) {
+        final m = <String, dynamic>{};
+        n.forEach((key, value) => m[key.toString()] = value);
+        final id = m['id']?.toString() ?? '';
+        if (id.isNotEmpty) {
+          ids.add(id);
+        }
+        rawItems.add(m);
+      }
+    }
+
+    final nodes = <LearningPathNode>[];
+    final byId = <String, LearningPathNode>{};
+
+    for (final m in rawItems) {
+      final type = m['type']?.toString();
+      final id = m['id']?.toString() ?? '';
+      if (type == 'branch') {
+        final branches = <String, String>{};
+        final rawBranches = m['branches'];
+        if (rawBranches is Map) {
+          rawBranches.forEach((k, v) {
+            branches[k.toString()] = v.toString();
+          });
+        }
+        final node = LearningBranchNode(
+          id: id,
+          prompt: m['prompt']?.toString() ?? '',
+          branches: branches,
+        );
+        nodes.add(node);
+        byId[id] = node;
+      } else if (type == 'stage') {
+        final stageId = m['stageId']?.toString() ?? id;
+        final nextIds = <String>[for (final v in (m['next'] as List? ?? [])) v.toString()];
+        final dependsOn = <String>[for (final v in (m['dependsOn'] as List? ?? [])) v.toString()];
+        final stageType = _parseStageType(m['stageType']);
+        final StageNode node = stageType == StageType.theory
+            ? TheoryStageNode(id: stageId, nextIds: nextIds, dependsOn: dependsOn)
+            : TrainingStageNode(id: stageId, nextIds: nextIds, dependsOn: dependsOn);
+        nodes.add(node);
+        byId[id] = node;
+      }
+    }
+
+    for (final node in nodes) {
+      if (node is LearningBranchNode) {
+        for (final target in node.branches.values) {
+          if (!ids.contains(target)) {
+            warnings.add('Unknown node id $target referenced from branch ${node.id}');
+          }
+        }
+      } else if (node is StageNode) {
+        for (final n in node.nextIds) {
+          if (!ids.contains(n)) {
+            warnings.add('Unknown node id $n referenced from nextIds of ${node.id}');
+          }
+        }
+        for (final d in node.dependsOn) {
+          if (!ids.contains(d)) {
+            warnings.add('Unknown node id $d referenced from dependsOn of ${node.id}');
+          }
+        }
+      }
+    }
+
+    if (nodes.isNotEmpty) {
+      final reachable = <String>{};
+      final queue = <String>[nodes.first.id];
+      while (queue.isNotEmpty) {
+        final id = queue.removeAt(0);
+        if (!reachable.add(id)) continue;
+        final node = byId[id];
+        if (node is LearningBranchNode) {
+          queue.addAll(node.branches.values);
+        } else if (node is StageNode) {
+          queue.addAll(node.nextIds);
+        }
+      }
+      for (final id in ids.difference(reachable)) {
+        warnings.add('Unreachable node $id');
+      }
+    }
+
+    if (warnings.isNotEmpty) {
+      // ignore: avoid_print
+      for (final w in warnings) {
+        print('GraphPathTemplateParser: $w');
+      }
+    }
+
+    return nodes;
+  }
+
+  StageType _parseStageType(dynamic value) {
+    final s = value?.toString();
+    switch (s) {
+      case 'theory':
+        return StageType.theory;
+      case 'booster':
+        return StageType.booster;
+    }
+    return StageType.practice;
+  }
+}

--- a/test/graph_path_template_parser_test.dart
+++ b/test/graph_path_template_parser_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/graph_path_template_parser.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+import 'package:poker_analyzer/models/learning_branch_node.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('parseFromYaml builds nodes', () async {
+    const yaml = '''
+nodes:
+  - type: branch
+    id: start
+    prompt: Choose format
+    branches:
+      Cash: cash_intro
+      MTT: mtt_intro
+
+  - type: stage
+    id: cash_intro
+    stageId: cash_welcome
+    next: [mtt_intro]
+
+  - type: stage
+    id: mtt_intro
+    stageId: mtt_welcome
+''';
+    final parser = GraphPathTemplateParser();
+    final nodes = await parser.parseFromYaml(yaml);
+    expect(nodes.length, 3);
+    expect(nodes.first, isA<LearningBranchNode>());
+    final branch = nodes.first as LearningBranchNode;
+    expect(branch.branches['Cash'], 'cash_intro');
+    final stage = nodes[1] as StageNode;
+    expect(stage.nextIds, ['mtt_intro']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `GraphPathTemplateParser` for YAML branch graphs
- include unit test for parsing logic

## Testing
- `dart analyze` *(fails: analysis tried to scan flutter-sdk)*
- `flutter test test/graph_path_template_parser_test.dart --no-pub` *(fails: unable to find asset directory)*

------
https://chatgpt.com/codex/tasks/task_e_688629fa3be8832aaafa24fe4172409d