### PR TITLE
Implement SmartRecapBanner reinjection

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -123,6 +123,7 @@ import 'services/gift_drop_service.dart';
 import 'services/session_streak_overlay_prompt_service.dart';
 import 'services/smart_recap_auto_injector.dart';
 import 'services/smart_recap_banner_controller.dart';
+import 'services/smart_recap_banner_reinjection_service.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -581,6 +582,11 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(
       create: (_) => SmartRecapAutoInjector()..start(),
+    ),
+    Provider(
+      create: (context) => SmartRecapBannerReinjectionService(
+        controller: context.read<SmartRecapBannerController>(),
+      )..start(),
     ),
   ];
 }

--- a/lib/services/smart_recap_banner_controller.dart
+++ b/lib/services/smart_recap_banner_controller.dart
@@ -98,6 +98,15 @@ class SmartRecapBannerController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Shows the banner for a specific [lesson] without running selection logic.
+  Future<void> showManually(TheoryMiniLessonNode lesson) async {
+    if (_visible && _lesson?.id == lesson.id) return;
+    _lesson = lesson;
+    _visible = true;
+    await _markShown();
+    notifyListeners();
+  }
+
   /// Hides the banner and optionally registers a dismissal.
   Future<void> dismiss({bool recordDismissal = false}) async {
     if (!_visible) return;

--- a/lib/services/smart_recap_banner_reinjection_service.dart
+++ b/lib/services/smart_recap_banner_reinjection_service.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'mini_lesson_library_service.dart';
+import 'recap_auto_repeat_scheduler.dart';
+import 'smart_recap_banner_controller.dart';
+import 'recap_fatigue_evaluator.dart';
+import 'theory_recap_suppression_engine.dart';
+import 'smart_theory_recap_dismissal_memory.dart';
+
+/// Listens for due recap lessons and reinserts them into the banner flow.
+class SmartRecapBannerReinjectionService {
+  final RecapAutoRepeatScheduler scheduler;
+  final MiniLessonLibraryService library;
+  final SmartRecapBannerController controller;
+  final RecapFatigueEvaluator fatigue;
+  final TheoryRecapSuppressionEngine suppression;
+  final SmartTheoryRecapDismissalMemory dismissal;
+
+  SmartRecapBannerReinjectionService({
+    RecapAutoRepeatScheduler? scheduler,
+    MiniLessonLibraryService? library,
+    required this.controller,
+    RecapFatigueEvaluator? fatigue,
+    TheoryRecapSuppressionEngine? suppression,
+    SmartTheoryRecapDismissalMemory? dismissal,
+  })  : scheduler = scheduler ?? RecapAutoRepeatScheduler.instance,
+        library = library ?? MiniLessonLibraryService.instance,
+        fatigue = fatigue ?? RecapFatigueEvaluator.instance,
+        suppression = suppression ?? TheoryRecapSuppressionEngine.instance,
+        dismissal = dismissal ?? SmartTheoryRecapDismissalMemory.instance;
+
+  StreamSubscription<List<String>>? _sub;
+
+  /// Starts listening for pending recap ids.
+  Future<void> start({Duration interval = const Duration(hours: 1)}) async {
+    await library.loadAll();
+    _sub?.cancel();
+    _sub = scheduler
+        .getPendingRecapIds(interval: interval)
+        .listen(_handleIds);
+  }
+
+  /// Disposes the service and cancels listeners.
+  Future<void> dispose() async {
+    await _sub?.cancel();
+  }
+
+  Future<void> _handleIds(List<String> ids) async {
+    for (final id in ids) {
+      final lesson = library.getById(id);
+      if (lesson == null) continue;
+      if (controller.shouldShowBanner() &&
+          controller.getPendingLesson()?.id == lesson.id) {
+        continue;
+      }
+      if (await fatigue.isFatigued(lesson.id)) continue;
+      if (await suppression.shouldSuppress(
+        lessonId: lesson.id,
+        trigger: 'reinjection',
+      )) {
+        continue;
+      }
+      if (await dismissal.shouldThrottle('lesson:${lesson.id}')) continue;
+      await controller.showManually(lesson);
+    }
+  }
+}
+

--- a/test/services/smart_recap_banner_reinjection_service_test.dart
+++ b/test/services/smart_recap_banner_reinjection_service_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/smart_recap_banner_reinjection_service.dart';
+import 'package:poker_analyzer/services/recap_auto_repeat_scheduler.dart';
+import 'package:poker_analyzer/services/smart_recap_banner_controller.dart';
+import 'package:poker_analyzer/services/recap_fatigue_evaluator.dart';
+import 'package:poker_analyzer/services/theory_recap_suppression_engine.dart';
+import 'package:poker_analyzer/services/smart_theory_recap_dismissal_memory.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/recap_history_tracker.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeController extends SmartRecapBannerController {
+  _FakeController() : super(sessions: TrainingSessionService());
+  int count = 0;
+  TheoryMiniLessonNode? last;
+  @override
+  Future<void> showManually(TheoryMiniLessonNode lesson) async {
+    count++;
+    last = lesson;
+  }
+}
+
+class _FakeSuppression extends TheoryRecapSuppressionEngine {
+  final bool value;
+  _FakeSuppression(this.value) : super();
+  @override
+  Future<bool> shouldSuppress({required String lessonId, required String trigger}) async => value;
+}
+
+class _FakeDismissal extends SmartTheoryRecapDismissalMemory {
+  final bool value;
+  _FakeDismissal(this.value) : super._();
+  @override
+  Future<bool> shouldThrottle(String key) async => value;
+}
+
+class _FakeFatigue extends RecapFatigueEvaluator {
+  final bool value;
+  _FakeFatigue(this.value) : super(tracker: RecapHistoryTracker.instance);
+  @override
+  Future<bool> isFatigued(String lessonId) async => value;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapAutoRepeatScheduler.instance.resetForTest();
+    RecapHistoryTracker.instance.resetForTest();
+  });
+
+  test('shows due recap banner', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final lib = _FakeLibrary([lesson]);
+    final controller = _FakeController();
+    final service = SmartRecapBannerReinjectionService(
+      scheduler: RecapAutoRepeatScheduler.instance,
+      library: lib,
+      controller: controller,
+      fatigue: _FakeFatigue(false),
+      suppression: _FakeSuppression(false),
+      dismissal: _FakeDismissal(false),
+    );
+    await RecapAutoRepeatScheduler.instance
+        .scheduleRepeat('l1', Duration.zero);
+    await service.start(interval: const Duration(milliseconds: 10));
+    await Future.delayed(const Duration(milliseconds: 20));
+    expect(controller.count, 1);
+    expect(controller.last?.id, 'l1');
+    await service.dispose();
+  });
+
+  test('skips when suppressed', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final lib = _FakeLibrary([lesson]);
+    final controller = _FakeController();
+    final service = SmartRecapBannerReinjectionService(
+      scheduler: RecapAutoRepeatScheduler.instance,
+      library: lib,
+      controller: controller,
+      fatigue: _FakeFatigue(false),
+      suppression: _FakeSuppression(true),
+      dismissal: _FakeDismissal(false),
+    );
+    await RecapAutoRepeatScheduler.instance
+        .scheduleRepeat('l1', Duration.zero);
+    await service.start(interval: const Duration(milliseconds: 10));
+    await Future.delayed(const Duration(milliseconds: 20));
+    expect(controller.count, 0);
+    await service.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartRecapBannerReinjectionService` to reinsert scheduled recaps
- allow `SmartRecapBannerController` to manually show a lesson
- register the new service in `AppProviders`
- test reinjection logic

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fed9dd94832aba8a347c197207a1