### PR TITLE
Add TheoryMilestoneUnlocker service

### DIFF
--- a/lib/services/theory_milestone_unlocker.dart
+++ b/lib/services/theory_milestone_unlocker.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_cluster_summary.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'theory_lesson_progress_tracker.dart';
+
+class TheoryMilestoneEvent {
+  final String clusterName;
+  final double progress;
+  final String type;
+
+  const TheoryMilestoneEvent({
+    required this.clusterName,
+    required this.progress,
+    required this.type,
+  });
+}
+
+class TheoryMilestoneUnlocker {
+  final TheoryLessonProgressTracker tracker;
+  static const _prefsPrefix = 'theory_milestone_';
+  static const List<double> thresholds = [0.25, 0.5, 1.0];
+
+  final StreamController<TheoryMilestoneEvent> _ctrl =
+      StreamController<TheoryMilestoneEvent>.broadcast();
+
+  TheoryMilestoneUnlocker({TheoryLessonProgressTracker? tracker})
+      : tracker = tracker ?? const TheoryLessonProgressTracker();
+
+  Stream<TheoryMilestoneEvent> get stream => _ctrl.stream;
+
+  Future<int> _loadIndex(String cluster) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt('$_prefsPrefix$cluster') ?? -1;
+  }
+
+  Future<void> _saveIndex(String cluster, int index) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('$_prefsPrefix$cluster', index);
+  }
+
+  Future<void> checkCluster({
+    required String clusterName,
+    required TheoryClusterSummary summary,
+    required Map<String, TheoryMiniLessonNode> allLessons,
+  }) async {
+    final progress =
+        await tracker.progressForCluster(summary, allLessons);
+    final prevIndex = await _loadIndex(clusterName);
+    var newIndex = prevIndex;
+    for (var i = thresholds.length - 1; i >= 0; i--) {
+      if (progress >= thresholds[i]) {
+        newIndex = i;
+        break;
+      }
+    }
+    if (newIndex > prevIndex) {
+      await _saveIndex(clusterName, newIndex);
+      final double t = thresholds[newIndex];
+      final String type;
+      if (t == 1.0) {
+        type = 'unlock';
+      } else if (t == 0.5) {
+        type = 'badge';
+      } else {
+        type = 'insight';
+      }
+      _ctrl.add(
+        TheoryMilestoneEvent(
+          clusterName: clusterName,
+          progress: progress,
+          type: type,
+        ),
+      );
+    }
+  }
+
+  Future<void> dispose() async {
+    await _ctrl.close();
+  }
+
+  Future<void> reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefsPrefix));
+    for (final k in keys) {
+      await prefs.remove(k);
+    }
+  }
+}

--- a/test/services/theory_milestone_unlocker_test.dart
+++ b/test/services/theory_milestone_unlocker_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_milestone_unlocker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('emits events when thresholds reached', () async {
+    final lessons = <String, TheoryMiniLessonNode>{
+      'l1': const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['a']),
+      'l2': const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['a']),
+      'l3': const TheoryMiniLessonNode(id: 'l3', title: 'L3', content: '', tags: ['a']),
+      'l4': const TheoryMiniLessonNode(id: 'l4', title: 'L4', content: '', tags: ['a']),
+    };
+    const summary = TheoryClusterSummary(
+      size: 4,
+      entryPointIds: [],
+      sharedTags: {'a'},
+    );
+    final unlocker = TheoryMilestoneUnlocker();
+    final events = <TheoryMilestoneEvent>[];
+    final sub = unlocker.stream.listen(events.add);
+
+    await unlocker.checkCluster(
+      clusterName: 'c',
+      summary: summary,
+      allLessons: lessons,
+    );
+    expect(events, isEmpty);
+
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    await unlocker.checkCluster(
+      clusterName: 'c',
+      summary: summary,
+      allLessons: lessons,
+    );
+    expect(events.length, 1);
+    expect(events.last.type, 'insight');
+
+    await MiniLessonProgressTracker.instance.markCompleted('l2');
+    await unlocker.checkCluster(
+      clusterName: 'c',
+      summary: summary,
+      allLessons: lessons,
+    );
+    expect(events.length, 2);
+    expect(events.last.type, 'badge');
+
+    await MiniLessonProgressTracker.instance.markCompleted('l3');
+    await MiniLessonProgressTracker.instance.markCompleted('l4');
+    await unlocker.checkCluster(
+      clusterName: 'c',
+      summary: summary,
+      allLessons: lessons,
+    );
+    expect(events.length, 3);
+    expect(events.last.type, 'unlock');
+
+    await sub.cancel();
+    await unlocker.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryMilestoneUnlocker` service and milestone event model
- trigger milestone events when a theory cluster passes 25%, 50% or 100%
- add unit test demonstrating milestone emission logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/theory_milestone_unlocker_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d00034d8832ab0ffc288fa04676d