### PR TITLE
Add TheoryMiniLessonNode with injection

### DIFF
--- a/assets/mini_lessons/bubble_fold.yaml
+++ b/assets/mini_lessons/bubble_fold.yaml
@@ -1,0 +1,6 @@
+id: bubble_fold
+title: 'Bubble Folds'
+content: 'Fold marginal hands near the money.'
+tags:
+  - bubble_fold
+type: mini

--- a/assets/mini_lessons/iso_vs_limp.yaml
+++ b/assets/mini_lessons/iso_vs_limp.yaml
@@ -1,0 +1,6 @@
+id: iso_vs_limp
+title: 'Isolate Limpers'
+content: 'Raise bigger to isolate limpers.'
+tags:
+  - iso_vs_limp
+type: mini

--- a/lib/models/theory_mini_lesson_node.dart
+++ b/lib/models/theory_mini_lesson_node.dart
@@ -1,0 +1,68 @@
+import 'learning_path_node.dart';
+import '../services/theory_content_service.dart';
+
+/// Node representing a short theory mini lesson within the learning path graph.
+class TheoryMiniLessonNode implements LearningPathNode {
+  @override
+  final String id;
+
+  /// Optional reference id of shared theory content.
+  final String? refId;
+
+  /// Display title of the lesson.
+  final String title;
+
+  /// Markdown or plain text content of the lesson.
+  final String content;
+
+  /// Tags associated with this mini lesson.
+  final List<String> tags;
+
+  /// IDs of nodes unlocked after reading this lesson.
+  final List<String> nextIds;
+
+  const TheoryMiniLessonNode({
+    required this.id,
+    this.refId,
+    required this.title,
+    required this.content,
+    List<String>? tags,
+    List<String>? nextIds,
+  })  : tags = tags ?? const [],
+        nextIds = nextIds ?? const [];
+
+  /// Returns [title] or the referenced block's title when empty.
+  String get resolvedTitle {
+    if (title.isNotEmpty) return title;
+    if (refId == null) return title;
+    final block = TheoryContentService.instance.get(refId!);
+    return block?.title ?? title;
+  }
+
+  /// Returns [content] or the referenced block's content when empty.
+  String get resolvedContent {
+    if (content.isNotEmpty) return content;
+    if (refId == null) return content;
+    final block = TheoryContentService.instance.get(refId!);
+    return block?.content ?? content;
+  }
+
+  factory TheoryMiniLessonNode.fromYaml(Map yaml) {
+    final tags = <String>[];
+    final rawTags = yaml['tags'];
+    if (rawTags is List) {
+      for (final t in rawTags) {
+        tags.add(t.toString());
+      }
+    }
+    final nextIds = <String>[for (final v in (yaml['next'] as List? ?? [])) v.toString()];
+    return TheoryMiniLessonNode(
+      id: yaml['id']?.toString() ?? '',
+      refId: yaml['refId']?.toString(),
+      title: yaml['title']?.toString() ?? '',
+      content: yaml['content']?.toString() ?? '',
+      tags: tags,
+      nextIds: nextIds,
+    );
+  }
+}

--- a/lib/services/graph_path_template_parser.dart
+++ b/lib/services/graph_path_template_parser.dart
@@ -6,6 +6,7 @@ import '../models/learning_branch_node.dart';
 import '../models/learning_path_node.dart';
 import '../models/stage_type.dart';
 import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
 import 'path_map_engine.dart';
 import 'theory_track_engine.dart';
 
@@ -106,6 +107,19 @@ class GraphPathTemplateParser {
         );
         nodes.add(node);
         byId[id] = node;
+      } else if (type == 'mini') {
+        final nextIds = <String>[for (final v in (m['next'] as List? ?? [])) v.toString()];
+        final tags = <String>[for (final t in (m['tags'] as List? ?? [])) t.toString()];
+        final node = TheoryMiniLessonNode(
+          id: id,
+          refId: m['refId']?.toString(),
+          title: m['title']?.toString() ?? '',
+          content: m['content']?.toString() ?? '',
+          tags: tags,
+          nextIds: nextIds,
+        );
+        nodes.add(node);
+        byId[id] = node;
       }
     }
 
@@ -116,8 +130,14 @@ class GraphPathTemplateParser {
             warnings.add('Unknown node id $target referenced from branch ${node.id}');
           }
         }
-      } else if (node is StageNode || node is TheoryLessonNode) {
-        final nextIds = (node is StageNode) ? node.nextIds : (node as TheoryLessonNode).nextIds;
+      } else if (node is StageNode ||
+          node is TheoryLessonNode ||
+          node is TheoryMiniLessonNode) {
+        final nextIds = node is StageNode
+            ? node.nextIds
+            : (node is TheoryLessonNode
+                ? node.nextIds
+                : (node as TheoryMiniLessonNode).nextIds);
         if (node is StageNode) {
           for (final d in node.dependsOn) {
             if (!ids.contains(d)) {
@@ -145,6 +165,8 @@ class GraphPathTemplateParser {
         } else if (node is StageNode) {
           queue.addAll(node.nextIds);
         } else if (node is TheoryLessonNode) {
+          queue.addAll(node.nextIds);
+        } else if (node is TheoryMiniLessonNode) {
           queue.addAll(node.nextIds);
         }
       }

--- a/lib/services/mini_lesson_booster_engine.dart
+++ b/lib/services/mini_lesson_booster_engine.dart
@@ -1,0 +1,190 @@
+import '../models/learning_branch_node.dart';
+import '../models/learning_path_node.dart';
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'learning_graph_engine.dart';
+import 'mini_lesson_library_service.dart';
+import 'path_map_engine.dart';
+
+/// Injects mini lesson nodes into the active learning path graph.
+class MiniLessonBoosterEngine {
+  final LearningPathEngine _engine;
+  final MiniLessonLibraryService _library;
+
+  const MiniLessonBoosterEngine({
+    LearningPathEngine? engine,
+    MiniLessonLibraryService? library,
+  })  : _engine = engine ?? LearningPathEngine.instance,
+        _library = library ?? MiniLessonLibraryService.instance;
+
+  /// Inserts matching mini lessons before [targetNodeId].
+  Future<void> injectBefore(String targetNodeId, List<String> tags) async {
+    final mapEngine = _engine.engine;
+    if (mapEngine == null || tags.isEmpty) return;
+    await _library.loadAll();
+    final lessons = _library.findByTags(tags);
+    if (lessons.isEmpty) return;
+
+    final nodes = mapEngine.allNodes;
+    final byId = {for (final n in nodes) n.id: n};
+    if (!byId.containsKey(targetNodeId)) return;
+
+    final inject = <TheoryMiniLessonNode>[];
+    for (final l in lessons.take(2)) {
+      var id = l.id;
+      if (byId.containsKey(id)) {
+        var i = 1;
+        while (byId.containsKey('$id#$i')) {
+          i++;
+        }
+        id = '$id#$i';
+      }
+      inject.add(TheoryMiniLessonNode(
+        id: id,
+        refId: l.refId,
+        title: l.title,
+        content: l.content,
+        tags: l.tags,
+        nextIds: const [],
+      ));
+      byId[id] = inject.last;
+    }
+    if (inject.isEmpty) return;
+
+    final updated = <LearningPathNode>[];
+    for (final n in nodes) {
+      updated.add(_clone(n));
+    }
+
+    final firstId = inject.first.id;
+
+    for (var i = 0; i < updated.length; i++) {
+      final n = updated[i];
+      if (n is StageNode) {
+        final next = List<String>.from(n.nextIds);
+        var changed = false;
+        for (var j = 0; j < next.length; j++) {
+          if (next[j] == targetNodeId) {
+            next[j] = firstId;
+            changed = true;
+          }
+        }
+        if (changed) {
+          updated[i] = n is TheoryStageNode
+              ? TheoryStageNode(id: n.id, nextIds: next, dependsOn: n.dependsOn)
+              : TrainingStageNode(id: n.id, nextIds: next, dependsOn: n.dependsOn);
+        }
+      } else if (n is TheoryLessonNode) {
+        final next = List<String>.from(n.nextIds);
+        var changed = false;
+        for (var j = 0; j < next.length; j++) {
+          if (next[j] == targetNodeId) {
+            next[j] = firstId;
+            changed = true;
+          }
+        }
+        if (changed) {
+          updated[i] = TheoryLessonNode(
+            id: n.id,
+            refId: n.refId,
+            title: n.title,
+            content: n.content,
+            nextIds: next,
+          );
+        }
+      } else if (n is TheoryMiniLessonNode) {
+        final next = List<String>.from(n.nextIds);
+        var changed = false;
+        for (var j = 0; j < next.length; j++) {
+          if (next[j] == targetNodeId) {
+            next[j] = firstId;
+            changed = true;
+          }
+        }
+        if (changed) {
+          updated[i] = TheoryMiniLessonNode(
+            id: n.id,
+            refId: n.refId,
+            title: n.title,
+            content: n.content,
+            tags: List<String>.from(n.tags),
+            nextIds: next,
+          );
+        }
+      } else if (n is LearningBranchNode) {
+        final branches = Map<String, String>.from(n.branches);
+        var changed = false;
+        n.branches.forEach((label, target) {
+          if (target == targetNodeId) {
+            branches[label] = firstId;
+            changed = true;
+          }
+        });
+        if (changed) {
+          updated[i] = LearningBranchNode(
+            id: n.id,
+            prompt: n.prompt,
+            branches: branches,
+          );
+        }
+      }
+    }
+
+    for (var i = 0; i < inject.length; i++) {
+      final next = (i < inject.length - 1) ? inject[i + 1].id : targetNodeId;
+      inject[i] = TheoryMiniLessonNode(
+        id: inject[i].id,
+        refId: inject[i].refId,
+        title: inject[i].title,
+        content: inject[i].content,
+        tags: inject[i].tags,
+        nextIds: [next],
+      );
+      updated.add(inject[i]);
+    }
+
+    final state = mapEngine.getState();
+    await mapEngine.loadNodes(updated);
+    await mapEngine.restoreState(state);
+  }
+
+  LearningPathNode _clone(LearningPathNode node) {
+    if (node is LearningBranchNode) {
+      return LearningBranchNode(
+        id: node.id,
+        prompt: node.prompt,
+        branches: Map<String, String>.from(node.branches),
+      );
+    } else if (node is TrainingStageNode) {
+      return TrainingStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+      );
+    } else if (node is TheoryStageNode) {
+      return TheoryStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+      );
+    } else if (node is TheoryLessonNode) {
+      return TheoryLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        nextIds: List<String>.from(node.nextIds),
+      );
+    } else if (node is TheoryMiniLessonNode) {
+      return TheoryMiniLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        tags: List<String>.from(node.tags),
+        nextIds: List<String>.from(node.nextIds),
+      );
+    }
+    return node;
+  }
+}

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Loads and indexes mini lesson blocks stored as YAML files.
+class MiniLessonLibraryService {
+  MiniLessonLibraryService._();
+  static final MiniLessonLibraryService instance = MiniLessonLibraryService._();
+
+  static const String _dir = 'assets/mini_lessons/';
+
+  final List<TheoryMiniLessonNode> _lessons = [];
+  final Map<String, TheoryMiniLessonNode> _byId = {};
+  final Map<String, List<TheoryMiniLessonNode>> _byTag = {};
+
+  List<TheoryMiniLessonNode> get all => List.unmodifiable(_lessons);
+
+  TheoryMiniLessonNode? getById(String id) => _byId[id];
+
+  Future<void> loadAll() async {
+    if (_lessons.isNotEmpty) return;
+    await reload();
+  }
+
+  Future<void> reload() async {
+    _lessons.clear();
+    _byId.clear();
+    _byTag.clear();
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        final node = TheoryMiniLessonNode.fromYaml(
+          Map<String, dynamic>.from(map),
+        );
+        if (node.id.isEmpty) continue;
+        _lessons.add(node);
+        _byId[node.id] = node;
+        for (final t in node.tags) {
+          final list = _byTag.putIfAbsent(t, () => []);
+          list.add(node);
+        }
+      } catch (_) {}
+    }
+  }
+
+  /// Returns lessons matching any of [tags], in insertion order.
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final seen = <String>{};
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      final list = _byTag[t] ?? const [];
+      for (final n in list) {
+        if (seen.add(n.id)) result.add(n);
+      }
+    }
+    return result;
+  }
+}

--- a/lib/services/path_map_engine.dart
+++ b/lib/services/path_map_engine.dart
@@ -5,6 +5,7 @@ import '../models/learning_path_node.dart';
 import '../models/stage_type.dart';
 import '../models/learning_path_session_state.dart';
 import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
 import 'learning_path_registry_service.dart';
 import 'training_path_progress_service_v2.dart';
 
@@ -165,6 +166,13 @@ class PathMapEngine {
           return next;
         }
       }
+    } else if (node is TheoryMiniLessonNode) {
+      for (final id in node.nextIds) {
+        final next = _nodes[id];
+        if (next != null && _isUnlocked(next) && !_isCompleted(next)) {
+          return next;
+        }
+      }
     }
     return null;
   }
@@ -192,7 +200,7 @@ class PathMapEngine {
   }
 
   bool _isCompleted(LearningPathNode node) {
-    if (node is StageNode || node is TheoryLessonNode) {
+    if (node is StageNode || node is TheoryLessonNode || node is TheoryMiniLessonNode) {
       return _completed.contains(node.id);
     }
     return false;
@@ -209,7 +217,7 @@ class PathMapEngine {
   Future<void> _advancePastCompleted() async {
     while (true) {
       final node = getCurrentNode();
-      if (node is! StageNode && node is! TheoryLessonNode) break;
+      if (node is! StageNode && node is! TheoryLessonNode && node is! TheoryMiniLessonNode) break;
       if (!_isCompleted(node)) break;
       await _advanceToNext();
       if (_currentId == null) break;
@@ -227,6 +235,14 @@ class PathMapEngine {
         }
       }
     } else if (current is TheoryLessonNode) {
+      for (final id in current.nextIds) {
+        final next = _nodes[id];
+        if (next != null && _isUnlocked(next)) {
+          _currentId = id;
+          return;
+        }
+      }
+    } else if (current is TheoryMiniLessonNode) {
       for (final id in current.nextIds) {
         final next = _nodes[id];
         if (next != null && _isUnlocked(next)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -110,6 +110,7 @@ flutter:
     - assets/theory_packs/
     - assets/theory_blocks/
     - assets/theory_tracks/
+    - assets/mini_lessons/
     - assets/lessons/
     - assets/lesson_tracks/
       - assets/pack_matrix.json

--- a/test/graph_path_template_parser_test.dart
+++ b/test/graph_path_template_parser_test.dart
@@ -3,6 +3,7 @@ import 'package:poker_analyzer/services/graph_path_template_parser.dart';
 import 'package:poker_analyzer/services/path_map_engine.dart';
 import 'package:poker_analyzer/models/learning_branch_node.dart';
 import 'package:poker_analyzer/models/theory_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -59,6 +60,26 @@ nodes:
     expect(theory.refId, 'welcome');
     expect(theory.title, 'Intro');
     expect(theory.nextIds, ['s1']);
+  });
+
+  test('parseFromYaml handles mini lesson nodes', () async {
+    const yaml = '''
+nodes:
+  - type: mini
+    id: m1
+    title: Mini
+    content: Tip
+    tags: [bubble]
+    next: [s1]
+  - type: stage
+    id: s1
+''';
+    final parser = GraphPathTemplateParser();
+    final nodes = await parser.parseFromYaml(yaml);
+    expect(nodes.first, isA<TheoryMiniLessonNode>());
+    final mini = nodes.first as TheoryMiniLessonNode;
+    expect(mini.tags, ['bubble']);
+    expect(mini.nextIds, ['s1']);
   });
 
   test('parseFromYaml expands include_track directive', () async {

--- a/test/mini_lesson_booster_engine_test.dart
+++ b/test/mini_lesson_booster_engine_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mini_lesson_booster_engine.dart';
+import 'package:poker_analyzer/services/learning_graph_engine.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+import 'package:poker_analyzer/models/learning_path_node.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_lesson_node.dart';
+import 'package:poker_analyzer/models/learning_branch_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeOrchestrator extends LearningPathGraphOrchestrator {
+  final List<LearningPathNode> nodes;
+  _FakeOrchestrator(this.nodes);
+  @override
+  Future<List<LearningPathNode>> loadGraph() async => nodes;
+}
+
+class _FakeProgress extends TrainingPathProgressServiceV2 {
+  final Set<String> completed;
+  _FakeProgress(this.completed)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<void> loadProgress(String pathId) async {}
+  @override
+  bool isStageUnlocked(String stageId) => true;
+  @override
+  bool getStageCompletion(String stageId) => completed.contains(stageId);
+  @override
+  double getStageAccuracy(String stageId) => 0.0;
+  @override
+  int getStageHands(String stageId) => 0;
+  @override
+  Future<void> markStageCompleted(String stageId, double accuracy) async {
+    completed.add(stageId);
+  }
+  @override
+  List<String> unlockedStageIds() => [];
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('injectBefore inserts mini lessons', () async {
+    final start = TrainingStageNode(id: 'start', nextIds: ['end']);
+    final end = TrainingStageNode(id: 'end');
+
+    final orch = _FakeOrchestrator([start, end]);
+    final progress = _FakeProgress({'start'});
+    final engine = LearningPathEngine(orchestrator: orch, progress: progress);
+    final mini = TheoryMiniLessonNode(
+      id: 'm1',
+      title: 'Mini',
+      content: '',
+      tags: const ['tag'],
+      nextIds: const [],
+    );
+    final library = _FakeLibrary([mini]);
+    final booster = MiniLessonBoosterEngine(engine: engine, library: library);
+
+    await engine.initialize();
+    await booster.injectBefore('end', ['tag']);
+
+    final nodes = engine.engine!.allNodes;
+    expect(nodes.any((n) => n is TheoryMiniLessonNode && n.id == 'm1'), isTrue);
+    final startNode = nodes.whereType<StageNode>().firstWhere((n) => n.id == 'start');
+    expect(startNode.nextIds.first, 'm1');
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `TheoryMiniLessonNode` for short theory snippets
- allow parsing `mini` nodes in path parser
- load mini lessons from new asset folder
- add `MiniLessonBoosterEngine` for injecting lessons
- support mini nodes in `PathMapEngine`
- update assets and include sample mini lessons
- test parser and injection logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c194cb58832a9580c69b6ad35de1