### PR TITLE
Add TheoryLessonProgressTracker service

### DIFF
--- a/lib/services/theory_lesson_progress_tracker.dart
+++ b/lib/services/theory_lesson_progress_tracker.dart
@@ -1,0 +1,54 @@
+import 'mini_lesson_progress_tracker.dart';
+import '../models/theory_cluster_summary.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Tracks progress of theory mini lessons and computes tag mastery gains.
+class TheoryLessonProgressTracker {
+  final MiniLessonProgressTracker progress;
+
+  /// Creates a tracker using [progress] to determine completed lessons.
+  const TheoryLessonProgressTracker({MiniLessonProgressTracker? progress})
+    : progress = progress ?? MiniLessonProgressTracker.instance;
+
+  /// Returns completion ratio (0.0 - 1.0) for [lessons].
+  Future<double> progressForLessons(List<TheoryMiniLessonNode> lessons) async {
+    if (lessons.isEmpty) return 0.0;
+    var done = 0;
+    for (final l in lessons) {
+      if (await progress.isCompleted(l.id)) done++;
+    }
+    return done / lessons.length;
+  }
+
+  /// Returns completion ratio (0.0 - 1.0) for [cluster] using [allLessons].
+  Future<double> progressForCluster(
+    TheoryClusterSummary cluster,
+    Map<String, TheoryMiniLessonNode> allLessons,
+  ) async {
+    final tagSet = {for (final t in cluster.sharedTags) t.trim().toLowerCase()};
+    final lessons = <TheoryMiniLessonNode>[];
+    for (final n in allLessons.values) {
+      final tags = n.tags.map((e) => e.trim().toLowerCase());
+      if (tags.any(tagSet.contains)) lessons.add(n);
+    }
+    return progressForLessons(lessons);
+  }
+
+  /// Computes mastery gain per tag from completed [lessons].
+  /// Each completed lesson contributes [gain] to its tags.
+  Future<Map<String, double>> computeMasteryGains(
+    List<TheoryMiniLessonNode> lessons, {
+    double gain = 0.05,
+  }) async {
+    final deltas = <String, double>{};
+    for (final l in lessons) {
+      if (!await progress.isCompleted(l.id)) continue;
+      for (final t in l.tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        deltas.update(key, (v) => v + gain, ifAbsent: () => gain);
+      }
+    }
+    return deltas;
+  }
+}

--- a/test/services/theory_lesson_progress_tracker_test.dart
+++ b/test/services/theory_lesson_progress_tracker_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_lesson_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  final lessons = <TheoryMiniLessonNode>[
+    const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['a']),
+    const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['b']),
+  ];
+
+  test('progressForLessons returns completion ratio', () async {
+    final tracker = TheoryLessonProgressTracker();
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    final p = await tracker.progressForLessons(lessons);
+    expect(p, 0.5);
+  });
+
+  test('progressForCluster filters by tags', () async {
+    final tracker = TheoryLessonProgressTracker();
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    final cluster = const TheoryClusterSummary(
+      size: 2,
+      entryPointIds: [],
+      sharedTags: {'a'},
+    );
+    final map = {for (final l in lessons) l.id: l};
+    final p = await tracker.progressForCluster(cluster, map);
+    expect(p, 1.0);
+  });
+
+  test('computeMasteryGains aggregates tags', () async {
+    final tracker = TheoryLessonProgressTracker();
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    final gains = await tracker.computeMasteryGains(lessons, gain: 0.1);
+    expect(gains['a'], 0.1);
+    expect(gains.containsKey('b'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryLessonProgressTracker` to compute progress over mini lessons or clusters
- provide helper to aggregate tag mastery gains from completed lessons
- test theory lesson progress tracker logic

## Testing
- `flutter pub get` *(succeeds with warnings)*
- `flutter test test/services/theory_lesson_progress_tracker_test.dart` *(fails: missing assets & plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6888cb871c6c832a954c25e6526090a7