### PR TITLE
Add booster injection logging

### DIFF
--- a/lib/services/theory_booster_injector.dart
+++ b/lib/services/theory_booster_injector.dart
@@ -4,6 +4,7 @@ import '../models/theory_lesson_node.dart';
 import 'learning_graph_engine.dart';
 import 'learning_path_graph_orchestrator.dart';
 import 'path_map_engine.dart';
+import 'theory_reinforcement_log_service.dart';
 
 /// Injects review theory nodes into the active learning path graph.
 class TheoryBoosterInjector {
@@ -122,6 +123,10 @@ class TheoryBoosterInjector {
     final state = mapEngine.getState();
     await mapEngine.loadNodes(updated);
     await mapEngine.restoreState(state);
+    for (final n in inject) {
+      await TheoryReinforcementLogService.instance
+          .logInjection(n.id, 'standard', 'auto');
+    }
   }
 
   LearningPathNode _clone(LearningPathNode node) {

--- a/test/auto_theory_review_engine_test.dart
+++ b/test/auto_theory_review_engine_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/services/auto_theory_review_engine.dart';
 import 'package:poker_analyzer/services/learning_graph_engine.dart';
@@ -118,6 +120,14 @@ void main() {
     final startNode =
         nodes.whereType<StageNode>().firstWhere((n) => n.id == 'start');
     expect(startNode.nextIds.first, 't1');
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_reinforcement_logs')!;
+    final list = jsonDecode(raw) as List;
+    expect(list.length, 1);
+    final data = list.first as Map<String, dynamic>;
+    expect(data['id'], 't1');
+    expect(data['type'], 'standard');
+    expect(data['source'], 'auto');
   });
 
   test('runAutoReviewIfNeeded injects mini lessons', () async {
@@ -179,5 +189,13 @@ void main() {
     final startNode =
         nodes.whereType<StageNode>().firstWhere((n) => n.id == 'start');
     expect(startNode.nextIds.first, 'm1');
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_reinforcement_logs')!;
+    final list = jsonDecode(raw) as List;
+    expect(list.length, 1);
+    final data = list.first as Map<String, dynamic>;
+    expect(data['id'], 'm1');
+    expect(data['type'], 'mini');
+    expect(data['source'], 'auto');
   });
 }

--- a/test/theory_booster_injector_test.dart
+++ b/test/theory_booster_injector_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_booster_injector.dart';
+import 'package:poker_analyzer/services/learning_graph_engine.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/learning_path_node.dart';
+import 'package:poker_analyzer/models/theory_lesson_node.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeOrchestrator extends LearningPathGraphOrchestrator {
+  final List<LearningPathNode> nodes;
+  _FakeOrchestrator(this.nodes);
+  @override
+  Future<List<LearningPathNode>> loadGraph() async => nodes;
+}
+
+class _FakeProgress extends TrainingPathProgressServiceV2 {
+  final Set<String> completed;
+  _FakeProgress(this.completed)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<void> loadProgress(String pathId) async {}
+  @override
+  bool isStageUnlocked(String stageId) => true;
+  @override
+  bool getStageCompletion(String stageId) => completed.contains(stageId);
+  @override
+  double getStageAccuracy(String stageId) => 0.0;
+  @override
+  int getStageHands(String stageId) => 0;
+  @override
+  Future<void> markStageCompleted(String stageId, double accuracy) async {
+    completed.add(stageId);
+  }
+  @override
+  List<String> unlockedStageIds() => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('injectBefore logs inserted nodes', () async {
+    SharedPreferences.setMockInitialValues({});
+    final start = TrainingStageNode(id: 'start', nextIds: ['end']);
+    final end = TrainingStageNode(id: 'end');
+    final review = TheoryLessonNode(id: 't1', title: 'T', content: '', nextIds: []);
+
+    final orch = _FakeOrchestrator([start, end, review]);
+    final progress = _FakeProgress({'start'});
+    final engine = LearningPathEngine(orchestrator: orch, progress: progress);
+    final injector = TheoryBoosterInjector(engine: engine, orchestrator: orch);
+
+    await engine.initialize();
+    await injector.injectBefore('end', ['t1']);
+
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_reinforcement_logs')!;
+    final list = jsonDecode(raw) as List;
+    expect(list.length, 1);
+    final data = list.first as Map<String, dynamic>;
+    expect(data['id'], 't1');
+    expect(data['type'], 'standard');
+    expect(data['source'], 'auto');
+  });
+}


### PR DESCRIPTION
## Summary
- connect AutoTheoryReviewEngine and TheoryBoosterInjector with TheoryReinforcementLogService
- guard against duplicate log entries by checking existing nodes
- add tests for automatic logging in both auto review and injector services

## Testing
- `flutter analyze` *(fails: 6223 issues found)*
- `flutter test` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886d217dd70832a8ebef926d348547b