### PR TITLE
Implement StageFlowInjectionRunner

### DIFF
--- a/lib/services/stage_flow_injection_runner.dart
+++ b/lib/services/stage_flow_injection_runner.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+
+import '../models/learning_path_block.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/theory_and_booster_flow_composer.dart';
+import '../services/booster_injection_orchestrator.dart';
+import '../services/tag_mastery_service.dart';
+import '../services/booster_inventory_service.dart';
+import '../services/session_log_service.dart';
+import '../services/training_session_service.dart';
+import '../services/training_session_launcher.dart';
+import 'path_map_engine.dart';
+import '../widgets/injected_theory_block_renderer.dart';
+import '../widgets/drill_preview_block.dart';
+
+/// Injects theory and booster blocks into the stage UI.
+class StageFlowInjectionRunner {
+  final TheoryAndBoosterFlowComposer composer;
+  final MiniLessonLibraryService miniLessons;
+  final BoosterInventoryService boosters;
+  final TrainingSessionLauncher launcher;
+
+  StageFlowInjectionRunner({
+    TheoryAndBoosterFlowComposer? composer,
+    MiniLessonLibraryService? miniLessons,
+    BoosterInventoryService? boosters,
+    TrainingSessionLauncher launcher = const TrainingSessionLauncher(),
+  })  : composer = composer ??
+            TheoryAndBoosterFlowComposer(
+              boosterOrchestrator: BoosterInjectionOrchestrator(
+                mastery: TagMasteryService(
+                  logs: SessionLogService(
+                    sessions: TrainingSessionService(),
+                  ),
+                ),
+                inventory: boosters ?? BoosterInventoryService(),
+              ),
+            ),
+        miniLessons = miniLessons ?? MiniLessonLibraryService.instance,
+        boosters = boosters ?? BoosterInventoryService(),
+        launcher = launcher;
+
+  /// Returns widgets to inject for [stage].
+  Future<List<Widget>> injectBlocks(StageNode stage) async {
+    final blocks = await composer.buildStageFlow(stage);
+    if (blocks.isEmpty) return [];
+    await miniLessons.loadAll();
+    await boosters.loadAll();
+    final widgets = <Widget>[];
+    for (final block in blocks) {
+      final lesson = miniLessons.getById(block.lessonId);
+      if (lesson != null) {
+        widgets.add(InjectedTheoryBlockRenderer(block: block));
+      } else {
+        widgets.add(
+          DrillPreviewBlock(
+            block: block,
+            inventory: boosters,
+            launcher: launcher,
+          ),
+        );
+      }
+    }
+    return widgets;
+  }
+}

--- a/lib/widgets/drill_preview_block.dart
+++ b/lib/widgets/drill_preview_block.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import '../models/learning_path_block.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../services/booster_inventory_service.dart';
+import '../services/training_session_launcher.dart';
+
+/// Renders a preview card for a drill [LearningPathBlock].
+class DrillPreviewBlock extends StatefulWidget {
+  final LearningPathBlock block;
+  final BoosterInventoryService inventory;
+  final TrainingSessionLauncher launcher;
+
+  DrillPreviewBlock({
+    Key? key,
+    required this.block,
+    BoosterInventoryService? inventory,
+    this.launcher = const TrainingSessionLauncher(),
+  })  : inventory = inventory ?? BoosterInventoryService(),
+        super(key: key);
+
+  @override
+  State<DrillPreviewBlock> createState() => _DrillPreviewBlockState();
+}
+
+class _DrillPreviewBlockState extends State<DrillPreviewBlock> {
+  bool _loading = true;
+  TrainingPackTemplateV2? _pack;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await widget.inventory.loadAll();
+    final tpl = widget.inventory.getById(widget.block.lessonId);
+    if (mounted) {
+      setState(() {
+        _pack = tpl;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _start() async {
+    final pack = _pack;
+    if (pack == null) return;
+    await widget.launcher.launch(pack);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _pack == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            widget.block.header,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          if (widget.block.content.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              widget.block.content,
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _start,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: Text(widget.block.ctaLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `DrillPreviewBlock` widget for displaying booster previews
- add `StageFlowInjectionRunner` service to build widgets for stage header injection

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3d43e204832aa32b755ed8ac7baf