### PR TITLE
Add BoosterRecapScreen

### DIFF
--- a/lib/screens/booster_recap_screen.dart
+++ b/lib/screens/booster_recap_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/booster_backlink.dart';
+import '../models/weak_cluster_info.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/training_pack.dart';
+import '../services/training_session_service.dart';
+import '../theme/app_colors.dart';
+import 'training_session_screen.dart';
+
+class BoosterRecapScreen extends StatelessWidget {
+  final TrainingSessionResult result;
+  final TrainingPackTemplateV2 booster;
+  final BoosterBacklink? backlink;
+  final WeakClusterInfo? cluster;
+  final Map<String, double> tagDeltas;
+
+  const BoosterRecapScreen({
+    super.key,
+    required this.result,
+    required this.booster,
+    this.backlink,
+    this.cluster,
+    this.tagDeltas = const {},
+  });
+
+  List<Widget> _improvementWidgets() {
+    final entries = booster.tags
+        .map((t) => t.trim())
+        .where((t) => t.isNotEmpty)
+        .map((t) {
+      final delta = tagDeltas[t.toLowerCase()] ?? 0.0;
+      final sign = delta >= 0 ? '+' : '';
+      final pct = (delta * 100).toStringAsFixed(1);
+      return '$t: $sign$pct%';
+    }).toList();
+    if (entries.isEmpty) return [];
+    return [
+      const Text('Improvement:',
+          style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+      const SizedBox(height: 4),
+      for (final e in entries)
+        Text(e, style: const TextStyle(color: Colors.white70)),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final improvements = _improvementWidgets();
+    final clusterTags = backlink?.matchingTags.join(', ');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Booster Recap')),
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                booster.name,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '${result.correct} / ${result.total}',
+                style: const TextStyle(color: Colors.white),
+              ),
+              const SizedBox(height: 8),
+              if (improvements.isNotEmpty) ...[
+                ...improvements,
+                const SizedBox(height: 8),
+              ],
+              if (clusterTags != null && clusterTags.isNotEmpty) ...[
+                Text('Origin: $clusterTags',
+                    style: const TextStyle(color: Colors.white70)),
+                const SizedBox(height: 8),
+              ],
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () =>
+                          Navigator.popUntil(context, (r) => r.isFirst),
+                      child: const Text('Done'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () async {
+                        await context
+                            .read<TrainingSessionService>()
+                            .startSession(booster);
+                        if (!context.mounted) return;
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const TrainingSessionScreen()),
+                        );
+                      },
+                      style: OutlinedButton.styleFrom(
+                          foregroundColor: accent,
+                          side: BorderSide(color: accent)),
+                      child: const Text('Train Again'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `BoosterRecapScreen` for post-booster summary
- open BoosterRecapScreen when finishing booster sessions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c1fdc308832ab96361869b20bad5