### PR TITLE
Add SmartRecapPreviewWidget

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -33,6 +33,7 @@ import '../widgets/resume_training_card.dart';
 import '../widgets/resume_lesson_card.dart';
 import '../widgets/next_learning_step_card.dart';
 import '../widgets/next_up_banner.dart';
+import '../widgets/smart_recap_preview_widget.dart';
 import '../widgets/training_recommender_banner.dart';
 import '../widgets/leak_insight_banner.dart';
 import '../widgets/daily_focus_recap_card.dart';
@@ -147,6 +148,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
         children: [
           const StarterPathCard(),
           const NextUpBanner(),
+          const SmartRecapPreviewWidget(),
           const LeakInsightBanner(),
           const TrainingRecommenderBanner(),
           const TrackUnlockPreviewCard(),

--- a/lib/widgets/smart_recap_preview_widget.dart
+++ b/lib/widgets/smart_recap_preview_widget.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/smart_recap_banner_controller.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/mini_lesson_screen.dart';
+
+/// Small widget previewing an upcoming smart recap lesson.
+class SmartRecapPreviewWidget extends StatefulWidget {
+  const SmartRecapPreviewWidget({super.key});
+
+  @override
+  State<SmartRecapPreviewWidget> createState() => _SmartRecapPreviewWidgetState();
+}
+
+class _SmartRecapPreviewWidgetState extends State<SmartRecapPreviewWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  TheoryMiniLessonNode? _lesson;
+  late SmartRecapBannerController _banner;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 300));
+    WidgetsBinding.instance.addPostFrameCallback((_) => _setup());
+  }
+
+  @override
+  void dispose() {
+    _banner.removeListener(_onChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _setup() {
+    _banner = context.read<SmartRecapBannerController>();
+    _banner.addListener(_onChanged);
+    _onChanged();
+  }
+
+  void _onChanged() {
+    final lesson = _banner.getPendingLesson();
+    if (lesson != null) {
+      _lesson = lesson;
+      _controller.forward();
+    } else {
+      _lesson = null;
+      _controller.reverse();
+    }
+    if (mounted) setState(() {});
+  }
+
+  void _openLesson() {
+    final lesson = _lesson;
+    if (lesson == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lesson = _lesson;
+    if (lesson == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return SizeTransition(
+      sizeFactor: _controller,
+      axisAlignment: -1,
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    lesson.resolvedTitle,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    'Рекомендовано к повторению',
+                    style: TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _openLesson,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Повторить'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add SmartRecapPreviewWidget to preview queued recap lessons
- display widget near the top of TrainingHomeScreen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a419b48b0832ab6135f969210f4ce