### PR TITLE
Implement TheoryInboxGoalEngine service

### DIFF
--- a/lib/models/xp_guided_goal.dart
+++ b/lib/models/xp_guided_goal.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// Lightweight goal representing short-term XP reward.
+class XPGuidedGoal {
+  final String id;
+  final String label;
+  final int xp;
+  final String source;
+  final VoidCallback onComplete;
+
+  const XPGuidedGoal({
+    required this.id,
+    required this.label,
+    required this.xp,
+    required this.source,
+    required this.onComplete,
+  });
+}

--- a/lib/services/theory_inbox_goal_engine.dart
+++ b/lib/services/theory_inbox_goal_engine.dart
@@ -1,0 +1,70 @@
+import 'dart:math';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../models/xp_guided_goal.dart';
+import 'booster_suggestion_engine.dart';
+import 'inbox_booster_tracker_service.dart';
+import 'recap_effectiveness_analyzer.dart';
+
+class TheoryInboxGoalEngine {
+  final BoosterSuggestionEngine booster;
+  final InboxBoosterTrackerService tracker;
+  final RecapEffectivenessAnalyzer recap;
+
+  TheoryInboxGoalEngine({
+    BoosterSuggestionEngine? booster,
+    InboxBoosterTrackerService? tracker,
+    RecapEffectivenessAnalyzer? recap,
+  })  : booster = booster ?? const BoosterSuggestionEngine(),
+        tracker = tracker ?? InboxBoosterTrackerService.instance,
+        recap = recap ?? RecapEffectivenessAnalyzer.instance;
+
+  static final TheoryInboxGoalEngine instance = TheoryInboxGoalEngine();
+
+  Future<List<XPGuidedGoal>> generateGoals({int maxGoals = 2}) async {
+    if (maxGoals <= 0) return [];
+    final lessons =
+        await booster.getRecommendedBoosters(maxCount: maxGoals * 3);
+    if (lessons.isEmpty) return [];
+
+    await recap.refresh();
+    final interactionMap = await tracker.getInteractionStats();
+
+    final items = <_Candidate>[];
+    for (final l in lessons) {
+      if (await tracker.wasRecentlyShown(l.id)) continue;
+      final tag = l.tags.isNotEmpty ? l.tags.first.toLowerCase() : '';
+      final stat = recap.stats[tag];
+      final urgency = stat == null
+          ? 0.0
+          : 1 / (stat.count + 1) +
+              1 / (stat.averageDuration.inSeconds + 1) +
+              (1 - stat.repeatRate);
+      final clicks = interactionMap[l.id]?['clicks'] as int? ?? 0;
+      final score = urgency - clicks * 0.1;
+      items.add(_Candidate(l, score));
+    }
+
+    items.sort((a, b) => b.score.compareTo(a.score));
+    final goals = <XPGuidedGoal>[];
+    for (final c in items.take(maxGoals)) {
+      final l = c.lesson;
+      goals.add(
+        XPGuidedGoal(
+          id: l.id,
+          label: l.resolvedTitle,
+          xp: 25,
+          source: 'booster',
+          onComplete: () => tracker.markClicked(l.id),
+        ),
+      );
+    }
+    return goals;
+  }
+}
+
+class _Candidate {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  _Candidate(this.lesson, this.score);
+}


### PR DESCRIPTION
## Summary
- add XPGuidedGoal model for short-term XP rewards
- implement TheoryInboxGoalEngine to convert booster suggestions into XP goals

## Testing
- `dart format -o none --set-exit-if-changed lib/models/xp_guided_goal.dart lib/services/theory_inbox_goal_engine.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a71e489bc832abf3ab2d3c166b8d0