### PR TITLE
Add cluster node navigator

### DIFF
--- a/lib/screens/theory_lesson_preview_screen.dart
+++ b/lib/screens/theory_lesson_preview_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../widgets/theory_lesson_preview_tile.dart';
+import 'theory_lesson_viewer_screen.dart';
+
+/// Displays a lightweight preview for a [TheoryMiniLessonNode].
+class TheoryLessonPreviewScreen extends StatefulWidget {
+  final String lessonId;
+  const TheoryLessonPreviewScreen({super.key, required this.lessonId});
+
+  @override
+  State<TheoryLessonPreviewScreen> createState() => _TheoryLessonPreviewScreenState();
+}
+
+class _TheoryLessonPreviewScreenState extends State<TheoryLessonPreviewScreen> {
+  late Future<TheoryMiniLessonNode?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<TheoryMiniLessonNode?> _load() async {
+    await MiniLessonLibraryService.instance.loadAll();
+    return MiniLessonLibraryService.instance.getById(widget.lessonId);
+  }
+
+  void _open(TheoryMiniLessonNode lesson) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheoryLessonViewerScreen(
+          lesson: lesson,
+          currentIndex: 1,
+          totalCount: 1,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Предпросмотр урока')),
+      backgroundColor: const Color(0xFF121212),
+      body: FutureBuilder<TheoryMiniLessonNode?>(
+        future: _future,
+        builder: (context, snapshot) {
+          final lesson = snapshot.data;
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (lesson == null) {
+            return const Center(child: Text('Lesson not found'));
+          }
+          return Column(
+            children: [
+              TheoryLessonPreviewTile(node: lesson),
+              const Spacer(),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () => _open(lesson),
+                    style: ElevatedButton.styleFrom(backgroundColor: accent),
+                    child: const Text('Начать'),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/cluster_node_navigator.dart
+++ b/lib/services/cluster_node_navigator.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../models/player_profile.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../screens/theory_lesson_preview_screen.dart';
+
+/// Handles navigation from cluster map nodes to lesson previews.
+class ClusterNodeNavigator {
+  const ClusterNodeNavigator._();
+
+  /// Opens the preview for [node] if unlocked, otherwise shows a snack.
+  static Future<void> handleTap(
+    BuildContext context,
+    TheoryMiniLessonNode node,
+    PlayerProfile profile,
+  ) async {
+    final unlocked = await _isUnlocked(node.id, profile);
+    if (!unlocked) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Урок пока недоступен')),
+      );
+      return;
+    }
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheoryLessonPreviewScreen(lessonId: node.id),
+      ),
+    );
+  }
+
+  /// Returns true if the lesson is reachable based on [profile] progress.
+  static Future<bool> _isUnlocked(String lessonId, PlayerProfile profile) async {
+    await MiniLessonLibraryService.instance.loadAll();
+    final lessons = MiniLessonLibraryService.instance.all;
+    if (lessons.isEmpty) return false;
+
+    final byId = {for (final l in lessons) l.id: l};
+    final incoming = {for (final l in lessons) l.id: <String>{}};
+    for (final l in lessons) {
+      for (final next in l.nextIds) {
+        if (incoming.containsKey(next)) incoming[next]!.add(l.id);
+      }
+    }
+
+    final roots = <String>{};
+    for (final l in lessons) {
+      if (incoming[l.id]!.isEmpty) roots.add(l.id);
+    }
+    final queue = <String>[
+      if (profile.completedLessonIds.isEmpty)
+        ...roots
+      else
+        ...profile.completedLessonIds.where(byId.containsKey),
+    ];
+    final reachable = <String>{...queue};
+    while (queue.isNotEmpty) {
+      final id = queue.removeLast();
+      final node = byId[id];
+      if (node == null) continue;
+      for (final next in node.nextIds) {
+        if (!byId.containsKey(next)) continue;
+        if (reachable.add(next)) queue.add(next);
+      }
+    }
+
+    return reachable.contains(lessonId);
+  }
+}

--- a/lib/widgets/theory_cluster_map_overlay.dart
+++ b/lib/widgets/theory_cluster_map_overlay.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../models/mini_map_graph.dart';
+import '../models/mini_map_node.dart';
+import '../models/player_profile.dart';
+import '../services/cluster_node_navigator.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Simple overlay showing a cluster mini map.
+class TheoryClusterMapOverlay extends StatelessWidget {
+  final MiniMapGraph graph;
+  final PlayerProfile profile;
+  final ValueChanged<MiniMapNode>? onTap;
+
+  const TheoryClusterMapOverlay({
+    super.key,
+    required this.graph,
+    required this.profile,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final n in graph.nodes)
+              GestureDetector(
+                onTap: () async {
+                  if (onTap != null) onTap!(n);
+                  final lesson = MiniLessonLibraryService.instance.getById(n.id);
+                  if (lesson != null) {
+                    await ClusterNodeNavigator.handleTap(context, lesson, profile);
+                  }
+                },
+                child: Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: n.isCurrent
+                        ? Colors.orangeAccent
+                        : Colors.grey[800],
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    n.title,
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ClusterNodeNavigator` service for lesson node taps
- create a `TheoryLessonPreviewScreen` for viewing lesson previews
- render cluster map overlay with tap support calling the navigator

## Testing
- `flutter analyze` *(fails: numerous missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888ecef1b84832a826cbf64282b5f78