### PR TITLE
Add lesson tag clusterer

### DIFF
--- a/lib/models/theory_lesson_cluster.dart
+++ b/lib/models/theory_lesson_cluster.dart
@@ -1,0 +1,11 @@
+import 'theory_mini_lesson_node.dart';
+
+class TheoryLessonCluster {
+  final List<TheoryMiniLessonNode> lessons;
+  final Set<String> tags;
+
+  const TheoryLessonCluster({
+    required this.lessons,
+    required this.tags,
+  });
+}

--- a/lib/services/theory_lesson_tag_clusterer.dart
+++ b/lib/services/theory_lesson_tag_clusterer.dart
@@ -1,0 +1,79 @@
+import '../models/theory_lesson_cluster.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Groups theory mini lessons into connected clusters using tags and links.
+class TheoryLessonTagClusterer {
+  final MiniLessonLibraryService library;
+
+  TheoryLessonTagClusterer({MiniLessonLibraryService? library})
+      : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns clusters of lessons connected by tag overlap or next links.
+  Future<List<TheoryLessonCluster>> clusterLessons() async {
+    await library.loadAll();
+    final lessons = library.all;
+    if (lessons.isEmpty) return [];
+
+    final byId = {for (final l in lessons) l.id: l};
+    final adj = <String, Set<String>>{for (final l in lessons) l.id: <String>{}};
+
+    // Build edges based on shared tags.
+    final tagIndex = <String, List<String>>{};
+    for (final l in lessons) {
+      for (final tag in l.tags) {
+        final key = tag.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        tagIndex.putIfAbsent(key, () => []).add(l.id);
+      }
+    }
+    for (final ids in tagIndex.values) {
+      for (var i = 0; i < ids.length; i++) {
+        for (var j = i + 1; j < ids.length; j++) {
+          adj[ids[i]]!.add(ids[j]);
+          adj[ids[j]]!.add(ids[i]);
+        }
+      }
+    }
+
+    // Build edges based on direct path links.
+    for (final l in lessons) {
+      for (final next in l.nextIds) {
+        if (byId.containsKey(next)) {
+          adj[l.id]!.add(next);
+          adj[next]!.add(l.id);
+        }
+      }
+    }
+
+    final visited = <String>{};
+    final clusters = <TheoryLessonCluster>[];
+
+    for (final id in byId.keys) {
+      if (!visited.add(id)) continue;
+      final stack = <String>[id];
+      final ids = <String>[];
+      final tags = <String>{};
+
+      while (stack.isNotEmpty) {
+        final cur = stack.removeLast();
+        ids.add(cur);
+        final node = byId[cur];
+        if (node != null) {
+          for (final t in node.tags) {
+            final tr = t.trim();
+            if (tr.isNotEmpty) tags.add(tr);
+          }
+          for (final n in adj[cur] ?? {}) {
+            if (visited.add(n)) stack.add(n);
+          }
+        }
+      }
+      final clusterLessons = [for (final cid in ids) byId[cid]!];
+      clusters.add(TheoryLessonCluster(lessons: clusterLessons, tags: tags));
+    }
+
+    clusters.sort((a, b) => b.lessons.length.compareTo(a.lessons.length));
+    return clusters;
+  }
+}

--- a/test/services/theory_lesson_tag_clusterer_test.dart
+++ b/test/services/theory_lesson_tag_clusterer_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_clusterer.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('clusterLessons groups connected lessons', () async {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      tags: const ['preflop'],
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      tags: const ['preflop'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+      tags: const ['postflop'],
+      nextIds: const ['d'],
+    );
+    final d = TheoryMiniLessonNode(
+      id: 'd',
+      title: 'D',
+      content: '',
+      tags: const ['postflop'],
+    );
+
+    final clusterer = TheoryLessonTagClusterer(
+      library: _FakeLibrary([a, b, c, d]),
+    );
+
+    final clusters = await clusterer.clusterLessons();
+
+    expect(clusters.length, 2);
+    final ids = clusters.map((c) => c.lessons.map((e) => e.id).toSet()).toList();
+    expect(ids, containsAll([{'a', 'b'}, {'c', 'd'}]));
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `TheoryLessonCluster` model
- implement `TheoryLessonTagClusterer` service for grouping connected mini-lessons
- add unit test for tag clusterer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880d49ffe4832aaf077e84f9f8c28e