### PR TITLE
Implement decay booster launcher service

### DIFF
--- a/lib/services/decay_booster_training_launcher.dart
+++ b/lib/services/decay_booster_training_launcher.dart
@@ -1,0 +1,38 @@
+import 'package:uuid/uuid.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_spot_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'training_session_launcher.dart';
+import 'booster_queue_service.dart';
+import 'user_action_logger.dart';
+
+/// Launches queued decay booster spots as a training session.
+class DecayBoosterTrainingLauncher {
+  final BoosterQueueService queue;
+  final TrainingSessionLauncher launcher;
+
+  const DecayBoosterTrainingLauncher({
+    this.queue = BoosterQueueService.instance,
+    this.launcher = const TrainingSessionLauncher(),
+  });
+
+  /// Builds a temporary pack from queued spots and launches it.
+  Future<void> launch() async {
+    final spots = queue.getQueue();
+    if (spots.isEmpty) return;
+
+    final tpl = TrainingPackTemplateV2(
+      id: const Uuid().v4(),
+      name: 'Decay Booster',
+      tags: const ['decayBooster'],
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+    );
+
+    await launcher.launch(tpl);
+    queue.clear();
+    await UserActionLogger.instance
+        .logEvent({'event': 'decay_booster_completed'});
+  }
+}

--- a/test/services/decay_booster_training_launcher_test.dart
+++ b/test/services/decay_booster_training_launcher_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/decay_booster_training_launcher.dart';
+import 'package:poker_analyzer/services/booster_queue_service.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+
+class _FakeLauncher extends TrainingSessionLauncher {
+  TrainingPackTemplateV2? launched;
+  _FakeLauncher() : super();
+  @override
+  Future<void> launch(TrainingPackTemplateV2 template,{int startIndex = 0,List<String>? sessionTags}) async {
+    launched = template;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserActionLogger.instance.load();
+    BoosterQueueService.instance.clear();
+  });
+
+  test('launch opens session and clears queue', () async {
+    final spot = TrainingPackSpot(id: 's1');
+    await BoosterQueueService.instance.addSpots([spot]);
+    final launcher = _FakeLauncher();
+    final service = DecayBoosterTrainingLauncher(launcher: launcher);
+    await service.launch();
+    expect(launcher.launched?.spots.length, 1);
+    expect(BoosterQueueService.instance.getQueue(), isEmpty);
+    expect(UserActionLogger.instance.events.last['event'], 'decay_booster_completed');
+  });
+}


### PR DESCRIPTION
## Summary
- add `DecayBoosterTrainingLauncher` to convert queued decay spots into a training session
- test launching of decay booster queue with analytics logging

## Testing
- `flutter analyze` *(fails: Dart SDK version solving failed)*
- `flutter test` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b7f428e2c832ab1136313e31521fe