### PR TITLE
Add MiniLessonNodeBuilder

### DIFF
--- a/lib/utils/mini_lesson_node_builder.dart
+++ b/lib/utils/mini_lesson_node_builder.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:uuid/uuid.dart';
+import 'package:yaml/yaml.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+
+/// Utility to create [TheoryMiniLessonNode] objects or YAML fragments
+/// from short text snippets.
+class MiniLessonNodeBuilder {
+  final Uuid _uuid;
+
+  const MiniLessonNodeBuilder({Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  /// Generates a unique identifier using [tag] as prefix.
+  String _generateId(String tag) {
+    final safeTag = tag.toLowerCase().replaceAll(RegExp(r'[^a-z0-9_]+'), '_');
+    return '${safeTag}_${_uuid.v4()}';
+  }
+
+  /// Builds a new [TheoryMiniLessonNode].
+  TheoryMiniLessonNode build({
+    required String tag,
+    required String title,
+    required String content,
+    List<String>? nextIds,
+  }) {
+    return TheoryMiniLessonNode(
+      id: _generateId(tag),
+      title: title,
+      content: content,
+      tags: [tag],
+      nextIds: nextIds ?? const [],
+    );
+  }
+
+  /// Returns a YAML compatible map for serialization.
+  Map<String, dynamic> toYamlMap({
+    required String tag,
+    required String title,
+    required String content,
+    List<String>? nextIds,
+    int? priority,
+    List<String>? examples,
+  }) {
+    final node = build(
+      tag: tag,
+      title: title,
+      content: content,
+      nextIds: nextIds,
+    );
+    final map = <String, dynamic>{
+      'id': node.id,
+      'title': node.title,
+      'content': node.content,
+      'tags': node.tags,
+      if (node.nextIds.isNotEmpty) 'next': node.nextIds,
+      'type': 'mini',
+    };
+    if (priority != null) map['priority'] = priority;
+    if (examples != null && examples.isNotEmpty) map['examples'] = examples;
+    return map;
+  }
+
+  /// Encodes the node to a YAML string.
+  String toYaml({
+    required String tag,
+    required String title,
+    required String content,
+    List<String>? nextIds,
+    int? priority,
+    List<String>? examples,
+  }) {
+    final map = toYamlMap(
+      tag: tag,
+      title: title,
+      content: content,
+      nextIds: nextIds,
+      priority: priority,
+      examples: examples,
+    );
+    return const YamlEncoder().convert(map);
+  }
+
+  /// Encodes the node to a JSON string.
+  String toJson({
+    required String tag,
+    required String title,
+    required String content,
+    List<String>? nextIds,
+    int? priority,
+    List<String>? examples,
+  }) {
+    final map = toYamlMap(
+      tag: tag,
+      title: title,
+      content: content,
+      nextIds: nextIds,
+      priority: priority,
+      examples: examples,
+    );
+    return jsonEncode(map);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MiniLessonNodeBuilder` for generating `TheoryMiniLessonNode`s
- provide YAML/JSON export helpers

## Testing
- `dart analyze` *(fails: 77009 issues due to missing Flutter)*
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea144894832aaa3644938b32c1d8