### PR TITLE
Add BoosterSlotAllocator

### DIFF
--- a/lib/services/booster_slot_allocator.dart
+++ b/lib/services/booster_slot_allocator.dart
@@ -1,0 +1,91 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'booster_path_history_service.dart';
+import 'inbox_booster_tracker_service.dart';
+import 'inbox_booster_tuner_service.dart';
+import 'recap_effectiveness_analyzer.dart';
+
+/// Decision describing where a booster lesson should appear.
+class BoosterSlotDecision {
+  final String lessonId;
+  final String tag;
+  final String slot; // 'recap', 'inbox', or 'goal'
+
+  const BoosterSlotDecision({
+    required this.lessonId,
+    required this.tag,
+    required this.slot,
+  });
+}
+
+/// Allocates boosters to delivery slots based on user engagement context.
+class BoosterSlotAllocator {
+  final InboxBoosterTrackerService tracker;
+  final BoosterPathHistoryService history;
+  final InboxBoosterTunerService tuner;
+  final RecapEffectivenessAnalyzer recap;
+
+  BoosterSlotAllocator({
+    InboxBoosterTrackerService? tracker,
+    BoosterPathHistoryService? history,
+    InboxBoosterTunerService? tuner,
+    RecapEffectivenessAnalyzer? recap,
+  }) : tracker = tracker ?? InboxBoosterTrackerService.instance,
+       history = history ?? BoosterPathHistoryService.instance,
+       tuner = tuner ?? InboxBoosterTunerService.instance,
+       recap = recap ?? RecapEffectivenessAnalyzer.instance;
+
+  static final BoosterSlotAllocator instance = BoosterSlotAllocator();
+
+  /// Returns a slot decision for each lesson in [lessons]. Lessons recently
+  /// surfaced via inbox or recap will be ignored.
+  Future<List<BoosterSlotDecision>> allocateSlots(
+    List<TheoryMiniLessonNode> lessons,
+  ) async {
+    if (lessons.isEmpty) return [];
+
+    final histMap = await history.getHistory();
+    final scoreMap = await tuner.computeTagBoostScores();
+    await recap.refresh();
+
+    final result = <BoosterSlotDecision>[];
+    for (final lesson in lessons) {
+      if (await tracker.wasRecentlyShown(lesson.id)) continue;
+      final tag = lesson.tags.isEmpty
+          ? ''
+          : lesson.tags.first.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+
+      final hist = histMap[tag];
+      if (hist != null &&
+          DateTime.now().difference(hist.lastInteraction) <
+              const Duration(days: 1)) {
+        continue; // recently repeated
+      }
+
+      final score = scoreMap[tag] ?? 1.0;
+      final stats = recap.stats[tag];
+      final urgency = stats == null
+          ? 0.0
+          : 1 / (stats.count + 1) +
+                1 / (stats.averageDuration.inSeconds + 1) +
+                (1 - stats.repeatRate);
+
+      String slot;
+      if (stats != null && urgency > 1.8) {
+        slot = 'recap';
+      } else if ((hist == null ||
+              hist.shownCount + hist.startedCount + hist.completedCount < 2) &&
+          score > 1.5) {
+        slot = 'goal';
+      } else {
+        slot = 'inbox';
+      }
+
+      result.add(
+        BoosterSlotDecision(lessonId: lesson.id, tag: tag, slot: slot),
+      );
+    }
+
+    return result;
+  }
+}

--- a/test/services/booster_slot_allocator_test.dart
+++ b/test/services/booster_slot_allocator_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/booster_slot_allocator.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tuner_service.dart';
+import 'package:poker_analyzer/services/recap_effectiveness_analyzer.dart';
+import 'package:poker_analyzer/services/recap_completion_tracker.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeTuner extends InboxBoosterTunerService {
+  final Map<String, double> scores;
+  _FakeTuner(this.scores);
+  @override
+  Future<Map<String, double>> computeTagBoostScores({
+    DateTime? now,
+    int recencyDays = 3,
+  }) async => scores;
+}
+
+class _FakeRecap extends RecapEffectivenessAnalyzer {
+  final Map<String, TagEffectiveness> data;
+  _FakeRecap(this.data) : super(tracker: RecapCompletionTracker.instance);
+  @override
+  Map<String, TagEffectiveness> get stats => data;
+  @override
+  Future<void> refresh({Duration window = const Duration(days: 14)}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+    RecapCompletionTracker.instance.resetForTest();
+  });
+
+  test('assigns goal for new high scoring tag', () async {
+    final allocator = BoosterSlotAllocator(
+      tuner: _FakeTuner({'icm': 2.0}),
+      recap: _FakeRecap({}),
+    );
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: ['icm'],
+    );
+    final res = await allocator.allocateSlots([lesson]);
+    expect(res.single.slot, 'goal');
+  });
+
+  test('skips lessons shown recently', () async {
+    await InboxBoosterTrackerService.instance.markShown('l1');
+    final allocator = BoosterSlotAllocator(
+      tuner: _FakeTuner({'icm': 2.0}),
+      recap: _FakeRecap({}),
+    );
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l1',
+      title: '',
+      content: '',
+      tags: ['icm'],
+    );
+    final res = await allocator.allocateSlots([lesson]);
+    expect(res, isEmpty);
+  });
+
+  test('allocates recap slot for urgent tag', () async {
+    final recap = _FakeRecap({
+      'cbet': TagEffectiveness(
+        tag: 'cbet',
+        count: 0,
+        averageDuration: const Duration(seconds: 1),
+        repeatRate: 0.0,
+      ),
+    });
+    final allocator = BoosterSlotAllocator(
+      tuner: _FakeTuner({'cbet': 1.0}),
+      recap: recap,
+    );
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l2',
+      title: '',
+      content: '',
+      tags: ['cbet'],
+    );
+    final res = await allocator.allocateSlots([lesson]);
+    expect(res.single.slot, 'recap');
+  });
+
+  test('defaults to inbox for medium tags', () async {
+    await BoosterPathHistoryService.instance.markShown('call');
+    await BoosterPathHistoryService.instance.markStarted('call');
+    await BoosterPathHistoryService.instance.markCompleted('call');
+
+    final recap = _FakeRecap({
+      'call': TagEffectiveness(
+        tag: 'call',
+        count: 3,
+        averageDuration: const Duration(seconds: 10),
+        repeatRate: 0.7,
+      ),
+    });
+    final allocator = BoosterSlotAllocator(
+      tuner: _FakeTuner({'call': 1.0}),
+      recap: recap,
+    );
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l3',
+      title: '',
+      content: '',
+      tags: ['call'],
+    );
+    final res = await allocator.allocateSlots([lesson]);
+    expect(res.single.slot, 'inbox');
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterSlotAllocator service
- return slot decisions for recap, inbox, or goal
- test BoosterSlotAllocator logic

## Testing
- `flutter analyze`
- `flutter test test/services/booster_slot_allocator_test.dart` *(fails: Error when reading some files)*

------
https://chatgpt.com/codex/tasks/task_e_688a786da1d0832a9cb472acdb645341