### PR TITLE
Add doc note about inline graph editor; fix duplicate test

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ where the complete UI and logic are not required.
   one step with confirmation dialogs.
 - Opponent folds animate their cards sliding down with a fade-out. The hero's
   cards disappear instantly without animation for clarity.
+- Inline graph editor lets admins build learning paths with theory lessons and
+  branching practice stages.
 
 
 ## Converter plug-ins

--- a/test/graph_path_template_parser_test.dart
+++ b/test/graph_path_template_parser_test.dart
@@ -59,27 +59,3 @@ nodes:
     expect(theory.nextIds, ['s1']);
   });
 }
-
-  test('parseFromYaml handles theory nodes', () async {
-    const yaml = '''
-nodes:
-  - type: theory
-    id: t1
-    title: Intro
-    content: Welcome
-    next: [s1]
-  - type: stage
-    id: s1
-  - type: branch
-    id: end
-    branches:
-      A: s1
-''';
-    final parser = GraphPathTemplateParser();
-    final nodes = await parser.parseFromYaml(yaml);
-    expect(nodes.first, isA<TheoryLessonNode>());
-    final theory = nodes.first as TheoryLessonNode;
-    expect(theory.title, 'Intro');
-    expect(theory.nextIds, ['s1']);
-  });
-}


### PR DESCRIPTION
## Summary
- mention inline graph editor with theory lessons in README
- clean up duplicate test in graph path template parser

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886574cc484832a870e97db7353d682