### PR TITLE
Add BoosterPathHistoryService

### DIFF
--- a/lib/models/booster_tag_history.dart
+++ b/lib/models/booster_tag_history.dart
@@ -1,0 +1,46 @@
+class BoosterTagHistory {
+  final String tag;
+  final int shownCount;
+  final int startedCount;
+  final int completedCount;
+  final DateTime lastInteraction;
+
+  const BoosterTagHistory({
+    required this.tag,
+    required this.shownCount,
+    required this.startedCount,
+    required this.completedCount,
+    required this.lastInteraction,
+  });
+
+  BoosterTagHistory copyWith({
+    int? shownCount,
+    int? startedCount,
+    int? completedCount,
+    DateTime? lastInteraction,
+  }) {
+    return BoosterTagHistory(
+      tag: tag,
+      shownCount: shownCount ?? this.shownCount,
+      startedCount: startedCount ?? this.startedCount,
+      completedCount: completedCount ?? this.completedCount,
+      lastInteraction: lastInteraction ?? this.lastInteraction,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'shownCount': shownCount,
+        'startedCount': startedCount,
+        'completedCount': completedCount,
+        'lastInteraction': lastInteraction.toIso8601String(),
+      };
+
+  factory BoosterTagHistory.fromJson(Map<String, dynamic> json) => BoosterTagHistory(
+        tag: json['tag'] as String? ?? '',
+        shownCount: (json['shownCount'] as num?)?.toInt() ?? 0,
+        startedCount: (json['startedCount'] as num?)?.toInt() ?? 0,
+        completedCount: (json['completedCount'] as num?)?.toInt() ?? 0,
+        lastInteraction: DateTime.tryParse(json['lastInteraction'] as String? ?? '') ?? DateTime.now(),
+      );
+}

--- a/lib/services/booster_path_history_service.dart
+++ b/lib/services/booster_path_history_service.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/booster_tag_history.dart';
+
+/// Stores booster tag interaction history in local preferences.
+class BoosterPathHistoryService {
+  BoosterPathHistoryService._();
+  static final BoosterPathHistoryService instance = BoosterPathHistoryService._();
+
+  static const String _prefix = 'booster_tag_history_';
+
+  Future<BoosterTagHistory?> _loadTag(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix$tag';
+    final raw = prefs.getString(key);
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map<String, dynamic>) {
+        return BoosterTagHistory.fromJson(data);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<void> _saveTag(String tag, BoosterTagHistory hist) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix$tag';
+    await prefs.setString(key, jsonEncode(hist.toJson()));
+  }
+
+  Future<void> _update(String tag, {bool shown = false, bool started = false, bool completed = false}) async {
+    tag = tag.trim().toLowerCase();
+    if (tag.isEmpty) return;
+    final existing = await _loadTag(tag);
+    final now = DateTime.now();
+    final updated = (existing ?? BoosterTagHistory(tag: tag, shownCount: 0, startedCount: 0, completedCount: 0, lastInteraction: now)).copyWith(
+      shownCount: (existing?.shownCount ?? 0) + (shown ? 1 : 0),
+      startedCount: (existing?.startedCount ?? 0) + (started ? 1 : 0),
+      completedCount: (existing?.completedCount ?? 0) + (completed ? 1 : 0),
+      lastInteraction: now,
+    );
+    await _saveTag(tag, updated);
+  }
+
+  /// Record that a booster with [tag] was shown to the user.
+  Future<void> markShown(String tag) async {
+    await _update(tag, shown: true);
+  }
+
+  /// Record that a booster with [tag] was started by the user.
+  Future<void> markStarted(String tag) async {
+    await _update(tag, started: true);
+  }
+
+  /// Record that a booster with [tag] was completed by the user.
+  Future<void> markCompleted(String tag) async {
+    await _update(tag, completed: true);
+  }
+
+  /// Returns aggregated history keyed by tag.
+  Future<Map<String, BoosterTagHistory>> getHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, BoosterTagHistory>{};
+    for (final key in prefs.getKeys()) {
+      if (!key.startsWith(_prefix)) continue;
+      final raw = prefs.getString(key);
+      if (raw == null) continue;
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map<String, dynamic>) {
+          final hist = BoosterTagHistory.fromJson(data);
+          result[hist.tag] = hist;
+        }
+      } catch (_) {}
+    }
+    return result;
+  }
+}

--- a/test/services/booster_path_history_service_test.dart
+++ b/test/services/booster_path_history_service_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/models/booster_tag_history.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('records interactions per tag', () async {
+    final service = BoosterPathHistoryService.instance;
+
+    await service.markShown('cbet');
+    await service.markStarted('cbet');
+    await service.markCompleted('cbet');
+    await service.markShown('3bet');
+
+    final hist = await service.getHistory();
+    expect(hist.length, 2);
+    final cbet = hist['cbet']!;
+    expect(cbet.shownCount, 1);
+    expect(cbet.startedCount, 1);
+    expect(cbet.completedCount, 1);
+    final tbet = hist['3bet']!;
+    expect(tbet.shownCount, 1);
+    expect(tbet.startedCount, 0);
+    expect(tbet.completedCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- implement BoosterTagHistory model
- add BoosterPathHistoryService to persist booster interactions per tag
- tests for BoosterPathHistoryService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7691fa9c832ab8babdc8223c0577