### PR TITLE
Implement SmartRecapAutoInjector

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -121,6 +121,7 @@ import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/gift_drop_service.dart';
 import 'services/session_streak_overlay_prompt_service.dart';
+import 'services/smart_recap_auto_injector.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -571,6 +572,9 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => RecapOpportunityDetector(
         retention: context.read<TagRetentionTracker>(),
       )..start(),
+    ),
+    Provider(
+      create: (_) => SmartRecapAutoInjector()..start(),
     ),
   ];
 }

--- a/lib/services/smart_recap_auto_injector.dart
+++ b/lib/services/smart_recap_auto_injector.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import '../main.dart';
+import '../widgets/theory_recap_dialog.dart';
+import 'recap_opportunity_detector.dart';
+import 'smart_theory_recap_engine.dart';
+import 'theory_recap_suppression_engine.dart';
+import 'smart_theory_recap_dismissal_memory.dart';
+
+/// Automatically shows recap dialogs at ideal moments without user interaction.
+class SmartRecapAutoInjector {
+  final RecapOpportunityDetector detector;
+  final SmartTheoryRecapEngine engine;
+  final TheoryRecapSuppressionEngine suppression;
+  final SmartTheoryRecapDismissalMemory dismissal;
+
+  SmartRecapAutoInjector({
+    RecapOpportunityDetector? detector,
+    SmartTheoryRecapEngine? engine,
+    TheoryRecapSuppressionEngine? suppression,
+    SmartTheoryRecapDismissalMemory? dismissal,
+  })  : detector = detector ?? RecapOpportunityDetector.instance,
+        engine = engine ?? SmartTheoryRecapEngine.instance,
+        suppression = suppression ?? TheoryRecapSuppressionEngine.instance,
+        dismissal = dismissal ?? SmartTheoryRecapDismissalMemory.instance;
+
+  static final SmartRecapAutoInjector instance = SmartRecapAutoInjector();
+
+  static const _lastKey = 'smart_recap_auto_last';
+  Timer? _timer;
+
+  Future<void> start({Duration interval = const Duration(minutes: 5)}) async {
+    _timer?.cancel();
+    _timer = Timer.periodic(interval, (_) => maybeInject());
+  }
+
+  Future<void> dispose() async {
+    _timer?.cancel();
+  }
+
+  Future<DateTime?> _lastInjected() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_lastKey);
+    return str == null ? null : DateTime.tryParse(str);
+  }
+
+  Future<void> _markInjected() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+  }
+
+  Future<bool> _recentlyDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('smart_theory_recap_dismissed');
+    if (str == null) return false;
+    final ts = DateTime.tryParse(str);
+    if (ts == null) return false;
+    return DateTime.now().difference(ts) < const Duration(hours: 12);
+  }
+
+  /// Checks for recap opportunity and shows dialog if suitable.
+  Future<void> maybeInject() async {
+    if (!await detector.isGoodRecapMoment()) return;
+    if (await _recentlyDismissed()) return;
+    final last = await _lastInjected();
+    if (last != null &&
+        DateTime.now().difference(last) < const Duration(hours: 6)) {
+      return;
+    }
+    final lesson = await engine.getNextRecap();
+    if (lesson == null) return;
+    if (await suppression.shouldSuppress(
+      lessonId: lesson.id,
+      trigger: 'autoInject',
+    )) {
+      return;
+    }
+    if (await dismissal.shouldThrottle('lesson:${lesson.id}')) return;
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return;
+    await showTheoryRecapDialog(
+      ctx,
+      lessonId: lesson.id,
+      trigger: 'autoInject',
+    );
+    await _markInjected();
+  }
+}

--- a/test/smart_recap_auto_injector_test.dart
+++ b/test/smart_recap_auto_injector_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/theory_recap_dialog.dart';
+import 'package:poker_analyzer/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_recap_auto_injector.dart';
+import 'package:poker_analyzer/services/recap_opportunity_detector.dart';
+import 'package:poker_analyzer/services/smart_theory_recap_engine.dart';
+import 'package:poker_analyzer/services/theory_recap_suppression_engine.dart';
+import 'package:poker_analyzer/services/smart_theory_recap_dismissal_memory.dart';
+import 'package:poker_analyzer/services/tag_retention_tracker.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeDetector implements RecapOpportunityDetector {
+  final bool value;
+  _FakeDetector(this.value)
+      : super(
+          retention: FakeRetentionTracker([]),
+        );
+  @override
+  Future<bool> isGoodRecapMoment() async => value;
+}
+
+class FakeRetentionTracker extends TagRetentionTracker {
+  FakeRetentionTracker(List<String> tags)
+      : super(
+          mastery: TagMasteryService(
+            logs: SessionLogService(sessions: TrainingSessionService()),
+          ),
+        ) {
+    _tags = tags;
+  }
+
+  late final List<String> _tags;
+
+  @override
+  Future<List<String>> getDecayedTags({double threshold = 0.75, DateTime? now})
+      async => _tags;
+}
+
+class _FakeEngine extends SmartTheoryRecapEngine {
+  final TheoryMiniLessonNode? lesson;
+  _FakeEngine(this.lesson);
+  @override
+  Future<TheoryMiniLessonNode?> getNextRecap() async => lesson;
+}
+
+class _FakeSuppression extends TheoryRecapSuppressionEngine {
+  final bool value;
+  _FakeSuppression(this.value) : super();
+  @override
+  Future<bool> shouldSuppress({required String lessonId, required String trigger}) async => value;
+}
+
+class _FakeDismissal extends SmartTheoryRecapDismissalMemory {
+  final bool value;
+  _FakeDismissal(this.value) : super._();
+  @override
+  Future<bool> shouldThrottle(String key) async => value;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> _pump(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()));
+  }
+
+  testWidgets('injects recap when opportunity available', (tester) async {
+    await _pump(tester);
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final service = SmartRecapAutoInjector(
+      detector: _FakeDetector(true),
+      engine: _FakeEngine(lesson),
+      suppression: _FakeSuppression(false),
+      dismissal: _FakeDismissal(false),
+    );
+    await service.maybeInject();
+    await tester.pump();
+    expect(find.byType(TheoryRecapDialog), findsOneWidget);
+  });
+
+  testWidgets('respects cooldown between injections', (tester) async {
+    await _pump(tester);
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final service = SmartRecapAutoInjector(
+      detector: _FakeDetector(true),
+      engine: _FakeEngine(lesson),
+      suppression: _FakeSuppression(false),
+      dismissal: _FakeDismissal(false),
+    );
+    await service.maybeInject();
+    await tester.pump();
+    expect(find.byType(TheoryRecapDialog), findsOneWidget);
+    await tester.tap(find.text('Got it'));
+    await tester.pumpAndSettle();
+    await service.maybeInject();
+    await tester.pump();
+    expect(find.byType(TheoryRecapDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartRecapAutoInjector` service to auto show recap dialogs
- register the service in `app_providers`
- cover behaviour with widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e9eb2a70832ab64c78036eee17a7