### PR TITLE
Implement localized theory content fallback

### DIFF
--- a/assets/theory_blocks/welcome_ru.yaml
+++ b/assets/theory_blocks/welcome_ru.yaml
@@ -1,0 +1,3 @@
+id: welcome
+title: 'Добро пожаловать'
+content: 'Добро пожаловать в Poker Analyzer.'

--- a/test/services/theory_content_service_test.dart
+++ b/test/services/theory_content_service_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_content_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await TheoryContentService.instance.reload();
+  });
+
+  test('loads default block when no locale override', () async {
+    final block = TheoryContentService.instance.get('welcome', locale: 'en');
+    expect(block, isNotNull);
+    expect(block!.title, 'Welcome');
+  });
+
+  test('loads localized block when available', () async {
+    final block = TheoryContentService.instance.get('welcome', locale: 'ru');
+    expect(block, isNotNull);
+    expect(block!.title, 'Добро пожаловать');
+  });
+}


### PR DESCRIPTION
## Summary
- allow language-specific overrides for theory blocks via `get(id, {locale})`
- load and index localized blocks by filename in `TheoryContentService`
- add Russian sample theory block
- unit tests for default vs localized block loading

## Testing
- `flutter test test/services/theory_content_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a0996410832a8a6016c5caad96f5