### PR TITLE
Implement BoosterGoalRecommender

### DIFF
--- a/lib/services/booster_goal_recommender.dart
+++ b/lib/services/booster_goal_recommender.dart
@@ -1,0 +1,71 @@
+import '../models/booster_stats.dart';
+import '../models/weak_theory_tag.dart';
+import '../models/player_profile.dart';
+import '../models/training_goal.dart';
+
+/// Generates simple short-term goals from booster stats and weaknesses.
+class BoosterGoalRecommender {
+  const BoosterGoalRecommender();
+
+  /// Returns up to two training goals based on [stats], [weakTags] and [profile].
+  List<TrainingGoal> recommend({
+    required BoosterStats stats,
+    required List<WeakTheoryTag> weakTags,
+    required PlayerProfile profile,
+  }) {
+    final goals = <TrainingGoal>[];
+
+    // Goal 1: encourage booster streaks.
+    if (stats.streak < 5) {
+      goals.add(
+        const TrainingGoal(
+          '🔥 Достигни серии из 5 дней',
+          description: 'Играйте хотя бы один бустер каждый день',
+          tag: 'boosterStreak',
+        ),
+      );
+    }
+
+    // Goal 2: focus on weakest tag or most played tag.
+    String? focusTag;
+    if (weakTags.isNotEmpty) {
+      focusTag = weakTags.first.tag;
+    } else if (stats.counts.isNotEmpty) {
+      final entries = stats.counts.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value));
+      focusTag = entries.first.key;
+    }
+
+    if (focusTag != null) {
+      final completed = stats.counts[focusTag] ?? 0;
+      final target = completed + 2;
+      goals.add(
+        TrainingGoal(
+          '🎯 Заверши $target бустера по $focusTag',
+          description: 'Текущий прогресс: $completed из $target',
+          tag: focusTag,
+        ),
+      );
+    }
+
+    // Additional goal: review tags with low accuracy.
+    if (goals.length < 2) {
+      final lowAcc = profile.tagAccuracy.entries
+          .where((e) => e.value < 0.7)
+          .map((e) => e.key)
+          .toList();
+      if (lowAcc.isNotEmpty) {
+        final list = lowAcc.take(3).join(', ');
+        goals.add(
+          TrainingGoal(
+            '📚 Повтори теги: $list',
+            description: 'Отработай бустеры по слабым тегам',
+            tag: lowAcc.first,
+          ),
+        );
+      }
+    }
+
+    return goals.take(2).toList();
+  }
+}

--- a/test/services/booster_goal_recommender_test.dart
+++ b/test/services/booster_goal_recommender_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/booster_stats.dart';
+import 'package:poker_analyzer/models/player_profile.dart';
+import 'package:poker_analyzer/models/weak_theory_tag.dart';
+import 'package:poker_analyzer/services/booster_goal_recommender.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('recommend returns goals from stats', () {
+    final stats = BoosterStats(
+      counts: {'pushfold': 3},
+      totalCompleted: 3,
+      streak: 2,
+      lastCompleted: DateTime.now(),
+    );
+    final weakTags = [
+      const WeakTheoryTag(tag: 'pushfold', completedCount: 1, accuracy: 0.5, score: 1.0),
+    ];
+    final profile = PlayerProfile(tagAccuracy: {'pushfold': 0.6});
+
+    final rec = const BoosterGoalRecommender();
+    final goals = rec.recommend(stats: stats, weakTags: weakTags, profile: profile);
+
+    expect(goals, isNotEmpty);
+    expect(goals.first.title, contains('серии')); // streak goal
+    expect(goals.last.tag, 'pushfold');
+  });
+}


### PR DESCRIPTION
## Summary
- add new `BoosterGoalRecommender` service for generating short‑term training goals
- add unit test covering recommendation logic

## Testing
- `flutter test test/services/booster_goal_recommender_test.dart --no-version-check` *(fails: Dart SDK 3.3.2 < 3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_6888b6aa7e48832ab8dcba7d55d2f94c