### PR TITLE
Add booster exhaustion overlay

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -128,6 +128,7 @@ import 'services/smart_recap_banner_reinjection_service.dart';
 import 'services/recap_to_drill_launcher.dart';
 import 'services/smart_booster_unlock_scheduler.dart';
 import 'services/overlay_booster_manager.dart';
+import 'services/booster_exhaustion_overlay_manager.dart';
 import 'services/theory_recall_overlay_scheduler.dart';
 import 'services/theory_recall_inbox_reinjection_service.dart';
 import 'services/adaptive_next_step_engine.dart';
@@ -627,6 +628,9 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(
       create: (_) => OverlayBoosterManager()..start(),
+    ),
+    Provider(
+      create: (_) => BoosterExhaustionOverlayManager()..start(),
     ),
     Provider(
       create: (_) => TheoryRecallOverlayScheduler()..start(),

--- a/lib/services/booster_exhaustion_overlay_manager.dart
+++ b/lib/services/booster_exhaustion_overlay_manager.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import 'theory_injection_horizon_service.dart';
+
+/// Warns user about booster fatigue if too many are launched in a short time.
+class BoosterExhaustionOverlayManager {
+  final int maxCount;
+  final Duration window;
+  final Duration suppression;
+
+  BoosterExhaustionOverlayManager({
+    this.maxCount = 4,
+    this.window = const Duration(hours: 2),
+    this.suppression = const Duration(hours: 1),
+  });
+
+  static final BoosterExhaustionOverlayManager instance =
+      BoosterExhaustionOverlayManager();
+
+  final List<DateTime> _history = [];
+  DateTime? _suppressedUntil;
+  StreamSubscription<String>? _sub;
+  bool _dialogOpen = false;
+
+  Future<void> start() async {
+    _sub =
+        TheoryInjectionHorizonService.instance.injections.listen(_onInject);
+  }
+
+  Future<void> dispose() async {
+    await _sub?.cancel();
+  }
+
+  void _onInject(String type) {
+    final now = DateTime.now();
+    _history.add(now);
+    _history.removeWhere((t) => now.difference(t) > window);
+    if (_shouldWarn()) {
+      _show();
+    }
+  }
+
+  bool _shouldWarn() {
+    if (_dialogOpen) return false;
+    if (_suppressedUntil != null &&
+        DateTime.now().isBefore(_suppressedUntil!)) return false;
+    return _history.length >= maxCount;
+  }
+
+  Future<void> _show() async {
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return;
+    _dialogOpen = true;
+    await showDialog(
+      context: ctx,
+      builder: (_) => AlertDialog(
+        title: const Text('\uD83D\uDCDA Хороший прогресс!'),
+        content: const Text('Сделай перерыв, чтобы закрепить материал.'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _suppressedUntil = DateTime.now().add(suppression);
+              _history.clear();
+            },
+            child: const Text('Напомнить позже'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Ок'),
+          ),
+        ],
+      ),
+    );
+    _dialogOpen = false;
+    _history.clear();
+  }
+}

--- a/lib/services/theory_injection_horizon_service.dart
+++ b/lib/services/theory_injection_horizon_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Enforces minimum delay between theory booster injections.
@@ -9,6 +10,11 @@ class TheoryInjectionHorizonService {
   static const String _prefsPrefix = 'theory_inject_last_';
 
   final Map<String, DateTime?> _cache = {};
+  final StreamController<String> _injectController =
+      StreamController<String>.broadcast();
+
+  /// Stream of booster types that were marked as injected.
+  Stream<String> get injections => _injectController.stream;
 
   Future<DateTime?> _getLast(String type) async {
     if (_cache.containsKey(type)) return _cache[type];
@@ -35,5 +41,6 @@ class TheoryInjectionHorizonService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('$_prefsPrefix$type', now.toIso8601String());
     _cache[type] = now;
+    _injectController.add(type);
   }
 }


### PR DESCRIPTION
## Summary
- emit a stream of injection events from `TheoryInjectionHorizonService`
- warn when many boosters launch quickly via `BoosterExhaustionOverlayManager`
- wire up the new manager in `app_providers`

## Testing
- `flutter analyze` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b251e61bc832a872c4d8cafbe1109