### PR TITLE
Add theory streak badge

### DIFF
--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -16,6 +16,7 @@ import '../services/daily_target_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
+import '../widgets/theory_streak_badge.dart';
 import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
 import '../utils/responsive.dart';
@@ -145,6 +146,10 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
         title: const Text('Progress Dashboard'),
         centerTitle: true,
         actions: [
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: StreakBadge(),
+          ),
           IconButton(onPressed: _share, icon: const Icon(Icons.share)),
           IconButton(onPressed: _exportCsv, icon: const Icon(Icons.download)),
           IconButton(onPressed: _exportPdf, icon: const Icon(Icons.picture_as_pdf)),

--- a/lib/screens/theory_pack_debugger_screen.dart
+++ b/lib/screens/theory_pack_debugger_screen.dart
@@ -11,6 +11,7 @@ import '../services/theory_pack_auto_fix_engine.dart';
 import '../services/booster_pack_auto_fix_engine.dart';
 import '../services/theory_pack_auto_tagger.dart';
 import '../services/theory_pack_auto_booster_suggester.dart';
+import '../widgets/theory_streak_badge.dart';
 
 /// Developer screen to browse and preview all bundled theory packs.
 class TheoryPackDebuggerScreen extends StatefulWidget {
@@ -77,6 +78,7 @@ class _TheoryPackDebuggerScreenState extends State<TheoryPackDebuggerScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('📘 Theory Pack Debugger'),
+        actions: const [Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: StreakBadge())],
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kToolbarHeight),
           child: Padding(

--- a/lib/widgets/theory_streak_badge.dart
+++ b/lib/widgets/theory_streak_badge.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../services/theory_streak_service.dart';
+
+/// Small badge showing current theory streak with best streak in a tooltip.
+class StreakBadge extends StatelessWidget {
+  const StreakBadge({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<int>(
+      future: TheoryStreakService.instance.getCurrentStreak(),
+      builder: (context, snapshot) {
+        final current = snapshot.data ?? 0;
+        if (current <= 0) return const SizedBox.shrink();
+        return FutureBuilder<int>(
+          future: TheoryStreakService.instance.getMaxStreak(),
+          builder: (context, maxSnap) {
+            final best = maxSnap.data ?? current;
+            final badge = Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.deepOrangeAccent.withOpacity(0.8),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.local_fire_department,
+                    color: Colors.white,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '$current д',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            );
+            return Tooltip(
+              message: 'Лучший стрик: $best',
+              child: badge,
+            );
+          },
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show theory streak in ProgressDashboardScreen and TheoryPackDebuggerScreen
- implement `StreakBadge` widget that displays current and best streak

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/theory_streak_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d81ac2e8832a8a2ee3c46f5bc110