### PR TITLE
Add theory lesson feedback bar

### DIFF
--- a/lib/models/theory_lesson_feedback.dart
+++ b/lib/models/theory_lesson_feedback.dart
@@ -1,0 +1,28 @@
+enum TheoryLessonFeedbackChoice { useful, unclear, hard }
+
+class TheoryLessonFeedback {
+  final String lessonId;
+  final TheoryLessonFeedbackChoice choice;
+  final DateTime timestamp;
+
+  TheoryLessonFeedback({
+    required this.lessonId,
+    required this.choice,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  factory TheoryLessonFeedback.fromJson(Map<String, dynamic> json) {
+    return TheoryLessonFeedback(
+      lessonId: json['lessonId'] as String? ?? '',
+      choice: TheoryLessonFeedbackChoice.values[json['choice'] as int? ?? 0],
+      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'choice': choice.index,
+        'timestamp': timestamp.toIso8601String(),
+      };
+}

--- a/lib/screens/theory_lesson_viewer_screen.dart
+++ b/lib/screens/theory_lesson_viewer_screen.dart
@@ -7,6 +7,7 @@ import '../models/theory_mini_lesson_node.dart';
 import '../theme/app_colors.dart';
 import '../widgets/theory_lesson_context_overlay.dart';
 import '../widgets/theory_path_map_toggle_button.dart';
+import '../widgets/theory_lesson_feedback_bar.dart';
 
 /// Inline markdown syntax for ==highlight== spans.
 class _HighlightSyntax extends md.InlineSyntax {
@@ -118,6 +119,7 @@ class TheoryLessonViewerScreen extends StatelessWidget {
               ),
             ),
           ),
+          TheoryLessonFeedbackBar(lessonId: lesson.id),
           SafeArea(
             child: Container(
               color: AppColors.cardBackground,

--- a/lib/services/theory_feedback_storage.dart
+++ b/lib/services/theory_feedback_storage.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_lesson_feedback.dart';
+
+class TheoryFeedbackStorage {
+  TheoryFeedbackStorage._();
+
+  static final TheoryFeedbackStorage instance = TheoryFeedbackStorage._();
+
+  static const String _key = 'theory_lesson_feedback';
+
+  Future<List<TheoryLessonFeedback>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_key) ?? [];
+    return [
+      for (final s in raw)
+        if (s.isNotEmpty)
+          try {
+            TheoryLessonFeedback.fromJson(
+                jsonDecode(s) as Map<String, dynamic>)
+          } catch (_) {
+            null
+          }
+    ].whereType<TheoryLessonFeedback>().toList();
+  }
+
+  Future<void> _save(List<TheoryLessonFeedback> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _key,
+      [for (final f in list) jsonEncode(f.toJson())],
+    );
+  }
+
+  Future<void> record(String lessonId, TheoryLessonFeedbackChoice choice) async {
+    final list = await _load();
+    final idx = list.indexWhere((e) => e.lessonId == lessonId);
+    final entry = TheoryLessonFeedback(lessonId: lessonId, choice: choice);
+    if (idx >= 0) {
+      list[idx] = entry;
+    } else {
+      list.add(entry);
+    }
+    while (list.length > 200) {
+      list.removeAt(0);
+    }
+    await _save(list);
+  }
+
+  Future<TheoryLessonFeedback?> getFeedback(String lessonId) async {
+    final list = await _load();
+    return list.firstWhere(
+      (e) => e.lessonId == lessonId,
+      orElse: () => null,
+    );
+  }
+
+  Future<List<TheoryLessonFeedback>> getAll() => _load();
+}

--- a/lib/widgets/theory_lesson_feedback_bar.dart
+++ b/lib/widgets/theory_lesson_feedback_bar.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_lesson_feedback.dart';
+import '../services/theory_feedback_storage.dart';
+
+class TheoryLessonFeedbackBar extends StatefulWidget {
+  final String lessonId;
+
+  const TheoryLessonFeedbackBar({super.key, required this.lessonId});
+
+  @override
+  State<TheoryLessonFeedbackBar> createState() =>
+      _TheoryLessonFeedbackBarState();
+}
+
+class _TheoryLessonFeedbackBarState extends State<TheoryLessonFeedbackBar> {
+  TheoryLessonFeedbackChoice? _choice;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final fb =
+        await TheoryFeedbackStorage.instance.getFeedback(widget.lessonId);
+    if (mounted) setState(() => _choice = fb?.choice);
+  }
+
+  Future<void> _select(TheoryLessonFeedbackChoice choice) async {
+    await TheoryFeedbackStorage.instance.record(widget.lessonId, choice);
+    if (mounted) {
+      setState(() => _choice = choice);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Спасибо за отзыв!')),
+      );
+    }
+  }
+
+  Widget _button(TheoryLessonFeedbackChoice choice, String label, IconData icon) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final selected = _choice == choice;
+    return Expanded(
+      child: OutlinedButton.icon(
+        onPressed: () => _select(choice),
+        icon: Icon(icon, color: accent),
+        label: Text(label),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: selected ? Colors.white : accent,
+          side: BorderSide(color: accent),
+          backgroundColor: selected ? accent.withOpacity(0.2) : null,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Оцените урок:',
+              style: TextStyle(color: Colors.white)),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              _button(TheoryLessonFeedbackChoice.useful, 'Полезно',
+                  Icons.thumb_up_alt_outlined),
+              const SizedBox(width: 8),
+              _button(TheoryLessonFeedbackChoice.unclear, 'Непонятно',
+                  Icons.help_outline),
+              const SizedBox(width: 8),
+              _button(TheoryLessonFeedbackChoice.hard, 'Сложно',
+                  Icons.whatshot_outlined),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow users to give quick feedback after each theory lesson
- store `TheoryLessonFeedback` records in `SharedPreferences`
- display `TheoryLessonFeedbackBar` below lesson content

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68894db14014832a839ec8adbb3c3650