### PR TITLE
Add booster injection engine

### DIFF
--- a/lib/services/booster_injection_engine.dart
+++ b/lib/services/booster_injection_engine.dart
@@ -1,0 +1,61 @@
+import '../models/weak_cluster_info.dart';
+import '../models/player_profile.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'xp_level_engine.dart';
+
+class BoosterInjectionEngine {
+  final XPLevelEngine xpEngine;
+
+  const BoosterInjectionEngine({this.xpEngine = XPLevelEngine.instance});
+
+  List<TrainingPackTemplateV2> scheduleBoosters({
+    required List<WeakClusterInfo> clusters,
+    required List<TrainingPackTemplateV2> boosters,
+    required PlayerProfile profile,
+    DateTime? now,
+  }) {
+    if (boosters.isEmpty || clusters.isEmpty) return [];
+
+    final tagCount = <String, int>{};
+    for (final c in clusters) {
+      for (final t in c.cluster.sharedTags) {
+        final tag = t.trim().toLowerCase();
+        if (tag.isEmpty) continue;
+        tagCount.update(tag, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+
+    final mastered = <String, bool>{};
+    profile.tagAccuracy.forEach((k, v) {
+      mastered[k.trim().toLowerCase()] = v >= 0.8;
+    });
+
+    final recent = {for (final t in profile.tags) t.trim().toLowerCase()};
+    final plateau = xpEngine.getProgressToNextLevel(profile.xp) < 0.2;
+
+    final scored = <_ScoredBooster>[];
+    for (final b in boosters) {
+      final tags = {
+        for (final t in b.tags) t.trim().toLowerCase()
+      }..removeWhere((t) => t.isEmpty);
+      if (tags.isEmpty) continue;
+      if (tags.every((t) => mastered[t] == true || recent.contains(t))) {
+        continue;
+      }
+      var score = 0;
+      if (plateau) score++;
+      if (tags.any((t) => (tagCount[t] ?? 0) >= 2)) score++;
+      if (tags.every((t) => !recent.contains(t))) score++;
+      scored.add(_ScoredBooster(b, score));
+    }
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return [for (final s in scored) s.booster];
+  }
+}
+
+class _ScoredBooster {
+  final TrainingPackTemplateV2 booster;
+  final int score;
+  const _ScoredBooster(this.booster, this.score);
+}

--- a/test/booster_injection_engine_test.dart
+++ b/test/booster_injection_engine_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/booster_injection_engine.dart';
+import 'package:poker_analyzer/models/weak_cluster_info.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+WeakClusterInfo _cluster(String tag) => WeakClusterInfo(
+      cluster: TheoryClusterSummary(
+        size: 1,
+        entryPointIds: const ['l1'],
+        sharedTags: {tag},
+      ),
+      coverage: 1.0,
+      score: 1.0,
+    );
+
+TrainingPackTemplateV2 _booster(String id, String tag) => TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.theory,
+      tags: [tag],
+      spots: const [],
+      spotCount: 0,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('scheduleBoosters prioritizes repeating tags', () {
+    final clusters = [_cluster('a'), _cluster('a'), _cluster('b')];
+    final boosters = [_booster('b1', 'a'), _booster('b2', 'b')];
+    final profile = PlayerProfile(
+      xp: 150,
+      tags: {'c'},
+      tagAccuracy: {'a': 0.5, 'b': 0.5},
+    );
+
+    const engine = BoosterInjectionEngine();
+    final result = engine.scheduleBoosters(
+      clusters: clusters,
+      boosters: boosters,
+      profile: profile,
+    );
+
+    expect(result.length, 2);
+    expect(result.first.id, 'b1');
+  });
+
+  test('scheduleBoosters skips mastered tags', () {
+    final clusters = [_cluster('a')];
+    final boosters = [_booster('b1', 'a')];
+    final profile = PlayerProfile(
+      xp: 0,
+      tags: {'a'},
+      tagAccuracy: {'a': 0.9},
+    );
+
+    const engine = BoosterInjectionEngine();
+    final result = engine.scheduleBoosters(
+      clusters: clusters,
+      boosters: boosters,
+      profile: profile,
+    );
+
+    expect(result, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `BoosterInjectionEngine` to recommend booster packs based on weak clusters and player profile
- test booster injection logic

## Testing
- `flutter test test/booster_injection_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b14ae3d8832a960b120998a07a01