### PR TITLE
Implement SmartMiniBoosterPlanner service

### DIFF
--- a/lib/services/smart_mini_booster_planner.dart
+++ b/lib/services/smart_mini_booster_planner.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/learning_path_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'learning_graph_engine.dart';
+import 'mini_lesson_library_service.dart';
+import 'learning_path_stage_library.dart';
+import 'path_map_engine.dart';
+
+/// Suggests mini theory lessons relevant to the current learning path node.
+class SmartMiniBoosterPlanner {
+  final LearningPathEngine engine;
+  final MiniLessonLibraryService library;
+  final LearningPathStageLibrary stageLibrary;
+
+  SmartMiniBoosterPlanner({
+    LearningPathEngine? engine,
+    MiniLessonLibraryService? library,
+    LearningPathStageLibrary? stageLibrary,
+  })  : engine = engine ?? LearningPathEngine.instance,
+        library = library ?? MiniLessonLibraryService.instance,
+        stageLibrary = stageLibrary ?? LearningPathStageLibrary.instance;
+
+  static final SmartMiniBoosterPlanner instance = SmartMiniBoosterPlanner();
+
+  /// Returns ids of mini lessons relevant to the current node using tag matching.
+  Future<List<String>> getRelevantMiniLessons({int max = 2}) async {
+    if (max <= 0) return [];
+    final current = engine.getCurrentNode();
+    if (current == null) return [];
+
+    final tags = <String>{};
+
+    if (current is StageNode) {
+      final stage = stageLibrary.getById(current.id);
+      if (stage != null) {
+        for (final t in stage.tags) {
+          final tag = t.trim().toLowerCase();
+          if (tag.isNotEmpty) tags.add(tag);
+        }
+      }
+    } else if (current is TheoryMiniLessonNode) {
+      for (final t in current.tags) {
+        final tag = t.trim().toLowerCase();
+        if (tag.isNotEmpty) tags.add(tag);
+      }
+    }
+
+    if (tags.isEmpty) return [];
+
+    await library.loadAll();
+    final lessons = library.getByTags(tags);
+    if (lessons.isEmpty) return [];
+
+    lessons.sort((a, b) {
+      final aCount = a.tags.where((t) => tags.contains(t)).length;
+      final bCount = b.tags.where((t) => tags.contains(t)).length;
+      return bCount.compareTo(aCount);
+    });
+
+    return [for (final l in lessons.take(max)) l.id];
+  }
+}

--- a/test/smart_mini_booster_planner_test.dart
+++ b/test/smart_mini_booster_planner_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_node.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/learning_graph_engine.dart';
+import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/smart_mini_booster_planner.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeOrchestrator extends LearningPathGraphOrchestrator {
+  final List<LearningPathNode> nodes;
+  _FakeOrchestrator(this.nodes);
+  @override
+  Future<List<LearningPathNode>> loadGraph() async => nodes;
+}
+
+class _FakeProgress extends TrainingPathProgressServiceV2 {
+  final Set<String> completed;
+  _FakeProgress(this.completed)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<void> loadProgress(String pathId) async {}
+  @override
+  bool isStageUnlocked(String stageId) => true;
+  @override
+  bool getStageCompletion(String stageId) => completed.contains(stageId);
+  @override
+  double getStageAccuracy(String stageId) => 0.0;
+  @override
+  int getStageHands(String stageId) => 0;
+  @override
+  Future<void> markStageCompleted(String stageId, double accuracy) async {
+    completed.add(stageId);
+  }
+  @override
+  List<String> unlockedStageIds() => [];
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getRelevantMiniLessons returns matching ids', () async {
+    final start = TrainingStageNode(id: 'start', nextIds: ['end']);
+    final end = TrainingStageNode(id: 'end');
+
+    final orch = _FakeOrchestrator([start, end]);
+    final progress = _FakeProgress({'start'});
+    final engine = LearningPathEngine(orchestrator: orch, progress: progress);
+
+    LearningPathStageLibrary.instance.clear();
+    LearningPathStageLibrary.instance.add(
+      const LearningPathStageModel(
+        id: 'start',
+        title: 'Start',
+        description: '',
+        packId: 'p1',
+        requiredAccuracy: 80,
+        minHands: 10,
+        tags: ['bubble_fold'],
+      ),
+    );
+
+    final mini = TheoryMiniLessonNode(
+      id: 'm1',
+      title: 'Mini',
+      content: '',
+      tags: const ['bubble_fold'],
+      nextIds: const [],
+    );
+    final library = _FakeLibrary([mini]);
+    final planner = SmartMiniBoosterPlanner(
+      engine: engine,
+      library: library,
+      stageLibrary: LearningPathStageLibrary.instance,
+    );
+
+    await engine.initialize();
+    final res = await planner.getRelevantMiniLessons();
+
+    expect(res, ['m1']);
+  });
+
+  test('getRelevantMiniLessons respects max parameter', () async {
+    final start = TrainingStageNode(id: 'start', nextIds: ['end']);
+    final end = TrainingStageNode(id: 'end');
+
+    final orch = _FakeOrchestrator([start, end]);
+    final progress = _FakeProgress({'start'});
+    final engine = LearningPathEngine(orchestrator: orch, progress: progress);
+
+    LearningPathStageLibrary.instance.clear();
+    LearningPathStageLibrary.instance.add(
+      const LearningPathStageModel(
+        id: 'start',
+        title: 'Start',
+        description: '',
+        packId: 'p1',
+        requiredAccuracy: 80,
+        minHands: 10,
+        tags: ['bubble_fold'],
+      ),
+    );
+
+    final mini1 = TheoryMiniLessonNode(
+      id: 'm1',
+      title: 'Mini1',
+      content: '',
+      tags: const ['bubble_fold'],
+      nextIds: const [],
+    );
+    final mini2 = TheoryMiniLessonNode(
+      id: 'm2',
+      title: 'Mini2',
+      content: '',
+      tags: const ['bubble_fold'],
+      nextIds: const [],
+    );
+    final library = _FakeLibrary([mini1, mini2]);
+    final planner = SmartMiniBoosterPlanner(
+      engine: engine,
+      library: library,
+      stageLibrary: LearningPathStageLibrary.instance,
+    );
+
+    await engine.initialize();
+    final res = await planner.getRelevantMiniLessons(max: 1);
+
+    expect(res.length, 1);
+    expect(res.first, 'm1');
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartMiniBoosterPlanner` to suggest mini lessons based on tags
- include new unit tests for planner logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c4c9e948832aa4f0b47c026864cd