### PR TITLE
Add TheoryRecapReviewTracker

### DIFF
--- a/lib/models/theory_recap_review_entry.dart
+++ b/lib/models/theory_recap_review_entry.dart
@@ -1,0 +1,23 @@
+class TheoryRecapReviewEntry {
+  final String lessonId;
+  final String trigger;
+  final DateTime timestamp;
+
+  const TheoryRecapReviewEntry({
+    required this.lessonId,
+    required this.trigger,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'trigger': trigger,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory TheoryRecapReviewEntry.fromJson(Map<String, dynamic> json) => TheoryRecapReviewEntry(
+        lessonId: json['lessonId'] as String? ?? '',
+        trigger: json['trigger'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/services/booster_recap_hook.dart
+++ b/lib/services/booster_recap_hook.dart
@@ -6,6 +6,8 @@ import '../models/v2/training_pack_template.dart';
 import '../models/drill_result.dart';
 import 'smart_theory_recap_engine.dart';
 import 'theory_boost_recap_linker.dart';
+import 'theory_recap_review_tracker.dart';
+import '../models/theory_recap_review_entry.dart';
 
 /// Listens to booster and drill results and triggers theory recap when needed.
 class BoosterRecapHook {
@@ -65,6 +67,13 @@ class BoosterRecapHook {
         ? const TheoryBoostRecapLinker().getLinkedLesson(tags.first)
         : null;
     await engine.maybePrompt(lessonId: lessonId, tags: tags);
+    await TheoryRecapReviewTracker.instance.log(
+      TheoryRecapReviewEntry(
+        lessonId: lessonId ?? '',
+        trigger: 'boosterFailure',
+        timestamp: DateTime.now(),
+      ),
+    );
   }
 }
 

--- a/lib/services/theory_recap_review_tracker.dart
+++ b/lib/services/theory_recap_review_tracker.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_recap_review_entry.dart';
+
+/// Stores history of recap sessions triggered by various reminders.
+class TheoryRecapReviewTracker {
+  TheoryRecapReviewTracker._();
+  static final TheoryRecapReviewTracker instance = TheoryRecapReviewTracker._();
+
+  static const _key = 'theory_recap_review_history';
+
+  final List<TheoryRecapReviewEntry> _history = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is List) {
+          _history.addAll(data.whereType<Map>().map(
+              (e) => TheoryRecapReviewEntry.fromJson(Map<String, dynamic>.from(e))));
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _key,
+      jsonEncode([for (final h in _history) h.toJson()]),
+    );
+  }
+
+  /// Logs a recap review entry.
+  Future<void> log(TheoryRecapReviewEntry entry) async {
+    await _load();
+    _history.insert(0, entry);
+    if (_history.length > 100) _history.removeRange(100, _history.length);
+    await _save();
+  }
+
+  /// Returns stored history, filtered by [trigger] if provided.
+  Future<List<TheoryRecapReviewEntry>> getHistory({String? trigger}) async {
+    await _load();
+    final list = trigger == null
+        ? _history
+        : _history.where((e) => e.trigger == trigger);
+    return List<TheoryRecapReviewEntry>.unmodifiable(list);
+  }
+}

--- a/lib/services/weak_theory_review_launcher.dart
+++ b/lib/services/weak_theory_review_launcher.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../models/mistake_tag.dart';
 import '../models/mistake_tag_history_entry.dart';
 import '../widgets/theory_recap_dialog.dart';
+import 'theory_recap_review_tracker.dart';
+import '../models/theory_recap_review_entry.dart';
 import 'mistake_tag_history_service.dart';
 import 'theory_replay_cooldown_manager.dart';
 import 'theory_boost_recap_linker.dart';
@@ -71,6 +73,13 @@ class WeakTheoryReviewLauncher {
         lessonId: lessonId,
         tags: lessonId == null ? [tag.name] : null,
         trigger: 'weakness',
+      );
+      await TheoryRecapReviewTracker.instance.log(
+        TheoryRecapReviewEntry(
+          lessonId: lessonId ?? '',
+          trigger: 'weakness',
+          timestamp: DateTime.now(),
+        ),
       );
       await TheoryReplayCooldownManager.markSuggested(key);
       break;

--- a/lib/widgets/theory_progress_recovery_banner.dart
+++ b/lib/widgets/theory_progress_recovery_banner.dart
@@ -12,6 +12,8 @@ import '../services/recall_analytics_service.dart';
 import '../widgets/theory_recap_dialog.dart';
 import '../services/weak_theory_review_launcher.dart';
 import '../services/theory_boost_recap_linker.dart';
+import '../services/theory_recap_review_tracker.dart';
+import '../models/theory_recap_review_entry.dart';
 import 'package:collection/collection.dart';
 
 /// Banner suggesting theory recap or booster after a session.
@@ -125,6 +127,13 @@ class _TheoryProgressRecoveryBannerState
       lessonId: _lesson?.id,
       tags: _lesson == null ? [tag.name] : null,
       trigger: 'recoveryBanner',
+    );
+    await TheoryRecapReviewTracker.instance.log(
+      TheoryRecapReviewEntry(
+        lessonId: _lesson?.id ?? '',
+        trigger: 'recoveryBanner',
+        timestamp: DateTime.now(),
+      ),
     );
     RecallAnalyticsService.instance.logPrompt(
       trigger: 'recoveryBanner',


### PR DESCRIPTION
## Summary
- add `TheoryRecapReviewEntry` model
- implement `TheoryRecapReviewTracker` service
- log recap review usage from WeakTheoryReviewLauncher
- log recap review usage from TheoryProgressRecoveryBanner
- log recap review usage on booster failure via BoosterRecapHook

## Testing
- `flutter analyze --no-pub` *(fails: 15548 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a4b08e84832ab141c9abf22354fb