### PR TITLE
Add SmartTheoryBoosterLinker

### DIFF
--- a/lib/services/smart_theory_booster_linker.dart
+++ b/lib/services/smart_theory_booster_linker.dart
@@ -1,0 +1,54 @@
+import '../models/theory_lesson_cluster.dart';
+import '../services/theory_cluster_summary_service.dart';
+import '../services/theory_lesson_tag_clusterer.dart';
+
+/// Generates deep links to theory clusters based on completed lessons or tags.
+class SmartTheoryBoosterLinker {
+  final TheoryLessonTagClusterer clusterer;
+  final TheoryClusterSummaryService summaryService;
+
+  const SmartTheoryBoosterLinker({
+    TheoryLessonTagClusterer? clusterer,
+    TheoryClusterSummaryService? summaryService,
+  })  : clusterer = clusterer ?? TheoryLessonTagClusterer(),
+        summaryService = summaryService ?? TheoryClusterSummaryService();
+
+  /// Returns a deep link for the cluster containing [lessonId].
+  Future<String?> linkForLesson(String lessonId) async {
+    final clusters = await clusterer.clusterLessons();
+    for (final c in clusters) {
+      if (c.lessons.any((l) => l.id == lessonId)) {
+        final summary = summaryService.generateSummary(c);
+        if (summary.entryPointIds.isNotEmpty) {
+          return '/theory/cluster?clusterId=${summary.entryPointIds.first}';
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Returns a deep link to the best matching cluster for [tags].
+  Future<String?> linkForTags(List<String> tags) async {
+    final queryTags = {for (final t in tags) t.trim().toLowerCase()}
+      ..removeWhere((t) => t.isEmpty);
+    if (queryTags.isEmpty) return null;
+
+    final clusters = await clusterer.clusterLessons();
+    String? link;
+    double best = 0;
+    for (final c in clusters) {
+      final clusterTags = {for (final t in c.tags) t.trim().toLowerCase()}
+        ..removeWhere((t) => t.isEmpty);
+      final overlap = clusterTags.intersection(queryTags).length.toDouble();
+      if (overlap > best && clusterTags.isNotEmpty) {
+        final summary = summaryService.generateSummary(c);
+        if (summary.entryPointIds.isNotEmpty) {
+          best = overlap;
+          link = '/theory/cluster?clusterId=${summary.entryPointIds.first}';
+        }
+      }
+    }
+    return link;
+  }
+}
+

--- a/test/services/smart_theory_booster_linker_test.dart
+++ b/test/services/smart_theory_booster_linker_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/services/smart_theory_booster_linker.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_clusterer.dart';
+import 'package:poker_analyzer/services/theory_cluster_summary_service.dart';
+
+class _StubClusterer extends TheoryLessonTagClusterer {
+  final List<TheoryLessonCluster> clusters;
+  _StubClusterer(this.clusters);
+  @override
+  Future<List<TheoryLessonCluster>> clusterLessons() async => clusters;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('linkForLesson returns deep link to containing cluster', () async {
+    const l1 = TheoryMiniLessonNode(id: 'a', title: 'A', content: '', nextIds: ['b']);
+    const l2 = TheoryMiniLessonNode(id: 'b', title: 'B', content: '');
+    const cluster = TheoryLessonCluster(lessons: [l1, l2], tags: {'preflop'});
+
+    final linker = SmartTheoryBoosterLinker(
+      clusterer: _StubClusterer(const [cluster]),
+      summaryService: TheoryClusterSummaryService(),
+    );
+
+    final link = await linker.linkForLesson('b');
+    expect(link, '/theory/cluster?clusterId=a');
+  });
+
+  test('linkForTags picks cluster with overlapping tags', () async {
+    const c1 = TheoryLessonCluster(
+      lessons: [TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '')],
+      tags: {'push'},
+    );
+    const c2 = TheoryLessonCluster(
+      lessons: [TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '')],
+      tags: {'call'},
+    );
+
+    final linker = SmartTheoryBoosterLinker(
+      clusterer: _StubClusterer(const [c1, c2]),
+      summaryService: TheoryClusterSummaryService(),
+    );
+
+    final link = await linker.linkForTags(['call']);
+    expect(link, '/theory/cluster?clusterId=l2');
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `SmartTheoryBoosterLinker` for mapping lessons or tags to theory clusters
- test cluster link generation logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895e86b37c832a8a973c013e0e2c6b