### PR TITLE
Add XP goal streak tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add Import Starter Packs button to Template Library.
 - Suggest next built-in pack from the same category when one is completed.
 - Add hand analysis history with EV/ICM stats and filters.
+- Track XP goal streaks via new GoalStreakTrackerService.
 - Introduce XPLevelEngine for computing user level progression.
 - Add TheoryPackPreviewScreen for theory-only training packs.
 - Track consecutive days of theory reinforcement via TheoryStreakService.

--- a/lib/services/goal_progress_persistence_service.dart
+++ b/lib/services/goal_progress_persistence_service.dart
@@ -84,6 +84,14 @@ class GoalProgressPersistenceService {
     ];
   }
 
+  /// Returns a copy of all stored goal completion logs sorted by time.
+  Future<List<GoalCompletionLog>> getAllLogs() async {
+    await _load();
+    final list = List<GoalCompletionLog>.from(_logs)
+      ..sort((a, b) => a.completedAt.compareTo(b.completedAt));
+    return list;
+  }
+
   /// Returns total XP earned from goal completions during the current week.
   /// [xpPerGoal] allows overriding the XP value granted per goal.
   Future<int> getWeeklyXP({int xpPerGoal = 25}) async {

--- a/lib/services/goal_streak_tracker_service.dart
+++ b/lib/services/goal_streak_tracker_service.dart
@@ -1,0 +1,89 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'goal_progress_persistence_service.dart';
+
+class GoalStreakInfo {
+  final int currentStreak;
+  final int longestStreak;
+  final DateTime lastCompletedDay;
+
+  const GoalStreakInfo({
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.lastCompletedDay,
+  });
+}
+
+class GoalStreakTrackerService {
+  GoalStreakTrackerService._();
+  static final GoalStreakTrackerService instance = GoalStreakTrackerService._();
+
+  static const _currentKey = 'goal_streak_current';
+  static const _longestKey = 'goal_streak_longest';
+  static const _lastKey = 'goal_streak_last_day';
+
+  Future<void> resetForTest() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_currentKey);
+    await prefs.remove(_longestKey);
+    await prefs.remove(_lastKey);
+  }
+
+  Future<GoalStreakInfo> getStreakInfo() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastKey);
+    var current = prefs.getInt(_currentKey) ?? 0;
+    var longest = prefs.getInt(_longestKey) ?? current;
+    DateTime? lastDay =
+        lastStr != null ? DateTime.tryParse(lastStr) : null;
+
+    final logs = await GoalProgressPersistenceService.instance.getAllLogs();
+    if (logs.isNotEmpty) {
+      final days = <DateTime>[];
+      for (final l in logs..sort((a, b) => a.completedAt.compareTo(b.completedAt))) {
+        final d = DateTime(l.completedAt.year, l.completedAt.month, l.completedAt.day);
+        if (days.isEmpty || days.last != d) {
+          days.add(d);
+        }
+      }
+
+      int best = 1;
+      int count = 1;
+      for (var i = 1; i < days.length; i++) {
+        final diff = days[i].difference(days[i - 1]).inDays;
+        if (diff == 1) {
+          count += 1;
+        } else if (diff > 1) {
+          if (count > best) best = count;
+          count = 1;
+        }
+      }
+      if (count > best) best = count;
+      longest = best;
+      lastDay = days.last;
+      current = count;
+      final today = DateTime.now();
+      final diff = DateTime(today.year, today.month, today.day)
+          .difference(lastDay)
+          .inDays;
+      if (diff > 1) current = 0;
+    } else {
+      current = 0;
+      lastDay = null;
+    }
+
+    await prefs.setInt(_currentKey, current);
+    await prefs.setInt(_longestKey, longest);
+    if (lastDay != null) {
+      await prefs.setString(_lastKey, lastDay.toIso8601String());
+    } else {
+      await prefs.remove(_lastKey);
+    }
+
+    return GoalStreakInfo(
+      currentStreak: current,
+      longestStreak: longest,
+      lastCompletedDay: lastDay ?? DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+}

--- a/test/services/goal_streak_tracker_service_test.dart
+++ b/test/services/goal_streak_tracker_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/goal_progress_persistence_service.dart';
+import 'package:poker_analyzer/services/goal_streak_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    GoalProgressPersistenceService.instance.resetForTest();
+    await GoalStreakTrackerService.instance.resetForTest();
+  });
+
+  test('streak increments with consecutive days', () async {
+    final persist = GoalProgressPersistenceService.instance;
+    final tracker = GoalStreakTrackerService.instance;
+    final now = DateTime.now();
+    await persist.markCompleted('a', now.subtract(const Duration(days: 2)));
+    await persist.markCompleted('b', now.subtract(const Duration(days: 1)));
+    await persist.markCompleted('c', now);
+
+    final info = await tracker.getStreakInfo();
+    expect(info.currentStreak, 3);
+    expect(info.longestStreak, 3);
+  });
+
+  test('streak resets when day missed', () async {
+    final persist = GoalProgressPersistenceService.instance;
+    final tracker = GoalStreakTrackerService.instance;
+    final now = DateTime.now();
+    await persist.markCompleted('a', now.subtract(const Duration(days: 2)));
+    final info = await tracker.getStreakInfo();
+    expect(info.currentStreak, 0);
+    expect(info.longestStreak, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- persist goal completion logs fetch via new `getAllLogs`
- track XP goal streaks with `GoalStreakTrackerService`
- cover new service with tests
- document feature in `CHANGELOG`

## Testing
- `flutter pub get` *(fails: missing `shared.sh` in Flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_688a956f39e0832aa919ea9d4530d2bf