### PR TITLE
Implement InjectionBlockAssembler

### DIFF
--- a/lib/models/learning_path_block.dart
+++ b/lib/models/learning_path_block.dart
@@ -1,0 +1,17 @@
+class LearningPathBlock {
+  final String id;
+  final String header;
+  final String content;
+  final String ctaLabel;
+  final String lessonId;
+  final String injectedInStageId;
+
+  const LearningPathBlock({
+    required this.id,
+    required this.header,
+    required this.content,
+    required this.ctaLabel,
+    required this.lessonId,
+    required this.injectedInStageId,
+  });
+}

--- a/lib/services/injection_block_assembler.dart
+++ b/lib/services/injection_block_assembler.dart
@@ -1,0 +1,38 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/learning_path_block.dart';
+
+/// Builds [LearningPathBlock]s from injected mini lessons.
+class InjectionBlockAssembler {
+  const InjectionBlockAssembler();
+
+  /// Creates a [LearningPathBlock] presentation for [lesson].
+  LearningPathBlock build(
+    TheoryMiniLessonNode lesson,
+    String injectedInStageId,
+  ) {
+    final header = 'Краткий разбор: ${lesson.resolvedTitle}';
+    final summary = _shorten(lesson.resolvedContent);
+    return LearningPathBlock(
+      id: lesson.id,
+      header: header,
+      content: summary,
+      ctaLabel: 'Читать подробнее',
+      lessonId: lesson.id,
+      injectedInStageId: injectedInStageId,
+    );
+  }
+
+  String _shorten(String text, {int maxLen = 300}) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return trimmed;
+    final parts = trimmed.split(RegExp(r'\n\n+'));
+    var first = parts.first.trim();
+    if (first.length > maxLen) {
+      first = first.substring(0, maxLen).trim();
+      if (!first.endsWith('...')) {
+        first = '$first...';
+      }
+    }
+    return first;
+  }
+}

--- a/test/injection_block_assembler_test.dart
+++ b/test/injection_block_assembler_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/injection_block_assembler.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+void main() {
+  test('build creates formatted block', () {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'Title',
+      content: 'Paragraph one.\n\nParagraph two.',
+      tags: [],
+      nextIds: [],
+    );
+    final assembler = InjectionBlockAssembler();
+    final block = assembler.build(lesson, 's1');
+    expect(block.header, 'Краткий разбор: Title');
+    expect(block.content, 'Paragraph one.');
+    expect(block.ctaLabel, 'Читать подробнее');
+    expect(block.lessonId, 'l1');
+    expect(block.injectedInStageId, 's1');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathBlock` data model
- implement `InjectionBlockAssembler` to build blocks from mini lessons
- test assembly logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2ee17ef4832aaf2bd9331a330272