### PR TITLE
Implement recap completion tracker

### DIFF
--- a/lib/models/recap_completion_log.dart
+++ b/lib/models/recap_completion_log.dart
@@ -1,0 +1,27 @@
+class RecapCompletionLog {
+  final String lessonId;
+  final String tag;
+  final DateTime timestamp;
+  final Duration duration;
+
+  const RecapCompletionLog({
+    required this.lessonId,
+    required this.tag,
+    required this.timestamp,
+    required this.duration,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'tag': tag,
+        'timestamp': timestamp.toIso8601String(),
+        'durationMs': duration.inMilliseconds,
+      };
+
+  factory RecapCompletionLog.fromJson(Map<String, dynamic> json) => RecapCompletionLog(
+        lessonId: json['lessonId'] as String? ?? '',
+        tag: json['tag'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+        duration: Duration(milliseconds: (json['durationMs'] as int?) ?? 0),
+      );
+}

--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -1,22 +1,52 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../models/theory_mini_lesson_node.dart';
+import '../services/recap_completion_tracker.dart';
 
 /// Simple viewer for a [TheoryMiniLessonNode].
-class MiniLessonScreen extends StatelessWidget {
+class MiniLessonScreen extends StatefulWidget {
   final TheoryMiniLessonNode lesson;
-  const MiniLessonScreen({super.key, required this.lesson});
+  final String? recapTag;
+  const MiniLessonScreen({super.key, required this.lesson, this.recapTag});
+
+  @override
+  State<MiniLessonScreen> createState() => _MiniLessonScreenState();
+}
+
+class _MiniLessonScreenState extends State<MiniLessonScreen> {
+  late DateTime _started;
+
+  @override
+  void initState() {
+    super.initState();
+    _started = DateTime.now();
+  }
+
+  @override
+  void dispose() {
+    final tag = widget.recapTag;
+    if (tag != null) {
+      final duration = DateTime.now().difference(_started);
+      unawaited(
+        RecapCompletionTracker.instance
+            .logCompletion(widget.lesson.id, tag, duration),
+      );
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(lesson.resolvedTitle)),
+      appBar: AppBar(title: Text(widget.lesson.resolvedTitle)),
       backgroundColor: const Color(0xFF121212),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Markdown(
-          data: lesson.resolvedContent,
+          data: widget.lesson.resolvedContent,
           styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)),
         ),
       ),

--- a/lib/services/recap_completion_tracker.dart
+++ b/lib/services/recap_completion_tracker.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/recap_completion_log.dart';
+
+/// Records completion of recap mini lessons for engagement analytics.
+class RecapCompletionTracker {
+  RecapCompletionTracker._();
+  static final RecapCompletionTracker instance = RecapCompletionTracker._();
+
+  static const String _prefsKey = 'recap_completion_logs';
+
+  final List<RecapCompletionLog> _logs = [];
+  bool _loaded = false;
+
+  /// Clears cached data for testing.
+  void resetForTest() {
+    _loaded = false;
+    _logs.clear();
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is List) {
+          _logs.addAll(data.whereType<Map>().map(
+            (e) => RecapCompletionLog.fromJson(Map<String, dynamic>.from(e)),
+          ));
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final l in _logs) l.toJson()]),
+    );
+  }
+
+  /// Logs a completed recap lesson.
+  Future<void> logCompletion(
+    String lessonId,
+    String tag,
+    Duration duration, {
+    DateTime? timestamp,
+  }) async {
+    await _load();
+    _logs.insert(
+      0,
+      RecapCompletionLog(
+        lessonId: lessonId,
+        tag: tag,
+        timestamp: timestamp ?? DateTime.now(),
+        duration: duration,
+      ),
+    );
+    if (_logs.length > 200) _logs.removeRange(200, _logs.length);
+    await _save();
+  }
+
+  /// Returns completions within [window] sorted newest first.
+  Future<List<RecapCompletionLog>> getRecentCompletions({
+    Duration window = const Duration(days: 7),
+  }) async {
+    await _load();
+    final cutoff = DateTime.now().subtract(window);
+    final list = _logs.where((e) => e.timestamp.isAfter(cutoff));
+    return List<RecapCompletionLog>.unmodifiable(list);
+  }
+
+  /// Frequency of completions per tag within [window].
+  Future<Map<String, int>> tagFrequency({
+    Duration window = const Duration(days: 7),
+  }) async {
+    final list = await getRecentCompletions(window: window);
+    final map = <String, int>{};
+    for (final l in list) {
+      map[l.tag] = (map[l.tag] ?? 0) + 1;
+    }
+    return map;
+  }
+}

--- a/lib/widgets/smart_recap_preview_widget.dart
+++ b/lib/widgets/smart_recap_preview_widget.dart
@@ -57,7 +57,12 @@ class _SmartRecapPreviewWidgetState extends State<SmartRecapPreviewWidget>
     if (lesson == null) return;
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+      MaterialPageRoute(
+        builder: (_) => MiniLessonScreen(
+          lesson: lesson,
+          recapTag: 'recap',
+        ),
+      ),
     );
   }
 

--- a/test/services/recap_completion_tracker_test.dart
+++ b/test/services/recap_completion_tracker_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/recap_completion_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapCompletionTracker.instance.resetForTest();
+  });
+
+  test('logs and retrieves recent completions', () async {
+    await RecapCompletionTracker.instance
+        .logCompletion('l1', 'recap', const Duration(seconds: 5));
+    final list = await RecapCompletionTracker.instance.getRecentCompletions();
+    expect(list.length, 1);
+    expect(list.first.lessonId, 'l1');
+    expect(list.first.tag, 'recap');
+    expect(list.first.duration.inSeconds, 5);
+  });
+
+  test('older completions filtered by window', () async {
+    final now = DateTime.now();
+    await RecapCompletionTracker.instance.logCompletion(
+      'l1',
+      'recap',
+      const Duration(seconds: 1),
+      timestamp: now.subtract(const Duration(days: 8)),
+    );
+    final list = await RecapCompletionTracker.instance.getRecentCompletions();
+    expect(list, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `RecapCompletionTracker` service and model
- log recap completion when leaving `MiniLessonScreen`
- pass `recapTag` from `SmartRecapPreviewWidget`
- test new completion tracker

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4509fcc8832a85efed062646f38e