### PR TITLE
Implement booster recommendation logic

### DIFF
--- a/lib/services/auto_theory_review_engine.dart
+++ b/lib/services/auto_theory_review_engine.dart
@@ -9,6 +9,13 @@ import 'mini_lesson_booster_engine.dart';
 import 'mini_lesson_library_service.dart';
 import 'mini_lesson_scheduler.dart';
 import 'theory_reinforcement_log_service.dart';
+import 'weakness_cluster_engine.dart';
+import 'tag_mastery_service.dart';
+import 'theory_booster_reinjection_policy.dart';
+import 'theory_pack_library_service.dart';
+import 'smart_booster_summary_engine.dart';
+import 'session_log_service.dart';
+import 'training_session_service.dart';
 
 /// Background service that injects weak theory lessons before the next node.
 class AutoTheoryReviewEngine {
@@ -18,6 +25,11 @@ class AutoTheoryReviewEngine {
   final SmartMiniBoosterPlanner miniPlanner;
   final MiniLessonBoosterEngine miniInjector;
   final MiniLessonScheduler scheduler;
+  final WeaknessClusterEngine clusterEngine;
+  final TagMasteryService masteryService;
+  final TheoryBoosterReinjectionPolicy reinjectionPolicy;
+  final TheoryPackLibraryService library;
+  final SmartBoosterSummaryEngine summaryEngine;
 
   AutoTheoryReviewEngine({
     LearningPathEngine? engine,
@@ -26,12 +38,26 @@ class AutoTheoryReviewEngine {
     SmartMiniBoosterPlanner? miniPlanner,
     MiniLessonBoosterEngine? miniInjector,
     MiniLessonScheduler? scheduler,
+    WeaknessClusterEngine? clusterEngine,
+    TagMasteryService? masteryService,
+    TheoryBoosterReinjectionPolicy? reinjectionPolicy,
+    TheoryPackLibraryService? library,
+    SmartBoosterSummaryEngine? summaryEngine,
   })  : engine = engine ?? LearningPathEngine.instance,
         planner = planner ?? SmartWeakReviewPlanner.instance,
         injector = injector ?? TheoryBoosterInjector.instance,
         miniPlanner = miniPlanner ?? SmartMiniBoosterPlanner.instance,
         miniInjector = miniInjector ?? const MiniLessonBoosterEngine(),
-        scheduler = scheduler ?? const MiniLessonScheduler();
+        scheduler = scheduler ?? const MiniLessonScheduler(),
+        clusterEngine = clusterEngine ?? const WeaknessClusterEngine(),
+        masteryService = masteryService ??
+            TagMasteryService(
+              logs: SessionLogService(sessions: TrainingSessionService()),
+            ),
+        reinjectionPolicy =
+            reinjectionPolicy ?? TheoryBoosterReinjectionPolicy.instance,
+        library = library ?? TheoryPackLibraryService.instance,
+        summaryEngine = summaryEngine ?? const SmartBoosterSummaryEngine();
 
   static final AutoTheoryReviewEngine instance = AutoTheoryReviewEngine();
 
@@ -88,4 +114,49 @@ class AutoTheoryReviewEngine {
       _lastRun = DateTime.now();
     }
   }
+
+  /// Returns booster ids ranked by relevance to [recentWeakTags].
+  /// Candidates without tag overlap or failing reinjection policy are skipped.
+  Future<List<String>> getRecommendedBoosters({
+    required List<String> recentWeakTags,
+    required List<String> candidateBoosters,
+  }) async {
+    if (recentWeakTags.isEmpty || candidateBoosters.isEmpty) return [];
+
+    await library.loadAll();
+    final masteryMap = await masteryService.computeMastery();
+
+    final tagSet = {
+      for (final t in recentWeakTags) t.trim().toLowerCase()
+    }..removeWhere((e) => e.isEmpty);
+
+    final scored = <_BoosterScore>[];
+    for (final id in candidateBoosters) {
+      final pack = library.getById(id);
+      if (pack == null) continue;
+      final tags = {for (final t in pack.tags) t.toLowerCase()};
+      if (tags.intersection(tagSet).isEmpty) continue;
+      if (!await reinjectionPolicy.shouldReinject(id)) continue;
+
+      final mastery = tags
+          .map((t) => masteryMap[t] ?? 1.0)
+          .fold<double>(1.0, (a, b) => a < b ? a : b);
+      final summary = await summaryEngine.summarize(id);
+      scored.add(_BoosterScore(id, mastery, summary.avgDeltaEV));
+    }
+
+    scored.sort((a, b) {
+      final m = a.mastery.compareTo(b.mastery);
+      if (m != 0) return m;
+      return b.impact.compareTo(a.impact);
+    });
+    return [for (final s in scored) s.id];
+  }
+}
+
+class _BoosterScore {
+  final String id;
+  final double mastery;
+  final double impact;
+  const _BoosterScore(this.id, this.mastery, this.impact);
 }

--- a/test/services/auto_theory_review_engine_recommendation_test.dart
+++ b/test/services/auto_theory_review_engine_recommendation_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/auto_theory_review_engine.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/theory_booster_reinjection_policy.dart';
+import 'package:poker_analyzer/services/theory_pack_library_service.dart';
+import 'package:poker_analyzer/services/smart_booster_summary_engine.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeMasteryService extends TagMasteryService {
+  final Map<String, double> _map;
+  _FakeMasteryService(this._map)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => _map;
+}
+
+class _FakePolicy extends TheoryBoosterReinjectionPolicy {
+  final bool allow;
+  _FakePolicy(this.allow);
+  @override
+  Future<bool> shouldReinject(String boosterId) async => allow;
+}
+
+class _FakeSummary extends SmartBoosterSummaryEngine {
+  final Map<String, double> impact;
+  const _FakeSummary(this.impact);
+  @override
+  Future<BoosterSummary> summarize(String boosterId) async => BoosterSummary(
+        id: boosterId,
+        avgDeltaEV: impact[boosterId] ?? 0.0,
+        totalSpots: 0,
+        injections: 1,
+      );
+}
+
+class _FakeLibrary implements TheoryPackLibraryService {
+  final Map<String, TheoryPackModel> packs;
+  _FakeLibrary(this.packs);
+  @override
+  List<TheoryPackModel> get all => packs.values.toList();
+  @override
+  TheoryPackModel? getById(String id) => packs[id];
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getRecommendedBoosters filters and sorts boosters', () async {
+    final library = _FakeLibrary({
+      'b1': TheoryPackModel(id: 'b1', title: 'B1', sections: const [], tags: const ['icm']),
+      'b2': TheoryPackModel(id: 'b2', title: 'B2', sections: const [], tags: const ['cbet']),
+    });
+    final mastery = _FakeMasteryService({'icm': 0.3, 'cbet': 0.8});
+    final policy = _FakePolicy(true);
+    const summary = _FakeSummary({'b1': 0.2, 'b2': 0.1});
+
+    final engine = AutoTheoryReviewEngine(
+      library: library,
+      masteryService: mastery,
+      reinjectionPolicy: policy,
+      summaryEngine: summary,
+    );
+
+    final result = await engine.getRecommendedBoosters(
+      recentWeakTags: const ['icm'],
+      candidateBoosters: const ['b1', 'b2'],
+    );
+    expect(result, ['b1']);
+  });
+}


### PR DESCRIPTION
## Summary
- extend `AutoTheoryReviewEngine` with booster recommendation support
- add test for the new recommendation method

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e2959608832a8c106253554675e7