### PR TITLE
Add recap analytics reporter

### DIFF
--- a/lib/services/theory_recap_analytics_reporter.dart
+++ b/lib/services/theory_recap_analytics_reporter.dart
@@ -1,0 +1,26 @@
+import 'user_action_logger.dart';
+
+/// Reports theory recap trigger analytics.
+class TheoryRecapAnalyticsReporter {
+  TheoryRecapAnalyticsReporter._();
+  static final TheoryRecapAnalyticsReporter instance =
+      TheoryRecapAnalyticsReporter._();
+
+  /// Logs a recap event for analytics.
+  Future<void> logEvent({
+    required String lessonId,
+    required String trigger,
+    required String outcome,
+    required Duration? delay,
+  }) async {
+    final data = <String, dynamic>{
+      'event': 'theory_recap',
+      'lessonId': lessonId,
+      'trigger': trigger,
+      'outcome': outcome,
+      if (delay != null) 'delayMs': delay.inMilliseconds,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    await UserActionLogger.instance.logEvent(data);
+  }
+}

--- a/test/services/theory_recap_analytics_reporter_test.dart
+++ b/test/services/theory_recap_analytics_reporter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_recap_analytics_reporter.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserActionLogger.instance.load();
+  });
+
+  test('logs recap analytics event', () async {
+    await TheoryRecapAnalyticsReporter.instance.logEvent(
+      lessonId: 'l1',
+      trigger: 't',
+      outcome: 'shown',
+      delay: const Duration(seconds: 5),
+    );
+    expect(UserActionLogger.instance.events.last['event'], 'theory_recap');
+    expect(UserActionLogger.instance.events.last['lessonId'], 'l1');
+    expect(UserActionLogger.instance.events.last['trigger'], 't');
+    expect(UserActionLogger.instance.events.last['outcome'], 'shown');
+    expect(UserActionLogger.instance.events.last['delayMs'], 5000);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryRecapAnalyticsReporter` for detailed recap event logging
- integrate analytics with fatigue guard, delay manager, recap hook and engine
- expose last prompt time helper
- test analytics reporter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889bb34ef34832abe170d29e6ff5097