### PR TITLE
Add SmartBoosterRecallEngine

### DIFF
--- a/lib/services/booster_context_evaluator.dart
+++ b/lib/services/booster_context_evaluator.dart
@@ -1,0 +1,10 @@
+import 'package:meta/meta.dart';
+
+/// Evaluates whether a booster type is relevant to current weaknesses.
+@immutable
+class BoosterContextEvaluator {
+  const BoosterContextEvaluator();
+
+  /// Returns `true` if [type] is currently relevant.
+  Future<bool> isRelevant(String type) async => true;
+}

--- a/lib/services/smart_booster_recall_engine.dart
+++ b/lib/services/smart_booster_recall_engine.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'booster_context_evaluator.dart';
+import 'booster_suggestion_stats_service.dart';
+
+/// Detects ignored boosters and suggests them again after a cooldown.
+class SmartBoosterRecallEngine {
+  final BoosterContextEvaluator evaluator;
+
+  SmartBoosterRecallEngine({BoosterContextEvaluator? evaluator})
+      : evaluator = evaluator ?? const BoosterContextEvaluator();
+
+  static final SmartBoosterRecallEngine instance = SmartBoosterRecallEngine();
+
+  static const String _prefsKey = 'smart_booster_recall';
+
+  final Map<String, DateTime> _dismissed = <String, DateTime>{};
+  bool _loaded = false;
+
+  /// Clears cached data for tests.
+  void resetForTest() {
+    _loaded = false;
+    _dismissed.clear();
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          data.forEach((key, value) {
+            final ts = DateTime.tryParse(value.toString());
+            if (ts != null) _dismissed[key.toString()] = ts;
+          });
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({for (final e in _dismissed.entries) e.key: e.value.toIso8601String()}),
+    );
+  }
+
+  Duration _cooldownFor(String type) => const Duration(hours: 48);
+
+  /// Records that a booster of [type] was dismissed.
+  Future<void> recordDismissed(String type, {DateTime? timestamp}) async {
+    if (type.isEmpty) return;
+    await _load();
+    _dismissed[type] = timestamp ?? DateTime.now();
+    await _save();
+    await BoosterSuggestionStatsService.instance.recordDismissed(type);
+  }
+
+  /// Returns booster types whose dismissal cooldown has expired and are still relevant.
+  Future<List<String>> getRecallableTypes(DateTime now) async {
+    await _load();
+    final result = <String>[];
+    for (final entry in _dismissed.entries) {
+      final cooldown = _cooldownFor(entry.key);
+      if (!entry.value.add(cooldown).isAfter(now)) {
+        if (await evaluator.isRelevant(entry.key)) {
+          result.add(entry.key);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/test/services/smart_booster_recall_engine_test.dart
+++ b/test/services/smart_booster_recall_engine_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/smart_booster_recall_engine.dart';
+import 'package:poker_analyzer/services/booster_context_evaluator.dart';
+
+class _FakeEvaluator extends BoosterContextEvaluator {
+  final Set<String> relevant;
+  const _FakeEvaluator(this.relevant);
+
+  @override
+  Future<bool> isRelevant(String type) async => relevant.contains(type);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    SmartBoosterRecallEngine.instance.resetForTest();
+  });
+
+  test('recalls types after cooldown when relevant', () async {
+    final engine = SmartBoosterRecallEngine(
+      evaluator: const _FakeEvaluator({'a'}),
+    );
+    final old = DateTime.now().subtract(const Duration(hours: 50));
+    await engine.recordDismissed('a', timestamp: old);
+    await engine.recordDismissed('b', timestamp: old);
+    final types = await engine.getRecallableTypes(DateTime.now());
+    expect(types, ['a']);
+  });
+
+  test('ignores types before cooldown', () async {
+    final engine = SmartBoosterRecallEngine(
+      evaluator: const _FakeEvaluator({'a'}),
+    );
+    final recent = DateTime.now().subtract(const Duration(hours: 10));
+    await engine.recordDismissed('a', timestamp: recent);
+    final types = await engine.getRecallableTypes(DateTime.now());
+    expect(types, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- create `BoosterContextEvaluator` stub
- implement `SmartBoosterRecallEngine` to track dismissed booster types and resuggest them later
- test recall logic

## Testing
- `flutter test test/services/smart_booster_recall_engine_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688b36c4e68c832a8bd318201cc7c0e7