### PR TITLE
Implement booster goal completion handler

### DIFF
--- a/lib/services/theory_booster_goal_completion_handler.dart
+++ b/lib/services/theory_booster_goal_completion_handler.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import '../models/xp_guided_goal.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'xp_goal_panel_controller.dart';
+
+/// Handles completion of booster XP goals when a mini lesson is finished.
+class TheoryBoosterGoalCompletionHandler {
+  final MiniLessonProgressTracker progress;
+  final XpGoalPanelController panel;
+
+  TheoryBoosterGoalCompletionHandler({
+    MiniLessonProgressTracker? progress,
+    XpGoalPanelController? panel,
+  })  : progress = progress ?? MiniLessonProgressTracker.instance,
+        panel = panel ?? XpGoalPanelController.instance {
+    _sub = this.progress.onLessonCompleted.listen(_handle);
+  }
+
+  static final TheoryBoosterGoalCompletionHandler instance =
+      TheoryBoosterGoalCompletionHandler();
+
+  StreamSubscription<String>? _sub;
+
+  void dispose() {
+    _sub?.cancel();
+  }
+
+  void _handle(String lessonId) {
+    final goals = List<XPGuidedGoal>.from(panel.goals);
+    for (final g in goals) {
+      if (g.id == lessonId) {
+        g.onComplete();
+        panel.removeGoal(lessonId);
+        break;
+      }
+    }
+  }
+}

--- a/test/services/theory_booster_goal_completion_handler_test.dart
+++ b/test/services/theory_booster_goal_completion_handler_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/xp_guided_goal.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_booster_goal_completion_handler.dart';
+import 'package:poker_analyzer/services/xp_goal_panel_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('completes matching goal when lesson completed', () async {
+    final panel = XpGoalPanelController();
+    bool completed = false;
+    panel.addGoal(
+      XPGuidedGoal(
+        id: 'l1',
+        label: 'L1',
+        xp: 25,
+        source: 'booster',
+        onComplete: () => completed = true,
+      ),
+    );
+
+    final handler = TheoryBoosterGoalCompletionHandler(
+      progress: MiniLessonProgressTracker.instance,
+      panel: panel,
+    );
+
+    await MiniLessonProgressTracker.instance.markCompleted('l1');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completed, isTrue);
+    expect(panel.goals, isEmpty);
+    handler.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryBoosterGoalCompletionHandler` to observe mini-lesson completions
- create tests for new handler

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/theory_booster_goal_completion_handler_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af11dff40832a8964a9582b18f594