### PR TITLE
Implement MiniLessonProgressTracker

### DIFF
--- a/lib/services/mini_lesson_progress_tracker.dart
+++ b/lib/services/mini_lesson_progress_tracker.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks view and completion stats for theory mini lessons.
+class MiniLessonProgressTracker {
+  MiniLessonProgressTracker._();
+  static final MiniLessonProgressTracker instance = MiniLessonProgressTracker._();
+
+  static const String _prefix = 'mini_lesson_progress_';
+
+  final Map<String, _MiniProgress> _cache = {};
+
+  Future<_MiniProgress> _load(String id) async {
+    final cached = _cache[id];
+    if (cached != null) return cached;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_prefix$id');
+    if (raw != null) {
+      try {
+        final map = jsonDecode(raw);
+        if (map is Map<String, dynamic>) {
+          return _cache[id] = _MiniProgress.fromMap(map);
+        }
+      } catch (_) {}
+    }
+    return _cache[id] = _MiniProgress();
+  }
+
+  Future<void> _save(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = _cache[id] ?? _MiniProgress();
+    await prefs.setString('$_prefix$id', jsonEncode(data.toMap()));
+  }
+
+  /// Increments view count and updates timestamp for [id].
+  Future<void> markViewed(String id) async {
+    final data = await _load(id);
+    data.viewCount++;
+    data.lastViewed = DateTime.now();
+    await _save(id);
+  }
+
+  /// Marks [id] as completed and updates timestamp.
+  Future<void> markCompleted(String id) async {
+    final data = await _load(id);
+    data.completed = true;
+    data.lastViewed = DateTime.now();
+    await _save(id);
+  }
+
+  /// Returns true if [id] was completed.
+  Future<bool> isCompleted(String id) async {
+    final data = await _load(id);
+    return data.completed;
+  }
+
+  /// Timestamp of the last view for [id], or null if never viewed.
+  Future<DateTime?> lastViewed(String id) async {
+    final data = await _load(id);
+    return data.lastViewed;
+  }
+
+  /// Returns the id with the lowest view count from [ids].
+  Future<String?> getLeastViewed(List<String> ids) async {
+    if (ids.isEmpty) return null;
+    String? bestId;
+    int? bestCount;
+    for (final id in ids) {
+      final data = await _load(id);
+      final count = data.viewCount;
+      if (bestId == null || count < bestCount!) {
+        bestId = id;
+        bestCount = count;
+      }
+    }
+    return bestId;
+  }
+}
+
+class _MiniProgress {
+  int viewCount;
+  DateTime? lastViewed;
+  bool completed;
+
+  _MiniProgress({this.viewCount = 0, this.lastViewed, this.completed = false});
+
+  factory _MiniProgress.fromMap(Map<String, dynamic> map) => _MiniProgress(
+        viewCount: map['viewCount'] is int
+            ? map['viewCount'] as int
+            : int.tryParse(map['viewCount']?.toString() ?? '') ?? 0,
+        lastViewed: map['lastViewed'] != null
+            ? DateTime.tryParse(map['lastViewed'].toString())
+            : null,
+        completed: map['completed'] == true,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'viewCount': viewCount,
+        if (lastViewed != null) 'lastViewed': lastViewed!.toIso8601String(),
+        'completed': completed,
+      };
+}
+

--- a/test/services/mini_lesson_progress_tracker_test.dart
+++ b/test/services/mini_lesson_progress_tracker_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('markViewed increments count and sets timestamp', () async {
+    final tracker = MiniLessonProgressTracker.instance;
+    await tracker.markViewed('m1');
+    await tracker.markViewed('m1');
+    expect(await tracker.isCompleted('m1'), isFalse);
+    expect(await tracker.lastViewed('m1'), isNotNull);
+    final least = await tracker.getLeastViewed(['m1']);
+    expect(least, 'm1');
+  });
+
+  test('markCompleted sets completed flag', () async {
+    final tracker = MiniLessonProgressTracker.instance;
+    await tracker.markCompleted('m2');
+    expect(await tracker.isCompleted('m2'), isTrue);
+  });
+
+  test('getLeastViewed returns id with lowest count', () async {
+    final tracker = MiniLessonProgressTracker.instance;
+    await tracker.markViewed('a');
+    await tracker.markViewed('b');
+    await tracker.markViewed('b');
+    final id = await tracker.getLeastViewed(['a', 'b']);
+    expect(id, 'a');
+  });
+}


### PR DESCRIPTION
## Summary
- add MiniLessonProgressTracker service for mini lesson analytics
- provide basic unit tests

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886cbec69c0832a95de231469b5902f