### PR TITLE
Implement SkillDecayTagFilter

### DIFF
--- a/lib/services/skill_decay_tag_filter.dart
+++ b/lib/services/skill_decay_tag_filter.dart
@@ -1,0 +1,55 @@
+import 'mini_lesson_library_service.dart';
+import 'recap_booster_queue.dart';
+import 'goal_queue.dart';
+import 'tag_mastery_history_service.dart';
+
+/// Filters out tags that were recently reinforced or are already queued.
+class SkillDecayTagFilter {
+  final TagMasteryHistoryService history;
+  final MiniLessonLibraryService lessons;
+  final RecapBoosterQueue recapQueue;
+  final GoalQueue goalQueue;
+  final Duration recent;
+
+  SkillDecayTagFilter({
+    required this.history,
+    MiniLessonLibraryService? lessons,
+    RecapBoosterQueue? recapQueue,
+    GoalQueue? goalQueue,
+    this.recent = const Duration(days: 3),
+  })  : lessons = lessons ?? MiniLessonLibraryService.instance,
+        recapQueue = recapQueue ?? RecapBoosterQueue.instance,
+        goalQueue = goalQueue ?? GoalQueue.instance;
+
+  /// Returns [tags] excluding those recently reinforced or already queued.
+  Future<List<String>> filter(List<String> tags, {DateTime? now}) async {
+    if (tags.isEmpty) return [];
+    await lessons.loadAll();
+    final current = now ?? DateTime.now();
+    final hist = await history.getHistory();
+
+    // Collect queued tags from recap and goal queues.
+    final queued = <String>{};
+    for (final id in recapQueue.getQueue()) {
+      final lesson = lessons.getById(id);
+      if (lesson != null) {
+        queued.addAll(lesson.tags.map((e) => e.toLowerCase()));
+      }
+    }
+    for (final lesson in goalQueue.getQueue()) {
+      queued.addAll(lesson.tags.map((e) => e.toLowerCase()));
+    }
+
+    final result = <String>[];
+    for (final t in tags) {
+      final tag = t.toLowerCase();
+      final entries = hist[tag];
+      final last = entries == null || entries.isEmpty ? null : entries.last.date;
+      final recentlyReinforced =
+          last != null && current.difference(last) < recent;
+      if (recentlyReinforced || queued.contains(tag)) continue;
+      result.add(tag);
+    }
+    return result;
+  }
+}

--- a/test/services/skill_decay_tag_filter_test.dart
+++ b/test/services/skill_decay_tag_filter_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/tag_xp_history_entry.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/goal_queue.dart';
+import 'package:poker_analyzer/services/recap_booster_queue.dart';
+import 'package:poker_analyzer/services/skill_decay_tag_filter.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeHistoryService extends TagMasteryHistoryService {
+  final Map<String, List<TagXpHistoryEntry>> map;
+  _FakeHistoryService(this.map);
+  @override
+  Future<Map<String, List<TagXpHistoryEntry>>> getHistory() async => map;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    return [
+      for (final l in lessons)
+        if (l.tags.any((t) => tags.contains(t))) l
+    ];
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    RecapBoosterQueue.instance.clear();
+    GoalQueue.instance.clear();
+  });
+
+  test('filters queued or recently reinforced tags', () async {
+    final now = DateTime(2024, 1, 10);
+    final lessons = [
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'A',
+        content: '',
+        tags: ['push'],
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'B',
+        content: '',
+        tags: ['call'],
+      ),
+    ];
+
+    final history = _FakeHistoryService({
+      'push': [TagXpHistoryEntry(date: now.subtract(const Duration(days: 10)), xp: 5, source: '')],
+      'call': [TagXpHistoryEntry(date: now.subtract(const Duration(days: 10)), xp: 5, source: '')],
+      'fold': [TagXpHistoryEntry(date: now.subtract(const Duration(days: 2)), xp: 5, source: '')],
+      'bluff': [TagXpHistoryEntry(date: now.subtract(const Duration(days: 5)), xp: 5, source: '')],
+    });
+
+    final filter = SkillDecayTagFilter(
+      history: history,
+      lessons: _FakeLibrary(lessons),
+      recapQueue: RecapBoosterQueue.instance,
+      goalQueue: GoalQueue.instance,
+    );
+
+    await RecapBoosterQueue.instance.add('l1');
+    GoalQueue.instance.push(lessons[1]);
+
+    final result = await filter.filter(['push', 'call', 'fold', 'bluff'], now: now);
+    expect(result, ['bluff']);
+  });
+}


### PR DESCRIPTION
## Summary
- add a service to filter decayed tags based on reinforcement history and existing queues
- unit test SkillDecayTagFilter

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aff9e98b8832a84aea3a917ec9aa0