### PR TITLE
Add XP booster goal injection

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -12,6 +12,7 @@ import 'services/evaluation_executor_service.dart';
 import 'services/training_pack_service.dart';
 import 'services/service_registry.dart';
 import 'services/pack_library_loader_service.dart';
+import 'services/xp_goal_panel_booster_injector.dart';
 import 'helpers/training_pack_storage.dart';
 import 'core/plugin_runtime.dart';
 import 'core/training/library/training_pack_library_v2.dart';
@@ -54,6 +55,7 @@ class AppBootstrap {
       await TrainingPackService.generateDefaultPersonalPack(cloud: cloud);
     }
     registry.registerIfAbsent<EvaluationExecutor>(EvaluationExecutorService());
+    XpGoalPanelBoosterInjector.instance.inject();
     _registry = registry;
     return registry;
   }

--- a/lib/services/xp_goal_panel_booster_injector.dart
+++ b/lib/services/xp_goal_panel_booster_injector.dart
@@ -1,0 +1,26 @@
+import 'booster_goal_service.dart';
+import 'xp_goal_panel_controller.dart';
+
+/// Injects booster XP goals into [XpGoalPanelController].
+class XpGoalPanelBoosterInjector {
+  final BoosterGoalService booster;
+  final XpGoalPanelController panel;
+
+  XpGoalPanelBoosterInjector({
+    BoosterGoalService? booster,
+    XpGoalPanelController? panel,
+  })  : booster = booster ?? BoosterGoalService.instance,
+        panel = panel ?? XpGoalPanelController.instance;
+
+  static final XpGoalPanelBoosterInjector instance =
+      XpGoalPanelBoosterInjector();
+
+  /// Fetches booster goals and injects them into the XP goal panel.
+  void inject({int maxGoals = 2}) {
+    final goals = booster.getGoals(maxGoals: maxGoals);
+    for (final g in goals) {
+      if (panel.goals.any((e) => e.id == g.id)) continue;
+      panel.addGoal(g);
+    }
+  }
+}

--- a/lib/services/xp_goal_panel_controller.dart
+++ b/lib/services/xp_goal_panel_controller.dart
@@ -1,0 +1,29 @@
+import '../models/xp_guided_goal.dart';
+
+/// Manages XP goals displayed in the goal panel UI.
+class XpGoalPanelController {
+  XpGoalPanelController();
+
+  static final XpGoalPanelController instance = XpGoalPanelController();
+
+  final List<XPGuidedGoal> _goals = [];
+
+  /// Returns an unmodifiable list of panel goals.
+  List<XPGuidedGoal> get goals => List.unmodifiable(_goals);
+
+  /// Adds [goal] if not already present.
+  void addGoal(XPGuidedGoal goal) {
+    if (_goals.any((g) => g.id == goal.id)) return;
+    _goals.add(goal);
+  }
+
+  /// Removes goal with [id] if it exists.
+  void removeGoal(String id) {
+    _goals.removeWhere((g) => g.id == id);
+  }
+
+  /// Clears all panel goals.
+  void clear() {
+    _goals.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- add `XpGoalPanelBoosterInjector` to push booster XP goals into the goal panel
- create a minimal `XpGoalPanelController`
- hook injector into `AppBootstrap` so goals appear on startup

## Testing
- `mise exec flutter@3.32.7 -- flutter analyze` *(fails: 6627 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad67d5540832ab884de7cf64d6bd6