### PR TITLE
Implement TheoryReplayCooldownManager

### DIFF
--- a/lib/services/smart_theory_booster_bridge.dart
+++ b/lib/services/smart_theory_booster_bridge.dart
@@ -6,6 +6,7 @@ import 'booster_library_service.dart';
 import 'theory_lesson_tag_clusterer.dart';
 import 'theory_cluster_summary_service.dart';
 import 'theory_booster_recommender.dart';
+import 'theory_replay_cooldown_manager.dart';
 
 /// Links weak theory lessons to relevant booster packs.
 class SmartTheoryBoosterBridge {
@@ -77,6 +78,9 @@ class SmartTheoryBoosterBridge {
       }
 
       if (best != null && bestTag != null) {
+        if (await TheoryReplayCooldownManager.isUnderCooldown(bestTag!)) {
+          continue;
+        }
         results.add(
           BoosterRecommendationResult(
             boosterId: best!.id,

--- a/lib/services/theory_replay_cooldown_manager.dart
+++ b/lib/services/theory_replay_cooldown_manager.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages cooldowns for theory replay suggestions by tag.
+class TheoryReplayCooldownManager {
+  static const String _prefsKey = 'theory_replay_cooldowns';
+
+  /// Default cooldown duration between suggestions.
+  static Duration defaultCooldown = const Duration(hours: 24);
+
+  static Map<String, DateTime>? _cache;
+
+  static Future<Map<String, DateTime>> _load() async {
+    if (_cache != null) return _cache!;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          _cache = {
+            for (final e in data.entries)
+              if (e.value is String && DateTime.tryParse(e.value as String) != null)
+                e.key.toString(): DateTime.parse(e.value as String),
+          };
+          return _cache!;
+        }
+      } catch (_) {}
+    }
+    _cache = <String, DateTime>{};
+    return _cache!;
+  }
+
+  static Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final map = _cache ?? <String, DateTime>{};
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({for (final e in map.entries) e.key: e.value.toIso8601String()}),
+    );
+  }
+
+  /// Returns true if [tag] was suggested within [cooldown].
+  static Future<bool> isUnderCooldown(
+    String tag, {
+    Duration? cooldown,
+  }) async {
+    final map = await _load();
+    final last = map[tag];
+    if (last == null) return false;
+    final cd = cooldown ?? defaultCooldown;
+    return DateTime.now().difference(last) < cd;
+  }
+
+  /// Marks [tag] as suggested and prunes stale entries.
+  static Future<void> markSuggested(String tag) async {
+    final map = await _load();
+    map[tag] = DateTime.now();
+    final cutoff = DateTime.now().subtract(const Duration(days: 60));
+    map.removeWhere((_, ts) => ts.isBefore(cutoff));
+    await _save();
+  }
+}

--- a/lib/services/weak_theory_review_launcher.dart
+++ b/lib/services/weak_theory_review_launcher.dart
@@ -4,7 +4,7 @@ import '../models/mistake_tag.dart';
 import '../models/mistake_tag_history_entry.dart';
 import '../widgets/theory_recap_dialog.dart';
 import 'mistake_tag_history_service.dart';
-import 'suggestion_cooldown_manager.dart';
+import 'theory_replay_cooldown_manager.dart';
 
 /// Launches theory recap when repeated weaknesses are detected.
 class WeakTheoryReviewLauncher {
@@ -58,10 +58,10 @@ class WeakTheoryReviewLauncher {
       final packCount = tagPacks[tag]?.length ?? 0;
       if (count < threshold || packCount < 2) continue;
       final key = 'weak_theory_${tag.name.toLowerCase()}';
-      if (await SuggestionCooldownManager.isUnderCooldown(
-          key,
-          cooldown: const Duration(days: 1),
-        )) {
+      if (await TheoryReplayCooldownManager.isUnderCooldown(
+        key,
+        cooldown: const Duration(days: 1),
+      )) {
         continue;
       }
       await showTheoryRecapDialog(
@@ -69,7 +69,7 @@ class WeakTheoryReviewLauncher {
         tags: [tag.name],
         trigger: 'weakness',
       );
-      await SuggestionCooldownManager.markSuggested(key);
+      await TheoryReplayCooldownManager.markSuggested(key);
       break;
     }
   }

--- a/lib/widgets/theory_progress_recovery_banner.dart
+++ b/lib/widgets/theory_progress_recovery_banner.dart
@@ -7,7 +7,7 @@ import '../services/mini_lesson_library_service.dart';
 import '../services/smart_theory_booster_bridge.dart';
 import '../services/booster_library_service.dart';
 import '../services/training_session_launcher.dart';
-import '../services/suggestion_cooldown_manager.dart';
+import '../services/theory_replay_cooldown_manager.dart';
 import '../services/recall_analytics_service.dart';
 import '../widgets/theory_recap_dialog.dart';
 import '../services/weak_theory_review_launcher.dart';
@@ -67,12 +67,12 @@ class _TheoryProgressRecoveryBannerState
       final packCount = tagPacks[tag]?.length ?? 0;
       if (count < launcher.threshold || packCount < 2) continue;
       final key = 'weak_theory_${tag.name.toLowerCase()}';
-      final under = await SuggestionCooldownManager.isUnderCooldown(
+      final under = await TheoryReplayCooldownManager.isUnderCooldown(
         key,
         cooldown: const Duration(days: 1),
       );
       if (under) continue;
-      await SuggestionCooldownManager.markSuggested(key);
+      await TheoryReplayCooldownManager.markSuggested(key);
       return tag;
     }
     return null;


### PR DESCRIPTION
## Summary
- add `TheoryReplayCooldownManager` to handle tag-based cooldowns
- gate recovery banner prompts using new manager
- update weak theory review launcher to respect replay cooldowns
- filter booster recommendations by cooldowns

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68899dc67070832a960defe85c4f6319