### PR TITLE
Add BoosterPathHistoryService

### DIFF
--- a/lib/models/booster_path_log_entry.dart
+++ b/lib/models/booster_path_log_entry.dart
@@ -1,0 +1,38 @@
+class BoosterPathLogEntry {
+  final String lessonId;
+  final String tag;
+  final DateTime shownAt;
+  final DateTime? completedAt;
+
+  const BoosterPathLogEntry({
+    required this.lessonId,
+    required this.tag,
+    required this.shownAt,
+    this.completedAt,
+  });
+
+  BoosterPathLogEntry copyWith({DateTime? completedAt}) {
+    return BoosterPathLogEntry(
+      lessonId: lessonId,
+      tag: tag,
+      shownAt: shownAt,
+      completedAt: completedAt ?? this.completedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'tag': tag,
+        'shownAt': shownAt.toIso8601String(),
+        if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
+      };
+
+  factory BoosterPathLogEntry.fromJson(Map<String, dynamic> json) =>
+      BoosterPathLogEntry(
+        lessonId: json['lessonId'] as String? ?? '',
+        tag: json['tag'] as String? ?? '',
+        shownAt: DateTime.tryParse(json['shownAt'] as String? ?? '') ??
+            DateTime.now(),
+        completedAt: DateTime.tryParse(json['completedAt'] as String? ?? ''),
+      );
+}

--- a/lib/screens/smart_goal_summary_screen.dart
+++ b/lib/screens/smart_goal_summary_screen.dart
@@ -36,7 +36,7 @@ class _SmartGoalSummaryScreenState extends State<SmartGoalSummaryScreen> {
     final goals = await controller.getInboxGoals(maxGoals: 10);
     final assignments = await GoalSlotAllocator.instance.allocate(goals);
     await MiniLessonLibraryService.instance.loadAll();
-    final history = await BoosterPathHistoryService.instance.getHistory();
+    final history = await BoosterPathHistoryService.instance.getTagStats();
     final map = <String, List<_GoalItem>>{};
     for (final a in assignments) {
       final lesson = MiniLessonLibraryService.instance.getById(a.goal.id);

--- a/lib/services/booster_lesson_status_service.dart
+++ b/lib/services/booster_lesson_status_service.dart
@@ -2,6 +2,7 @@ import '../models/theory_mini_lesson_node.dart';
 import '../models/booster_lesson_status.dart';
 import 'inbox_booster_tracker_service.dart';
 import 'booster_path_history_service.dart';
+import '../models/booster_path_log_entry.dart';
 
 /// Resolves [BoosterLessonStatus] for theory mini lessons.
 class BoosterLessonStatusService {
@@ -28,10 +29,9 @@ class BoosterLessonStatusService {
       tag = lesson.tags.first.trim().toLowerCase();
       if (tag.isEmpty) tag = null;
     }
-    final histMap = await history.getHistory();
-    final hist = tag != null ? histMap[tag] : null;
-    final started = hist?.startedCount ?? 0;
-    final completed = hist?.completedCount ?? 0;
+    final logs = tag != null ? await history.getHistory(tag: tag) : <BoosterPathLogEntry>[];
+    final completed = logs.where((e) => e.completedAt != null).length;
+    final hasProgress = logs.isNotEmpty;
 
     if (shows >= 5 && clicks == 0 && completed == 0) {
       return BoosterLessonStatus.skipped;
@@ -39,7 +39,7 @@ class BoosterLessonStatusService {
     if (completed >= 2) {
       return BoosterLessonStatus.repeated;
     }
-    if ((shows > 0 || started > 0 || clicks > 0) && completed == 0) {
+    if ((shows > 0 || hasProgress || clicks > 0) && completed == 0) {
       return BoosterLessonStatus.inProgress;
     }
     return BoosterLessonStatus.newLesson;

--- a/lib/services/booster_path_history_service.dart
+++ b/lib/services/booster_path_history_service.dart
@@ -2,80 +2,118 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/booster_path_log_entry.dart';
 import '../models/booster_tag_history.dart';
 
-/// Stores booster tag interaction history in local preferences.
+/// Stores booster lesson interaction history in local preferences.
 class BoosterPathHistoryService {
   BoosterPathHistoryService._();
   static final BoosterPathHistoryService instance = BoosterPathHistoryService._();
 
-  static const String _prefix = 'booster_tag_history_';
+  static const String _prefsKey = 'booster_path_logs';
 
-  Future<BoosterTagHistory?> _loadTag(String tag) async {
+  List<BoosterPathLogEntry> _logs = [];
+  bool _loaded = false;
+
+  /// Clears cached data for testing.
+  void resetForTest() {
+    _loaded = false;
+    _logs = [];
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
-    final key = '$_prefix$tag';
-    final raw = prefs.getString(key);
-    if (raw == null) return null;
-    try {
-      final data = jsonDecode(raw);
-      if (data is Map<String, dynamic>) {
-        return BoosterTagHistory.fromJson(data);
-      }
-    } catch (_) {}
-    return null;
-  }
-
-  Future<void> _saveTag(String tag, BoosterTagHistory hist) async {
-    final prefs = await SharedPreferences.getInstance();
-    final key = '$_prefix$tag';
-    await prefs.setString(key, jsonEncode(hist.toJson()));
-  }
-
-  Future<void> _update(String tag, {bool shown = false, bool started = false, bool completed = false}) async {
-    tag = tag.trim().toLowerCase();
-    if (tag.isEmpty) return;
-    final existing = await _loadTag(tag);
-    final now = DateTime.now();
-    final updated = (existing ?? BoosterTagHistory(tag: tag, shownCount: 0, startedCount: 0, completedCount: 0, lastInteraction: now)).copyWith(
-      shownCount: (existing?.shownCount ?? 0) + (shown ? 1 : 0),
-      startedCount: (existing?.startedCount ?? 0) + (started ? 1 : 0),
-      completedCount: (existing?.completedCount ?? 0) + (completed ? 1 : 0),
-      lastInteraction: now,
-    );
-    await _saveTag(tag, updated);
-  }
-
-  /// Record that a booster with [tag] was shown to the user.
-  Future<void> markShown(String tag) async {
-    await _update(tag, shown: true);
-  }
-
-  /// Record that a booster with [tag] was started by the user.
-  Future<void> markStarted(String tag) async {
-    await _update(tag, started: true);
-  }
-
-  /// Record that a booster with [tag] was completed by the user.
-  Future<void> markCompleted(String tag) async {
-    await _update(tag, completed: true);
-  }
-
-  /// Returns aggregated history keyed by tag.
-  Future<Map<String, BoosterTagHistory>> getHistory() async {
-    final prefs = await SharedPreferences.getInstance();
-    final result = <String, BoosterTagHistory>{};
-    for (final key in prefs.getKeys()) {
-      if (!key.startsWith(_prefix)) continue;
-      final raw = prefs.getString(key);
-      if (raw == null) continue;
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
       try {
         final data = jsonDecode(raw);
-        if (data is Map<String, dynamic>) {
-          final hist = BoosterTagHistory.fromJson(data);
-          result[hist.tag] = hist;
+        if (data is List) {
+          _logs = [
+            for (final e in data)
+              if (e is Map)
+                BoosterPathLogEntry.fromJson(
+                    Map<String, dynamic>.from(e))
+          ];
+          _logs.sort((a, b) => b.shownAt.compareTo(a.shownAt));
         }
       } catch (_) {}
     }
-    return result;
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final l in _logs) l.toJson()]),
+    );
+  }
+
+  /// Record that [lessonId] with [tag] was shown now.
+  Future<void> markShown(String lessonId, String tag) async {
+    await _load();
+    final entry = BoosterPathLogEntry(
+      lessonId: lessonId,
+      tag: tag.trim().toLowerCase(),
+      shownAt: DateTime.now(),
+    );
+    _logs.add(entry);
+    await _save();
+  }
+
+  /// Record that [lessonId] with [tag] was completed now.
+  Future<void> markCompleted(String lessonId, String tag) async {
+    await _load();
+    final normTag = tag.trim().toLowerCase();
+    for (var i = _logs.length - 1; i >= 0; i--) {
+      final e = _logs[i];
+      if (e.lessonId == lessonId && e.tag == normTag && e.completedAt == null) {
+        _logs[i] = e.copyWith(completedAt: DateTime.now());
+        await _save();
+        return;
+      }
+    }
+    _logs.add(BoosterPathLogEntry(
+      lessonId: lessonId,
+      tag: normTag,
+      shownAt: DateTime.now(),
+      completedAt: DateTime.now(),
+    ));
+    await _save();
+  }
+
+  /// Returns log entries optionally filtered by [tag]. Most recent first.
+  Future<List<BoosterPathLogEntry>> getHistory({String? tag}) async {
+    await _load();
+    if (tag == null) return List.unmodifiable(_logs);
+    final normTag = tag.trim().toLowerCase();
+    return List.unmodifiable(_logs.where((e) => e.tag == normTag));
+  }
+
+  /// Returns aggregated history keyed by tag.
+  Future<Map<String, BoosterTagHistory>> getTagStats() async {
+    final logs = await getHistory();
+    final map = <String, BoosterTagHistory>{};
+    for (final e in logs) {
+      final hist = map[e.tag];
+      if (hist == null) {
+        map[e.tag] = BoosterTagHistory(
+          tag: e.tag,
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: e.completedAt != null ? 1 : 0,
+          lastInteraction: e.completedAt ?? e.shownAt,
+        );
+      } else {
+        map[e.tag] = hist.copyWith(
+          shownCount: hist.shownCount + 1,
+          completedCount:
+              hist.completedCount + (e.completedAt != null ? 1 : 0),
+          lastInteraction: e.completedAt ?? e.shownAt,
+        );
+      }
+    }
+    return map;
   }
 }

--- a/lib/services/booster_slot_allocator.dart
+++ b/lib/services/booster_slot_allocator.dart
@@ -43,7 +43,7 @@ class BoosterSlotAllocator {
   ) async {
     if (lessons.isEmpty) return [];
 
-    final histMap = await history.getHistory();
+    final histMap = await history.getTagStats();
     final scoreMap = await tuner.computeTagBoostScores();
     await recap.refresh();
 
@@ -74,7 +74,7 @@ class BoosterSlotAllocator {
       if (stats != null && urgency > 1.8) {
         slot = 'recap';
       } else if ((hist == null ||
-              hist.shownCount + hist.startedCount + hist.completedCount < 2) &&
+              hist.shownCount + hist.completedCount < 2) &&
           score > 1.5) {
         slot = 'goal';
       } else {

--- a/lib/services/goal_slot_allocator.dart
+++ b/lib/services/goal_slot_allocator.dart
@@ -38,7 +38,7 @@ class GoalSlotAllocator {
     final topWeak = <String>{
       for (final i in weak.take(3)) i.tag.label.toLowerCase(),
     };
-    final hist = await history.getHistory();
+    final hist = await history.getTagStats();
 
     final result = <GoalSlotAssignment>[];
     for (final g in goals) {

--- a/lib/services/goal_smart_suggestion_engine.dart
+++ b/lib/services/goal_smart_suggestion_engine.dart
@@ -69,7 +69,8 @@ class GoalSmartSuggestionEngine {
           xp: 25,
           source: 'smart',
           onComplete: () {
-            BoosterPathHistoryService.instance.markCompleted(c.tag);
+            BoosterPathHistoryService.instance
+                .markCompleted(c.lesson.id, c.tag);
             GoalProgressPersistenceService.instance
                 .markCompleted(c.lesson.id, DateTime.now());
           },

--- a/test/services/booster_lesson_status_service_test.dart
+++ b/test/services/booster_lesson_status_service_test.dart
@@ -38,8 +38,9 @@ void main() {
 
   test('determines repeated status', () async {
     final lesson = const TheoryMiniLessonNode(id: 'l3', title: '', content: '', tags: ['call']);
-    await BoosterPathHistoryService.instance.markCompleted('call');
-    await BoosterPathHistoryService.instance.markCompleted('call');
+    await BoosterPathHistoryService.instance.markShown('l3', 'call');
+    await BoosterPathHistoryService.instance.markCompleted('l3', 'call');
+    await BoosterPathHistoryService.instance.markCompleted('l3', 'call');
     final service = BoosterLessonStatusService(
       tracker: InboxBoosterTrackerService.instance,
       history: BoosterPathHistoryService.instance,

--- a/test/services/booster_path_history_service_test.dart
+++ b/test/services/booster_path_history_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/models/booster_path_log_entry.dart';
 import 'package:poker_analyzer/models/booster_tag_history.dart';
 
 void main() {
@@ -15,20 +16,20 @@ void main() {
   test('records interactions per tag', () async {
     final service = BoosterPathHistoryService.instance;
 
-    await service.markShown('cbet');
-    await service.markStarted('cbet');
-    await service.markCompleted('cbet');
-    await service.markShown('3bet');
+    await service.markShown('l1', 'cbet');
+    await service.markCompleted('l1', 'cbet');
+    await service.markShown('l2', '3bet');
 
-    final hist = await service.getHistory();
-    expect(hist.length, 2);
-    final cbet = hist['cbet']!;
+    final logs = await service.getHistory();
+    expect(logs.length, 2);
+    expect(logs.first.lessonId, 'l2');
+
+    final stats = await service.getTagStats();
+    final cbet = stats['cbet']!;
     expect(cbet.shownCount, 1);
-    expect(cbet.startedCount, 1);
     expect(cbet.completedCount, 1);
-    final tbet = hist['3bet']!;
+    final tbet = stats['3bet']!;
     expect(tbet.shownCount, 1);
-    expect(tbet.startedCount, 0);
     expect(tbet.completedCount, 0);
   });
 }

--- a/test/services/booster_slot_allocator_test.dart
+++ b/test/services/booster_slot_allocator_test.dart
@@ -92,9 +92,8 @@ void main() {
   });
 
   test('defaults to inbox for medium tags', () async {
-    await BoosterPathHistoryService.instance.markShown('call');
-    await BoosterPathHistoryService.instance.markStarted('call');
-    await BoosterPathHistoryService.instance.markCompleted('call');
+    await BoosterPathHistoryService.instance.markShown('l3a', 'call');
+    await BoosterPathHistoryService.instance.markCompleted('l3a', 'call');
 
     final recap = _FakeRecap({
       'call': TagEffectiveness(

--- a/test/services/goal_slot_allocator_test.dart
+++ b/test/services/goal_slot_allocator_test.dart
@@ -85,7 +85,8 @@ void main() {
   });
 
   test('assigns postrecap slot when tag completed recently', () async {
-    await BoosterPathHistoryService.instance.markCompleted('btn overfold');
+    await BoosterPathHistoryService.instance
+        .markCompleted('l2', 'btn overfold');
     final lesson = const TheoryMiniLessonNode(
       id: 'l2',
       title: 'B',


### PR DESCRIPTION
## Summary
- add `BoosterPathLogEntry` model for per-lesson history
- implement `BoosterPathHistoryService` with log storage and tag stats
- integrate new service in slot allocators, status service and goal logic
- update smart goal UI and tests to use new APIs

## Testing
- `flutter` and `dart` commands not available in the environment, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_688ab268142c832a94f592c6268cba35