### PR TITLE
Implement theory streak service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add hand analysis history with EV/ICM stats and filters.
 - Introduce XPLevelEngine for computing user level progression.
 - Add TheoryPackPreviewScreen for theory-only training packs.
+- Track consecutive days of theory reinforcement via TheoryStreakService.

--- a/lib/services/theory_streak_service.dart
+++ b/lib/services/theory_streak_service.dart
@@ -1,0 +1,50 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'theory_reinforcement_log_service.dart';
+
+class TheoryStreakService {
+  TheoryStreakService._();
+
+  static final TheoryStreakService instance = TheoryStreakService._();
+
+  static const String _countKey = 'theory_streak_count';
+  static const String _bestKey = 'theory_streak_best';
+
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final logs = await TheoryReinforcementLogService.instance.getRecent(
+      within: const Duration(days: 60),
+    );
+    final days = <String>{};
+    for (final l in logs) {
+      final d = DateTime(l.timestamp.year, l.timestamp.month, l.timestamp.day)
+          .toIso8601String()
+          .split('T')
+          .first;
+      days.add(d);
+    }
+    final today = DateTime.now();
+    int streak = 0;
+    for (var i = 0;; i++) {
+      final day = DateTime(today.year, today.month, today.day)
+          .subtract(Duration(days: i))
+          .toIso8601String()
+          .split('T')
+          .first;
+      if (days.contains(day)) {
+        streak += 1;
+      } else {
+        break;
+      }
+    }
+    await prefs.setInt(_countKey, streak);
+    final best = prefs.getInt(_bestKey) ?? 0;
+    if (streak > best) await prefs.setInt(_bestKey, streak);
+    return streak;
+  }
+
+  Future<int> getMaxStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_bestKey) ?? 0;
+  }
+}

--- a/test/services/theory_streak_service_test.dart
+++ b/test/services/theory_streak_service_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_streak_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('current streak computed from logs', () async {
+    final now = DateTime.now();
+    final logs = [
+      {
+        'id': 'a',
+        'type': 'standard',
+        'source': 'auto',
+        'timestamp': now.toIso8601String(),
+      },
+      {
+        'id': 'b',
+        'type': 'mini',
+        'source': 'auto',
+        'timestamp': now.subtract(const Duration(days: 1)).toIso8601String(),
+      },
+      {
+        'id': 'c',
+        'type': 'standard',
+        'source': 'auto',
+        'timestamp': now.subtract(const Duration(days: 2)).toIso8601String(),
+      },
+    ];
+    SharedPreferences.setMockInitialValues({
+      'theory_reinforcement_logs': jsonEncode(logs),
+    });
+    final streak = await TheoryStreakService.instance.getCurrentStreak();
+    expect(streak, 3);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getInt('theory_streak_count'), 3);
+    expect(prefs.getInt('theory_streak_best'), 3);
+  });
+
+  test('streak resets when a day is missed', () async {
+    final now = DateTime.now();
+    final logs = [
+      {
+        'id': 'a',
+        'type': 'standard',
+        'source': 'auto',
+        'timestamp': now.toIso8601String(),
+      },
+      {
+        'id': 'b',
+        'type': 'mini',
+        'source': 'auto',
+        'timestamp': now.subtract(const Duration(days: 2)).toIso8601String(),
+      },
+    ];
+    SharedPreferences.setMockInitialValues({
+      'theory_reinforcement_logs': jsonEncode(logs),
+    });
+    final streak = await TheoryStreakService.instance.getCurrentStreak();
+    expect(streak, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- track daily theory booster engagement with `TheoryStreakService`
- add tests verifying streak computation
- document the new feature in the changelog

## Testing
- `flutter analyze` *(fails: 6223 issues)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_6886d52ca2e0832a9dcf04727bffecf5