### PR TITLE
Add refId fallback in theory lessons

### DIFF
--- a/lib/models/theory_lesson_node.dart
+++ b/lib/models/theory_lesson_node.dart
@@ -1,4 +1,5 @@
 import 'learning_path_node.dart';
+import '../services/theory_content_service.dart';
 
 /// Node representing an inline theory lesson within the learning path graph.
 class TheoryLessonNode implements LearningPathNode {
@@ -24,4 +25,20 @@ class TheoryLessonNode implements LearningPathNode {
     required this.content,
     List<String>? nextIds,
   }) : nextIds = nextIds ?? const [];
+
+  /// Returns [title] or the referenced block's title when empty.
+  String get resolvedTitle {
+    if (title.isNotEmpty) return title;
+    if (refId == null) return title;
+    final block = TheoryContentService.instance.get(refId!);
+    return block?.title ?? title;
+  }
+
+  /// Returns [content] or the referenced block's content when empty.
+  String get resolvedContent {
+    if (content.isNotEmpty) return content;
+    if (refId == null) return content;
+    final block = TheoryContentService.instance.get(refId!);
+    return block?.content ?? content;
+  }
 }

--- a/lib/screens/learning_path_runner_screen.dart
+++ b/lib/screens/learning_path_runner_screen.dart
@@ -82,11 +82,8 @@ class _LearningPathRunnerScreenState extends State<LearningPathRunnerScreen> {
   }
 
   Widget _buildTheory(TheoryLessonNode node) {
-    final block = node.refId == null
-        ? null
-        : TheoryContentService.instance.get(node.refId!);
-    final title = block?.title.isNotEmpty == true ? block!.title : node.title;
-    final content = block?.content.isNotEmpty == true ? block!.content : node.content;
+    final title = node.resolvedTitle;
+    final content = node.resolvedContent;
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(

--- a/test/theory_lesson_node_fallback_test.dart
+++ b/test/theory_lesson_node_fallback_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_content_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await TheoryContentService.instance.reload();
+  });
+
+  test('fallback uses shared block when title or content empty', () {
+    const node = TheoryLessonNode(id: 't1', refId: 'welcome', title: '', content: '');
+    expect(node.resolvedTitle, 'Welcome');
+    expect(node.resolvedContent, 'Welcome to the Poker Analyzer.');
+  });
+}


### PR DESCRIPTION
## Summary
- add fallback methods to `TheoryLessonNode`
- simplify theory screen rendering using new accessors
- test fallback behaviour when title and content are empty

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a7fda828832ab3687e47d6a41b19