### PR TITLE
Add inbox booster tracking service

### DIFF
--- a/lib/services/inbox_booster_tracker_service.dart
+++ b/lib/services/inbox_booster_tracker_service.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'user_action_logger.dart';
+
+/// Tracks inbox booster banner interactions for engagement analytics.
+class InboxBoosterTrackerService {
+  InboxBoosterTrackerService._();
+  static final InboxBoosterTrackerService instance =
+      InboxBoosterTrackerService._();
+
+  static const _prefsKey = 'inbox_booster_interactions';
+
+  final Map<String, _BoosterStats> _cache = {};
+  bool _loaded = false;
+
+  /// Clears cache for testing purposes.
+  void resetForTest() {
+    _loaded = false;
+    _cache.clear();
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          data.forEach((key, value) {
+            if (value is Map) {
+              _cache[key.toString()] =
+                  _BoosterStats.fromJson(Map<String, dynamic>.from(value));
+            }
+          });
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({for (final e in _cache.entries) e.key: e.value.toJson()}),
+    );
+  }
+
+  /// Marks [lessonId] as shown now.
+  Future<void> markShown(String lessonId) async {
+    await _load();
+    final stats = _cache[lessonId] ?? const _BoosterStats();
+    final updated = stats.copyWith(
+      shows: stats.shows + 1,
+      lastShown: DateTime.now(),
+    );
+    _cache[lessonId] = updated;
+    await _save();
+    await UserActionLogger.instance.logEvent({
+      'event': 'inbox_booster.shown',
+      'lesson': lessonId,
+    });
+  }
+
+  /// Marks [lessonId] as clicked now.
+  Future<void> markClicked(String lessonId) async {
+    await _load();
+    final stats = _cache[lessonId] ?? const _BoosterStats();
+    final updated = stats.copyWith(
+      clicks: stats.clicks + 1,
+      lastClicked: DateTime.now(),
+    );
+    _cache[lessonId] = updated;
+    await _save();
+    await UserActionLogger.instance.logEvent({
+      'event': 'inbox_booster.clicked',
+      'lesson': lessonId,
+    });
+  }
+
+  /// Whether [lessonId] was shown within [window].
+  Future<bool> wasRecentlyShown(String lessonId,
+      {Duration window = const Duration(days: 1)}) async {
+    await _load();
+    final stats = _cache[lessonId];
+    final ts = stats?.lastShown;
+    if (ts == null) return false;
+    return DateTime.now().difference(ts) < window;
+  }
+
+  /// Returns raw interaction data keyed by lesson id.
+  Future<Map<String, Map<String, dynamic>>> getInteractionStats() async {
+    await _load();
+    return {
+      for (final e in _cache.entries) e.key: e.value.toJson(),
+    };
+  }
+}
+
+class _BoosterStats {
+  final int shows;
+  final int clicks;
+  final DateTime? lastShown;
+  final DateTime? lastClicked;
+
+  const _BoosterStats({
+    this.shows = 0,
+    this.clicks = 0,
+    this.lastShown,
+    this.lastClicked,
+  });
+
+  _BoosterStats copyWith({
+    int? shows,
+    int? clicks,
+    DateTime? lastShown,
+    DateTime? lastClicked,
+  }) {
+    return _BoosterStats(
+      shows: shows ?? this.shows,
+      clicks: clicks ?? this.clicks,
+      lastShown: lastShown ?? this.lastShown,
+      lastClicked: lastClicked ?? this.lastClicked,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'shows': shows,
+        'clicks': clicks,
+        if (lastShown != null) 'lastShown': lastShown!.toIso8601String(),
+        if (lastClicked != null) 'lastClicked': lastClicked!.toIso8601String(),
+      };
+
+  factory _BoosterStats.fromJson(Map<String, dynamic> json) => _BoosterStats(
+        shows: (json['shows'] as num?)?.toInt() ?? 0,
+        clicks: (json['clicks'] as num?)?.toInt() ?? 0,
+        lastShown: DateTime.tryParse(json['lastShown'] as String? ?? ''),
+        lastClicked: DateTime.tryParse(json['lastClicked'] as String? ?? ''),
+      );
+}

--- a/lib/widgets/theory_inbox_banner.dart
+++ b/lib/widgets/theory_inbox_banner.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../models/theory_mini_lesson_node.dart';
 import '../services/theory_inbox_banner_controller.dart';
+import '../services/inbox_booster_tracker_service.dart';
 import '../screens/mini_lesson_screen.dart';
 
 /// Simple banner showing a booster lesson suggestion from inbox engine.
@@ -16,6 +17,7 @@ class TheoryInboxBanner extends StatefulWidget {
 class _TheoryInboxBannerState extends State<TheoryInboxBanner> {
   TheoryMiniLessonNode? _lesson;
   late TheoryInboxBannerController _controller;
+  bool _recorded = false;
 
   @override
   void initState() {
@@ -37,12 +39,14 @@ class _TheoryInboxBannerState extends State<TheoryInboxBanner> {
 
   void _update() {
     _lesson = _controller.getLesson();
+    _recorded = false;
     if (mounted) setState(() {});
   }
 
   Future<void> _open() async {
     final lesson = _lesson;
     if (lesson == null) return;
+    await InboxBoosterTrackerService.instance.markClicked(lesson.id);
     await Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
@@ -54,6 +58,10 @@ class _TheoryInboxBannerState extends State<TheoryInboxBanner> {
     final lesson = _lesson;
     if (!_controller.shouldShowInboxBanner() || lesson == null) {
       return const SizedBox.shrink();
+    }
+    if (!_recorded) {
+      InboxBoosterTrackerService.instance.markShown(lesson.id);
+      _recorded = true;
     }
     final accent = Theme.of(context).colorScheme.secondary;
     return Container(

--- a/test/services/inbox_booster_tracker_service_test.dart
+++ b/test/services/inbox_booster_tracker_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  test('markShown records timestamp and count', () async {
+    await InboxBoosterTrackerService.instance.markShown('l1');
+    final recent = await InboxBoosterTrackerService.instance.wasRecentlyShown('l1');
+    expect(recent, isTrue);
+    final stats = await InboxBoosterTrackerService.instance.getInteractionStats();
+    expect(stats['l1']?['shows'], 1);
+  });
+
+  test('markClicked increments clicks', () async {
+    await InboxBoosterTrackerService.instance.markClicked('l2');
+    await InboxBoosterTrackerService.instance.markClicked('l2');
+    final stats = await InboxBoosterTrackerService.instance.getInteractionStats();
+    expect(stats['l2']?['clicks'], 2);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `InboxBoosterTrackerService` for recording banner impressions and clicks
- log interactions on the banner widget
- cover tracker service with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a70596168832aa01c1c61ea68f7f0