### PR TITLE
Implement BoosterInjectionOrchestrator

### DIFF
--- a/lib/services/booster_injection_orchestrator.dart
+++ b/lib/services/booster_injection_orchestrator.dart
@@ -1,0 +1,84 @@
+import '../models/learning_path_block.dart';
+import 'booster_inventory_service.dart';
+import 'tag_mastery_service.dart';
+import 'skill_gap_detector_service.dart';
+import 'smart_booster_recall_engine.dart';
+import 'learning_path_stage_library.dart';
+import 'path_map_engine.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Selects booster previews to inject into a stage flow.
+class BoosterInjectionOrchestrator {
+  final TagMasteryService mastery;
+  final BoosterInventoryService inventory;
+  final SkillGapDetectorService gaps;
+  final SmartBoosterRecallEngine recall;
+
+  final Set<String> _shown = <String>{};
+
+  BoosterInjectionOrchestrator({
+    required this.mastery,
+    required this.inventory,
+    SkillGapDetectorService? gaps,
+    SmartBoosterRecallEngine? recall,
+  })  : gaps = gaps ?? SkillGapDetectorService(),
+        recall = recall ?? SmartBoosterRecallEngine.instance;
+
+  /// Returns booster blocks relevant to [stage].
+  Future<List<LearningPathBlock>> getInjectableBoosters(StageNode stage) async {
+    await inventory.loadAll();
+
+    final model = LearningPathStageLibrary.instance.getById(stage.id);
+    if (model == null) return [];
+
+    final stageTags = <String>{
+      for (final t in model.tags) t.trim().toLowerCase()
+    }..removeWhere((t) => t.isEmpty);
+    if (stageTags.isEmpty) return [];
+
+    final masteryMap = await mastery.computeMastery();
+    final weakTags = masteryMap.entries
+        .where((e) => e.value < 0.6)
+        .map((e) => e.key)
+        .toSet();
+
+    final gapTags = (await gaps.getMissingTags()).toSet();
+
+    final recallable = await recall.getRecallableTypes(DateTime.now());
+
+    final targetTags = <String>{}
+      ..addAll(stageTags.intersection({...weakTags, ...gapTags}))
+      ..addAll(recallable.where(stageTags.contains));
+
+    if (targetTags.isEmpty) return [];
+
+    final candidates = <TrainingPackTemplateV2>[];
+    for (final tag in targetTags) {
+      candidates.addAll(inventory.findByTag(tag));
+    }
+
+    if (candidates.isEmpty) return [];
+
+    final unique = <TrainingPackTemplateV2>[];
+    final seen = <String>{};
+    for (final b in candidates) {
+      if (unique.length >= 2) break;
+      if (seen.contains(b.id) || _shown.contains(b.id)) continue;
+      unique.add(b);
+      seen.add(b.id);
+      _shown.add(b.id);
+    }
+
+    return [
+      for (final b in unique)
+        LearningPathBlock(
+          id: b.id,
+          header: b.name,
+          content: b.description,
+          ctaLabel: 'Начать',
+          lessonId: b.id,
+          injectedInStageId: stage.id,
+        )
+    ];
+  }
+}

--- a/lib/services/booster_inventory_service.dart
+++ b/lib/services/booster_inventory_service.dart
@@ -1,0 +1,21 @@
+import '../models/v2/training_pack_template_v2.dart';
+import 'booster_library_service.dart';
+
+/// Provides access to available booster training packs.
+class BoosterInventoryService {
+  final BoosterLibraryService library;
+
+  BoosterInventoryService({this.library = BoosterLibraryService.instance});
+
+  /// Loads booster packs from the underlying library.
+  Future<void> loadAll({int limit = 500}) => library.loadAll(limit: limit);
+
+  /// Returns all boosters with [tag] in their metadata.
+  List<TrainingPackTemplateV2> findByTag(String tag) => library.findByTag(tag);
+
+  /// Returns booster pack by [id] or `null`.
+  TrainingPackTemplateV2? getById(String id) => library.getById(id);
+
+  /// Returns all loaded booster packs.
+  List<TrainingPackTemplateV2> get all => library.all;
+}

--- a/test/services/booster_injection_orchestrator_test.dart
+++ b/test/services/booster_injection_orchestrator_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:collection/collection.dart';
+
+import 'package:poker_analyzer/services/booster_injection_orchestrator.dart';
+import 'package:poker_analyzer/services/booster_inventory_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/skill_gap_detector_service.dart';
+import 'package:poker_analyzer/services/smart_booster_recall_engine.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+
+class _FakeMastery extends TagMasteryService {
+  final Map<String, double> map;
+  _FakeMastery(this.map)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => map;
+}
+
+class _FakeInventory extends BoosterInventoryService {
+  final List<TrainingPackTemplateV2> items;
+  _FakeInventory(this.items);
+
+  @override
+  Future<void> loadAll({int limit = 500}) async {}
+
+  @override
+  List<TrainingPackTemplateV2> findByTag(String tag) =>
+      [for (final b in items) if (b.tags.contains(tag)) b];
+
+  @override
+  TrainingPackTemplateV2? getById(String id) =>
+      items.firstWhereOrNull((b) => b.id == id);
+
+  @override
+  List<TrainingPackTemplateV2> get all => items;
+}
+
+class _FakeGapDetector extends SkillGapDetectorService {
+  final List<String> tags;
+  _FakeGapDetector(this.tags);
+  @override
+  Future<List<String>> getMissingTags({double threshold = 0.1}) async => tags;
+}
+
+class _FakeRecall extends SmartBoosterRecallEngine {
+  final List<String> types;
+  _FakeRecall(this.types) : super();
+  @override
+  Future<List<String>> getRecallableTypes(DateTime now) async => types;
+}
+
+TrainingPackTemplateV2 _pack(String id, String tag) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    description: '',
+    trainingType: TrainingType.pushFold,
+    gameType: GameType.tournament,
+    tags: [tag],
+    spots: const [],
+    spotCount: 0,
+    created: DateTime.now(),
+    positions: const [],
+    meta: const {'type': 'booster', 'tag': tag},
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    LearningPathStageLibrary.instance.clear();
+    LearningPathStageLibrary.instance.add(
+      const LearningPathStageModel(
+        id: 's1',
+        title: 's1',
+        description: '',
+        packId: 'p1',
+        requiredAccuracy: 0,
+        minHands: 0,
+        tags: ['push', 'call'],
+      ),
+    );
+  });
+
+  test('returns boosters matching weak tags', () async {
+    final orch = BoosterInjectionOrchestrator(
+      mastery: _FakeMastery({'push': 0.4}),
+      inventory: _FakeInventory([
+        _pack('b1', 'push'),
+        _pack('b2', 'call'),
+      ]),
+      gaps: _FakeGapDetector([]),
+      recall: _FakeRecall([]),
+    );
+    final blocks = await orch.getInjectableBoosters(const TrainingStageNode(id: 's1'));
+    expect(blocks.length, 1);
+    expect(blocks.first.id, 'b1');
+  });
+
+  test('prioritizes recallable types', () async {
+    final orch = BoosterInjectionOrchestrator(
+      mastery: _FakeMastery({'push': 0.8}),
+      inventory: _FakeInventory([
+        _pack('b1', 'push'),
+        _pack('b2', 'call'),
+      ]),
+      gaps: _FakeGapDetector([]),
+      recall: _FakeRecall(['call']),
+    );
+    final blocks = await orch.getInjectableBoosters(const TrainingStageNode(id: 's1'));
+    expect(blocks.length, 1);
+    expect(blocks.first.id, 'b2');
+  });
+
+  test('avoids duplicates in same session', () async {
+    final orch = BoosterInjectionOrchestrator(
+      mastery: _FakeMastery({'push': 0.4}),
+      inventory: _FakeInventory([
+        _pack('b1', 'push'),
+      ]),
+      gaps: _FakeGapDetector([]),
+      recall: _FakeRecall([]),
+    );
+    final first = await orch.getInjectableBoosters(const TrainingStageNode(id: 's1'));
+    final second = await orch.getInjectableBoosters(const TrainingStageNode(id: 's1'));
+    expect(first.length, 1);
+    expect(second, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterInventoryService` for managing available boosters
- implement `BoosterInjectionOrchestrator` that selects booster previews for stages
- add tests covering basic behavior

## Testing
- `flutter test test/services/booster_injection_orchestrator_test.dart -r expanded` *(fails: command not found)*
- `dart test test/services/booster_injection_orchestrator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3a10b7c0832a8f747d8cd1cab027