### PR TITLE
Add GoalSlotAllocator service

### DIFF
--- a/lib/services/goal_slot_allocator.dart
+++ b/lib/services/goal_slot_allocator.dart
@@ -1,0 +1,64 @@
+import '../models/xp_guided_goal.dart';
+import 'mistake_tag_insights_service.dart';
+import 'booster_path_history_service.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Assignment describing where a short-term XP goal should appear.
+class GoalSlotAssignment {
+  final XPGuidedGoal goal;
+  final String slot; // 'home', 'theory', or 'postrecap'
+
+  const GoalSlotAssignment({
+    required this.goal,
+    required this.slot,
+  });
+}
+
+/// Routes XP goals to delivery slots based on urgency and context.
+class GoalSlotAllocator {
+  final MistakeTagInsightsService insights;
+  final BoosterPathHistoryService history;
+  final MiniLessonLibraryService library;
+
+  GoalSlotAllocator({
+    this.insights = const MistakeTagInsightsService(),
+    BoosterPathHistoryService? history,
+    MiniLessonLibraryService? library,
+  })  : history = history ?? BoosterPathHistoryService.instance,
+        library = library ?? MiniLessonLibraryService.instance;
+
+  static final GoalSlotAllocator instance = GoalSlotAllocator();
+
+  /// Returns slot assignments for each [goal].
+  Future<List<GoalSlotAssignment>> allocate(List<XPGuidedGoal> goals) async {
+    if (goals.isEmpty) return [];
+
+    await library.loadAll();
+    final weak = await insights.buildInsights(sortByEvLoss: true);
+    final topWeak = <String>{
+      for (final i in weak.take(3)) i.tag.label.toLowerCase(),
+    };
+    final hist = await history.getHistory();
+
+    final result = <GoalSlotAssignment>[];
+    for (final g in goals) {
+      final lesson = library.getById(g.id);
+      final tag = lesson != null && lesson.tags.isNotEmpty
+          ? lesson.tags.first.toLowerCase()
+          : '';
+      var slot = 'theory';
+      if (g.source == 'smart' && topWeak.contains(tag)) {
+        slot = 'home';
+      } else {
+        final h = hist[tag];
+        if (h != null &&
+            DateTime.now().difference(h.lastInteraction) <
+                const Duration(hours: 1)) {
+          slot = 'postrecap';
+        }
+      }
+      result.add(GoalSlotAssignment(goal: g, slot: slot));
+    }
+    return result;
+  }
+}

--- a/test/services/goal_slot_allocator_test.dart
+++ b/test/services/goal_slot_allocator_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/goal_slot_allocator.dart';
+import 'package:poker_analyzer/services/mistake_tag_insights_service.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/models/xp_guided_goal.dart';
+import 'package:poker_analyzer/models/mistake_insight.dart';
+import 'package:poker_analyzer/models/mistake_tag.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeInsights extends MistakeTagInsightsService {
+  final List<MistakeInsight> list;
+  const _FakeInsights(this.list);
+  @override
+  Future<List<MistakeInsight>> buildInsights({bool sortByEvLoss = false}) async => list;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, TheoryMiniLessonNode> items;
+  _FakeLibrary(List<TheoryMiniLessonNode> lessons)
+      : items = {for (final l in lessons) l.id: l};
+
+  @override
+  List<TheoryMiniLessonNode> get all => items.values.toList();
+
+  @override
+  TheoryMiniLessonNode? getById(String id) => items[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final res = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      res.addAll(items.values.where((e) => e.tags.contains(t)));
+    }
+    return res;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('assigns home slot for top weakness smart goal', () async {
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'A',
+      content: '',
+      tags: ['overly loose push'],
+    );
+    final goal = XPGuidedGoal(
+      id: 'l1',
+      label: 'G1',
+      xp: 10,
+      source: 'smart',
+      onComplete: () {},
+    );
+    final allocator = GoalSlotAllocator(
+      insights: _FakeInsights([
+        const MistakeInsight(
+          tag: MistakeTag.overpush,
+          count: 3,
+          evLoss: 5,
+          shortExplanation: '',
+          examples: const [],
+        ),
+      ]),
+      library: _FakeLibrary([lesson]),
+    );
+    final res = await allocator.allocate([goal]);
+    expect(res.single.slot, 'home');
+  });
+
+  test('assigns postrecap slot when tag completed recently', () async {
+    await BoosterPathHistoryService.instance.markCompleted('btn overfold');
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l2',
+      title: 'B',
+      content: '',
+      tags: ['btn overfold'],
+    );
+    final goal = XPGuidedGoal(
+      id: 'l2',
+      label: 'G2',
+      xp: 10,
+      source: 'theory',
+      onComplete: () {},
+    );
+    final allocator = GoalSlotAllocator(
+      insights: const _FakeInsights([]),
+      library: _FakeLibrary([lesson]),
+    );
+    final res = await allocator.allocate([goal]);
+    expect(res.single.slot, 'postrecap');
+  });
+
+  test('defaults to theory slot', () async {
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l3',
+      title: 'C',
+      content: '',
+      tags: ['other'],
+    );
+    final goal = XPGuidedGoal(
+      id: 'l3',
+      label: 'G3',
+      xp: 5,
+      source: 'manual',
+      onComplete: () {},
+    );
+    final allocator = GoalSlotAllocator(
+      insights: const _FakeInsights([]),
+      library: _FakeLibrary([lesson]),
+    );
+    final res = await allocator.allocate([goal]);
+    expect(res.single.slot, 'theory');
+  });
+}


### PR DESCRIPTION
## Summary
- add `GoalSlotAllocator` for routing XP goals to home, theory or postrecap slots
- unit tests for the allocator

## Testing
- `dart` and `flutter` were unavailable so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_688a878a6f18832a9516571eb3c3dbd3