### PR TITLE
Implement TheoryCompletionEventDispatcher

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -38,6 +38,7 @@ import '../services/daily_learning_goal_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/pack_library_loader_service.dart';
 import '../services/smart_stage_unlock_engine.dart';
+import '../services/theory_completion_event_dispatcher.dart';
 import '../services/training_milestone_engine.dart';
 import '../widgets/confetti_overlay.dart';
 import '../widgets/booster_progress_overlay.dart';
@@ -496,6 +497,12 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text(milestone.message)));
       }
+      TheoryCompletionEventDispatcher.instance.dispatch(
+        TheoryCompletionEvent(
+          lessonId: tpl.id,
+          wasSuccessful: total == 0 ? true : correct / total >= 0.5,
+        ),
+      );
     }
   }
 

--- a/lib/services/theory_completion_event_dispatcher.dart
+++ b/lib/services/theory_completion_event_dispatcher.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'recall_analytics_service.dart';
+import 'theory_reinforcement_scheduler.dart';
+import 'theory_replay_cooldown_manager.dart';
+
+class TheoryCompletionEvent {
+  final String lessonId;
+  final bool wasSuccessful;
+  final DateTime timestamp;
+
+  TheoryCompletionEvent({
+    required this.lessonId,
+    required this.wasSuccessful,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+}
+
+class TheoryCompletionEventDispatcher {
+  TheoryCompletionEventDispatcher._() {
+    addListener((event) {
+      unawaited(TheoryReplayCooldownManager.markSuggested(event.lessonId));
+    });
+    addListener((event) {
+      if (event.wasSuccessful) {
+        unawaited(
+            TheoryReinforcementScheduler.instance.registerSuccess(event.lessonId));
+      } else {
+        unawaited(
+            TheoryReinforcementScheduler.instance.registerFailure(event.lessonId));
+      }
+    });
+    addListener((event) {
+      RecallAnalyticsService.instance.logPrompt(
+        trigger: 'theoryCompletion',
+        lessonId: event.lessonId,
+        dismissed: false,
+      );
+    });
+  }
+
+  static final TheoryCompletionEventDispatcher instance =
+      TheoryCompletionEventDispatcher._();
+
+  final List<void Function(TheoryCompletionEvent)> _listeners = [];
+
+  void addListener(void Function(TheoryCompletionEvent) fn) {
+    _listeners.add(fn);
+  }
+
+  void removeListener(void Function(TheoryCompletionEvent) fn) {
+    _listeners.remove(fn);
+  }
+
+  void dispatch(TheoryCompletionEvent event) {
+    for (final l in List<void Function(TheoryCompletionEvent)>.from(_listeners)) {
+      try {
+        l(event);
+      } catch (_) {}
+    }
+  }
+}

--- a/lib/services/theory_session_service.dart
+++ b/lib/services/theory_session_service.dart
@@ -4,6 +4,7 @@ import '../models/theory_mini_lesson_node.dart';
 import 'mini_lesson_progress_tracker.dart';
 import 'mistake_tag_history_service.dart';
 import 'theory_booster_recommender.dart';
+import 'theory_completion_event_dispatcher.dart';
 
 class TheorySessionService extends ChangeNotifier {
   final MiniLessonProgressTracker progress;
@@ -20,6 +21,12 @@ class TheorySessionService extends ChangeNotifier {
     await progress.markCompleted(lesson.id);
     final history = await MistakeTagHistoryService.getRecentHistory(limit: 50);
     final rec = await recommender.recommend(lesson, recentMistakes: history);
+    TheoryCompletionEventDispatcher.instance.dispatch(
+      TheoryCompletionEvent(
+        lessonId: lesson.id,
+        wasSuccessful: true,
+      ),
+    );
     return rec;
   }
 }

--- a/test/services/theory_completion_event_dispatcher_test.dart
+++ b/test/services/theory_completion_event_dispatcher_test.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_completion_event_dispatcher.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('dispatch triggers default listeners', () async {
+    final dispatcher = TheoryCompletionEventDispatcher.instance;
+    dispatcher.dispatch(TheoryCompletionEvent(lessonId: 'l1', wasSuccessful: true));
+
+    await Future.delayed(const Duration(milliseconds: 10));
+    final prefs = await SharedPreferences.getInstance();
+    final cooldown = prefs.getString('theory_replay_cooldowns');
+    expect(cooldown, isNotNull);
+
+    final schedule = prefs.getString('theory_reinforcement_schedule');
+    expect(schedule, isNotNull);
+
+    final log = prefs.getStringList('user_action_log');
+    expect(log, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- create `TheoryCompletionEventDispatcher` singleton
- emit unified completion events from theory sessions and booster summaries
- notify default systems: cooldowns, reinforcement scheduler, analytics
- add unit test for dispatcher

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a15417e8832aaa094cac358b2013