### PR TITLE
Implement TheoryPromptDismissTracker

### DIFF
--- a/lib/models/theory_prompt_dismiss_entry.dart
+++ b/lib/models/theory_prompt_dismiss_entry.dart
@@ -1,0 +1,25 @@
+class TheoryPromptDismissEntry {
+  final String lessonId;
+  final String trigger;
+  final DateTime timestamp;
+
+  const TheoryPromptDismissEntry({
+    required this.lessonId,
+    required this.trigger,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'trigger': trigger,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory TheoryPromptDismissEntry.fromJson(Map<String, dynamic> json) =>
+      TheoryPromptDismissEntry(
+        lessonId: json['lessonId'] as String? ?? '',
+        trigger: json['trigger'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}

--- a/lib/services/theory_prompt_dismiss_tracker.dart
+++ b/lib/services/theory_prompt_dismiss_tracker.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_prompt_dismiss_entry.dart';
+
+/// Tracks dismissed theory recap or booster prompts to reduce annoyance.
+class TheoryPromptDismissTracker {
+  TheoryPromptDismissTracker._();
+  static final TheoryPromptDismissTracker instance =
+      TheoryPromptDismissTracker._();
+
+  static const _key = 'theory_prompt_dismiss_history';
+
+  final List<TheoryPromptDismissEntry> _history = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is List) {
+          _history.addAll(data.whereType<Map>().map((e) =>
+              TheoryPromptDismissEntry.fromJson(
+                  Map<String, dynamic>.from(e))));
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _key,
+      jsonEncode([for (final h in _history) h.toJson()]),
+    );
+  }
+
+  /// Logs a dismissed prompt.
+  Future<void> logDismiss(String lessonId, String trigger) async {
+    await _load();
+    _history.insert(
+      0,
+      TheoryPromptDismissEntry(
+        lessonId: lessonId,
+        trigger: trigger,
+        timestamp: DateTime.now(),
+      ),
+    );
+    if (_history.length > 50) {
+      _history.removeRange(50, _history.length);
+    }
+    await _save();
+  }
+
+  /// Returns true if [lessonId] was dismissed within [cooldown].
+  Future<bool> isRecentlyDismissed(String lessonId,
+      {Duration cooldown = const Duration(days: 2)}) async {
+    await _load();
+    for (final e in _history) {
+      if (e.lessonId == lessonId &&
+          DateTime.now().difference(e.timestamp) < cooldown) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryPromptDismissEntry` model
- add `TheoryPromptDismissTracker` service
- use tracker in `TheoryProgressRecoveryBanner`
- use tracker in `WeakTheoryReviewLauncher`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a70bff3c832a8ff83c94f5c8270a