### PR TITLE
Add TheoryBoosterLauncher

### DIFF
--- a/lib/services/theory_booster_launcher.dart
+++ b/lib/services/theory_booster_launcher.dart
@@ -1,0 +1,80 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/player_profile.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'tag_mastery_service.dart';
+import 'training_session_launcher.dart';
+
+/// Launches a booster pack relevant to a theory mini lesson.
+class TheoryBoosterLauncher {
+  final TagMasteryService mastery;
+  final TrainingPackLibraryV2 library;
+  final TrainingSessionLauncher launcher;
+  final PlayerProfile? profile;
+
+  const TheoryBoosterLauncher({
+    required this.mastery,
+    this.profile,
+    TrainingPackLibraryV2? library,
+    this.launcher = const TrainingSessionLauncher(),
+  }) : library = library ?? TrainingPackLibraryV2.instance;
+
+  /// Selects and launches the best booster for [lesson].
+  /// Returns the chosen template or `null` if none found.
+  Future<TrainingPackTemplateV2?> launchBoosterFor(
+    TheoryMiniLessonNode lesson,
+  ) async {
+    final tagSet = <String>{
+      for (final t in lesson.tags) t.toLowerCase(),
+      if (profile != null)
+        for (final t in profile!.tags) t.toLowerCase(),
+    };
+    if (tagSet.isEmpty) return null;
+
+    await library.loadFromFolder();
+    final all = library.filterBy(type: TrainingType.pushFold);
+    final candidates = <TrainingPackTemplateV2>[];
+    for (final p in all) {
+      final packTags = p.tags.map((e) => e.toLowerCase()).toSet();
+      if (packTags.intersection(tagSet).isNotEmpty) {
+        candidates.add(p);
+      }
+    }
+    if (candidates.isEmpty) return null;
+
+    final moderate = [
+      for (final p in candidates)
+        if (p.spotCount >= 5 && p.spotCount <= 10) p,
+    ];
+    final pool = moderate.isNotEmpty ? moderate : candidates;
+
+    final masteryMap = await mastery.computeMastery();
+    pool.sort((a, b) {
+      final aScore = _scorePack(a, masteryMap, tagSet);
+      final bScore = _scorePack(b, masteryMap, tagSet);
+      return aScore.compareTo(bScore);
+    });
+
+    final chosen = pool.first;
+    await launcher.launch(chosen);
+    return chosen;
+  }
+
+  double _scorePack(
+    TrainingPackTemplateV2 p,
+    Map<String, double> masteryMap,
+    Set<String> relevant,
+  ) {
+    var sum = 0.0;
+    var count = 0;
+    for (final t in p.tags) {
+      final lc = t.toLowerCase();
+      if (relevant.contains(lc)) {
+        sum += masteryMap[lc] ?? 1.0;
+        count++;
+      }
+    }
+    return count == 0 ? 1.0 : sum / count;
+  }
+}

--- a/test/services/theory_booster_launcher_test.dart
+++ b/test/services/theory_booster_launcher_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_booster_launcher.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:collection/collection.dart';
+
+class _FakeMasteryService extends TagMasteryService {
+  final Map<String, double> _map;
+  _FakeMasteryService(this._map)
+    : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async =>
+      _map;
+}
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  TrainingPackTemplateV2? launched;
+  _FakeLauncher();
+  @override
+  Future<void> launch(
+    TrainingPackTemplateV2 template, {
+    int startIndex = 0,
+  }) async {
+    launched = template;
+  }
+}
+
+class _FakeLibrary implements TrainingPackLibraryV2 {
+  final List<TrainingPackTemplateV2> _packs;
+  _FakeLibrary(this._packs);
+
+  @override
+  List<TrainingPackTemplateV2> get packs => List.unmodifiable(_packs);
+
+  @override
+  void addPack(TrainingPackTemplateV2 pack) => _packs.add(pack);
+
+  @override
+  void clear() => _packs.clear();
+
+  @override
+  List<TrainingPackTemplateV2> filterBy({
+    GameType? gameType,
+    TrainingType? type,
+    List<String>? tags,
+  }) {
+    return [
+      for (final p in _packs)
+        if ((gameType == null || p.gameType == gameType) &&
+            (type == null || p.trainingType == type) &&
+            (tags == null || tags.every((t) => p.tags.contains(t))))
+          p,
+    ];
+  }
+
+  @override
+  TrainingPackTemplateV2? getById(String id) =>
+      _packs.firstWhereOrNull((p) => p.id == id);
+
+  @override
+  Future<void> loadFromFolder([
+    String path = TrainingPackLibraryV2.packsDir,
+  ]) async {}
+
+  @override
+  Future<void> reload() async {}
+}
+
+TrainingPackTemplateV2 tpl({
+  required String id,
+  required List<String> tags,
+  int spots = 6,
+}) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: tags,
+    spotCount: spots,
+    spots: const [],
+    created: DateTime.now(),
+    positions: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('picks pack with lowest mastery', () async {
+    final mastery = _FakeMasteryService({'icm': 0.2, 'cbet': 0.8});
+    final library = _FakeLibrary([
+      tpl(id: 'a', tags: ['icm'], spots: 6),
+      tpl(id: 'b', tags: ['cbet'], spots: 6),
+    ]);
+    final launcher = _FakeLauncher();
+    final service = TheoryBoosterLauncher(
+      mastery: mastery,
+      library: library,
+      launcher: launcher,
+    );
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: const ['icm', 'cbet'],
+      nextIds: const [],
+    );
+    final pack = await service.launchBoosterFor(lesson);
+    expect(pack?.id, 'a');
+    expect(launcher.launched?.id, 'a');
+  });
+
+  test('returns null when no match', () async {
+    final mastery = _FakeMasteryService({'icm': 0.2});
+    final library = _FakeLibrary([
+      tpl(id: 'a', tags: ['other'], spots: 6),
+    ]);
+    final launcher = _FakeLauncher();
+    final service = TheoryBoosterLauncher(
+      mastery: mastery,
+      library: library,
+      launcher: launcher,
+    );
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: const ['icm'],
+      nextIds: const [],
+    );
+    final pack = await service.launchBoosterFor(lesson);
+    expect(pack, isNull);
+    expect(launcher.launched, isNull);
+  });
+
+  test('prefers moderate length packs', () async {
+    final mastery = _FakeMasteryService({'icm': 0.5});
+    final library = _FakeLibrary([
+      tpl(id: 'short', tags: ['icm'], spots: 4),
+      tpl(id: 'mod', tags: ['icm'], spots: 8),
+    ]);
+    final launcher = _FakeLauncher();
+    final service = TheoryBoosterLauncher(
+      mastery: mastery,
+      library: library,
+      launcher: launcher,
+    );
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: const ['icm'],
+      nextIds: const [],
+    );
+    final pack = await service.launchBoosterFor(lesson);
+    expect(pack?.id, 'mod');
+    expect(launcher.launched?.id, 'mod');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryBoosterLauncher` for selecting & launching drills after theory lessons
- test booster selection logic

## Testing
- `flutter analyze` *(fails: Package file_picker missing inline implementation)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_6888e29b7af8832a9155dcd6984b1494