### PR TITLE
Add theory injection seeder

### DIFF
--- a/lib/services/theory_pack_seeder_level2.dart
+++ b/lib/services/theory_pack_seeder_level2.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/generation/yaml_writer.dart';
+
+/// Injects short theory spots into Level II training packs.
+class TheoryPackSeederLevel2 {
+  /// Mapping from tag to lesson title and explanation.
+  final Map<String, Map<String, String>> templates;
+  final YamlReader reader;
+  final YamlWriter writer;
+
+  const TheoryPackSeederLevel2({
+    Map<String, Map<String, String>>? templates,
+    this.reader = const YamlReader(),
+    this.writer = const YamlWriter(),
+  }) : templates = templates ?? _defaultTemplates;
+
+  /// Scans [dir] for YAML packs and injects theory spots.
+  /// Returns list of updated file paths.
+  Future<List<String>> seed({String dir = 'assets/packs/v2'}) async {
+    final directory = Directory(dir);
+    if (!directory.existsSync()) return [];
+    final files = directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.yaml'));
+    final updated = <String>[];
+    for (final file in files) {
+      final map = reader.read(await file.readAsString());
+      final tags = [for (final t in (map['tags'] as List? ?? [])) t.toString()];
+      if (!tags.contains('level2')) continue;
+      final lessons = <Map<String, String>>[];
+      for (final t in tags) {
+        if (t == 'level2') continue;
+        final tpl = templates[t];
+        if (tpl != null) {
+          lessons.add({'tag': t, 'title': tpl['title']!, 'content': tpl['content']!});
+          if (lessons.length >= 2) break;
+        }
+      }
+      if (lessons.isEmpty) continue;
+      final spots = (map['spots'] as List? ?? []).cast<Map>();
+      final packId = map['id']?.toString() ?? p.basenameWithoutExtension(file.path);
+      final newSpots = <Map<String, dynamic>>[];
+      for (var i = 0; i < lessons.length; i++) {
+        final l = lessons[i];
+        newSpots.add({
+          'id': '${packId}_theory_${i + 1}',
+          'type': 'theory',
+          'title': l['title'],
+          'explanation': l['content'],
+          'tags': [l['tag']],
+        });
+      }
+      map['spots'] = [...newSpots, ...spots];
+      map['spotCount'] = (map['spotCount'] as int? ?? spots.length) + newSpots.length;
+      final meta = Map<String, dynamic>.from(map['meta'] as Map? ?? {});
+      meta['hasTheory'] = true;
+      map['meta'] = meta;
+      await writer.write(map, file.path);
+      updated.add(file.path);
+    }
+    return updated;
+  }
+}
+
+const Map<String, Map<String, String>> _defaultTemplates = {
+  'openfold': {
+    'title': 'Open/Fold Strategy Basics',
+    'content': 'Tighten early positions and widen from late position.'
+  },
+  'open-fold': {
+    'title': 'Open/Fold Strategy Basics',
+    'content': 'Tighten early positions and widen from late position.'
+  },
+  '3bet-push': {
+    'title': '3bet Push vs Open',
+    'content': 'Shove strong hands over opens when short stacked.'
+  },
+  'callVsOpen': {
+    'title': 'Call vs Open',
+    'content': 'Defend with hands that play well postflop.'
+  },
+  'cbet': {
+    'title': 'C-Bet Fundamentals',
+    'content': 'Bet the flop frequently with range advantage.'
+  },
+  'check-raise': {
+    'title': 'Check-Raise Tactics',
+    'content': 'Use check-raises to apply pressure from out of position.'
+  },
+  'float': {
+    'title': 'Turn Float Strategy',
+    'content': 'Call flop to take the pot on later streets when conditions are right.'
+  },
+  'donk': {
+    'title': 'Donk Bet Insights',
+    'content': 'Lead out from out of position on favourable boards.'
+  },
+};

--- a/test/theory_pack_seeder_level2_test.dart
+++ b/test/theory_pack_seeder_level2_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_pack_seeder_level2.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('seed prepends theory spots to level2 pack', () async {
+    final dir = await Directory.systemTemp.createTemp('level2_pack');
+    final file = File('${dir.path}/test.yaml');
+    await file.writeAsString('''
+id: test
+name: Test Pack
+trainingType: mtt
+bb: 20
+gameType: tournament
+positions:
+  - co
+tags:
+  - level2
+  - openfold
+spots:
+  - id: s1
+    title: AKo CO 20bb
+    villainAction: none
+    heroOptions:
+      - open
+      - fold
+    hand:
+      heroCards: As Kc
+      position: co
+      heroIndex: 0
+      playerCount: 6
+      stacks:
+        "0": 20
+        "1": 20
+spotCount: 1
+meta:
+  schemaVersion: 2.0.0
+''');
+
+    final seeder = TheoryPackSeederLevel2();
+    final updated = await seeder.seed(dir: dir.path);
+    expect(updated, contains(file.path));
+
+    final updatedYaml = loadYaml(await file.readAsString()) as YamlMap;
+    final spots = updatedYaml['spots'] as YamlList;
+    expect(spots.length, 2);
+    final first = spots.first as YamlMap;
+    expect(first['type'], 'theory');
+    expect(updatedYaml['meta']['hasTheory'], true);
+    expect(updatedYaml['spotCount'], 2);
+
+    dir.deleteSync(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryPackSeederLevel2` to prepend mini theory lessons
- cover the seeder with unit test

## Testing
- `dart` command not found
- `flutter` command not found

------
https://chatgpt.com/codex/tasks/task_e_688aa38fe100832ab60e00befefe6c49