### PR TITLE
Implement MiniLessonScheduler

### DIFF
--- a/lib/services/mini_lesson_progress_tracker.dart
+++ b/lib/services/mini_lesson_progress_tracker.dart
@@ -61,6 +61,12 @@ class MiniLessonProgressTracker {
     return data.lastViewed;
   }
 
+  /// Current view count for [id].
+  Future<int> viewCount(String id) async {
+    final data = await _load(id);
+    return data.viewCount;
+  }
+
   /// Returns the id with the lowest view count from [ids].
   Future<String?> getLeastViewed(List<String> ids) async {
     if (ids.isEmpty) return null;

--- a/lib/services/mini_lesson_scheduler.dart
+++ b/lib/services/mini_lesson_scheduler.dart
@@ -1,0 +1,62 @@
+import 'mini_lesson_progress_tracker.dart';
+
+/// Schedules mini lessons using view statistics to avoid repetition.
+class MiniLessonScheduler {
+  final MiniLessonProgressTracker tracker;
+
+  const MiniLessonScheduler({MiniLessonProgressTracker? tracker})
+      : tracker = tracker ?? MiniLessonProgressTracker.instance;
+
+  /// Returns [max] lesson ids from [candidates] prioritized by usage data.
+  /// Lessons that appear in [excludeIds] or are already completed are skipped.
+  Future<List<String>> schedule(
+    List<String> candidates, {
+    int max = 2,
+    List<String> excludeIds = const [],
+  }) async {
+    if (max <= 0 || candidates.isEmpty) return [];
+
+    final remaining = <String>[];
+    for (final id in candidates) {
+      if (excludeIds.contains(id)) continue;
+      if (await tracker.isCompleted(id)) continue;
+      remaining.add(id);
+    }
+    if (remaining.isEmpty) return [];
+
+    final result = <String>[];
+    while (result.length < max && remaining.isNotEmpty) {
+      final least = await tracker.getLeastViewed(remaining);
+      if (least == null) break;
+
+      final count = await tracker.viewCount(least);
+      final ties = <_Entry>[];
+      for (final id in List<String>.from(remaining)) {
+        final c = await tracker.viewCount(id);
+        if (c == count) {
+          final last = await tracker.lastViewed(id);
+          ties.add(_Entry(id, c, last));
+        }
+      }
+
+      ties.sort((a, b) {
+        final at = a.lastViewed ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final bt = b.lastViewed ?? DateTime.fromMillisecondsSinceEpoch(0);
+        return at.compareTo(bt);
+      });
+
+      final chosen = ties.first.id;
+      result.add(chosen);
+      remaining.remove(chosen);
+    }
+
+    return result;
+  }
+}
+
+class _Entry {
+  final String id;
+  final int viewCount;
+  final DateTime? lastViewed;
+  _Entry(this.id, this.viewCount, this.lastViewed);
+}

--- a/test/mini_lesson_scheduler_test.dart
+++ b/test/mini_lesson_scheduler_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/mini_lesson_scheduler.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('schedule orders by view count and recency', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'mini_lesson_progress_a',
+      jsonEncode({
+        'viewCount': 2,
+        'lastViewed': '2024-01-02T00:00:00.000',
+        'completed': false,
+      }),
+    );
+    await prefs.setString(
+      'mini_lesson_progress_b',
+      jsonEncode({
+        'viewCount': 1,
+        'lastViewed': '2024-01-02T00:00:00.000',
+        'completed': false,
+      }),
+    );
+    await prefs.setString(
+      'mini_lesson_progress_c',
+      jsonEncode({
+        'viewCount': 1,
+        'lastViewed': '2024-01-01T00:00:00.000',
+        'completed': false,
+      }),
+    );
+
+    final scheduler = MiniLessonScheduler();
+    final res = await scheduler.schedule(['a', 'b', 'c']);
+    expect(res, ['c', 'b']);
+  });
+
+  test('schedule skips completed and excluded ids', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'mini_lesson_progress_a',
+      jsonEncode({'viewCount': 0, 'completed': true}),
+    );
+    await prefs.setString(
+      'mini_lesson_progress_c',
+      jsonEncode({'viewCount': 0}),
+    );
+
+    final scheduler = MiniLessonScheduler();
+    final res = await scheduler.schedule(
+      ['a', 'b', 'c'],
+      excludeIds: ['b'],
+    );
+    expect(res, ['c']);
+  });
+}


### PR DESCRIPTION
## Summary
- add method to read current view count in `MiniLessonProgressTracker`
- create `MiniLessonScheduler` to pick mini lessons using progress data
- test ordering, exclusion and completion filtering for scheduled mini lessons

## Testing
- `flutter test test/mini_lesson_scheduler_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886ccef3a14832ab3ea7a2b37812643