### PR TITLE
Implement TheoryInjectionHorizonService

### DIFF
--- a/lib/services/overlay_booster_manager.dart
+++ b/lib/services/overlay_booster_manager.dart
@@ -8,6 +8,7 @@ import '../screens/mini_lesson_screen.dart';
 import 'theory_booster_recall_engine.dart';
 import 'user_action_logger.dart';
 import 'booster_queue_pressure_monitor.dart';
+import 'theory_injection_horizon_service.dart';
 
 /// Schedules and displays [SkillGapOverlayBanner] when major theory gaps exist.
 class OverlayBoosterManager with WidgetsBindingObserver {
@@ -58,7 +59,12 @@ class OverlayBoosterManager with WidgetsBindingObserver {
     if (await BoosterQueuePressureMonitor.instance.isOverloaded()) return;
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
-    if (DateTime.now().difference(_lastShown) < cooldown) return;
+    if (!await TheoryInjectionHorizonService.instance.canInject(
+      'skill_gap',
+      minGap: cooldown,
+    )) {
+      return;
+    }
     _checking = true;
     try {
       final lessons = await engine.recommend(max: 1);
@@ -70,13 +76,16 @@ class OverlayBoosterManager with WidgetsBindingObserver {
       Future<void> open() async {
         _remove();
         await TheoryBoosterRecallEngine.instance.recordLaunch(lesson.id);
-        await UserActionLogger.instance
-            .logEvent({'event': 'skill_gap_overlay.open', 'lesson': lesson.id});
+        await UserActionLogger.instance.logEvent({
+          'event': 'skill_gap_overlay.open',
+          'lesson': lesson.id,
+        });
         await Navigator.push(
           ctx,
           MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
         );
       }
+
       _entry = OverlayEntry(
         builder: (_) => SkillGapOverlayBanner(
           tags: lesson.tags,
@@ -86,9 +95,12 @@ class OverlayBoosterManager with WidgetsBindingObserver {
       );
       overlay.insert(_entry!);
       await TheoryBoosterRecallEngine.instance.recordSuggestion(lesson.id);
-      await UserActionLogger.instance
-          .logEvent({'event': 'skill_gap_overlay.shown', 'lesson': lesson.id});
+      await UserActionLogger.instance.logEvent({
+        'event': 'skill_gap_overlay.shown',
+        'lesson': lesson.id,
+      });
       _lastShown = DateTime.now();
+      await TheoryInjectionHorizonService.instance.markInjected('skill_gap');
     } finally {
       _checking = false;
     }

--- a/lib/services/smart_booster_injector.dart
+++ b/lib/services/smart_booster_injector.dart
@@ -6,6 +6,7 @@ import 'recap_booster_queue.dart';
 import 'inbox_booster_tracker_service.dart';
 import 'goal_queue.dart';
 import 'booster_queue_pressure_monitor.dart';
+import 'theory_injection_horizon_service.dart';
 
 /// Injects theory boosters into recap, inbox, or goal queues after training spots.
 class SmartBoosterInjector {
@@ -21,11 +22,11 @@ class SmartBoosterInjector {
     RecapBoosterQueue? recapQueue,
     InboxBoosterTrackerService? inboxTracker,
     GoalQueue? goalQueue,
-  })  : recall = recall ?? const TheoryRecallEvaluator(),
-        allocator = allocator ?? BoosterSlotAllocator.instance,
-        recapQueue = recapQueue ?? RecapBoosterQueue.instance,
-        inboxTracker = inboxTracker ?? InboxBoosterTrackerService.instance,
-        goalQueue = goalQueue ?? GoalQueue.instance;
+  }) : recall = recall ?? const TheoryRecallEvaluator(),
+       allocator = allocator ?? BoosterSlotAllocator.instance,
+       recapQueue = recapQueue ?? RecapBoosterQueue.instance,
+       inboxTracker = inboxTracker ?? InboxBoosterTrackerService.instance,
+       goalQueue = goalQueue ?? GoalQueue.instance;
 
   static final SmartBoosterInjector instance = SmartBoosterInjector();
 
@@ -40,14 +41,23 @@ class SmartBoosterInjector {
     for (final lesson in ranked) {
       final slot = await allocator.decideSlot(lesson, completedSpot);
       if (slot == BoosterSlot.recap) {
-        await recapQueue.add(lesson.id);
-        break;
+        if (await TheoryInjectionHorizonService.instance.canInject('recap')) {
+          await recapQueue.add(lesson.id);
+          await TheoryInjectionHorizonService.instance.markInjected('recap');
+          break;
+        }
       } else if (slot == BoosterSlot.inbox) {
-        await inboxTracker.addToInbox(lesson.id);
-        break;
+        if (await TheoryInjectionHorizonService.instance.canInject('inbox')) {
+          await inboxTracker.addToInbox(lesson.id);
+          await TheoryInjectionHorizonService.instance.markInjected('inbox');
+          break;
+        }
       } else if (slot == BoosterSlot.goal) {
-        goalQueue.push(lesson);
-        break;
+        if (await TheoryInjectionHorizonService.instance.canInject('goal')) {
+          goalQueue.push(lesson);
+          await TheoryInjectionHorizonService.instance.markInjected('goal');
+          break;
+        }
       }
     }
   }

--- a/lib/services/theory_injection_horizon_service.dart
+++ b/lib/services/theory_injection_horizon_service.dart
@@ -1,0 +1,39 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Enforces minimum delay between theory booster injections.
+class TheoryInjectionHorizonService {
+  TheoryInjectionHorizonService._();
+  static final TheoryInjectionHorizonService instance =
+      TheoryInjectionHorizonService._();
+
+  static const String _prefsPrefix = 'theory_inject_last_';
+
+  final Map<String, DateTime?> _cache = {};
+
+  Future<DateTime?> _getLast(String type) async {
+    if (_cache.containsKey(type)) return _cache[type];
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('$_prefsPrefix$type');
+    final ts = str == null ? null : DateTime.tryParse(str);
+    _cache[type] = ts;
+    return ts;
+  }
+
+  /// Returns `true` if enough time has passed since last [type] injection.
+  Future<bool> canInject(
+    String type, {
+    Duration minGap = const Duration(hours: 6),
+  }) async {
+    final last = await _getLast(type);
+    if (last == null) return true;
+    return DateTime.now().difference(last) >= minGap;
+  }
+
+  /// Updates last injection timestamp for [type] to now.
+  Future<void> markInjected(String type) async {
+    final now = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('$_prefsPrefix$type', now.toIso8601String());
+    _cache[type] = now;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `TheoryInjectionHorizonService` to throttle injections per booster type
- check injection horizons in `SmartBoosterInjector`
- gate recap auto injection and banner reinjection with the new service
- respect horizons for mistake-based boosters and skill gap overlay

## Testing
- `dart format lib/services/theory_injection_horizon_service.dart lib/services/smart_booster_injector.dart lib/services/smart_recap_auto_injector.dart lib/services/overlay_booster_manager.dart lib/services/smart_booster_unlocker.dart lib/services/smart_recap_banner_reinjection_service.dart`
- `dart analyze` *(fails: many warnings)*
- `dart pub get` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_688b23013108832a9c2964494098cb6b