### PR TITLE
Implement DecayBoosterInjectorScheduler

### DIFF
--- a/lib/services/app_usage_tracker.dart
+++ b/lib/services/app_usage_tracker.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'decay_booster_injector_scheduler.dart';
 
 /// Tracks last active timestamp to estimate user idle duration.
 class AppUsageTracker with WidgetsBindingObserver {
@@ -28,6 +30,7 @@ class AppUsageTracker with WidgetsBindingObserver {
   Future<void> markActive() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_prefsKey, DateTime.now().toIso8601String());
+    unawaited(DecayBoosterInjectorScheduler.instance.maybeInject());
   }
 
   /// Returns duration since the app was last active.

--- a/lib/services/decay_booster_injector_scheduler.dart
+++ b/lib/services/decay_booster_injector_scheduler.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'decay_booster_spot_injector.dart';
+
+/// Schedules automatic injection of decay booster spots.
+class DecayBoosterInjectorScheduler {
+  DecayBoosterInjectorScheduler({DecayBoosterSpotInjector? injector})
+      : injector = injector ?? DecayBoosterSpotInjector.instance;
+
+  final DecayBoosterSpotInjector injector;
+
+  static final DecayBoosterInjectorScheduler instance =
+      DecayBoosterInjectorScheduler();
+
+  static const String _prefsKey = 'decay_booster_inject_last';
+
+  bool _running = false;
+
+  /// Injects decayed spots if at least 24h passed since last injection.
+  Future<void> maybeInject({DateTime? now}) async {
+    if (_running) return;
+    _running = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final str = prefs.getString(_prefsKey);
+      final last = str != null ? DateTime.tryParse(str) : null;
+      final current = now ?? DateTime.now();
+      if (last == null || current.difference(last).inHours >= 24) {
+        await injector.inject(now: now);
+        await prefs.setString(_prefsKey, current.toIso8601String());
+      }
+    } finally {
+      _running = false;
+    }
+  }
+}

--- a/test/services/decay_booster_injector_scheduler_test.dart
+++ b/test/services/decay_booster_injector_scheduler_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/decay_booster_injector_scheduler.dart';
+import 'package:poker_analyzer/services/decay_booster_spot_injector.dart';
+
+class _FakeInjector extends DecayBoosterSpotInjector {
+  int calls = 0;
+  _FakeInjector() : super();
+  @override
+  Future<void> inject({DateTime? now}) async {
+    calls++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('injects when day passed', () async {
+    final injector = _FakeInjector();
+    final sched = DecayBoosterInjectorScheduler(injector: injector);
+    await sched.maybeInject(now: DateTime(2024, 1, 1));
+    expect(injector.calls, 1);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('decay_booster_inject_last'), isNotNull);
+  });
+
+  test('skips when recent', () async {
+    final now = DateTime(2024, 1, 2, 10);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        'decay_booster_inject_last', now.subtract(const Duration(hours: 2)).toIso8601String());
+    final injector = _FakeInjector();
+    final sched = DecayBoosterInjectorScheduler(injector: injector);
+    await sched.maybeInject(now: now);
+    expect(injector.calls, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- schedule automatic decay booster injection with a new service
- track user activity to run the scheduler
- unit test the scheduler logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8c79209c832a9b687671f2cbb5d1