### PR TITLE
Implement LearningPathSessionState

### DIFF
--- a/lib/models/learning_path_session_state.dart
+++ b/lib/models/learning_path_session_state.dart
@@ -1,0 +1,51 @@
+/// Stores progress within an adaptive learning path graph.
+class LearningPathSessionState {
+  /// Identifier of the node currently in focus.
+  final String currentNodeId;
+
+  /// Mapping of branch node id to the label chosen by the user.
+  final Map<String, String> branchChoices;
+
+  /// IDs of stages marked as completed in this session.
+  final Set<String> completedStageIds;
+
+  LearningPathSessionState({
+    required this.currentNodeId,
+    Map<String, String>? branchChoices,
+    Set<String>? completedStageIds,
+  })  : branchChoices = branchChoices ?? const {},
+        completedStageIds = completedStageIds ?? const {};
+
+  /// Converts this state to a JSON map for persistence.
+  Map<String, dynamic> toJson() => {
+        'currentNodeId': currentNodeId,
+        if (branchChoices.isNotEmpty) 'branchChoices': branchChoices,
+        if (completedStageIds.isNotEmpty)
+          'completedStageIds': completedStageIds.toList(),
+      };
+
+  /// Restores a [LearningPathSessionState] from [json].
+  factory LearningPathSessionState.fromJson(Map<String, dynamic> json) {
+    final branches = <String, String>{};
+    final rawBranches = json['branchChoices'];
+    if (rawBranches is Map) {
+      rawBranches.forEach((key, value) {
+        branches[key.toString()] = value.toString();
+      });
+    }
+
+    final completed = <String>{};
+    final rawCompleted = json['completedStageIds'];
+    if (rawCompleted is List) {
+      for (final id in rawCompleted) {
+        completed.add(id.toString());
+      }
+    }
+
+    return LearningPathSessionState(
+      currentNodeId: json['currentNodeId']?.toString() ?? '',
+      branchChoices: branches,
+      completedStageIds: completed,
+    );
+  }
+}

--- a/lib/services/learning_graph_engine.dart
+++ b/lib/services/learning_graph_engine.dart
@@ -4,6 +4,7 @@ import 'learning_path_graph_orchestrator.dart';
 import 'path_map_engine.dart';
 import 'training_path_progress_service_v2.dart';
 import '../models/learning_path_node.dart';
+import '../models/learning_path_session_state.dart';
 
 /// Coordinates loading and traversal of the adaptive learning path graph.
 class LearningPathEngine {
@@ -44,4 +45,14 @@ class LearningPathEngine {
 
   /// Returns the next node that should be presented to the user.
   LearningPathNode? getNextNode() => _engine?.getNextNode();
+
+  /// Returns a snapshot of the current session state.
+  LearningPathSessionState? getSessionState() => _engine?.getState();
+
+  /// Restores engine state from [state].
+  Future<void> restoreState(LearningPathSessionState state) async {
+    if (_engine != null) {
+      await _engine!.restoreState(state);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add `LearningPathSessionState` model with JSON helpers
- track branch choices and completed nodes in `PathMapEngine`
- expose save/restore APIs via `LearningPathEngine`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688631a35d78832a96e8bc9914dbd716