### PR TITLE
Add skill gap overlay banner

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -127,6 +127,7 @@ import 'services/theory_inbox_banner_controller.dart';
 import 'services/smart_recap_banner_reinjection_service.dart';
 import 'services/recap_to_drill_launcher.dart';
 import 'services/smart_booster_unlock_scheduler.dart';
+import 'services/overlay_booster_manager.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -621,6 +622,9 @@ List<SingleChildWidget> buildTrainingProviders() {
         banner: context.read<SmartRecapBannerController>(),
         sessions: context.read<TrainingSessionService>(),
       ),
+    ),
+    Provider(
+      create: (_) => OverlayBoosterManager()..start(),
     ),
   ];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'services/training_pack_stats_service.dart';
 import 'services/learning_path_summary_cache.dart';
 import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
+import 'services/overlay_booster_manager.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
 import 'services/app_init_service.dart';
@@ -236,6 +237,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
       sessions: context.read<TrainingSessionService>(),
     ));
     unawaited(context.read<SkillLossOverlayPromptService>().run(context));
+    unawaited(context.read<OverlayBoosterManager>().onAfterXpScreen());
     unawaited(
       TheoryLessonNotificationScheduler.instance.scheduleReminderIfNeeded(),
     );

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -42,6 +42,7 @@ import '../widgets/mistake_review_button.dart';
 import '../services/streak_tracker_service.dart';
 import '../services/streak_milestone_queue_service.dart';
 import '../widgets/confetti_overlay.dart';
+import '../services/overlay_booster_manager.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -142,6 +143,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       await NextStepSuggestionDialog.show(context);
       await StreakMilestoneQueueService.instance
           .showNextMilestoneCelebrationIfAny(context);
+      await context.read<OverlayBoosterManager>().onAfterXpScreen();
     });
     _loadWeakPack();
   }

--- a/lib/widgets/skill_gap_overlay_banner.dart
+++ b/lib/widgets/skill_gap_overlay_banner.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// Small overlay banner prompting the user to learn high priority theory gaps.
+class SkillGapOverlayBanner extends StatefulWidget {
+  final List<String> tags;
+  final VoidCallback onDismiss;
+  final VoidCallback onOpen;
+
+  const SkillGapOverlayBanner({
+    super.key,
+    required this.tags,
+    required this.onDismiss,
+    required this.onOpen,
+  });
+
+  @override
+  State<SkillGapOverlayBanner> createState() => _SkillGapOverlayBannerState();
+}
+
+class _SkillGapOverlayBannerState extends State<SkillGapOverlayBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+    Future.delayed(const Duration(seconds: 15), widget.onDismiss);
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final text = widget.tags.take(2).join(', ');
+    return Positioned(
+      bottom: 20,
+      left: 16,
+      right: 16,
+      child: SafeArea(
+        child: FadeTransition(
+          opacity: _anim,
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '🎯 Усильте незакрытую тему: $text',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: widget.onOpen,
+                    style:
+                        ElevatedButton.styleFrom(backgroundColor: accent),
+                    child: const Text('Пройти бустер'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a new `SkillGapOverlayBanner` overlay when theory gaps are detected
- handle scheduling via new `OverlayBoosterManager`
- trigger skill gap booster checks on app resume and after training summary
- wire manager through providers and main initialization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b053f2e28832a91400366bd702199