### PR TITLE
Implement SkillGapDetectorService

### DIFF
--- a/lib/services/skill_gap_detector_service.dart
+++ b/lib/services/skill_gap_detector_service.dart
@@ -1,0 +1,54 @@
+import 'mini_lesson_library_service.dart';
+import 'tag_mastery_history_service.dart';
+
+/// Detects theory tags that lack reinforcement in user history.
+class SkillGapDetectorService {
+  final TagMasteryHistoryService history;
+  final MiniLessonLibraryService library;
+
+  SkillGapDetectorService({
+    TagMasteryHistoryService? history,
+    MiniLessonLibraryService? library,
+  })  : history = history ?? TagMasteryHistoryService(),
+        library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns tags never reinforced or in the bottom [threshold] fraction
+  /// of total XP across all tags.
+  Future<List<String>> getMissingTags({double threshold = 0.1}) async {
+    if (threshold < 0) threshold = 0;
+    await library.loadAll();
+    final hist = await history.getHistory();
+    final allTags = <String>{};
+    for (final l in library.all) {
+      for (final t in l.tags) {
+        final tag = t.trim().toLowerCase();
+        if (tag.isNotEmpty) allTags.add(tag);
+      }
+    }
+
+    final missing = <String>[];
+    final totals = <String, int>{};
+    for (final tag in allTags) {
+      final entries = hist[tag];
+      if (entries == null || entries.isEmpty) {
+        missing.add(tag);
+      } else {
+        final xp = entries.fold<int>(0, (sum, e) => sum + e.xp);
+        totals[tag] = xp;
+      }
+    }
+
+    if (totals.isNotEmpty && threshold > 0) {
+      final list = totals.entries.toList()
+        ..sort((a, b) => a.value.compareTo(b.value));
+      var count = (list.length * threshold).ceil();
+      if (count <= 0) count = 1;
+      for (final e in list.take(count)) {
+        if (!missing.contains(e.key)) missing.add(e.key);
+      }
+    }
+
+    return missing;
+  }
+}
+

--- a/test/services/skill_gap_detector_service_test.dart
+++ b/test/services/skill_gap_detector_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/tag_xp_history_entry.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/skill_gap_detector_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_history_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeHistoryService extends TagMasteryHistoryService {
+  final Map<String, List<TagXpHistoryEntry>> map;
+  _FakeHistoryService(this.map);
+  @override
+  Future<Map<String, List<TagXpHistoryEntry>>> getHistory() async => map;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('detects untrained and low-exposure tags', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['push']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['call']),
+      const TheoryMiniLessonNode(id: 'l3', title: 'C', content: '', tags: ['fold']),
+    ];
+
+    final history = _FakeHistoryService({
+      'push': [TagXpHistoryEntry(date: DateTime.now(), xp: 100, source: '')],
+      'call': [TagXpHistoryEntry(date: DateTime.now(), xp: 5, source: '')],
+    });
+
+    final service = SkillGapDetectorService(
+      history: history,
+      library: _FakeLibrary(lessons),
+    );
+
+    final result = await service.getMissingTags(threshold: 0.5);
+    expect(result, contains('fold')); // never reinforced
+    expect(result, contains('call')); // bottom 50%
+    expect(result, isNot(contains('push')));
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillGapDetectorService` for detecting untrained or underexposed theory tags
- create accompanying unit test

## Testing
- `flutter analyze` *(fails: Package file_picker missing inline implementation)*
- `flutter test test/services/skill_gap_detector_service_test.dart` *(fails: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688b01411050832aa15d1a344ea713e8