### PR TITLE
Implement booster recall decay cleaner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ import 'services/suggested_pack_push_service.dart';
 import 'services/lesson_path_reminder_scheduler.dart';
 import 'services/decay_reminder_scheduler.dart';
 import 'services/theory_lesson_notification_scheduler.dart';
+import 'services/booster_recall_decay_cleaner.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -115,6 +116,7 @@ Future<void> main() async {
   await tagCache.load();
   unawaited(SuggestedPackPushService.instance.schedulePushReminder());
   unawaited(DecayReminderScheduler.instance.register());
+  await BoosterRecallDecayCleaner.instance.init();
   await AppInitService.instance.init();
   runApp(
     MultiProvider(

--- a/lib/services/booster_recall_decay_cleaner.dart
+++ b/lib/services/booster_recall_decay_cleaner.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'booster_recall_scheduler.dart';
+
+/// Periodically trims outdated skipped booster records.
+class BoosterRecallDecayCleaner with WidgetsBindingObserver {
+  BoosterRecallDecayCleaner._();
+  static final BoosterRecallDecayCleaner instance =
+      BoosterRecallDecayCleaner._();
+
+  static const String _lastKey = 'booster_recall_decay_last';
+
+  Future<void> init() async {
+    WidgetsBinding.instance.addObserver(this);
+    await _runIfNeeded();
+  }
+
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _runIfNeeded();
+    }
+  }
+
+  Future<void> _runIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_lastKey);
+    final last = str != null ? DateTime.tryParse(str) : null;
+    if (last == null || DateTime.now().difference(last).inDays >= 7) {
+      await BoosterRecallScheduler.instance.applyDecay();
+      await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+    }
+  }
+}

--- a/lib/services/booster_recall_scheduler.dart
+++ b/lib/services/booster_recall_scheduler.dart
@@ -66,6 +66,13 @@ class BoosterRecallScheduler {
     }
   }
 
+  /// Applies decay to stored records and persists changes.
+  Future<void> applyDecay() async {
+    await _load();
+    _applyDecay();
+    await _save();
+  }
+
   /// Records that [boosterId] was skipped.
   Future<void> markBoosterSkipped(String boosterId) async {
     if (boosterId.isEmpty) return;


### PR DESCRIPTION
## Summary
- add BoosterRecallDecayCleaner service
- expose `applyDecay` in BoosterRecallScheduler
- start decay cleaner during app startup

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4fbeea60832a995378b63894798e