### PR TITLE
Add booster recommendation banner

### DIFF
--- a/lib/screens/theory_recap_screen.dart
+++ b/lib/screens/theory_recap_screen.dart
@@ -5,9 +5,11 @@ import '../models/theory_cluster_summary.dart';
 import '../services/theory_lesson_navigator_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../widgets/tag_badge.dart';
+import '../widgets/booster_recommendation_banner.dart';
+import '../services/theory_booster_recommender.dart';
 
 /// Displays a recap after completing a [TheoryMiniLessonNode].
-class TheoryRecapScreen extends StatelessWidget {
+class TheoryRecapScreen extends StatefulWidget {
   final TheoryMiniLessonNode lesson;
   final TheoryClusterSummary? cluster;
   final TheoryLessonNavigatorService? navigator;
@@ -25,14 +27,24 @@ class TheoryRecapScreen extends StatelessWidget {
     this.onContinue,
     this.onReviewAgain,
     this.onGoToPath,
+    this.boosterRecommendation,
   });
+
+  final BoosterRecommendationResult? boosterRecommendation;
+
+  @override
+  State<TheoryRecapScreen> createState() => _TheoryRecapScreenState();
+}
+
+class _TheoryRecapScreenState extends State<TheoryRecapScreen> {
+  bool _showBooster = true;
 
   @override
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
-    final next = navigator?.getNext(lesson.id);
-    final clusterLabel = cluster != null && cluster!.sharedTags.isNotEmpty
-        ? cluster!.sharedTags.join(', ')
+    final next = widget.navigator?.getNext(widget.lesson.id);
+    final clusterLabel = widget.cluster != null && widget.cluster!.sharedTags.isNotEmpty
+        ? widget.cluster!.sharedTags.join(', ')
         : null;
     return Scaffold(
       appBar: AppBar(title: const Text('Theory Recap')),
@@ -43,19 +55,19 @@ class TheoryRecapScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              '${lesson.resolvedTitle} \u2014 \u2713',
+              '${widget.lesson.resolvedTitle} \u2014 \u2713',
               style: const TextStyle(
                 color: Colors.white,
                 fontSize: 20,
                 fontWeight: FontWeight.bold,
               ),
             ),
-            if (lesson.tags.isNotEmpty) ...[
+            if (widget.lesson.tags.isNotEmpty) ...[
               const SizedBox(height: 8),
               Wrap(
                 spacing: 4,
                 runSpacing: -4,
-                children: [for (final t in lesson.tags) TagBadge(t)],
+                children: [for (final t in widget.lesson.tags) TagBadge(t)],
               ),
             ],
             if (clusterLabel != null) ...[
@@ -63,6 +75,14 @@ class TheoryRecapScreen extends StatelessWidget {
               Text(
                 'Cluster: $clusterLabel',
                 style: const TextStyle(color: Colors.white70),
+              ),
+            ],
+            if (_showBooster && widget.boosterRecommendation != null) ...[
+              const SizedBox(height: 12),
+              BoosterRecommendationBanner(
+                recommendation: widget.boosterRecommendation!,
+                onStarted: () => setState(() => _showBooster = false),
+                onDismissed: () => setState(() => _showBooster = false),
               ),
             ],
             const Spacer(),
@@ -77,7 +97,8 @@ class TheoryRecapScreen extends StatelessWidget {
               children: [
                 Expanded(
                   child: ElevatedButton(
-                    onPressed: onContinue ?? () => Navigator.pop(context),
+                    onPressed:
+                        widget.onContinue ?? () => Navigator.pop(context),
                     style: ElevatedButton.styleFrom(backgroundColor: accent),
                     child: Text(next != null ? 'Continue' : 'Done'),
                   ),
@@ -85,7 +106,8 @@ class TheoryRecapScreen extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: OutlinedButton(
-                    onPressed: onReviewAgain ?? () => Navigator.pop(context),
+                    onPressed:
+                        widget.onReviewAgain ?? () => Navigator.pop(context),
                     style: OutlinedButton.styleFrom(
                       foregroundColor: accent,
                       side: BorderSide(color: accent),
@@ -95,12 +117,12 @@ class TheoryRecapScreen extends StatelessWidget {
                 ),
               ],
             ),
-            if (onGoToPath != null) ...[
+            if (widget.onGoToPath != null) ...[
               const SizedBox(height: 8),
               SizedBox(
                 width: double.infinity,
                 child: TextButton(
-                  onPressed: onGoToPath,
+                  onPressed: widget.onGoToPath,
                   child: const Text('Go to path'),
                 ),
               ),

--- a/lib/services/theory_exit_handler.dart
+++ b/lib/services/theory_exit_handler.dart
@@ -7,6 +7,7 @@ import '../models/booster_backlink.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/booster_pack_launcher.dart';
+import '../services/theory_session_service.dart';
 import '../screens/theory_lesson_viewer_screen.dart';
 import '../screens/theory_recap_screen.dart';
 
@@ -23,6 +24,8 @@ class TheoryExitHandler {
     dynamic skillMapStatus,
     BoosterBacklink? backlink,
   }) async {
+    final session = TheorySessionService();
+    final boosterRec = await session.onComplete(node);
     final nextId = node.nextIds.isNotEmpty ? node.nextIds.first : null;
     if (nextId != null) {
       await MiniLessonLibraryService.instance.loadAll();
@@ -54,6 +57,7 @@ class TheoryExitHandler {
         builder: (_) => TheoryRecapScreen(
           lesson: node,
           cluster: cluster,
+          boosterRecommendation: boosterRec,
         ),
       ),
     );

--- a/lib/widgets/booster_recommendation_banner.dart
+++ b/lib/widgets/booster_recommendation_banner.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import '../services/theory_booster_recommender.dart';
+import '../services/booster_library_service.dart';
+import '../services/training_session_launcher.dart';
+
+/// Persistent banner recommending a booster pack after theory lessons.
+class BoosterRecommendationBanner extends StatefulWidget {
+  final BoosterRecommendationResult recommendation;
+  final VoidCallback? onStarted;
+  final VoidCallback? onDismissed;
+
+  const BoosterRecommendationBanner({
+    super.key,
+    required this.recommendation,
+    this.onStarted,
+    this.onDismissed,
+  });
+
+  @override
+  State<BoosterRecommendationBanner> createState() =>
+      _BoosterRecommendationBannerState();
+}
+
+class _BoosterRecommendationBannerState
+    extends State<BoosterRecommendationBanner> {
+  bool _loading = true;
+  bool _visible = true;
+  
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await BoosterLibraryService.instance.loadAll();
+    if (mounted) setState(() => _loading = false);
+  }
+
+  Future<void> _start() async {
+    final tpl = BoosterLibraryService.instance
+        .getById(widget.recommendation.boosterId);
+    if (tpl == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Booster pack not found')),
+      );
+      return;
+    }
+    await const TrainingSessionLauncher().launch(tpl);
+    widget.onStarted?.call();
+    if (mounted) setState(() => _visible = false);
+  }
+
+  void _dismiss() {
+    widget.onDismissed?.call();
+    setState(() => _visible = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible || _loading) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final rec = widget.recommendation;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Укрепите теорию на практике',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _dismiss,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text('Booster: ${rec.reasonTag}',
+              style: const TextStyle(color: Colors.white70)),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _start,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Начать тренировку'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add banner widget to prompt users to launch recommended booster drills
- show the banner on the theory recap screen
- return booster recommendation from TheoryExitHandler

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68898ed6d104832aad4bc968f73944cb