### PR TITLE
Implement TheoryInboxBannerEngine

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -123,6 +123,7 @@ import 'services/gift_drop_service.dart';
 import 'services/session_streak_overlay_prompt_service.dart';
 import 'services/smart_recap_auto_injector.dart';
 import 'services/smart_recap_banner_controller.dart';
+import 'services/theory_inbox_banner_controller.dart';
 import 'services/smart_recap_banner_reinjection_service.dart';
 import 'services/recap_to_drill_launcher.dart';
 import 'services/adaptive_next_step_engine.dart';
@@ -578,6 +579,9 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => SkillLossOverlayPromptService(
         logs: context.read<SessionLogService>(),
       ),
+    ),
+    ChangeNotifierProvider(
+      create: (_) => TheoryInboxBannerController()..start(),
     ),
     Provider(create: (_) => GiftDropService()),
     Provider(create: (_) => SessionStreakOverlayPromptService()),

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -35,6 +35,7 @@ import '../widgets/resume_lesson_card.dart';
 import '../widgets/next_learning_step_card.dart';
 import '../widgets/next_up_banner.dart';
 import '../widgets/smart_recap_preview_widget.dart';
+import '../widgets/theory_inbox_banner.dart';
 import '../widgets/training_recommender_banner.dart';
 import '../widgets/leak_insight_banner.dart';
 import '../widgets/daily_focus_recap_card.dart';
@@ -146,6 +147,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const StarterPathCard(),
           const NextUpBanner(),
           const SmartRecapPreviewWidget(),
+          const TheoryInboxBanner(),
           const LeakInsightBanner(),
           const TrainingRecommenderBanner(),
           const TrackUnlockPreviewCard(),

--- a/lib/services/theory_inbox_banner_controller.dart
+++ b/lib/services/theory_inbox_banner_controller.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'theory_inbox_banner_engine.dart';
+
+/// Controls visibility of the inbox theory banner.
+class TheoryInboxBannerController extends ChangeNotifier {
+  final TheoryInboxBannerEngine engine;
+
+  TheoryInboxBannerController({TheoryInboxBannerEngine? engine})
+      : engine = engine ?? TheoryInboxBannerEngine.instance;
+
+  TheoryMiniLessonNode? _lesson;
+  Timer? _timer;
+
+  /// Starts periodic checks for inbox banner.
+  Future<void> start({Duration interval = const Duration(hours: 12)}) async {
+    _timer?.cancel();
+    await _check();
+    if (interval > Duration.zero) {
+      _timer = Timer.periodic(interval, (_) => _check());
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _check() async {
+    await engine.run();
+    _lesson = engine.lesson;
+    notifyListeners();
+  }
+
+  /// Whether inbox banner should be shown.
+  bool shouldShowInboxBanner() => _lesson != null;
+
+  /// Recommended lesson for the banner.
+  TheoryMiniLessonNode? getLesson() => _lesson;
+}

--- a/lib/services/theory_inbox_banner_engine.dart
+++ b/lib/services/theory_inbox_banner_engine.dart
@@ -1,0 +1,36 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'booster_suggestion_engine.dart';
+
+/// Fetches booster lessons for inbox banner reminders.
+class TheoryInboxBannerEngine {
+  final BoosterSuggestionEngine booster;
+  final Duration cooldown;
+
+  TheoryInboxBannerEngine({
+    BoosterSuggestionEngine? booster,
+    this.cooldown = const Duration(hours: 12),
+  }) : booster = booster ?? const BoosterSuggestionEngine();
+
+  static final TheoryInboxBannerEngine instance = TheoryInboxBannerEngine();
+
+  static const _lastKey = 'theory_inbox_banner_last';
+
+  TheoryMiniLessonNode? _lesson;
+
+  /// Runs recommendation check if enough time elapsed since last run.
+  Future<void> run() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr == null ? null : DateTime.tryParse(lastStr);
+    if (last != null && now.difference(last) < cooldown) return;
+    final lessons = await booster.getRecommendedBoosters(maxCount: 1);
+    _lesson = lessons.isNotEmpty ? lessons.first : null;
+    await prefs.setString(_lastKey, now.toIso8601String());
+  }
+
+  /// Returns the recommended lesson if any.
+  TheoryMiniLessonNode? get lesson => _lesson;
+}

--- a/lib/widgets/theory_inbox_banner.dart
+++ b/lib/widgets/theory_inbox_banner.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/theory_inbox_banner_controller.dart';
+import '../screens/mini_lesson_screen.dart';
+
+/// Simple banner showing a booster lesson suggestion from inbox engine.
+class TheoryInboxBanner extends StatefulWidget {
+  const TheoryInboxBanner({super.key});
+
+  @override
+  State<TheoryInboxBanner> createState() => _TheoryInboxBannerState();
+}
+
+class _TheoryInboxBannerState extends State<TheoryInboxBanner> {
+  TheoryMiniLessonNode? _lesson;
+  late TheoryInboxBannerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _setup());
+  }
+
+  void _setup() {
+    _controller = context.read<TheoryInboxBannerController>();
+    _controller.addListener(_update);
+    _update();
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_update);
+    super.dispose();
+  }
+
+  void _update() {
+    _lesson = _controller.getLesson();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _open() async {
+    final lesson = _lesson;
+    if (lesson == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lesson = _lesson;
+    if (!_controller.shouldShowInboxBanner() || lesson == null) {
+      return const SizedBox.shrink();
+    }
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            lesson.resolvedTitle,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'Missed recap',
+            style: TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _open,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Review now'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/theory_inbox_banner_controller_test.dart
+++ b/test/services/theory_inbox_banner_controller_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/theory_inbox_banner_controller.dart';
+import 'package:poker_analyzer/services/theory_inbox_banner_engine.dart';
+import 'package:poker_analyzer/services/booster_suggestion_engine.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeBooster extends BoosterSuggestionEngine {
+  final List<TheoryMiniLessonNode> lessons;
+  const _FakeBooster(this.lessons);
+  @override
+  Future<List<TheoryMiniLessonNode>> getRecommendedBoosters({int maxCount = 3}) async {
+    return lessons.take(maxCount).toList();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('shows banner when lesson available', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: 't', content: '');
+    final engine = TheoryInboxBannerEngine(booster: const _FakeBooster([lesson]));
+    final controller = TheoryInboxBannerController(engine: engine);
+    await controller.start(interval: Duration.zero);
+    expect(controller.shouldShowInboxBanner(), isTrue);
+    expect(controller.getLesson()?.id, 'l1');
+    controller.dispose();
+  });
+
+  test('hidden when no lessons', () async {
+    final engine = TheoryInboxBannerEngine(booster: const _FakeBooster([]));
+    final controller = TheoryInboxBannerController(engine: engine);
+    await controller.start(interval: Duration.zero);
+    expect(controller.shouldShowInboxBanner(), isFalse);
+    expect(controller.getLesson(), isNull);
+    controller.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryInboxBannerEngine and controller to suggest missed recap lessons
- display new TheoryInboxBanner on the home screen
- wire up controller via app providers
- test controller behaviour

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688a6dddb830832a950f6f89b05594c2