### PR TITLE
Implement local theory recap dismiss cooldown

### DIFF
--- a/lib/services/theory_prompt_dismiss_tracker.dart
+++ b/lib/services/theory_prompt_dismiss_tracker.dart
@@ -40,8 +40,9 @@ class TheoryPromptDismissTracker {
     );
   }
 
-  /// Logs a dismissed prompt.
-  Future<void> logDismiss(String lessonId, String trigger) async {
+  /// Marks [lessonId] as dismissed so it won't be suggested again within the
+  /// cooldown period.
+  Future<void> markDismissed(String lessonId, {String trigger = ''}) async {
     await _load();
     _history.insert(
       0,
@@ -57,9 +58,14 @@ class TheoryPromptDismissTracker {
     await _save();
   }
 
+  /// Deprecated: use [markDismissed] instead.
+  @Deprecated('Use markDismissed')
+  Future<void> logDismiss(String lessonId, String trigger) =>
+      markDismissed(lessonId, trigger: trigger);
+
   /// Returns true if [lessonId] was dismissed within [cooldown].
   Future<bool> isRecentlyDismissed(String lessonId,
-      {Duration cooldown = const Duration(days: 2)}) async {
+      {Duration cooldown = const Duration(hours: 12)}) async {
     await _load();
     for (final e in _history) {
       if (e.lessonId == lessonId &&

--- a/lib/services/weak_theory_review_launcher.dart
+++ b/lib/services/weak_theory_review_launcher.dart
@@ -82,7 +82,7 @@ class WeakTheoryReviewLauncher {
       );
       if (result != true && lessonId != null) {
         await TheoryPromptDismissTracker.instance
-            .logDismiss(lessonId, 'weakness');
+            .markDismissed(lessonId, trigger: 'weakness');
       }
       await TheoryRecapReviewTracker.instance.log(
         TheoryRecapReviewEntry(

--- a/lib/widgets/theory_progress_recovery_banner.dart
+++ b/lib/widgets/theory_progress_recovery_banner.dart
@@ -166,7 +166,7 @@ class _TheoryProgressRecoveryBannerState
       );
       if (_lesson != null) {
         TheoryPromptDismissTracker.instance
-            .logDismiss(_lesson!.id, 'recoveryBanner');
+            .markDismissed(_lesson!.id, trigger: 'recoveryBanner');
       }
     }
     setState(() => _visible = false);


### PR DESCRIPTION
## Summary
- add a persistent `markDismissed` helper to `TheoryPromptDismissTracker`
- default the cooldown of `isRecentlyDismissed` to 12 hours
- use `markDismissed` from recap UI and weak review launcher

## Testing
- `flutter analyze` *(fails: 6470 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6889b129c838832a819331128da59faa