### PR TITLE
Add theory cluster dashboard

### DIFF
--- a/lib/screens/theory_cluster_dashboard_screen.dart
+++ b/lib/screens/theory_cluster_dashboard_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../services/theory_lesson_tag_clusterer.dart';
+import '../services/theory_cluster_progress_service.dart';
+import '../widgets/theory_cluster_summary_card.dart';
+import '../screens/theory_lesson_preview_screen.dart';
+
+/// Dashboard listing all theory clusters with progress.
+class TheoryClusterDashboardScreen extends StatefulWidget {
+  const TheoryClusterDashboardScreen({super.key});
+
+  @override
+  State<TheoryClusterDashboardScreen> createState() =>
+      _TheoryClusterDashboardScreenState();
+}
+
+class _TheoryClusterDashboardScreenState
+    extends State<TheoryClusterDashboardScreen> {
+  bool _loading = true;
+  List<ClusterProgress> _data = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final clusterer = TheoryLessonTagClusterer();
+    final clusters = await clusterer.clusterLessons();
+    final progress =
+        await const TheoryClusterProgressService().computeProgress(clusters);
+    if (!mounted) return;
+    setState(() {
+      _data = progress;
+      _loading = false;
+    });
+  }
+
+  Future<void> _openCluster(ClusterProgress c) async {
+    if (c.cluster.lessons.isEmpty) return;
+    final lesson = c.cluster.lessons.first;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TheoryLessonPreviewScreen(lessonId: lesson.id),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Theory Clusters')),
+      backgroundColor: const Color(0xFF121212),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                for (final c in _data)
+                  TheoryClusterSummaryCard(
+                    progress: c,
+                    onTap: () => _openCluster(c),
+                  ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/widgets/theory_cluster_summary_card.dart
+++ b/lib/widgets/theory_cluster_summary_card.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_lesson_cluster.dart';
+import '../services/theory_cluster_progress_service.dart';
+
+/// Card showing cluster tags, lesson count and progress bar.
+class TheoryClusterSummaryCard extends StatelessWidget {
+  final ClusterProgress progress;
+  final VoidCallback? onTap;
+
+  const TheoryClusterSummaryCard({
+    super.key,
+    required this.progress,
+    this.onTap,
+  });
+
+  TheoryLessonCluster get cluster => progress.cluster;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final tags = cluster.tags.join(', ');
+    final percent = progress.percent.clamp(0.0, 1.0);
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              tags.isNotEmpty ? tags : 'Cluster',
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${progress.completed} / ${progress.total} lessons',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: percent,
+                backgroundColor: Colors.white24,
+                valueColor: AlwaysStoppedAnimation<Color>(accent),
+                minHeight: 6,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement TheoryClusterDashboardScreen to list clusters with progress
- add TheoryClusterSummaryCard widget

## Testing
- `dart analyze` (shows many lint warnings)

------
https://chatgpt.com/codex/tasks/task_e_688953878bac832a9c7f9231878128ad