### PR TITLE
Add TheoryWeaknessRepeater service

### DIFF
--- a/lib/models/lesson_failure.dart
+++ b/lib/models/lesson_failure.dart
@@ -1,0 +1,17 @@
+class LessonFailure {
+  final DateTime timestamp;
+  final double evLoss;
+
+  const LessonFailure({required this.timestamp, required this.evLoss});
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': timestamp.toIso8601String(),
+        'evLoss': evLoss,
+      };
+
+  factory LessonFailure.fromJson(Map<String, dynamic> j) => LessonFailure(
+        timestamp:
+            DateTime.tryParse(j['timestamp']?.toString() ?? '') ?? DateTime.now(),
+        evLoss: (j['evLoss'] as num?)?.toDouble() ?? 0,
+      );
+}

--- a/lib/services/theory_weakness_repeater.dart
+++ b/lib/services/theory_weakness_repeater.dart
@@ -1,0 +1,50 @@
+import '../models/lesson_failure.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+
+/// Suggests previously failed theory lessons for spaced repetition.
+class TheoryWeaknessRepeater {
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+
+  const TheoryWeaknessRepeater({
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance;
+
+  /// Returns lessons ranked by failure recency and EV loss.
+  Future<List<TheoryMiniLessonNode>> recommend({
+    int limit = 5,
+    int minDays = 3,
+  }) async {
+    await library.loadAll();
+    final now = DateTime.now();
+    final cutoff = now.subtract(Duration(days: minDays));
+    final scored = <_Entry>[];
+
+    for (final lesson in library.all) {
+      final failures = await progress.failures(lesson.id);
+      if (failures.isEmpty) continue;
+      final last = failures.first.timestamp;
+      if (last.isAfter(cutoff)) continue;
+      final days = now.difference(last).inDays;
+      var loss = 0.0;
+      for (final f in failures) {
+        loss += f.evLoss.abs();
+      }
+      final score = days + loss;
+      scored.add(_Entry(lesson, score));
+    }
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return [for (final s in scored.take(limit)) s.lesson];
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  _Entry(this.lesson, this.score);
+}

--- a/test/services/theory_weakness_repeater_test.dart
+++ b/test/services/theory_weakness_repeater_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_weakness_repeater.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('recommends failed lessons after delay', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'mini_lesson_failure_l1': jsonEncode([
+        {
+          'timestamp': now.subtract(const Duration(days: 5)).toIso8601String(),
+          'evLoss': -1.0
+        }
+      ]),
+      'mini_lesson_failure_l2': jsonEncode([
+        {
+          'timestamp': now.subtract(const Duration(days: 4)).toIso8601String(),
+          'evLoss': -0.2
+        }
+      ]),
+      'mini_lesson_failure_l3': jsonEncode([
+        {
+          'timestamp': now.subtract(const Duration(days: 1)).toIso8601String(),
+          'evLoss': -2.0
+        }
+      ]),
+    });
+
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: ''),
+      const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: ''),
+      const TheoryMiniLessonNode(id: 'l3', title: 'L3', content: ''),
+    ];
+
+    final repeater = TheoryWeaknessRepeater(
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+    );
+
+    final result = await repeater.recommend(limit: 2, minDays: 3);
+    expect(result.map((e) => e.id).toList(), ['l1', 'l2']);
+  });
+}


### PR DESCRIPTION
## Summary
- track lesson failures in `MiniLessonProgressTracker`
- add model `LessonFailure`
- implement `TheoryWeaknessRepeater` service
- test recommendation logic for old failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889981462dc832a840cfbd84c8ffa42