### PR TITLE
Implement overlay decay booster orchestrator

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -121,6 +121,7 @@ import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/gift_drop_service.dart';
 import 'services/session_streak_overlay_prompt_service.dart';
+import 'services/overlay_decay_booster_orchestrator.dart';
 import 'services/smart_recap_auto_injector.dart';
 import 'services/smart_recap_banner_controller.dart';
 import 'services/theory_inbox_banner_controller.dart';
@@ -592,6 +593,7 @@ List<SingleChildWidget> buildTrainingProviders() {
     ),
     Provider(create: (_) => GiftDropService()),
     Provider(create: (_) => SessionStreakOverlayPromptService()),
+    Provider(create: (_) => OverlayDecayBoosterOrchestrator()),
     Provider(
       create: (context) => RecapOpportunityDetector(
         retention: context.read<TagRetentionTracker>(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,6 +55,7 @@ import 'services/learning_path_summary_cache.dart';
 import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/overlay_booster_manager.dart';
+import 'services/overlay_decay_booster_orchestrator.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
 import 'services/app_init_service.dart';
@@ -241,6 +242,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
       sessions: context.read<TrainingSessionService>(),
     ));
     unawaited(context.read<SkillLossOverlayPromptService>().run(context));
+    unawaited(
+        context.read<OverlayDecayBoosterOrchestrator>().maybeShowIfIdle(context));
     unawaited(context.read<OverlayBoosterManager>().onAfterXpScreen());
     unawaited(
       TheoryLessonNotificationScheduler.instance.scheduleReminderIfNeeded(),

--- a/lib/screens/learning_path_dashboard.dart
+++ b/lib/screens/learning_path_dashboard.dart
@@ -14,6 +14,8 @@ import '../services/streak_progress_service.dart';
 import '../services/learning_path_stage_launcher.dart';
 import '../widgets/learning_path_stage_tile.dart';
 import 'learning_path_stage_list_screen.dart';
+import '../services/overlay_decay_booster_orchestrator.dart';
+import 'dart:async';
 
 /// Dashboard summarizing progress in a learning path and suggesting
 /// the next stage to continue.
@@ -72,6 +74,8 @@ class _LearningPathDashboardState extends State<LearningPathDashboard> {
       _streak = streak;
       _loading = false;
     });
+    unawaited(
+        OverlayDecayBoosterOrchestrator.instance.maybeShow(context));
   }
 
   Future<void> _continueTraining() async {

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -66,6 +66,8 @@ import '../widgets/sync_status_widget.dart';
 import '../user_preferences.dart';
 import '../services/gift_drop_service.dart';
 import '../services/session_streak_overlay_prompt_service.dart';
+import '../services/overlay_decay_booster_orchestrator.dart';
+import 'dart:async';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -275,6 +277,8 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
       AppUsageTracker.instance.markActive();
       _maybeShowTrainingReminder();
       _maybeLaunchScheduledTraining();
+      unawaited(
+          context.read<OverlayDecayBoosterOrchestrator>().maybeShowIfIdle(context));
     }
   }
 

--- a/lib/services/learning_path_stage_launcher.dart
+++ b/lib/services/learning_path_stage_launcher.dart
@@ -9,6 +9,8 @@ import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
 import '../screens/theory_pack_reader_screen.dart';
 import 'user_action_logger.dart';
+import 'overlay_decay_booster_orchestrator.dart';
+import 'dart:async';
 
 /// Helper to open a learning path stage.
 class LearningPathStageLauncher {
@@ -32,6 +34,8 @@ class LearningPathStageLauncher {
       if (stage.tags.isNotEmpty) 'tags': stage.tags,
       'timestamp': DateTime.now().toIso8601String(),
     });
+
+    unawaited(OverlayDecayBoosterOrchestrator.instance.maybeShow(context));
 
     switch (stage.type) {
       case StageType.theory:

--- a/lib/services/overlay_decay_booster_orchestrator.dart
+++ b/lib/services/overlay_decay_booster_orchestrator.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/theory_lesson_viewer_screen.dart';
+import 'app_usage_tracker.dart';
+import 'inbox_booster_service.dart';
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+import 'theory_tag_decay_tracker.dart';
+
+/// Surfaces overlay prompts to review decayed theory tags during navigation.
+class OverlayDecayBoosterOrchestrator {
+  final TheoryTagDecayTracker decay;
+  final MiniLessonLibraryService lessons;
+  final MiniLessonProgressTracker progress;
+  final InboxBoosterService inbox;
+  final AppUsageTracker usage;
+  final double threshold;
+  final Duration recency;
+  final Duration idleThreshold;
+
+  OverlayDecayBoosterOrchestrator({
+    TheoryTagDecayTracker? decay,
+    MiniLessonLibraryService? lessons,
+    MiniLessonProgressTracker? progress,
+    InboxBoosterService? inbox,
+    AppUsageTracker? usage,
+    this.threshold = 55,
+    this.recency = const Duration(days: 7),
+    this.idleThreshold = const Duration(minutes: 2),
+  })  : decay = decay ?? TheoryTagDecayTracker(),
+        lessons = lessons ?? MiniLessonLibraryService.instance,
+        progress = progress ?? MiniLessonProgressTracker.instance,
+        inbox = inbox ?? InboxBoosterService.instance,
+        usage = usage ?? AppUsageTracker.instance;
+
+  static final OverlayDecayBoosterOrchestrator instance =
+      OverlayDecayBoosterOrchestrator();
+
+  static const _lastKey = 'overlay_decay_last';
+
+  /// Shows a prompt if a highly decayed tag is detected.
+  Future<void> maybeShow(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_lastKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null && now.difference(last) < const Duration(days: 1)) return;
+
+    final lesson = await findCandidateLesson(now: now);
+    if (lesson == null) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final controller = messenger.showSnackBar(
+      SnackBar(
+        content:
+            const Text('This concept might be fading — want to refresh?'),
+        action: SnackBarAction(
+          label: 'Review now',
+          onPressed: () async {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => TheoryLessonViewerScreen(
+                  lesson: lesson,
+                  currentIndex: 1,
+                  totalCount: 1,
+                ),
+              ),
+            );
+          },
+        ),
+        duration: const Duration(seconds: 8),
+      ),
+    );
+    controller.closed.then((reason) {
+      if (reason != SnackBarClosedReason.action) {
+        unawaited(inbox.addReminder(lesson.id));
+      }
+    });
+    await prefs.setString(_lastKey, now.toIso8601String());
+  }
+
+  /// Shows a prompt if idle time exceeds [idleThreshold].
+  Future<void> maybeShowIfIdle(BuildContext context) async {
+    final idle = await usage.idleDuration();
+    if (idle < idleThreshold) return;
+    await maybeShow(context);
+  }
+
+  /// Finds a lesson for the most decayed tag above [threshold].
+  Future<TheoryMiniLessonNode?> findCandidateLesson({DateTime? now}) async {
+    final scores = await decay.computeDecayScores(now: now);
+    final entries = scores.entries
+        .where((e) => e.value > threshold)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    if (entries.isEmpty) return null;
+
+    await lessons.loadAll();
+    final current = now ?? DateTime.now();
+    for (final entry in entries) {
+      final tag = entry.key;
+      final list = lessons.findByTags([tag]);
+      for (final lesson in list) {
+        final ts = await progress.lastViewed(lesson.id);
+        if (ts != null && current.difference(ts) < recency) continue;
+        return lesson;
+      }
+    }
+    return null;
+  }
+}
+

--- a/test/services/overlay_decay_booster_orchestrator_test.dart
+++ b/test/services/overlay_decay_booster_orchestrator_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/overlay_decay_booster_orchestrator.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_progress_tracker.dart';
+import 'package:poker_analyzer/services/inbox_booster_service.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_tag_decay_tracker.dart';
+
+class _FakeDecay extends TheoryTagDecayTracker {
+  final Map<String, double> scores;
+  _FakeDecay(this.scores);
+
+  @override
+  Future<Map<String, double>> computeDecayScores({DateTime? now}) async => scores;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(lessons.where((e) => e.tags.contains(t)));
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('findCandidateLesson returns decayed lesson', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+      const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['b']),
+    ];
+    final service = OverlayDecayBoosterOrchestrator(
+      decay: _FakeDecay({'a': 60, 'b': 20}),
+      lessons: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      inbox: InboxBoosterService(),
+    );
+    final lesson = await service.findCandidateLesson();
+    expect(lesson?.id, 'l1');
+  });
+
+  test('recently viewed lesson skipped', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'mini_lesson_progress_l1': jsonEncode({'lastViewed': now.toIso8601String()}),
+    });
+    final lessons = [
+      const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']),
+    ];
+    final service = OverlayDecayBoosterOrchestrator(
+      decay: _FakeDecay({'a': 60}),
+      lessons: _FakeLibrary(lessons),
+      progress: MiniLessonProgressTracker.instance,
+      inbox: InboxBoosterService(),
+    );
+    final lesson = await service.findCandidateLesson(now: now.add(const Duration(days: 1)));
+    expect(lesson, isNull);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `OverlayDecayBoosterOrchestrator` service for toast reminders when tags decay
- invoke orchestrator on stage opens, dashboard loads, idle resume
- wire orchestrator through providers and startup flow
- test candidate selection logic

## Testing
- `dart test test/services/overlay_decay_booster_orchestrator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b721abb88832a898ab010480395ee