### PR TITLE
Implement TheoryAndBoosterFlowComposer

### DIFF
--- a/lib/services/theory_and_booster_flow_composer.dart
+++ b/lib/services/theory_and_booster_flow_composer.dart
@@ -1,0 +1,34 @@
+import 'booster_injection_orchestrator.dart';
+import 'injection_block_assembler.dart';
+import 'smart_theory_injection_engine.dart';
+import '../models/learning_path_block.dart';
+import 'path_map_engine.dart';
+
+/// Builds the adaptive flow of a stage combining theory and booster injections.
+class TheoryAndBoosterFlowComposer {
+  final SmartTheoryInjectionEngine theoryEngine;
+  final BoosterInjectionOrchestrator boosterOrchestrator;
+  final InjectionBlockAssembler assembler;
+
+  const TheoryAndBoosterFlowComposer({
+    SmartTheoryInjectionEngine? theoryEngine,
+    required BoosterInjectionOrchestrator boosterOrchestrator,
+    InjectionBlockAssembler? assembler,
+  })  : theoryEngine = theoryEngine ?? const SmartTheoryInjectionEngine(),
+        boosterOrchestrator = boosterOrchestrator,
+        assembler = assembler ?? const InjectionBlockAssembler();
+
+  /// Returns ordered blocks for [stage] with theory first and boosters after.
+  Future<List<LearningPathBlock>> buildStageFlow(StageNode stage) async {
+    final result = <LearningPathBlock>[];
+    final miniLesson = await theoryEngine.getInjectionCandidate(stage.id);
+    if (miniLesson != null) {
+      result.add(assembler.build(miniLesson, stage.id));
+    }
+    final boosters = await boosterOrchestrator.getInjectableBoosters(stage);
+    if (boosters.isNotEmpty) {
+      result.addAll(boosters.take(2));
+    }
+    return result;
+  }
+}

--- a/test/services/theory_and_booster_flow_composer_test.dart
+++ b/test/services/theory_and_booster_flow_composer_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_block.dart';
+import 'package:poker_analyzer/services/theory_and_booster_flow_composer.dart';
+import 'package:poker_analyzer/services/injection_block_assembler.dart';
+import 'package:poker_analyzer/services/smart_theory_injection_engine.dart';
+import 'package:poker_analyzer/services/booster_injection_orchestrator.dart';
+import 'package:poker_analyzer/services/learning_path_stage_library.dart';
+import 'package:poker_analyzer/models/learning_path_stage_model.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/stage_type.dart';
+import 'package:poker_analyzer/services/path_map_engine.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/booster_inventory_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeTheory extends SmartTheoryInjectionEngine {
+  final TheoryMiniLessonNode? lesson;
+  const _FakeTheory(this.lesson);
+
+  @override
+  Future<TheoryMiniLessonNode?> getInjectionCandidate(String stageId) async => lesson;
+}
+
+class _FakeOrch extends BoosterInjectionOrchestrator {
+  final List<LearningPathBlock> blocks;
+  _FakeOrch(this.blocks)
+      : super(
+          mastery: TagMasteryService(
+            logs: SessionLogService(sessions: TrainingSessionService()),
+          ),
+          inventory: BoosterInventoryService(),
+        );
+
+  @override
+  Future<List<LearningPathBlock>> getInjectableBoosters(StageNode stage) async => blocks;
+}
+
+LearningPathBlock _booster(String id) {
+  return LearningPathBlock(
+    id: id,
+    header: id,
+    content: '',
+    ctaLabel: 'Start',
+    lessonId: id,
+    injectedInStageId: 's1',
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    LearningPathStageLibrary.instance.clear();
+    LearningPathStageLibrary.instance.add(
+      const LearningPathStageModel(
+        id: 's1',
+        title: 's1',
+        description: '',
+        packId: 'p1',
+        requiredAccuracy: 0,
+        minHands: 0,
+        tags: ['x'],
+        type: StageType.practice,
+      ),
+    );
+  });
+
+  test('theory first then boosters', () async {
+    const lesson = TheoryMiniLessonNode(id: 't1', title: 't', content: 'c');
+    final composer = TheoryAndBoosterFlowComposer(
+      theoryEngine: const _FakeTheory(lesson),
+      boosterOrchestrator: _FakeOrch([
+        _booster('b1'),
+        _booster('b2'),
+      ]),
+      assembler: const InjectionBlockAssembler(),
+    );
+    final blocks = await composer.buildStageFlow(const TrainingStageNode(id: 's1'));
+    expect(blocks.length, 3);
+    expect(blocks.first.id, 't1');
+    expect(blocks[1].id, 'b1');
+    expect(blocks[2].id, 'b2');
+  });
+
+  test('limits boosters to two', () async {
+    final composer = TheoryAndBoosterFlowComposer(
+      theoryEngine: const _FakeTheory(null),
+      boosterOrchestrator: _FakeOrch([
+        _booster('b1'),
+        _booster('b2'),
+        _booster('b3'),
+      ]),
+      assembler: const InjectionBlockAssembler(),
+    );
+    final blocks = await composer.buildStageFlow(const TrainingStageNode(id: 's1'));
+    expect(blocks.length, 2);
+    expect(blocks[0].id, 'b1');
+    expect(blocks[1].id, 'b2');
+  });
+
+  test('returns empty when none available', () async {
+    final composer = TheoryAndBoosterFlowComposer(
+      theoryEngine: const _FakeTheory(null),
+      boosterOrchestrator: _FakeOrch([]),
+      assembler: const InjectionBlockAssembler(),
+    );
+    final blocks = await composer.buildStageFlow(const TrainingStageNode(id: 's1'));
+    expect(blocks, isEmpty);
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement `TheoryAndBoosterFlowComposer` to combine theory and booster injections
- add unit tests covering flow composition order and limits

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3bf9f508832aa3f334c1578dc785