### PR TITLE
Add recap history viewer

### DIFF
--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -126,6 +126,7 @@ import '../services/live_hud_pack_seeder.dart';
 import '../services/cash_path_seeder.dart';
 import '../services/learning_path_config_loader.dart';
 import 'pack_filter_debug_screen.dart';
+import 'theory_recap_history_viewer_screen.dart';
 import 'pack_library_conflicts_screen.dart';
 import 'pack_suggestion_preview_screen.dart';
 import 'yaml_coverage_stats_screen.dart';
@@ -4225,6 +4226,18 @@ class _DevMenuScreenState extends State<DevMenuScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const PackFilterDebugScreen(),
+                    ),
+                  );
+                },
+              ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('📜 Recap History Viewer'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const TheoryRecapHistoryViewerScreen(),
                     ),
                   );
                 },

--- a/lib/screens/theory_recap_history_viewer_screen.dart
+++ b/lib/screens/theory_recap_history_viewer_screen.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../models/theory_recap_review_entry.dart';
+import '../services/theory_booster_recap_delay_manager.dart';
+import '../services/theory_recap_review_tracker.dart';
+import '../services/theory_recap_suppression_engine.dart';
+import '../theme/app_colors.dart';
+
+class TheoryRecapHistoryViewerScreen extends StatefulWidget {
+  const TheoryRecapHistoryViewerScreen({super.key});
+
+  @override
+  State<TheoryRecapHistoryViewerScreen> createState() =>
+      _TheoryRecapHistoryViewerScreenState();
+}
+
+class _EntryInfo {
+  final TheoryRecapReviewEntry entry;
+  final bool suppressed;
+  final String? reason;
+  final bool cooldown;
+
+  _EntryInfo(this.entry, this.suppressed, this.reason, this.cooldown);
+}
+
+class _TheoryRecapHistoryViewerScreenState
+    extends State<TheoryRecapHistoryViewerScreen> {
+  final List<_EntryInfo> _items = [];
+  final Set<String> _triggers = {};
+  bool _loading = true;
+  String? _filter;
+  bool _suppressedOnly = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final history = await TheoryRecapReviewTracker.instance.getHistory();
+    final List<_EntryInfo> items = [];
+    for (final e in history) {
+      final reason = await TheoryRecapSuppressionEngine.instance
+          .getSuppressionReason(lessonId: e.lessonId, trigger: e.trigger);
+      final cooldown = e.lessonId.isNotEmpty
+          ? await TheoryBoosterRecapDelayManager.isUnderCooldown(
+              'lesson:${e.lessonId}', const Duration(hours: 24))
+          : false;
+      items.add(_EntryInfo(e, reason != null, reason, cooldown));
+      _triggers.add(e.trigger);
+    }
+    setState(() {
+      _items
+        ..clear()
+        ..addAll(items);
+      _loading = false;
+    });
+  }
+
+  List<_EntryInfo> get _filtered {
+    Iterable<_EntryInfo> list = _items;
+    if (_filter != null) {
+      list = list.where((e) => e.entry.trigger == _filter);
+    }
+    if (_suppressedOnly) {
+      list = list.where((e) => e.suppressed);
+    }
+    return list.toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Theory Recap History')),
+      backgroundColor: AppColors.background,
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Row(
+                    children: [
+                      DropdownButton<String?>(
+                        hint: const Text('Trigger'),
+                        value: _filter,
+                        items: [
+                          const DropdownMenuItem(value: null, child: Text('All')),
+                          ..._triggers.map(
+                            (t) => DropdownMenuItem(value: t, child: Text(t)),
+                          ),
+                        ],
+                        onChanged: (v) => setState(() => _filter = v),
+                      ),
+                      const SizedBox(width: 16),
+                      Checkbox(
+                        value: _suppressedOnly,
+                        onChanged: (v) =>
+                            setState(() => _suppressedOnly = v ?? false),
+                      ),
+                      const Text('Suppressed only'),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: _filtered.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 8),
+                    itemBuilder: (_, i) {
+                      final item = _filtered[i];
+                      final ts = item.entry.timestamp.toIso8601String();
+                      return Card(
+                        color: AppColors.cardBackground,
+                        child: ListTile(
+                          title: Text(item.entry.lessonId.isEmpty
+                              ? '(no lesson)'
+                              : item.entry.lessonId),
+                          subtitle: Text('${item.entry.trigger} • $ts'),
+                          trailing: Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                item.suppressed
+                                    ? 'Suppressed${item.reason != null ? ' (${item.reason})' : ''}'
+                                    : 'Shown',
+                              ),
+                              Text(item.cooldown ? 'Cooldown' : ''),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/test/services/theory_recap_suppression_engine_reason_test.dart
+++ b/test/services/theory_recap_suppression_engine_reason_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_recap_suppression_engine.dart';
+import 'package:poker_analyzer/models/recap_analytics_summary.dart';
+import 'package:poker_analyzer/services/theory_recap_analytics_summarizer.dart';
+
+class _StubSummarizer extends TheoryRecapAnalyticsSummarizer {
+  final RecapAnalyticsSummary _summary;
+  _StubSummarizer(this._summary) : super(loader: ({int limit = 50}) async => []);
+  @override
+  Future<RecapAnalyticsSummary> summarize({int limit = 50}) async => _summary;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns lowAcceptance reason', () async {
+    final summarizer = _StubSummarizer(
+      const RecapAnalyticsSummary(
+        acceptanceRatesByTrigger: {'weakness': 10},
+        mostDismissedLessonIds: [],
+        ignoredStreakCount: 0,
+      ),
+    );
+    final engine = TheoryRecapSuppressionEngine(summarizer: summarizer);
+    final reason = await engine.getSuppressionReason(
+        lessonId: 'l1', trigger: 'weakness');
+    expect(reason, 'lowAcceptance');
+  });
+
+  test('returns triggerCooldown when marked', () async {
+    final summarizer = _StubSummarizer(
+      const RecapAnalyticsSummary(
+        acceptanceRatesByTrigger: {'weakness': 10},
+        mostDismissedLessonIds: [],
+        ignoredStreakCount: 0,
+      ),
+    );
+    final engine = TheoryRecapSuppressionEngine(summarizer: summarizer);
+    await engine.shouldSuppress(lessonId: 'l1', trigger: 'weakness');
+    final reason = await engine.getSuppressionReason(
+        lessonId: 'l1', trigger: 'weakness');
+    expect(reason, 'triggerCooldown');
+  });
+}


### PR DESCRIPTION
## Summary
- add `getSuppressionReason` to recap suppression engine
- implement `TheoryRecapHistoryViewerScreen` debug screen
- wire viewer into dev menu
- test suppression reason helper

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889b835ef88832ab354852ec60808db