### PR TITLE
Implement persistent XP goal log

### DIFF
--- a/lib/services/goal_progress_persistence_service.dart
+++ b/lib/services/goal_progress_persistence_service.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Log entry describing when a short-term XP goal was completed.
+class GoalCompletionLog {
+  final String goalId;
+  final DateTime completedAt;
+
+  GoalCompletionLog({required this.goalId, required this.completedAt});
+
+  Map<String, dynamic> toJson() => {
+        'goalId': goalId,
+        'completedAt': completedAt.toIso8601String(),
+      };
+
+  factory GoalCompletionLog.fromJson(Map<String, dynamic> json) =>
+      GoalCompletionLog(
+        goalId: json['goalId'] as String? ?? '',
+        completedAt: DateTime.tryParse(json['completedAt'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}
+
+/// Persists completed XP goals to local storage and provides basic analytics.
+class GoalProgressPersistenceService {
+  GoalProgressPersistenceService._();
+  static final GoalProgressPersistenceService instance =
+      GoalProgressPersistenceService._();
+
+  static const _prefsKey = 'xp_goal_completion_logs';
+
+  final List<GoalCompletionLog> _logs = [];
+  bool _loaded = false;
+
+  /// Clears cached data for tests.
+  void resetForTest() {
+    _loaded = false;
+    _logs.clear();
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        final data = jsonDecode(raw) as List;
+        _logs
+          ..clear()
+          ..addAll(data.map((e) =>
+              GoalCompletionLog.fromJson(Map<String, dynamic>.from(e as Map))));
+      } catch (_) {
+        _logs.clear();
+      }
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final l in _logs) l.toJson()]),
+    );
+  }
+
+  /// Records that [goalId] was completed at [when].
+  Future<void> markCompleted(String goalId, DateTime when) async {
+    await _load();
+    _logs.add(GoalCompletionLog(goalId: goalId, completedAt: when));
+    await _save();
+  }
+
+  /// Returns all goal completions logged for today.
+  Future<List<GoalCompletionLog>> getTodayGoals() async {
+    await _load();
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day);
+    final end = start.add(const Duration(days: 1));
+    return [
+      for (final l in _logs)
+        if (!l.completedAt.isBefore(start) && l.completedAt.isBefore(end)) l
+    ];
+  }
+
+  /// Returns total XP earned from goal completions during the current week.
+  /// [xpPerGoal] allows overriding the XP value granted per goal.
+  Future<int> getWeeklyXP({int xpPerGoal = 25}) async {
+    await _load();
+    final now = DateTime.now();
+    final startOfWeek = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: now.weekday - 1));
+    final endOfWeek = startOfWeek.add(const Duration(days: 7));
+    int count = 0;
+    for (final l in _logs) {
+      if (!l.completedAt.isBefore(startOfWeek) &&
+          l.completedAt.isBefore(endOfWeek)) {
+        count++;
+      }
+    }
+    return count * xpPerGoal;
+  }
+
+  /// Returns true if [goalId] was completed today.
+  Future<bool> isCompletedToday(String goalId) async {
+    final todayGoals = await getTodayGoals();
+    return todayGoals.any((g) => g.goalId == goalId);
+  }
+}

--- a/lib/services/goal_smart_suggestion_engine.dart
+++ b/lib/services/goal_smart_suggestion_engine.dart
@@ -6,6 +6,7 @@ import 'booster_path_history_service.dart';
 import 'inbox_booster_tuner_service.dart';
 import 'mini_lesson_library_service.dart';
 import 'mistake_tag_insights_service.dart';
+import 'goal_progress_persistence_service.dart';
 
 /// Suggests XP goals targeting weak tags using mini boosters.
 class GoalSmartSuggestionEngine {
@@ -67,8 +68,11 @@ class GoalSmartSuggestionEngine {
           label: c.lesson.resolvedTitle,
           xp: 25,
           source: 'smart',
-          onComplete: () =>
-              BoosterPathHistoryService.instance.markCompleted(c.tag),
+          onComplete: () {
+            BoosterPathHistoryService.instance.markCompleted(c.tag);
+            GoalProgressPersistenceService.instance
+                .markCompleted(c.lesson.id, DateTime.now());
+          },
         ),
       );
     }

--- a/lib/services/theory_inbox_goal_engine.dart
+++ b/lib/services/theory_inbox_goal_engine.dart
@@ -5,6 +5,7 @@ import '../models/xp_guided_goal.dart';
 import 'booster_suggestion_engine.dart';
 import 'inbox_booster_tracker_service.dart';
 import 'recap_effectiveness_analyzer.dart';
+import 'goal_progress_persistence_service.dart';
 
 class TheoryInboxGoalEngine {
   final BoosterSuggestionEngine booster;
@@ -55,7 +56,11 @@ class TheoryInboxGoalEngine {
           label: l.resolvedTitle,
           xp: 25,
           source: 'booster',
-          onComplete: () => tracker.markClicked(l.id),
+          onComplete: () {
+            tracker.markClicked(l.id);
+            GoalProgressPersistenceService.instance
+                .markCompleted(l.id, DateTime.now());
+          },
         ),
       );
     }

--- a/test/services/goal_progress_persistence_service_test.dart
+++ b/test/services/goal_progress_persistence_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/goal_progress_persistence_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    GoalProgressPersistenceService.instance.resetForTest();
+  });
+
+  test('markCompleted persists logs', () async {
+    final service = GoalProgressPersistenceService.instance;
+    await service.markCompleted('g1', DateTime.utc(2024, 7, 30));
+    final todayGoals = await service.getTodayGoals();
+    // Should be empty because completion date is in the past.
+    expect(todayGoals, isEmpty);
+
+    // Now mark one for today.
+    final now = DateTime.now();
+    await service.markCompleted('g2', now);
+    final loaded = await service.getTodayGoals();
+    expect(loaded.length, 1);
+    expect(loaded.first.goalId, 'g2');
+  });
+
+  test('isCompletedToday works', () async {
+    final service = GoalProgressPersistenceService.instance;
+    final now = DateTime.now();
+    await service.markCompleted('g3', now);
+    final result = await service.isCompletedToday('g3');
+    expect(result, true);
+    final result2 = await service.isCompletedToday('other');
+    expect(result2, false);
+  });
+
+  test('weekly XP sums completions', () async {
+    final service = GoalProgressPersistenceService.instance;
+    final now = DateTime.now();
+    await service.markCompleted('a', now.subtract(const Duration(days: 1)));
+    await service.markCompleted('b', now.subtract(const Duration(days: 2)));
+    await service.markCompleted('c', now.subtract(const Duration(days: 8)));
+    final xp = await service.getWeeklyXP(xpPerGoal: 10);
+    // Only two entries should count (within 7 days)
+    expect(xp, 20);
+  });
+}


### PR DESCRIPTION
## Summary
- track XP goal completions in `GoalProgressPersistenceService`
- log goal completions from suggestion engines
- add unit tests for the new service

## Testing
- `flutter analyze`
- `dart tools/validate_training_content.dart --ci`
- `flutter test test/services/goal_progress_persistence_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688a8ff48614832a974ba3c4b076e2c0