### PR TITLE
Add TheoryLessonReviewQueue

### DIFF
--- a/lib/services/theory_lesson_review_queue.dart
+++ b/lib/services/theory_lesson_review_queue.dart
@@ -1,0 +1,77 @@
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'session_log_service.dart';
+import 'training_session_service.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Provides a personalized queue of theory mini lessons to review.
+class TheoryLessonReviewQueue {
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+  final SessionLogService logs;
+
+  TheoryLessonReviewQueue({
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+    SessionLogService? logs,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance,
+        logs = logs ?? SessionLogService(sessions: TrainingSessionService());
+
+  static final TheoryLessonReviewQueue instance = TheoryLessonReviewQueue();
+
+  /// Returns the next [limit] lessons to review, optionally filtered by [focusTags].
+  Future<List<TheoryMiniLessonNode>> getNextLessonsToReview({
+    int limit = 5,
+    Set<String> focusTags = const {},
+  }) async {
+    if (limit <= 0) return [];
+    await library.loadAll();
+    await logs.load();
+
+    final mistakeMap = logs.getRecentMistakes();
+    final normalizedFocus = {
+      for (final t in focusTags) t.trim().toLowerCase()
+    }..removeWhere((e) => e.isEmpty);
+
+    final entries = <_Entry>[];
+    for (final lesson in library.all) {
+      if (normalizedFocus.isNotEmpty &&
+          !lesson.tags
+              .map((e) => e.trim().toLowerCase())
+              .any(normalizedFocus.contains)) {
+        continue;
+      }
+      final completed = await progress.isCompleted(lesson.id);
+      final last = await progress.lastViewed(lesson.id);
+      var mistakes = 0;
+      for (final tag in lesson.tags) {
+        final key = tag.trim().toLowerCase();
+        mistakes += mistakeMap[key] ?? 0;
+      }
+      entries.add(_Entry(lesson, completed, mistakes, last));
+    }
+
+    entries.sort((a, b) {
+      if (a.completed != b.completed) {
+        return a.completed ? 1 : -1;
+      }
+      if (a.mistakes != b.mistakes) {
+        return b.mistakes.compareTo(a.mistakes);
+      }
+      final at = a.lastViewed ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bt = b.lastViewed ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return at.compareTo(bt);
+    });
+
+    return [for (final e in entries.take(limit)) e.lesson];
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final bool completed;
+  final int mistakes;
+  final DateTime? lastViewed;
+  _Entry(this.lesson, this.completed, this.mistakes, this.lastViewed);
+}

--- a/test/theory_lesson_review_queue_test.dart
+++ b/test/theory_lesson_review_queue_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_lesson_review_queue.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getNextLessonsToReview orders lessons by priority', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'mini_lesson_progress_l1': '{"viewCount":2,"lastViewed":"${now.subtract(const Duration(days: 10)).toIso8601String()}","completed":false}',
+      'mini_lesson_progress_l2': '{"viewCount":1,"lastViewed":"${now.subtract(const Duration(days: 5)).toIso8601String()}","completed":true}',
+      'mini_lesson_progress_l3': '{"viewCount":1,"lastViewed":"${now.subtract(const Duration(days: 2)).toIso8601String()}","completed":false}',
+    });
+
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['b']),
+      const TheoryMiniLessonNode(id: 'l3', title: 'L3', content: '', tags: ['a', 'b']),
+    ];
+
+    final logs = [
+      SessionLog(
+        sessionId: 's1',
+        templateId: 'p1',
+        startedAt: now,
+        completedAt: now,
+        correctCount: 0,
+        mistakeCount: 0,
+        categories: {'a': 3, 'b': 1},
+      ),
+    ];
+
+    final queue = TheoryLessonReviewQueue(
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      logs: _FakeLogService(logs),
+    );
+
+    final result = await queue.getNextLessonsToReview(limit: 3);
+    expect(result.map((e) => e.id).toList(), ['l3', 'l1', 'l2']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryLessonReviewQueue` service for prioritizing theory mini lessons
- cover service with a unit test

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688928b84898832a8c1b52c168e18a05