### PR TITLE
Add booster→theory recap linker

### DIFF
--- a/lib/services/booster_recap_hook.dart
+++ b/lib/services/booster_recap_hook.dart
@@ -5,6 +5,7 @@ import '../models/training_pack.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/drill_result.dart';
 import 'smart_theory_recap_engine.dart';
+import 'theory_boost_recap_linker.dart';
 
 /// Listens to booster and drill results and triggers theory recap when needed.
 class BoosterRecapHook {
@@ -60,6 +61,9 @@ class BoosterRecapHook {
         lessonId = backlink.relatedLessonIds.first;
       }
     }
+    lessonId ??= tags != null && tags.isNotEmpty
+        ? const TheoryBoostRecapLinker().getLinkedLesson(tags.first)
+        : null;
     await engine.maybePrompt(lessonId: lessonId, tags: tags);
   }
 }

--- a/lib/services/theory_boost_recap_linker.dart
+++ b/lib/services/theory_boost_recap_linker.dart
@@ -1,0 +1,43 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Links booster tags to theory mini lessons for recap suggestions.
+class TheoryBoostRecapLinker {
+  /// Mapping of booster tag to lesson id.
+  final Map<String, String> tagMap;
+
+  /// Creates a linker with an optional [tagMap]. Defaults to [_defaultMap].
+  const TheoryBoostRecapLinker({Map<String, String>? tagMap})
+      : tagMap = tagMap ?? _defaultMap;
+
+  static const Map<String, String> _defaultMap = {
+    'bubble_fold': 'bubble_fold',
+    'iso_vs_limp': 'iso_vs_limp',
+  };
+
+  /// Returns the lesson id linked to [tag] or null if none found.
+  /// Matching is case-insensitive and also supports prefix matches.
+  String? getLinkedLesson(String tag) {
+    final key = tag.trim();
+    if (key.isEmpty) return null;
+    final direct = tagMap[key];
+    if (direct != null) return direct;
+    final lower = key.toLowerCase();
+    final lowerMatch = tagMap[lower];
+    if (lowerMatch != null) return lowerMatch;
+    for (final entry in tagMap.entries) {
+      if (lower.startsWith(entry.key.toLowerCase())) {
+        return entry.value;
+      }
+    }
+    return null;
+  }
+
+  /// Convenience to get the actual lesson node for [tag].
+  Future<TheoryMiniLessonNode?> fetchLesson(String tag) async {
+    await MiniLessonLibraryService.instance.loadAll();
+    final id = getLinkedLesson(tag);
+    return id != null ? MiniLessonLibraryService.instance.getById(id) : null;
+  }
+}
+

--- a/lib/services/weak_theory_review_launcher.dart
+++ b/lib/services/weak_theory_review_launcher.dart
@@ -5,6 +5,7 @@ import '../models/mistake_tag_history_entry.dart';
 import '../widgets/theory_recap_dialog.dart';
 import 'mistake_tag_history_service.dart';
 import 'theory_replay_cooldown_manager.dart';
+import 'theory_boost_recap_linker.dart';
 
 /// Launches theory recap when repeated weaknesses are detected.
 class WeakTheoryReviewLauncher {
@@ -64,9 +65,11 @@ class WeakTheoryReviewLauncher {
       )) {
         continue;
       }
+      final lessonId = const TheoryBoostRecapLinker().getLinkedLesson(tag.name);
       await showTheoryRecapDialog(
         context,
-        tags: [tag.name],
+        lessonId: lessonId,
+        tags: lessonId == null ? [tag.name] : null,
         trigger: 'weakness',
       );
       await TheoryReplayCooldownManager.markSuggested(key);

--- a/lib/widgets/theory_progress_recovery_banner.dart
+++ b/lib/widgets/theory_progress_recovery_banner.dart
@@ -11,6 +11,8 @@ import '../services/theory_replay_cooldown_manager.dart';
 import '../services/recall_analytics_service.dart';
 import '../widgets/theory_recap_dialog.dart';
 import '../services/weak_theory_review_launcher.dart';
+import '../services/theory_boost_recap_linker.dart';
+import 'package:collection/collection.dart';
 
 /// Banner suggesting theory recap or booster after a session.
 class TheoryProgressRecoveryBanner extends StatefulWidget {
@@ -83,10 +85,11 @@ class _TheoryProgressRecoveryBannerState
     if (tag != null) {
       _tag = tag;
       await MiniLessonLibraryService.instance.loadAll();
-      final lessons =
-          MiniLessonLibraryService.instance.findByTags([tag.name]);
-      if (lessons.isNotEmpty) {
-        _lesson = lessons.first;
+      final linker = const TheoryBoostRecapLinker();
+      _lesson = await linker.fetchLesson(tag.name);
+      _lesson ??=
+          MiniLessonLibraryService.instance.findByTags([tag.name]).firstOrNull;
+      if (_lesson != null) {
         final bridge = SmartTheoryBoosterBridge();
         final recs = await bridge.recommend([_lesson!]);
         if (recs.isNotEmpty) {


### PR DESCRIPTION
## Summary
- map booster tags to mini lessons via `TheoryBoostRecapLinker`
- suggest recaps based on this map in `WeakTheoryReviewLauncher`
- surface mapped lessons in `TheoryProgressRecoveryBanner`
- fallback to linked lesson when showing booster recap results

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a3505184832a805b383acec6a2a6