### PR TITLE
Implement TheoryRecapTriggerLogger

### DIFF
--- a/lib/models/theory_recap_prompt_event.dart
+++ b/lib/models/theory_recap_prompt_event.dart
@@ -1,0 +1,29 @@
+class TheoryRecapPromptEvent {
+  final String lessonId;
+  final String trigger;
+  final DateTime timestamp;
+  final String outcome;
+
+  const TheoryRecapPromptEvent({
+    required this.lessonId,
+    required this.trigger,
+    required this.timestamp,
+    required this.outcome,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'trigger': trigger,
+        'timestamp': timestamp.toIso8601String(),
+        'outcome': outcome,
+      };
+
+  factory TheoryRecapPromptEvent.fromJson(Map<String, dynamic> json) =>
+      TheoryRecapPromptEvent(
+        lessonId: json['lessonId'] as String? ?? '',
+        trigger: json['trigger'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+        outcome: json['outcome'] as String? ?? '',
+      );
+}

--- a/lib/services/theory_recap_trigger_logger.dart
+++ b/lib/services/theory_recap_trigger_logger.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/theory_recap_prompt_event.dart';
+
+class TheoryRecapTriggerLogger {
+  static Future<File> _file() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File(p.join(dir.path, 'app_data', 'recap_prompt_log.json'));
+  }
+
+  static Future<List<TheoryRecapPromptEvent>> _load(File file) async {
+    if (!await file.exists()) return [];
+    try {
+      final data = jsonDecode(await file.readAsString());
+      if (data is List) {
+        return [
+          for (final e in data)
+            if (e is Map)
+              TheoryRecapPromptEvent.fromJson(
+                Map<String, dynamic>.from(e),
+              )
+        ];
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  static Future<void> logPrompt(
+    String lessonId,
+    String trigger,
+    String outcome,
+  ) async {
+    final file = await _file();
+    final list = await _load(file);
+    list.insert(
+      0,
+      TheoryRecapPromptEvent(
+        lessonId: lessonId,
+        trigger: trigger,
+        timestamp: DateTime.now(),
+        outcome: outcome,
+      ),
+    );
+    while (list.length > 200) {
+      list.removeLast();
+    }
+    await file.create(recursive: true);
+    await file.writeAsString(
+      jsonEncode([for (final e in list) e.toJson()]),
+      flush: true,
+    );
+  }
+
+  static Future<List<TheoryRecapPromptEvent>> getRecentEvents({
+    int limit = 50,
+  }) async {
+    final file = await _file();
+    final list = await _load(file);
+    return list.take(limit).toList();
+  }
+}

--- a/test/services/theory_recap_trigger_logger_test.dart
+++ b/test/services/theory_recap_trigger_logger_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/services/theory_recap_trigger_logger.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('logs events and retrieves recent list', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+
+    await TheoryRecapTriggerLogger.logPrompt('l1', 'weakness', 'accepted');
+    await TheoryRecapTriggerLogger.logPrompt('l2', 'booster', 'dismissed');
+
+    final file = File('${dir.path}/app_data/recap_prompt_log.json');
+    expect(await file.exists(), true);
+    final data = jsonDecode(await file.readAsString()) as List;
+    expect(data.length, 2);
+
+    final events = await TheoryRecapTriggerLogger.getRecentEvents();
+    expect(events.length, 2);
+    expect(events.first.lessonId, 'l2');
+    expect(events.first.outcome, 'dismissed');
+
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- create model `TheoryRecapPromptEvent`
- implement `TheoryRecapTriggerLogger` for logging recap prompt outcomes
- add unit test covering file persistence and retrieval

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6889b3063710832a99d471f5a801f053