### PR TITLE
Implement theory booster goal completion handler

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -13,6 +13,7 @@ import 'services/training_pack_service.dart';
 import 'services/service_registry.dart';
 import 'services/pack_library_loader_service.dart';
 import 'services/xp_goal_panel_booster_injector.dart';
+import 'services/theory_booster_goal_completion_handler.dart';
 import 'helpers/training_pack_storage.dart';
 import 'core/plugin_runtime.dart';
 import 'core/training/library/training_pack_library_v2.dart';
@@ -56,6 +57,7 @@ class AppBootstrap {
     }
     registry.registerIfAbsent<EvaluationExecutor>(EvaluationExecutorService());
     XpGoalPanelBoosterInjector.instance.inject();
+    TheoryBoosterGoalCompletionHandler.instance;
     _registry = registry;
     return registry;
   }

--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import '../models/theory_mini_lesson_node.dart';
 import '../services/recap_completion_tracker.dart';
 import '../services/theory_streak_service.dart';
+import '../services/mini_lesson_progress_tracker.dart';
 
 /// Simple viewer for a [TheoryMiniLessonNode].
 class MiniLessonScreen extends StatefulWidget {
@@ -28,6 +29,9 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
 
   @override
   void dispose() {
+    unawaited(
+      MiniLessonProgressTracker.instance.markCompleted(widget.lesson.id),
+    );
     final tag = widget.recapTag;
     if (tag != null) {
       final duration = DateTime.now().difference(_started);

--- a/lib/services/theory_booster_goal_completion_handler.dart
+++ b/lib/services/theory_booster_goal_completion_handler.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import '../models/xp_guided_goal.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'xp_goal_panel_controller.dart';
+
+/// Listens to mini lesson completions and resolves matching XP goals.
+class TheoryBoosterGoalCompletionHandler {
+  final MiniLessonProgressTracker tracker;
+  final XpGoalPanelController panel;
+
+  TheoryBoosterGoalCompletionHandler({
+    MiniLessonProgressTracker? tracker,
+    XpGoalPanelController? panel,
+  })  : tracker = tracker ?? MiniLessonProgressTracker.instance,
+        panel = panel ?? XpGoalPanelController.instance {
+    _sub = this.tracker.onLessonCompleted.listen(_handle);
+  }
+
+  static final TheoryBoosterGoalCompletionHandler instance =
+      TheoryBoosterGoalCompletionHandler();
+
+  StreamSubscription<String>? _sub;
+
+  /// Releases stream subscription resources.
+  void dispose() {
+    _sub?.cancel();
+  }
+
+  void _handle(String lessonId) {
+    final goals = List<XPGuidedGoal>.from(panel.goals);
+    for (final g in goals) {
+      if (g.id == lessonId) {
+        g.onComplete();
+        panel.removeGoal(lessonId);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TheoryBoosterGoalCompletionHandler to sync completed mini-lessons with XP goals
- mark mini-lessons as completed on screen exit
- initialize the goal completion handler during app bootstrap

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae53d7158832aa1f4653738055582