### PR TITLE
Add SmartTheoryBoosterBridge

### DIFF
--- a/lib/services/smart_theory_booster_bridge.dart
+++ b/lib/services/smart_theory_booster_bridge.dart
@@ -1,0 +1,94 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/theory_cluster_summary.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'booster_library_service.dart';
+import 'theory_lesson_tag_clusterer.dart';
+import 'theory_cluster_summary_service.dart';
+import 'theory_booster_recommender.dart';
+
+/// Links weak theory lessons to relevant booster packs.
+class SmartTheoryBoosterBridge {
+  final BoosterLibraryService library;
+  final TheoryLessonTagClusterer clusterer;
+  final TheoryClusterSummaryService summaryService;
+
+  const SmartTheoryBoosterBridge({
+    this.library = BoosterLibraryService.instance,
+    TheoryLessonTagClusterer? clusterer,
+    TheoryClusterSummaryService? summaryService,
+  })  : clusterer = clusterer ?? TheoryLessonTagClusterer(),
+        summaryService = summaryService ?? TheoryClusterSummaryService();
+
+  /// Returns booster recommendations for [lessons] sorted by score.
+  Future<List<BoosterRecommendationResult>> recommend(
+    List<TheoryMiniLessonNode> lessons,
+  ) async {
+    if (lessons.isEmpty) return <BoosterRecommendationResult>[];
+    await library.loadAll();
+    final boosters = library.all;
+    if (boosters.isEmpty) return <BoosterRecommendationResult>[];
+
+    final clusters = await clusterer.clusterLessons();
+    final lessonClusters = <String, TheoryClusterSummary>{};
+    for (final c in clusters) {
+      final summary = summaryService.generateSummary(c);
+      for (final l in c.lessons) {
+        lessonClusters[l.id] = summary;
+      }
+    }
+
+    final results = <BoosterRecommendationResult>[];
+
+    for (final lesson in lessons) {
+      final tags = {
+        for (final t in lesson.tags) t.trim().toLowerCase()
+      }..removeWhere((t) => t.isEmpty);
+      final cluster = lessonClusters[lesson.id];
+      final clusterTags = cluster != null
+          ? cluster.sharedTags.map((e) => e.trim().toLowerCase()).toSet()
+          : <String>{};
+
+      TrainingPackTemplateV2? best;
+      String? bestTag;
+      double bestScore = 0;
+
+      for (final booster in boosters) {
+        final bTags = <String>{
+          ...booster.tags.map((e) => e.trim().toLowerCase()),
+          if (booster.meta['tag'] != null)
+            booster.meta['tag'].toString().toLowerCase(),
+        }..removeWhere((t) => t.isEmpty);
+
+        final overlap = bTags.intersection(tags);
+        final clusterOverlap = bTags.intersection(clusterTags);
+        if (overlap.isEmpty && clusterOverlap.isEmpty) continue;
+
+        var score = overlap.length + clusterOverlap.length;
+        if (booster.trainingType == TrainingType.pushFold) {
+          score += 0.5;
+        }
+        if (score > bestScore) {
+          best = booster;
+          bestScore = score.toDouble();
+          bestTag =
+              overlap.isNotEmpty ? overlap.first : clusterOverlap.first;
+        }
+      }
+
+      if (best != null && bestTag != null) {
+        results.add(
+          BoosterRecommendationResult(
+            boosterId: best!.id,
+            reasonTag: bestTag!,
+            priority: bestScore,
+            origin: 'weakTheory',
+          ),
+        );
+      }
+    }
+
+    results.sort((a, b) => b.priority.compareTo(a.priority));
+    return results;
+  }
+}

--- a/lib/services/theory_booster_recommender.dart
+++ b/lib/services/theory_booster_recommender.dart
@@ -8,11 +8,13 @@ class BoosterRecommendationResult {
   final String boosterId;
   final String reasonTag;
   final double priority;
+  final String origin;
 
   const BoosterRecommendationResult({
     required this.boosterId,
     required this.reasonTag,
     required this.priority,
+    this.origin = '',
   });
 }
 
@@ -65,6 +67,7 @@ class TheoryBoosterRecommender {
       boosterId: best!.id,
       reasonTag: bestTag ?? '',
       priority: bestScore,
+      origin: 'lesson',
     );
   }
 }

--- a/test/services/smart_theory_booster_bridge_test.dart
+++ b/test/services/smart_theory_booster_bridge_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/smart_theory_booster_bridge.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_clusterer.dart';
+import 'package:poker_analyzer/services/theory_cluster_summary_service.dart';
+import 'package:poker_analyzer/services/booster_library_service.dart';
+import 'package:poker_analyzer/services/theory_booster_recommender.dart';
+import 'package:collection/collection.dart';
+
+TrainingPackTemplateV2 booster(String id, String tag) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: [tag],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+    meta: {'type': 'booster', 'tag': tag},
+  );
+}
+
+class _FakeLibrary implements BoosterLibraryService {
+  final List<TrainingPackTemplateV2> boosters;
+  _FakeLibrary(this.boosters);
+  @override
+  Future<void> loadAll({int limit = 500}) async {}
+  @override
+  List<TrainingPackTemplateV2> get all => boosters;
+  @override
+  TrainingPackTemplateV2? getById(String id) =>
+      boosters.firstWhereOrNull((b) => b.id == id);
+  @override
+  List<TrainingPackTemplateV2> findByTag(String tag) => [];
+}
+
+class _StubClusterer extends TheoryLessonTagClusterer {
+  final List<TheoryLessonCluster> clusters;
+  _StubClusterer(this.clusters);
+  @override
+  Future<List<TheoryLessonCluster>> clusterLessons() async => clusters;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('recommend links lessons to boosters by tag', () async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: ['push'],
+    );
+    final cluster = TheoryLessonCluster(lessons: const [lesson], tags: const {'push'});
+    final library = _FakeLibrary([booster('b1', 'push')]);
+    final bridge = SmartTheoryBoosterBridge(
+      library: library,
+      clusterer: _StubClusterer([cluster]),
+      summaryService: TheoryClusterSummaryService(),
+    );
+
+    final recs = await bridge.recommend(const [lesson]);
+    expect(recs.length, 1);
+    expect(recs.first.boosterId, 'b1');
+    expect(recs.first.origin, 'weakTheory');
+  });
+
+  test('falls back to cluster tags when lesson has none', () async {
+    const l1 = TheoryMiniLessonNode(id: 'a', title: '', content: '', tags: []);
+    const l2 = TheoryMiniLessonNode(id: 'b', title: '', content: '', tags: ['call']);
+    final cluster = TheoryLessonCluster(lessons: const [l1, l2], tags: const {'call'});
+    final library = _FakeLibrary([booster('b2', 'call')]);
+    final bridge = SmartTheoryBoosterBridge(
+      library: library,
+      clusterer: _StubClusterer([cluster]),
+      summaryService: TheoryClusterSummaryService(),
+    );
+
+    final recs = await bridge.recommend(const [l1]);
+    expect(recs.length, 1);
+    expect(recs.first.boosterId, 'b2');
+  });
+}

--- a/test/services/theory_booster_recommender_test.dart
+++ b/test/services/theory_booster_recommender_test.dart
@@ -73,6 +73,7 @@ void main() {
     expect(rec!.boosterId, 'b1');
     expect(rec.reasonTag, 'btn overfold');
     expect(rec.priority, greaterThan(0));
+    expect(rec.origin, 'lesson');
   });
 
   test('returns null when no booster matches', () async {

--- a/test/services/theory_session_service_test.dart
+++ b/test/services/theory_session_service_test.dart
@@ -24,6 +24,7 @@ void main() {
       boosterId: 'b',
       reasonTag: 'tag',
       priority: 1.0,
+      origin: 'lesson',
     );
     final service = TheorySessionService(
       recommender: const _FakeRecommender(rec),
@@ -37,6 +38,7 @@ void main() {
     final res = await service.onComplete(lesson);
     expect(res, isNotNull);
     expect(res!.boosterId, 'b');
+    expect(res.origin, 'lesson');
     final completed = await service.progress.isCompleted('l1');
     expect(completed, true);
   });


### PR DESCRIPTION
## Summary
- add SmartTheoryBoosterBridge service to connect weak theory lessons with booster packs
- extend BoosterRecommendationResult with `origin`
- adjust TheoryBoosterRecommender to set origin
- unit tests for new bridge and updated recommender

## Testing
- `dart` or `flutter` commands unavailable in the environment

------
https://chatgpt.com/codex/tasks/task_e_68899992a320832aa564edef64df09bb