### PR TITLE
Implement theory priority gatekeeper

### DIFF
--- a/lib/services/smart_booster_unlocker.dart
+++ b/lib/services/smart_booster_unlocker.dart
@@ -5,6 +5,7 @@ import 'mini_lesson_library_service.dart';
 import 'tag_mastery_service.dart';
 import 'recap_booster_queue.dart';
 import 'goal_queue.dart';
+import 'theory_priority_gatekeeper_service.dart';
 
 /// Schedules theory boosters based on recent mistakes and weak tags.
 class SmartBoosterUnlocker {
@@ -60,6 +61,10 @@ class SmartBoosterUnlocker {
       int added = 0;
       for (final lesson in lessonList) {
         if (!used.add(lesson.id)) continue;
+        if (await TheoryPriorityGatekeeperService.instance
+            .isBlocked(lesson.id)) {
+          continue;
+        }
         if (urgent) {
           await recapQueue.add(lesson.id);
         } else {

--- a/lib/services/smart_recap_auto_injector.dart
+++ b/lib/services/smart_recap_auto_injector.dart
@@ -7,6 +7,7 @@ import 'recap_opportunity_detector.dart';
 import 'smart_theory_recap_engine.dart';
 import 'theory_recap_suppression_engine.dart';
 import 'smart_theory_recap_dismissal_memory.dart';
+import 'theory_priority_gatekeeper_service.dart';
 
 /// Automatically shows recap dialogs at ideal moments without user interaction.
 class SmartRecapAutoInjector {
@@ -70,6 +71,10 @@ class SmartRecapAutoInjector {
     }
     final lesson = await engine.getNextRecap();
     if (lesson == null) return;
+    if (await TheoryPriorityGatekeeperService.instance
+        .isBlocked(lesson.id)) {
+      return;
+    }
     if (await suppression.shouldSuppress(
       lessonId: lesson.id,
       trigger: 'autoInject',

--- a/lib/services/theory_priority_gatekeeper_service.dart
+++ b/lib/services/theory_priority_gatekeeper_service.dart
@@ -1,0 +1,105 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'recap_booster_queue.dart';
+import 'inbox_booster_tracker_service.dart';
+import 'goal_queue.dart';
+import 'theory_booster_recall_engine.dart';
+import 'smart_skill_gap_booster_engine.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'learning_graph_engine.dart';
+import 'learning_path_stage_library.dart';
+import 'theory_stage_progress_tracker.dart';
+import '../models/stage_type.dart';
+import '../models/learning_path_node.dart';
+import 'path_map_engine.dart';
+
+/// Blocks low priority theory boosters when higher priority content is pending.
+class TheoryPriorityGatekeeperService {
+  final RecapBoosterQueue recapQueue;
+  final InboxBoosterTrackerService inboxQueue;
+  final GoalQueue goalQueue;
+  final TheoryBoosterRecallEngine recall;
+  final SmartSkillGapBoosterEngine skillGap;
+  final LearningPathEngine path;
+
+  TheoryPriorityGatekeeperService({
+    RecapBoosterQueue? recapQueue,
+    InboxBoosterTrackerService? inboxQueue,
+    GoalQueue? goalQueue,
+    TheoryBoosterRecallEngine? recall,
+    SmartSkillGapBoosterEngine? skillGap,
+    LearningPathEngine? path,
+  })  : recapQueue = recapQueue ?? RecapBoosterQueue.instance,
+        inboxQueue = inboxQueue ?? InboxBoosterTrackerService.instance,
+        goalQueue = goalQueue ?? GoalQueue.instance,
+        recall = recall ?? TheoryBoosterRecallEngine.instance,
+        skillGap = skillGap ?? const SmartSkillGapBoosterEngine(),
+        path = path ?? LearningPathEngine.instance;
+
+  static final TheoryPriorityGatekeeperService instance =
+      TheoryPriorityGatekeeperService();
+
+  final List<String> _reasons = <String>[];
+
+  /// Reasons why the last call to [isBlocked] returned true.
+  List<String> getBlockingReasons() => List.unmodifiable(_reasons);
+
+  /// Returns `true` if [lessonId] should not be injected because higher
+  /// priority content is pending. Set [force] to bypass the check.
+  Future<bool> isBlocked(String lessonId, {bool force = false}) async {
+    _reasons.clear();
+    if (force) return false;
+
+    // Matching lesson already queued.
+    final queued = <String>{
+      ...recapQueue.getQueue(),
+      ...(await inboxQueue.getInbox()),
+      for (final l in goalQueue.getQueue()) l.id,
+    };
+    if (queued.contains(lessonId)) {
+      _reasons.add('alreadyQueued');
+      return true;
+    }
+
+    // Recall boosters waiting to be completed.
+    final recallLessons = await recall.recallUnlaunched();
+    if (recallLessons.isNotEmpty) {
+      _reasons.add('recallPending');
+    }
+
+    // Pending weak skill boosters.
+    final weak = await skillGap.recommend(max: 1);
+    if (weak.isNotEmpty) {
+      final id = weak.first.id;
+      if (!await MiniLessonProgressTracker.instance.isCompleted(id)) {
+        if (id != lessonId) {
+          _reasons.add('weakSkillPending');
+        }
+      }
+    }
+
+    // Uncompleted theory in the current path stage.
+    if (await _hasUnlockedTheory()) {
+      _reasons.add('stageTheoryPending');
+    }
+
+    return _reasons.isNotEmpty;
+  }
+
+  Future<bool> _hasUnlockedTheory() async {
+    final node = path.getCurrentNode();
+    if (node == null) return false;
+    if (node is TheoryLessonNode || node is TheoryMiniLessonNode) return true;
+    if (node is TheoryStageNode) return true;
+    if (node is TrainingStageNode) {
+      final stage = LearningPathStageLibrary.instance.getById(node.id);
+      if (stage == null) return false;
+      if (stage.type == StageType.theory) return true;
+      if (stage.theoryPackId != null) {
+        final completed = await TheoryStageProgressTracker.instance
+            .isCompleted(stage.id);
+        return !completed;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add TheoryPriorityGatekeeperService to block low-priority theory boosters
- gate recap auto injection through the new service
- gate smart booster unlocker with the priority service

## Testing
- `dart --version`
- `flutter --version`
- `dart analyze` *(failed: file picker plugin warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688b1c5c65a0832a8b0d7c3a03c3cd30