### PR TITLE
Implement BoosterGoalService

### DIFF
--- a/lib/services/booster_goal_service.dart
+++ b/lib/services/booster_goal_service.dart
@@ -1,0 +1,40 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/xp_guided_goal.dart';
+import 'goal_queue.dart';
+import 'inbox_booster_tracker_service.dart';
+
+/// Turns queued boosters into XP goals for the goal engine.
+class BoosterGoalService {
+  final GoalQueue queue;
+  final InboxBoosterTrackerService tracker;
+
+  BoosterGoalService({GoalQueue? queue, InboxBoosterTrackerService? tracker})
+      : queue = queue ?? GoalQueue.instance,
+        tracker = tracker ?? InboxBoosterTrackerService.instance;
+
+  static final BoosterGoalService instance = BoosterGoalService();
+
+  /// Returns XP goals built from the queued mini lessons.
+  /// [maxGoals] limits how many goals are returned.
+  List<XPGuidedGoal> getGoals({int maxGoals = 2}) {
+    final lessons = queue.getQueue();
+    if (lessons.isEmpty) return [];
+
+    final goals = <XPGuidedGoal>[];
+    for (final l in lessons.take(maxGoals)) {
+      goals.add(
+        XPGuidedGoal(
+          id: l.id,
+          label: 'Пройти мини-урок: ${l.resolvedTitle}',
+          xp: 25,
+          source: 'booster',
+          onComplete: () {
+            tracker.markClicked(l.id);
+            queue.remove(l.id);
+          },
+        ),
+      );
+    }
+    return goals;
+  }
+}

--- a/lib/services/goal_queue.dart
+++ b/lib/services/goal_queue.dart
@@ -10,6 +10,10 @@ class GoalQueue {
     _items.add(lesson);
   }
 
+  void remove(String lessonId) {
+    _items.removeWhere((e) => e.id == lessonId);
+  }
+
   List<TheoryMiniLessonNode> getQueue() => List.unmodifiable(_items);
 
   void clear() => _items.clear();


### PR DESCRIPTION
## Summary
- add ability to remove lessons from `GoalQueue`
- implement `BoosterGoalService` to turn queued lessons into XP booster goals

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad4e3aa70832aa19c7c441d599f8d