### PR TITLE
Implement BoosterTheoryInjector

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -19,6 +19,7 @@ class TrainingPackSpot {
   /// Ephemeral flag — used only in RAM to highlight freshly imported spots.
   /// Never written to / read from JSON.
   bool isNew = false;
+
   /// Ephemeral flag – marks automatically generated variations.
   /// Never written to / read from JSON.
   bool isGenerated = false;
@@ -200,7 +201,9 @@ class TrainingPackSpot {
 
     map['type'] = yaml['type']?.toString() ?? 'quiz';
 
-    final board = <String>[for (final c in (yaml['board'] as List? ?? [])) c.toString()];
+    final board = <String>[
+      for (final c in (yaml['board'] as List? ?? [])) c.toString()
+    ];
     if (board.length >= 3 && board.length <= 5) map['board'] = board;
 
     final street = (yaml['street'] as num?)?.toInt() ?? 0;
@@ -211,7 +214,9 @@ class TrainingPackSpot {
       map['villainAction'] = villain;
     }
 
-    final heroOptions = <String>[for (final o in (yaml['heroOptions'] as List? ?? [])) o.toString()];
+    final heroOptions = <String>[
+      for (final o in (yaml['heroOptions'] as List? ?? [])) o.toString()
+    ];
     if (heroOptions.isNotEmpty) map['heroOptions'] = heroOptions;
 
     if (yaml['meta'] is Map) {
@@ -265,7 +270,7 @@ class TrainingPackSpot {
           const DeepCollectionEquality().equals(meta, other.meta);
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
         id,
         type,
         title,
@@ -287,7 +292,7 @@ class TrainingPackSpot {
         villainAction,
         const ListEquality().hash(heroOptions),
         const DeepCollectionEquality().hash(meta),
-      );
+      ]);
 }
 
 extension TrainingPackSpotStreet on TrainingPackSpot {

--- a/lib/services/booster_theory_injector.dart
+++ b/lib/services/booster_theory_injector.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/mistake_tag.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../widgets/theory_recap_dialog.dart';
+import 'suggestion_cooldown_manager.dart';
+
+enum BoosterTheoryInjectionMode { preDrill, postDrill }
+
+/// Injects theory recap dialogs into booster drills based on weakness tags.
+class BoosterTheoryInjector {
+  final BoosterTheoryInjectionMode mode;
+  const BoosterTheoryInjector(
+      {this.mode = BoosterTheoryInjectionMode.preDrill});
+
+  /// Shows a [TheoryRecapDialog] when [spot] contains a tag in [weakTags].
+  Future<void> maybeInject(
+    BuildContext context, {
+    required TrainingPackSpot spot,
+    required List<MistakeTag> weakTags,
+  }) async {
+    final spotTags = {for (final t in spot.tags) t.trim().toLowerCase()};
+    MistakeTag? matched;
+    for (final tag in weakTags) {
+      if (spotTags.contains(tag.name.toLowerCase())) {
+        matched = tag;
+        break;
+      }
+    }
+    if (matched == null) return;
+    final key = 'booster_theory_${matched.name.toLowerCase()}';
+    final underCooldown = await SuggestionCooldownManager.isUnderCooldown(
+      key,
+      cooldown: const Duration(days: 1),
+    );
+    if (underCooldown) return;
+    await showTheoryRecapDialog(
+      context,
+      tags: [matched.name],
+      trigger: 'booster',
+    );
+    await SuggestionCooldownManager.markSuggested(key);
+  }
+}

--- a/test/services/booster_theory_injector_test.dart
+++ b/test/services/booster_theory_injector_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/booster_theory_injector.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/widgets/theory_recap_dialog.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> _pump(WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+  }
+
+  testWidgets('shows recap when tag matches weakness', (tester) async {
+    await _pump(tester);
+    final spot =
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['overfoldBtn']);
+    const injector = BoosterTheoryInjector();
+    await injector.maybeInject(
+      tester.element(find.byType(SizedBox)),
+      spot: spot,
+      weakTags: [MistakeTag.overfoldBtn],
+    );
+    await tester.pump();
+    expect(find.byType(TheoryRecapDialog), findsOneWidget);
+  });
+
+  testWidgets('respects cooldown per tag', (tester) async {
+    await _pump(tester);
+    final spot =
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['overfoldBtn']);
+    const injector = BoosterTheoryInjector();
+    await injector.maybeInject(
+      tester.element(find.byType(SizedBox)),
+      spot: spot,
+      weakTags: [MistakeTag.overfoldBtn],
+    );
+    await tester.pump();
+    await tester.tap(find.text('Got it'));
+    await tester.pumpAndSettle();
+    await injector.maybeInject(
+      tester.element(find.byType(SizedBox)),
+      spot: spot,
+      weakTags: [MistakeTag.overfoldBtn],
+    );
+    await tester.pump();
+    expect(find.byType(TheoryRecapDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterTheoryInjector logic for theory recaps
- handle tag-based recap injection with cooldown check
- test BoosterTheoryInjector behaviour
- fix TrainingPackSpot hashCode to use `hashAll`

## Testing
- `flutter analyze --no-pub` *(fails: 6431 issues found)*
- `flutter test --no-pub test/services/booster_theory_injector_test.dart` *(failed to run due to missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68897809e294832a939ac49f82b133fd