### PR TITLE
Implement TheoryMiniMapRenderer

### DIFF
--- a/lib/models/mini_map_edge.dart
+++ b/lib/models/mini_map_edge.dart
@@ -1,0 +1,9 @@
+class MiniMapEdge {
+  final String fromId;
+  final String toId;
+
+  const MiniMapEdge({
+    required this.fromId,
+    required this.toId,
+  });
+}

--- a/lib/models/mini_map_graph.dart
+++ b/lib/models/mini_map_graph.dart
@@ -1,0 +1,12 @@
+import 'mini_map_edge.dart';
+import 'mini_map_node.dart';
+
+class MiniMapGraph {
+  final List<MiniMapNode> nodes;
+  final List<MiniMapEdge> edges;
+
+  const MiniMapGraph({
+    required this.nodes,
+    required this.edges,
+  });
+}

--- a/lib/models/mini_map_node.dart
+++ b/lib/models/mini_map_node.dart
@@ -1,0 +1,11 @@
+class MiniMapNode {
+  final String id;
+  final String title;
+  final bool isCurrent;
+
+  const MiniMapNode({
+    required this.id,
+    required this.title,
+    required this.isCurrent,
+  });
+}

--- a/lib/services/theory_mini_map_renderer.dart
+++ b/lib/services/theory_mini_map_renderer.dart
@@ -1,0 +1,39 @@
+import '../models/mini_map_edge.dart';
+import '../models/mini_map_graph.dart';
+import '../models/mini_map_node.dart';
+import '../models/theory_lesson_cluster.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Generates a graph representation of a theory lesson cluster
+/// suitable for rendering a minimap.
+class TheoryMiniMapRenderer {
+  final TheoryLessonCluster cluster;
+  final Map<String, TheoryMiniLessonNode> _byId = {};
+
+  TheoryMiniMapRenderer(this.cluster) {
+    for (final l in cluster.lessons) {
+      _byId[l.id] = l;
+    }
+  }
+
+  /// Builds a [MiniMapGraph] marking [currentLessonId] as the active node.
+  MiniMapGraph build(String currentLessonId) {
+    final nodes = <MiniMapNode>[];
+    final edges = <MiniMapEdge>[];
+    for (final l in cluster.lessons) {
+      nodes.add(
+        MiniMapNode(
+          id: l.id,
+          title: l.title,
+          isCurrent: l.id == currentLessonId,
+        ),
+      );
+      for (final next in l.nextIds) {
+        if (_byId.containsKey(next)) {
+          edges.add(MiniMapEdge(fromId: l.id, toId: next));
+        }
+      }
+    }
+    return MiniMapGraph(nodes: nodes, edges: edges);
+  }
+}

--- a/test/services/theory_mini_map_renderer_test.dart
+++ b/test/services/theory_mini_map_renderer_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_mini_map_renderer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('build returns nodes and edges for cluster', () {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      tags: const [],
+      nextIds: const ['b'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      tags: const [],
+      nextIds: const ['c'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+      tags: const [],
+      nextIds: const [],
+    );
+    final cluster = TheoryLessonCluster(lessons: [a, b, c], tags: const {});
+    final renderer = TheoryMiniMapRenderer(cluster);
+
+    final graph = renderer.build('b');
+
+    expect(graph.nodes.length, 3);
+    expect(graph.edges.length, 2);
+    final current = graph.nodes.firstWhere((n) => n.id == 'b');
+    expect(current.isCurrent, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add MiniMapNode, MiniMapEdge and MiniMapGraph models
- implement `TheoryMiniMapRenderer` service to build a graph from lesson clusters
- unit test verifying mini map output

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/theory_mini_map_renderer_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881a73cd84832aa0a33c1217682170