### PR TITLE
Add InboxBoosterTunerService

### DIFF
--- a/lib/services/inbox_booster_tuner_service.dart
+++ b/lib/services/inbox_booster_tuner_service.dart
@@ -1,0 +1,73 @@
+import 'inbox_booster_tracker_service.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Adjusts booster tag priority weights based on inbox banner engagement.
+class InboxBoosterTunerService {
+  final InboxBoosterTrackerService tracker;
+  final MiniLessonLibraryService library;
+
+  InboxBoosterTunerService({
+    InboxBoosterTrackerService? tracker,
+    MiniLessonLibraryService? library,
+  })  : tracker = tracker ?? InboxBoosterTrackerService.instance,
+        library = library ?? MiniLessonLibraryService.instance;
+
+  static final InboxBoosterTunerService instance = InboxBoosterTunerService();
+
+  /// Returns boost scores per tag derived from historical interactions.
+  Future<Map<String, double>> computeTagBoostScores({
+    DateTime? now,
+    int recencyDays = 3,
+  }) async {
+    final data = await tracker.getInteractionStats();
+    await library.loadAll();
+    final map = <String, _MutableTagStats>{};
+
+    for (final entry in data.entries) {
+      final lesson = library.getById(entry.key);
+      if (lesson == null) continue;
+      final tags = lesson.tags;
+      if (tags.isEmpty) continue;
+
+      final shows = (entry.value['shows'] as num?)?.toInt() ?? 0;
+      final clicks = (entry.value['clicks'] as num?)?.toInt() ?? 0;
+      final lastShown = DateTime.tryParse(entry.value['lastShown'] as String? ?? '');
+      final lastClicked = DateTime.tryParse(entry.value['lastClicked'] as String? ?? '');
+
+      for (final t in tags) {
+        final key = t.toLowerCase();
+        final stat = map.putIfAbsent(key, () => _MutableTagStats());
+        stat.shownCount += shows;
+        stat.clickCount += clicks;
+        if (lastShown != null && (stat.lastShown == null || lastShown.isAfter(stat.lastShown!))) {
+          stat.lastShown = lastShown;
+        }
+        if (lastClicked != null && (stat.lastClicked == null || lastClicked.isAfter(stat.lastClicked!))) {
+          stat.lastClicked = lastClicked;
+        }
+      }
+    }
+
+    final result = <String, double>{};
+    final cutoff = (now ?? DateTime.now()).subtract(Duration(days: recencyDays));
+    map.forEach((tag, stat) {
+      final rate = stat.shownCount > 0 ? stat.clickCount / stat.shownCount : 0.0;
+      var score = 1.0;
+      if (rate > 0.3) score += 0.5;
+      if (stat.shownCount > 5 && stat.clickCount < 1) score -= 0.3;
+      final recent = stat.lastClicked ?? stat.lastShown;
+      if (recent != null && recent.isAfter(cutoff)) score += 0.2;
+      result[tag] = score;
+    });
+
+    return result;
+  }
+}
+
+class _MutableTagStats {
+  int shownCount = 0;
+  int clickCount = 0;
+  DateTime? lastShown;
+  DateTime? lastClicked;
+}
+

--- a/test/services/inbox_booster_tuner_service_test.dart
+++ b/test/services/inbox_booster_tuner_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/inbox_booster_tuner_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeLibrary extends MiniLessonLibraryService {
+  final Map<String, TheoryMiniLessonNode> items;
+  _FakeLibrary(List<TheoryMiniLessonNode> lessons)
+      : items = {for (final l in lessons) l.id: l};
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) => items[id];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  test('computeTagBoostScores calculates scores', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['icm']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['call']),
+    ];
+    final library = _FakeLibrary(lessons);
+
+    for (var i = 0; i < 10; i++) {
+      await InboxBoosterTrackerService.instance.markShown('l1');
+    }
+    for (var i = 0; i < 4; i++) {
+      await InboxBoosterTrackerService.instance.markClicked('l1');
+    }
+    for (var i = 0; i < 6; i++) {
+      await InboxBoosterTrackerService.instance.markShown('l2');
+    }
+
+    final tuner = InboxBoosterTunerService(
+      tracker: InboxBoosterTrackerService.instance,
+      library: library,
+    );
+    final scores = await tuner.computeTagBoostScores();
+
+    expect(scores['icm'], closeTo(1.7, 0.01));
+    expect(scores['call'], closeTo(0.9, 0.01));
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `InboxBoosterTunerService` for adjusting booster tag weights
- test the new service logic

## Testing
- `flutter test test/services/inbox_booster_tuner_service_test.dart` *(fails: command not found)*
- `dart test test/services/inbox_booster_tuner_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a731e09a0832a928fcb71a2104057