### PR TITLE
Implement LearningPathGraphOrchestrator

### DIFF
--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -1,0 +1,3 @@
+nodes:
+  - type: stage
+    id: start

--- a/lib/services/learning_path_graph_orchestrator.dart
+++ b/lib/services/learning_path_graph_orchestrator.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/learning_path_node.dart';
+import 'game_mode_profile_engine.dart';
+import 'graph_path_template_parser.dart';
+
+/// Loads a learning path graph for the active [GameModeProfile].
+class LearningPathGraphOrchestrator {
+  final GraphPathTemplateParser parser;
+  final GameModeProfileEngine profiles;
+
+  const LearningPathGraphOrchestrator({
+    GraphPathTemplateParser? parser,
+    GameModeProfileEngine? profiles,
+  })  : parser = parser ?? GraphPathTemplateParser(),
+        profiles = profiles ?? GameModeProfileEngine.instance;
+
+  /// Loads the graph defined for the currently active profile.
+  Future<List<LearningPathNode>> loadGraph() async {
+    final profile = profiles.getActiveProfile();
+    final fileName = _fileNameForProfile(profile);
+    final path = 'assets/paths/' + fileName;
+    String? raw;
+    try {
+      raw = await rootBundle.loadString(path);
+    } catch (_) {
+      final file = File(path);
+      if (file.existsSync()) {
+        raw = await file.readAsString();
+      }
+    }
+    if (raw == null) return [];
+    return parser.parseFromYaml(raw);
+  }
+
+  String _fileNameForProfile(GameModeProfile profile) {
+    switch (profile) {
+      case GameModeProfile.cashOnline:
+        return 'cash_online.yaml';
+      case GameModeProfile.cashLive:
+        return 'cash_live.yaml';
+      case GameModeProfile.mttOnline:
+        return 'mtt_online.yaml';
+      case GameModeProfile.mttLive:
+        return 'mtt_live.yaml';
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -117,6 +117,7 @@ flutter:
     - assets/learning_path_tracks.yaml
     - assets/animations/congrats.json
     - assets/images/
+    - assets/paths/
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo

--- a/test/learning_path_graph_orchestrator_test.dart
+++ b/test/learning_path_graph_orchestrator_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
+import 'package:poker_analyzer/services/game_mode_profile_engine.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadGraph loads file for active profile', () async {
+    SharedPreferences.setMockInitialValues({});
+    await GameModeProfileEngine.instance.load();
+    await GameModeProfileEngine.instance
+        .setActiveProfile(GameModeProfile.cashOnline);
+
+    final orchestrator = LearningPathGraphOrchestrator();
+    final nodes = await orchestrator.loadGraph();
+    expect(nodes, isNotEmpty);
+    expect(nodes.first.id, 'start');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathGraphOrchestrator` to load graph YAMLs for active profile
- register new assets/paths directory
- include example graph `cash_online.yaml`
- add unit test for orchestrator

## Testing
- `flutter test test/learning_path_graph_orchestrator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862d4ea0ec832a98d15b009529978d