### PR TITLE
Add TheoryGoalDashboardSection widget

### DIFF
--- a/lib/widgets/goal_list_section.dart
+++ b/lib/widgets/goal_list_section.dart
@@ -9,7 +9,14 @@ class GoalListSection extends StatefulWidget {
   /// Optional callback when a goal is tapped.
   final void Function(TheoryGoal goal)? onTap;
 
-  const GoalListSection({super.key, this.onTap});
+  /// Message displayed when no goals are available.
+  final String emptyMessage;
+
+  const GoalListSection({
+    super.key,
+    this.onTap,
+    this.emptyMessage = 'Нет целей',
+  });
 
   @override
   State<GoalListSection> createState() => _GoalListSectionState();
@@ -34,10 +41,10 @@ class _GoalListSectionState extends State<GoalListSection> {
         }
         final goals = snapshot.data ?? const <TheoryGoal>[];
         if (goals.isEmpty) {
-          return const Padding(
-            padding: EdgeInsets.all(16),
-            child: Text('\u041D\u0435\u0442 \u0446\u0435\u043B\u0435\u0439',
-                style: TextStyle(color: Colors.white70)),
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(widget.emptyMessage,
+                style: const TextStyle(color: Colors.white70)),
           );
         }
         return ListView.separated(

--- a/lib/widgets/theory_goal_dashboard_section.dart
+++ b/lib/widgets/theory_goal_dashboard_section.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_goal.dart';
+import '../services/theory_goal_engine.dart';
+import 'goal_list_section.dart';
+
+/// Dashboard card displaying active [TheoryGoal]s with an optional refresh
+/// action.
+class TheoryGoalDashboardSection extends StatefulWidget {
+  /// Callback when a goal is tapped.
+  final void Function(TheoryGoal goal)? onTap;
+
+  /// Whether to show the refresh button.
+  final bool showRefresh;
+
+  const TheoryGoalDashboardSection({
+    super.key,
+    this.onTap,
+    this.showRefresh = true,
+  });
+
+  @override
+  State<TheoryGoalDashboardSection> createState() =>
+      _TheoryGoalDashboardSectionState();
+}
+
+class _TheoryGoalDashboardSectionState
+    extends State<TheoryGoalDashboardSection> {
+  bool _refreshing = false;
+  Key _listKey = UniqueKey();
+
+  Future<void> _refreshGoals() async {
+    setState(() => _refreshing = true);
+    await TheoryGoalEngine.instance.refreshGoals();
+    if (!mounted) return;
+    setState(() {
+      _refreshing = false;
+      _listKey = UniqueKey();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '📚 Цели обучения',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+              ),
+              if (widget.showRefresh)
+                ElevatedButton(
+                  onPressed: _refreshing ? null : _refreshGoals,
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  child: _refreshing
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('🔄 Обновить'),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          GoalListSection(
+            key: _listKey,
+            onTap: widget.onTap,
+            emptyMessage: 'Цели скоро появятся!',
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow customizing empty-message for `GoalListSection`
- add new `TheoryGoalDashboardSection` card widget wrapping goal list

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_6888dd23a4d4832a8705b5ee91d87322