### PR TITLE
Implement DecayRecallMasteryIntegrator

### DIFF
--- a/lib/services/decay_recall_mastery_integrator.dart
+++ b/lib/services/decay_recall_mastery_integrator.dart
@@ -1,0 +1,70 @@
+
+import '../models/decay_tag_reinforcement_event.dart';
+import 'decay_session_tag_impact_recorder.dart';
+import 'mastery_persistence_service.dart';
+import 'tag_mastery_adjustment_log_service.dart';
+
+/// Adjusts persisted tag mastery based on recent reinforcement history.
+class DecayRecallMasteryIntegrator {
+  final Future<List<DecayTagReinforcementEvent>> Function(String tag)
+      _historyLoader;
+  final MasteryPersistenceService _persistence;
+  final TagMasteryAdjustmentLogService? _logger;
+  final Duration staleThreshold;
+  final double negativeDelta;
+  final double positiveDelta;
+  final double maxDelta;
+
+  DecayRecallMasteryIntegrator({
+    Future<List<DecayTagReinforcementEvent>> Function(String tag)? historyLoader,
+    MasteryPersistenceService? persistence,
+    TagMasteryAdjustmentLogService? logger,
+    this.staleThreshold = const Duration(days: 30),
+    this.negativeDelta = -0.02,
+    this.positiveDelta = 0.01,
+    this.maxDelta = 0.05,
+  })  : _historyLoader =
+            historyLoader ??
+            DecaySessionTagImpactRecorder.instance.getRecentReinforcements,
+        _persistence = persistence ?? MasteryPersistenceService(),
+        _logger = logger;
+
+  /// Runs the integrator, adjusting stored mastery values.
+  Future<void> integrate({DateTime? now}) async {
+    final current = now ?? DateTime.now();
+    final map = await _persistence.load();
+    if (map.isEmpty) return;
+    final updated = Map<String, double>.from(map);
+    for (final entry in map.entries) {
+      final tag = entry.key;
+      final events = await _historyLoader(tag);
+      int recent = 0;
+      for (final e in events) {
+        if (current.difference(e.timestamp) <= staleThreshold) {
+          recent++;
+        } else {
+          break;
+        }
+      }
+      double delta;
+      if (recent == 0) {
+        delta = negativeDelta;
+      } else {
+        delta = (positiveDelta * recent).clamp(-maxDelta, maxDelta);
+      }
+      delta = delta.clamp(-maxDelta, maxDelta);
+      if (delta.abs() > 1e-6) {
+        final newVal = (entry.value + delta).clamp(0.0, 1.0);
+        updated[tag] = newVal;
+        if (_logger != null) {
+          await _logger!.add(TagMasteryAdjustmentEntry(
+            tag: tag,
+            delta: delta,
+            timestamp: current,
+          ));
+        }
+      }
+    }
+    await _persistence.save(updated);
+  }
+}

--- a/lib/services/tag_mastery_adjustment_log_service.dart
+++ b/lib/services/tag_mastery_adjustment_log_service.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TagMasteryAdjustmentEntry {
+  final String tag;
+  final double delta;
+  final DateTime timestamp;
+
+  const TagMasteryAdjustmentEntry({
+    required this.tag,
+    required this.delta,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'delta': delta,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory TagMasteryAdjustmentEntry.fromJson(Map<String, dynamic> json) =>
+      TagMasteryAdjustmentEntry(
+        tag: json['tag'] as String? ?? '',
+        delta: (json['delta'] as num?)?.toDouble() ?? 0.0,
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}
+
+/// Persists mastery adjustment logs for debugging.
+class TagMasteryAdjustmentLogService {
+  static const _key = 'tag_mastery_adjust_logs';
+  TagMasteryAdjustmentLogService._();
+  static final instance = TagMasteryAdjustmentLogService._();
+
+  final List<TagMasteryAdjustmentEntry> _logs = [];
+
+  List<TagMasteryAdjustmentEntry> get logs => List.unmodifiable(_logs);
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return;
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        _logs
+          ..clear()
+          ..addAll(data.map((e) =>
+              TagMasteryAdjustmentEntry.fromJson(Map<String, dynamic>.from(e))));
+        _logs.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode([for (final l in _logs) l.toJson()]));
+  }
+
+  Future<void> add(TagMasteryAdjustmentEntry entry) async {
+    _logs.insert(0, entry);
+    while (_logs.length > 100) {
+      _logs.removeLast();
+    }
+    await _save();
+  }
+}

--- a/test/services/decay_recall_mastery_integrator_test.dart
+++ b/test/services/decay_recall_mastery_integrator_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/decay_tag_reinforcement_event.dart';
+import 'package:poker_analyzer/services/decay_recall_mastery_integrator.dart';
+import 'package:poker_analyzer/services/mastery_persistence_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('applies negative delta when no recent reinforcement', () async {
+    final store = MasteryPersistenceService();
+    await store.save({'push': 0.5});
+    final integrator = DecayRecallMasteryIntegrator(
+      historyLoader: (_) async => <DecayTagReinforcementEvent>[],
+      persistence: store,
+    );
+    await integrator.integrate(now: DateTime(2024, 1, 10));
+    final map = await store.load();
+    expect(map['push'], closeTo(0.48, 0.0001));
+  });
+
+  test('positive adjustments accumulate and are capped', () async {
+    final store = MasteryPersistenceService();
+    await store.save({'push': 0.5});
+    final events = [
+      for (int i = 0; i < 7; i++)
+        DecayTagReinforcementEvent(
+          tag: 'push',
+          delta: 0.01,
+          timestamp: DateTime(2024, 1, 10).subtract(Duration(days: i)),
+        ),
+    ];
+    final integrator = DecayRecallMasteryIntegrator(
+      historyLoader: (_) async => events,
+      persistence: store,
+    );
+    await integrator.integrate(now: DateTime(2024, 1, 10));
+    final map = await store.load();
+    expect(map['push'], closeTo(0.55, 0.0001));
+  });
+}


### PR DESCRIPTION
## Summary
- add `DecayRecallMasteryIntegrator` to adjust tag mastery using decay history
- persist adjustment logs via `TagMasteryAdjustmentLogService`
- cover integrator with unit tests

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e5c200c832abb79c5bf3b7fe622