### PR TITLE
Implement theory reinforcement logging

### DIFF
--- a/lib/models/reinforcement_log.dart
+++ b/lib/models/reinforcement_log.dart
@@ -1,0 +1,28 @@
+class ReinforcementLog {
+  final String id;
+  final String type;
+  final String source;
+  final DateTime timestamp;
+
+  ReinforcementLog({
+    required this.id,
+    required this.type,
+    required this.source,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type,
+    'source': source,
+    'timestamp': timestamp.toIso8601String(),
+  };
+
+  factory ReinforcementLog.fromJson(Map<String, dynamic> j) => ReinforcementLog(
+    id: j['id'] as String? ?? '',
+    type: j['type'] as String? ?? '',
+    source: j['source'] as String? ?? '',
+    timestamp:
+        DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
+  );
+}

--- a/lib/services/theory_reinforcement_log_service.dart
+++ b/lib/services/theory_reinforcement_log_service.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/reinforcement_log.dart';
+
+class TheoryReinforcementLogService {
+  TheoryReinforcementLogService._();
+  static final instance = TheoryReinforcementLogService._();
+
+  static const _prefsKey = 'theory_reinforcement_logs';
+
+  Future<List<ReinforcementLog>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return <ReinforcementLog>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [
+          for (final e in data.whereType<Map>())
+            ReinforcementLog.fromJson(Map<String, dynamic>.from(e as Map)),
+        ];
+      }
+    } catch (_) {}
+    return <ReinforcementLog>[];
+  }
+
+  Future<void> _save(List<ReinforcementLog> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final l in list) l.toJson()]),
+    );
+  }
+
+  Future<void> logInjection(String id, String type, String source) async {
+    final list = await _load();
+    list.insert(
+      0,
+      ReinforcementLog(
+        id: id,
+        type: type,
+        source: source,
+        timestamp: DateTime.now(),
+      ),
+    );
+    if (list.length > 500) list.removeRange(500, list.length);
+    await _save(list);
+  }
+
+  Future<List<ReinforcementLog>> getRecent({Duration? within}) async {
+    final list = await _load();
+    if (within == null) return list;
+    final cutoff = DateTime.now().subtract(within);
+    return [
+      for (final l in list)
+        if (l.timestamp.isAfter(cutoff)) l,
+    ];
+  }
+}

--- a/test/services/theory_reinforcement_log_service_test.dart
+++ b/test/services/theory_reinforcement_log_service_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_reinforcement_log_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('logInjection stores entry', () async {
+    await TheoryReinforcementLogService.instance.logInjection(
+      'b1',
+      'mini',
+      'auto',
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_reinforcement_logs')!;
+    final list = jsonDecode(raw) as List;
+    expect(list.length, 1);
+    final data = list.first as Map<String, dynamic>;
+    expect(data['id'], 'b1');
+    expect(data['type'], 'mini');
+    expect(data['source'], 'auto');
+    expect(data['timestamp'], isNotEmpty);
+  });
+
+  test('getRecent filters by duration', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'theory_reinforcement_logs': jsonEncode([
+        {
+          'id': 'old',
+          'type': 'standard',
+          'source': 'manual',
+          'timestamp': now.subtract(const Duration(days: 5)).toIso8601String(),
+        },
+        {
+          'id': 'new',
+          'type': 'mini',
+          'source': 'auto',
+          'timestamp': now.subtract(const Duration(hours: 1)).toIso8601String(),
+        },
+      ]),
+    });
+    final list = await TheoryReinforcementLogService.instance.getRecent(
+      within: const Duration(days: 2),
+    );
+    expect(list.length, 1);
+    expect(list.first.id, 'new');
+  });
+}


### PR DESCRIPTION
## Summary
- add `ReinforcementLog` model
- implement `TheoryReinforcementLogService` for storing booster injections
- cover the service with unit tests

## Testing
- `flutter analyze` *(fails: 6220 issues)*
- `flutter test test/services/theory_reinforcement_log_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6886cff16b04832a98b42fff567f91d4