### PR TITLE
Implement WeakTheoryZoneHighlighter

### DIFF
--- a/lib/models/player_profile.dart
+++ b/lib/models/player_profile.dart
@@ -7,6 +7,7 @@ class PlayerProfile {
   GameType gameType;
   SkillLevel skillLevel;
   Set<String> completedLessonIds;
+  Map<String, double> tagAccuracy;
 
   PlayerProfile({
     this.xp = 0,
@@ -14,6 +15,8 @@ class PlayerProfile {
     this.gameType = GameType.tournament,
     this.skillLevel = SkillLevel.beginner,
     Set<String>? completedLessonIds,
+    Map<String, double>? tagAccuracy,
   })  : tags = tags ?? <String>{},
-        completedLessonIds = completedLessonIds ?? <String>{};
+        completedLessonIds = completedLessonIds ?? <String>{},
+        tagAccuracy = tagAccuracy ?? <String, double>{};
 }

--- a/lib/models/weak_cluster_info.dart
+++ b/lib/models/weak_cluster_info.dart
@@ -1,0 +1,13 @@
+import '../models/theory_cluster_summary.dart';
+
+class WeakClusterInfo {
+  final TheoryClusterSummary cluster;
+  final double coverage;
+  final double score;
+
+  const WeakClusterInfo({
+    required this.cluster,
+    required this.coverage,
+    required this.score,
+  });
+}

--- a/lib/models/weak_theory_tag.dart
+++ b/lib/models/weak_theory_tag.dart
@@ -1,0 +1,13 @@
+class WeakTheoryTag {
+  final String tag;
+  final int completedCount;
+  final double accuracy;
+  final double score;
+
+  const WeakTheoryTag({
+    required this.tag,
+    required this.completedCount,
+    required this.accuracy,
+    required this.score,
+  });
+}

--- a/lib/services/weak_theory_zone_highlighter.dart
+++ b/lib/services/weak_theory_zone_highlighter.dart
@@ -1,0 +1,105 @@
+import '../models/player_profile.dart';
+import '../models/theory_cluster_summary.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../models/weak_theory_tag.dart';
+import '../models/weak_cluster_info.dart';
+
+/// Identifies weak theory tags and clusters based on player progress.
+class WeakTheoryZoneHighlighter {
+  const WeakTheoryZoneHighlighter();
+
+  /// Returns weak tags sorted by [WeakTheoryTag.score] descending.
+  List<WeakTheoryTag> detectWeakTags({
+    required PlayerProfile profile,
+    required Map<String, TheoryMiniLessonNode> lessons,
+  }) {
+    if (lessons.isEmpty) return [];
+
+    final completed = profile.completedLessonIds;
+    final totals = <String, int>{};
+    final done = <String, int>{};
+
+    for (final node in lessons.values) {
+      final tags = node.tags
+          .map((t) => t.trim().toLowerCase())
+          .where((t) => t.isNotEmpty);
+      for (final tag in tags) {
+        totals[tag] = (totals[tag] ?? 0) + 1;
+        if (completed.contains(node.id)) {
+          done[tag] = (done[tag] ?? 0) + 1;
+        }
+      }
+    }
+
+    final result = <WeakTheoryTag>[];
+    for (final tag in totals.keys) {
+      final total = totals[tag] ?? 0;
+      if (total == 0) continue;
+      final completedCount = done[tag] ?? 0;
+      final accuracy = profile.tagAccuracy[tag] ?? 1.0;
+      final coverage = completedCount / total;
+      final score = (1 - accuracy) + (1 - coverage);
+      result.add(
+        WeakTheoryTag(
+          tag: tag,
+          completedCount: completedCount,
+          accuracy: accuracy,
+          score: double.parse(score.toStringAsFixed(4)),
+        ),
+      );
+    }
+
+    result.sort((a, b) => b.score.compareTo(a.score));
+    return result;
+  }
+
+  /// Returns weak clusters sorted by [WeakClusterInfo.score] descending.
+  List<WeakClusterInfo> detectWeakClusters({
+    required PlayerProfile profile,
+    required List<TheoryClusterSummary> clusters,
+    required Map<String, TheoryMiniLessonNode> lessons,
+  }) {
+    if (clusters.isEmpty || lessons.isEmpty) return [];
+
+    final tagScores = {
+      for (final t in detectWeakTags(profile: profile, lessons: lessons)) t.tag: t.score
+    };
+    final lessonList = lessons.values.toList();
+    final result = <WeakClusterInfo>[];
+
+    for (final c in clusters) {
+      final clusterLessons = <TheoryMiniLessonNode>[];
+      for (final n in lessonList) {
+        for (final tag in n.tags) {
+          if (c.sharedTags.contains(tag.trim().toLowerCase())) {
+            clusterLessons.add(n);
+            break;
+          }
+        }
+      }
+      if (clusterLessons.isEmpty) continue;
+      final total = clusterLessons.length;
+      final completed = clusterLessons
+          .where((l) => profile.completedLessonIds.contains(l.id))
+          .length;
+      final coverage = completed / total;
+      final scores = c.sharedTags
+          .map((t) => tagScores[t.trim().toLowerCase()] ?? 0.0)
+          .toList();
+      final avg = scores.isEmpty
+          ? 0.0
+          : scores.reduce((a, b) => a + b) / scores.length;
+      final score = (1 - coverage) + avg;
+      result.add(
+        WeakClusterInfo(
+          cluster: c,
+          coverage: coverage,
+          score: double.parse(score.toStringAsFixed(4)),
+        ),
+      );
+    }
+
+    result.sort((a, b) => b.score.compareTo(a.score));
+    return result;
+  }
+}

--- a/test/services/weak_theory_zone_highlighter_test.dart
+++ b/test/services/weak_theory_zone_highlighter_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/weak_theory_zone_highlighter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final lessons = <String, TheoryMiniLessonNode>{
+    'l1': const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['a', 'b']),
+    'l2': const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['a']),
+    'l3': const TheoryMiniLessonNode(id: 'l3', title: 'L3', content: '', tags: ['b']),
+    'l4': const TheoryMiniLessonNode(id: 'l4', title: 'L4', content: '', tags: ['c']),
+  };
+
+  test('detectWeakTags ranks by accuracy and coverage', () {
+    final profile = PlayerProfile(
+      completedLessonIds: {'l1', 'l3'},
+      tagAccuracy: {'a': 0.6, 'b': 0.8, 'c': 1.0},
+    );
+    const service = WeakTheoryZoneHighlighter();
+
+    final result = service.detectWeakTags(profile: profile, lessons: lessons);
+
+    expect(result.first.tag, 'c');
+    expect(result[1].tag, 'a');
+    expect(result.last.tag, 'b');
+  });
+
+  test('detectWeakClusters uses tag scores and coverage', () {
+    final profile = PlayerProfile(
+      completedLessonIds: {'l1', 'l3'},
+      tagAccuracy: {'a': 0.6, 'b': 0.8, 'c': 1.0},
+    );
+    final clusters = [
+      const TheoryClusterSummary(size: 2, entryPointIds: ['l1'], sharedTags: {'a'}),
+      const TheoryClusterSummary(size: 2, entryPointIds: ['l3'], sharedTags: {'b'}),
+    ];
+
+    const service = WeakTheoryZoneHighlighter();
+    final result = service.detectWeakClusters(
+      profile: profile,
+      clusters: clusters,
+      lessons: lessons,
+    );
+
+    expect(result.first.cluster.sharedTags, {'a'});
+    expect(result.last.cluster.sharedTags, {'b'});
+  });
+}


### PR DESCRIPTION
## Summary
- add `WeakTheoryZoneHighlighter` service to highlight weak theory zones
- support weak tag/cluster models
- extend `PlayerProfile` with optional `tagAccuracy`
- add tests for the new service

## Testing
- `dart format -o none --set-exit-if-changed lib/models/weak_theory_tag.dart lib/models/weak_cluster_info.dart lib/services/weak_theory_zone_highlighter.dart test/services/weak_theory_zone_highlighter_test.dart lib/models/player_profile.dart`
- `dart analyze` *(fails: missing Flutter packages)*

------
https://chatgpt.com/codex/tasks/task_e_6888aceb34d4832a95e6923065369fce