### PR TITLE
Implement GoalToTrainingLauncher

### DIFF
--- a/lib/screens/smart_goal_summary_screen.dart
+++ b/lib/screens/smart_goal_summary_screen.dart
@@ -3,8 +3,8 @@ import '../models/xp_guided_goal.dart';
 import '../services/goal_inbox_delivery_controller.dart';
 import '../services/goal_slot_allocator.dart';
 import '../services/booster_path_history_service.dart';
+import '../services/goal_to_training_launcher.dart';
 import '../services/mini_lesson_library_service.dart';
-import '../services/training_session_launcher.dart';
 
 class SmartGoalSummaryScreen extends StatefulWidget {
   const SmartGoalSummaryScreen({super.key});
@@ -57,11 +57,7 @@ class _SmartGoalSummaryScreenState extends State<SmartGoalSummaryScreen> {
   }
 
   Future<void> _start(_GoalItem item) async {
-    item.goal.onComplete();
-    final lesson = MiniLessonLibraryService.instance.getById(item.goal.id);
-    if (lesson != null) {
-      await const TrainingSessionLauncher().launchForMiniLesson(lesson);
-    }
+    await const GoalToTrainingLauncher().launchFromGoal(item.goal);
     if (!mounted) return;
     await _load();
   }

--- a/lib/services/goal_to_training_launcher.dart
+++ b/lib/services/goal_to_training_launcher.dart
@@ -1,0 +1,23 @@
+import '../models/xp_guided_goal.dart';
+import 'mini_lesson_library_service.dart';
+import 'training_session_launcher.dart';
+
+/// Dispatches XP goals to the appropriate training flow.
+class GoalToTrainingLauncher {
+  final MiniLessonLibraryService library;
+  final TrainingSessionLauncher launcher;
+
+  const GoalToTrainingLauncher({
+    this.library = MiniLessonLibraryService.instance,
+    this.launcher = const TrainingSessionLauncher(),
+  });
+
+  /// Resolves the lesson for [goal] and launches it as a mini lesson.
+  Future<void> launchFromGoal(XPGuidedGoal goal) async {
+    await library.loadAll();
+    final lesson = library.getById(goal.id);
+    if (lesson == null) return;
+    goal.onComplete();
+    await launcher.launchForMiniLesson(lesson);
+  }
+}


### PR DESCRIPTION
## Summary
- add `GoalToTrainingLauncher` service to open training from XP goals
- use the new service in `SmartGoalSummaryScreen`

## Testing
- `flutter dart analyze lib` *(fails: many existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_688a95da857c832a81fc36bc3d9160e8