### PR TITLE
Add booster effectiveness tracking service

### DIFF
--- a/lib/models/booster_effect_log.dart
+++ b/lib/models/booster_effect_log.dart
@@ -1,0 +1,31 @@
+class BoosterEffectLog {
+  final String id;
+  final String type;
+  final double deltaEV;
+  final int spotsTracked;
+  final DateTime timestamp;
+
+  BoosterEffectLog({
+    required this.id,
+    required this.type,
+    required this.deltaEV,
+    required this.spotsTracked,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'type': type,
+        'deltaEV': deltaEV,
+        'spotsTracked': spotsTracked,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory BoosterEffectLog.fromJson(Map<String, dynamic> json) => BoosterEffectLog(
+        id: json['id'] as String? ?? '',
+        type: json['type'] as String? ?? '',
+        deltaEV: (json['deltaEV'] as num?)?.toDouble() ?? 0.0,
+        spotsTracked: json['spotsTracked'] as int? ?? 0,
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/services/theory_booster_effectiveness_service.dart
+++ b/lib/services/theory_booster_effectiveness_service.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/booster_effect_log.dart';
+
+class TheoryBoosterEffectivenessService {
+  TheoryBoosterEffectivenessService._();
+  static final instance = TheoryBoosterEffectivenessService._();
+
+  static const _prefsKey = 'booster_effectiveness_logs';
+
+  Future<List<BoosterEffectLog>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return <BoosterEffectLog>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [
+          for (final e in data.whereType<Map>())
+            BoosterEffectLog.fromJson(Map<String, dynamic>.from(e as Map)),
+        ];
+      }
+    } catch (_) {}
+    return <BoosterEffectLog>[];
+  }
+
+  Future<void> _save(List<BoosterEffectLog> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final l in list) l.toJson()]),
+    );
+  }
+
+  Future<void> trackBoosterEffect(
+    String id,
+    String type,
+    double deltaEV,
+    int spotCount,
+  ) async {
+    final list = await _load();
+    list.insert(
+      0,
+      BoosterEffectLog(
+        id: id,
+        type: type,
+        deltaEV: double.parse(deltaEV.toStringAsFixed(4)),
+        spotsTracked: spotCount,
+        timestamp: DateTime.now(),
+      ),
+    );
+    if (list.length > 500) list.removeRange(500, list.length);
+    await _save(list);
+  }
+
+  Future<List<BoosterEffectLog>> getImpactStats(String id) async {
+    final list = await _load();
+    return [for (final l in list) if (l.id == id) l];
+  }
+}

--- a/test/services/theory_booster_effectiveness_service_test.dart
+++ b/test/services/theory_booster_effectiveness_service_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_booster_effectiveness_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('trackBoosterEffect stores entry', () async {
+    await TheoryBoosterEffectivenessService.instance.trackBoosterEffect(
+      'b1',
+      'standard',
+      0.05,
+      10,
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('booster_effectiveness_logs')!;
+    final list = jsonDecode(raw) as List;
+    expect(list.length, 1);
+    final data = list.first as Map<String, dynamic>;
+    expect(data['id'], 'b1');
+    expect(data['type'], 'standard');
+    expect(data['deltaEV'], 0.05);
+    expect(data['spotsTracked'], 10);
+  });
+
+  test('getImpactStats filters by id', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'booster_effectiveness_logs': jsonEncode([
+        {
+          'id': 'a',
+          'type': 'mini',
+          'deltaEV': 0.1,
+          'spotsTracked': 5,
+          'timestamp': now.toIso8601String(),
+        },
+        {
+          'id': 'b',
+          'type': 'standard',
+          'deltaEV': -0.02,
+          'spotsTracked': 8,
+          'timestamp': now.toIso8601String(),
+        }
+      ])
+    });
+    final list = await TheoryBoosterEffectivenessService.instance.getImpactStats('b');
+    expect(list.length, 1);
+    expect(list.first.id, 'b');
+    expect(list.first.deltaEV, -0.02);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterEffectLog` model for storing EV delta of boosters
- implement `TheoryBoosterEffectivenessService` to persist effectiveness logs
- cover service with unit tests

## Testing
- `flutter test test/services/theory_booster_effectiveness_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d9690fc0832a99d55a5e813e6c49