### PR TITLE
Render theory content with markdown

### DIFF
--- a/lib/screens/learning_path_runner_screen.dart
+++ b/lib/screens/learning_path_runner_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../models/learning_branch_node.dart';
 import '../models/theory_lesson_node.dart';
@@ -95,8 +96,9 @@ class _LearningPathRunnerScreenState extends State<LearningPathRunnerScreen> {
           ),
           const SizedBox(height: 16),
           Expanded(
-            child: SingleChildScrollView(
-              child: Text(content),
+            child: Markdown(
+              data: content,
+              styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)),
             ),
           ),
           const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- improve theory view by rendering markdown content in `LearningPathRunnerScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886b12f2598832a8c99593bd541df71