### PR TITLE
Implement TheoryTagDecayTracker

### DIFF
--- a/lib/services/theory_tag_decay_tracker.dart
+++ b/lib/services/theory_tag_decay_tracker.dart
@@ -1,0 +1,52 @@
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'theory_tag_summary_service.dart';
+
+/// Computes knowledge decay scores for theory tags.
+class TheoryTagDecayTracker {
+  final MiniLessonLibraryService library;
+  final MiniLessonProgressTracker progress;
+  final TheoryTagSummaryService summary;
+
+  TheoryTagDecayTracker({
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+    TheoryTagSummaryService? summary,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance,
+        summary =
+            summary ?? TheoryTagSummaryService(library: library ?? MiniLessonLibraryService.instance);
+
+  /// Returns decay scores for all tags using [now] as reference time.
+  Future<Map<String, double>> computeDecayScores({DateTime? now}) async {
+    await library.loadAll();
+    final stats = await summary.computeSummary();
+    final current = now ?? DateTime.now();
+
+    final lastTimes = <String, DateTime?>{};
+    for (final lesson in library.all) {
+      final ts = await progress.lastViewed(lesson.id);
+      for (final tag in lesson.tags) {
+        final key = tag.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        final prev = lastTimes[key];
+        if (prev == null || (ts != null && ts.isAfter(prev))) {
+          lastTimes[key] = ts;
+        }
+      }
+    }
+
+    final scores = <String, double>{};
+    for (final entry in stats.entries) {
+      final tag = entry.key;
+      final coverage = entry.value.lessonCount;
+      final ts = lastTimes[tag];
+      final days = ts == null
+          ? 9999.0
+          : current.difference(ts).inDays.toDouble();
+      final decay = days / (coverage > 0 ? coverage : 1);
+      scores[tag] = decay;
+    }
+    return scores;
+  }
+}

--- a/test/services/theory_tag_decay_tracker_test.dart
+++ b/test/services/theory_tag_decay_tracker_test.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_tag_decay_tracker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/theory_tag_summary_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(items.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('computeDecayScores factors recency and coverage', () async {
+    final now = DateTime(2024, 1, 10);
+    SharedPreferences.setMockInitialValues({
+      'mini_lesson_progress_l1': jsonEncode({'lastViewed': now.subtract(const Duration(days: 1)).toIso8601String()}),
+      'mini_lesson_progress_l2': jsonEncode({'lastViewed': now.subtract(const Duration(days: 5)).toIso8601String()}),
+      'mini_lesson_progress_l3': jsonEncode({'lastViewed': now.subtract(const Duration(days: 2)).toIso8601String()}),
+    });
+
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l3', title: 'C', content: '', tags: ['b']),
+    ];
+
+    final library = _FakeLibrary(lessons);
+    final tracker = TheoryTagDecayTracker(
+      library: library,
+      progress: MiniLessonProgressTracker.instance,
+      summary: TheoryTagSummaryService(library: library),
+    );
+
+    final scores = await tracker.computeDecayScores(now: now);
+    expect(scores['b']! > scores['a']!, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryTagDecayTracker service to estimate decay per theory tag
- test TheoryTagDecayTracker to verify decay weighting by recency and coverage

## Testing
- `flutter analyze` *(fails: Package file_picker... does not provide an inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_688b577a1804832a9caaf8e466e13a03