### PR TITLE
Implement TheoryClusterSummaryService

### DIFF
--- a/lib/models/theory_cluster_summary.dart
+++ b/lib/models/theory_cluster_summary.dart
@@ -1,0 +1,11 @@
+class TheoryClusterSummary {
+  final int size;
+  final List<String> entryPointIds;
+  final Set<String> sharedTags;
+
+  const TheoryClusterSummary({
+    required this.size,
+    required this.entryPointIds,
+    required this.sharedTags,
+  });
+}

--- a/lib/services/theory_cluster_summary_service.dart
+++ b/lib/services/theory_cluster_summary_service.dart
@@ -1,0 +1,46 @@
+import '../models/theory_cluster_summary.dart';
+import '../models/theory_lesson_cluster.dart';
+
+/// Computes high-level summary metrics for a cluster of theory lessons.
+class TheoryClusterSummaryService {
+  /// Returns summaries for all [clusters].
+  List<TheoryClusterSummary> summarize(List<TheoryLessonCluster> clusters) {
+    return [for (final c in clusters) generateSummary(c)];
+  }
+
+  /// Builds a summary for a single [cluster].
+  TheoryClusterSummary generateSummary(TheoryLessonCluster cluster) {
+    final lessons = cluster.lessons;
+    final byId = {for (final l in lessons) l.id: l};
+    final incoming = <String, int>{for (final l in lessons) l.id: 0};
+
+    for (final l in lessons) {
+      for (final next in l.nextIds) {
+        if (byId.containsKey(next)) {
+          incoming[next] = (incoming[next] ?? 0) + 1;
+        }
+      }
+    }
+
+    final entryPoints = <String>[for (final l in lessons) if ((incoming[l.id] ?? 0) == 0) l.id];
+
+    final tagCounts = <String, int>{};
+    for (final l in lessons) {
+      for (final t in l.tags) {
+        final trimmed = t.trim();
+        if (trimmed.isEmpty) continue;
+        tagCounts[trimmed] = (tagCounts[trimmed] ?? 0) + 1;
+      }
+    }
+    final sharedTags = tagCounts.entries
+        .where((e) => e.value >= 2)
+        .map((e) => e.key)
+        .toSet();
+
+    return TheoryClusterSummary(
+      size: lessons.length,
+      entryPointIds: entryPoints,
+      sharedTags: sharedTags,
+    );
+  }
+}

--- a/test/services/theory_cluster_summary_service_test.dart
+++ b/test/services/theory_cluster_summary_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_cluster_summary_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generateSummary computes size, entry points and shared tags', () {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      tags: const ['preflop'],
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      tags: const ['preflop', 'icm'],
+      nextIds: const [],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+      tags: const ['icm'],
+      nextIds: const ['b'],
+    );
+
+    final cluster = TheoryLessonCluster(lessons: [a, b, c], tags: const {'preflop', 'icm'});
+    final service = TheoryClusterSummaryService();
+
+    final summary = service.generateSummary(cluster);
+
+    expect(summary.size, 3);
+    expect(summary.entryPointIds.toSet(), {'a', 'c'});
+    expect(summary.sharedTags, {'preflop', 'icm'});
+  });
+
+  test('summarize returns summary per cluster', () {
+    final cluster1 = TheoryLessonCluster(lessons: [
+      TheoryMiniLessonNode(id: 'x', title: 'X', content: '', nextIds: const [], tags: const ['a']),
+    ], tags: const {'a'});
+    final cluster2 = TheoryLessonCluster(lessons: [
+      TheoryMiniLessonNode(id: 'y', title: 'Y', content: '', nextIds: const [], tags: const ['b']),
+    ], tags: const {'b'});
+
+    final service = TheoryClusterSummaryService();
+    final result = service.summarize([cluster1, cluster2]);
+
+    expect(result.length, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryClusterSummary` model
- add `TheoryClusterSummaryService` to compute cluster metrics
- test service logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688814aef8d0832ab63f6ff384d78a86