### PR TITLE
Add theory lesson tag heatmap service

### DIFF
--- a/lib/models/theory_tag_heatmap_stats.dart
+++ b/lib/models/theory_tag_heatmap_stats.dart
@@ -1,0 +1,13 @@
+class TheoryTagStats {
+  final String tag;
+  final int count;
+  final int incomingLinks;
+  final int outgoingLinks;
+
+  const TheoryTagStats({
+    required this.tag,
+    required this.count,
+    required this.incomingLinks,
+    required this.outgoingLinks,
+  });
+}

--- a/lib/services/theory_lesson_tag_heatmap_service.dart
+++ b/lib/services/theory_lesson_tag_heatmap_service.dart
@@ -1,0 +1,69 @@
+import '../models/theory_tag_heatmap_stats.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Computes tag-level heatmap metrics for theory mini lessons.
+class TheoryLessonTagHeatmapService {
+  final MiniLessonLibraryService library;
+
+  TheoryLessonTagHeatmapService({MiniLessonLibraryService? library})
+      : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns statistics for each tag found in [library].
+  Future<Map<String, TheoryTagStats>> computeHeatmap() async {
+    await library.loadAll();
+    final lessons = library.all;
+    final byId = {for (final l in lessons) l.id: l};
+    final incoming = <String, int>{for (final l in lessons) l.id: 0};
+
+    for (final l in lessons) {
+      for (final next in l.nextIds) {
+        if (byId.containsKey(next)) {
+          incoming[next] = (incoming[next] ?? 0) + 1;
+        }
+      }
+    }
+
+    final Map<String, _Builder> map = {};
+    for (final l in lessons) {
+      final inc = incoming[l.id] ?? 0;
+      final out = l.nextIds.where((id) => byId.containsKey(id)).length;
+      for (final tag in l.tags) {
+        final trimmed = tag.trim();
+        if (trimmed.isEmpty) continue;
+        final b = map.putIfAbsent(trimmed, () => _Builder());
+        b.count++;
+        b.incoming += inc;
+        b.outgoing += out;
+      }
+    }
+
+    final result = <String, TheoryTagStats>{};
+    for (final entry in map.entries) {
+      result[entry.key] = TheoryTagStats(
+        tag: entry.key,
+        count: entry.value.count,
+        incomingLinks: entry.value.incoming,
+        outgoingLinks: entry.value.outgoing,
+      );
+    }
+    return result;
+  }
+
+  /// Returns tags with no incoming or outgoing links.
+  List<String> deadTags(Map<String, TheoryTagStats> stats) {
+    final result = <String>[];
+    for (final s in stats.values) {
+      if (s.incomingLinks == 0 && s.outgoingLinks == 0) {
+        result.add(s.tag);
+      }
+    }
+    return result;
+  }
+}
+
+class _Builder {
+  int count = 0;
+  int incoming = 0;
+  int outgoing = 0;
+}

--- a/test/services/theory_lesson_tag_heatmap_service_test.dart
+++ b/test/services/theory_lesson_tag_heatmap_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_heatmap_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computeHeatmap aggregates link metrics per tag', () async {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      tags: const ['preflop'],
+      nextIds: const ['b', 'c'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      tags: const ['preflop', 'icm'],
+      nextIds: const ['c'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+      tags: const ['icm'],
+      nextIds: const [],
+    );
+    final service = TheoryLessonTagHeatmapService(library: _FakeLibrary([a, b, c]));
+
+    final result = await service.computeHeatmap();
+
+    expect(result['preflop']!.count, 2);
+    expect(result['preflop']!.incomingLinks, 1);
+    expect(result['preflop']!.outgoingLinks, 3);
+    expect(result['icm']!.count, 2);
+    expect(result['icm']!.incomingLinks, 2);
+    expect(result['icm']!.outgoingLinks, 1);
+  });
+
+  test('deadTags lists tags with no links', () {
+    final stats = {
+      'x': const TheoryTagStats(tag: 'x', count: 1, incomingLinks: 0, outgoingLinks: 0),
+      'y': const TheoryTagStats(tag: 'y', count: 2, incomingLinks: 1, outgoingLinks: 1),
+    };
+    final service = TheoryLessonTagHeatmapService(library: _FakeLibrary([]));
+    final dead = service.deadTags(stats);
+    expect(dead, ['x']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryTagStats` data model for heatmap metrics
- implement `TheoryLessonTagHeatmapService` to compute coverage and link density per tag
- test `TheoryLessonTagHeatmapService`

## Testing
- `flutter` / `dart` not available, so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_688808659564832a93321723d392300b