### PR TITLE
Implement decay tag impact recorder

### DIFF
--- a/lib/models/decay_tag_reinforcement_event.dart
+++ b/lib/models/decay_tag_reinforcement_event.dart
@@ -1,0 +1,26 @@
+class DecayTagReinforcementEvent {
+  final String tag;
+  final double delta;
+  final DateTime timestamp;
+
+  DecayTagReinforcementEvent({
+    required this.tag,
+    required this.delta,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'delta': delta,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory DecayTagReinforcementEvent.fromJson(Map<String, dynamic> json) =>
+      DecayTagReinforcementEvent(
+        tag: json['tag'] as String? ?? '',
+        delta: (json['delta'] as num?)?.toDouble() ?? 0.0,
+        timestamp:
+            DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+                DateTime.now(),
+      );
+}

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -44,6 +45,7 @@ import '../services/streak_milestone_queue_service.dart';
 import '../widgets/confetti_overlay.dart';
 import '../services/overlay_booster_manager.dart';
 import '../widgets/decay_recall_stats_card.dart';
+import '../services/decay_session_tag_impact_recorder.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -145,6 +147,11 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       await StreakMilestoneQueueService.instance
           .showNextMilestoneCelebrationIfAny(context);
       await context.read<OverlayBoosterManager>().onAfterXpScreen();
+      if (widget.template.tags.contains('decayBooster') &&
+          widget.tagDeltas.isNotEmpty) {
+        unawaited(DecaySessionTagImpactRecorder.instance
+            .recordSession(widget.tagDeltas, DateTime.now()));
+      }
     });
     _loadWeakPack();
   }

--- a/lib/services/decay_session_tag_impact_recorder.dart
+++ b/lib/services/decay_session_tag_impact_recorder.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/decay_tag_reinforcement_event.dart';
+
+class DecaySessionTagImpactRecorder {
+  DecaySessionTagImpactRecorder._();
+  static final DecaySessionTagImpactRecorder instance =
+      DecaySessionTagImpactRecorder._();
+
+  static const _prefix = 'decay_tag_reinf_';
+
+  Future<List<DecayTagReinforcementEvent>> _load(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix${tag.toLowerCase()}';
+    final raw = prefs.getString(key);
+    if (raw == null) return <DecayTagReinforcementEvent>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [
+          for (final e in data.whereType<Map>())
+            DecayTagReinforcementEvent.fromJson(
+                Map<String, dynamic>.from(e as Map)),
+        ];
+      }
+    } catch (_) {}
+    return <DecayTagReinforcementEvent>[];
+  }
+
+  Future<void> _save(String tag, List<DecayTagReinforcementEvent> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix${tag.toLowerCase()}';
+    await prefs.setString(
+        key, jsonEncode([for (final e in list) e.toJson()]));
+  }
+
+  Future<void> recordSession(
+      Map<String, double> tagDeltas, DateTime timestamp) async {
+    for (final entry in tagDeltas.entries) {
+      final tag = entry.key.toLowerCase();
+      if (tag.isEmpty) continue;
+      final list = await _load(tag);
+      list.insert(
+          0,
+          DecayTagReinforcementEvent(
+            tag: tag,
+            delta: entry.value,
+            timestamp: timestamp,
+          ));
+      while (list.length > 100) {
+        list.removeLast();
+      }
+      await _save(tag, list);
+    }
+  }
+
+  Future<List<DecayTagReinforcementEvent>> getRecentReinforcements(String tag) {
+    return _load(tag);
+  }
+}


### PR DESCRIPTION
## Summary
- add model `DecayTagReinforcementEvent`
- implement `DecaySessionTagImpactRecorder` for storing tag deltas after decay sessions
- log decay booster reinforcements on the session summary screen

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9b27a238832aa5e32d25aa355a69