### PR TITLE
Implement TheoryGoalCompletionNotifier

### DIFF
--- a/lib/services/mini_lesson_progress_tracker.dart
+++ b/lib/services/mini_lesson_progress_tracker.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -10,6 +11,11 @@ class MiniLessonProgressTracker {
   static const String _prefix = 'mini_lesson_progress_';
 
   final Map<String, _MiniProgress> _cache = {};
+  final StreamController<String> _completedController =
+      StreamController<String>.broadcast();
+
+  /// Stream of lesson ids that were marked as completed.
+  Stream<String> get onLessonCompleted => _completedController.stream;
 
   Future<_MiniProgress> _load(String id) async {
     final cached = _cache[id];
@@ -47,6 +53,7 @@ class MiniLessonProgressTracker {
     data.completed = true;
     data.lastViewed = DateTime.now();
     await _save(id);
+    _completedController.add(id);
   }
 
   /// Returns true if [id] was completed.

--- a/lib/services/theory_goal_completion_notifier.dart
+++ b/lib/services/theory_goal_completion_notifier.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import '../models/theory_goal.dart';
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'theory_goal_engine.dart';
+import 'theory_lesson_progress_tracker.dart';
+
+/// Singleton service that notifies when a theory goal reaches 100% progress.
+class TheoryGoalCompletionNotifier {
+  final MiniLessonProgressTracker tracker;
+  final TheoryGoalEngine engine;
+
+  TheoryGoalCompletionNotifier({
+    MiniLessonProgressTracker? tracker,
+    TheoryGoalEngine? engine,
+  })  : tracker = tracker ?? MiniLessonProgressTracker.instance,
+        engine = engine ?? TheoryGoalEngine.instance {
+    _sub = this.tracker.onLessonCompleted.listen((_) => _checkGoals());
+  }
+
+  static final TheoryGoalCompletionNotifier instance =
+      TheoryGoalCompletionNotifier();
+
+  StreamSubscription<String>? _sub;
+  void Function(TheoryGoal goal)? _callback;
+
+  /// Sets the callback invoked when a goal is completed.
+  void setOnGoalCompleted(void Function(TheoryGoal goal) callback) {
+    _callback = callback;
+  }
+
+  Future<void> _checkGoals() async {
+    final goals = await engine.getActiveGoals(autoRefresh: false);
+    if (goals.isEmpty) return;
+    await MiniLessonLibraryService.instance.loadAll();
+    const progressTracker = TheoryLessonProgressTracker();
+
+    for (final g in List<TheoryGoal>.from(goals)) {
+      final progress = await _goalProgress(g, progressTracker);
+      if (progress >= g.targetProgress) {
+        await engine.markCompleted(g.tagOrCluster);
+        _callback?.call(g);
+      }
+    }
+  }
+
+  Future<double> _goalProgress(
+      TheoryGoal goal, TheoryLessonProgressTracker tracker) async {
+    final tags = goal.tagOrCluster
+        .split(',')
+        .map((e) => e.trim().toLowerCase())
+        .where((e) => e.isNotEmpty)
+        .toList();
+    final lessons = MiniLessonLibraryService.instance.findByTags(tags);
+    if (lessons.isEmpty) return 0.0;
+    return tracker.progressForLessons(lessons);
+  }
+
+  Future<void> dispose() async {
+    await _sub?.cancel();
+  }
+}

--- a/test/services/mini_lesson_progress_tracker_test.dart
+++ b/test/services/mini_lesson_progress_tracker_test.dart
@@ -33,4 +33,14 @@ void main() {
     final id = await tracker.getLeastViewed(['a', 'b']);
     expect(id, 'a');
   });
+
+  test('onLessonCompleted emits lesson id when completed', () async {
+    final tracker = MiniLessonProgressTracker.instance;
+    final events = <String>[];
+    final sub = tracker.onLessonCompleted.listen(events.add);
+    await tracker.markCompleted('x1');
+    await Future.delayed(Duration.zero);
+    expect(events, contains('x1'));
+    await sub.cancel();
+  });
 }

--- a/test/services/theory_goal_completion_notifier_test.dart
+++ b/test/services/theory_goal_completion_notifier_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_goal.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_goal_completion_notifier.dart';
+import 'package:poker_analyzer/services/theory_goal_engine.dart';
+import 'package:poker_analyzer/services/theory_goal_recommender.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_clusterer.dart';
+import 'package:poker_analyzer/services/theory_cluster_summary_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/theory_cluster_summary.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+
+class _FakeRecommender extends TheoryGoalRecommender {
+  final List<TheoryGoal> goals;
+  _FakeRecommender(this.goals)
+      : super(mastery: TagMasteryService(logs: SessionLogService(sessions: TrainingSessionService())));
+
+  @override
+  Future<List<TheoryGoal>> recommend({
+    required List<TheoryClusterSummary> clusters,
+    required Map<String, TheoryMiniLessonNode> lessons,
+  }) async {
+    return goals;
+  }
+}
+
+class _StubClusterer extends TheoryLessonTagClusterer {
+  final List<TheoryLessonCluster> clusters;
+  _StubClusterer(this.clusters);
+  @override
+  Future<List<TheoryLessonCluster>> clusterLessons() async => clusters;
+}
+
+class _StubLibrary extends MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _StubLibrary(this.items) : super._();
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('notifies when goal is completed', () async {
+    SharedPreferences.setMockInitialValues({});
+    final library = _StubLibrary([
+      const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['t']),
+    ]);
+    final goal = const TheoryGoal(
+      title: 'G',
+      description: 'D',
+      tagOrCluster: 't',
+      targetProgress: 1.0,
+    );
+    final engine = TheoryGoalEngine(
+      recommender: _FakeRecommender([goal]),
+      clusterer: _StubClusterer(const []),
+      library: library,
+      summaryService: TheoryClusterSummaryService(),
+    );
+
+    await engine.refreshGoals();
+
+    bool fired = false;
+    final notifier = TheoryGoalCompletionNotifier(
+      tracker: MiniLessonProgressTracker.instance,
+      engine: engine,
+    );
+    notifier.setOnGoalCompleted((g) => fired = true);
+
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    await Future.delayed(Duration.zero);
+
+    expect(fired, isTrue);
+    final remaining = await engine.getActiveGoals(autoRefresh: false);
+    expect(remaining, isEmpty);
+    await notifier.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- emit lesson completion events from `MiniLessonProgressTracker`
- add `TheoryGoalCompletionNotifier` service
- test lesson complete events
- test goal completion notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892b5eb474832ab155c2135b911398