### PR TITLE
Implement TheoryRecapAnalyticsSummarizer

### DIFF
--- a/lib/models/recap_analytics_summary.dart
+++ b/lib/models/recap_analytics_summary.dart
@@ -1,0 +1,11 @@
+class RecapAnalyticsSummary {
+  final Map<String, double> acceptanceRatesByTrigger;
+  final List<String> mostDismissedLessonIds;
+  final int ignoredStreakCount;
+
+  const RecapAnalyticsSummary({
+    this.acceptanceRatesByTrigger = const {},
+    this.mostDismissedLessonIds = const [],
+    this.ignoredStreakCount = 0,
+  });
+}

--- a/lib/services/theory_recap_analytics_summarizer.dart
+++ b/lib/services/theory_recap_analytics_summarizer.dart
@@ -1,0 +1,71 @@
+import '../models/recap_analytics_summary.dart';
+import '../models/theory_recap_prompt_event.dart';
+import 'theory_recap_trigger_logger.dart';
+
+/// Aggregates recap prompt logs and produces performance metrics.
+class TheoryRecapAnalyticsSummarizer {
+  final Future<List<TheoryRecapPromptEvent>> Function({int limit}) _loader;
+  final Duration cacheDuration;
+
+  RecapAnalyticsSummary? _cache;
+  DateTime? _cacheTime;
+
+  TheoryRecapAnalyticsSummarizer({
+    Future<List<TheoryRecapPromptEvent>> Function({int limit})? loader,
+    this.cacheDuration = const Duration(minutes: 10),
+  }) : _loader = loader ?? TheoryRecapTriggerLogger.getRecentEvents;
+
+  /// Returns summary statistics for recent recap events.
+  Future<RecapAnalyticsSummary> summarize({int limit = 50}) async {
+    if (_cache != null &&
+        _cacheTime != null &&
+        DateTime.now().difference(_cacheTime!) < cacheDuration) {
+      return _cache!;
+    }
+
+    final events = await _loader(limit: limit);
+
+    final totalByTrigger = <String, int>{};
+    final acceptedByTrigger = <String, int>{};
+    final dismissedByLesson = <String, int>{};
+
+    int streak = 0;
+    for (final e in events) {
+      totalByTrigger.update(e.trigger, (v) => v + 1, ifAbsent: () => 1);
+      if (e.outcome == 'accepted') {
+        acceptedByTrigger.update(e.trigger, (v) => v + 1, ifAbsent: () => 1);
+        if (streak == 0) {
+          // no-op, break not needed
+        }
+      } else {
+        dismissedByLesson.update(e.lessonId, (v) => v + 1, ifAbsent: () => 1);
+      }
+      if (streak >= 0) {
+        if (e.outcome == 'accepted') {
+          break;
+        } else {
+          streak++;
+        }
+      }
+    }
+
+    final rates = <String, double>{};
+    totalByTrigger.forEach((trigger, total) {
+      final acc = acceptedByTrigger[trigger] ?? 0;
+      rates[trigger] = total == 0 ? 0 : acc * 100 / total;
+    });
+
+    final mostDismissed = dismissedByLesson.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final summary = RecapAnalyticsSummary(
+      acceptanceRatesByTrigger: rates,
+      mostDismissedLessonIds: [for (final e in mostDismissed) e.key],
+      ignoredStreakCount: streak,
+    );
+
+    _cache = summary;
+    _cacheTime = DateTime.now();
+    return summary;
+  }
+}

--- a/test/services/theory_recap_analytics_summarizer_test.dart
+++ b/test/services/theory_recap_analytics_summarizer_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/services/theory_recap_trigger_logger.dart';
+import 'package:poker_analyzer/services/theory_recap_analytics_summarizer.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('summarizes recap logs', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(dir.path);
+
+    await TheoryRecapTriggerLogger.logPrompt('l1', 'weakness', 'accepted');
+    await TheoryRecapTriggerLogger.logPrompt('l2', 'weakness', 'dismissed');
+    await TheoryRecapTriggerLogger.logPrompt('l3', 'weakness', 'dismissed');
+
+    final summarizer = TheoryRecapAnalyticsSummarizer();
+    final summary = await summarizer.summarize(limit: 10);
+
+    expect(summary.ignoredStreakCount, 2);
+    expect(summary.acceptanceRatesByTrigger['weakness'], closeTo(33.3, 0.1));
+    expect(summary.mostDismissedLessonIds.length, 2);
+    expect(summary.mostDismissedLessonIds, contains('l2'));
+    expect(summary.mostDismissedLessonIds, contains('l3'));
+
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `RecapAnalyticsSummary` model
- create `TheoryRecapAnalyticsSummarizer` to aggregate recap logs
- test summarizer functionality

## Testing
- `flutter test test/services/theory_recap_analytics_summarizer_test.dart -r expanded` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889b45f495c832aaf3d1fda8d69d924