### PR TITLE
Implement ClusterReviewBoosterBuilder

### DIFF
--- a/lib/services/cluster_review_booster_builder.dart
+++ b/lib/services/cluster_review_booster_builder.dart
@@ -1,0 +1,82 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/weak_cluster_info.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../core/training/generation/training_pack_source_tagger.dart';
+
+/// Builds review training packs from weak theory clusters.
+class ClusterReviewBoosterBuilder {
+  final Uuid _uuid;
+  final TrainingPackSourceTagger _tagger;
+  final TrainingTypeEngine _typeEngine;
+
+  const ClusterReviewBoosterBuilder({
+    Uuid uuid = const Uuid(),
+    TrainingPackSourceTagger tagger = const TrainingPackSourceTagger(),
+    TrainingTypeEngine typeEngine = const TrainingTypeEngine(),
+  })  : _uuid = uuid,
+        _tagger = tagger,
+        _typeEngine = typeEngine;
+
+  /// Generates a [TrainingPackTemplateV2] containing lessons from [weakCluster].
+  ///
+  /// Lessons already completed with high accuracy are excluded. Tag accuracy
+  /// below `0.7` is treated as weak.
+  TrainingPackTemplateV2 build({
+    required WeakClusterInfo weakCluster,
+    required Map<String, TheoryMiniLessonNode> allLessons,
+    Set<String> completedLessons = const {},
+    Map<String, double> tagAccuracy = const {},
+  }) {
+    final tags = weakCluster.cluster.sharedTags
+        .map((t) => t.trim().toLowerCase())
+        .where((t) => t.isNotEmpty)
+        .toSet();
+
+    final relevant = allLessons.values.where((l) {
+      final lessonTags = l.tags
+          .map((t) => t.trim().toLowerCase())
+          .where((t) => t.isNotEmpty);
+      return lessonTags.any(tags.contains);
+    }).where((l) {
+      if (!completedLessons.contains(l.id)) return true;
+      for (final t in l.tags) {
+        final acc = tagAccuracy[t.trim().toLowerCase()] ?? 1.0;
+        if (acc < 0.7) return true;
+      }
+      return false;
+    }).toList();
+
+    final spots = <TrainingPackSpot>[for (final l in relevant)
+      TrainingPackSpot(
+        id: l.id,
+        type: 'theory',
+        title: l.resolvedTitle,
+        note: l.resolvedContent,
+        tags: List<String>.from(l.tags),
+        meta: {'lessonId': l.id},
+      )
+    ];
+
+    final tpl = TrainingPackTemplateV2(
+      id: _uuid.v4(),
+      name: 'Review: ${tags.join(', ')}',
+      trainingType: TrainingType.theory,
+      tags: List<String>.from(tags),
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      meta: {
+        'generatedFromClusterId': weakCluster.cluster.entryPointIds.join(','),
+      },
+    );
+
+    _tagger.tag(tpl, source: 'booster');
+    tpl.trainingType = _typeEngine.detectTrainingType(tpl);
+    return tpl;
+  }
+}
+

--- a/test/services/cluster_review_booster_builder_test.dart
+++ b/test/services/cluster_review_booster_builder_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/cluster_review_booster_builder.dart';
+import 'package:poker_analyzer/models/weak_cluster_info.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('build creates booster pack from cluster', () {
+    final cluster = TheoryClusterSummary(
+      size: 3,
+      entryPointIds: const ['c1'],
+      sharedTags: const {'push', 'call'},
+    );
+    final weak = WeakClusterInfo(cluster: cluster, coverage: 0.5, score: 1.0);
+
+    final lessons = <String, TheoryMiniLessonNode>{
+      'l1': const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['push']),
+      'l2': const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['push']),
+      'l3': const TheoryMiniLessonNode(id: 'l3', title: 'L3', content: '', tags: ['call']),
+      'l4': const TheoryMiniLessonNode(id: 'l4', title: 'L4', content: '', tags: ['fold']),
+    };
+
+    final builder = ClusterReviewBoosterBuilder();
+    final tpl = builder.build(
+      weakCluster: weak,
+      allLessons: lessons,
+      completedLessons: const {'l1'},
+      tagAccuracy: const {'push': 0.6},
+    );
+
+    expect(tpl.name.startsWith('Review:'), isTrue);
+    expect(tpl.tags, contains('push'));
+    expect(tpl.spots.length, 3);
+    expect(tpl.spots.every((s) => s.type == 'theory'), isTrue);
+    expect(tpl.meta['source'], 'booster');
+    expect(tpl.meta['generatedFromClusterId'], 'c1');
+  });
+}


### PR DESCRIPTION
## Summary
- build service to create training packs from weak theory clusters
- add unit test for the builder

## Testing
- `flutter analyze` *(fails: dart SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888aedf1550832a974e8393103e62ab