### PR TITLE
Implement BoosterMistakeRecorder

### DIFF
--- a/lib/screens/booster_recap_screen.dart
+++ b/lib/screens/booster_recap_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -7,6 +8,7 @@ import '../models/v2/training_pack_template_v2.dart';
 import '../models/training_pack.dart';
 import '../services/training_session_service.dart';
 import '../services/booster_recap_hook.dart';
+import '../services/booster_mistake_recorder.dart';
 import '../theme/app_colors.dart';
 import 'training_session_screen.dart';
 
@@ -40,6 +42,11 @@ class _BoosterRecapScreenState extends State<BoosterRecapScreen> {
         booster: widget.booster,
         backlink: widget.backlink,
       );
+      unawaited(BoosterMistakeRecorder.instance.recordSession(
+        booster: widget.booster,
+        actions: context.read<TrainingSessionService>().actionLog,
+        spots: context.read<TrainingSessionService>().spots,
+      ));
     });
   }
 

--- a/lib/services/booster_mistake_recorder.dart
+++ b/lib/services/booster_mistake_recorder.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/training_spot_attempt.dart';
+import '../models/v2/training_action.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'auto_mistake_tagger_engine.dart';
+import 'mistake_tag_history_service.dart';
+
+class BoosterMistakeRecorder {
+  BoosterMistakeRecorder._();
+  static final BoosterMistakeRecorder instance = BoosterMistakeRecorder._();
+
+  static const _enabledKey = 'booster_mistake_recorder_enabled';
+  bool _enabled = true;
+  final Set<String> _recorded = <String>{};
+
+  bool get enabled => _enabled;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_enabledKey) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    _enabled = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+  }
+
+  Future<void> recordSession({
+    required TrainingPackTemplateV2 booster,
+    required List<TrainingAction> actions,
+    required List<TrainingPackSpot> spots,
+  }) async {
+    if (!_enabled) return;
+    final map = {for (final s in spots) s.id: s};
+    for (final a in actions) {
+      if (a.isCorrect) continue;
+      if (!_recorded.add(a.spotId)) continue;
+      final spot = map[a.spotId];
+      if (spot == null) continue;
+      final correct = spot.correctAction ?? '';
+      final heroEv = _actionEv(spot, a.chosenAction);
+      final bestEv = _bestEv(spot);
+      final diff = _calcEvDiff(heroEv, bestEv, a.chosenAction, correct) ?? 0;
+      final attempt = TrainingSpotAttempt(
+        spot: spot,
+        userAction: a.chosenAction,
+        correctAction: correct,
+        evDiff: diff,
+      );
+      final tags = const AutoMistakeTaggerEngine().tag(attempt);
+      await MistakeTagHistoryService.logTags(booster.id, attempt, tags);
+    }
+    _recorded.clear();
+  }
+
+  double? _actionEv(TrainingPackSpot spot, String action) {
+    for (final a in spot.hand.actions[0] ?? []) {
+      if (a.playerIndex == spot.hand.heroIndex &&
+          a.action.toLowerCase() == action.toLowerCase()) {
+        return a.ev;
+      }
+    }
+    return null;
+  }
+
+  double? _bestEv(TrainingPackSpot spot) {
+    double? best;
+    for (final a in spot.hand.actions[0] ?? []) {
+      if (a.playerIndex == spot.hand.heroIndex && a.ev != null) {
+        best = best == null ? a.ev! : max(best, a.ev!);
+      }
+    }
+    return best;
+  }
+
+  double? _calcEvDiff(
+    double? heroEv,
+    double? bestEv,
+    String user,
+    String correct,
+  ) {
+    if (heroEv == null || bestEv == null) return null;
+    final c = correct.toLowerCase();
+    if (c == 'push' || c == 'call' || c == 'raise') {
+      return bestEv - heroEv;
+    }
+    return heroEv - bestEv;
+  }
+}

--- a/test/services/booster_mistake_recorder_test.dart
+++ b/test/services/booster_mistake_recorder_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/services/booster_mistake_recorder.dart';
+import 'package:poker_analyzer/services/mistake_tag_history_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_action.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+TrainingPackTemplateV2 _tpl(TrainingPackSpot spot) => TrainingPackTemplateV2(
+      id: 'b1',
+      name: 'b1',
+      trainingType: TrainingType.theory,
+      tags: const ['cbet'],
+      spots: [spot],
+      spotCount: 1,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      positions: const [],
+      meta: const {},
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('records booster mistakes', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+    SharedPreferences.setMockInitialValues({});
+
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(
+        position: HeroPosition.btn,
+        heroIndex: 0,
+        actions: {
+          0: [
+            ActionEntry(0, 0, 'push', ev: 1),
+            ActionEntry(0, 0, 'fold', ev: 0),
+          ],
+        },
+        stacks: const {'0': 10, '1': 10},
+      ),
+      correctAction: 'push',
+      tags: const ['cbet'],
+    );
+    final booster = _tpl(spot);
+
+    await BoosterMistakeRecorder.instance.load();
+    await BoosterMistakeRecorder.instance.recordSession(
+      booster: booster,
+      actions: [
+        TrainingAction(spotId: 's1', chosenAction: 'fold', isCorrect: false),
+      ],
+      spots: [spot],
+    );
+
+    final history = await MistakeTagHistoryService.getRecentHistory(limit: 10);
+    expect(history.length, 1);
+    expect(history.first.tags, contains(MistakeTag.overfoldBtn));
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterMistakeRecorder` service for saving booster errors
- hook recorder into `BoosterRecapScreen`
- test booster mistake recording

## Testing
- `flutter test test/services/booster_mistake_recorder_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898137cc10832a8d338e34fa0ea484