### PR TITLE
Add fatigue check for recap banners

### DIFF
--- a/lib/services/smart_recap_banner_controller.dart
+++ b/lib/services/smart_recap_banner_controller.dart
@@ -9,6 +9,7 @@ import 'recap_opportunity_detector.dart';
 import 'smart_theory_recap_engine.dart';
 import 'theory_recap_suppression_engine.dart';
 import 'smart_theory_recap_dismissal_memory.dart';
+import 'recap_fatigue_evaluator.dart';
 import 'training_session_service.dart';
 
 /// Controls when the [SmartRecapSuggestionBanner] should be visible.
@@ -17,6 +18,7 @@ class SmartRecapBannerController extends ChangeNotifier {
   final SmartTheoryRecapEngine engine;
   final TheoryRecapSuppressionEngine suppression;
   final SmartTheoryRecapDismissalMemory dismissal;
+  final RecapFatigueEvaluator fatigue;
   final TrainingSessionService sessions;
 
   SmartRecapBannerController({
@@ -24,11 +26,13 @@ class SmartRecapBannerController extends ChangeNotifier {
     SmartTheoryRecapEngine? engine,
     TheoryRecapSuppressionEngine? suppression,
     SmartTheoryRecapDismissalMemory? dismissal,
+    RecapFatigueEvaluator? fatigue,
     required this.sessions,
-  })  : detector = detector ?? RecapOpportunityDetector.instance,
-        engine = engine ?? SmartTheoryRecapEngine.instance,
-        suppression = suppression ?? TheoryRecapSuppressionEngine.instance,
-        dismissal = dismissal ?? SmartTheoryRecapDismissalMemory.instance;
+  }) : detector = detector ?? RecapOpportunityDetector.instance,
+       engine = engine ?? SmartTheoryRecapEngine.instance,
+       suppression = suppression ?? TheoryRecapSuppressionEngine.instance,
+       dismissal = dismissal ?? SmartTheoryRecapDismissalMemory.instance,
+       fatigue = fatigue ?? RecapFatigueEvaluator.instance;
 
   static const _lastKey = 'smart_recap_banner_last';
   TheoryMiniLessonNode? _lesson;
@@ -80,6 +84,7 @@ class SmartRecapBannerController extends ChangeNotifier {
     }
     final lesson = await engine.getNextRecap();
     if (lesson == null) return;
+    if (await fatigue.isFatigued(lesson.id)) return;
     if (await suppression.shouldSuppress(
       lessonId: lesson.id,
       trigger: 'banner',
@@ -104,4 +109,3 @@ class SmartRecapBannerController extends ChangeNotifier {
     notifyListeners();
   }
 }
-

--- a/test/services/recap_fatigue_evaluator_test.dart
+++ b/test/services/recap_fatigue_evaluator_test.dart
@@ -13,8 +13,7 @@ void main() {
 
   test('global fatigue after dismissals', () async {
     for (var i = 0; i < 2; i++) {
-      await RecapHistoryTracker.instance
-          .logRecapEvent('l$i', 't', 'dismissed');
+      await RecapHistoryTracker.instance.logRecapEvent('l$i', 't', 'dismissed');
     }
     final fatigued = await RecapFatigueEvaluator.instance.isFatiguedGlobally();
     expect(fatigued, isTrue);
@@ -24,11 +23,15 @@ void main() {
 
   test('lesson fatigue after repeated dismissals', () async {
     for (var i = 0; i < 3; i++) {
-      await RecapHistoryTracker.instance
-          .logRecapEvent('lesson1', 't', 'dismissed');
+      await RecapHistoryTracker.instance.logRecapEvent(
+        'lesson1',
+        't',
+        'dismissed',
+      );
     }
-    final fatigued =
-        await RecapFatigueEvaluator.instance.isLessonFatigued('lesson1');
+    final fatigued = await RecapFatigueEvaluator.instance.isLessonFatigued(
+      'lesson1',
+    );
     expect(fatigued, isTrue);
     final cd = await RecapFatigueEvaluator.instance.recommendedCooldown();
     expect(cd.inDays, greaterThanOrEqualTo(2));
@@ -42,5 +45,41 @@ void main() {
     expect(fatigued, isTrue);
     final cd = await RecapFatigueEvaluator.instance.recommendedCooldown();
     expect(cd.inHours, inInclusiveRange(11, 12));
+  });
+
+  test('isFatigued returns true after 3 dismissals in 24h', () async {
+    final now = DateTime.now();
+    for (var i = 0; i < 3; i++) {
+      await RecapHistoryTracker.instance.logRecapEvent(
+        'l$i',
+        'banner',
+        'dismissed',
+        timestamp: now.subtract(Duration(hours: i)),
+      );
+    }
+    final result = await RecapFatigueEvaluator.instance.isFatigued('x');
+    expect(result, isTrue);
+  });
+
+  test('isFatigued true when same lesson shown recently', () async {
+    final now = DateTime.now();
+    await RecapHistoryTracker.instance.logRecapEvent(
+      'lesson1',
+      'banner',
+      'shown',
+      timestamp: now.subtract(const Duration(hours: 2)),
+    );
+    final result = await RecapFatigueEvaluator.instance.isFatigued('lesson1');
+    expect(result, isTrue);
+  });
+
+  test('isFatigued true when lesson completed today', () async {
+    await RecapHistoryTracker.instance.logRecapEvent(
+      'lesson2',
+      'banner',
+      'completed',
+    );
+    final result = await RecapFatigueEvaluator.instance.isFatigued('lesson2');
+    expect(result, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- enhance `RecapFatigueEvaluator` with `isFatigued` based on recent interaction
- inject fatigue evaluator into `SmartRecapBannerController`
- skip showing banner if user is fatigued
- expand tests for new fatigue logic

## Testing
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6889f5ab3f48832a84dd70d50b307db2