### PR TITLE
Implement DecayBoosterCronJob

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,6 +63,7 @@ import 'services/suggested_pack_push_service.dart';
 import 'services/lesson_path_reminder_scheduler.dart';
 import 'services/decay_reminder_scheduler.dart';
 import 'services/decay_booster_notification_service.dart';
+import 'services/decay_booster_cron_job.dart';
 import 'services/theory_lesson_notification_scheduler.dart';
 import 'services/booster_recall_decay_cleaner.dart';
 
@@ -119,6 +120,7 @@ Future<void> main() async {
   unawaited(SuggestedPackPushService.instance.schedulePushReminder());
   unawaited(DecayBoosterNotificationService.instance.init());
   unawaited(DecayReminderScheduler.instance.register());
+  unawaited(DecayBoosterCronJob.instance.start());
   await BoosterRecallDecayCleaner.instance.init();
   await AppInitService.instance.init();
   runApp(

--- a/lib/services/decay_booster_cron_job.dart
+++ b/lib/services/decay_booster_cron_job.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'decay_spot_booster_engine.dart';
+
+/// Background job that periodically enqueues decay boosters.
+class DecayBoosterCronJob with WidgetsBindingObserver {
+  DecayBoosterCronJob({DecaySpotBoosterEngine? engine})
+      : engine = engine ?? DecaySpotBoosterEngine();
+
+  final DecaySpotBoosterEngine engine;
+
+  static final DecayBoosterCronJob instance = DecayBoosterCronJob();
+
+  static const String _prefsKey = 'decay_booster_cron_last';
+
+  bool _running = false;
+
+  Future<void> start() async {
+    WidgetsBinding.instance.addObserver(this);
+    await _runIfNeeded();
+  }
+
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _runIfNeeded();
+    }
+  }
+
+  Future<void> _runIfNeeded() async {
+    if (_running) return;
+    _running = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final str = prefs.getString(_prefsKey);
+      final last = str != null ? DateTime.tryParse(str) : null;
+      if (last == null || DateTime.now().difference(last).inDays >= 7) {
+        await engine.enqueueDecayBoosters();
+        await prefs.setString(_prefsKey, DateTime.now().toIso8601String());
+      }
+    } finally {
+      _running = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `DecayBoosterCronJob` to enqueue decay boosters weekly
- start the cron job from `main.dart`

## Testing
- `flutter pub get`
- `flutter analyze --no-pub`

------
https://chatgpt.com/codex/tasks/task_e_688b7c64d278832aac2ae543cb02a454