### PR TITLE
Implement DOT exporter for theory mini lessons

### DIFF
--- a/lib/services/theory_lesson_graph_exporter.dart
+++ b/lib/services/theory_lesson_graph_exporter.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Exports theory mini lessons as a Graphviz DOT graph.
+class TheoryLessonGraphExporter {
+  final MiniLessonLibraryService library;
+
+  TheoryLessonGraphExporter({MiniLessonLibraryService? library})
+    : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Generates the DOT representation of all lessons in [library].
+  ///
+  /// When [clusterByTag] is true, lessons are grouped into clusters using
+  /// their first tag as label.
+  Future<String> generateDotGraph({bool clusterByTag = false}) async {
+    await library.loadAll();
+    final lessons = library.all;
+    final buffer = StringBuffer('digraph theory {\n');
+
+    if (clusterByTag) {
+      final Map<String, List<TheoryMiniLessonNode>> byTag = {};
+      for (final l in lessons) {
+        final tag = l.tags.isNotEmpty ? l.tags.first : 'other';
+        byTag.putIfAbsent(tag, () => []).add(l);
+      }
+      for (final entry in byTag.entries) {
+        buffer.writeln('  subgraph "cluster_${entry.key}" {');
+        buffer.writeln('    label="${_escape(entry.key)}";');
+        for (final l in entry.value) {
+          final labelTag = l.tags.isNotEmpty ? l.tags.first : '';
+          final label = labelTag.isNotEmpty
+              ? '${_escape(labelTag)}\\n${_escape(l.title)}'
+              : _escape(l.title);
+          buffer.writeln('    "${l.id}" [label="$label"];');
+        }
+        buffer.writeln('  }');
+      }
+    } else {
+      for (final l in lessons) {
+        final tag = l.tags.isNotEmpty ? l.tags.first : '';
+        final label = tag.isNotEmpty
+            ? '${_escape(tag)}\\n${_escape(l.title)}'
+            : _escape(l.title);
+        buffer.writeln('  "${l.id}" [label="$label"];');
+      }
+    }
+
+    for (final l in lessons) {
+      for (final next in l.nextIds) {
+        buffer.writeln('  "${l.id}" -> "${next}";');
+      }
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  /// Saves the generated DOT graph to [path] and returns the created file.
+  Future<File> saveToFile(String path, {bool clusterByTag = false}) async {
+    final dot = await generateDotGraph(clusterByTag: clusterByTag);
+    final file = File(path);
+    await file.writeAsString(dot);
+    return file;
+  }
+
+  String _escape(String value) => value.replaceAll('"', '\\"');
+}

--- a/test/services/theory_lesson_graph_exporter_test.dart
+++ b/test/services/theory_lesson_graph_exporter_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_graph_exporter.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generateDotGraph outputs nodes and edges', () async {
+    final lesson1 = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'One',
+      content: 'c1',
+      tags: const ['a'],
+      nextIds: const ['l2'],
+    );
+    final lesson2 = TheoryMiniLessonNode(
+      id: 'l2',
+      title: 'Two',
+      content: 'c2',
+      tags: const ['b'],
+    );
+
+    final exporter = TheoryLessonGraphExporter(
+      library: _FakeLibrary([lesson1, lesson2]),
+    );
+    final dot = await exporter.generateDotGraph();
+
+    expect(dot, contains('"l1" [label="a\\nOne"]'));
+    expect(dot, contains('"l1" -> "l2"'));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryLessonGraphExporter` for exporting mini lesson graphs
- test DOT generation with a fake lesson library

## Testing
- `dart analyze lib/services/theory_lesson_graph_exporter.dart test/services/theory_lesson_graph_exporter_test.dart`
- `dart format lib/services/theory_lesson_graph_exporter.dart test/services/theory_lesson_graph_exporter_test.dart`
- ❌ `flutter pub get` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6887e8f51000832ab31c0b3685bb27ed