### PR TITLE
Add MiniLessonPackGenerator

### DIFF
--- a/lib/services/mini_lesson_pack_generator.dart
+++ b/lib/services/mini_lesson_pack_generator.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+import 'mini_lesson_library_builder.dart';
+
+/// Groups [MiniLessonEntry] objects into YAML packs by tag prefix.
+class MiniLessonPackGenerator {
+  final MiniLessonLibraryBuilder builder;
+  final YamlReader reader;
+  final YamlWriter writer;
+
+  const MiniLessonPackGenerator({
+    MiniLessonLibraryBuilder? builder,
+    YamlReader? reader,
+    YamlWriter? writer,
+  })  : builder = builder ?? const MiniLessonLibraryBuilder(),
+        reader = reader ?? const YamlReader(),
+        writer = writer ?? const YamlWriter();
+
+  String _groupKey(String tag) {
+    final match = RegExp(r'^[^:_]+').firstMatch(tag);
+    return match?.group(0) ?? tag;
+  }
+
+  Future<List<File>> generate(
+    List<MiniLessonEntry> entries, {
+    String dir = 'yaml_out',
+    Map<String, String> titles = const {},
+    Map<String, String> merge = const {},
+  }) async {
+    final groups = <String, List<MiniLessonEntry>>{};
+    for (final e in entries) {
+      final key = _groupKey(e.tag.toLowerCase());
+      groups.putIfAbsent(key, () => []).add(e);
+    }
+
+    final files = <File>[];
+    await Directory(dir).create(recursive: true);
+
+    for (final key in groups.keys) {
+      final list = groups[key]!;
+      final title = titles[key] ?? key;
+      final packId = 'mini_lessons_${key.replaceAll(RegExp(r'[^a-z0-9]+'), '_')}';
+
+      final existing = <MiniLessonEntry>[];
+      final mergePath = merge[key];
+      if (mergePath != null && File(mergePath).existsSync()) {
+        try {
+          final raw = await File(mergePath).readAsString();
+          final map = reader.read(raw);
+          final lessons = map['lessons'];
+          if (lessons is List) {
+            for (final l in lessons) {
+              if (l is Map) {
+                final tag = (l['tags'] as List?)?.first ?? key;
+                final title = l['title']?.toString() ?? '';
+                final content = l['content']?.toString() ?? '';
+                existing.add(MiniLessonEntry(tag: tag, title: title, content: content));
+              }
+            }
+          }
+        } catch (_) {}
+      }
+
+      final combined = [...existing, ...list];
+      final lessonsYaml = builder.buildYaml(combined, autoPriority: true);
+      final lessonMap = reader.read(lessonsYaml);
+      final outMap = {
+        'pack_id': packId,
+        'title': title,
+        'type': 'theory',
+        'lessons': lessonMap['lessons'],
+      };
+      final path = p.join(dir, '$packId.yaml');
+      await writer.write(outMap, path);
+      files.add(File(path));
+    }
+
+    return files;
+  }
+}

--- a/test/mini_lesson_pack_generator_test.dart
+++ b/test/mini_lesson_pack_generator_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mini_lesson_pack_generator.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_builder.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generate groups lessons by prefix into packs', () async {
+    final entries = [
+      const MiniLessonEntry(tag: 'pos_btn', title: 'BTN Play', content: 'c1'),
+      const MiniLessonEntry(tag: 'pos_bb', title: 'BB Play', content: 'c2'),
+      const MiniLessonEntry(tag: 'icm_bubble', title: 'Bubble', content: 'c3'),
+    ];
+    final dir = Directory.systemTemp.createTempSync();
+    final generator = MiniLessonPackGenerator();
+    final files = await generator.generate(entries, dir: dir.path);
+    expect(files.length, 2);
+
+    final first = loadYaml(await files.first.readAsString()) as YamlMap;
+    expect(first['pack_id'], isNotEmpty);
+    expect(first['lessons'], isA<YamlList>());
+
+    dir.deleteSync(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- group mini lessons by tag prefix into YAML packs
- add a test for MiniLessonPackGenerator

## Testing
- `flutter analyze` *(fails: 6261 issues)*
- `flutter test test/mini_lesson_pack_generator_test.dart` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886f69ae924832a9ee8afef74d187ea