### PR TITLE
Implement AutoTheoryBoosterLauncher

### DIFF
--- a/lib/services/auto_theory_booster_launcher.dart
+++ b/lib/services/auto_theory_booster_launcher.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../models/recap_completion_log.dart';
+import 'recap_completion_tracker.dart';
+import 'theory_boost_trigger_service.dart';
+
+/// Automatically launches theory boosters after recap completions when warranted.
+class AutoTheoryBoosterLauncher {
+  final RecapCompletionTracker tracker;
+  final TheoryBoostTriggerService trigger;
+  final Duration cooldown;
+
+  AutoTheoryBoosterLauncher({
+    RecapCompletionTracker? tracker,
+    TheoryBoostTriggerService? trigger,
+    this.cooldown = const Duration(minutes: 10),
+  })  : tracker = tracker ?? RecapCompletionTracker.instance,
+        trigger = trigger ?? TheoryBoostTriggerService.instance {
+    _sub = this.tracker.onCompletion.listen(_handle);
+  }
+
+  static final AutoTheoryBoosterLauncher instance = AutoTheoryBoosterLauncher();
+
+  StreamSubscription<RecapCompletionLog>? _sub;
+  DateTime _lastLaunch = DateTime.fromMillisecondsSinceEpoch(0);
+
+  void dispose() {
+    _sub?.cancel();
+  }
+
+  bool _underCooldown() =>
+      DateTime.now().difference(_lastLaunch) < cooldown;
+
+  Future<void> _handle(RecapCompletionLog log) async {
+    if (_underCooldown()) return;
+    final lesson = await trigger.getBoostCandidate(log.tag);
+    if (lesson == null) return;
+    final ctx = navigatorKey.currentState?.context;
+    if (ctx == null) return;
+    _lastLaunch = DateTime.now();
+    Navigator.push(
+      ctx,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+}

--- a/test/services/auto_theory_booster_launcher_test.dart
+++ b/test/services/auto_theory_booster_launcher_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:provider/provider.dart';
+
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/services/auto_theory_booster_launcher.dart';
+import 'package:poker_analyzer/services/recap_completion_tracker.dart';
+import 'package:poker_analyzer/services/theory_boost_trigger_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/screens/mini_lesson_screen.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeTrigger extends TheoryBoostTriggerService {
+  final TheoryMiniLessonNode? lesson;
+  _FakeTrigger(this.lesson)
+      : super(tracker: RecapCompletionTracker.instance);
+  @override
+  Future<TheoryMiniLessonNode?> getBoostCandidate(String tag) async => lesson;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('launches booster when candidate available', (tester) async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final service = AutoTheoryBoosterLauncher(
+      trigger: _FakeTrigger(lesson),
+      cooldown: Duration.zero,
+    );
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => TrainingSessionService(),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    await RecapCompletionTracker.instance
+        .logCompletion('r1', 'tag', const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MiniLessonScreen), findsOneWidget);
+    service.dispose();
+  });
+
+  testWidgets('respects cooldown', (tester) async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final service = AutoTheoryBoosterLauncher(
+      trigger: _FakeTrigger(lesson),
+      cooldown: const Duration(seconds: 30),
+    );
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => TrainingSessionService(),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    await RecapCompletionTracker.instance
+        .logCompletion('r1', 'tag', const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+    Navigator.of(navigatorKey.currentContext!).pop();
+
+    await RecapCompletionTracker.instance
+        .logCompletion('r2', 'tag', const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MiniLessonScreen), findsNothing);
+    service.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- allow listening to recap completions
- add `AutoTheoryBoosterLauncher` service that watches recap completions and opens boosters
- test service behaviour

## Testing
- `flutter test test/services/auto_theory_booster_launcher_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a62e71c98832aaea19eebf1e4df8b