### PR TITLE
Add DecayRecallStatsCard

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -43,6 +43,7 @@ import '../services/streak_tracker_service.dart';
 import '../services/streak_milestone_queue_service.dart';
 import '../widgets/confetti_overlay.dart';
 import '../services/overlay_booster_manager.dart';
+import '../widgets/decay_recall_stats_card.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -326,6 +327,11 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
                   '🔥 Бонус за стрик: +${((widget.streakMultiplier - 1) * 100).round()}% XP',
                   style: const TextStyle(color: Colors.orange),
                 ),
+              ),
+            if (widget.template.tags.contains('decayBooster'))
+              DecayRecallStatsCard(
+                tagDeltas: widget.tagDeltas,
+                spotCount: widget.session.results.length,
               ),
             const SizedBox(height: 16),
             if (widget.tagDeltas.isNotEmpty) ...[

--- a/lib/widgets/decay_recall_stats_card.dart
+++ b/lib/widgets/decay_recall_stats_card.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/tag_retention_tracker.dart';
+
+/// Small card summarizing how many decayed tags were reinforced during a booster session.
+class DecayRecallStatsCard extends StatelessWidget {
+  final Map<String, double> tagDeltas;
+  final int spotCount;
+  const DecayRecallStatsCard({
+    super.key,
+    required this.tagDeltas,
+    required this.spotCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<String>>(
+      future: context.read<TagRetentionTracker>().getDecayedTags(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return const SizedBox.shrink();
+        final decayed = snapshot.data!.map((e) => e.toLowerCase()).toSet();
+        final refreshed = tagDeltas.keys
+            .map((e) => e.toLowerCase())
+            .where(decayed.contains)
+            .toSet()
+            .length;
+        if (refreshed == 0) return const SizedBox.shrink();
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              const Text('🔥', style: TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'You refreshed $refreshed key topics · $spotCount spots reviewed',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `DecayRecallStatsCard` widget for boosters
- show the card in `TrainingSessionSummaryScreen` after decay booster sessions

## Testing
- `flutter pub get` *(fails: Package file_picker plugin warnings, but succeeds)*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_688b9602362c832abbc95162e6ee52b4