### PR TITLE
Add SmartBoosterSummaryEngine

### DIFF
--- a/lib/models/booster_summary.dart
+++ b/lib/models/booster_summary.dart
@@ -1,0 +1,29 @@
+class BoosterSummary {
+  final String id;
+  final double avgDeltaEV;
+  final int totalSpots;
+  final int injections;
+
+  BoosterSummary({
+    required this.id,
+    required this.avgDeltaEV,
+    required this.totalSpots,
+    required this.injections,
+  });
+
+  bool get isEffective => avgDeltaEV > 0.01;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'avgDeltaEV': avgDeltaEV,
+        'totalSpots': totalSpots,
+        'injections': injections,
+      };
+
+  factory BoosterSummary.fromJson(Map<String, dynamic> json) => BoosterSummary(
+        id: json['id'] as String? ?? '',
+        avgDeltaEV: (json['avgDeltaEV'] as num?)?.toDouble() ?? 0.0,
+        totalSpots: json['totalSpots'] as int? ?? 0,
+        injections: json['injections'] as int? ?? 0,
+      );
+}

--- a/lib/services/smart_booster_summary_engine.dart
+++ b/lib/services/smart_booster_summary_engine.dart
@@ -1,0 +1,47 @@
+import '../models/booster_summary.dart';
+import 'theory_booster_effectiveness_service.dart';
+
+class SmartBoosterSummaryEngine {
+  final TheoryBoosterEffectivenessService _effectiveness;
+
+  const SmartBoosterSummaryEngine({TheoryBoosterEffectivenessService? effectiveness})
+      : _effectiveness = effectiveness ?? TheoryBoosterEffectivenessService.instance;
+
+  Future<BoosterSummary> summarize(String boosterId) async {
+    final logs = await _effectiveness.getImpactStats(boosterId);
+    if (logs.isEmpty) {
+      return BoosterSummary(id: boosterId, avgDeltaEV: 0.0, totalSpots: 0, injections: 0);
+    }
+    double deltaSum = 0.0;
+    int spotSum = 0;
+    for (final l in logs) {
+      deltaSum += l.deltaEV;
+      spotSum += l.spotsTracked;
+    }
+    final injections = logs.length;
+    final avg = injections > 0 ? deltaSum / injections : 0.0;
+    return BoosterSummary(
+      id: boosterId,
+      avgDeltaEV: double.parse(avg.toStringAsFixed(4)),
+      totalSpots: spotSum,
+      injections: injections,
+    );
+  }
+
+  Future<List<BoosterSummary>> summarizeAll(
+    List<String> boosterIds, {
+    bool sortByEffectiveness = false,
+    bool sortByUsage = false,
+  }) async {
+    final result = <BoosterSummary>[];
+    for (final id in boosterIds) {
+      result.add(await summarize(id));
+    }
+    if (sortByEffectiveness) {
+      result.sort((a, b) => b.avgDeltaEV.compareTo(a.avgDeltaEV));
+    } else if (sortByUsage) {
+      result.sort((a, b) => b.injections.compareTo(a.injections));
+    }
+    return result;
+  }
+}

--- a/test/services/smart_booster_summary_engine_test.dart
+++ b/test/services/smart_booster_summary_engine_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_booster_summary_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('summarize aggregates logs', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'booster_effectiveness_logs': jsonEncode([
+        {
+          'id': 'b1',
+          'type': 'standard',
+          'deltaEV': 0.05,
+          'spotsTracked': 10,
+          'timestamp': now.toIso8601String(),
+        },
+        {
+          'id': 'b1',
+          'type': 'standard',
+          'deltaEV': -0.01,
+          'spotsTracked': 5,
+          'timestamp': now.toIso8601String(),
+        }
+      ])
+    });
+    final engine = SmartBoosterSummaryEngine();
+    final summary = await engine.summarize('b1');
+    expect(summary.injections, 2);
+    expect(summary.totalSpots, 15);
+    expect(summary.avgDeltaEV, closeTo(0.02, 0.0001));
+    expect(summary.isEffective, true);
+  });
+
+  test('summarizeAll sorts by effectiveness', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'booster_effectiveness_logs': jsonEncode([
+        {
+          'id': 'b1',
+          'type': 'standard',
+          'deltaEV': 0.02,
+          'spotsTracked': 4,
+          'timestamp': now.toIso8601String(),
+        },
+        {
+          'id': 'b2',
+          'type': 'standard',
+          'deltaEV': -0.01,
+          'spotsTracked': 6,
+          'timestamp': now.toIso8601String(),
+        },
+        {
+          'id': 'b2',
+          'type': 'standard',
+          'deltaEV': 0.01,
+          'spotsTracked': 6,
+          'timestamp': now.toIso8601String(),
+        }
+      ])
+    });
+    final engine = SmartBoosterSummaryEngine();
+    final list = await engine.summarizeAll(['b1', 'b2'], sortByEffectiveness: true);
+    expect(list.first.id, 'b1');
+    expect(list.last.id, 'b2');
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterSummary` model
- implement `SmartBoosterSummaryEngine` to aggregate booster impact
- add unit tests for the new engine

## Testing
- `flutter test test/services/smart_booster_summary_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886deabd47c832aa86b6b3d7612b82c