### PR TITLE
Add TheoryLessonNavigatorService

### DIFF
--- a/lib/services/theory_lesson_navigator_service.dart
+++ b/lib/services/theory_lesson_navigator_service.dart
@@ -1,0 +1,54 @@
+import '../models/theory_lesson_cluster.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Provides forward and backward navigation helpers within a cluster of theory
+/// lessons.
+class TheoryLessonNavigatorService {
+  final TheoryLessonCluster cluster;
+
+  final Map<String, TheoryMiniLessonNode> _byId = {};
+
+  TheoryLessonNavigatorService(this.cluster) {
+    for (final l in cluster.lessons) {
+      _byId[l.id] = l;
+    }
+  }
+
+  /// Returns the first reachable next lesson from [id] or null when none.
+  TheoryMiniLessonNode? getNext(String id) {
+    final node = _byId[id];
+    if (node == null) return null;
+    for (final next in node.nextIds) {
+      final candidate = _byId[next];
+      if (candidate != null) return candidate;
+    }
+    return null;
+  }
+
+  /// Returns the previous lesson linking to [id] or null when none.
+  TheoryMiniLessonNode? getPrevious(String id) {
+    for (final l in cluster.lessons) {
+      if (l.nextIds.contains(id)) return _byId[l.id];
+    }
+    return null;
+  }
+
+  /// Returns all reachable next lesson ids from [id] limited to this cluster.
+  List<String> getAllNextIds(String id) {
+    final node = _byId[id];
+    if (node == null) return [];
+    return [
+      for (final n in node.nextIds)
+        if (_byId.containsKey(n)) n
+    ];
+  }
+
+  /// Returns all lessons that link to [id] within this cluster.
+  List<String> getAllPreviousIds(String id) {
+    final result = <String>[];
+    for (final l in cluster.lessons) {
+      if (l.nextIds.contains(id)) result.add(l.id);
+    }
+    return result;
+  }
+}

--- a/test/services/theory_lesson_navigator_service_test.dart
+++ b/test/services/theory_lesson_navigator_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_navigator_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('forward and backward navigation within cluster', () {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      nextIds: const ['c'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+    );
+
+    final cluster = TheoryLessonCluster(lessons: [a, b, c], tags: const {});
+    final nav = TheoryLessonNavigatorService(cluster);
+
+    expect(nav.getNext('a')?.id, 'b');
+    expect(nav.getNext('b')?.id, 'c');
+    expect(nav.getNext('c'), isNull);
+
+    expect(nav.getPrevious('c')?.id, 'b');
+    expect(nav.getPrevious('b')?.id, 'a');
+    expect(nav.getPrevious('a'), isNull);
+  });
+
+  test('allNextIds and allPreviousIds filter unknown lessons', () {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      nextIds: const ['x', 'b', 'c'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+    );
+
+    final cluster = TheoryLessonCluster(lessons: [a, b, c], tags: const {});
+    final nav = TheoryLessonNavigatorService(cluster);
+
+    expect(nav.getNext('a')?.id, 'b');
+    expect(nav.getAllNextIds('a'), ['b', 'c']);
+    expect(nav.getAllPreviousIds('b'), ['a']);
+    expect(nav.getAllPreviousIds('c'), ['a']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryLessonNavigatorService` for navigating between mini lessons
- add unit tests for navigation service

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 6333 issues)*
- `flutter test test/services/theory_lesson_navigator_service_test.dart` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_688817ecd6ec832ab7d7d6c9f7d1fd56