### PR TITLE
Add recap repeat scheduler

### DIFF
--- a/lib/services/recap_auto_repeat_scheduler.dart
+++ b/lib/services/recap_auto_repeat_scheduler.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Background scheduler for auto-repeating recap lessons.
+class RecapAutoRepeatScheduler {
+  RecapAutoRepeatScheduler._();
+  static final RecapAutoRepeatScheduler instance = RecapAutoRepeatScheduler._();
+
+  static const String _prefsKey = 'recap_auto_repeat_schedule';
+
+  final Map<String, DateTime> _cache = {};
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          data.forEach((key, value) {
+            final ts = DateTime.tryParse(value.toString());
+            if (ts != null) _cache[key.toString()] = ts;
+          });
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({for (final e in _cache.entries) e.key: e.value.toIso8601String()}),
+    );
+  }
+
+  /// Schedules [lessonId] to resurface after [delay].
+  Future<void> scheduleRepeat(String lessonId, Duration delay) async {
+    if (lessonId.isEmpty) return;
+    await _load();
+    _cache[lessonId] = DateTime.now().add(delay);
+    await _save();
+  }
+
+  Future<List<String>> _consumeDueIds() async {
+    await _load();
+    final now = DateTime.now();
+    final due = <String>[];
+    final remove = <String>[];
+    _cache.forEach((id, ts) {
+      if (!ts.isAfter(now)) {
+        due.add(id);
+        remove.add(id);
+      }
+    });
+    for (final id in remove) {
+      _cache.remove(id);
+    }
+    if (remove.isNotEmpty) await _save();
+    return due;
+  }
+
+  /// Periodically emits lesson ids whose repeat delay elapsed.
+  Stream<List<String>> getPendingRecapIds({Duration interval = const Duration(hours: 1)}) async* {
+    yield await _consumeDueIds();
+    yield* Stream.periodic(interval, (_) => _consumeDueIds()).asyncMap((f) => f);
+  }
+
+  /// Clears cached data for tests.
+  void resetForTest() {
+    _loaded = false;
+    _cache.clear();
+  }
+}

--- a/lib/services/smart_recap_event_logger.dart
+++ b/lib/services/smart_recap_event_logger.dart
@@ -1,15 +1,19 @@
 import 'recap_history_tracker.dart';
+import 'recap_auto_repeat_scheduler.dart';
 
 /// Lightweight logger for recap banner impressions and actions.
 class SmartRecapEventLogger {
   final RecapHistoryTracker history;
   final DateTime Function() _now;
+  final RecapAutoRepeatScheduler scheduler;
 
   SmartRecapEventLogger({
     RecapHistoryTracker? history,
     DateTime Function()? timestampProvider,
+    RecapAutoRepeatScheduler? scheduler,
   })  : history = history ?? RecapHistoryTracker.instance,
-        _now = timestampProvider ?? DateTime.now;
+        _now = timestampProvider ?? DateTime.now,
+        scheduler = scheduler ?? RecapAutoRepeatScheduler.instance;
 
   Future<void> logShown(String lessonId, {String trigger = 'smart'}) {
     return history.logRecapEvent(
@@ -20,22 +24,34 @@ class SmartRecapEventLogger {
     );
   }
 
-  Future<void> logDismissed(String lessonId, {String trigger = 'smart'}) {
-    return history.logRecapEvent(
+  Future<void> logDismissed(String lessonId, {String trigger = 'smart'}) async {
+    await history.logRecapEvent(
       lessonId,
       trigger,
       'dismissed',
       timestamp: _now(),
     );
+    await scheduler.scheduleRepeat(lessonId, const Duration(days: 2));
   }
 
-  Future<void> logCompleted(String lessonId, {String trigger = 'smart'}) {
-    return history.logRecapEvent(
+  Future<void> logCompleted(
+    String lessonId, {
+    String trigger = 'smart',
+    bool lowConfidence = false,
+    bool highConfidence = false,
+  }) async {
+    await history.logRecapEvent(
       lessonId,
       trigger,
       'completed',
       timestamp: _now(),
     );
+    if (lowConfidence) {
+      await scheduler.scheduleRepeat(lessonId, const Duration(days: 1));
+    } else if (!highConfidence) {
+      // default moderate confidence -> 3 days
+      await scheduler.scheduleRepeat(lessonId, const Duration(days: 3));
+    }
   }
 
   Future<void> logTapped(String lessonId, {String trigger = 'smart'}) {

--- a/test/services/recap_auto_repeat_scheduler_test.dart
+++ b/test/services/recap_auto_repeat_scheduler_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/recap_auto_repeat_scheduler.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapAutoRepeatScheduler.instance.resetForTest();
+  });
+
+  test('scheduleRepeat persists entry', () async {
+    final sched = RecapAutoRepeatScheduler.instance;
+    await sched.scheduleRepeat('l1', const Duration(days: 2));
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('recap_auto_repeat_schedule');
+    expect(raw, isNotNull);
+    final data = jsonDecode(raw!) as Map;
+    expect(data.containsKey('l1'), isTrue);
+  });
+
+  test('getPendingRecapIds yields due id and clears', () async {
+    final sched = RecapAutoRepeatScheduler.instance;
+    await sched.scheduleRepeat('l2', Duration.zero);
+    final ids = await sched.getPendingRecapIds(interval: const Duration(seconds: 1)).first;
+    expect(ids, ['l2']);
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('recap_auto_repeat_schedule');
+    if (raw != null) {
+      final data = jsonDecode(raw) as Map;
+      expect(data.containsKey('l2'), isFalse);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- implement `RecapAutoRepeatScheduler` service
- trigger repeats from `SmartRecapEventLogger`
- test repeat scheduler logic

## Testing
- `apt-get update`
- `apt-get install -y apt-transport-https wget gpg`
- `wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list | tee /etc/apt/sources.list.d/dart_stable.list`
- `wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_gpg.asc | gpg --dearmor > /usr/share/keyrings/dart.gpg` *(failed: no valid OpenPGP data)*
- `apt-get install -y dart` *(failed: Unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_6889f72902e4832aa53e92b5df85d611