### PR TITLE
Implement SmartRecapInjectionPlanner

### DIFF
--- a/lib/services/smart_recap_injection_planner.dart
+++ b/lib/services/smart_recap_injection_planner.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'booster_path_history_service.dart';
+import 'recap_effectiveness_analyzer.dart';
+
+/// Planned recap tag injection.
+class RecapInjectionPlan {
+  final List<String> tagIds;
+  final DateTime plannedAt;
+
+  const RecapInjectionPlan({required this.tagIds, required this.plannedAt});
+
+  Map<String, dynamic> toJson() => {
+        'tags': tagIds,
+        'time': plannedAt.toIso8601String(),
+      };
+
+  factory RecapInjectionPlan.fromJson(Map<String, dynamic> json) {
+    final tags = <String>[];
+    final list = json['tags'];
+    if (list is List) {
+      for (final t in list) {
+        if (t is String) tags.add(t);
+      }
+    }
+    final ts = DateTime.tryParse(json['time']?.toString() ?? '') ?? DateTime.now();
+    return RecapInjectionPlan(tagIds: tags, plannedAt: ts);
+  }
+}
+
+class SmartRecapInjectionPlanner {
+  final BoosterPathHistoryService history;
+  final RecapEffectivenessAnalyzer analyzer;
+
+  SmartRecapInjectionPlanner({
+    BoosterPathHistoryService? history,
+    RecapEffectivenessAnalyzer? analyzer,
+  })  : history = history ?? BoosterPathHistoryService.instance,
+        analyzer = analyzer ?? RecapEffectivenessAnalyzer.instance;
+
+  static final SmartRecapInjectionPlanner instance = SmartRecapInjectionPlanner();
+
+  static const _prefsKey = 'smart_recap_injection_plan';
+
+  Future<RecapInjectionPlan?> _loadLast() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        return RecapInjectionPlan.fromJson(Map<String, dynamic>.from(data));
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<void> _save(RecapInjectionPlan plan) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(plan.toJson()));
+  }
+
+  /// Computes tag ids to inject into the recap banner.
+  Future<RecapInjectionPlan?> computePlan({
+    int maxTags = 2,
+    Duration excludeRecent = const Duration(days: 3),
+  }) async {
+    if (maxTags <= 0) return null;
+    await analyzer.refresh();
+    final stats = analyzer.stats;
+    if (stats.isEmpty) return null;
+    final histMap = await history.getHistory();
+    final now = DateTime.now();
+    final last = await _loadLast();
+
+    final candidates = <_Candidate>[];
+    stats.forEach((tag, eff) {
+      final hist = histMap[tag];
+      if (hist != null && now.difference(hist.lastInteraction) < excludeRecent) {
+        return;
+      }
+      final urgency =
+          (1 - eff.repeatRate) + 1 / (eff.count + 1) + 1 / (eff.averageDuration.inSeconds + 1);
+      final recency = hist == null
+          ? 1000.0
+          : now.difference(hist.lastInteraction).inHours.toDouble();
+      final score = urgency * 2 + recency / 24.0;
+      candidates.add(_Candidate(tag, score));
+    });
+
+    if (candidates.isEmpty) return null;
+    candidates.sort((a, b) => b.score.compareTo(a.score));
+
+    final tags = <String>[];
+    for (final c in candidates) {
+      if (tags.length >= maxTags) break;
+      if (last != null && last.tagIds.contains(c.tag)) continue;
+      tags.add(c.tag);
+    }
+
+    if (tags.isEmpty) return null;
+    final plan = RecapInjectionPlan(tagIds: tags, plannedAt: now);
+    await _save(plan);
+    return plan;
+  }
+}
+
+class _Candidate {
+  final String tag;
+  final double score;
+  const _Candidate(this.tag, this.score);
+}

--- a/test/services/smart_recap_injection_planner_test.dart
+++ b/test/services/smart_recap_injection_planner_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/smart_recap_injection_planner.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/services/recap_effectiveness_analyzer.dart';
+import 'package:poker_analyzer/services/recap_completion_tracker.dart';
+import 'package:poker_analyzer/models/booster_tag_history.dart';
+
+class _FakeHistory extends BoosterPathHistoryService {
+  final Map<String, BoosterTagHistory> map;
+  _FakeHistory(this.map);
+  @override
+  Future<Map<String, BoosterTagHistory>> getHistory() async => map;
+}
+
+class _FakeAnalyzer extends RecapEffectivenessAnalyzer {
+  final Map<String, TagEffectiveness> data;
+  _FakeAnalyzer(this.data) : super(tracker: RecapCompletionTracker.instance);
+  @override
+  Map<String, TagEffectiveness> get stats => data;
+  @override
+  Future<void> refresh({Duration window = const Duration(days: 14)}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapCompletionTracker.instance.resetForTest();
+  });
+
+  test('selects most urgent and old tags', () async {
+    final hist = _FakeHistory({
+      'icm': BoosterTagHistory(
+        tag: 'icm',
+        shownCount: 0,
+        startedCount: 0,
+        completedCount: 1,
+        lastInteraction: DateTime.now().subtract(const Duration(days: 10)),
+      ),
+      'push': BoosterTagHistory(
+        tag: 'push',
+        shownCount: 0,
+        startedCount: 0,
+        completedCount: 1,
+        lastInteraction: DateTime.now().subtract(const Duration(days: 1)),
+      ),
+    });
+    final analyzer = _FakeAnalyzer({
+      'icm': const TagEffectiveness(
+        tag: 'icm',
+        count: 1,
+        averageDuration: Duration(seconds: 5),
+        repeatRate: 0.1,
+      ),
+      'push': const TagEffectiveness(
+        tag: 'push',
+        count: 1,
+        averageDuration: Duration(seconds: 5),
+        repeatRate: 0.1,
+      ),
+    });
+    final planner = SmartRecapInjectionPlanner(history: hist, analyzer: analyzer);
+    final plan = await planner.computePlan();
+    expect(plan, isNotNull);
+    expect(plan!.tagIds.first, 'icm');
+  });
+
+  test('excludes recently completed tags', () async {
+    final hist = _FakeHistory({
+      'icm': BoosterTagHistory(
+        tag: 'icm',
+        shownCount: 0,
+        startedCount: 0,
+        completedCount: 1,
+        lastInteraction: DateTime.now().subtract(const Duration(days: 1)),
+      ),
+    });
+    final analyzer = _FakeAnalyzer({
+      'icm': const TagEffectiveness(
+        tag: 'icm',
+        count: 1,
+        averageDuration: Duration(seconds: 5),
+        repeatRate: 0.1,
+      ),
+    });
+    final planner = SmartRecapInjectionPlanner(history: hist, analyzer: analyzer);
+    final plan = await planner.computePlan();
+    expect(plan, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartRecapInjectionPlanner` for scheduling recap tags
- provide `RecapInjectionPlan` model
- test planner logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a80193978832a8b87b39a5994ee4a