### PR TITLE
Add SmartGoalProgressBar widget

### DIFF
--- a/lib/widgets/smart_goal_progress_bar.dart
+++ b/lib/widgets/smart_goal_progress_bar.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import '../services/goal_progress_persistence_service.dart';
+
+/// Progress bar widget showing weekly XP progress towards [weeklyTarget].
+class SmartGoalProgressBar extends StatelessWidget {
+  /// Weekly XP target to reach.
+  final int weeklyTarget;
+
+  const SmartGoalProgressBar({super.key, this.weeklyTarget = 200});
+
+  Future<int> _loadXP() {
+    return GoalProgressPersistenceService.instance.getWeeklyXP();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<int>(
+      future: _loadXP(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final xp = snapshot.data ?? 0;
+        final pct = (xp / weeklyTarget).clamp(0.0, 1.0);
+        final completed = xp >= weeklyTarget;
+        final color = completed ? Colors.green : accent;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '$xp/$weeklyTarget XP this week',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+                const Spacer(),
+                if (completed)
+                  const Icon(Icons.check_circle,
+                      color: Colors.greenAccent, size: 16),
+              ],
+            ),
+            const SizedBox(height: 4),
+            TweenAnimationBuilder<double>(
+              tween: Tween(begin: 0.0, end: pct),
+              duration: const Duration(milliseconds: 300),
+              builder: (context, value, _) {
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: value,
+                    backgroundColor: Colors.white24,
+                    valueColor: AlwaysStoppedAnimation<Color>(color),
+                    minHeight: 6,
+                  ),
+                );
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/test/widgets/smart_goal_progress_bar_test.dart
+++ b/test/widgets/smart_goal_progress_bar_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/smart_goal_progress_bar.dart';
+import 'package:poker_analyzer/services/goal_progress_persistence_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    GoalProgressPersistenceService.instance.resetForTest();
+  });
+
+  testWidgets('shows weekly XP progress', (tester) async {
+    final service = GoalProgressPersistenceService.instance;
+    final now = DateTime.now();
+    await service.markCompleted('a', now.subtract(const Duration(days: 1)));
+    await service.markCompleted('b', now.subtract(const Duration(days: 2)));
+
+    await tester.pumpWidget(const MaterialApp(home: SmartGoalProgressBar(weeklyTarget: 100)));
+    await tester.pump();
+
+    expect(find.text('50/100 XP this week'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsNothing);
+  });
+
+  testWidgets('shows badge when goal reached', (tester) async {
+    final service = GoalProgressPersistenceService.instance;
+    final now = DateTime.now();
+    await service.markCompleted('a', now);
+    await service.markCompleted('b', now);
+    await service.markCompleted('c', now);
+    await service.markCompleted('d', now);
+
+    await tester.pumpWidget(const MaterialApp(home: SmartGoalProgressBar(weeklyTarget: 100)));
+    await tester.pump();
+
+    expect(find.text('100/100 XP this week'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SmartGoalProgressBar` widget for weekly XP tracking
- create widget tests for progress and completion badge

## Testing
- `flutter test test/widgets/smart_goal_progress_bar_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a9b23d610832aae1afa432f91532c