### PR TITLE
Add booster lesson status badge

### DIFF
--- a/lib/models/booster_lesson_status.dart
+++ b/lib/models/booster_lesson_status.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+enum BoosterLessonStatus {
+  newLesson,
+  inProgress,
+  repeated,
+  skipped,
+}
+
+extension BoosterLessonStatusText on BoosterLessonStatus {
+  String get label {
+    switch (this) {
+      case BoosterLessonStatus.newLesson:
+        return 'New';
+      case BoosterLessonStatus.inProgress:
+        return 'In Progress';
+      case BoosterLessonStatus.repeated:
+        return 'Repeated';
+      case BoosterLessonStatus.skipped:
+        return 'Skipped';
+    }
+  }
+
+  Color get color {
+    switch (this) {
+      case BoosterLessonStatus.newLesson:
+        return Colors.blueAccent;
+      case BoosterLessonStatus.inProgress:
+        return Colors.orangeAccent;
+      case BoosterLessonStatus.repeated:
+        return Colors.greenAccent;
+      case BoosterLessonStatus.skipped:
+        return Colors.grey;
+    }
+  }
+}

--- a/lib/services/booster_lesson_status_service.dart
+++ b/lib/services/booster_lesson_status_service.dart
@@ -1,0 +1,47 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/booster_lesson_status.dart';
+import 'inbox_booster_tracker_service.dart';
+import 'booster_path_history_service.dart';
+
+/// Resolves [BoosterLessonStatus] for theory mini lessons.
+class BoosterLessonStatusService {
+  final InboxBoosterTrackerService tracker;
+  final BoosterPathHistoryService history;
+
+  BoosterLessonStatusService({
+    InboxBoosterTrackerService? tracker,
+    BoosterPathHistoryService? history,
+  })  : tracker = tracker ?? InboxBoosterTrackerService.instance,
+        history = history ?? BoosterPathHistoryService.instance;
+
+  static final BoosterLessonStatusService instance =
+      BoosterLessonStatusService();
+
+  Future<BoosterLessonStatus> getStatus(TheoryMiniLessonNode lesson) async {
+    final interaction = await tracker.getInteractionStats();
+    final stats = interaction[lesson.id];
+    final shows = (stats?['shows'] as num?)?.toInt() ?? 0;
+    final clicks = (stats?['clicks'] as num?)?.toInt() ?? 0;
+
+    String? tag;
+    if (lesson.tags.isNotEmpty) {
+      tag = lesson.tags.first.trim().toLowerCase();
+      if (tag.isEmpty) tag = null;
+    }
+    final histMap = await history.getHistory();
+    final hist = tag != null ? histMap[tag] : null;
+    final started = hist?.startedCount ?? 0;
+    final completed = hist?.completedCount ?? 0;
+
+    if (shows >= 5 && clicks == 0 && completed == 0) {
+      return BoosterLessonStatus.skipped;
+    }
+    if (completed >= 2) {
+      return BoosterLessonStatus.repeated;
+    }
+    if ((shows > 0 || started > 0 || clicks > 0) && completed == 0) {
+      return BoosterLessonStatus.inProgress;
+    }
+    return BoosterLessonStatus.newLesson;
+  }
+}

--- a/lib/widgets/theory_lesson_preview_tile.dart
+++ b/lib/widgets/theory_lesson_preview_tile.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../models/theory_mini_lesson_node.dart';
+import '../models/booster_lesson_status.dart';
+import '../services/booster_lesson_status_service.dart';
 import '../theme/app_colors.dart';
 import 'tag_badge.dart';
 
@@ -32,43 +34,74 @@ class TheoryLessonPreviewTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
     final border = isCurrent ? Border.all(color: accent, width: 2) : null;
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-      color: AppColors.cardBackground,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8), side: border ?? BorderSide.none),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(8),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                node.resolvedTitle,
-                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+    return FutureBuilder<BoosterLessonStatus>(
+      future: BoosterLessonStatusService.instance.getStatus(node),
+      builder: (context, snapshot) {
+        final status = snapshot.data;
+        Widget? badge;
+        if (status != null) {
+          badge = Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: status.color,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              status.label,
+              style: const TextStyle(color: Colors.black, fontSize: 12),
+            ),
+          );
+        }
+
+        return Card(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          color: AppColors.cardBackground,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: border ?? BorderSide.none),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          node.resolvedTitle,
+                          style: const TextStyle(
+                              fontSize: 16, fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      if (badge != null) badge,
+                    ],
+                  ),
+                  if (node.tags.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Wrap(
+                        spacing: 4,
+                        runSpacing: -4,
+                        children: [for (final t in node.tags.take(3)) TagBadge(t)],
+                      ),
+                    ),
+                  if (node.resolvedContent.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        _shortDescription(node.resolvedContent),
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                    ),
+                ],
               ),
-              if (node.tags.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Wrap(
-                    spacing: 4,
-                    runSpacing: -4,
-                    children: [for (final t in node.tags.take(3)) TagBadge(t)],
-                  ),
-                ),
-              if (node.resolvedContent.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Text(
-                    _shortDescription(node.resolvedContent),
-                    style: const TextStyle(color: Colors.white70),
-                  ),
-                ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/test/services/booster_lesson_status_service_test.dart
+++ b/test/services/booster_lesson_status_service_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/booster_lesson_status_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/models/booster_lesson_status.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  test('determines new lesson status', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l1', title: '', content: '', tags: ['cbet']);
+    final service = BoosterLessonStatusService(
+      tracker: InboxBoosterTrackerService.instance,
+      history: BoosterPathHistoryService.instance,
+    );
+    final status = await service.getStatus(lesson);
+    expect(status, BoosterLessonStatus.newLesson);
+  });
+
+  test('determines in progress status', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l2', title: '', content: '', tags: ['fold']);
+    await InboxBoosterTrackerService.instance.markShown('l2');
+    final service = BoosterLessonStatusService(
+      tracker: InboxBoosterTrackerService.instance,
+      history: BoosterPathHistoryService.instance,
+    );
+    final status = await service.getStatus(lesson);
+    expect(status, BoosterLessonStatus.inProgress);
+  });
+
+  test('determines repeated status', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l3', title: '', content: '', tags: ['call']);
+    await BoosterPathHistoryService.instance.markCompleted('call');
+    await BoosterPathHistoryService.instance.markCompleted('call');
+    final service = BoosterLessonStatusService(
+      tracker: InboxBoosterTrackerService.instance,
+      history: BoosterPathHistoryService.instance,
+    );
+    final status = await service.getStatus(lesson);
+    expect(status, BoosterLessonStatus.repeated);
+  });
+
+  test('determines skipped status', () async {
+    final lesson = const TheoryMiniLessonNode(id: 'l4', title: '', content: '', tags: ['raise']);
+    for (var i = 0; i < 5; i++) {
+      await InboxBoosterTrackerService.instance.markShown('l4');
+    }
+    final service = BoosterLessonStatusService(
+      tracker: InboxBoosterTrackerService.instance,
+      history: BoosterPathHistoryService.instance,
+    );
+    final status = await service.getStatus(lesson);
+    expect(status, BoosterLessonStatus.skipped);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterLessonStatus` model and status service
- show status badge in `TheoryLessonPreviewTile`
- cover status logic with unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/booster_lesson_status_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7da2ab28832a8ef7fc21a492352d