### PR TITLE
Add booster recap replay flag

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -97,6 +97,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
   Timer? _timer;
   bool _continue = false;
   bool _summaryShown = false;
+  bool _boosterRecapShown = false;
 
   void _restart() {
     final pack = widget.pack;
@@ -111,6 +112,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       _correct = null;
       _continue = false;
       _summaryShown = false;
+      _boosterRecapShown = false;
     });
   }
 
@@ -308,6 +310,14 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final tpl = service.template;
     if (tpl != null) {
       final isBooster = tpl.meta['type']?.toString().toLowerCase() == 'booster';
+      if (isBooster && _boosterRecapShown) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Booster recap already shown')),
+          );
+        }
+        return;
+      }
       double? accBefore;
       String? boosterTag;
       if (isBooster) {
@@ -462,6 +472,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                   categoryCounts: counts,
                 ),
         );
+        if (isBooster) _boosterRecapShown = true;
       } else {
         await service.complete(
           context,
@@ -482,6 +493,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                   elapsed: elapsed,
                 ),
         );
+        if (isBooster) _boosterRecapShown = true;
       }
 
       if (isBooster && boosterTag != null) {


### PR DESCRIPTION
## Summary
- prevent duplicate booster recap with `_boosterRecapShown`
- skip booster recap if already shown and notify user

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 6685 issues)*

------
https://chatgpt.com/codex/tasks/task_e_688b4cec7d84832a91b6262d677bf86d