### PR TITLE
Add theory lesson graph validator

### DIFF
--- a/lib/services/theory_lesson_reachability_validator.dart
+++ b/lib/services/theory_lesson_reachability_validator.dart
@@ -1,0 +1,101 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Result of [TheoryLessonReachabilityValidator] run.
+class TheoryLessonReachabilityResult {
+  final List<String> orphanIds;
+  final List<String> unreachableIds;
+  final List<String> cycleIds;
+
+  const TheoryLessonReachabilityResult({
+    this.orphanIds = const [],
+    this.unreachableIds = const [],
+    this.cycleIds = const [],
+  });
+}
+
+/// Validates reachability of mini theory lessons.
+class TheoryLessonReachabilityValidator {
+  final MiniLessonLibraryService library;
+
+  const TheoryLessonReachabilityValidator({MiniLessonLibraryService? library})
+      : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Analyzes the mini lesson graph and returns [TheoryLessonReachabilityResult].
+  TheoryLessonReachabilityResult validate({List<String> rootIds = const []}) {
+    final lessons = library.all;
+    if (lessons.isEmpty) return const TheoryLessonReachabilityResult();
+
+    final byId = {for (final n in lessons) n.id: n};
+    final incoming = <String, int>{for (final n in lessons) n.id: 0};
+
+    for (final n in lessons) {
+      for (final next in n.nextIds) {
+        if (byId.containsKey(next)) {
+          incoming[next] = (incoming[next] ?? 0) + 1;
+        }
+      }
+    }
+
+    final orphans = <String>[];
+    for (final n in lessons) {
+      if ((incoming[n.id] ?? 0) == 0 && !rootIds.contains(n.id)) {
+        orphans.add(n.id);
+      }
+    }
+
+    final queue = <String>[];
+    if (rootIds.isNotEmpty) {
+      queue.addAll(rootIds.where((id) => byId.containsKey(id)));
+    } else {
+      queue.addAll([for (final n in lessons) if ((incoming[n.id] ?? 0) == 0) n.id]);
+    }
+
+    final reachable = <String>{};
+    while (queue.isNotEmpty) {
+      final id = queue.removeAt(0);
+      if (!reachable.add(id)) continue;
+      final node = byId[id];
+      if (node == null) continue;
+      for (final next in node.nextIds) {
+        if (byId.containsKey(next)) queue.add(next);
+      }
+    }
+
+    final unreachable = <String>[for (final n in lessons) if (!reachable.contains(n.id)) n.id];
+
+    final color = <String, int>{};
+    final cycle = <String>{};
+
+    bool dfs(String id) {
+      final state = color[id] ?? 0;
+      if (state == 1) {
+        cycle.add(id);
+        return true;
+      }
+      if (state == 2) return false;
+      color[id] = 1;
+      final node = byId[id];
+      if (node != null) {
+        for (final next in node.nextIds) {
+          if (byId.containsKey(next) && dfs(next)) {
+            cycle.add(id);
+          }
+        }
+      }
+      color[id] = 2;
+      return cycle.contains(id);
+    }
+
+    for (final id in byId.keys) {
+      if (color[id] != 2) dfs(id);
+    }
+
+    return TheoryLessonReachabilityResult(
+      orphanIds: orphans,
+      unreachableIds: unreachable,
+      cycleIds: cycle.toList(),
+    );
+  }
+}
+

--- a/test/theory_lesson_reachability_validator_test.dart
+++ b/test/theory_lesson_reachability_validator_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_reachability_validator.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('validator detects unreachable and orphaned lessons', () {
+    final lessons = [
+      TheoryMiniLessonNode(id: 'a', title: 'A', content: '', nextIds: ['b']),
+      TheoryMiniLessonNode(id: 'b', title: 'B', content: '', nextIds: ['c']),
+      TheoryMiniLessonNode(id: 'c', title: 'C', content: '', nextIds: []),
+      TheoryMiniLessonNode(id: 'orphan', title: 'O', content: '', nextIds: []),
+      TheoryMiniLessonNode(id: 'cycle1', title: '', content: '', nextIds: ['cycle2']),
+      TheoryMiniLessonNode(id: 'cycle2', title: '', content: '', nextIds: ['cycle1']),
+    ];
+
+    final library = _FakeLibrary(lessons);
+    final validator = TheoryLessonReachabilityValidator(library: library);
+    final result = validator.validate(rootIds: ['a']);
+
+    expect(result.orphanIds, contains('orphan'));
+    expect(result.unreachableIds, contains('orphan'));
+    expect(result.cycleIds, contains('cycle1'));
+    expect(result.cycleIds, contains('cycle2'));
+    expect(result.unreachableIds.contains('b'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryLessonReachabilityValidator` for mini-lesson graph QA
- test validator logic for detecting orphans, unreachable nodes and cycles

## Testing
- `dart test test/theory_lesson_reachability_validator_test.dart -p vm` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f2674dd4832a9a8a3714749912d0