### PR TITLE
Add RecapHistoryTracker logging service

### DIFF
--- a/lib/models/recap_event.dart
+++ b/lib/models/recap_event.dart
@@ -1,0 +1,28 @@
+class RecapEvent {
+  final String lessonId;
+  final String trigger;
+  final String eventType;
+  final DateTime timestamp;
+
+  const RecapEvent({
+    required this.lessonId,
+    required this.trigger,
+    required this.eventType,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'trigger': trigger,
+        'eventType': eventType,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory RecapEvent.fromJson(Map<String, dynamic> json) => RecapEvent(
+        lessonId: json['lessonId'] as String? ?? '',
+        trigger: json['trigger'] as String? ?? '',
+        eventType: json['eventType'] as String? ?? '',
+        timestamp:
+            DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/services/recap_history_tracker.dart
+++ b/lib/services/recap_history_tracker.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/recap_event.dart';
+
+/// Persistently tracks recap-related events.
+class RecapHistoryTracker {
+  RecapHistoryTracker._();
+  static final RecapHistoryTracker instance = RecapHistoryTracker._();
+
+  static const String _prefsKey = 'recap_history_events';
+
+  final List<RecapEvent> _events = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is List) {
+          _events.addAll(data.whereType<Map>().map((e) {
+            return RecapEvent.fromJson(Map<String, dynamic>.from(e));
+          }));
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final e in _events) e.toJson()]),
+    );
+  }
+
+  /// Logs a recap [eventType] for [lessonId] and [trigger].
+  Future<void> logRecapEvent(
+    String lessonId,
+    String trigger,
+    String eventType,
+  ) async {
+    await _load();
+    _events.insert(
+      0,
+      RecapEvent(
+        lessonId: lessonId,
+        trigger: trigger,
+        eventType: eventType,
+        timestamp: DateTime.now(),
+      ),
+    );
+    if (_events.length > 200) _events.removeRange(200, _events.length);
+    await _save();
+  }
+
+  /// Returns history filtered by [lessonId] and [trigger] if provided.
+  Future<List<RecapEvent>> getHistory({
+    String? lessonId,
+    String? trigger,
+  }) async {
+    await _load();
+    Iterable<RecapEvent> list = _events;
+    if (lessonId != null) list = list.where((e) => e.lessonId == lessonId);
+    if (trigger != null) list = list.where((e) => e.trigger == trigger);
+    return List<RecapEvent>.unmodifiable(list);
+  }
+}


### PR DESCRIPTION
## Summary
- add `RecapEvent` data model
- implement `RecapHistoryTracker` to log recap events into SharedPreferences

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ed47c970832a972f0aaaaf42df44