### PR TITLE
Implement GoalInboxDeliveryController

### DIFF
--- a/lib/services/goal_inbox_delivery_controller.dart
+++ b/lib/services/goal_inbox_delivery_controller.dart
@@ -1,0 +1,56 @@
+import '../models/xp_guided_goal.dart';
+import 'goal_slot_allocator.dart';
+import 'inbox_booster_tracker_service.dart';
+
+/// Queues XP goals for delivery via the theory inbox banner.
+class GoalInboxDeliveryController {
+  final InboxBoosterTrackerService tracker;
+
+  GoalInboxDeliveryController({InboxBoosterTrackerService? tracker})
+      : tracker = tracker ?? InboxBoosterTrackerService.instance;
+
+  static final GoalInboxDeliveryController instance =
+      GoalInboxDeliveryController();
+
+  List<GoalSlotAssignment> _assignments = [];
+
+  /// Replaces the current queue with [assignments].
+  void updateAssignments(List<GoalSlotAssignment> assignments) {
+    _assignments = List.from(assignments);
+  }
+
+  /// Returns prioritized inbox goals after filtering. Returned goals are marked
+  /// as shown via [InboxBoosterTrackerService].
+  Future<List<XPGuidedGoal>> getInboxGoals({int maxGoals = 2}) async {
+    if (maxGoals <= 0 || _assignments.isEmpty) return [];
+
+    final seenIds = <String>{};
+    final items = <_Candidate>[];
+    var index = 0;
+    for (final a in _assignments) {
+      index++;
+      if (a.slot != 'theory' && a.slot != 'home') continue;
+      final id = a.goal.id;
+      if (!seenIds.add(id)) continue;
+      if (await tracker.wasRecentlyShown(id)) continue;
+      final score = a.goal.xp.toDouble() + (1000 - index) / 1000.0;
+      items.add(_Candidate(a.goal, score));
+    }
+
+    if (items.isEmpty) return [];
+    items.sort((a, b) => b.score.compareTo(a.score));
+
+    final goals = <XPGuidedGoal>[];
+    for (final c in items.take(maxGoals)) {
+      goals.add(c.goal);
+      await tracker.markShown(c.goal.id);
+    }
+    return goals;
+  }
+}
+
+class _Candidate {
+  final XPGuidedGoal goal;
+  final double score;
+  _Candidate(this.goal, this.score);
+}

--- a/test/services/goal_inbox_delivery_controller_test.dart
+++ b/test/services/goal_inbox_delivery_controller_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/xp_guided_goal.dart';
+import 'package:poker_analyzer/services/goal_inbox_delivery_controller.dart';
+import 'package:poker_analyzer/services/goal_slot_allocator.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  XPGuidedGoal _goal(String id, int xp) =>
+      XPGuidedGoal(id: id, label: id, xp: xp, source: 't', onComplete: () {});
+
+  test('filters by slot and prioritizes by xp', () async {
+    final controller = GoalInboxDeliveryController(
+      tracker: InboxBoosterTrackerService.instance,
+    );
+    controller.updateAssignments([
+      GoalSlotAssignment(goal: _goal('g1', 10), slot: 'theory'),
+      GoalSlotAssignment(goal: _goal('g2', 20), slot: 'home'),
+      GoalSlotAssignment(goal: _goal('g3', 5), slot: 'postrecap'),
+    ]);
+    final res = await controller.getInboxGoals();
+    expect(res.length, 2);
+    expect(res.first.id, 'g2');
+    expect(res[1].id, 'g1');
+  });
+
+  test('excludes previously shown goals', () async {
+    await InboxBoosterTrackerService.instance.markShown('g1');
+    final controller = GoalInboxDeliveryController(
+      tracker: InboxBoosterTrackerService.instance,
+    );
+    controller.updateAssignments([
+      GoalSlotAssignment(goal: _goal('g1', 10), slot: 'theory'),
+      GoalSlotAssignment(goal: _goal('g2', 20), slot: 'home'),
+    ]);
+    final res = await controller.getInboxGoals();
+    expect(res.length, 1);
+    expect(res.first.id, 'g2');
+  });
+
+  test('marks goals as shown', () async {
+    final controller = GoalInboxDeliveryController(
+      tracker: InboxBoosterTrackerService.instance,
+    );
+    controller.updateAssignments([
+      GoalSlotAssignment(goal: _goal('g1', 10), slot: 'theory'),
+    ]);
+    final res = await controller.getInboxGoals();
+    expect(res.length, 1);
+    final stats =
+        await InboxBoosterTrackerService.instance.getInteractionStats();
+    expect(stats['g1']?['shows'], 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `GoalInboxDeliveryController` service for queuing goals in the inbox
- create tests covering filtering, deduplication and tracking

## Testing
- `flutter test test/services/goal_inbox_delivery_controller_test.dart --no-pub` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a89ae13cc832a87f2c12200a9fe1e