### PR TITLE
Implement TheoryBoosterCandidatePicker

### DIFF
--- a/lib/services/theory_booster_candidate_picker.dart
+++ b/lib/services/theory_booster_candidate_picker.dart
@@ -1,0 +1,72 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mistake_tag_history_service.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Picks theory mini lessons for booster reinforcement based on recent mistakes.
+class TheoryBoosterCandidatePicker {
+  final MiniLessonLibraryService library;
+
+  const TheoryBoosterCandidatePicker({
+    this.library = MiniLessonLibraryService.instance,
+  });
+
+  /// Returns up to 3 mini lessons linked to repeated recent mistakes.
+  Future<List<TheoryMiniLessonNode>> getTopBoosterCandidates() async {
+    await library.loadAll();
+    final history = await MistakeTagHistoryService.getRecentHistory(limit: 50);
+    if (history.isEmpty) return <TheoryMiniLessonNode>[];
+
+    final tagCounts = <String, int>{};
+    final tagSessions = <String, Set<String>>{};
+    final tagLast = <String, DateTime>{};
+
+    for (final entry in history) {
+      for (final tag in entry.tags) {
+        final key = tag.label.toLowerCase();
+        tagCounts.update(key, (v) => v + 1, ifAbsent: () => 1);
+        tagSessions.putIfAbsent(key, () => <String>{}).add(entry.packId);
+        final last = tagLast[key];
+        if (last == null || entry.timestamp.isAfter(last)) {
+          tagLast[key] = entry.timestamp;
+        }
+      }
+    }
+
+    final candidates = <_Candidate>[];
+    final now = DateTime.now();
+
+    for (final tag in tagCounts.keys) {
+      final count = tagCounts[tag] ?? 0;
+      final sessions = tagSessions[tag]?.length ?? 0;
+      if (count < 3 || sessions < 2) continue;
+      final last = tagLast[tag] ?? now;
+      final days = now.difference(last).inDays.clamp(0, 30);
+      final recency = 1 - days / 30;
+      final score = count + recency;
+      final lessons = library.findByTags([tag]);
+      for (final l in lessons) {
+        candidates.add(_Candidate(l, score));
+      }
+    }
+
+    if (candidates.isEmpty) return <TheoryMiniLessonNode>[];
+
+    final map = <String, _Candidate>{};
+    for (final c in candidates) {
+      final existing = map[c.lesson.id];
+      if (existing == null || c.score > existing.score) {
+        map[c.lesson.id] = c;
+      }
+    }
+
+    final sorted = map.values.toList()
+      ..sort((a, b) => b.score.compareTo(a.score));
+    return [for (final c in sorted.take(3)) c.lesson];
+  }
+}
+
+class _Candidate {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  _Candidate(this.lesson, this.score);
+}

--- a/test/services/theory_booster_candidate_picker_test.dart
+++ b/test/services/theory_booster_candidate_picker_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/services/theory_booster_candidate_picker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  final String path;
+  _FakePathProvider(this.path);
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final lc = tags.map((e) => e.toLowerCase()).toSet();
+    final result = <TheoryMiniLessonNode>[];
+    for (final l in lessons) {
+      final tagsLc = l.tags.map((e) => e.toLowerCase());
+      if (tagsLc.any(lc.contains)) result.add(l);
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('picks lessons for repeated mistake tags', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+
+    final now = DateTime.now();
+    final history = [
+      {
+        'timestamp': now.subtract(const Duration(days: 1)).toIso8601String(),
+        'packId': 'p1',
+        'spotId': 's1',
+        'tags': ['overfoldBtn'],
+        'evDiff': -1
+      },
+      {
+        'timestamp': now.subtract(const Duration(days: 2)).toIso8601String(),
+        'packId': 'p2',
+        'spotId': 's2',
+        'tags': ['overfoldBtn'],
+        'evDiff': -2
+      },
+      {
+        'timestamp': now.subtract(const Duration(days: 3)).toIso8601String(),
+        'packId': 'p1',
+        'spotId': 's3',
+        'tags': ['overfoldBtn'],
+        'evDiff': -0.5
+      },
+      {
+        'timestamp': now.subtract(const Duration(days: 1)).toIso8601String(),
+        'packId': 'p1',
+        'spotId': 's4',
+        'tags': ['looseCallBb'],
+        'evDiff': -0.8
+      },
+    ];
+    final file = File('${dir.path}/app_data/mistake_tag_history.json');
+    await file.create(recursive: true);
+    await file.writeAsString(jsonEncode(history), flush: true);
+
+    final lessons = [
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'BTN Overfold',
+        content: '',
+        tags: ['btn overfold'],
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'Loose Calls',
+        content: '',
+        tags: ['loose call bb'],
+      ),
+    ];
+    final picker = TheoryBoosterCandidatePicker(library: _FakeLibrary(lessons));
+
+    final result = await picker.getTopBoosterCandidates();
+    expect(result.map((e) => e.id).toList(), ['l1']);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryBoosterCandidatePicker service for selecting mini lessons tied to frequent recent mistakes
- test candidate selection using fake lesson library

## Testing
- `apt-get update` *(fails: cannot install dart)*

------
https://chatgpt.com/codex/tasks/task_e_6889ae28ea70832aa956905253bef47c