### PR TITLE
Implement SmartRecapEventLogger

### DIFF
--- a/lib/services/recap_history_tracker.dart
+++ b/lib/services/recap_history_tracker.dart
@@ -49,8 +49,9 @@ class RecapHistoryTracker {
   Future<void> logRecapEvent(
     String lessonId,
     String trigger,
-    String eventType,
-  ) async {
+    String eventType, {
+    DateTime? timestamp,
+  }) async {
     await _load();
     _events.insert(
       0,
@@ -58,7 +59,7 @@ class RecapHistoryTracker {
         lessonId: lessonId,
         trigger: trigger,
         eventType: eventType,
-        timestamp: DateTime.now(),
+        timestamp: timestamp ?? DateTime.now(),
       ),
     );
     if (_events.length > 200) _events.removeRange(200, _events.length);

--- a/lib/services/smart_recap_event_logger.dart
+++ b/lib/services/smart_recap_event_logger.dart
@@ -1,0 +1,49 @@
+import 'recap_history_tracker.dart';
+
+/// Lightweight logger for recap banner impressions and actions.
+class SmartRecapEventLogger {
+  final RecapHistoryTracker history;
+  final DateTime Function() _now;
+
+  SmartRecapEventLogger({
+    RecapHistoryTracker? history,
+    DateTime Function()? timestampProvider,
+  })  : history = history ?? RecapHistoryTracker.instance,
+        _now = timestampProvider ?? DateTime.now;
+
+  Future<void> logShown(String lessonId, {String trigger = 'smart'}) {
+    return history.logRecapEvent(
+      lessonId,
+      trigger,
+      'shown',
+      timestamp: _now(),
+    );
+  }
+
+  Future<void> logDismissed(String lessonId, {String trigger = 'smart'}) {
+    return history.logRecapEvent(
+      lessonId,
+      trigger,
+      'dismissed',
+      timestamp: _now(),
+    );
+  }
+
+  Future<void> logCompleted(String lessonId, {String trigger = 'smart'}) {
+    return history.logRecapEvent(
+      lessonId,
+      trigger,
+      'completed',
+      timestamp: _now(),
+    );
+  }
+
+  Future<void> logTapped(String lessonId, {String trigger = 'smart'}) {
+    return history.logRecapEvent(
+      lessonId,
+      trigger,
+      'tapped',
+      timestamp: _now(),
+    );
+  }
+}

--- a/test/services/smart_recap_event_logger_test.dart
+++ b/test/services/smart_recap_event_logger_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_recap_event_logger.dart';
+import 'package:poker_analyzer/services/recap_history_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapHistoryTracker.instance.resetForTest();
+  });
+
+  test('logs shown event with default trigger', () async {
+    final logger = SmartRecapEventLogger();
+    await logger.logShown('l1');
+    final events = await RecapHistoryTracker.instance.getHistory();
+    expect(events.length, 1);
+    expect(events.first.lessonId, 'l1');
+    expect(events.first.eventType, 'shown');
+    expect(events.first.trigger, 'smart');
+  });
+
+  test('allows injecting timestamp', () async {
+    final t = DateTime(2020, 1, 1);
+    final logger = SmartRecapEventLogger(timestampProvider: () => t);
+    await logger.logDismissed('l2', trigger: 'banner');
+    final events = await RecapHistoryTracker.instance.getHistory();
+    expect(events.first.timestamp, t);
+    expect(events.first.trigger, 'banner');
+    expect(events.first.eventType, 'dismissed');
+  });
+}


### PR DESCRIPTION
## Summary
- extend `RecapHistoryTracker` with optional timestamp parameter
- add new `SmartRecapEventLogger` service for lightweight recap event logging
- test that the logger records events correctly

## Testing
- `flutter test test/services/recap_fatigue_evaluator_test.dart -j1` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f12ba070832abf0c4da1ee54ab70