### PR TITLE
Add overlay reminders for unlaunched boosters

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -128,6 +128,7 @@ import 'services/smart_recap_banner_reinjection_service.dart';
 import 'services/recap_to_drill_launcher.dart';
 import 'services/smart_booster_unlock_scheduler.dart';
 import 'services/overlay_booster_manager.dart';
+import 'services/theory_recall_overlay_scheduler.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -625,6 +626,9 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(
       create: (_) => OverlayBoosterManager()..start(),
+    ),
+    Provider(
+      create: (_) => TheoryRecallOverlayScheduler()..start(),
     ),
   ];
 }

--- a/lib/widgets/theory_recall_overlay_banner.dart
+++ b/lib/widgets/theory_recall_overlay_banner.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+/// Overlay banner nudging user to complete an unlaunched booster.
+class TheoryRecallOverlayBanner extends StatefulWidget {
+  final String title;
+  final VoidCallback onDismiss;
+  final VoidCallback onOpen;
+
+  const TheoryRecallOverlayBanner({
+    super.key,
+    required this.title,
+    required this.onDismiss,
+    required this.onOpen,
+  });
+
+  @override
+  State<TheoryRecallOverlayBanner> createState() => _TheoryRecallOverlayBannerState();
+}
+
+class _TheoryRecallOverlayBannerState extends State<TheoryRecallOverlayBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+    Future.delayed(const Duration(seconds: 15), widget.onDismiss);
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Positioned(
+      bottom: 20,
+      left: 16,
+      right: 16,
+      child: SafeArea(
+        child: FadeTransition(
+          opacity: _anim,
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey[850],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Завершите начатое: ${widget.title}',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: widget.onOpen,
+                    style: ElevatedButton.styleFrom(backgroundColor: accent),
+                    child: const Text('Открыть'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryRecallOverlayBanner` widget
- implement `TheoryRecallOverlayScheduler` to surface unlaunched boosters
- expose `isShowing` on `OverlayBoosterManager`
- wire up scheduler in `app_providers`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688b1739cfec832aae6468d71293f9a1