### PR TITLE
Add booster reinforcement summary panel

### DIFF
--- a/lib/screens/booster_recap_screen.dart
+++ b/lib/screens/booster_recap_screen.dart
@@ -13,6 +13,8 @@ import '../theme/app_colors.dart';
 import 'training_session_screen.dart';
 import '../widgets/theory_progress_recovery_banner.dart';
 import '../widgets/booster_recall_banner.dart';
+import '../widgets/decay_booster_summary_stats_panel.dart';
+import '../models/decay_tag_reinforcement_event.dart';
 
 class BoosterRecapScreen extends StatefulWidget {
   final TrainingSessionResult result;
@@ -20,6 +22,7 @@ class BoosterRecapScreen extends StatefulWidget {
   final BoosterBacklink? backlink;
   final WeakClusterInfo? cluster;
   final Map<String, double> tagDeltas;
+  final List<DecayTagReinforcementEvent> reinforcements;
 
   const BoosterRecapScreen({
     super.key,
@@ -28,6 +31,7 @@ class BoosterRecapScreen extends StatefulWidget {
     this.backlink,
     this.cluster,
     this.tagDeltas = const {},
+    this.reinforcements = const [],
   });
 
   @override
@@ -112,6 +116,7 @@ class _BoosterRecapScreenState extends State<BoosterRecapScreen> {
               ],
               const BoosterRecallBanner(),
               const TheoryProgressRecoveryBanner(),
+              DecayBoosterSummaryStatsPanel(events: widget.reinforcements),
               Row(
                 children: [
                   Expanded(

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -38,6 +38,7 @@ import '../services/daily_learning_goal_service.dart';
 import '../services/pack_dependency_map.dart';
 import '../services/pack_library_loader_service.dart';
 import '../services/smart_stage_unlock_engine.dart';
+import '../models/decay_tag_reinforcement_event.dart';
 import '../services/theory_completion_event_dispatcher.dart';
 import '../services/training_milestone_engine.dart';
 import '../widgets/confetti_overlay.dart';
@@ -446,6 +447,15 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         }
       }
 
+      final reinforcements = [
+        for (final e in deltas.entries)
+          DecayTagReinforcementEvent(
+            tag: e.key,
+            delta: e.value,
+            timestamp: DateTime.now(),
+          )
+      ];
+
       if (service.totalCount < 3) {
         Map<String, int>? counts;
         if (tpl.id == 'suggested_weekly') {
@@ -466,6 +476,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                   ),
                   booster: boosterTpl!,
                   tagDeltas: deltas,
+                  reinforcements: reinforcements,
                 )
               : PackStatsScreen(
                   templateId: tpl.id,
@@ -494,6 +505,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                   ),
                   booster: boosterTpl!,
                   tagDeltas: deltas,
+                  reinforcements: reinforcements,
                 )
               : TrainingRecapScreen(
                   templateId: tpl.id,

--- a/lib/widgets/decay_booster_summary_stats_panel.dart
+++ b/lib/widgets/decay_booster_summary_stats_panel.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/decay_tag_reinforcement_event.dart';
+import '../services/tag_retention_tracker.dart';
+
+/// Compact panel summarizing how many decayed skills were reinforced in a booster session.
+class DecayBoosterSummaryStatsPanel extends StatefulWidget {
+  final List<DecayTagReinforcementEvent> events;
+  final bool initiallyExpanded;
+  const DecayBoosterSummaryStatsPanel({
+    super.key,
+    required this.events,
+    this.initiallyExpanded = false,
+  });
+
+  @override
+  State<DecayBoosterSummaryStatsPanel> createState() => _DecayBoosterSummaryStatsPanelState();
+}
+
+class _DecayBoosterSummaryStatsPanelState extends State<DecayBoosterSummaryStatsPanel> {
+  late Future<_SummaryData> _future;
+  late bool _expanded;
+
+  @override
+  void initState() {
+    super.initState();
+    _expanded = widget.initiallyExpanded;
+    _future = _load();
+  }
+
+  Future<_SummaryData> _load() async {
+    final decayed = await context.read<TagRetentionTracker>().getDecayedTags();
+    final decayedSet = decayed.map((e) => e.toLowerCase()).toSet();
+    final filtered = widget.events
+        .where((e) => decayedSet.contains(e.tag.toLowerCase()))
+        .toList();
+    if (filtered.isEmpty) return const _SummaryData.empty();
+    final tags = filtered.map((e) => e.tag.toLowerCase()).toSet().length;
+    final delta = filtered.fold<double>(0.0, (s, e) => s + e.delta);
+    return _SummaryData(tags: tags, delta: delta, events: filtered);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_SummaryData>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return const SizedBox.shrink();
+        final data = snapshot.data!;
+        if (data.isEmpty) return const SizedBox.shrink();
+        final deltaStr = data.delta >= 0
+            ? '+${data.delta.toStringAsFixed(2)}'
+            : data.delta.toStringAsFixed(2);
+        final summary = '🎯 ${data.tags} забытых навыков восстановлены · $deltaStr мастерства';
+        final accent = Theme.of(context).colorScheme.secondary;
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: ExpansionTile(
+            initiallyExpanded: _expanded,
+            onExpansionChanged: (v) => setState(() => _expanded = v),
+            title: Text(summary, style: const TextStyle(color: Colors.white70)),
+            collapsedIconColor: Colors.white,
+            iconColor: Colors.white,
+            textColor: Colors.white,
+            childrenPadding: const EdgeInsets.all(12),
+            children: [
+              for (final e in data.events)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(e.tag, style: const TextStyle(color: Colors.white70)),
+                      Text(
+                        e.delta >= 0
+                            ? '+${e.delta.toStringAsFixed(2)}'
+                            : e.delta.toStringAsFixed(2),
+                        style: TextStyle(
+                          color: e.delta >= 0 ? accent : Colors.redAccent,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SummaryData {
+  final int tags;
+  final double delta;
+  final List<DecayTagReinforcementEvent> events;
+  const _SummaryData({required this.tags, required this.delta, required this.events});
+  const _SummaryData.empty()
+      : tags = 0,
+        delta = 0,
+        events = const [];
+  bool get isEmpty => tags == 0;
+}


### PR DESCRIPTION
## Summary
- add `DecayBoosterSummaryStatsPanel` to summarize how many forgotten skills were refreshed
- pass reinforcement data from training sessions to booster recap screen
- display the new panel in booster recap

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688b9ff40b48832a8bdbf528630570ad