### PR TITLE
Add smart recap suggestion engine

### DIFF
--- a/lib/services/smart_recap_suggestion_engine.dart
+++ b/lib/services/smart_recap_suggestion_engine.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+import 'recap_fatigue_evaluator.dart';
+import 'recap_history_tracker.dart';
+import 'theory_reinforcement_scheduler.dart';
+import 'theory_weakness_repeater.dart';
+
+/// Central orchestrator selecting the most appropriate recap lesson.
+class SmartRecapSuggestionEngine {
+  final RecapFatigueEvaluator fatigue;
+  final TheoryReinforcementScheduler scheduler;
+  final TheoryWeaknessRepeater repeater;
+  final MiniLessonLibraryService library;
+  final RecapHistoryTracker history;
+  final bool debug;
+
+  SmartRecapSuggestionEngine({
+    RecapFatigueEvaluator? fatigue,
+    TheoryReinforcementScheduler? scheduler,
+    TheoryWeaknessRepeater? repeater,
+    MiniLessonLibraryService? library,
+    RecapHistoryTracker? history,
+    this.debug = false,
+  })  : fatigue = fatigue ?? RecapFatigueEvaluator.instance,
+        scheduler = scheduler ?? TheoryReinforcementScheduler.instance,
+        repeater = repeater ?? const TheoryWeaknessRepeater(),
+        library = library ?? MiniLessonLibraryService.instance,
+        history = history ?? RecapHistoryTracker.instance;
+
+  static final SmartRecapSuggestionEngine instance = SmartRecapSuggestionEngine();
+
+  Future<Map<String, DateTime>> _loadSchedule() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_reinforcement_schedule');
+    if (raw == null) return {};
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        final map = <String, DateTime>{};
+        for (final e in data.entries) {
+          if (e.value is Map) {
+            final m = Map<String, dynamic>.from(e.value as Map);
+            final ts = DateTime.tryParse(m['next']?.toString() ?? '');
+            if (ts != null) map[e.key.toString()] = ts;
+          }
+        }
+        return map;
+      }
+    } catch (_) {}
+    return {};
+  }
+
+  Future<DateTime?> _lastShown(String id) async {
+    final events = await history.getHistory(lessonId: id);
+    return events.isEmpty ? null : events.first.timestamp;
+  }
+
+  Future<TheoryMiniLessonNode?> getBestRecapCandidate() async {
+    if (await fatigue.isFatiguedGlobally()) {
+      if (debug) debugPrint('recap: global fatigue');
+      return null;
+    }
+
+    await library.loadAll();
+    final schedule = await _loadSchedule();
+    final now = DateTime.now();
+    final due = schedule.entries
+        .where((e) => !e.value.isAfter(now))
+        .toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    final candidates = <_Entry>[];
+
+    for (final e in due) {
+      final lesson = library.getById(e.key);
+      if (lesson == null) continue;
+      if (await fatigue.isLessonFatigued(lesson.id)) {
+        if (debug) debugPrint('recap: skip ${lesson.id} fatigued');
+        continue;
+      }
+      final last = await _lastShown(lesson.id);
+      final overdue = now.difference(e.value).inMinutes.toDouble();
+      final recency = last == null ? 1e6 : now.difference(last).inMinutes.toDouble();
+      final score = 1000 + overdue + recency;
+      candidates.add(_Entry(lesson, score));
+      if (debug) debugPrint('recap candidate due ${lesson.id} score $score');
+    }
+
+    if (candidates.isEmpty) {
+      final weak = await repeater.recommend();
+      for (final lesson in weak) {
+        if (await fatigue.isLessonFatigued(lesson.id)) {
+          if (debug) debugPrint('recap: skip ${lesson.id} fatigued');
+          continue;
+        }
+        final last = await _lastShown(lesson.id);
+        final recency = last == null ? 1e6 : now.difference(last).inMinutes.toDouble();
+        final score = recency;
+        candidates.add(_Entry(lesson, score));
+        if (debug) debugPrint('recap candidate weak ${lesson.id} score $score');
+      }
+    }
+
+    if (candidates.isEmpty) return null;
+    candidates.sort((a, b) => b.score.compareTo(a.score));
+    final chosen = candidates.first.lesson;
+    if (debug) debugPrint('recap chosen ${chosen.id}');
+    return chosen;
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  _Entry(this.lesson, this.score);
+}
+

--- a/test/services/smart_recap_suggestion_engine_test.dart
+++ b/test/services/smart_recap_suggestion_engine_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/recap_history_tracker.dart';
+import 'package:poker_analyzer/services/smart_recap_suggestion_engine.dart';
+import 'package:poker_analyzer/services/theory_reinforcement_scheduler.dart';
+import 'package:poker_analyzer/services/theory_weakness_repeater.dart';
+import 'package:poker_analyzer/services/recap_fatigue_evaluator.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeRepeater extends TheoryWeaknessRepeater {
+  final List<TheoryMiniLessonNode> lessons;
+  const _FakeRepeater(this.lessons);
+
+  @override
+  Future<List<TheoryMiniLessonNode>> recommend({int limit = 5, int minDays = 3})
+      async => lessons;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapHistoryTracker.instance.resetForTest();
+  });
+
+  test('returns null when globally fatigued', () async {
+    for (var i = 0; i < 2; i++) {
+      await RecapHistoryTracker.instance.logRecapEvent('l$i', 't', 'dismissed');
+    }
+    final engine = SmartRecapSuggestionEngine(
+      library: _FakeLibrary([]),
+      repeater: const _FakeRepeater([]),
+    );
+    final result = await engine.getBestRecapCandidate();
+    expect(result, isNull);
+  });
+
+  test('picks earliest due lesson', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'theory_reinforcement_schedule': jsonEncode({
+        'l1': {'level': 0, 'next': now.subtract(const Duration(hours: 2)).toIso8601String()},
+        'l2': {'level': 0, 'next': now.subtract(const Duration(hours: 1)).toIso8601String()},
+      })
+    });
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'L1', content: ''),
+      const TheoryMiniLessonNode(id: 'l2', title: 'L2', content: ''),
+    ];
+    final engine = SmartRecapSuggestionEngine(
+      library: _FakeLibrary(lessons),
+      repeater: const _FakeRepeater([]),
+    );
+    final result = await engine.getBestRecapCandidate();
+    expect(result?.id, 'l1');
+  });
+
+  test('falls back to weakness repeater', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'w1', title: 'W1', content: '');
+    final engine = SmartRecapSuggestionEngine(
+      library: _FakeLibrary([lesson]),
+      repeater: _FakeRepeater([lesson]),
+    );
+    final result = await engine.getBestRecapCandidate();
+    expect(result?.id, 'w1');
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `SmartRecapSuggestionEngine` to unify recap signals
- provide tests for global fatigue, due lesson selection and weakness fallback

## Testing
- `flutter test test/services/smart_recap_suggestion_engine_test.dart` *(fails: command not found)*
- `dart test test/services/smart_recap_suggestion_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ef9d1cd4832aa94a94a6a3214138