### PR TITLE
Add cluster completion overlay

### DIFF
--- a/lib/widgets/theory_cluster_completion_overlay.dart
+++ b/lib/widgets/theory_cluster_completion_overlay.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_progress_tracker.dart';
+
+/// Displays completion status for a group of theory lessons.
+/// Shows a checkmark when 100% complete, a progress ring when
+/// partially done and an empty ring when untouched.
+class TheoryClusterCompletionOverlay extends StatelessWidget {
+  final List<TheoryMiniLessonNode> lessons;
+  final double size;
+
+  const TheoryClusterCompletionOverlay({
+    super.key,
+    required this.lessons,
+    this.size = 20,
+  });
+
+  Future<double> _progress() async {
+    if (lessons.isEmpty) return 0.0;
+    final tracker = MiniLessonProgressTracker.instance;
+    var done = 0;
+    for (final l in lessons) {
+      if (await tracker.isCompleted(l.id)) done++;
+    }
+    return done / lessons.length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<double>(
+      future: _progress(),
+      builder: (context, snapshot) {
+        final value = snapshot.data ?? 0.0;
+        if (value >= 1.0) {
+          return Icon(Icons.check_circle, color: Colors.green, size: size);
+        }
+        if (value <= 0.0) {
+          return Icon(Icons.radio_button_unchecked,
+              color: Colors.grey, size: size);
+        }
+        final ring = SizedBox(
+          width: size,
+          height: size,
+          child: CircularProgressIndicator(
+            value: value.clamp(0.0, 1.0),
+            strokeWidth: 3,
+            backgroundColor: Colors.black26,
+            color: Theme.of(context).colorScheme.secondary,
+          ),
+        );
+        final pct = (value * 100).round();
+        return Stack(
+          alignment: Alignment.center,
+          children: [
+            ring,
+            Text(
+              '$pct%',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: size * 0.4,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/theory_cluster_map_overlay.dart
+++ b/lib/widgets/theory_cluster_map_overlay.dart
@@ -6,11 +6,13 @@ import '../models/player_profile.dart';
 import '../services/cluster_node_navigator.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../models/theory_mini_lesson_node.dart';
+import 'theory_cluster_completion_overlay.dart';
 
 /// Simple overlay showing a cluster mini map.
 class TheoryClusterMapOverlay extends StatelessWidget {
   final MiniMapGraph graph;
   final PlayerProfile profile;
+  final List<TheoryMiniLessonNode> lessons;
   final ValueChanged<MiniMapNode>? onTap;
   final Set<String> tagsFilter;
 
@@ -18,6 +20,7 @@ class TheoryClusterMapOverlay extends StatelessWidget {
     super.key,
     required this.graph,
     required this.profile,
+    required this.lessons,
     this.onTap,
     this.tagsFilter = const {},
   });
@@ -33,39 +36,50 @@ class TheoryClusterMapOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Align(
       alignment: Alignment.topCenter,
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final n in graph.nodes)
-              if (tagsFilter.isEmpty ||
-                  _lessonMatchesTags(n.id, tagsFilter))
-              GestureDetector(
-                onTap: () async {
-                  if (onTap != null) onTap!(n);
-                  final lesson = MiniLessonLibraryService.instance.getById(n.id);
-                  if (lesson != null) {
-                    await ClusterNodeNavigator.handleTap(context, lesson, profile);
-                  }
-                },
-                child: Container(
-                  padding: const EdgeInsets.all(6),
-                  decoration: BoxDecoration(
-                    color: n.isCurrent
-                        ? Colors.orangeAccent
-                        : Colors.grey[800],
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Text(
-                    n.title,
-                    style: const TextStyle(fontSize: 12),
-                  ),
-                ),
-              ),
-          ],
-        ),
+      child: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final n in graph.nodes)
+                  if (tagsFilter.isEmpty ||
+                      _lessonMatchesTags(n.id, tagsFilter))
+                    GestureDetector(
+                      onTap: () async {
+                        if (onTap != null) onTap!(n);
+                        final lesson =
+                            MiniLessonLibraryService.instance.getById(n.id);
+                        if (lesson != null) {
+                          await ClusterNodeNavigator.handleTap(
+                              context, lesson, profile);
+                        }
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.all(6),
+                        decoration: BoxDecoration(
+                          color: n.isCurrent
+                              ? Colors.orangeAccent
+                              : Colors.grey[800],
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          n.title,
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ),
+                    ),
+              ],
+            ),
+          ),
+          Positioned(
+            right: 0,
+            top: 0,
+            child: TheoryClusterCompletionOverlay(lessons: lessons, size: 24),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- show completion overlay icon for theory clusters
- display overlay in cluster map

## Testing
- `flutter test` *(fails: Type 'TrainingPackTemplateV2' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688942f5fa14832ab7f690b2f52ba26a