### PR TITLE
Implement TheoryContentService

### DIFF
--- a/assets/theory_blocks/welcome.yaml
+++ b/assets/theory_blocks/welcome.yaml
@@ -1,0 +1,3 @@
+id: welcome
+title: 'Welcome'
+content: 'Welcome to the Poker Analyzer.'

--- a/lib/models/theory_content_block.dart
+++ b/lib/models/theory_content_block.dart
@@ -1,0 +1,25 @@
+class TheoryContentBlock {
+  final String id;
+  final String title;
+  final String content;
+
+  const TheoryContentBlock({
+    required this.id,
+    required this.title,
+    required this.content,
+  });
+
+  factory TheoryContentBlock.fromYaml(Map yaml) {
+    return TheoryContentBlock(
+      id: yaml['id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      content: yaml['content']?.toString() ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'content': content,
+      };
+}

--- a/lib/models/theory_lesson_node.dart
+++ b/lib/models/theory_lesson_node.dart
@@ -5,6 +5,9 @@ class TheoryLessonNode implements LearningPathNode {
   @override
   final String id;
 
+  /// Optional reference id of shared theory content.
+  final String? refId;
+
   /// Display title of the lesson.
   final String title;
 
@@ -16,6 +19,7 @@ class TheoryLessonNode implements LearningPathNode {
 
   const TheoryLessonNode({
     required this.id,
+    this.refId,
     required this.title,
     required this.content,
     List<String>? nextIds,

--- a/lib/screens/learning_path_runner_screen.dart
+++ b/lib/screens/learning_path_runner_screen.dart
@@ -4,6 +4,7 @@ import '../models/learning_branch_node.dart';
 import '../models/theory_lesson_node.dart';
 import '../services/learning_graph_engine.dart';
 import '../services/path_map_engine.dart';
+import '../services/theory_content_service.dart';
 
 /// Simple UI that walks through a learning path graph interactively.
 class LearningPathRunnerScreen extends StatefulWidget {
@@ -81,19 +82,24 @@ class _LearningPathRunnerScreenState extends State<LearningPathRunnerScreen> {
   }
 
   Widget _buildTheory(TheoryLessonNode node) {
+    final block = node.refId == null
+        ? null
+        : TheoryContentService.instance.get(node.refId!);
+    final title = block?.title.isNotEmpty == true ? block!.title : node.title;
+    final content = block?.content.isNotEmpty == true ? block!.content : node.content;
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text(
-            node.title,
+            title,
             style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 16),
           Expanded(
             child: SingleChildScrollView(
-              child: Text(node.content),
+              child: Text(content),
             ),
           ),
           const SizedBox(height: 16),

--- a/lib/services/graph_path_template_parser.dart
+++ b/lib/services/graph_path_template_parser.dart
@@ -67,6 +67,7 @@ class GraphPathTemplateParser {
         final nextIds = <String>[for (final v in (m['next'] as List? ?? [])) v.toString()];
         final node = TheoryLessonNode(
           id: id,
+          refId: m['refId']?.toString(),
           title: m['title']?.toString() ?? '',
           content: m['content']?.toString() ?? '',
           nextIds: nextIds,

--- a/lib/services/graph_template_exporter.dart
+++ b/lib/services/graph_template_exporter.dart
@@ -85,6 +85,7 @@ class GraphTemplateExporter {
       return {
         'type': 'theory',
         'id': node.id,
+        if (node.refId != null) 'refId': node.refId,
         'title': node.title,
         'content': node.content,
         if (node.nextIds.isNotEmpty) 'next': node.nextIds,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -108,6 +108,7 @@ flutter:
     - assets/packs/v2/library_index.json
     - assets/built_in_packs.yaml
     - assets/theory_packs/
+    - assets/theory_blocks/
     - assets/lessons/
     - assets/lesson_tracks/
       - assets/pack_matrix.json

--- a/test/graph_path_template_parser_test.dart
+++ b/test/graph_path_template_parser_test.dart
@@ -41,6 +41,7 @@ nodes:
 nodes:
   - type: theory
     id: t1
+    refId: welcome
     title: Intro
     content: Welcome
     next: [s1]
@@ -55,6 +56,7 @@ nodes:
     final nodes = await parser.parseFromYaml(yaml);
     expect(nodes.first, isA<TheoryLessonNode>());
     final theory = nodes.first as TheoryLessonNode;
+    expect(theory.refId, 'welcome');
     expect(theory.title, 'Intro');
     expect(theory.nextIds, ['s1']);
   });

--- a/test/learning_path_validator_test.dart
+++ b/test/learning_path_validator_test.dart
@@ -33,7 +33,7 @@ void main() {
 
   test('validator handles theory nodes', () {
     const nodes = [
-      TheoryLessonNode(id: 't1', title: 'T', content: 'C', nextIds: ['end']),
+      TheoryLessonNode(id: 't1', refId: 'welcome', title: 'T', content: 'C', nextIds: ['end']),
       TrainingStageNode(id: 'end'),
     ];
     final errors = LearningPathValidator.validate(nodes);


### PR DESCRIPTION
## Summary
- add reusable theory content blocks
- load blocks via new `TheoryContentService`
- reference optional theory content via `refId`
- export/import `refId` in graph templates
- display resolved theory block content in the runner screen
- update tests

## Testing
- `flutter test test/graph_path_template_parser_test.dart test/learning_path_validator_test.dart -r expanded` *(fails: `bash: command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68865ae53998832a9c5c8f3358160a84