### PR TITLE
Add MiniLessonLibraryBuilder generator

### DIFF
--- a/lib/services/mini_lesson_library_builder.dart
+++ b/lib/services/mini_lesson_library_builder.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import '../utils/mini_lesson_node_builder.dart';
+import '../core/training/generation/yaml_writer.dart';
+import 'package:yaml/yaml.dart';
+
+/// Simple data holder for mini lesson source information.
+class MiniLessonEntry {
+  final String tag;
+  final String title;
+  final String content;
+
+  const MiniLessonEntry({
+    required this.tag,
+    required this.title,
+    required this.content,
+  });
+}
+
+/// Generates YAML libraries of mini lessons from basic text snippets.
+class MiniLessonLibraryBuilder {
+  final MiniLessonNodeBuilder nodeBuilder;
+  final YamlWriter writer;
+
+  const MiniLessonLibraryBuilder({
+    MiniLessonNodeBuilder? nodeBuilder,
+    YamlWriter? yamlWriter,
+  })  : nodeBuilder = nodeBuilder ?? const MiniLessonNodeBuilder(),
+        writer = yamlWriter ?? const YamlWriter();
+
+  /// Builds a list of YAML compatible lesson maps.
+  List<Map<String, dynamic>> _buildList(
+    List<MiniLessonEntry> entries, {
+    bool autoPriority = false,
+    bool deduplicate = true,
+  }) {
+    final seen = <String>{};
+    final list = <Map<String, dynamic>>[];
+    var prio = 1;
+    for (final e in entries) {
+      final key = '${e.tag.toLowerCase()}|${e.title.toLowerCase()}';
+      if (deduplicate && !seen.add(key)) continue;
+      list.add(nodeBuilder.toYamlMap(
+        tag: e.tag,
+        title: e.title,
+        content: e.content,
+        priority: autoPriority ? prio++ : null,
+      ));
+    }
+    return list;
+  }
+
+  /// Returns YAML for the given [entries].
+  String buildYaml(
+    List<MiniLessonEntry> entries, {
+    bool autoPriority = false,
+    bool deduplicate = true,
+  }) {
+    final map = {'lessons': _buildList(entries, autoPriority: autoPriority, deduplicate: deduplicate)};
+    return const YamlEncoder().convert(map);
+  }
+
+  /// Writes the generated YAML to [path]. Returns the created file.
+  Future<File> saveTo(
+    String path,
+    List<MiniLessonEntry> entries, {
+    bool autoPriority = false,
+    bool deduplicate = true,
+  }) async {
+    final map = {'lessons': _buildList(entries, autoPriority: autoPriority, deduplicate: deduplicate)};
+    await writer.write(map, path);
+    return File(path);
+  }
+}

--- a/test/mini_lesson_library_builder_test.dart
+++ b/test/mini_lesson_library_builder_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_builder.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('buildYaml returns unique lessons with priority', () {
+    final builder = MiniLessonLibraryBuilder();
+    final entries = [
+      const MiniLessonEntry(tag: 'tag1', title: 'A', content: 'c1'),
+      const MiniLessonEntry(tag: 'tag1', title: 'A', content: 'dup'),
+      const MiniLessonEntry(tag: 'tag2', title: 'B', content: 'c2'),
+    ];
+    final yaml = builder.buildYaml(entries, autoPriority: true);
+    final map = loadYaml(yaml) as YamlMap;
+    final list = map['lessons'] as YamlList;
+    expect(list.length, 2);
+    expect(list.first['priority'], 1);
+    expect(list[1]['priority'], 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `MiniLessonLibraryBuilder` to generate YAML libraries of mini lessons
- provide a simple test for library generation

## Testing
- `flutter test test/mini_lesson_library_builder_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886f56b0120832a94dd5a04b1514e01