### PR TITLE
Add RecapTagAnalyticsService

### DIFF
--- a/lib/models/recap_tag_performance.dart
+++ b/lib/models/recap_tag_performance.dart
@@ -1,0 +1,5 @@
+class RecapTagPerformance {
+  final String tag;
+  final double improvement;
+  const RecapTagPerformance({required this.tag, required this.improvement});
+}

--- a/lib/services/recap_tag_analytics_service.dart
+++ b/lib/services/recap_tag_analytics_service.dart
@@ -1,0 +1,43 @@
+import '../models/recap_tag_performance.dart';
+import 'session_log_service.dart';
+
+class RecapTagAnalyticsService {
+  final SessionLogService logs;
+
+  const RecapTagAnalyticsService({required this.logs});
+
+  Future<Map<String, RecapTagPerformance>> computeRecapTagImprovements() async {
+    await logs.load();
+    final recapStats = <String, _MutableStat>{};
+    final baselineStats = <String, _MutableStat>{};
+
+    for (final log in logs.logs) {
+      final tags = {for (final t in log.tags) t.trim().toLowerCase()};
+      final isRecap = tags.contains('recap') || tags.contains('reinforcement');
+      final total = log.correctCount + log.mistakeCount;
+      if (total <= 0) continue;
+      for (final t in tags) {
+        if (t.isEmpty || t == 'recap' || t == 'reinforcement') continue;
+        final map = isRecap ? recapStats : baselineStats;
+        final stat = map.putIfAbsent(t, () => _MutableStat());
+        stat.total += total;
+        stat.correct += log.correctCount;
+      }
+    }
+
+    final result = <String, RecapTagPerformance>{};
+    recapStats.forEach((tag, stat) {
+      final recapAcc = stat.accuracy;
+      final baseAcc = baselineStats[tag]?.accuracy ?? 0;
+      result[tag] =
+          RecapTagPerformance(tag: tag, improvement: recapAcc - baseAcc);
+    });
+    return result;
+  }
+}
+
+class _MutableStat {
+  int total = 0;
+  int correct = 0;
+  double get accuracy => total > 0 ? correct / total : 0;
+}

--- a/test/services/recap_tag_analytics_service_test.dart
+++ b/test/services/recap_tag_analytics_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/services/recap_tag_analytics_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeLogService extends SessionLogService {
+  final List<SessionLog> entries;
+  _FakeLogService(this.entries) : super(sessions: TrainingSessionService());
+  @override
+  Future<void> load() async {}
+  @override
+  List<SessionLog> get logs => List.unmodifiable(entries);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('computes improvement per tag', () async {
+    final logs = [
+      SessionLog(
+        sessionId: 'b1',
+        templateId: 't1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 4,
+        mistakeCount: 6,
+        tags: const ['cbet'],
+      ),
+      SessionLog(
+        sessionId: 'b2',
+        templateId: 't1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 7,
+        mistakeCount: 3,
+        tags: const ['cbet'],
+      ),
+      SessionLog(
+        sessionId: 'r1',
+        templateId: 't1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 9,
+        mistakeCount: 1,
+        tags: const ['cbet', 'recap'],
+      ),
+    ];
+
+    final service = RecapTagAnalyticsService(logs: _FakeLogService(logs));
+    final result = await service.computeRecapTagImprovements();
+    final improvement = result['cbet']?.improvement ?? 0;
+    expect(improvement, closeTo(0.35, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary
- add `RecapTagPerformance` model
- implement `RecapTagAnalyticsService` to compute recap tag improvements
- test the analytics service

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f80a380832a96f27331fb1355a0