### PR TITLE
Add SmartRecapScheduler service

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -496,6 +496,16 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(create: (_) => TagCoverageService()),
     Provider(create: (_) => TagMasteryHistoryService()),
     Provider(
+      create: (context) => SkillTagDecayTracker(
+        logs: context.read<SessionLogService>(),
+        history: context.read<TagMasteryHistoryService>(),
+      ),
+    ),
+    Provider(
+      create: (context) =>
+          RecapTagAnalyticsService(logs: context.read<SessionLogService>()),
+    ),
+    Provider(
       create: (context) => TagInsightReminderEngine(
         history: context.read<TagMasteryHistoryService>(),
       ),
@@ -579,6 +589,13 @@ List<SingleChildWidget> buildTrainingProviders() {
     ChangeNotifierProvider(
       create: (context) => SmartRecapBannerController(
         sessions: context.read<TrainingSessionService>(),
+      )..start(),
+    ),
+    Provider(
+      create: (context) => SmartRecapScheduler(
+        decay: context.read<SkillTagDecayTracker>(),
+        analytics: context.read<RecapTagAnalyticsService>(),
+        controller: context.read<SmartRecapBannerController>(),
       )..start(),
     ),
     Provider(

--- a/lib/services/smart_recap_scheduler.dart
+++ b/lib/services/smart_recap_scheduler.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'skill_tag_decay_tracker.dart';
+import 'recap_tag_analytics_service.dart';
+import 'smart_recap_banner_controller.dart';
+import 'theory_boost_recap_linker.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Background scheduler that precomputes smart recap suggestions.
+class SmartRecapScheduler with WidgetsBindingObserver {
+  SmartRecapScheduler({
+    required this.decay,
+    required this.analytics,
+    required this.controller,
+    TheoryBoostRecapLinker? theoryLinker,
+    MiniLessonLibraryService? library,
+  })  : theoryLinker = theoryLinker ?? const TheoryBoostRecapLinker(),
+        library = library ?? MiniLessonLibraryService.instance;
+
+  final SkillTagDecayTracker decay;
+  final RecapTagAnalyticsService analytics;
+  final SmartRecapBannerController controller;
+  final TheoryBoostRecapLinker theoryLinker;
+  final MiniLessonLibraryService library;
+
+  Timer? _timer;
+
+  Future<void> start({Duration interval = const Duration(hours: 1)}) async {
+    WidgetsBinding.instance.addObserver(this);
+    await _evaluate();
+    _timer?.cancel();
+    _timer = Timer.periodic(interval, (_) => _evaluate());
+  }
+
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+    _timer?.cancel();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _evaluate();
+    }
+  }
+
+  Future<void> _evaluate() async {
+    final tags = await decay.getDecayingTags();
+    if (tags.isEmpty) return;
+    final perf = await analytics.computeRecapTagImprovements();
+    String tag = tags.first;
+    double best = perf[tag]?.improvement ?? double.infinity;
+    for (final t in tags.skip(1)) {
+      final val = perf[t]?.improvement ?? double.infinity;
+      if (val < best) {
+        best = val;
+        tag = t;
+      }
+    }
+    var lesson = await theoryLinker.fetchLesson(tag);
+    lesson ??= (await library.loadAll(), library.findByTags([tag]).firstOrNull);
+    if (lesson != null) {
+      await controller.queueBannerFor(lesson);
+    }
+  }
+}

--- a/test/services/smart_recap_scheduler_test.dart
+++ b/test/services/smart_recap_scheduler_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/smart_recap_scheduler.dart';
+import 'package:poker_analyzer/services/skill_tag_decay_tracker.dart';
+import 'package:poker_analyzer/services/recap_tag_analytics_service.dart';
+import 'package:poker_analyzer/services/smart_recap_banner_controller.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/theory_boost_recap_linker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+import 'package:poker_analyzer/models/recap_tag_performance.dart';
+
+class _FakeDecay extends SkillTagDecayTracker {
+  final List<String> tags;
+  _FakeDecay(this.tags)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()),
+            history: TagMasteryHistoryService());
+  @override
+  Future<List<String>> getDecayingTags({int maxTags = 5, int recentSessions = 10, DateTime? now, double timeWeight = 0.5, double trendWeight = 0.5}) async {
+    return tags;
+  }
+}
+
+class _FakeAnalytics extends RecapTagAnalyticsService {
+  final Map<String, double> map;
+  _FakeAnalytics(this.map)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<Map<String, RecapTagPerformance>> computeRecapTagImprovements() async {
+    return {for (final e in map.entries) e.key: RecapTagPerformance(tag: e.key, improvement: e.value)};
+  }
+}
+
+class _FakeController extends SmartRecapBannerController {
+  _FakeController() : super(sessions: TrainingSessionService());
+  TheoryMiniLessonNode? queued;
+  @override
+  Future<void> queueBannerFor(TheoryMiniLessonNode lesson) async {
+    queued = lesson;
+  }
+}
+
+class _FakeLinker extends TheoryBoostRecapLinker {
+  final TheoryMiniLessonNode lesson;
+  const _FakeLinker(this.lesson) : super();
+  @override
+  Future<TheoryMiniLessonNode?> fetchLesson(String tag) async => lesson;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final TheoryMiniLessonNode lesson;
+  _FakeLibrary(this.lesson);
+  @override
+  List<TheoryMiniLessonNode> get all => [lesson];
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  TheoryMiniLessonNode? getById(String id) => lesson.id == id ? lesson : null;
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [lesson];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [lesson];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('queues banner for decaying tag', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final controller = _FakeController();
+    final scheduler = SmartRecapScheduler(
+      decay: _FakeDecay(['push']),
+      analytics: _FakeAnalytics({'push': 0}),
+      controller: controller,
+      theoryLinker: _FakeLinker(lesson),
+      library: _FakeLibrary(lesson),
+    );
+    await scheduler.start(interval: const Duration(milliseconds: 10));
+    await Future.delayed(const Duration(milliseconds: 20));
+    expect(controller.queued?.id, 'l1');
+    await scheduler.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add queueBannerFor to SmartRecapBannerController
- implement SmartRecapScheduler background service
- wire scheduler and analytics providers
- test SmartRecapScheduler

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3b36b9d4832aa38ddb45588c8f6b