### PR TITLE
Add tag sidebar filtering

### DIFF
--- a/lib/widgets/theory_cluster_map_overlay.dart
+++ b/lib/widgets/theory_cluster_map_overlay.dart
@@ -12,13 +12,22 @@ class TheoryClusterMapOverlay extends StatelessWidget {
   final MiniMapGraph graph;
   final PlayerProfile profile;
   final ValueChanged<MiniMapNode>? onTap;
+  final Set<String> tagsFilter;
 
   const TheoryClusterMapOverlay({
     super.key,
     required this.graph,
     required this.profile,
     this.onTap,
+    this.tagsFilter = const {},
   });
+
+  bool _lessonMatchesTags(String id, Set<String> tags) {
+    final lesson = MiniLessonLibraryService.instance.getById(id);
+    if (lesson == null) return false;
+    final lessonTags = lesson.tags.map((e) => e.trim().toLowerCase());
+    return tags.every((t) => lessonTags.contains(t.toLowerCase()));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +40,8 @@ class TheoryClusterMapOverlay extends StatelessWidget {
           runSpacing: 8,
           children: [
             for (final n in graph.nodes)
+              if (tagsFilter.isEmpty ||
+                  _lessonMatchesTags(n.id, tagsFilter))
               GestureDetector(
                 onTap: () async {
                   if (onTap != null) onTap!(n);

--- a/lib/widgets/theory_lesson_search_bar.dart
+++ b/lib/widgets/theory_lesson_search_bar.dart
@@ -10,7 +10,9 @@ import '../screens/theory_lesson_preview_screen.dart';
 
 /// Search bar widget for quick theory lesson lookup.
 class TheoryLessonSearchBar extends StatefulWidget {
-  const TheoryLessonSearchBar({super.key});
+  final Set<String> tagsFilter;
+
+  const TheoryLessonSearchBar({super.key, this.tagsFilter = const {}});
 
   @override
   State<TheoryLessonSearchBar> createState() => _TheoryLessonSearchBarState();
@@ -42,7 +44,19 @@ class _TheoryLessonSearchBarState extends State<TheoryLessonSearchBar> {
   }
 
   void _search(String q) {
-    setState(() => _results = _engine.search(q, limit: 10));
+    final found = _engine.search(q, limit: 10);
+    if (widget.tagsFilter.isEmpty) {
+      setState(() => _results = found);
+      return;
+    }
+    final tags = widget.tagsFilter.map((e) => e.toLowerCase()).toSet();
+    final filtered = [
+      for (final l in found)
+        if (tags.every((t) =>
+            l.tags.map((e) => e.toLowerCase()).contains(t)))
+          l
+    ];
+    setState(() => _results = filtered);
   }
 
   @override

--- a/lib/widgets/theory_lesson_tag_sidebar.dart
+++ b/lib/widgets/theory_lesson_tag_sidebar.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_library_service.dart';
+
+/// Vertical sidebar for filtering theory lessons by tag.
+class TheoryLessonTagSidebar extends StatefulWidget {
+  /// Optional lesson source for testing.
+  final List<TheoryMiniLessonNode>? lessons;
+
+  /// Callback when the selected tag set changes.
+  final ValueChanged<Set<String>>? onChanged;
+
+  /// Tags selected initially.
+  final Set<String> initialSelection;
+
+  const TheoryLessonTagSidebar({
+    super.key,
+    this.lessons,
+    this.onChanged,
+    this.initialSelection = const {},
+  });
+
+  @override
+  State<TheoryLessonTagSidebar> createState() => _TheoryLessonTagSidebarState();
+}
+
+class _TheoryLessonTagSidebarState extends State<TheoryLessonTagSidebar> {
+  bool _loading = true;
+  final Map<String, int> _counts = {};
+  late List<String> _tags;
+  late Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = {...widget.initialSelection};
+    _load();
+  }
+
+  Future<void> _load() async {
+    List<TheoryMiniLessonNode> lessons = widget.lessons ?? [];
+    if (lessons.isEmpty) {
+      await MiniLessonLibraryService.instance.loadAll();
+      lessons = MiniLessonLibraryService.instance.all;
+    }
+    final tags = <String>{};
+    for (final l in lessons) {
+      for (final t in l.tags) {
+        final tag = t.trim();
+        if (tag.isEmpty) continue;
+        tags.add(tag);
+        _counts[tag] = (_counts[tag] ?? 0) + 1;
+      }
+    }
+    _tags = tags.toList()..sort();
+    setState(() => _loading = false);
+  }
+
+  void _toggle(String tag) {
+    setState(() {
+      if (_selected.contains(tag)) {
+        _selected.remove(tag);
+      } else {
+        _selected.add(tag);
+      }
+    });
+    widget.onChanged?.call(_selected);
+  }
+
+  void _reset() {
+    setState(() => _selected.clear());
+    widget.onChanged?.call(_selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Column(
+      children: [
+        Expanded(
+          child: ListView(
+            children: [
+              for (final tag in _tags)
+                CheckboxListTile(
+                  value: _selected.contains(tag),
+                  onChanged: (_) => _toggle(tag),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  dense: true,
+                  title: Text('$tag (${_counts[tag]})'),
+                ),
+            ],
+          ),
+        ),
+        TextButton(
+          onPressed: _reset,
+          child: const Text('Показать всё'),
+        ),
+      ],
+    );
+  }
+}

--- a/tests/widgets/theory_lesson_tag_sidebar_test.dart
+++ b/tests/widgets/theory_lesson_tag_sidebar_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/theory_lesson_tag_sidebar.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+void main() {
+  testWidgets('sidebar toggles tag selection', (tester) async {
+    const l1 = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'A',
+      content: '',
+      tags: ['icm', 'push'],
+    );
+    const l2 = TheoryMiniLessonNode(
+      id: 'l2',
+      title: 'B',
+      content: '',
+      tags: ['defense', 'icm'],
+    );
+
+    Set<String>? selected;
+    await tester.pumpWidget(MaterialApp(
+      home: SizedBox(
+        width: 200,
+        child: TheoryLessonTagSidebar(
+          lessons: const [l1, l2],
+          onChanged: (s) => selected = s,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('defense (1)'), findsOneWidget);
+    expect(find.text('icm (2)'), findsOneWidget);
+    expect(find.text('push (1)'), findsOneWidget);
+
+    await tester.tap(find.text('icm (2)'));
+    await tester.pumpAndSettle();
+    expect(selected, contains('icm'));
+
+    await tester.tap(find.text('Показать всё'));
+    await tester.pumpAndSettle();
+    expect(selected, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- allow filtering nodes by tags in `TheoryClusterMapOverlay`
- filter search results by tags in `TheoryLessonSearchBar`
- implement new `TheoryLessonTagSidebar` widget with checkbox tag filters
- add widget test for tag sidebar

## Testing
- `flutter test` *(fails: `bash: command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_688905b102d0832aa82e66ce426b7da3