### PR TITLE
Implement recap opportunity detector

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -101,6 +101,7 @@ import 'services/tag_retention_tracker.dart';
 import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
+import 'services/recap_opportunity_detector.dart';
 import 'services/tag_mastery_history_service.dart';
 import 'services/tag_insight_reminder_engine.dart';
 import 'services/learning_path_prefs.dart';
@@ -566,6 +567,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => GiftDropService()),
     Provider(create: (_) => SessionStreakOverlayPromptService()),
+    Provider(
+      create: (context) => RecapOpportunityDetector(
+        retention: context.read<TagRetentionTracker>(),
+      )..start(),
+    ),
   ];
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'services/user_action_logger.dart';
 import 'services/mistake_hint_service.dart';
 import 'services/remote_config_service.dart';
 import 'services/theme_service.dart';
+import 'services/app_usage_tracker.dart';
 import 'services/ab_test_engine.dart';
 import 'services/suggestion_banner_ab_test_service.dart';
 import 'services/asset_sync_service.dart';
@@ -214,6 +215,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     super.initState();
     _sync = AppBootstrap.sync!;
     context.read<UserActionLogger>().log('opened_app');
+    AppUsageTracker.instance.markActive();
     unawaited(NotificationService.scheduleDailyReminder(context));
     unawaited(() async {
       final t = await DailyChallengeNotificationService.getScheduledTime();

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -31,6 +31,7 @@ import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/streak_widget.dart';
+import '../services/app_usage_tracker.dart';
 import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../services/daily_training_reminder_service.dart';
@@ -271,6 +272,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
+      AppUsageTracker.instance.markActive();
       _maybeShowTrainingReminder();
       _maybeLaunchScheduledTraining();
     }

--- a/lib/services/recap_opportunity_detector.dart
+++ b/lib/services/recap_opportunity_detector.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'app_usage_tracker.dart';
+import 'smart_theory_recap_engine.dart';
+import 'tag_retention_tracker.dart';
+import 'session_streak_tracker_service.dart';
+import 'theory_recap_suppression_engine.dart';
+import 'smart_theory_recap_dismissal_memory.dart';
+import 'booster_fatigue_guard.dart';
+import 'tag_mastery_service.dart';
+import 'session_log_service.dart';
+import 'training_session_service.dart';
+
+/// Detects optimal moments to surface recap suggestions.
+class RecapOpportunityDetector {
+  final SmartTheoryRecapEngine engine;
+  final TagRetentionTracker retention;
+  final SessionStreakTrackerService streak;
+  final AppUsageTracker usage;
+  final TheoryRecapSuppressionEngine suppression;
+  final SmartTheoryRecapDismissalMemory memory;
+  final BoosterFatigueGuard fatigue;
+
+  RecapOpportunityDetector({
+    SmartTheoryRecapEngine? engine,
+    required this.retention,
+    SessionStreakTrackerService? streak,
+    AppUsageTracker? usage,
+    TheoryRecapSuppressionEngine? suppression,
+    SmartTheoryRecapDismissalMemory? memory,
+    BoosterFatigueGuard? fatigue,
+  })  : engine = engine ?? SmartTheoryRecapEngine.instance,
+        streak = streak ?? SessionStreakTrackerService.instance,
+        usage = usage ?? AppUsageTracker.instance,
+        suppression = suppression ?? TheoryRecapSuppressionEngine.instance,
+        memory = memory ?? SmartTheoryRecapDismissalMemory.instance,
+        fatigue = fatigue ?? BoosterFatigueGuard.instance;
+
+  static final RecapOpportunityDetector instance = RecapOpportunityDetector(
+    retention: TagRetentionTracker(
+      mastery: TagMasteryService(logs: SessionLogService(sessions: TrainingSessionService())),
+    ),
+  );
+
+  static const _lastKey = 'recap_detector_last';
+  DateTime? _lastCompletion;
+  Timer? _timer;
+
+  Future<void> start({Duration interval = const Duration(minutes: 5)}) async {
+    await usage.init();
+    _timer?.cancel();
+    _timer = Timer.periodic(interval, (_) => _check());
+
+  }
+  void notifyDrillCompleted() {
+    _lastCompletion = DateTime.now();
+  }
+
+  Future<void> dispose() async {
+    await usage.dispose();
+    _timer?.cancel();
+  }
+
+  Future<DateTime?> _lastPromptTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_lastKey);
+    return str == null ? null : DateTime.tryParse(str);
+  }
+
+  Future<void> _markPrompted() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+  }
+
+  Future<void> _check() async {
+    if (!await isGoodRecapMoment()) return;
+    final tags = await retention.getDecayedTags();
+    if (tags.isEmpty) return;
+    final tag = tags.first;
+    if (await memory.shouldThrottle('tag:$tag')) return;
+    if (await suppression.getSuppressionReason(
+          lessonId: '',
+          trigger: 'opportunity',
+        ) !=
+        null) {
+      return;
+    }
+    await engine.maybePrompt(tags: [tag], trigger: 'opportunity');
+    await _markPrompted();
+  }
+
+  /// Returns true if conditions are favorable for showing a recap prompt.
+  Future<bool> isGoodRecapMoment() async {
+    final idle = await usage.idleDuration();
+    if (idle < const Duration(minutes: 1)) return false;
+
+    final recentCompletion = _lastCompletion != null &&
+        DateTime.now().difference(_lastCompletion!) <
+            const Duration(minutes: 10);
+    if (!recentCompletion) {
+      final last = await _lastPromptTime();
+      if (last != null &&
+          DateTime.now().difference(last) < const Duration(hours: 6)) {
+        return false;
+      }
+    }
+
+    if (await fatigue.isFatigued(trigger: 'opportunity')) return false;
+
+    final tags = await retention.getDecayedTags();
+    if (tags.isEmpty) return false;
+
+    final streakCount = await streak.getCurrentStreak();
+    return streakCount >= 3 || idle > const Duration(minutes: 5);
+  }
+}

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -28,6 +28,7 @@ import '../models/v2/training_session.dart';
 import '../models/v2/training_action.dart';
 import '../models/v2/focus_goal.dart';
 import '../models/category_progress.dart';
+import 'recap_opportunity_detector.dart';
 import 'daily_reminder_scheduler.dart';
 import 'training_reminder_push_service.dart';
 import 'tag_mastery_service.dart';
@@ -619,6 +620,7 @@ class TrainingSessionService extends ChangeNotifier {
         _resumedAt = null;
       }
       _timer?.cancel();
+      unawaited(RecapOpportunityDetector.instance.notifyDrillCompleted());
       unawaited(_clearIndex());
     }
     if (_box != null) _box!.put(_session!.id, _session!.toJson());

--- a/test/services/recap_opportunity_detector_test.dart
+++ b/test/services/recap_opportunity_detector_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/recap_opportunity_detector.dart';
+import 'package:poker_analyzer/services/tag_retention_tracker.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/session_streak_tracker_service.dart';
+import 'package:poker_analyzer/services/app_usage_tracker.dart';
+import 'package:poker_analyzer/services/booster_fatigue_guard.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FakeUsageTracker implements AppUsageTracker {
+  Duration idle;
+  FakeUsageTracker(this.idle);
+  @override
+  Future<void> dispose() async {}
+  @override
+  Future<void> init() async {}
+  @override
+  Future<Duration> idleDuration() async => idle;
+  @override
+  void didChangeAppLifecycleState(state) {}
+  @override
+  Future<void> markActive() async {}
+}
+
+class FakeRetentionTracker extends TagRetentionTracker {
+  final List<String> list;
+  FakeRetentionTracker(this.list)
+      : super(mastery: TagMasteryService(
+            logs: SessionLogService(sessions: TrainingSessionService())));
+  @override
+  Future<List<String>> getDecayedTags({double threshold = 0.75, DateTime? now})
+      async => list;
+}
+
+class FakeStreakTrackerService implements SessionStreakTrackerService {
+  final int value;
+  FakeStreakTrackerService(this.value);
+  @override
+  Future<int> getCurrentStreak() async => value;
+  @override
+  Future<void> markCompletedToday() async {}
+  @override
+  Future<void> checkAndTriggerRewards() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('detects good recap moment', () async {
+    final detector = RecapOpportunityDetector(
+      retention: FakeRetentionTracker(['push']),
+      usage: FakeUsageTracker(const Duration(minutes: 6)),
+      streak: FakeStreakTrackerService(4),
+      fatigue: BoosterFatigueGuard(loader: ({int limit = 10}) async => []),
+    );
+    final ok = await detector.isGoodRecapMoment();
+    expect(ok, isTrue);
+  });
+
+  test('returns false when idle time short', () async {
+    final detector = RecapOpportunityDetector(
+      retention: FakeRetentionTracker(['push']),
+      usage: FakeUsageTracker(const Duration(seconds: 30)),
+      streak: FakeStreakTrackerService(4),
+      fatigue: BoosterFatigueGuard(loader: ({int limit = 10}) async => []),
+    );
+    final ok = await detector.isGoodRecapMoment();
+    expect(ok, isFalse);
+  });
+
+  test('returns false when recently prompted', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'recap_detector_last': now.toIso8601String(),
+    });
+    final detector = RecapOpportunityDetector(
+      retention: FakeRetentionTracker(['push']),
+      usage: FakeUsageTracker(const Duration(minutes: 6)),
+      streak: FakeStreakTrackerService(4),
+      fatigue: BoosterFatigueGuard(loader: ({int limit = 10}) async => []),
+    );
+    final ok = await detector.isGoodRecapMoment();
+    expect(ok, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- create AppUsageTracker for idle time monitoring
- add RecapOpportunityDetector background service
- track completed drills for recap timing
- wire detector into providers and UI lifecycle hooks
- unit tests for opportunity detection logic

## Testing
- `flutter analyze` *(fails: Dart SDK 3.6 required)*

------
https://chatgpt.com/codex/tasks/task_e_6889c4a46528832a88ee4a936992f97a