### PR TITLE
Add completion handler for booster goals

### DIFF
--- a/lib/services/theory_booster_goal_completion_handler.dart
+++ b/lib/services/theory_booster_goal_completion_handler.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'mini_lesson_progress_tracker.dart';
+import '../models/xp_guided_goal.dart';
+import 'xp_goal_panel_controller.dart';
+
+/// Listens for mini lesson completions and marks matching XP goals complete.
+class TheoryBoosterGoalCompletionHandler {
+  final MiniLessonProgressTracker tracker;
+  final XpGoalPanelController panel;
+
+  TheoryBoosterGoalCompletionHandler({
+    MiniLessonProgressTracker? tracker,
+    XpGoalPanelController? panel,
+  })  : tracker = tracker ?? MiniLessonProgressTracker.instance,
+        panel = panel ?? XpGoalPanelController.instance {
+    _sub = this.tracker.onLessonCompleted.listen(_handle);
+  }
+
+  static final TheoryBoosterGoalCompletionHandler instance =
+      TheoryBoosterGoalCompletionHandler();
+
+  StreamSubscription<String>? _sub;
+
+  void dispose() {
+    _sub?.cancel();
+  }
+
+  void _handle(String lessonId) {
+    final goals = List<XPGuidedGoal>.from(panel.goals);
+    for (final g in goals) {
+      if (g.id == lessonId) {
+        g.onComplete();
+        panel.removeGoal(g.id);
+      }
+    }
+  }
+}

--- a/test/services/theory_booster_goal_completion_handler_test.dart
+++ b/test/services/theory_booster_goal_completion_handler_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/theory_booster_goal_completion_handler.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/xp_goal_panel_controller.dart';
+import 'package:poker_analyzer/models/xp_guided_goal.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    XpGoalPanelController.instance.clear();
+    MiniLessonProgressTracker.instance.onLessonCompleted.listen((_) {});
+  });
+
+  test('marks matching goal complete and removes from panel', () async {
+    var completed = 0;
+    final goal = XPGuidedGoal(
+      id: 'l1',
+      label: 'Goal',
+      xp: 25,
+      source: 'booster',
+      onComplete: () => completed++,
+    );
+    XpGoalPanelController.instance.addGoal(goal);
+
+    final handler = TheoryBoosterGoalCompletionHandler(
+      tracker: MiniLessonProgressTracker.instance,
+      panel: XpGoalPanelController.instance,
+    );
+
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    await Future.delayed(Duration.zero);
+
+    expect(completed, 1);
+    expect(XpGoalPanelController.instance.goals, isEmpty);
+    handler.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryBoosterGoalCompletionHandler`
- trigger goal completion when mini lessons end
- test that XP goals are marked complete and removed

## Testing
- `git commit -m "feat: auto-complete XP goals on booster completion" && git status --short` *(tests fail: Dart/Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ad95e4894832abf0cdd6e9ce55912