### PR TITLE
Implement SkillDecayDashboardTile

### DIFF
--- a/lib/screens/learning_dashboard_screen.dart
+++ b/lib/screens/learning_dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/next_up_banner.dart';
 import '../widgets/learning_path_planner_banner.dart';
 import '../widgets/skill_loss_banner_v2.dart';
 import '../widgets/tag_insight_reminder_card.dart';
+import '../widgets/skill_decay_dashboard_tile.dart';
 import '../widgets/review_path_card.dart';
 import '../widgets/smart_recovery_banner.dart';
 import '../widgets/streak_recovery_block.dart';
@@ -257,6 +258,8 @@ class _LearningDashboardScreenState extends State<LearningDashboardScreen> {
               _improvements(data.improvements),
               const SizedBox(height: 12),
               const TagInsightReminderCard(),
+              const SizedBox(height: 12),
+              const SkillDecayDashboardTile(),
               const SizedBox(height: 12),
               const SkillLossBannerV2(),
             ],

--- a/lib/services/decay_spot_booster_engine.dart
+++ b/lib/services/decay_spot_booster_engine.dart
@@ -48,4 +48,25 @@ class DecaySpotBoosterEngine {
       await queue.addSpots(spots);
     }
   }
+
+  /// Queues practice spots related to a single [tag].
+  Future<void> enqueueForTag(String tag) async {
+    final lc = tag.trim().toLowerCase();
+    if (lc.isEmpty) return;
+    if (await suppressor.shouldSuppress(lc)) return;
+    final list = await library.indexByTag(lc);
+    if (list.isEmpty) return;
+    final spots = <TrainingSpotV2>[];
+    final seen = <String>{};
+    for (final spot in list) {
+      final key = '${spot.hand.position}_${spot.hand.stacks['0']}';
+      if (seen.add(key)) {
+        spots.add(spot);
+      }
+      if (seen.length >= 3) break;
+    }
+    if (spots.isNotEmpty) {
+      await queue.addSpots(spots);
+    }
+  }
 }

--- a/lib/services/theory_booster_queue_service.dart
+++ b/lib/services/theory_booster_queue_service.dart
@@ -1,0 +1,22 @@
+import 'dart:collection';
+
+/// Simple queue of theory tags scheduled for boosters.
+class TheoryBoosterQueueService {
+  TheoryBoosterQueueService._();
+  static final TheoryBoosterQueueService instance = TheoryBoosterQueueService._();
+
+  final Queue<String> _queue = Queue<String>();
+
+  /// Adds [tag] to the queue if not already present.
+  Future<void> enqueue(String tag) async {
+    final lc = tag.trim().toLowerCase();
+    if (lc.isEmpty) return;
+    if (_queue.contains(lc)) return;
+    _queue.addLast(lc);
+  }
+
+  /// Returns queued tags.
+  List<String> getQueue() => List.unmodifiable(_queue);
+
+  void clear() => _queue.clear();
+}

--- a/lib/widgets/skill_decay_dashboard_tile.dart
+++ b/lib/widgets/skill_decay_dashboard_tile.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../services/decay_spot_booster_engine.dart';
+import '../services/theory_tag_decay_tracker.dart';
+import '../services/theory_booster_queue_service.dart';
+
+/// Dashboard tile showing most decayed theory tags with quick actions.
+class SkillDecayDashboardTile extends StatefulWidget {
+  const SkillDecayDashboardTile({super.key});
+
+  @override
+  State<SkillDecayDashboardTile> createState() => _SkillDecayDashboardTileState();
+}
+
+class _SkillDecayDashboardTileState extends State<SkillDecayDashboardTile> {
+  late Future<List<MapEntry<String, double>>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<List<MapEntry<String, double>>> _load() async {
+    final tracker = TheoryTagDecayTracker();
+    final scores = await tracker.computeDecayScores();
+    final entries = scores.entries
+        .where((e) => e.value > 50)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return entries.take(3).toList();
+  }
+
+  Future<void> _trainSpots(String tag) async {
+    final engine = DecaySpotBoosterEngine();
+    await engine.enqueueForTag(tag);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Споты добавлены в очередь')),
+    );
+  }
+
+  Future<void> _reviewTheory(String tag) async {
+    await TheoryBoosterQueueService.instance.enqueue(tag);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Теория добавлена в очередь')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<List<MapEntry<String, double>>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final list = snapshot.data ?? [];
+        if (list.isEmpty) return const SizedBox.shrink();
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: accent),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '📉 Skill Decay',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              for (final e in list)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '${e.key} • ${e.value.toStringAsFixed(0)}%',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () => _trainSpots(e.key),
+                        child: const Text('Тренировать споты'),
+                      ),
+                      const SizedBox(width: 4),
+                      TextButton(
+                        onPressed: () => _reviewTheory(e.key),
+                        child: const Text('Повторить теорию'),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a small queue for theory booster tags
- allow `DecaySpotBoosterEngine` to enqueue drills for a single tag
- display decayed tags in `SkillDecayDashboardTile`
- embed the new tile in the learning dashboard

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b829327a8832ab27e3749fd937575