### PR TITLE
Add theory lesson context overlay

### DIFF
--- a/lib/screens/theory_lesson_viewer_screen.dart
+++ b/lib/screens/theory_lesson_viewer_screen.dart
@@ -5,6 +5,7 @@ import 'package:markdown/markdown.dart' as md;
 
 import '../models/theory_mini_lesson_node.dart';
 import '../theme/app_colors.dart';
+import '../widgets/theory_lesson_context_overlay.dart';
 
 /// Inline markdown syntax for ==highlight== spans.
 class _HighlightSyntax extends md.InlineSyntax {
@@ -78,8 +79,10 @@ class TheoryLessonViewerScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: Column(
+      body: Stack(
         children: [
+          Column(
+            children: [
           StickyHeader(
             header: Container(
               color: AppColors.cardBackground,
@@ -148,6 +151,7 @@ class TheoryLessonViewerScreen extends StatelessWidget {
               ),
             ),
           ),
+          TheoryLessonContextOverlay(lessonId: lesson.id),
         ],
       ),
     );

--- a/lib/widgets/theory_lesson_context_overlay.dart
+++ b/lib/widgets/theory_lesson_context_overlay.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_lesson_cluster.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/mini_lesson_progress_tracker.dart';
+import '../services/theory_lesson_navigator_service.dart';
+import '../services/theory_lesson_review_queue.dart';
+import '../screens/theory_lesson_viewer_screen.dart';
+
+/// Contextual overlay shown at the bottom of a theory mini lesson.
+class TheoryLessonContextOverlay extends StatefulWidget {
+  /// Currently viewed lesson id.
+  final String lessonId;
+
+  /// Optional cluster to compute progress and sibling lessons.
+  final TheoryLessonCluster? cluster;
+
+  /// Optional tag filter for review suggestions.
+  final Set<String> tags;
+
+  /// Whether the lesson is already complete. If null it will be
+  /// resolved from [MiniLessonProgressTracker].
+  final bool? isComplete;
+
+  /// Number of mistakes related to this lesson.
+  final int? mistakeCount;
+
+  /// Optional services for testing.
+  final MiniLessonLibraryService? library;
+  final MiniLessonProgressTracker? progress;
+  final TheoryLessonReviewQueue? review;
+
+  const TheoryLessonContextOverlay({
+    super.key,
+    required this.lessonId,
+    this.cluster,
+    this.tags = const {},
+    this.isComplete,
+    this.mistakeCount,
+    this.library,
+    this.progress,
+    this.review,
+  });
+
+  @override
+  State<TheoryLessonContextOverlay> createState() =>
+      _TheoryLessonContextOverlayState();
+}
+
+class _TheoryLessonContextOverlayState
+    extends State<TheoryLessonContextOverlay> {
+  late final MiniLessonLibraryService _library;
+  late final MiniLessonProgressTracker _progress;
+  late final TheoryLessonReviewQueue _review;
+  late final TheoryLessonNavigatorService _nav;
+
+  bool _loading = true;
+  int _completed = 0;
+  int _total = 0;
+  TheoryMiniLessonNode? _next;
+  TheoryMiniLessonNode? _prev;
+  List<TheoryMiniLessonNode> _siblings = [];
+  bool _hasWeakReviews = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _library = widget.library ?? MiniLessonLibraryService.instance;
+    _progress = widget.progress ?? MiniLessonProgressTracker.instance;
+    _review = widget.review ?? TheoryLessonReviewQueue.instance;
+    _nav = TheoryLessonNavigatorService(
+      library: _library,
+      cluster: widget.cluster,
+      tagFilter: widget.tags,
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    await _nav.initialize();
+    _next = _nav.getNext(widget.lessonId);
+    _prev = _nav.getPrevious(widget.lessonId);
+    _siblings = _nav.getSiblings(widget.lessonId);
+
+    if (widget.cluster != null) {
+      _total = widget.cluster!.lessons.length;
+      for (final l in widget.cluster!.lessons) {
+        if (await _progress.isCompleted(l.id)) _completed++;
+      }
+    }
+
+    if (widget.tags.isNotEmpty) {
+      final items = await _review.getNextLessonsToReview(
+        focusTags: widget.tags,
+        limit: 1,
+      );
+      _hasWeakReviews = items.isNotEmpty;
+    } else if ((widget.mistakeCount ?? 0) > 0) {
+      _hasWeakReviews = true;
+    }
+
+    setState(() => _loading = false);
+  }
+
+  bool get _hasActions =>
+      _next != null || _prev != null || _hasWeakReviews || _total > 0;
+
+  void _openLesson(TheoryMiniLessonNode lesson) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheoryLessonViewerScreen(
+          lesson: lesson,
+          currentIndex: 1,
+          totalCount: 1,
+        ),
+      ),
+    );
+  }
+
+  void _retry() {
+    final lesson = _library.getById(widget.lessonId);
+    if (lesson != null) _openLesson(lesson);
+  }
+
+  void _reviewWeak() async {
+    final items = await _review.getNextLessonsToReview(
+      focusTags: widget.tags,
+      limit: 1,
+    );
+    if (items.isNotEmpty) _openLesson(items.first);
+  }
+
+  void _showSiblings() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => ListView(
+        children: [
+          for (final l in _siblings)
+            ListTile(
+              title: Text(l.resolvedTitle),
+              onTap: () {
+                Navigator.pop(context);
+                _openLesson(l);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || !_hasActions) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: SafeArea(
+        child: Container(
+          margin: const EdgeInsets.all(8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (_total > 0)
+                Text(
+                  '$_completed of $_total complete',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              if (_siblings.isNotEmpty)
+                TextButton(
+                  onPressed: _showSiblings,
+                  child: Text('See similar (${_siblings.length})'),
+                ),
+              Row(
+                children: [
+                  if (_prev != null)
+                    OutlinedButton(
+                      onPressed: () => _openLesson(_prev!),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: accent,
+                        side: BorderSide(color: accent),
+                      ),
+                      child: const Text('Go Back'),
+                    ),
+                  if (_next != null) ...[
+                    if (_prev != null) const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: () => _openLesson(_next!),
+                      style: ElevatedButton.styleFrom(backgroundColor: accent),
+                      child: const Text('Next'),
+                    ),
+                  ],
+                  if (_next == null && _prev == null) ...[
+                    ElevatedButton(
+                      onPressed: _retry,
+                      style: ElevatedButton.styleFrom(backgroundColor: accent),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                  const Spacer(),
+                  if (_hasWeakReviews)
+                    TextButton(
+                      onPressed: _reviewWeak,
+                      child: const Text('Review Weak Spots'),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/tests/widgets/theory_lesson_context_overlay_test.dart
+++ b/tests/widgets/theory_lesson_context_overlay_test.dart
@@ -1,0 +1,83 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/widgets/theory_lesson_context_overlay.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_lesson_review_queue.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+class _FakeReview extends TheoryLessonReviewQueue {
+  _FakeReview() : super();
+  @override
+  Future<List<TheoryMiniLessonNode>> getNextLessonsToReview({
+    int limit = 5,
+    Set<String> focusTags = const {},
+  }) async {
+    return const [];
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('hides when no data', (tester) async {
+    const lesson = TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '');
+    final lib = _FakeLibrary(const [lesson]);
+    await tester.pumpWidget(MaterialApp(
+      home: TheoryLessonContextOverlay(
+        lessonId: 'l1',
+        library: lib,
+        progress: MiniLessonProgressTracker.instance,
+        review: _FakeReview(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('complete'), findsNothing);
+    expect(find.text('Next'), findsNothing);
+  });
+
+  testWidgets('shows cluster progress', (tester) async {
+    const l1 = TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '');
+    const l2 = TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '');
+    final cluster = TheoryLessonCluster(lessons: const [l1, l2], tags: const {});
+    final lib = _FakeLibrary(const [l1, l2]);
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+
+    await tester.pumpWidget(MaterialApp(
+      home: TheoryLessonContextOverlay(
+        lessonId: 'l1',
+        cluster: cluster,
+        library: lib,
+        progress: MiniLessonProgressTracker.instance,
+        review: _FakeReview(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('1 of 2 complete'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryLessonContextOverlay` widget for mini-lesson context
- integrate overlay in `TheoryLessonViewerScreen`
- cover behaviour with widget tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688935a5c7d4832a98cd2c5d59b7c994