### PR TITLE
Add include_track directive support

### DIFF
--- a/test/graph_path_template_parser_test.dart
+++ b/test/graph_path_template_parser_test.dart
@@ -60,4 +60,18 @@ nodes:
     expect(theory.title, 'Intro');
     expect(theory.nextIds, ['s1']);
   });
+
+  test('parseFromYaml expands include_track directive', () async {
+    const yaml = '''
+nodes:
+  - include_track: pushfold_basics
+''';
+    final parser = GraphPathTemplateParser();
+    final nodes = await parser.parseFromYaml(yaml);
+    expect(nodes.length, 4);
+    expect(nodes.first, isA<TheoryLessonNode>());
+    final first = nodes.first as TheoryLessonNode;
+    expect(first.id.isNotEmpty, isTrue);
+    expect(first.nextIds, isNotEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- support `include_track` in `GraphPathTemplateParser`
- expand YAML track references into sequenced `TheoryLessonNode`s
- test include_track parsing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a3a99b44832a8ccda6598b6f027d