### PR TITLE
Add recap prompt orchestrator

### DIFF
--- a/lib/services/theory_recap_prompt_orchestrator.dart
+++ b/lib/services/theory_recap_prompt_orchestrator.dart
@@ -1,0 +1,45 @@
+import 'theory_booster_candidate_picker.dart';
+import 'theory_reinforcement_queue_service.dart';
+import 'theory_replay_cooldown_manager.dart';
+import 'theory_prompt_dismiss_tracker.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Decides which theory lesson recap prompt to show based on queues and cooldowns.
+class TheoryRecapPromptOrchestrator {
+  final TheoryReinforcementQueueService queue;
+  final TheoryBoosterCandidatePicker boosterPicker;
+
+  final Set<String> _suggested = <String>{};
+
+  TheoryRecapPromptOrchestrator({
+    TheoryReinforcementQueueService? queue,
+    TheoryBoosterCandidatePicker? boosterPicker,
+  })  : queue = queue ?? TheoryReinforcementQueueService.instance,
+        boosterPicker = boosterPicker ?? const TheoryBoosterCandidatePicker();
+
+  /// Picks a lesson for recap if one is due and not under cooldown.
+  Future<TheoryMiniLessonNode?> pickRecapCandidate() async {
+    final dueLessons = await queue.getDueLessons();
+    for (final l in dueLessons) {
+      if (_suggested.contains(l.id)) continue;
+      if (await TheoryReplayCooldownManager.isUnderCooldown(l.id)) continue;
+      if (await TheoryPromptDismissTracker.instance.isRecentlyDismissed(l.id)) {
+        continue;
+      }
+      _suggested.add(l.id);
+      return l;
+    }
+
+    final boosterLessons = await boosterPicker.getTopBoosterCandidates();
+    for (final l in boosterLessons) {
+      if (_suggested.contains(l.id)) continue;
+      if (await TheoryReplayCooldownManager.isUnderCooldown(l.id)) continue;
+      if (await TheoryPromptDismissTracker.instance.isRecentlyDismissed(l.id)) {
+        continue;
+      }
+      _suggested.add(l.id);
+      return l;
+    }
+    return null;
+  }
+}

--- a/test/services/theory_recap_prompt_orchestrator_test.dart
+++ b/test/services/theory_recap_prompt_orchestrator_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_recap_prompt_orchestrator.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_booster_candidate_picker.dart';
+import 'package:poker_analyzer/services/theory_reinforcement_queue_service.dart';
+import 'package:poker_analyzer/services/theory_replay_cooldown_manager.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeQueue implements TheoryReinforcementQueueService {
+  final List<TheoryMiniLessonNode> due;
+  _FakeQueue(this.due);
+  @override
+  Future<void> registerSuccess(String lessonId) async {}
+  @override
+  Future<void> registerFailure(String lessonId) async {}
+  @override
+  Future<List<TheoryMiniLessonNode>> getDueLessons({int max = 3, MiniLessonLibraryService? library}) async {
+    return due.take(max).toList();
+  }
+}
+
+class _FakePicker extends TheoryBoosterCandidatePicker {
+  final List<TheoryMiniLessonNode> lessons;
+  const _FakePicker(this.lessons);
+  @override
+  Future<List<TheoryMiniLessonNode>> getTopBoosterCandidates() async => lessons;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns due lesson when available', () async {
+    final dueLesson = const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '');
+    final orch = TheoryRecapPromptOrchestrator(
+      queue: _FakeQueue([dueLesson]),
+      boosterPicker: const _FakePicker([]),
+    );
+    final result = await orch.pickRecapCandidate();
+    expect(result?.id, 'l1');
+  });
+
+  test('skips cooldowned lesson and picks booster', () async {
+    final dueLesson = const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '');
+    await TheoryReplayCooldownManager.markSuggested('l1');
+    final booster = const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '');
+    final orch = TheoryRecapPromptOrchestrator(
+      queue: _FakeQueue([dueLesson]),
+      boosterPicker: _FakePicker([booster]),
+    );
+    final result = await orch.pickRecapCandidate();
+    expect(result?.id, 'l2');
+  });
+
+  test('does not repeat the same lesson in one session', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '');
+    final orch = TheoryRecapPromptOrchestrator(
+      queue: _FakeQueue([lesson]),
+      boosterPicker: const _FakePicker([]),
+    );
+    final first = await orch.pickRecapCandidate();
+    expect(first?.id, 'l1');
+    final second = await orch.pickRecapCandidate();
+    expect(second, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryRecapPromptOrchestrator` for selecting theory recap lessons
- test recap prompt selection logic

## Testing
- `flutter test test/services/theory_recap_prompt_orchestrator_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889afab25e4832a8ed386e79e9c508b