### PR TITLE
Integrate SmartMiniBoosterPlanner in auto review

### DIFF
--- a/lib/services/auto_theory_review_engine.dart
+++ b/lib/services/auto_theory_review_engine.dart
@@ -4,20 +4,29 @@ import '../models/learning_path_node.dart';
 import 'learning_graph_engine.dart';
 import 'smart_weak_review_planner.dart';
 import 'theory_booster_injector.dart';
+import 'smart_mini_booster_planner.dart';
+import 'mini_lesson_booster_engine.dart';
+import 'mini_lesson_library_service.dart';
 
 /// Background service that injects weak theory lessons before the next node.
 class AutoTheoryReviewEngine {
   final LearningPathEngine engine;
   final SmartWeakReviewPlanner planner;
   final TheoryBoosterInjector injector;
+  final SmartMiniBoosterPlanner miniPlanner;
+  final MiniLessonBoosterEngine miniInjector;
 
   AutoTheoryReviewEngine({
     LearningPathEngine? engine,
     SmartWeakReviewPlanner? planner,
     TheoryBoosterInjector? injector,
+    SmartMiniBoosterPlanner? miniPlanner,
+    MiniLessonBoosterEngine? miniInjector,
   })  : engine = engine ?? LearningPathEngine.instance,
         planner = planner ?? SmartWeakReviewPlanner.instance,
-        injector = injector ?? TheoryBoosterInjector.instance;
+        injector = injector ?? TheoryBoosterInjector.instance,
+        miniPlanner = miniPlanner ?? SmartMiniBoosterPlanner.instance,
+        miniInjector = miniInjector ?? const MiniLessonBoosterEngine();
 
   static final AutoTheoryReviewEngine instance = AutoTheoryReviewEngine();
 
@@ -33,11 +42,28 @@ class AutoTheoryReviewEngine {
     if (current == null) return;
     try {
       final candidates = await planner.getWeakReviewCandidates();
-      if (candidates.isEmpty) return;
-      await injector.injectBefore(
-        current.id,
-        candidates.take(max).toList(),
-      );
+      final miniIds = await miniPlanner.getRelevantMiniLessons();
+      if (candidates.isEmpty && miniIds.isEmpty) return;
+      if (candidates.isNotEmpty) {
+        await injector.injectBefore(
+          current.id,
+          candidates.take(max).toList(),
+        );
+      }
+      if (miniIds.isNotEmpty) {
+        var inserted = 0;
+        for (final id in miniIds) {
+          if (inserted >= 2) break;
+          final mini = MiniLessonLibraryService.instance.getById(id);
+          if (mini == null) continue;
+          await miniInjector.injectBefore(
+            current.id,
+            mini.tags,
+            max: 1,
+          );
+          inserted++;
+        }
+      }
     } catch (e) {
       debugPrint('AutoTheoryReviewEngine error: $e');
     } finally {

--- a/test/auto_theory_review_engine_test.dart
+++ b/test/auto_theory_review_engine_test.dart
@@ -5,6 +5,12 @@ import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
 import 'package:poker_analyzer/services/path_map_engine.dart';
 import 'package:poker_analyzer/services/smart_weak_review_planner.dart';
 import 'package:poker_analyzer/services/theory_booster_injector.dart';
+import 'package:poker_analyzer/services/mini_lesson_booster_engine.dart';
+import 'package:poker_analyzer/services/smart_mini_booster_planner.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
 import 'package:poker_analyzer/models/learning_branch_node.dart';
 import 'package:poker_analyzer/models/learning_path_node.dart';
 import 'package:poker_analyzer/models/theory_lesson_node.dart';
@@ -48,6 +54,37 @@ class _FakeProgress extends TrainingPathProgressServiceV2 {
   List<String> unlockedStageIds() => [];
 }
 
+class _FakeMiniLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeMiniLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -81,5 +118,66 @@ void main() {
     final startNode =
         nodes.whereType<StageNode>().firstWhere((n) => n.id == 'start');
     expect(startNode.nextIds.first, 't1');
+  });
+
+  test('runAutoReviewIfNeeded injects mini lessons', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    final start = TrainingStageNode(id: 'start', nextIds: ['end']);
+    final end = TrainingStageNode(id: 'end');
+
+    final orch = _FakeOrchestrator([start, end], [start, end]);
+    final progress = _FakeProgress({'start'});
+    final engine = LearningPathEngine(orchestrator: orch, progress: progress);
+    final injector = TheoryBoosterInjector(engine: engine, orchestrator: orch);
+    final planner = SmartWeakReviewPlanner(orchestrator: orch);
+
+    LearningPathStageLibrary.instance.clear();
+    LearningPathStageLibrary.instance.add(
+      const LearningPathStageModel(
+        id: 'start',
+        title: 'Start',
+        description: '',
+        packId: 'p1',
+        requiredAccuracy: 80,
+        minHands: 10,
+        tags: ['mini'],
+      ),
+    );
+
+    final mini = TheoryMiniLessonNode(
+      id: 'm1',
+      title: 'Mini',
+      content: '',
+      tags: const ['mini'],
+      nextIds: const [],
+    );
+    final miniLibrary = _FakeMiniLibrary([mini]);
+    final miniInjector = MiniLessonBoosterEngine(
+      engine: engine,
+      library: miniLibrary,
+    );
+    final miniPlanner = SmartMiniBoosterPlanner(
+      engine: engine,
+      library: miniLibrary,
+      stageLibrary: LearningPathStageLibrary.instance,
+    );
+
+    final auto = AutoTheoryReviewEngine(
+      engine: engine,
+      planner: planner,
+      injector: injector,
+      miniPlanner: miniPlanner,
+      miniInjector: miniInjector,
+    );
+
+    await engine.initialize();
+    await auto.runAutoReviewIfNeeded(throttle: Duration.zero);
+
+    final nodes = engine.engine!.allNodes;
+    expect(nodes.any((n) => n is TheoryMiniLessonNode && n.id == 'm1'), isTrue);
+    final startNode =
+        nodes.whereType<StageNode>().firstWhere((n) => n.id == 'start');
+    expect(startNode.nextIds.first, 'm1');
   });
 }


### PR DESCRIPTION
## Summary
- inject relevant mini-lessons during auto review
- test automatic mini booster injection

## Testing
- `flutter analyze` *(fails: many issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_6886c6554e34832a8c211c5a9ed5e4ff