### PR TITLE
Implement TheorySmartEntryPointSelector

### DIFF
--- a/lib/services/theory_smart_entry_point_selector.dart
+++ b/lib/services/theory_smart_entry_point_selector.dart
@@ -1,0 +1,65 @@
+import 'dart:math';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'theory_lesson_review_queue.dart';
+
+/// Chooses the best mini lesson to open when entering the theory map.
+class TheorySmartEntryPointSelector {
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+  final TheoryLessonReviewQueue review;
+
+  TheorySmartEntryPointSelector({
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+    TheoryLessonReviewQueue? review,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance,
+        review = review ?? TheoryLessonReviewQueue.instance;
+
+  static final TheorySmartEntryPointSelector instance =
+      TheorySmartEntryPointSelector();
+
+  /// Picks the best starting mini lesson using [focusTags], completion state
+  /// and recent mistakes. Returns null when no lessons are available.
+  Future<TheoryMiniLessonNode?> pickSmartStartLesson({
+    Set<String> focusTags = const {},
+  }) async {
+    await library.loadAll();
+    final normalized = {
+      for (final t in focusTags) t.trim().toLowerCase()
+    }..removeWhere((e) => e.isEmpty);
+
+    // 1) unfinished lesson matching focus tags
+    if (normalized.isNotEmpty) {
+      for (final lesson in library.all) {
+        if (await progress.isCompleted(lesson.id)) continue;
+        final tags = lesson.tags.map((e) => e.trim().toLowerCase());
+        if (tags.any(normalized.contains)) {
+          return lesson;
+        }
+      }
+    }
+
+    // 2) recent mistakes matching focus tags
+    final reviewLessons = await review.getNextLessonsToReview(
+      limit: 1,
+      focusTags: normalized,
+    );
+    if (reviewLessons.isNotEmpty) {
+      final l = reviewLessons.first;
+      if (!await progress.isCompleted(l.id)) return l;
+    }
+
+    // 3) random unfinished lesson
+    final remaining = [
+      for (final l in library.all)
+        if (!await progress.isCompleted(l.id)) l
+    ];
+    if (remaining.isEmpty) return null;
+    final rand = Random();
+    return remaining[rand.nextInt(remaining.length)];
+  }
+}

--- a/test/theory_smart_entry_point_selector_test.dart
+++ b/test/theory_smart_entry_point_selector_test.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_smart_entry_point_selector.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_lesson_review_queue.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeReview extends TheoryLessonReviewQueue {
+  final List<TheoryMiniLessonNode> items;
+  _FakeReview(this.items) : super();
+  @override
+  Future<List<TheoryMiniLessonNode>> getNextLessonsToReview({
+    int limit = 5,
+    Set<String> focusTags = const {},
+  }) async {
+    return items.take(limit).toList();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('prefers unfinished lesson matching focus tag', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['b']),
+    ];
+    final selector = TheorySmartEntryPointSelector(
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      review: _FakeReview([]),
+    );
+    final res = await selector.pickSmartStartLesson(focusTags: {'b'});
+    expect(res?.id, 'l2');
+  });
+
+  test('falls back to review queue when no unfinished match', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'mini_lesson_progress_l2': jsonEncode({'completed': true, 'viewCount': 1, 'lastViewed': now.toIso8601String()}),
+    });
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['b']),
+    ];
+    final selector = TheorySmartEntryPointSelector(
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      review: _FakeReview([lessons.first]),
+    );
+    final res = await selector.pickSmartStartLesson(focusTags: {'b'});
+    expect(res?.id, 'l1');
+  });
+
+  test('returns random unfinished lesson when no data', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['b']),
+    ];
+    final selector = TheorySmartEntryPointSelector(
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      review: _FakeReview([]),
+    );
+    final res = await selector.pickSmartStartLesson();
+    expect(res, isNotNull);
+    expect(['l1', 'l2'], contains(res!.id));
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheorySmartEntryPointSelector` to pick a starting theory mini lesson
- test smart entry point selection logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892a19af4c832a84123a03d8e4f279