### PR TITLE
Implement theory onboarding path recommender

### DIFF
--- a/lib/services/theory_onboarding_path_recommender.dart
+++ b/lib/services/theory_onboarding_path_recommender.dart
@@ -1,0 +1,47 @@
+import '../models/player_profile.dart';
+import '../models/theory_cluster_summary.dart';
+
+/// Suggests a starting point into theory learning for a new player.
+class TheoryOnboardingPathRecommender {
+  const TheoryOnboardingPathRecommender();
+
+  /// Chooses the best [TheoryClusterSummary] from [clusters] for [profile].
+  TheoryClusterSummary? recommendEntryCluster(
+    List<TheoryClusterSummary> clusters,
+    PlayerProfile profile,
+  ) {
+    if (clusters.isEmpty) return null;
+    var filtered = clusters
+        .where((c) =>
+            c.entryPointIds.isNotEmpty &&
+            c.sharedTags.any((t) => profile.tags.contains(t)))
+        .toList();
+    if (filtered.isEmpty) {
+      filtered = clusters.where((c) => c.entryPointIds.isNotEmpty).toList();
+    }
+    if (filtered.isEmpty) return null;
+    filtered.sort(
+        (a, b) => _score(b, profile).compareTo(_score(a, profile)));
+    return filtered.first;
+  }
+
+  /// Returns the lesson id of the recommended entry point.
+  String? recommendEntryLesson(
+    List<TheoryClusterSummary> clusters,
+    PlayerProfile profile,
+  ) {
+    final cluster = recommendEntryCluster(clusters, profile);
+    if (cluster == null) return null;
+    for (final id in cluster.entryPointIds) {
+      if (!profile.completedLessonIds.contains(id)) return id;
+    }
+    return cluster.entryPointIds.isNotEmpty ? cluster.entryPointIds.first : null;
+  }
+
+  double _score(TheoryClusterSummary c, PlayerProfile profile) {
+    final match = c.sharedTags.where(profile.tags.contains).length;
+    final gap = c.sharedTags.difference(profile.tags).length;
+    final base = match * 2 + gap;
+    return base / (c.size == 0 ? 1 : c.size);
+  }
+}

--- a/test/services/theory_onboarding_path_recommender_test.dart
+++ b/test/services/theory_onboarding_path_recommender_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/services/theory_onboarding_path_recommender.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('recommendEntryLesson chooses cluster matching profile tags', () {
+    final clusters = [
+      const TheoryClusterSummary(
+        size: 5,
+        entryPointIds: ['a'],
+        sharedTags: {'pushfold', 'icm'},
+      ),
+      const TheoryClusterSummary(
+        size: 3,
+        entryPointIds: ['b'],
+        sharedTags: {'cbet'},
+      ),
+    ];
+    final profile = PlayerProfile(tags: {'pushfold'});
+    const recommender = TheoryOnboardingPathRecommender();
+
+    final lesson = recommender.recommendEntryLesson(clusters, profile);
+
+    expect(lesson, 'a');
+  });
+
+  test('prefers smaller cluster when multiple match', () {
+    final clusters = [
+      const TheoryClusterSummary(
+        size: 4,
+        entryPointIds: ['l1'],
+        sharedTags: {'pushfold'},
+      ),
+      const TheoryClusterSummary(
+        size: 2,
+        entryPointIds: ['l2'],
+        sharedTags: {'pushfold'},
+      ),
+    ];
+    final profile = PlayerProfile(tags: {'pushfold'});
+    const recommender = TheoryOnboardingPathRecommender();
+
+    final lesson = recommender.recommendEntryLesson(clusters, profile);
+
+    expect(lesson, 'l2');
+  });
+
+  test('recommendEntryLesson falls back to any cluster when no tags match', () {
+    final clusters = [
+      const TheoryClusterSummary(
+        size: 2,
+        entryPointIds: ['x'],
+        sharedTags: {'icm'},
+      ),
+      const TheoryClusterSummary(
+        size: 1,
+        entryPointIds: ['y'],
+        sharedTags: {'cbet'},
+      ),
+    ];
+    final profile = PlayerProfile(tags: {'other'});
+    const recommender = TheoryOnboardingPathRecommender();
+
+    final lesson = recommender.recommendEntryLesson(clusters, profile);
+
+    expect(['x', 'y'], contains(lesson));
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryOnboardingPathRecommender` to suggest a lesson based on cluster summaries and player profile
- test recommender logic for tag matching, cluster sizing and fallback behavior

## Testing
- `flutter test test/services/theory_onboarding_path_recommender_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688816d982ac832a8f905aa717f7f82f