### PR TITLE
Add graph template library

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -100,7 +100,7 @@ import '../services/learning_path_template_validator.dart';
 import '../services/learning_path_library_validator.dart';
 import '../services/graph_path_template_validator.dart';
 import '../services/graph_path_template_parser.dart';
-import '../services/graph_path_template_generator.dart';
+import 'graph_template_library_screen.dart';
 import 'booster_preview_screen.dart';
 import 'booster_yaml_previewer_screen.dart';
 import 'booster_variation_editor_screen.dart';
@@ -2358,16 +2358,15 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
     );
   }
 
-  Future<void> _generateSampleGraph() async {
+  Future<void> _openGraphTemplateLibrary() async {
     if (_graphTemplateLoading || !kDebugMode) return;
     setState(() => _graphTemplateLoading = true);
-    const generator = GraphPathTemplateGenerator();
-    final yaml = generator.generateCashVsMttTemplate();
-    await Clipboard.setData(ClipboardData(text: yaml));
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const GraphTemplateLibraryScreen()),
+    );
     if (!mounted) return;
     setState(() => _graphTemplateLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Graph YAML copied')));
   }
 
   Future<void> _reviewYamlPack() async {
@@ -3972,8 +3971,8 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
               ),
             if (kDebugMode)
               ListTile(
-                title: const Text('📈 Generate Sample Graph'),
-                onTap: _graphTemplateLoading ? null : _generateSampleGraph,
+                title: const Text('📈 Graph Templates'),
+                onTap: _graphTemplateLoading ? null : _openGraphTemplateLibrary,
               ),
             if (kDebugMode)
               ListTile(

--- a/lib/screens/graph_template_library_screen.dart
+++ b/lib/screens/graph_template_library_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../services/graph_template_library.dart';
+import '../theme/app_colors.dart';
+import 'yaml_viewer_screen.dart';
+
+/// Displays available graph templates and allows previewing them.
+class GraphTemplateLibraryScreen extends StatelessWidget {
+  const GraphTemplateLibraryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final library = GraphTemplateLibrary.instance;
+    final templates = library.listTemplates();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Graph Templates')),
+      backgroundColor: AppColors.background,
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: templates.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (_, i) {
+          final id = templates[i];
+          return ListTile(
+            title: Text(id),
+            onTap: () {
+              final yaml = library.getTemplate(id);
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => YamlViewerScreen(yamlText: yaml, title: id),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/graph_path_template_generator.dart
+++ b/lib/services/graph_path_template_generator.dart
@@ -77,4 +77,78 @@ class GraphPathTemplateGenerator {
     };
     return const YamlEncoder().convert(map);
   }
+
+  /// Returns a simple ICM introduction graph template.
+  String generateIcmIntroTemplate() {
+    final map = {
+      'nodes': [
+        {
+          'type': 'stage',
+          'id': 'start',
+          'next': ['knowledge']
+        },
+        {
+          'type': 'branch',
+          'id': 'knowledge',
+          'prompt': 'ICM experience',
+          'branches': {
+            'Beginner': 'icm_basics',
+            'Advanced': 'icm_advanced'
+          }
+        },
+        {
+          'type': 'stage',
+          'id': 'icm_basics',
+          'next': ['end']
+        },
+        {
+          'type': 'stage',
+          'id': 'icm_advanced',
+          'next': ['end']
+        },
+        {
+          'type': 'stage',
+          'id': 'end'
+        }
+      ]
+    };
+    return const YamlEncoder().convert(map);
+  }
+
+  /// Returns a simple Heads-Up introduction graph template.
+  String generateHeadsUpIntroTemplate() {
+    final map = {
+      'nodes': [
+        {
+          'type': 'stage',
+          'id': 'start',
+          'next': ['experience']
+        },
+        {
+          'type': 'branch',
+          'id': 'experience',
+          'prompt': 'Heads-Up experience',
+          'branches': {
+            'New': 'hu_basics',
+            'Grinder': 'hu_strategy'
+          }
+        },
+        {
+          'type': 'stage',
+          'id': 'hu_basics',
+          'next': ['end']
+        },
+        {
+          'type': 'stage',
+          'id': 'hu_strategy',
+          'next': ['end']
+        },
+        {
+          'type': 'stage',
+          'id': 'end'
+        }
+      ]
+    };
+    return const YamlEncoder().convert(map);
+  }
 }

--- a/lib/services/graph_template_library.dart
+++ b/lib/services/graph_template_library.dart
@@ -1,0 +1,22 @@
+import 'graph_path_template_generator.dart';
+
+/// Central registry of reusable graph templates.
+class GraphTemplateLibrary {
+  GraphTemplateLibrary._();
+
+  /// Singleton instance.
+  static final GraphTemplateLibrary instance = GraphTemplateLibrary._();
+
+  final Map<String, String> _templates = {
+    'cash_vs_mtt': const GraphPathTemplateGenerator().generateCashVsMttTemplate(),
+    'live_vs_online': const GraphPathTemplateGenerator().generateLiveVsOnlineTemplate(),
+    'icm_intro': const GraphPathTemplateGenerator().generateIcmIntroTemplate(),
+    'heads_up_intro': const GraphPathTemplateGenerator().generateHeadsUpIntroTemplate(),
+  };
+
+  /// IDs of available templates.
+  List<String> listTemplates() => List.unmodifiable(_templates.keys);
+
+  /// Returns YAML template with [id] or empty string if not found.
+  String getTemplate(String id) => _templates[id] ?? '';
+}


### PR DESCRIPTION
## Summary
- implement `GraphTemplateLibrary` with built-in YAML templates
- extend `GraphPathTemplateGenerator` with extra templates
- add `GraphTemplateLibraryScreen` to preview templates
- integrate new screen into the Dev Menu

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688648df3e70832a895f41c5dcbfa5bb