### PR TITLE
Add graph template export

### DIFF
--- a/lib/screens/graph_path_authoring_wizard_screen.dart
+++ b/lib/screens/graph_path_authoring_wizard_screen.dart
@@ -7,6 +7,7 @@ import 'package:yaml/yaml.dart';
 
 import '../core/training/generation/yaml_reader.dart';
 import '../services/graph_template_library.dart';
+import '../services/graph_template_exporter.dart';
 import '../services/graph_path_template_parser.dart';
 import '../models/learning_path_node.dart';
 import '../theme/app_colors.dart';
@@ -251,7 +252,7 @@ class _GraphPathAuthoringWizardScreenState extends State<GraphPathAuthoringWizar
   Future<void> _saveYaml() async {
     final path = await FilePicker.platform.saveFile(
       dialogTitle: 'Save YAML',
-      fileName: '${_templateId ?? 'path'}.yaml',
+      fileName: '\${_templateId ?? 'path'}.yaml',
       type: FileType.custom,
       allowedExtensions: ['yaml'],
     );
@@ -261,6 +262,12 @@ class _GraphPathAuthoringWizardScreenState extends State<GraphPathAuthoringWizar
     if (!mounted) return;
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Saved')));
+  }
+
+  Future<void> _exportTemplate() async {
+    final id = _templateId;
+    if (id == null) return;
+    await const GraphTemplateExporter().exportTemplate(id);
   }
 
   Widget _templateStep() {
@@ -354,6 +361,11 @@ class _GraphPathAuthoringWizardScreenState extends State<GraphPathAuthoringWizar
             ),
             const SizedBox(width: 12),
             ElevatedButton(onPressed: _saveYaml, child: const Text('Save to File')),
+            const SizedBox(width: 12),
+            ElevatedButton(
+              onPressed: _templateId == null ? null : _exportTemplate,
+              child: const Text('💾 Export to file'),
+            ),
           ],
         ),
       ],

--- a/lib/services/graph_template_exporter.dart
+++ b/lib/services/graph_template_exporter.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import 'graph_template_library.dart';
+
+/// Exports graph templates to YAML files.
+class GraphTemplateExporter {
+  const GraphTemplateExporter();
+
+  /// Saves the template with [templateId] as a YAML file chosen by the user.
+  Future<void> exportTemplate(String templateId) async {
+    final yaml = GraphTemplateLibrary.instance.getTemplate(templateId);
+    if (yaml.isEmpty) {
+      final ctx = navigatorKey.currentContext;
+      if (ctx != null) {
+        ScaffoldMessenger.of(ctx).showSnackBar(
+          const SnackBar(content: Text('Template not found')),
+        );
+      }
+      return;
+    }
+
+    final savePath = await FilePicker.platform.saveFile(
+      dialogTitle: 'Export Graph Template',
+      fileName: '$templateId.yaml',
+      type: FileType.custom,
+      allowedExtensions: ['yaml'],
+    );
+    if (savePath == null) return;
+
+    try {
+      await File(savePath).writeAsString(yaml, flush: true);
+      final ctx = navigatorKey.currentContext;
+      if (ctx != null) {
+        final name = savePath.split(Platform.pathSeparator).last;
+        ScaffoldMessenger.of(ctx)
+            .showSnackBar(SnackBar(content: Text('Exported: $name')));
+      }
+    } catch (_) {
+      final ctx = navigatorKey.currentContext;
+      if (ctx != null) {
+        ScaffoldMessenger.of(ctx).showSnackBar(
+          const SnackBar(content: Text('Failed to export template')),
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GraphTemplateExporter` to save templates to YAML
- allow exporting selected template from the authoring wizard

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864e054e18832ab48a6f103d7aa606