### PR TITLE
Implement SmartRecapBoosterLauncher

### DIFF
--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+/// Simple wrapper around the global [navigatorKey].
+class NavigationService {
+  const NavigationService();
+
+  /// Current navigator context if available.
+  BuildContext? get context => navigatorKey.currentContext;
+
+  /// Pushes [route] using the root navigator.
+  Future<T?> push<T>(Route<T> route) async {
+    final state = navigatorKey.currentState;
+    if (state == null) return null;
+    return state.push(route);
+  }
+}

--- a/lib/services/smart_recap_booster_launcher.dart
+++ b/lib/services/smart_recap_booster_launcher.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_template.dart';
+import '../screens/training_session_screen.dart';
+import 'training_session_service.dart';
+import 'navigation_service.dart';
+import 'smart_recap_booster_linker.dart';
+
+/// Launches a booster pack related to a recap lesson when requested by the user.
+class SmartRecapBoosterLauncher {
+  final SmartRecapBoosterLinker linker;
+  final NavigationService navigation;
+
+  const SmartRecapBoosterLauncher({
+    required this.linker,
+    this.navigation = const NavigationService(),
+  });
+
+  /// Opens the best booster pack for [lesson] or shows a fallback dialog.
+  Future<void> launchBoosterForLesson(TheoryMiniLessonNode lesson) async {
+    final ctx = navigation.context;
+    if (ctx == null) return;
+
+    final List<TrainingPackTemplateV2> packs =
+        await linker.getBoostersForLesson(lesson);
+    if (packs.isEmpty) {
+      await showDialog<void>(
+        context: ctx,
+        builder: (_) => const AlertDialog(
+          content: Text('Нет тренировок по теме. Попробуйте позже'),
+        ),
+      );
+      return;
+    }
+
+    final template = TrainingPackTemplate.fromJson(packs.first.toJson());
+    await ctx
+        .read<TrainingSessionService>()
+        .startSession(template, persist: false);
+    await navigation.push(
+      MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+    );
+  }
+}

--- a/test/services/smart_recap_booster_launcher_test.dart
+++ b/test/services/smart_recap_booster_launcher_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/training_pack_template_storage_service.dart';
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/smart_recap_booster_launcher.dart';
+import 'package:poker_analyzer/services/smart_recap_booster_linker.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/navigation_service.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/screens/training_session_screen.dart';
+
+class _FakeLinker extends SmartRecapBoosterLinker {
+  final List<TrainingPackTemplateV2> packs;
+  _FakeLinker(this.packs) : super(storage: TrainingPackTemplateStorageService());
+
+  @override
+  Future<List<TrainingPackTemplateV2>> getBoostersForLesson(
+          TheoryMiniLessonNode lesson) async =>
+      packs;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('launches first matching booster', (tester) async {
+    final tpl = TrainingPackTemplateV2(
+      id: 'b1',
+      name: 'B',
+      trainingType: TrainingType.pushFold,
+      gameType: GameType.tournament,
+      spots: const [TrainingPackSpot(id: 's')],
+      spotCount: 1,
+      created: DateTime.now(),
+      positions: const [],
+    );
+    final service = SmartRecapBoosterLauncher(linker: _FakeLinker([tpl]));
+    await tester.pumpWidget(
+      ChangeNotifierProvider(create: (_) => TrainingSessionService(),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+    await service.launchBoosterForLesson(const TheoryMiniLessonNode(id: 'l', title: '', content: '', tags: ['t']));
+    await tester.pumpAndSettle();
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+
+  testWidgets('shows dialog when no booster found', (tester) async {
+    final service = SmartRecapBoosterLauncher(linker: _FakeLinker([]));
+    await tester.pumpWidget(
+      ChangeNotifierProvider(create: (_) => TrainingSessionService(),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+    await service.launchBoosterForLesson(const TheoryMiniLessonNode(id: 'l', title: '', content: '', tags: ['t']));
+    await tester.pumpAndSettle();
+    expect(find.text('Нет тренировок по теме. Попробуйте позже'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add NavigationService wrapper
- implement SmartRecapBoosterLauncher for recap booster CTA
- cover launcher with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a02b8e154832a97acff67362dd234