### PR TITLE
Implement lesson-pack linker

### DIFF
--- a/lib/models/theory_mini_lesson_node.dart
+++ b/lib/models/theory_mini_lesson_node.dart
@@ -18,18 +18,27 @@ class TheoryMiniLessonNode implements LearningPathNode {
   /// Tags associated with this mini lesson.
   final List<String> tags;
 
+  /// Optional stage identifier like `level2`.
+  final String? stage;
+
   /// IDs of nodes unlocked after reading this lesson.
   final List<String> nextIds;
+
+  /// Ids of training packs linked to this lesson.
+  List<String> linkedPackIds;
 
   const TheoryMiniLessonNode({
     required this.id,
     this.refId,
     required this.title,
     required this.content,
+    this.stage,
     List<String>? tags,
     List<String>? nextIds,
+    List<String>? linkedPackIds,
   })  : tags = tags ?? const [],
-        nextIds = nextIds ?? const [];
+        nextIds = nextIds ?? const [],
+        linkedPackIds = linkedPackIds ?? const [];
 
   /// Returns [title] or the referenced block's title when empty.
   String get resolvedTitle {
@@ -56,13 +65,16 @@ class TheoryMiniLessonNode implements LearningPathNode {
       }
     }
     final nextIds = <String>[for (final v in (yaml['next'] as List? ?? [])) v.toString()];
+    final linked = <String>[for (final v in (yaml['linkedPackIds'] as List? ?? [])) v.toString()];
     return TheoryMiniLessonNode(
       id: yaml['id']?.toString() ?? '',
       refId: yaml['refId']?.toString(),
       title: yaml['title']?.toString() ?? '',
       content: yaml['content']?.toString() ?? '',
       tags: tags,
+      stage: yaml['stage']?.toString(),
       nextIds: nextIds,
+      linkedPackIds: linked,
     );
   }
 }

--- a/lib/services/theory_mini_lesson_linker.dart
+++ b/lib/services/theory_mini_lesson_linker.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'mini_lesson_library_service.dart';
+import 'pack_library_loader_service.dart';
+
+/// Links theory mini lessons with training packs based on shared tags and stage.
+class TheoryMiniLessonLinker {
+  static const String _cacheKey = 'theory_mini_lesson_links';
+
+  final MiniLessonLibraryService library;
+  final PackLibraryLoaderService loader;
+
+  const TheoryMiniLessonLinker({
+    this.library = MiniLessonLibraryService.instance,
+    this.loader = PackLibraryLoaderService.instance,
+  });
+
+  /// Computes pack links for all lessons and persists results.
+  Future<void> link({bool force = false}) async {
+    await library.loadAll();
+    final packs = await loader.loadLibrary();
+
+    final prefs = await SharedPreferences.getInstance();
+    if (!force) {
+      final raw = prefs.getString(_cacheKey);
+      if (raw != null) {
+        final data = jsonDecode(raw) as Map<String, dynamic>;
+        for (final lesson in library.all) {
+          final ids = data[lesson.id];
+          lesson.linkedPackIds = [
+            for (final v in (ids as List? ?? [])) v.toString()
+          ];
+        }
+        return;
+      }
+    }
+
+    final map = <String, List<String>>{};
+    for (final lesson in library.all) {
+      final stage = lesson.stage ?? _extractStage(lesson.tags);
+      final lessonTags = {
+        for (final t in lesson.tags) t.toLowerCase().trim()
+      }..removeWhere(_isStageTag);
+
+      final links = <String>[];
+      for (final pack in packs) {
+        final packStage = _packStage(pack);
+        if (stage != null && packStage != null && stage != packStage) {
+          continue;
+        }
+        final packTags = {
+          for (final t in pack.tags) t.toLowerCase().trim()
+        }..removeWhere(_isStageTag);
+        if (packTags.intersection(lessonTags).isNotEmpty) {
+          links.add(pack.id);
+        }
+      }
+      lesson.linkedPackIds = links;
+      if (links.isNotEmpty) map[lesson.id] = links;
+    }
+
+    await prefs.setString(_cacheKey, jsonEncode(map));
+  }
+
+  bool _isStageTag(String tag) =>
+      RegExp(r'^level\\d+\$', caseSensitive: false).hasMatch(tag);
+
+  String? _extractStage(List<String> tags) {
+    for (final t in tags) {
+      final s = t.toLowerCase();
+      if (_isStageTag(s)) return s;
+    }
+    return null;
+  }
+
+  String? _packStage(TrainingPackTemplateV2 pack) {
+    final metaStage = pack.meta['stage']?.toString();
+    if (metaStage != null && metaStage.isNotEmpty) {
+      return metaStage.toLowerCase();
+    }
+    return _extractStage(pack.tags);
+  }
+}

--- a/test/services/theory_mini_lesson_linker_test.dart
+++ b/test/services/theory_mini_lesson_linker_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_linker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/pack_library_loader_service.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) =>
+      [for (final t in tags) ...lessons.where((l) => l.tags.contains(t))];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+class _FakeLoader implements PackLibraryLoaderService {
+  final List<TrainingPackTemplateV2> packs;
+  _FakeLoader(this.packs);
+
+  @override
+  Future<List<TrainingPackTemplateV2>> loadLibrary() async => packs;
+
+  @override
+  List<TrainingPackTemplateV2> get library => packs;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('linker maps lessons to packs by tags and stage', () async {
+    final lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'L1',
+      content: '',
+      stage: 'level2',
+      tags: const ['level2', '3bet-push'],
+    );
+    final packs = [
+      TrainingPackTemplateV2(
+        id: 'p1',
+        name: 'P1',
+        trainingType: TrainingType.pushFold,
+        tags: ['level2', '3bet-push'],
+        meta: {'stage': 'level2'},
+      ),
+      TrainingPackTemplateV2(
+        id: 'p2',
+        name: 'P2',
+        trainingType: TrainingType.pushFold,
+        tags: ['level1', '3bet-push'],
+        meta: {'stage': 'level1'},
+      ),
+    ];
+    final library = _FakeLibrary([lesson]);
+    final loader = _FakeLoader(packs);
+    final linker = TheoryMiniLessonLinker(library: library, loader: loader);
+
+    await linker.link(force: true);
+
+    expect(lesson.linkedPackIds, equals(['p1']));
+  });
+}


### PR DESCRIPTION
## Summary
- add `stage` and `linkedPackIds` fields to `TheoryMiniLessonNode`
- create `TheoryMiniLessonLinker` to match lessons with training packs
- provide tests for the linker

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa979142c832aa7168ddca792c960