### PR TITLE
Add DecaySpotBoosterEngine

### DIFF
--- a/lib/services/booster_queue_service.dart
+++ b/lib/services/booster_queue_service.dart
@@ -1,0 +1,23 @@
+import '../models/v2/training_spot_v2.dart';
+
+/// Stores training spots scheduled as boosters.
+class BoosterQueueService {
+  BoosterQueueService._();
+  static final BoosterQueueService instance = BoosterQueueService._();
+
+  final List<TrainingSpotV2> _queue = [];
+
+  /// Adds [spots] to the queue if not already present by id.
+  Future<void> addSpots(List<TrainingSpotV2> spots) async {
+    for (final s in spots) {
+      if (_queue.every((e) => e.id != s.id)) {
+        _queue.add(s);
+      }
+    }
+  }
+
+  /// Returns queued spots.
+  List<TrainingSpotV2> getQueue() => List.unmodifiable(_queue);
+
+  void clear() => _queue.clear();
+}

--- a/lib/services/decay_spot_booster_engine.dart
+++ b/lib/services/decay_spot_booster_engine.dart
@@ -1,0 +1,51 @@
+import '../models/v2/training_spot_v2.dart';
+import 'decay_topic_suppressor_service.dart';
+import 'theory_tag_decay_tracker.dart';
+import 'training_spot_library.dart';
+import 'booster_queue_service.dart';
+
+/// Suggests training spots for highly decayed theory tags.
+class DecaySpotBoosterEngine {
+  final TheoryTagDecayTracker decay;
+  final DecayTopicSuppressorService suppressor;
+  final TrainingSpotLibrary library;
+  final BoosterQueueService queue;
+
+  DecaySpotBoosterEngine({
+    TheoryTagDecayTracker? decay,
+    DecayTopicSuppressorService? suppressor,
+    TrainingSpotLibrary? library,
+    BoosterQueueService? queue,
+  })  : decay = decay ?? TheoryTagDecayTracker(),
+        suppressor = suppressor ?? DecayTopicSuppressorService.instance,
+        library = library ?? TrainingSpotLibrary(),
+        queue = queue ?? BoosterQueueService.instance;
+
+  /// Queues practical drills for decayed tags.
+  Future<void> enqueueDecayBoosters() async {
+    final scores = await decay.computeDecayScores();
+    final entries = scores.entries.where((e) => e.value > 50).toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final spots = <TrainingSpotV2>[];
+
+    for (final e in entries) {
+      final tag = e.key;
+      if (await suppressor.shouldSuppress(tag)) continue;
+      final list = await library.indexByTag(tag);
+      if (list.isEmpty) continue;
+      final seen = <String>{};
+      for (final spot in list) {
+        final key = '${spot.hand.position}_${spot.hand.stacks['0']}';
+        if (seen.add(key)) {
+          spots.add(spot);
+        }
+        if (seen.length >= 3) break;
+      }
+    }
+
+    if (spots.isNotEmpty) {
+      await queue.addSpots(spots);
+    }
+  }
+}

--- a/lib/services/training_spot_library.dart
+++ b/lib/services/training_spot_library.dart
@@ -1,0 +1,40 @@
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/v2/training_spot_v2.dart';
+
+/// Loads training spots from built-in pack templates and indexes them by tag.
+class TrainingSpotLibrary {
+  final TrainingPackLibraryV2 library;
+
+  TrainingSpotLibrary({TrainingPackLibraryV2? library})
+      : library = library ?? TrainingPackLibraryV2.instance;
+
+  bool _loaded = false;
+  final List<TrainingSpotV2> _spots = [];
+  final Map<String, List<TrainingSpotV2>> _index = {};
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    await library.loadFromFolder();
+    for (final pack in library.packs) {
+      final packTags = {for (final t in pack.tags) t.trim().toLowerCase()}
+        ..removeWhere((e) => e.isEmpty);
+      for (final spot in pack.spots) {
+        final spotTags = {for (final t in spot.tags) t.trim().toLowerCase()}
+          ..removeWhere((e) => e.isEmpty);
+        final tags = {...packTags, ...spotTags};
+        _spots.add(spot);
+        for (final tag in tags) {
+          _index.putIfAbsent(tag, () => []).add(spot);
+        }
+      }
+    }
+    _loaded = true;
+  }
+
+  /// Returns spots tagged with [tag].
+  Future<List<TrainingSpotV2>> indexByTag(String tag) async {
+    await _load();
+    final key = tag.trim().toLowerCase();
+    return List.unmodifiable(_index[key] ?? const []);
+  }
+}


### PR DESCRIPTION
## Summary
- add `BoosterQueueService` to store queued booster spots
- add `TrainingSpotLibrary` for indexing training pack spots by tag
- implement `DecaySpotBoosterEngine` that queues drills for highly decayed tags

## Testing
- `flutter analyze` *(fails: 6714 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_688b763ba3a0832ab3bf5e40fcc21481