### PR TITLE
Add booster queue indicator

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -29,6 +29,7 @@ import '../widgets/continue_training_button.dart';
 import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/decay_booster_dashboard_banner.dart';
 import '../widgets/decay_booster_reminder_banner.dart';
+import '../widgets/decay_booster_queue_indicator.dart';
 import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
@@ -297,7 +298,16 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
         ab.isVariant('resume_card', 'B')
             ? const ResumeTrainingCard()
             : const SizedBox.shrink(),
-        const ContinueTrainingButton(),
+        Stack(
+          children: const [
+            ContinueTrainingButton(),
+            Positioned(
+              right: 24,
+              top: 8,
+              child: DecayBoosterQueueIndicator(),
+            ),
+          ],
+        ),
         const DecayBoosterReminderBanner(),
         const DecayBoosterDashboardBanner(),
         const GoalReminderBanner(),

--- a/lib/services/booster_queue_service.dart
+++ b/lib/services/booster_queue_service.dart
@@ -3,6 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// Stores training spots scheduled as boosters.
 
+import 'package:flutter/foundation.dart';
+
 class BoosterQueueService {
   BoosterQueueService._();
   static final BoosterQueueService instance = BoosterQueueService._();
@@ -10,6 +12,7 @@ class BoosterQueueService {
   static const _lastKey = 'booster_queue_last_used';
 
   final List<TrainingSpotV2> _queue = [];
+  final ValueNotifier<int> queueLength = ValueNotifier(0);
   DateTime? _lastUsedAt;
 
   /// Adds [spots] to the queue if not already present by id.
@@ -19,12 +22,16 @@ class BoosterQueueService {
         _queue.add(s);
       }
     }
+    queueLength.value = _queue.length;
   }
 
   /// Returns queued spots.
   List<TrainingSpotV2> getQueue() => List.unmodifiable(_queue);
 
-  void clear() => _queue.clear();
+  void clear() {
+    _queue.clear();
+    queueLength.value = 0;
+  }
 
   Future<DateTime?> lastUsed() async {
     if (_lastUsedAt != null) return _lastUsedAt;

--- a/lib/widgets/decay_booster_queue_indicator.dart
+++ b/lib/widgets/decay_booster_queue_indicator.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../services/booster_queue_service.dart';
+import '../services/decay_booster_training_launcher.dart';
+
+/// Small badge showing when decay boosters are queued.
+class DecayBoosterQueueIndicator extends StatelessWidget {
+  final BoosterQueueService queue;
+  final DecayBoosterTrainingLauncher launcher;
+
+  const DecayBoosterQueueIndicator({
+    super.key,
+    this.queue = BoosterQueueService.instance,
+    this.launcher = const DecayBoosterTrainingLauncher(),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return ValueListenableBuilder<int>(
+      valueListenable: queue.queueLength,
+      builder: (context, value, _) {
+        if (value == 0) return const SizedBox.shrink();
+        return GestureDetector(
+          onTap: launcher.launch,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: accent,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Text(
+              '\uD83D\uDD25 Booster Ready',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- notify widgets of booster queue length with a `ValueNotifier`
- show a small badge when boosters are waiting
- overlay the badge on the Continue Training button

## Testing
- `flutter pub get` *(fails: SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b92a905c0832a995e6d6f97542892