### PR TITLE
Implement DecayBoosterSpotInjector

### DIFF
--- a/lib/services/decay_booster_spot_injector.dart
+++ b/lib/services/decay_booster_spot_injector.dart
@@ -1,0 +1,100 @@
+import '../models/v2/training_spot_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/training_history_entry_v2.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import 'booster_queue_service.dart';
+import 'mini_lesson_library_service.dart';
+import 'theory_tag_decay_tracker.dart';
+import 'training_history_service_v2.dart';
+
+/// Injects practice spots for highly decayed tags into the booster queue.
+class DecayBoosterSpotInjector {
+  final TheoryTagDecayTracker decay;
+  final MiniLessonLibraryService lessons;
+  final BoosterQueueService queue;
+  final TrainingPackLibraryV2 library;
+  final Future<List<TrainingHistoryEntryV2>> Function({int limit}) _historyLoader;
+
+  DecayBoosterSpotInjector({
+    TheoryTagDecayTracker? decay,
+    MiniLessonLibraryService? lessons,
+    BoosterQueueService? queue,
+    TrainingPackLibraryV2? library,
+    Future<List<TrainingHistoryEntryV2>> Function({int limit})? historyLoader,
+  })  : decay = decay ?? TheoryTagDecayTracker(),
+        lessons = lessons ?? MiniLessonLibraryService.instance,
+        queue = queue ?? BoosterQueueService.instance,
+        library = library ?? TrainingPackLibraryV2.instance,
+        _historyLoader = historyLoader ?? TrainingHistoryServiceV2.getHistory;
+
+  static final DecayBoosterSpotInjector instance = DecayBoosterSpotInjector();
+
+  /// Schedules spots for decayed tags into the booster queue.
+  Future<void> inject({DateTime? now}) async {
+    final scores = await decay.computeDecayScores(now: now);
+    final entries = scores.entries
+        .where((e) => e.value > 50)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    if (entries.isEmpty) return;
+
+    await library.loadFromFolder();
+    await lessons.loadAll();
+    final history = await _historyLoader(limit: 20);
+    final recentPacks = {for (final h in history) h.packId};
+
+    final spots = <TrainingSpotV2>[];
+    final used = <String>{};
+
+    for (final entry in entries) {
+      final tag = entry.key.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      var added = 0;
+
+      // Look in recent packs first.
+      for (final id in recentPacks) {
+        final pack = library.getById(id);
+        if (pack == null) continue;
+        added += _collectSpots(pack, tag, spots, used, max: 2 - added);
+        if (added >= 2) break;
+      }
+
+      // Fallback to packs linked via mini lessons.
+      if (added == 0) {
+        final lessonList = lessons.findByTags([tag]);
+        for (final lesson in lessonList) {
+          for (final pid in lesson.linkedPackIds) {
+            final pack = library.getById(pid);
+            if (pack == null) continue;
+            added += _collectSpots(pack, tag, spots, used, max: 2 - added);
+            if (added >= 2) break;
+          }
+          if (added >= 2) break;
+        }
+      }
+    }
+
+    if (spots.isNotEmpty) {
+      await queue.addSpots(spots);
+    }
+  }
+
+  int _collectSpots(
+    TrainingPackTemplateV2 pack,
+    String tag,
+    List<TrainingSpotV2> out,
+    Set<String> used, {
+    int max = 2,
+  }) {
+    var added = 0;
+    for (final spot in pack.spots) {
+      final tags = spot.tags.map((t) => t.trim().toLowerCase());
+      if (tags.contains(tag) && used.add(spot.id)) {
+        out.add(spot);
+        added++;
+        if (added >= max) break;
+      }
+    }
+    return added;
+  }
+}

--- a/test/services/decay_booster_spot_injector_test.dart
+++ b/test/services/decay_booster_spot_injector_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:collection/collection.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/training_history_entry_v2.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/decay_booster_spot_injector.dart';
+import 'package:poker_analyzer/services/booster_queue_service.dart';
+import 'package:poker_analyzer/services/theory_tag_decay_tracker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeDecay extends TheoryTagDecayTracker {
+  final Map<String, double> scores;
+  _FakeDecay(this.scores);
+  @override
+  Future<Map<String, double>> computeDecayScores({DateTime? now}) async => scores;
+}
+
+class _FakeLessonLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLessonLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhereOrNull((l) => l.id == id);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) =>
+      [for (final l in lessons) if (l.tags.any(tags.contains)) l];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+}
+
+class _FakePackLibrary implements TrainingPackLibraryV2 {
+  final List<TrainingPackTemplateV2> _packs;
+  _FakePackLibrary(this._packs);
+
+  @override
+  List<TrainingPackTemplateV2> get packs => List.unmodifiable(_packs);
+
+  @override
+  void addPack(TrainingPackTemplateV2 pack) => _packs.add(pack);
+
+  @override
+  void clear() => _packs.clear();
+
+  @override
+  TrainingPackTemplateV2? getById(String id) =>
+      _packs.firstWhereOrNull((p) => p.id == id);
+
+  @override
+  List<TrainingPackTemplateV2> filterBy({
+    GameType? gameType,
+    TrainingType? type,
+    List<String>? tags,
+  }) {
+    return [
+      for (final p in _packs)
+        if ((gameType == null || p.gameType == gameType) &&
+            (type == null || p.trainingType == type) &&
+            (tags == null || tags.every((t) => p.tags.contains(t))))
+          p
+    ];
+  }
+
+  @override
+  Future<void> loadFromFolder([String path = TrainingPackLibraryV2.packsDir]) async {}
+
+  @override
+  Future<void> reload() async {}
+}
+
+TrainingPackTemplateV2 _pack(String id, String tag, String spotId) {
+  return TrainingPackTemplateV2(
+    id: id,
+    name: id,
+    trainingType: TrainingType.pushFold,
+    tags: [tag],
+    spots: [TrainingPackSpot(id: spotId, tags: [tag])],
+    spotCount: 1,
+  );
+}
+
+TrainingHistoryEntryV2 _hist(String packId) => TrainingHistoryEntryV2(
+      timestamp: DateTime.now(),
+      tags: const [],
+      packId: packId,
+      type: TrainingType.pushFold,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BoosterQueueService.instance.clear();
+  });
+
+  test('queues spots from recent packs', () async {
+    final pack = _pack('p1', 'push', 's1');
+    final injector = DecayBoosterSpotInjector(
+      decay: _FakeDecay({'push': 60}),
+      lessons: _FakeLessonLibrary(const []),
+      library: _FakePackLibrary([pack]),
+      historyLoader: ({int limit = 20}) async => [_hist('p1')],
+    );
+
+    await injector.inject();
+
+    final q = BoosterQueueService.instance.getQueue();
+    expect(q.map((e) => e.id), ['s1']);
+  });
+
+  test('falls back to linked lesson packs', () async {
+    final pack = _pack('p1', 'push', 's1');
+    final lesson = const TheoryMiniLessonNode(
+      id: 'l1',
+      title: 't',
+      content: '',
+      tags: ['push'],
+      linkedPackIds: ['p1'],
+      nextIds: [],
+    );
+    final injector = DecayBoosterSpotInjector(
+      decay: _FakeDecay({'push': 70}),
+      lessons: _FakeLessonLibrary([lesson]),
+      library: _FakePackLibrary([pack]),
+      historyLoader: ({int limit = 20}) async => [],
+    );
+
+    await injector.inject();
+
+    final q = BoosterQueueService.instance.getQueue();
+    expect(q.map((e) => e.id), ['s1']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `DecayBoosterSpotInjector` service for scheduling practice spots for decayed theory tags
- test new injector with recent pack history and lesson fallback

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8a8157a8832a91ecae15c1de7b2f