### PR TITLE
Add TheoryTrack engine and runner

### DIFF
--- a/assets/theory_tracks/pushfold_basics.yaml
+++ b/assets/theory_tracks/pushfold_basics.yaml
@@ -1,0 +1,7 @@
+id: pushfold_basics
+title: Push/Fold Essentials
+blocks:
+  - welcome
+  - position_basics
+  - stack_depths
+  - range_examples

--- a/lib/models/theory_track.dart
+++ b/lib/models/theory_track.dart
@@ -1,0 +1,26 @@
+class TheoryTrack {
+  final String id;
+  final String title;
+  final List<String> blockIds;
+
+  const TheoryTrack({
+    required this.id,
+    required this.title,
+    required this.blockIds,
+  });
+
+  factory TheoryTrack.fromYaml(Map yaml) {
+    final list = yaml['blocks'];
+    final blocks = <String>[];
+    if (list is List) {
+      for (final v in list) {
+        blocks.add(v.toString());
+      }
+    }
+    return TheoryTrack(
+      id: yaml['id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      blockIds: blocks,
+    );
+  }
+}

--- a/lib/screens/theory_track_runner_screen.dart
+++ b/lib/screens/theory_track_runner_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_track.dart';
+import '../services/theory_content_service.dart';
+
+/// Simple UI to present theory blocks sequentially from a [TheoryTrack].
+class TheoryTrackRunnerScreen extends StatefulWidget {
+  final TheoryTrack track;
+  const TheoryTrackRunnerScreen({super.key, required this.track});
+
+  @override
+  State<TheoryTrackRunnerScreen> createState() => _TheoryTrackRunnerScreenState();
+}
+
+class _TheoryTrackRunnerScreenState extends State<TheoryTrackRunnerScreen> {
+  int _index = 0;
+
+  void _next() {
+    if (_index < widget.track.blockIds.length - 1) {
+      setState(() => _index++);
+    } else {
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final blockId = widget.track.blockIds[_index];
+    final block = TheoryContentService.instance.get(blockId);
+    final title = block?.title.isNotEmpty == true ? block!.title : blockId;
+    final content = block?.content ?? '';
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.track.title)),
+      backgroundColor: const Color(0xFF121212),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: SingleChildScrollView(child: Text(content)),
+            ),
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: _next,
+                child: Text(
+                  _index < widget.track.blockIds.length - 1
+                      ? 'Продолжить'
+                      : 'Завершить',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/theory_track_engine.dart
+++ b/lib/services/theory_track_engine.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/theory_track.dart';
+
+/// Loads and manages linear theory lesson tracks from YAML files.
+class TheoryTrackEngine {
+  TheoryTrackEngine._();
+  static final TheoryTrackEngine instance = TheoryTrackEngine._();
+
+  static const String _dir = 'assets/theory_tracks/';
+
+  final List<TheoryTrack> _tracks = [];
+  final Map<String, TheoryTrack> _index = {};
+
+  /// Returns all loaded tracks.
+  List<TheoryTrack> getAll() => List.unmodifiable(_tracks);
+
+  /// Returns a track by [id] if loaded.
+  TheoryTrack? get(String id) => _index[id];
+
+  /// Loads all tracks from assets if not already loaded.
+  Future<void> loadAll() async {
+    if (_tracks.isNotEmpty) return;
+    await reload();
+  }
+
+  /// Reloads tracks from assets.
+  Future<void> reload() async {
+    _tracks.clear();
+    _index.clear();
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        final track = TheoryTrack.fromYaml(Map<String, dynamic>.from(map));
+        if (track.id.isEmpty) continue;
+        _tracks.add(track);
+        _index[track.id] = track;
+      } catch (_) {}
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,6 +109,7 @@ flutter:
     - assets/built_in_packs.yaml
     - assets/theory_packs/
     - assets/theory_blocks/
+    - assets/theory_tracks/
     - assets/lessons/
     - assets/lesson_tracks/
       - assets/pack_matrix.json


### PR DESCRIPTION
## Summary
- implement `TheoryTrack` model for sequencing theory blocks
- add `TheoryTrackEngine` to load YAML theory tracks
- create a simple `TheoryTrackRunnerScreen` for sequential display
- include sample `pushfold_basics` track and register assets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a208f84c832a83d0f09b47002d16