### PR TITLE
Add SmartSkillGapBoosterEngine

### DIFF
--- a/lib/services/smart_skill_gap_booster_engine.dart
+++ b/lib/services/smart_skill_gap_booster_engine.dart
@@ -1,0 +1,68 @@
+import 'mini_lesson_library_service.dart';
+import 'skill_gap_detector_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Generates theory mini lesson boosters targeting missing or undertrained tags.
+class SmartSkillGapBoosterEngine {
+  final SkillGapDetectorService detector;
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+
+  const SmartSkillGapBoosterEngine({
+    SkillGapDetectorService? detector,
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+  })  : detector = detector ?? SkillGapDetectorService(),
+        library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance;
+
+  /// Returns up to [max] mini lessons that fill skill gaps.
+  Future<List<TheoryMiniLessonNode>> recommend({int max = 3}) async {
+    if (max <= 0) return [];
+    final tags = await detector.getMissingTags();
+    if (tags.isEmpty) return [];
+
+    final tagSet = {
+      for (final t in tags) t.trim().toLowerCase()
+    }..removeWhere((t) => t.isEmpty);
+    if (tagSet.isEmpty) return [];
+
+    await library.loadAll();
+    final lessons = library.getByTags(tagSet);
+    if (lessons.isEmpty) return [];
+
+    final scored = <_Entry>[];
+    for (final l in lessons) {
+      final lessonTags = {
+        for (final t in l.tags) t.trim().toLowerCase()
+      };
+      final overlap = lessonTags.intersection(tagSet);
+      if (overlap.isEmpty) continue;
+      final views = await progress.viewCount(l.id);
+      final score = overlap.length * 10 - views;
+      scored.add(_Entry(l, score, overlap));
+    }
+    if (scored.isEmpty) return [];
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+
+    final result = <TheoryMiniLessonNode>[];
+    final covered = <String>{};
+    for (final e in scored) {
+      if (result.length >= max) break;
+      final uncovered = e.tags.difference(covered);
+      if (uncovered.isEmpty) continue;
+      result.add(e.lesson);
+      covered.addAll(uncovered);
+    }
+    return result;
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final double score;
+  final Set<String> tags;
+  _Entry(this.lesson, this.score, this.tags);
+}

--- a/test/services/smart_skill_gap_booster_engine_test.dart
+++ b/test/services/smart_skill_gap_booster_engine_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/smart_skill_gap_booster_engine.dart';
+import 'package:poker_analyzer/services/skill_gap_detector_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+
+class _FakeDetector extends SkillGapDetectorService {
+  final List<String> tags;
+  _FakeDetector(this.tags);
+  @override
+  Future<List<String>> getMissingTags({double threshold = 0.1}) async => tags;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      [for (final t in tags) ...lessons.where((l) => l.tags.contains(t))];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('recommend returns lessons covering missing tags', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['push']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['call']),
+      const TheoryMiniLessonNode(id: 'l3', title: 'C', content: '', tags: ['push', 'call']),
+    ];
+    final engine = SmartSkillGapBoosterEngine(
+      detector: _FakeDetector(['push', 'call']),
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+    );
+
+    final result = await engine.recommend(max: 2);
+    expect(result.map((e) => e.id).toList(), ['l3']);
+  });
+
+  test('deduplicates by tag and prefers less viewed lessons', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['push']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['call']),
+      const TheoryMiniLessonNode(id: 'l3', title: 'C', content: '', tags: ['push']),
+    ];
+    await MiniLessonProgressTracker.instance.markViewed('l1');
+
+    final engine = SmartSkillGapBoosterEngine(
+      detector: _FakeDetector(['push', 'call']),
+      library: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+    );
+
+    final result = await engine.recommend(max: 2);
+    expect(result.map((e) => e.id).toList(), ['l2', 'l3']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SmartSkillGapBoosterEngine` that recommends mini lessons for missing tags
- unit tests for `SmartSkillGapBoosterEngine`

## Testing
- `flutter test test/services/smart_skill_gap_booster_engine_test.dart` *(fails: command not found)*
- `dart test test/services/smart_skill_gap_booster_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b03c44f74832aa7f948006d6de514