### PR TITLE
Implement TheoryPathPreviewBuilder service

### DIFF
--- a/lib/services/theory_path_preview_builder.dart
+++ b/lib/services/theory_path_preview_builder.dart
@@ -1,0 +1,29 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Builds a simplified forward chain of theory mini lessons starting from a root id.
+class TheoryPathPreviewBuilder {
+  final MiniLessonLibraryService library;
+
+  const TheoryPathPreviewBuilder({MiniLessonLibraryService? library})
+      : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns up to [maxDepth] lessons starting from [rootId].
+  /// Traversal follows the first `nextId` of each lesson and stops if a cycle
+  /// is detected or `maxDepth` is reached.
+  Future<List<TheoryMiniLessonNode>> build(String rootId, {int maxDepth = 10}) async {
+    if (rootId.isEmpty || maxDepth <= 0) return const [];
+    await library.loadAll();
+    final result = <TheoryMiniLessonNode>[];
+    final visited = <String>{};
+    var currentId = rootId;
+    while (result.length < maxDepth && visited.add(currentId)) {
+      final node = library.getById(currentId);
+      if (node == null) break;
+      result.add(node);
+      if (node.nextIds.isEmpty) break;
+      currentId = node.nextIds.first;
+    }
+    return result;
+  }
+}

--- a/test/services/theory_path_preview_builder_test.dart
+++ b/test/services/theory_path_preview_builder_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_path_preview_builder.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('build walks forward along nextIds', () async {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      nextIds: const ['c'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+    );
+    final builder = TheoryPathPreviewBuilder(library: _FakeLibrary([a, b, c]));
+
+    final result = await builder.build('a');
+
+    expect(result.map((e) => e.id), ['a', 'b', 'c']);
+  });
+
+  test('build stops on cycles', () async {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      nextIds: const ['a'],
+    );
+    final builder = TheoryPathPreviewBuilder(library: _FakeLibrary([a, b]));
+
+    final result = await builder.build('a');
+
+    expect(result.map((e) => e.id), ['a', 'b']);
+  });
+
+  test('build respects maxDepth', () async {
+    final chain = List.generate(
+      5,
+      (i) => TheoryMiniLessonNode(
+        id: 'n$i',
+        title: 'N$i',
+        content: '',
+        nextIds: i < 4 ? ['n${i + 1}'] : const [],
+      ),
+    );
+    final builder = TheoryPathPreviewBuilder(library: _FakeLibrary(chain));
+
+    final result = await builder.build('n0', maxDepth: 3);
+
+    expect(result.length, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryPathPreviewBuilder` for generating a forward mini lesson chain
- cover core behaviors with unit tests

## Testing
- `flutter analyze` *(fails: file_picker plugin warnings)*
- `flutter test test/services/theory_path_preview_builder_test.dart` *(fails: Flutter type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887f43a9790832aa312141da4b8d0bf