### PR TITLE
Implement BoosterQueuePressureMonitor

### DIFF
--- a/lib/services/booster_queue_pressure_monitor.dart
+++ b/lib/services/booster_queue_pressure_monitor.dart
@@ -1,0 +1,60 @@
+import 'recap_booster_queue.dart';
+import 'goal_queue.dart';
+import 'inbox_booster_tracker_service.dart';
+import 'smart_skill_gap_booster_engine.dart';
+
+/// Analyzes current booster queues to detect overload situations.
+class BoosterQueuePressureMonitor {
+  final RecapBoosterQueue recapQueue;
+  final GoalQueue goalQueue;
+  final InboxBoosterTrackerService inboxQueue;
+  final SmartSkillGapBoosterEngine skillGap;
+
+  /// Maximum queue sizes used for pressure normalization.
+  final int maxRecap;
+  final int maxGoal;
+  final int maxInbox;
+  final int maxSkillGap;
+
+  BoosterQueuePressureMonitor({
+    RecapBoosterQueue? recapQueue,
+    GoalQueue? goalQueue,
+    InboxBoosterTrackerService? inboxQueue,
+    SmartSkillGapBoosterEngine? skillGap,
+    this.maxRecap = 3,
+    this.maxGoal = 5,
+    this.maxInbox = 5,
+    this.maxSkillGap = 3,
+  })  : recapQueue = recapQueue ?? RecapBoosterQueue.instance,
+        goalQueue = goalQueue ?? GoalQueue.instance,
+        inboxQueue = inboxQueue ?? InboxBoosterTrackerService.instance,
+        skillGap = skillGap ?? const SmartSkillGapBoosterEngine();
+
+  static final BoosterQueuePressureMonitor instance =
+      BoosterQueuePressureMonitor();
+
+  /// Computes a normalized pressure score in the range [0.0, 1.0].
+  Future<double> computeScore() async {
+    final recapLen = recapQueue.getQueue().length;
+    final goalLen = goalQueue.getQueue().length;
+    final inboxLen = (await inboxQueue.getInbox()).length;
+    final gapLen = (await skillGap.recommend(max: maxSkillGap)).length;
+
+    final recapScore = recapLen / maxRecap;
+    final goalScore = goalLen / maxGoal;
+    final inboxScore = inboxLen / maxInbox;
+    final gapScore = gapLen / maxSkillGap;
+
+    final score =
+        (recapScore + goalScore + inboxScore + gapScore) / 4.0;
+    if (score < 0) return 0.0;
+    if (score > 1) return 1.0;
+    return score;
+  }
+
+  /// Returns `true` if the combined queue pressure exceeds [threshold].
+  Future<bool> isOverloaded({double threshold = 0.85}) async {
+    final score = await computeScore();
+    return score >= threshold;
+  }
+}

--- a/lib/services/overlay_booster_manager.dart
+++ b/lib/services/overlay_booster_manager.dart
@@ -7,6 +7,7 @@ import 'smart_skill_gap_booster_engine.dart';
 import '../screens/mini_lesson_screen.dart';
 import 'theory_booster_recall_engine.dart';
 import 'user_action_logger.dart';
+import 'booster_queue_pressure_monitor.dart';
 
 /// Schedules and displays [SkillGapOverlayBanner] when major theory gaps exist.
 class OverlayBoosterManager with WidgetsBindingObserver {
@@ -54,6 +55,7 @@ class OverlayBoosterManager with WidgetsBindingObserver {
 
   Future<void> _check() async {
     if (_checking || _anotherOverlayActive()) return;
+    if (await BoosterQueuePressureMonitor.instance.isOverloaded()) return;
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
     if (DateTime.now().difference(_lastShown) < cooldown) return;

--- a/lib/services/smart_booster_injector.dart
+++ b/lib/services/smart_booster_injector.dart
@@ -5,6 +5,7 @@ import 'booster_slot_allocator.dart';
 import 'recap_booster_queue.dart';
 import 'inbox_booster_tracker_service.dart';
 import 'goal_queue.dart';
+import 'booster_queue_pressure_monitor.dart';
 
 /// Injects theory boosters into recap, inbox, or goal queues after training spots.
 class SmartBoosterInjector {
@@ -33,6 +34,7 @@ class SmartBoosterInjector {
     TrainingSpotV2 completedSpot,
     List<TheoryMiniLessonNode> candidateBoosters,
   ) async {
+    if (await BoosterQueuePressureMonitor.instance.isOverloaded()) return;
     if (candidateBoosters.isEmpty) return;
     final ranked = await recall.rank(candidateBoosters, completedSpot);
     for (final lesson in ranked) {

--- a/lib/services/smart_booster_unlocker.dart
+++ b/lib/services/smart_booster_unlocker.dart
@@ -6,6 +6,7 @@ import 'tag_mastery_service.dart';
 import 'recap_booster_queue.dart';
 import 'goal_queue.dart';
 import 'theory_priority_gatekeeper_service.dart';
+import 'booster_queue_pressure_monitor.dart';
 
 /// Schedules theory boosters based on recent mistakes and weak tags.
 class SmartBoosterUnlocker {
@@ -32,6 +33,7 @@ class SmartBoosterUnlocker {
 
   /// Analyzes recent mistakes and mastery to enqueue targeted boosters.
   Future<void> schedule() async {
+    if (await BoosterQueuePressureMonitor.instance.isOverloaded()) return;
     await lessons.loadAll();
     final recent = await _history(limit: mistakeLimit);
     if (recent.isEmpty) return;

--- a/lib/services/smart_recap_auto_injector.dart
+++ b/lib/services/smart_recap_auto_injector.dart
@@ -8,6 +8,7 @@ import 'smart_theory_recap_engine.dart';
 import 'theory_recap_suppression_engine.dart';
 import 'smart_theory_recap_dismissal_memory.dart';
 import 'theory_priority_gatekeeper_service.dart';
+import 'booster_queue_pressure_monitor.dart';
 
 /// Automatically shows recap dialogs at ideal moments without user interaction.
 class SmartRecapAutoInjector {
@@ -62,6 +63,7 @@ class SmartRecapAutoInjector {
 
   /// Checks for recap opportunity and shows dialog if suitable.
   Future<void> maybeInject() async {
+    if (await BoosterQueuePressureMonitor.instance.isOverloaded()) return;
     if (!await detector.isGoodRecapMoment()) return;
     if (await _recentlyDismissed()) return;
     final last = await _lastInjected();

--- a/test/services/booster_queue_pressure_monitor_test.dart
+++ b/test/services/booster_queue_pressure_monitor_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/booster_queue_pressure_monitor.dart';
+import 'package:poker_analyzer/services/recap_booster_queue.dart';
+import 'package:poker_analyzer/services/goal_queue.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/smart_skill_gap_booster_engine.dart';
+
+class _FakeSkillGapEngine extends SmartSkillGapBoosterEngine {
+  final int count;
+  const _FakeSkillGapEngine(this.count);
+  @override
+  Future<List<TheoryMiniLessonNode>> recommend({int max = 3}) async {
+    final c = count < max ? count : max;
+    return [
+      for (var i = 0; i < c; i++)
+        const TheoryMiniLessonNode(id: 'l', title: 't', content: '', tags: [])
+    ];
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    RecapBoosterQueue.instance.clear();
+    GoalQueue.instance.clear();
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  test('pressure score accounts for queue sizes', () async {
+    await RecapBoosterQueue.instance.add('a1');
+    GoalQueue.instance.push(const TheoryMiniLessonNode(id: 'g1', title: 't', content: '', tags: []));
+    await InboxBoosterTrackerService.instance.addToInbox('i1');
+
+    final monitor = BoosterQueuePressureMonitor(
+      recapQueue: RecapBoosterQueue.instance,
+      goalQueue: GoalQueue.instance,
+      inboxQueue: InboxBoosterTrackerService.instance,
+      skillGap: const _FakeSkillGapEngine(2),
+    );
+    final score = await monitor.computeScore();
+    expect(score, greaterThan(0.0));
+    expect(await monitor.isOverloaded(threshold: score - 0.01), true);
+  });
+}


### PR DESCRIPTION
## Summary
- create `BoosterQueuePressureMonitor` to detect overload based on booster queues
- gate recap, mistake and skill-gap injections on overload
- test queue pressure computation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b21694428832a972bd69d99c262da