### PR TITLE
Implement LearningPathNodeHistory

### DIFF
--- a/lib/models/node_visit.dart
+++ b/lib/models/node_visit.dart
@@ -1,0 +1,30 @@
+class NodeVisit {
+  final String nodeId;
+  final DateTime firstSeen;
+  final DateTime? completedAt;
+
+  const NodeVisit({
+    required this.nodeId,
+    required this.firstSeen,
+    this.completedAt,
+  });
+
+  NodeVisit copyWith({DateTime? completedAt}) => NodeVisit(
+        nodeId: nodeId,
+        firstSeen: firstSeen,
+        completedAt: completedAt ?? this.completedAt,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'nodeId': nodeId,
+        'firstSeen': firstSeen.toIso8601String(),
+        if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
+      };
+
+  factory NodeVisit.fromJson(Map<String, dynamic> json) => NodeVisit(
+        nodeId: json['nodeId']?.toString() ?? '',
+        firstSeen: DateTime.tryParse(json['firstSeen']?.toString() ?? '') ??
+            DateTime.now(),
+        completedAt: DateTime.tryParse(json['completedAt']?.toString() ?? ''),
+      );
+}

--- a/lib/services/learning_path_node_history.dart
+++ b/lib/services/learning_path_node_history.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/node_visit.dart';
+
+class LearningPathNodeHistory {
+  LearningPathNodeHistory._();
+
+  static final instance = LearningPathNodeHistory._();
+
+  static const _prefsKey = 'learning_path_node_history';
+
+  final Map<String, NodeVisit> _visits = {};
+  bool _loaded = false;
+
+  Future<void> load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          for (final entry in data.entries) {
+            final m = entry.value;
+            if (m is Map) {
+              _visits[entry.key.toString()] =
+                  NodeVisit.fromJson(Map<String, dynamic>.from(m));
+            }
+          }
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final map = {for (final e in _visits.entries) e.key: e.value.toJson()};
+    await prefs.setString(_prefsKey, jsonEncode(map));
+  }
+
+  Future<void> markVisited(String nodeId) async {
+    await load();
+    _visits.putIfAbsent(
+      nodeId,
+      () => NodeVisit(nodeId: nodeId, firstSeen: DateTime.now()),
+    );
+    await _save();
+  }
+
+  Future<void> markCompleted(String nodeId) async {
+    await load();
+    final now = DateTime.now();
+    final visit = _visits[nodeId];
+    if (visit == null) {
+      _visits[nodeId] =
+          NodeVisit(nodeId: nodeId, firstSeen: now, completedAt: now);
+    } else if (visit.completedAt == null) {
+      _visits[nodeId] = visit.copyWith(completedAt: now);
+    }
+    await _save();
+  }
+
+  bool isCompleted(String nodeId) {
+    return _visits[nodeId]?.completedAt != null;
+  }
+
+  DateTime? lastVisit(String nodeId) {
+    final v = _visits[nodeId];
+    return v == null ? null : v.completedAt ?? v.firstSeen;
+  }
+
+  Future<void> clear() async {
+    _visits.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+  }
+}


### PR DESCRIPTION
## Summary
- add `NodeVisit` model for node tracking
- add `LearningPathNodeHistory` service for visit/completion persistence

## Testing
- `flutter test` *(fails: Dart SDK version 3.1.5 does not satisfy ">=3.6.0 <4.0.0" requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6886a914a9ec832ab44f17b266b37e27