### PR TITLE
Implement TheoryTagSummaryService

### DIFF
--- a/lib/models/theory_tag_stats.dart
+++ b/lib/models/theory_tag_stats.dart
@@ -1,0 +1,15 @@
+class TheoryTagStats {
+  final String tag;
+  final int lessonCount;
+  final int exampleCount;
+  final double avgLength;
+  final bool connectedToPath;
+
+  const TheoryTagStats({
+    required this.tag,
+    required this.lessonCount,
+    required this.exampleCount,
+    required this.avgLength,
+    required this.connectedToPath,
+  });
+}

--- a/lib/services/theory_tag_summary_service.dart
+++ b/lib/services/theory_tag_summary_service.dart
@@ -1,0 +1,75 @@
+import '../models/theory_tag_stats.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Summarizes theory mini lesson coverage by tag.
+class TheoryTagSummaryService {
+  final MiniLessonLibraryService library;
+
+  TheoryTagSummaryService({MiniLessonLibraryService? library})
+      : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns statistics for each tag found in [library].
+  Future<Map<String, TheoryTagStats>> computeSummary() async {
+    await library.loadAll();
+    final Map<String, _TagBuilder> map = {};
+    for (final lesson in library.all) {
+      final words = _countWords(lesson.content);
+      final examples = _countExamples(lesson.content);
+      final connected = lesson.nextIds.isNotEmpty;
+      for (final tag in lesson.tags) {
+        final trimmed = tag.trim();
+        if (trimmed.isEmpty) continue;
+        final data = map.putIfAbsent(trimmed, () => _TagBuilder());
+        data.lessonCount++;
+        data.exampleCount += examples;
+        data.totalLength += words;
+        data.connected |= connected;
+      }
+    }
+    final result = <String, TheoryTagStats>{};
+    for (final entry in map.entries) {
+      final builder = entry.value;
+      final avgLength = builder.lessonCount > 0
+          ? builder.totalLength / builder.lessonCount
+          : 0.0;
+      result[entry.key] = TheoryTagStats(
+        tag: entry.key,
+        lessonCount: builder.lessonCount,
+        exampleCount: builder.exampleCount,
+        avgLength: avgLength,
+        connectedToPath: builder.connected,
+      );
+    }
+    return result;
+  }
+
+  /// Builds a markdown table from [stats]. Useful for diagnostics.
+  String buildMarkdownReport(Map<String, TheoryTagStats> stats) {
+    final buffer = StringBuffer(
+        '| Tag | Lessons | Examples | Avg Length | Connected |\n');
+    buffer.writeln('| --- | --- | --- | --- | --- |');
+    final entries = stats.values.toList()
+      ..sort((a, b) => a.tag.compareTo(b.tag));
+    for (final s in entries) {
+      buffer.writeln('| ${s.tag} | ${s.lessonCount} | ${s.exampleCount} | '
+          '${s.avgLength.toStringAsFixed(1)} | ${s.connectedToPath} |');
+    }
+    return buffer.toString();
+  }
+
+  int _countWords(String text) =>
+      RegExp(r'\w+').allMatches(text).length;
+
+  int _countExamples(String text) {
+    final reg = RegExp(r'^(?:Example|Пример|Например)[:\-]',
+        caseSensitive: false, multiLine: true);
+    return reg.allMatches(text).length;
+  }
+}
+
+class _TagBuilder {
+  int lessonCount = 0;
+  int exampleCount = 0;
+  int totalLength = 0;
+  bool connected = false;
+}

--- a/test/services/theory_tag_summary_service_test.dart
+++ b/test/services/theory_tag_summary_service_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_tag_summary_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computeSummary aggregates stats per tag', () async {
+    final lesson1 = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'A1',
+      content: '- do this\n- do that',
+      tags: const ['a'],
+      nextIds: const ['x'],
+    );
+    final lesson2 = TheoryMiniLessonNode(
+      id: 'l2',
+      title: 'B1',
+      content: 'Example: stuff\n- bullet',
+      tags: const ['b', 'a'],
+      nextIds: const [],
+    );
+    final lesson3 = TheoryMiniLessonNode(
+      id: 'l3',
+      title: 'C1',
+      content: 'Just text',
+      tags: const ['c'],
+      nextIds: const ['y'],
+    );
+    final library = _FakeLibrary([lesson1, lesson2, lesson3]);
+    final service = TheoryTagSummaryService(library: library);
+
+    final summary = await service.computeSummary();
+
+    expect(summary['a']!.lessonCount, 2);
+    expect(summary['a']!.exampleCount, 1);
+    expect(summary['a']!.connectedToPath, isTrue);
+    expect(summary['b']!.lessonCount, 1);
+    expect(summary['b']!.exampleCount, 1);
+    expect(summary['b']!.connectedToPath, isFalse);
+    expect(summary['c']!.connectedToPath, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryTagStats` model
- implement `TheoryTagSummaryService` for analyzing mini-lesson tag coverage
- test tag summary computation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887deb2276c832ab423c56dd6a3c4ec