### PR TITLE
Add theory booster fallback for recaps

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -16,6 +16,7 @@ import '../services/weak_spot_recommendation_service.dart';
 import '../services/daily_spotlight_service.dart';
 
 import '../widgets/booster_suggestion_block.dart';
+import '../widgets/theory_booster_suggestion_block.dart';
 
 import '../services/spot_of_the_day_service.dart';
 import '../widgets/spot_of_the_day_card.dart';
@@ -125,9 +126,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => const BoosterLibraryScreen(),
-                ),
+                MaterialPageRoute(builder: (_) => const BoosterLibraryScreen()),
               );
             },
           ),
@@ -136,9 +135,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => const BoosterArchiveScreen(),
-                ),
+                MaterialPageRoute(builder: (_) => const BoosterArchiveScreen()),
               );
             },
           ),
@@ -168,6 +165,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const RecommendedDrillTile(),
           const TagProgressHistoryCard(),
           const BoosterSuggestionBlock(),
+          const TheoryBoosterSuggestionBlock(),
           if (!tablet) const DailySpotlightCard(),
           if (narrow) ...[
             const QuickContinueCard(),
@@ -256,8 +254,9 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final service = context.read<AdaptiveTrainingService>();
     await service.refresh();
     final list = service.recommended.toList();
-    final weak =
-        await context.read<WeakSpotRecommendationService>().buildPack();
+    final weak = await context
+        .read<WeakSpotRecommendationService>()
+        .buildPack();
     if (weak != null) list.insert(0, weak);
     final review = await MistakeReviewPackService.latestTemplate(context);
     if (review != null) list.insert(0, review);
@@ -266,7 +265,8 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
     final delta = <String, double?>{};
     final adjusted = <TrainingPackTemplate>[];
     for (final t in list) {
-      stats[t.id] = service.statFor(t.id) ??
+      stats[t.id] =
+          service.statFor(t.id) ??
           await TrainingPackStatsService.getStats(t.id);
       final hist = await TrainingPackStatsService.history(t.id);
       if (hist.length >= 2) {
@@ -407,14 +407,14 @@ class _PackCard extends StatelessWidget {
     final label = completed
         ? 'Пройдено'
         : progress > 0
-            ? 'Продолжить'
-            : 'Начать';
+        ? 'Продолжить'
+        : 'Начать';
     final color = completed ? Colors.green : Colors.orange;
     final spotlight =
         context.watch<DailySpotlightService>().template?.id == template.id;
     final hasMistakes = context.read<MistakeReviewPackService>().hasMistakes(
-          template.id,
-        );
+      template.id,
+    );
     final ev = stat?.postEvPct ?? 0;
     final icm = stat?.postIcmPct ?? 0;
     final rating = ((stat?.accuracy ?? 0) * 5).clamp(1, 5).round();
@@ -432,8 +432,10 @@ class _PackCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (spotlight)
-            const Text('🎯 Пак дня',
-                style: TextStyle(color: Colors.amber, fontSize: 12)),
+            const Text(
+              '🎯 Пак дня',
+              style: TextStyle(color: Colors.amber, fontSize: 12),
+            ),
           Icon(hasMistakes ? Icons.error : Icons.shield, color: color),
           const Spacer(),
           Text(template.name, maxLines: 2, overflow: TextOverflow.ellipsis),
@@ -500,8 +502,8 @@ class _PackCard extends StatelessWidget {
                 ? null
                 : () async {
                     await context.read<TrainingSessionService>().startSession(
-                          template,
-                        );
+                      template,
+                    );
                     if (context.mounted) {
                       await Navigator.push(
                         context,
@@ -527,8 +529,8 @@ class _PackCard extends StatelessWidget {
                     .review(context, template.id);
                 if (review != null && context.mounted) {
                   await context.read<TrainingSessionService>().startSession(
-                        review,
-                      );
+                    review,
+                  );
                   if (context.mounted) {
                     await Navigator.push(
                       context,

--- a/lib/widgets/theory_booster_suggestion_block.dart
+++ b/lib/widgets/theory_booster_suggestion_block.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../services/theory_booster_suggestion_engine.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/mini_lesson_screen.dart';
+
+class TheoryBoosterSuggestionBlock extends StatefulWidget {
+  const TheoryBoosterSuggestionBlock({super.key});
+
+  @override
+  State<TheoryBoosterSuggestionBlock> createState() =>
+      _TheoryBoosterSuggestionBlockState();
+}
+
+class _TheoryBoosterSuggestionBlockState
+    extends State<TheoryBoosterSuggestionBlock> {
+  bool _loading = true;
+  List<TheoryMiniLessonNode> _lessons = [];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final lessons = await TheoryBoosterSuggestionEngine.instance
+        .suggestBoosters(maxCount: 2);
+    if (mounted) {
+      setState(() {
+        _lessons = lessons;
+        _loading = false;
+      });
+    }
+  }
+
+  void _open(TheoryMiniLessonNode lesson) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    if (_loading || _lessons.isEmpty) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '📌 Need Review?',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          for (var i = 0; i < _lessons.length; i++) ...[
+            Text(
+              _lessons[i].resolvedTitle,
+              style: const TextStyle(color: Colors.white),
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () => _open(_lessons[i]),
+                style: TextButton.styleFrom(foregroundColor: accent),
+                child: const Text('Open'),
+              ),
+            ),
+            if (i != _lessons.length - 1) const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/smart_recap_banner_controller_test.dart
+++ b/test/services/smart_recap_banner_controller_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/smart_recap_banner_controller.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/smart_theory_recap_engine.dart';
+import 'package:poker_analyzer/services/theory_recap_suppression_engine.dart';
+import 'package:poker_analyzer/services/smart_theory_recap_dismissal_memory.dart';
+import 'package:poker_analyzer/services/recap_fatigue_evaluator.dart';
+import 'package:poker_analyzer/services/recap_history_tracker.dart';
+import 'package:poker_analyzer/services/theory_booster_suggestion_engine.dart';
+
+class _FakeRecapEngine extends SmartTheoryRecapEngine {
+  final TheoryMiniLessonNode? lesson;
+  const _FakeRecapEngine(this.lesson);
+  @override
+  Future<TheoryMiniLessonNode?> getNextRecap() async => lesson;
+}
+
+class _FakeSuppression extends TheoryRecapSuppressionEngine {
+  final bool value;
+  _FakeSuppression(this.value) : super();
+  @override
+  Future<bool> shouldSuppress({
+    required String lessonId,
+    required String trigger,
+  }) async => value;
+}
+
+class _FakeFatigue extends RecapFatigueEvaluator {
+  final bool value;
+  _FakeFatigue(this.value) : super(tracker: RecapHistoryTracker.instance);
+  @override
+  Future<bool> isFatigued(String lessonId) async => value;
+}
+
+class _FakeDismissal extends SmartTheoryRecapDismissalMemory {
+  final bool value;
+  _FakeDismissal(this.value) : super._();
+  @override
+  Future<bool> shouldThrottle(String key) async => value;
+}
+
+class _FakeBoosterEngine extends TheoryBoosterSuggestionEngine {
+  final List<TheoryMiniLessonNode> boosters;
+  const _FakeBoosterEngine(this.boosters) : super();
+  @override
+  Future<List<TheoryMiniLessonNode>> suggestBoosters({
+    int maxCount = 3,
+  }) async => boosters;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapHistoryTracker.instance.resetForTest();
+  });
+
+  test('fallbacks to boosters when no recap', () async {
+    final booster = const TheoryMiniLessonNode(
+      id: 'b1',
+      title: 't',
+      content: '',
+    );
+    final controller = SmartRecapBannerController(
+      engine: const _FakeRecapEngine(null),
+      suppression: _FakeSuppression(false),
+      dismissal: _FakeDismissal(false),
+      fatigue: _FakeFatigue(false),
+      boosterEngine: _FakeBoosterEngine([booster]),
+      sessions: TrainingSessionService(),
+    );
+
+    await controller.triggerBannerIfNeeded();
+    expect(controller.getBoosterLessons().length, 1);
+    expect(controller.shouldShowBanner(), isTrue);
+    expect(controller.getPendingLesson(), isNull);
+  });
+
+  test('uses boosters when recap suppressed', () async {
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l1',
+      title: 't',
+      content: '',
+    );
+    final booster = const TheoryMiniLessonNode(
+      id: 'b1',
+      title: 'b',
+      content: '',
+    );
+    final controller = SmartRecapBannerController(
+      engine: _FakeRecapEngine(lesson),
+      suppression: _FakeSuppression(true),
+      dismissal: _FakeDismissal(false),
+      fatigue: _FakeFatigue(false),
+      boosterEngine: _FakeBoosterEngine([booster]),
+      sessions: TrainingSessionService(),
+    );
+
+    await controller.triggerBannerIfNeeded();
+    expect(controller.getBoosterLessons().first.id, 'b1');
+    expect(controller.getPendingLesson(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- extend `SmartRecapBannerController` with booster support
- show booster lessons when recap unavailable or suppressed
- display theory booster suggestions block on the dashboard
- update recap banner widget for boosters
- test booster fallback logic

## Testing
- `dart format` *(success)*
- `flutter pub get` *(warnings)*
- `flutter analyze` *(failed: project has numerous compile errors)*
- `flutter test` *(failed: project does not build)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a1c9e58832aa8fc23de8b1ae397