### PR TITLE
Implement TheoryRecallEvaluator service

### DIFF
--- a/lib/services/theory_recall_evaluator.dart
+++ b/lib/services/theory_recall_evaluator.dart
@@ -1,0 +1,90 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_spot_v2.dart';
+import 'booster_cooldown_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+
+/// Scores theory lessons for recall based on relevance and recency.
+class TheoryRecallEvaluator {
+  final BoosterCooldownService cooldown;
+  final MiniLessonProgressTracker progress;
+  final double tagWeight;
+  final double stageWeight;
+  final double recencyWeight;
+  final double cooldownPenalty;
+  final double completionPenalty;
+
+  const TheoryRecallEvaluator({
+    BoosterCooldownService? cooldown,
+    MiniLessonProgressTracker? progress,
+    this.tagWeight = 1.0,
+    this.stageWeight = 1.0,
+    this.recencyWeight = 0.1,
+    this.cooldownPenalty = 1.0,
+    this.completionPenalty = 2.0,
+  })  : cooldown = cooldown ?? BoosterCooldownService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance;
+
+  static final RegExp _stageRe = RegExp(r'^level\\d+\$', caseSensitive: false);
+
+  String? _extractStage(Iterable<String> tags) {
+    for (final t in tags) {
+      final lc = t.trim().toLowerCase();
+      if (_stageRe.hasMatch(lc)) return lc;
+    }
+    return null;
+  }
+
+  /// Returns [candidates] ordered by descending score for [spot].
+  Future<List<TheoryMiniLessonNode>> rank(
+    List<TheoryMiniLessonNode> candidates,
+    TrainingSpotV2 spot,
+  ) async {
+    if (candidates.isEmpty) return [];
+    final now = DateTime.now();
+    final spotTags = {for (final t in spot.tags) t.trim().toLowerCase()};
+    final spotStage = _extractStage(spot.tags);
+
+    final entries = <_Entry>[];
+
+    for (final lesson in candidates) {
+      final lessonTags = {for (final t in lesson.tags) t.trim().toLowerCase()};
+      final overlap = lessonTags.intersection(spotTags).length;
+
+      double score = overlap * tagWeight;
+
+      final lessonStage = lesson.stage?.toLowerCase() ?? _extractStage(lesson.tags);
+      if (spotStage != null && lessonStage != null && spotStage == lessonStage) {
+        score += stageWeight;
+      }
+
+      final last = await progress.lastViewed(lesson.id);
+      if (last != null) {
+        final days = now.difference(last).inDays.toDouble();
+        score += days * recencyWeight;
+      }
+
+      if (await progress.isCompleted(lesson.id)) {
+        score -= completionPenalty;
+      }
+
+      for (final tag in lessonTags.intersection(spotTags)) {
+        final next = await cooldown.nextEligibleAt(lesson.id, tag);
+        if (next != null && next.isAfter(now)) {
+          final days = next.difference(now).inDays + 1;
+          score -= days * cooldownPenalty;
+        }
+      }
+
+      entries.add(_Entry(lesson, score));
+    }
+
+    entries.sort((a, b) => b.score.compareTo(a.score));
+    return [for (final e in entries) e.lesson];
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  _Entry(this.lesson, this.score);
+}

--- a/test/services/theory_recall_evaluator_test.dart
+++ b/test/services/theory_recall_evaluator_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/booster_cooldown_service.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_recall_evaluator.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BoosterPathHistoryService.instance.resetForTest();
+  });
+
+  test('rank orders lessons by relevance and penalties', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: '',
+        tags: ['level2', 'openfold'],
+        stage: 'level2',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'L2',
+        content: '',
+        tags: ['level2', 'openfold'],
+        stage: 'level2',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l3',
+        title: 'L3',
+        content: '',
+        tags: ['openfold', 'level1'],
+        stage: 'level1',
+      ),
+    ];
+
+    final spot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(),
+      tags: ['level2', 'openfold'],
+    );
+
+    // mark l3 completed so it's penalized
+    await MiniLessonProgressTracker.instance.markCompleted('l3');
+    // mark l2 shown to trigger cooldown
+    await BoosterPathHistoryService.instance.markShown('l2', 'openfold');
+
+    final evaluator = TheoryRecallEvaluator(
+      cooldown: BoosterCooldownService(cooldown: const Duration(days: 3)),
+      progress: MiniLessonProgressTracker.instance,
+    );
+
+    final ranked = await evaluator.rank(lessons, spot);
+
+    expect(ranked.first.id, 'l1');
+    expect(ranked.last.id, 'l2');
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryRecallEvaluator` service for ranking mini lessons
- cover basic scoring rules in new unit test

## Testing
- `flutter analyze` *(fails: Package file_picker does not provide inline implementation)*
- `flutter test test/services/theory_recall_evaluator_test.dart` *(fails: unable to load asset references)*

------
https://chatgpt.com/codex/tasks/task_e_688ab82101e0832ab3c3f0613c26a388