### PR TITLE
Implement TheoryBoosterRecommender engine

### DIFF
--- a/lib/services/booster_library_service.dart
+++ b/lib/services/booster_library_service.dart
@@ -1,0 +1,55 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'training_pack_library_loader_service.dart';
+
+class BoosterLibraryService {
+  BoosterLibraryService._();
+  static final BoosterLibraryService instance = BoosterLibraryService._();
+
+  final List<TrainingPackTemplateV2> _boosters = [];
+  final Map<String, TrainingPackTemplateV2> _index = {};
+  bool _loaded = false;
+
+  Future<void> loadAll({int limit = 500}) async {
+    if (_loaded) return;
+    await TrainingPackLibraryLoaderService.instance.preloadLibrary(limit: limit);
+    final all = TrainingPackLibraryLoaderService.instance.loadedTemplates;
+    _boosters.clear();
+    _index.clear();
+    for (final tpl in all) {
+      final meta = tpl.meta;
+      if (meta['type']?.toString().toLowerCase() == 'booster') {
+        _boosters.add(tpl);
+        _index[tpl.id] = tpl;
+      }
+    }
+    // Fallback to bundled packs
+    if (_boosters.isEmpty) {
+      await TrainingPackLibraryV2.instance.loadFromFolder();
+      final packs = TrainingPackLibraryV2.instance.filterBy(
+        type: TrainingType.pushFold,
+      );
+      for (final p in packs) {
+        final meta = p.meta;
+        if (meta['type']?.toString().toLowerCase() == 'booster') {
+          _boosters.add(p);
+          _index[p.id] = p;
+        }
+      }
+    }
+    _loaded = true;
+  }
+
+  List<TrainingPackTemplateV2> get all => List.unmodifiable(_boosters);
+
+  TrainingPackTemplateV2? getById(String id) => _index[id];
+
+  List<TrainingPackTemplateV2> findByTag(String tag) {
+    final lc = tag.toLowerCase();
+    return [
+      for (final p in _boosters)
+        if (p.meta['tag']?.toString().toLowerCase() == lc) p
+    ];
+  }
+}

--- a/lib/services/theory_booster_recommender.dart
+++ b/lib/services/theory_booster_recommender.dart
@@ -1,0 +1,70 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/mistake_tag_history_entry.dart';
+import '../services/mistake_tag_history_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/booster_library_service.dart';
+
+class BoosterRecommendationResult {
+  final String boosterId;
+  final String reasonTag;
+  final double priority;
+
+  const BoosterRecommendationResult({
+    required this.boosterId,
+    required this.reasonTag,
+    required this.priority,
+  });
+}
+
+class TheoryBoosterRecommender {
+  final BoosterLibraryService library;
+
+  const TheoryBoosterRecommender({this.library = BoosterLibraryService.instance});
+
+  Future<BoosterRecommendationResult?> recommend(
+    TheoryMiniLessonNode lesson, {
+    List<MistakeTagHistoryEntry>? recentMistakes,
+  }) async {
+    await library.loadAll();
+    final tags = {for (final t in lesson.tags) t.trim().toLowerCase()}
+      ..removeWhere((t) => t.isEmpty);
+    if (tags.isEmpty) return null;
+
+    recentMistakes ??=
+        await MistakeTagHistoryService.getRecentHistory(limit: 50);
+
+    final tagImpact = <String, double>{};
+    for (final entry in recentMistakes) {
+      final impact = entry.evDiff.abs();
+      for (final tag in entry.tags) {
+        final key = tag.label.toLowerCase();
+        if (tags.contains(key)) {
+          tagImpact.update(key, (v) => v + impact, ifAbsent: () => impact);
+        }
+      }
+    }
+
+    TrainingPackTemplateV2? best;
+    String? bestTag;
+    double bestScore = -1;
+
+    for (final tag in tags) {
+      final boosters = library.findByTag(tag);
+      if (boosters.isEmpty) continue;
+      final score = tagImpact[tag] ?? 0.0;
+      if (score > bestScore) {
+        best = boosters.first;
+        bestTag = tag;
+        bestScore = score;
+      }
+    }
+
+    if (best == null) return null;
+
+    return BoosterRecommendationResult(
+      boosterId: best!.id,
+      reasonTag: bestTag ?? '',
+      priority: bestScore,
+    );
+  }
+}

--- a/lib/services/theory_session_service.dart
+++ b/lib/services/theory_session_service.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'mistake_tag_history_service.dart';
+import 'theory_booster_recommender.dart';
+
+class TheorySessionService extends ChangeNotifier {
+  final MiniLessonProgressTracker progress;
+  final TheoryBoosterRecommender recommender;
+
+  TheorySessionService({
+    MiniLessonProgressTracker? progress,
+    TheoryBoosterRecommender? recommender,
+  })  : progress = progress ?? MiniLessonProgressTracker.instance,
+        recommender = recommender ?? const TheoryBoosterRecommender();
+
+  Future<BoosterRecommendationResult?> onComplete(
+      TheoryMiniLessonNode lesson) async {
+    await progress.markCompleted(lesson.id);
+    final history = await MistakeTagHistoryService.getRecentHistory(limit: 50);
+    final rec = await recommender.recommend(lesson, recentMistakes: history);
+    return rec;
+  }
+}

--- a/test/services/theory_booster_recommender_test.dart
+++ b/test/services/theory_booster_recommender_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_booster_recommender.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/mistake_tag_history_entry.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/booster_library_service.dart';
+import 'package:collection/collection.dart';
+
+TrainingPackTemplateV2 booster(String id, String tag) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: [tag],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+    meta: {'type': 'booster', 'tag': tag},
+  );
+}
+
+class _FakeLibrary implements BoosterLibraryService {
+  final List<TrainingPackTemplateV2> boosters;
+  _FakeLibrary(this.boosters);
+  @override
+  Future<void> loadAll({int limit = 500}) async {}
+  @override
+  List<TrainingPackTemplateV2> get all => boosters;
+  @override
+  TrainingPackTemplateV2? getById(String id) =>
+      boosters.firstWhereOrNull((b) => b.id == id);
+  @override
+  List<TrainingPackTemplateV2> findByTag(String tag) {
+    return [for (final b in boosters) if (b.meta['tag'] == tag) b];
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('recommends booster matching lesson tag and ev impact', () async {
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: ['btn overfold'],
+    );
+
+    final history = [
+      MistakeTagHistoryEntry(
+        timestamp: DateTime.now(),
+        packId: 'p1',
+        spotId: 's1',
+        tags: const [MistakeTag.overfoldBtn],
+        evDiff: -10,
+      ),
+    ];
+
+    final library = _FakeLibrary([
+      booster('b1', 'btn overfold'),
+      booster('b2', 'loose call'),
+    ]);
+
+    final rec = await TheoryBoosterRecommender(library: library)
+        .recommend(lesson, recentMistakes: history);
+
+    expect(rec, isNotNull);
+    expect(rec!.boosterId, 'b1');
+    expect(rec.reasonTag, 'btn overfold');
+    expect(rec.priority, greaterThan(0));
+  });
+
+  test('returns null when no booster matches', () async {
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: ['icm'],
+    );
+    final library = _FakeLibrary([booster('b1', 'push')]);
+    final rec = await TheoryBoosterRecommender(library: library)
+        .recommend(lesson, recentMistakes: const []);
+    expect(rec, isNull);
+  });
+}

--- a/test/services/theory_session_service_test.dart
+++ b/test/services/theory_session_service_test.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_session_service.dart';
+import 'package:poker_analyzer/services/theory_booster_recommender.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeRecommender extends TheoryBoosterRecommender {
+  final BoosterRecommendationResult? result;
+  const _FakeRecommender(this.result);
+  @override
+  Future<BoosterRecommendationResult?> recommend(
+      TheoryMiniLessonNode lesson, {List recentMistakes = const []}) async {
+    return result;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onComplete marks lesson and returns recommendation', () async {
+    SharedPreferences.setMockInitialValues({});
+    final rec = const BoosterRecommendationResult(
+      boosterId: 'b',
+      reasonTag: 'tag',
+      priority: 1.0,
+    );
+    final service = TheorySessionService(
+      recommender: const _FakeRecommender(rec),
+    );
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: const [],
+    );
+    final res = await service.onComplete(lesson);
+    expect(res, isNotNull);
+    expect(res!.boosterId, 'b');
+    final completed = await service.progress.isCompleted('l1');
+    expect(completed, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterLibraryService` to load booster packs
- implement `TheoryBoosterRecommender` for suggesting contextual boosters
- implement `TheorySessionService` with `onComplete` hook
- add unit tests for new recommender and session service

## Testing
- `dart`/`flutter` commands were unavailable so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_688985c491f0832aad171c1ca752d544