### PR TITLE
Implement banner drill launcher

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -124,6 +124,7 @@ import 'services/session_streak_overlay_prompt_service.dart';
 import 'services/smart_recap_auto_injector.dart';
 import 'services/smart_recap_banner_controller.dart';
 import 'services/smart_recap_banner_reinjection_service.dart';
+import 'services/recap_to_drill_launcher.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -587,6 +588,12 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => SmartRecapBannerReinjectionService(
         controller: context.read<SmartRecapBannerController>(),
       )..start(),
+    ),
+    Provider(
+      create: (context) => RecapToDrillLauncher(
+        banner: context.read<SmartRecapBannerController>(),
+        sessions: context.read<TrainingSessionService>(),
+      ),
     ),
   ];
 }

--- a/lib/services/recap_history_tracker.dart
+++ b/lib/services/recap_history_tracker.dart
@@ -66,6 +66,11 @@ class RecapHistoryTracker {
     await _save();
   }
 
+  /// Records that a drill was launched for [lessonId].
+  Future<void> registerDrillLaunch(String lessonId) async {
+    await logRecapEvent(lessonId, 'banner', 'drillLaunch');
+  }
+
   /// Returns history filtered by [lessonId] and [trigger] if provided.
   Future<List<RecapEvent>> getHistory({
     String? lessonId,

--- a/lib/services/recap_to_drill_launcher.dart
+++ b/lib/services/recap_to_drill_launcher.dart
@@ -1,0 +1,32 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'training_session_launcher.dart';
+import 'recap_history_tracker.dart';
+import 'smart_recap_banner_controller.dart';
+import 'training_session_service.dart';
+
+/// Handles launching a recap drill from the suggestion banner.
+class RecapToDrillLauncher {
+  final TrainingSessionLauncher launcher;
+  final RecapHistoryTracker history;
+  final SmartRecapBannerController banner;
+  final TrainingSessionService sessions;
+
+  RecapToDrillLauncher({
+    TrainingSessionLauncher? launcher,
+    RecapHistoryTracker? history,
+    required this.banner,
+    required this.sessions,
+  })  : launcher = launcher ?? const TrainingSessionLauncher(),
+        history = history ?? RecapHistoryTracker.instance;
+
+  bool get _inSession =>
+      sessions.currentSession != null && !sessions.isCompleted;
+
+  /// Launches [lesson] as a targeted drill if no session is active.
+  Future<void> launch(TheoryMiniLessonNode lesson) async {
+    if (_inSession) return;
+    await launcher.launchForMiniLesson(lesson);
+    await history.registerDrillLaunch(lesson.id);
+    await banner.dismiss(recordDismissal: false);
+  }
+}

--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -7,6 +7,10 @@ import '../screens/training_session_screen.dart';
 import '../screens/theory_pack_preview_screen.dart';
 import 'achievements_engine.dart';
 import 'dart:async';
+import '../models/theory_mini_lesson_node.dart';
+import 'smart_recap_booster_launcher.dart';
+import 'smart_recap_booster_linker.dart';
+import 'training_pack_template_storage_service.dart';
 
 /// Helper to start a training session from a pack template.
 class TrainingSessionLauncher {
@@ -40,5 +44,15 @@ class TrainingSessionLauncher {
       ),
     );
     unawaited(AchievementsEngine.instance.checkAll());
+  }
+
+  /// Finds and launches a booster drill relevant to [lesson].
+  Future<void> launchForMiniLesson(TheoryMiniLessonNode lesson) async {
+    final service = SmartRecapBoosterLauncher(
+      linker: SmartRecapBoosterLinker(
+        storage: TrainingPackTemplateStorageService(),
+      ),
+    );
+    await service.launchBoosterForLesson(lesson);
   }
 }

--- a/lib/widgets/smart_recap_suggestion_banner.dart
+++ b/lib/widgets/smart_recap_suggestion_banner.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/smart_recap_banner_controller.dart';
-import '../widgets/theory_recap_dialog.dart';
+import '../services/recap_to_drill_launcher.dart';
 import '../models/theory_mini_lesson_node.dart';
 
 class SmartRecapSuggestionBanner extends StatefulWidget {
@@ -76,12 +76,8 @@ class _SmartRecapSuggestionBannerState extends State<SmartRecapSuggestionBanner>
   Future<void> _open() async {
     final lesson = _lesson;
     if (lesson == null) return;
-    await showTheoryRecapDialog(
-      context,
-      lessonId: lesson.id,
-      trigger: 'smartBanner',
-    );
-    _dismiss(false);
+    final launcher = context.read<RecapToDrillLauncher>();
+    await launcher.launch(lesson);
   }
 
   @override

--- a/test/services/recap_to_drill_launcher_test.dart
+++ b/test/services/recap_to_drill_launcher_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/recap_to_drill_launcher.dart';
+import 'package:poker_analyzer/services/smart_recap_banner_controller.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/recap_history_tracker.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  int count = 0;
+  const _FakeLauncher();
+  @override
+  Future<void> launchForMiniLesson(TheoryMiniLessonNode lesson) async {
+    count++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapHistoryTracker.instance.resetForTest();
+  });
+
+  testWidgets('launches drill and dismisses banner', (tester) async {
+    final sessions = TrainingSessionService();
+    final controller = SmartRecapBannerController(sessions: sessions);
+    final launcher = _FakeLauncher();
+    final service = RecapToDrillLauncher(
+      banner: controller,
+      sessions: sessions,
+      launcher: launcher,
+    );
+
+    await controller.showManually(const TheoryMiniLessonNode(id: 'l1', title: 't', content: ''));
+    await tester.pump();
+    await service.launch(const TheoryMiniLessonNode(id: 'l1', title: 't', content: ''));
+
+    expect(launcher.count, 1);
+    expect(controller.shouldShowBanner(), isFalse);
+    final events = await RecapHistoryTracker.instance.getHistory();
+    expect(events.first.eventType, 'drillLaunch');
+    expect(events.first.lessonId, 'l1');
+  });
+
+  testWidgets('does nothing when session active', (tester) async {
+    final sessions = TrainingSessionService();
+    final controller = SmartRecapBannerController(sessions: sessions);
+    final launcher = _FakeLauncher();
+    final service = RecapToDrillLauncher(
+      banner: controller,
+      sessions: sessions,
+      launcher: launcher,
+    );
+
+    // Start dummy session
+    await sessions.startSession(
+      TrainingPackTemplate(id: 't', name: 'n'),
+      persist: false,
+    );
+
+    await controller.showManually(const TheoryMiniLessonNode(id: 'l1', title: 't', content: ''));
+    await tester.pump();
+    await service.launch(const TheoryMiniLessonNode(id: 'l1', title: 't', content: ''));
+
+    expect(launcher.count, 0);
+    expect(controller.shouldShowBanner(), isTrue);
+    final events = await RecapHistoryTracker.instance.getHistory();
+    expect(events, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add RecapToDrillLauncher for launching drills from recap banner
- log drill launch events
- support launching boosters for mini lessons
- wire launcher into SmartRecapSuggestionBanner
- register service in providers
- test RecapToDrillLauncher

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1c7438dc832a8d4b0b2dff7c55cd