### PR TITLE
Implement TheoryBoostTriggerService

### DIFF
--- a/lib/services/theory_boost_trigger_service.dart
+++ b/lib/services/theory_boost_trigger_service.dart
@@ -1,0 +1,52 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+import 'recap_completion_tracker.dart';
+import 'recap_effectiveness_analyzer.dart';
+import 'theory_replay_cooldown_manager.dart';
+import 'package:collection/collection.dart';
+
+/// Determines when theory boosters should be shown after recaps.
+class TheoryBoostTriggerService {
+  final RecapCompletionTracker tracker;
+  final RecapEffectivenessAnalyzer analyzer;
+  final MiniLessonLibraryService library;
+  final Duration cooldown;
+
+  TheoryBoostTriggerService({
+    RecapCompletionTracker? tracker,
+    RecapEffectivenessAnalyzer? analyzer,
+    MiniLessonLibraryService? library,
+    this.cooldown = const Duration(hours: 12),
+  })  : tracker = tracker ?? RecapCompletionTracker.instance,
+        analyzer = analyzer ?? RecapEffectivenessAnalyzer.instance,
+        library = library ?? MiniLessonLibraryService.instance;
+
+  static final TheoryBoostTriggerService instance = TheoryBoostTriggerService();
+
+  Future<bool> _underCooldown(String tag) =>
+      TheoryReplayCooldownManager.isUnderCooldown('boost:$tag',
+          cooldown: cooldown);
+
+  Future<void> _markCooldown(String tag) =>
+      TheoryReplayCooldownManager.markSuggested('boost:$tag');
+
+  /// Returns true if [tag] warrants a booster suggestion.
+  Future<bool> shouldTriggerBoost(String tag) async {
+    final key = tag.trim().toLowerCase();
+    if (key.isEmpty) return false;
+    if (await _underCooldown(key)) return false;
+    await analyzer.refresh();
+    if (!analyzer.isUnderperforming(key)) return false;
+    final freq = await tracker.tagFrequency();
+    if ((freq[key] ?? 0) < 1) return false;
+    await _markCooldown(key);
+    return true;
+  }
+
+  /// Returns a lesson to boost [tag] if conditions are met.
+  Future<TheoryMiniLessonNode?> getBoostCandidate(String tag) async {
+    if (!await shouldTriggerBoost(tag)) return null;
+    await library.loadAll();
+    return library.findByTags([tag]).firstOrNull;
+  }
+}

--- a/test/services/theory_boost_trigger_service_test.dart
+++ b/test/services/theory_boost_trigger_service_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_boost_trigger_service.dart';
+import 'package:poker_analyzer/services/recap_completion_tracker.dart';
+import 'package:poker_analyzer/services/recap_effectiveness_analyzer.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_replay_cooldown_manager.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeTracker extends RecapCompletionTracker {
+  final Map<String, int> freq;
+  _FakeTracker(this.freq);
+  @override
+  Future<Map<String, int>> tagFrequency(
+          {Duration window = const Duration(days: 7)}) async =>
+      freq;
+}
+
+class _FakeAnalyzer extends RecapEffectivenessAnalyzer {
+  final bool under;
+  _FakeAnalyzer(this.under) : super(tracker: RecapCompletionTracker.instance);
+  @override
+  bool isUnderperforming(String tag,
+          {int minCompletions = 3,
+          Duration minAvgDuration = const Duration(seconds: 5),
+          double minRepeatRate = 0.25}) =>
+      under;
+}
+
+class _FakeLibrary extends MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => lessons;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('shouldTriggerBoost returns true when conditions met', () async {
+    final tracker = _FakeTracker({'icm': 2});
+    final analyzer = _FakeAnalyzer(true);
+    final service =
+        TheoryBoostTriggerService(tracker: tracker, analyzer: analyzer);
+    final result = await service.shouldTriggerBoost('icm');
+    expect(result, true);
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('theory_replay_cooldowns');
+    expect(raw, isNotNull);
+  });
+
+  test('respects cooldown', () async {
+    final now = DateTime.now().toIso8601String();
+    SharedPreferences.setMockInitialValues({
+      'theory_replay_cooldowns': jsonEncode({'boost:icm': now})
+    });
+    final tracker = _FakeTracker({'icm': 3});
+    final analyzer = _FakeAnalyzer(true);
+    final service =
+        TheoryBoostTriggerService(tracker: tracker, analyzer: analyzer);
+    final result = await service.shouldTriggerBoost('icm');
+    expect(result, false);
+  });
+
+  test('getBoostCandidate returns lesson when trigger passes', () async {
+    final tracker = _FakeTracker({'cbet': 2});
+    final analyzer = _FakeAnalyzer(true);
+    final lesson = const TheoryMiniLessonNode(
+        id: 'l1', title: 'A', content: '', tags: ['cbet']);
+    final library = _FakeLibrary([lesson]);
+    final service = TheoryBoostTriggerService(
+        tracker: tracker, analyzer: analyzer, library: library);
+    final result = await service.getBoostCandidate('cbet');
+    expect(result?.id, 'l1');
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryBoostTriggerService` for deciding when to show theory boosters after recaps
- provide simple unit tests covering trigger logic and cooldown behavior

## Testing
- `dart format lib/services/theory_boost_trigger_service.dart test/services/theory_boost_trigger_service_test.dart`
- `flutter analyze` *(fails: requires Dart 3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_688a5f3af1e8832a8c9a532a37a4f0e7