### PR TITLE
Add MiniLessonPackImporter service and tests

### DIFF
--- a/lib/models/mini_lesson_pack_model.dart
+++ b/lib/models/mini_lesson_pack_model.dart
@@ -1,0 +1,36 @@
+import 'theory_mini_lesson_node.dart';
+
+/// Representation of a mini lesson pack loaded from YAML.
+class MiniLessonPackModel {
+  final String packId;
+  final String title;
+  final String type;
+  final List<TheoryMiniLessonNode> lessons;
+
+  MiniLessonPackModel({
+    required this.packId,
+    required this.title,
+    required this.type,
+    List<TheoryMiniLessonNode>? lessons,
+  }) : lessons = lessons ?? const [];
+
+  factory MiniLessonPackModel.fromYaml(Map yaml) {
+    final lessons = <TheoryMiniLessonNode>[];
+    final rawLessons = yaml['lessons'];
+    if (rawLessons is List) {
+      for (final l in rawLessons) {
+        if (l is Map) {
+          lessons.add(
+            TheoryMiniLessonNode.fromYaml(Map<String, dynamic>.from(l)),
+          );
+        }
+      }
+    }
+    return MiniLessonPackModel(
+      packId: yaml['pack_id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      type: yaml['type']?.toString() ?? '',
+      lessons: lessons,
+    );
+  }
+}

--- a/lib/services/mini_lesson_pack_importer.dart
+++ b/lib/services/mini_lesson_pack_importer.dart
@@ -1,0 +1,77 @@
+import '../core/error_logger.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/mini_lesson_pack_model.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Loads YAML mini lesson packs into [MiniLessonPackModel] objects.
+class MiniLessonPackImporter {
+  const MiniLessonPackImporter({YamlReader? yamlReader, ErrorLogger? logger})
+      : _reader = yamlReader ?? const YamlReader(),
+        _logger = logger ?? ErrorLogger.instance;
+
+  final YamlReader _reader;
+  final ErrorLogger _logger;
+
+  /// Parses [yamlContent] into a [MiniLessonPackModel]. Returns `null` on error.
+  MiniLessonPackModel? importFromYaml(
+    String yamlContent, {
+    bool validate = true,
+  }) {
+    try {
+      final map = _reader.read(yamlContent);
+      return _fromMap(map, validate: validate);
+    } catch (e, st) {
+      _logger.logError('MiniLessonPackImporter failed to parse YAML', e, st);
+      return null;
+    }
+  }
+
+  MiniLessonPackModel _fromMap(
+    Map<String, dynamic> map, {
+    required bool validate,
+  }) {
+    final packId = map['pack_id']?.toString() ?? '';
+    final title = map['title']?.toString() ?? '';
+    final type = map['type']?.toString() ?? '';
+
+    final lessons = <TheoryMiniLessonNode>[];
+    final ids = <String>{};
+    final rawLessons = map['lessons'];
+    if (rawLessons is List) {
+      for (final l in rawLessons) {
+        if (l is! Map) {
+          _logger.logError('Malformed lesson entry: $l');
+          continue;
+        }
+        try {
+          final node = TheoryMiniLessonNode.fromYaml(
+            Map<String, dynamic>.from(l),
+          );
+          if (node.id.isEmpty) {
+            _logger.logError('Mini lesson missing id');
+            continue;
+          }
+          if (validate && !ids.add(node.id)) {
+            _logger.logError('Duplicate lesson id ${node.id}');
+            continue;
+          }
+          lessons.add(node);
+        } catch (e, st) {
+          _logger.logError('Failed to parse mini lesson: ${l['id']}', e, st);
+        }
+      }
+    }
+
+    if (validate) {
+      if (packId.isEmpty) _logger.logError('Missing pack_id');
+      if (title.isEmpty) _logger.logError('Missing title');
+    }
+
+    return MiniLessonPackModel(
+      packId: packId,
+      title: title,
+      type: type,
+      lessons: lessons,
+    );
+  }
+}

--- a/test/mini_lesson_pack_importer_test.dart
+++ b/test/mini_lesson_pack_importer_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mini_lesson_pack_importer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const basicYaml = '''
+pack_id: mini_lessons_test
+title: Test Pack
+type: theory
+lessons:
+  - id: m1
+    title: A
+    content: c1
+    tags: [t1]
+  - id: m2
+    title: B
+    content: c2
+    tags: [t2]
+''';
+
+  test('importFromYaml parses pack and lessons', () {
+    final importer = MiniLessonPackImporter();
+    final pack = importer.importFromYaml(basicYaml);
+    expect(pack, isNotNull);
+    expect(pack!.packId, 'mini_lessons_test');
+    expect(pack.lessons.length, 2);
+    expect(pack.lessons.first.id, 'm1');
+  });
+
+  const dupYaml = '''
+pack_id: dup_pack
+title: Dup Pack
+type: theory
+lessons:
+  - id: m1
+    title: A
+    content: c1
+  - id: m1
+    title: B
+    content: c2
+''';
+
+  test('importFromYaml skips duplicate ids', () {
+    final importer = MiniLessonPackImporter();
+    final pack = importer.importFromYaml(dupYaml);
+    expect(pack, isNotNull);
+    expect(pack!.lessons.length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `MiniLessonPackModel` to represent YAML mini lesson packs
- implement `MiniLessonPackImporter` for loading packs from YAML
- create tests for importer functionality

## Testing
- `dart test test/mini_lesson_pack_importer_test.dart` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6886fba8e5b0832a9a36304ebc2fd8e3