### PR TITLE
Implement TheoryBoosterTrainingLauncher

### DIFF
--- a/lib/services/theory_booster_training_launcher.dart
+++ b/lib/services/theory_booster_training_launcher.dart
@@ -1,0 +1,62 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/theory_pack_model.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/theory_booster_queue_service.dart';
+import 'theory_training_launcher.dart';
+import 'user_action_logger.dart';
+
+/// Builds a temporary theory pack from queued booster tags and launches it.
+class TheoryBoosterTrainingLauncher {
+  final TheoryBoosterQueueService queue;
+  final MiniLessonLibraryService library;
+  final TheoryTrainingLauncher launcher;
+
+  const TheoryBoosterTrainingLauncher({
+    this.queue = TheoryBoosterQueueService.instance,
+    this.library = MiniLessonLibraryService.instance,
+    this.launcher = const TheoryTrainingLauncher(),
+  });
+
+  /// Builds a pack from queued tags and launches it in review mode.
+  Future<void> launch() async {
+    final tags = queue.getQueue();
+    if (tags.isEmpty) return;
+
+    await library.loadAll();
+
+    final sections = <TheorySectionModel>[];
+    final seen = <String>{};
+
+    for (final tag in tags) {
+      final lessons = library.findByTags([tag]);
+      for (final l in lessons) {
+        if (seen.add(l.id)) {
+          sections.add(
+            TheorySectionModel(
+              title: l.resolvedTitle,
+              text: l.resolvedContent,
+              type: 'booster',
+            ),
+          );
+        }
+      }
+    }
+
+    if (sections.isEmpty) {
+      queue.clear();
+      return;
+    }
+
+    final pack = TheoryPackModel(
+      id: const Uuid().v4(),
+      title: 'Theory Booster Review',
+      sections: sections,
+      tags: const ['theoryBooster'],
+    );
+
+    await launcher.launch(pack);
+    queue.clear();
+    await UserActionLogger.instance.log('theory_booster_launched');
+  }
+}

--- a/lib/services/theory_training_launcher.dart
+++ b/lib/services/theory_training_launcher.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import '../models/theory_pack_model.dart';
+import '../screens/theory_pack_reader_screen.dart';
+
+/// Helper to open a [TheoryPackModel] in reader mode.
+class TheoryTrainingLauncher {
+  const TheoryTrainingLauncher();
+
+  /// Pushes [pack] onto the navigation stack.
+  Future<void> launch(TheoryPackModel pack) async {
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return;
+    await Navigator.push(
+      ctx,
+      MaterialPageRoute(
+        builder: (_) => TheoryPackReaderScreen(pack: pack, stageId: pack.id),
+      ),
+    );
+  }
+}

--- a/test/services/theory_booster_training_launcher_test.dart
+++ b/test/services/theory_booster_training_launcher_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_booster_training_launcher.dart';
+import 'package:poker_analyzer/services/theory_booster_queue_service.dart';
+import 'package:poker_analyzer/services/theory_training_launcher.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_pack_model.dart';
+
+class _FakeLauncher extends TheoryTrainingLauncher {
+  TheoryPackModel? launched;
+  const _FakeLauncher();
+  @override
+  Future<void> launch(TheoryPackModel pack) async {
+    launched = pack;
+  }
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, List<TheoryMiniLessonNode>> lessons;
+  int loadCount = 0;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => [for (final l in lessons.values) ...l];
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      all.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {
+    loadCount++;
+  }
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(lessons[t] ?? const []);
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserActionLogger.instance.load();
+    TheoryBoosterQueueService.instance.clear();
+  });
+
+  test('launch builds pack and clears queue', () async {
+    final l1 = const TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['a']);
+    final l2 = const TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['b']);
+    final library = _FakeLibrary({'a': [l1], 'b': [l2]});
+    await TheoryBoosterQueueService.instance.enqueue('a');
+    await TheoryBoosterQueueService.instance.enqueue('b');
+    final launcher = _FakeLauncher();
+    final service = TheoryBoosterTrainingLauncher(
+      queue: TheoryBoosterQueueService.instance,
+      library: library,
+      launcher: launcher,
+    );
+    await service.launch();
+    expect(launcher.launched?.sections.length, 2);
+    expect(TheoryBoosterQueueService.instance.getQueue(), isEmpty);
+    expect(library.loadCount, 1);
+    expect(UserActionLogger.instance.events.last['event'], 'theory_booster_launched');
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryTrainingLauncher` to open theory packs in reader mode
- implement `TheoryBoosterTrainingLauncher` to create a review pack from queued tags
- test that launcher builds pack and clears queue

## Testing
- `dart`/`flutter` not available in container, so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_688b84354b94832aaad9fd4213ec6606