### PR TITLE
Add TheoryBoosterSuggestionService

### DIFF
--- a/lib/services/theory_booster_suggestion_service.dart
+++ b/lib/services/theory_booster_suggestion_service.dart
@@ -1,0 +1,67 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_spot_v2.dart';
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'theory_mini_lesson_linker.dart';
+
+/// Suggests mini theory lessons after a mistake based on spot tags and stage.
+class TheoryBoosterSuggestionService {
+  final TheoryMiniLessonLinker linker;
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+
+  TheoryBoosterSuggestionService({
+    TheoryMiniLessonLinker? linker,
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+  })  : linker = linker ?? const TheoryMiniLessonLinker(),
+        library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance;
+
+  static final TheoryBoosterSuggestionService instance =
+      TheoryBoosterSuggestionService();
+
+  static final RegExp _stageRe = RegExp(r'^level\\d+\$', caseSensitive: false);
+
+  bool _isStageTag(String tag) => _stageRe.hasMatch(tag);
+
+  String? _extractStage(Iterable<String> tags) {
+    for (final t in tags) {
+      final lc = t.toLowerCase().trim();
+      if (_isStageTag(lc)) return lc;
+    }
+    return null;
+  }
+
+  /// Returns up to two theory lessons relevant to [spot].
+  Future<List<TheoryMiniLessonNode>> suggestForSpot(TrainingSpotV2 spot) async {
+    await linker.link();
+    await library.loadAll();
+
+    final tags = {
+      for (final t in spot.tags) t.toLowerCase().trim()
+    }..removeWhere(_isStageTag);
+    final stage = _extractStage(spot.tags);
+
+    final candidates = <MapEntry<TheoryMiniLessonNode, int>>[];
+
+    for (final lesson in library.all) {
+      if (stage != null) {
+        final lessonStage =
+            lesson.stage?.toLowerCase() ?? _extractStage(lesson.tags);
+        if (lessonStage != null && lessonStage != stage) continue;
+      }
+      final lessonTags = {
+        for (final t in lesson.tags) t.toLowerCase().trim()
+      }..removeWhere(_isStageTag);
+      final overlap = lessonTags.intersection(tags).length;
+      if (overlap == 0) continue;
+      if (await progress.isCompleted(lesson.id)) continue;
+      candidates.add(MapEntry(lesson, overlap));
+    }
+
+    if (candidates.isEmpty) return [];
+    candidates.sort((a, b) => b.value.compareTo(a.value));
+    return [for (final c in candidates.take(2)) c.key];
+  }
+}

--- a/test/services/theory_booster_suggestion_service_test.dart
+++ b/test/services/theory_booster_suggestion_service_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/theory_booster_suggestion_service.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_linker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import "package:poker_analyzer/services/pack_library_loader_service.dart";
+import "package:poker_analyzer/models/v2/training_pack_template_v2.dart";
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeLinker extends TheoryMiniLessonLinker {
+  _FakeLinker({required MiniLessonLibraryService library})
+      : super(library: library, loader: _FakeLoader());
+}
+
+class _FakeLoader implements PackLibraryLoaderService {
+  @override
+  Future<List<TrainingPackTemplateV2>> loadLibrary() async => const [];
+
+  @override
+  List<TrainingPackTemplateV2> get library => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    MiniLessonProgressTracker.instance.onLessonCompleted.listen((_) {});
+  });
+
+  test('suggestForSpot returns lessons matching tags and stage', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'A',
+        content: '',
+        tags: ['level2', 'openfold'],
+        stage: 'level2',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'B',
+        content: '',
+        tags: ['level2', '3bet-push'],
+        stage: 'level2',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l3',
+        title: 'C',
+        content: '',
+        tags: ['level1', 'openfold'],
+        stage: 'level1',
+      ),
+    ];
+    final library = _FakeLibrary(lessons);
+    final linker = _FakeLinker(library: library);
+
+    await MiniLessonProgressTracker.instance.markCompleted('l2');
+
+    final spot = TrainingPackSpot(id: 's1', hand: HandData(), tags: ['level2', 'openfold']);
+
+    final service = TheoryBoosterSuggestionService(
+      linker: linker,
+      library: library,
+      progress: MiniLessonProgressTracker.instance,
+    );
+
+    final result = await service.suggestForSpot(spot);
+    expect(result.map((e) => e.id), ['l1']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryBoosterSuggestionService` to recommend theory mini-lessons after a mistake
- test that lessons are suggested based on spot tags and stage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aaf068c20832ab2b455393a1bf6ac