### PR TITLE
Add Booster recall banner

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -131,6 +131,7 @@ import 'services/overlay_booster_manager.dart';
 import 'services/booster_exhaustion_overlay_manager.dart';
 import 'services/theory_recall_overlay_scheduler.dart';
 import 'services/theory_recall_inbox_reinjection_service.dart';
+import 'services/booster_recall_banner_engine.dart';
 import 'services/adaptive_next_step_engine.dart';
 import 'services/suggested_next_step_engine.dart';
 
@@ -490,6 +491,7 @@ List<SingleChildWidget> buildTrainingProviders() {
         logs: context.read<SessionLogService>(),
       ),
     ),
+    Provider(create: (_) => BoosterRecallBannerEngine()),
     Provider(
       create: (context) =>
           TagMasteryService(logs: context.read<SessionLogService>()),

--- a/lib/screens/booster_recap_screen.dart
+++ b/lib/screens/booster_recap_screen.dart
@@ -12,6 +12,7 @@ import '../services/booster_mistake_recorder.dart';
 import '../theme/app_colors.dart';
 import 'training_session_screen.dart';
 import '../widgets/theory_progress_recovery_banner.dart';
+import '../widgets/booster_recall_banner.dart';
 
 class BoosterRecapScreen extends StatefulWidget {
   final TrainingSessionResult result;
@@ -109,6 +110,7 @@ class _BoosterRecapScreenState extends State<BoosterRecapScreen> {
                     style: const TextStyle(color: Colors.white70)),
                 const SizedBox(height: 8),
               ],
+              const BoosterRecallBanner(),
               const TheoryProgressRecoveryBanner(),
               Row(
                 children: [

--- a/lib/services/booster_recall_banner_engine.dart
+++ b/lib/services/booster_recall_banner_engine.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'theory_recall_evaluator.dart';
+
+/// Provides recall lesson suggestions after booster completion.
+class BoosterRecallBannerEngine {
+  final TheoryRecallEvaluator recall;
+
+  BoosterRecallBannerEngine({TheoryRecallEvaluator? recall})
+      : recall = recall ?? const TheoryRecallEvaluator();
+
+  static final BoosterRecallBannerEngine instance = BoosterRecallBannerEngine();
+
+  static const _dismissPrefix = 'booster_recall_banner_dismissed_';
+
+  /// Returns a lesson suggestion or null if none available or dismissed.
+  Future<TheoryMiniLessonNode?> getSuggestion() async {
+    final lessons = await recall.recallSuggestions(limit: 1);
+    if (lessons.isEmpty) return null;
+    final lesson = lessons.first;
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool('$_dismissPrefix${lesson.id}') ?? false) {
+      return null;
+    }
+    return lesson;
+  }
+
+  /// Marks [lessonId] dismissed so it won't be suggested again.
+  Future<void> dismiss(String lessonId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('$_dismissPrefix$lessonId', true);
+  }
+}

--- a/lib/widgets/booster_recall_banner.dart
+++ b/lib/widgets/booster_recall_banner.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../services/booster_recall_banner_engine.dart';
+
+/// Banner suggesting a theory lesson after booster completion.
+class BoosterRecallBanner extends StatefulWidget {
+  const BoosterRecallBanner({super.key});
+
+  @override
+  State<BoosterRecallBanner> createState() => _BoosterRecallBannerState();
+}
+
+class _BoosterRecallBannerState extends State<BoosterRecallBanner> {
+  TheoryMiniLessonNode? _lesson;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final engine = context.read<BoosterRecallBannerEngine>();
+    final lesson = await engine.getSuggestion();
+    if (mounted) {
+      setState(() {
+        _lesson = lesson;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _open() async {
+    final lesson = _lesson;
+    if (lesson == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+    await context.read<BoosterRecallBannerEngine>().dismiss(lesson.id);
+    if (mounted) setState(() => _lesson = null);
+  }
+
+  Future<void> _dismiss() async {
+    final lesson = _lesson;
+    if (lesson != null) {
+      await context.read<BoosterRecallBannerEngine>().dismiss(lesson.id);
+    }
+    if (mounted) setState(() => _lesson = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lesson = _lesson;
+    if (_loading || lesson == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final title = lesson.tags.isNotEmpty
+        ? 'Освежи теорию по теме: ${lesson.tags.first}'
+        : 'Освежи теорию';
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _dismiss,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _open,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Перейти к уроку'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show recall suggestions after booster results via BoosterRecallBanner
- engine fetches lessons through `TheoryRecallEvaluator`
- hook banner engine via providers
- prompt uses new banner widget on BoosterRecapScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b5614b4e0832aab2d85269de70b0f