### PR TITLE
Implement MistakeBoosterPathNodeDecorator

### DIFF
--- a/lib/models/learning_branch_node.dart
+++ b/lib/models/learning_branch_node.dart
@@ -5,6 +5,9 @@ class LearningBranchNode implements LearningPathNode {
   @override
   final String id;
 
+  @override
+  final bool recoveredFromMistake;
+
   /// Question shown to the user when choosing a branch.
   final String prompt;
 
@@ -15,6 +18,7 @@ class LearningBranchNode implements LearningPathNode {
     required this.id,
     required this.prompt,
     Map<String, String>? branches,
+    this.recoveredFromMistake = false,
   }) : branches = branches ?? const {};
 
   /// Returns the target node id for [choice] or `null` if not found.
@@ -32,6 +36,7 @@ class LearningBranchNode implements LearningPathNode {
       id: json['id']?.toString() ?? '',
       prompt: json['prompt']?.toString() ?? '',
       branches: map,
+      recoveredFromMistake: json['recoveredFromMistake'] as bool? ?? false,
     );
   }
 
@@ -39,6 +44,7 @@ class LearningBranchNode implements LearningPathNode {
         'id': id,
         'prompt': prompt,
         if (branches.isNotEmpty) 'branches': branches,
+        if (recoveredFromMistake) 'recoveredFromMistake': true,
       };
 
   factory LearningBranchNode.fromYaml(Map yaml) {

--- a/lib/models/learning_path_node.dart
+++ b/lib/models/learning_path_node.dart
@@ -1,4 +1,8 @@
 /// Base class for nodes in a learning path graph.
 abstract class LearningPathNode {
+  /// Unique identifier of this node.
   String get id;
+
+  /// Whether the node has been recovered from a mistake via boosters.
+  bool get recoveredFromMistake;
 }

--- a/lib/models/theory_lesson_node.dart
+++ b/lib/models/theory_lesson_node.dart
@@ -6,6 +6,9 @@ class TheoryLessonNode implements LearningPathNode {
   @override
   final String id;
 
+  @override
+  final bool recoveredFromMistake;
+
   /// Optional reference id of shared theory content.
   final String? refId;
 
@@ -24,6 +27,7 @@ class TheoryLessonNode implements LearningPathNode {
     required this.title,
     required this.content,
     List<String>? nextIds,
+    this.recoveredFromMistake = false,
   }) : nextIds = nextIds ?? const [];
 
   /// Returns [title] or the referenced block's title when empty.

--- a/lib/models/theory_mini_lesson_node.dart
+++ b/lib/models/theory_mini_lesson_node.dart
@@ -6,6 +6,9 @@ class TheoryMiniLessonNode implements LearningPathNode {
   @override
   final String id;
 
+  @override
+  final bool recoveredFromMistake;
+
   /// Optional reference id of shared theory content.
   final String? refId;
 
@@ -36,6 +39,7 @@ class TheoryMiniLessonNode implements LearningPathNode {
     List<String>? tags,
     List<String>? nextIds,
     List<String>? linkedPackIds,
+    this.recoveredFromMistake = false,
   })  : tags = tags ?? const [],
         nextIds = nextIds ?? const [],
         linkedPackIds = linkedPackIds ?? const [];
@@ -75,6 +79,7 @@ class TheoryMiniLessonNode implements LearningPathNode {
       stage: yaml['stage']?.toString(),
       nextIds: nextIds,
       linkedPackIds: linked,
+      recoveredFromMistake: yaml['recoveredFromMistake'] as bool? ?? false,
     );
   }
 }

--- a/lib/services/graph_path_template_parser.dart
+++ b/lib/services/graph_path_template_parser.dart
@@ -83,6 +83,7 @@ class GraphPathTemplateParser {
           id: id,
           prompt: m['prompt']?.toString() ?? '',
           branches: branches,
+          recoveredFromMistake: m['recoveredFromMistake'] as bool? ?? false,
         );
         nodes.add(node);
         byId[id] = node;
@@ -91,9 +92,20 @@ class GraphPathTemplateParser {
         final nextIds = <String>[for (final v in (m['next'] as List? ?? [])) v.toString()];
         final dependsOn = <String>[for (final v in (m['dependsOn'] as List? ?? [])) v.toString()];
         final stageType = _parseStageType(m['stageType']);
+        final recovered = m['recoveredFromMistake'] as bool? ?? false;
         final StageNode node = stageType == StageType.theory
-            ? TheoryStageNode(id: stageId, nextIds: nextIds, dependsOn: dependsOn)
-            : TrainingStageNode(id: stageId, nextIds: nextIds, dependsOn: dependsOn);
+            ? TheoryStageNode(
+                id: stageId,
+                nextIds: nextIds,
+                dependsOn: dependsOn,
+                recoveredFromMistake: recovered,
+              )
+            : TrainingStageNode(
+                id: stageId,
+                nextIds: nextIds,
+                dependsOn: dependsOn,
+                recoveredFromMistake: recovered,
+              );
         nodes.add(node);
         byId[id] = node;
       } else if (type == 'theory') {
@@ -104,6 +116,7 @@ class GraphPathTemplateParser {
           title: m['title']?.toString() ?? '',
           content: m['content']?.toString() ?? '',
           nextIds: nextIds,
+          recoveredFromMistake: m['recoveredFromMistake'] as bool? ?? false,
         );
         nodes.add(node);
         byId[id] = node;
@@ -117,6 +130,7 @@ class GraphPathTemplateParser {
           content: m['content']?.toString() ?? '',
           tags: tags,
           nextIds: nextIds,
+          recoveredFromMistake: m['recoveredFromMistake'] as bool? ?? false,
         );
         nodes.add(node);
         byId[id] = node;

--- a/lib/services/learning_graph_engine.dart
+++ b/lib/services/learning_graph_engine.dart
@@ -141,7 +141,12 @@ class LearningPathEngine {
         final branches = Map<String, String>.from(node.branches);
         branches.updateAll((key, value) => value == nodeId ? (replacement ?? value) : value);
         branches.removeWhere((key, value) => value.isEmpty);
-        return LearningBranchNode(id: node.id, prompt: node.prompt, branches: branches);
+        return LearningBranchNode(
+          id: node.id,
+          prompt: node.prompt,
+          branches: branches,
+          recoveredFromMistake: node.recoveredFromMistake,
+        );
       } else if (node is TrainingStageNode) {
         final next = [for (final n in node.nextIds) if (n != nodeId) n];
         if (replacement != null) {
@@ -149,7 +154,12 @@ class LearningPathEngine {
             if (node.nextIds[i] == nodeId) next.insert(i, replacement!);
           }
         }
-        return TrainingStageNode(id: node.id, nextIds: next, dependsOn: List<String>.from(node.dependsOn));
+        return TrainingStageNode(
+          id: node.id,
+          nextIds: next,
+          dependsOn: List<String>.from(node.dependsOn),
+          recoveredFromMistake: node.recoveredFromMistake,
+        );
       } else if (node is TheoryStageNode) {
         final next = [for (final n in node.nextIds) if (n != nodeId) n];
         if (replacement != null) {
@@ -157,7 +167,12 @@ class LearningPathEngine {
             if (node.nextIds[i] == nodeId) next.insert(i, replacement!);
           }
         }
-        return TheoryStageNode(id: node.id, nextIds: next, dependsOn: List<String>.from(node.dependsOn));
+        return TheoryStageNode(
+          id: node.id,
+          nextIds: next,
+          dependsOn: List<String>.from(node.dependsOn),
+          recoveredFromMistake: node.recoveredFromMistake,
+        );
       } else if (node is TheoryLessonNode) {
         final next = [for (final n in node.nextIds) if (n != nodeId) n];
         if (replacement != null) {
@@ -171,6 +186,7 @@ class LearningPathEngine {
           title: node.title,
           content: node.content,
           nextIds: next,
+          recoveredFromMistake: node.recoveredFromMistake,
         );
       } else if (node is TheoryMiniLessonNode) {
         final next = [for (final n in node.nextIds) if (n != nodeId) n];
@@ -186,6 +202,7 @@ class LearningPathEngine {
           content: node.content,
           tags: List<String>.from(node.tags),
           nextIds: next,
+          recoveredFromMistake: node.recoveredFromMistake,
         );
       }
       return node;

--- a/lib/services/learning_path_renderer.dart
+++ b/lib/services/learning_path_renderer.dart
@@ -1,0 +1,17 @@
+import '../models/learning_path_node.dart';
+import 'mistake_booster_path_node_decorator.dart';
+
+/// Renders learning path nodes applying various decorators before use.
+class LearningPathRenderer {
+  final MistakeBoosterPathNodeDecorator boosterDecorator;
+
+  const LearningPathRenderer({
+    MistakeBoosterPathNodeDecorator? boosterDecorator,
+  }) : boosterDecorator = boosterDecorator ?? const MistakeBoosterPathNodeDecorator();
+
+  /// Applies decorators to [nodes] and returns the updated list.
+  Future<List<LearningPathNode>> render(List<LearningPathNode> nodes) async {
+    final decorated = await boosterDecorator.decorate(nodes);
+    return decorated;
+  }
+}

--- a/lib/services/mini_lesson_booster_engine.dart
+++ b/lib/services/mini_lesson_booster_engine.dart
@@ -42,6 +42,7 @@ class MiniLessonBoosterEngine {
         content: l.content,
         tags: l.tags,
         nextIds: const [],
+        recoveredFromMistake: l.recoveredFromMistake,
       ));
       byId[id] = inject.last;
     }
@@ -105,6 +106,7 @@ class MiniLessonBoosterEngine {
             content: n.content,
             tags: List<String>.from(n.tags),
             nextIds: next,
+            recoveredFromMistake: n.recoveredFromMistake,
           );
         }
       } else if (n is LearningBranchNode) {
@@ -135,6 +137,7 @@ class MiniLessonBoosterEngine {
         content: inject[i].content,
         tags: inject[i].tags,
         nextIds: [next],
+        recoveredFromMistake: inject[i].recoveredFromMistake,
       );
       updated.add(inject[i]);
     }
@@ -156,12 +159,14 @@ class MiniLessonBoosterEngine {
         id: node.id,
         nextIds: List<String>.from(node.nextIds),
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryStageNode) {
       return TheoryStageNode(
         id: node.id,
         nextIds: List<String>.from(node.nextIds),
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryLessonNode) {
       return TheoryLessonNode(
@@ -170,6 +175,7 @@ class MiniLessonBoosterEngine {
         title: node.title,
         content: node.content,
         nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryMiniLessonNode) {
       return TheoryMiniLessonNode(
@@ -179,6 +185,7 @@ class MiniLessonBoosterEngine {
         content: node.content,
         tags: List<String>.from(node.tags),
         nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     }
     return node;

--- a/lib/services/mini_lesson_path_injector.dart
+++ b/lib/services/mini_lesson_path_injector.dart
@@ -107,12 +107,14 @@ class MiniLessonPathInjector {
         id: node.id,
         nextIds: next,
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryStageNode) {
       return TheoryStageNode(
         id: node.id,
         nextIds: next,
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryLessonNode) {
       return TheoryLessonNode(
@@ -121,6 +123,7 @@ class MiniLessonPathInjector {
         title: node.title,
         content: node.content,
         nextIds: next,
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryMiniLessonNode) {
       return TheoryMiniLessonNode(
@@ -130,6 +133,7 @@ class MiniLessonPathInjector {
         content: node.content,
         tags: List<String>.from(node.tags),
         nextIds: next,
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     }
     return node;

--- a/lib/services/mistake_booster_path_node_decorator.dart
+++ b/lib/services/mistake_booster_path_node_decorator.dart
@@ -1,0 +1,93 @@
+import '../models/learning_branch_node.dart';
+import '../models/learning_path_node.dart';
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'path_map_engine.dart';
+import 'mistake_booster_progress_tracker.dart';
+
+/// Decorates [LearningPathNode]s with recoveredFromMistake based on booster progress.
+class MistakeBoosterPathNodeDecorator {
+  final MistakeBoosterProgressTracker tracker;
+
+  const MistakeBoosterPathNodeDecorator({
+    MistakeBoosterProgressTracker? tracker,
+  }) : tracker = tracker ?? MistakeBoosterProgressTracker.instance;
+
+  /// Returns a copy of [nodes] with recovered status applied.
+  Future<List<LearningPathNode>> decorate(List<LearningPathNode> nodes) async {
+    final recovered = await tracker.getCompletedTags();
+    if (recovered.isEmpty) {
+      return [for (final n in nodes) _clone(n)];
+    }
+    final tags = {for (final r in recovered) r.tag.toLowerCase()};
+    return [for (final n in nodes) _decorateNode(n, tags)];
+  }
+
+  LearningPathNode _decorateNode(LearningPathNode node, Set<String> tags) {
+    if (node is TheoryMiniLessonNode) {
+      final flag = node.tags.any((t) => tags.contains(t.toLowerCase()));
+      return TheoryMiniLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        stage: node.stage,
+        tags: List<String>.from(node.tags),
+        nextIds: List<String>.from(node.nextIds),
+        linkedPackIds: List<String>.from(node.linkedPackIds),
+        recoveredFromMistake: flag,
+      );
+    }
+    if (node is LearningPathNode) {
+      return _clone(node);
+    }
+    return node;
+  }
+
+  LearningPathNode _clone(LearningPathNode node) {
+    if (node is LearningBranchNode) {
+      return LearningBranchNode(
+        id: node.id,
+        prompt: node.prompt,
+        branches: Map<String, String>.from(node.branches),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TrainingStageNode) {
+      return TrainingStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryStageNode) {
+      return TheoryStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryLessonNode) {
+      return TheoryLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryMiniLessonNode) {
+      return TheoryMiniLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        tags: List<String>.from(node.tags),
+        nextIds: List<String>.from(node.nextIds),
+        linkedPackIds: List<String>.from(node.linkedPackIds),
+        recoveredFromMistake: node.recoveredFromMistake,
+        stage: node.stage,
+      );
+    }
+    return node;
+  }
+}

--- a/lib/services/path_map_engine.dart
+++ b/lib/services/path_map_engine.dart
@@ -15,6 +15,9 @@ abstract class StageNode implements LearningPathNode {
   @override
   final String id;
 
+  @override
+  final bool recoveredFromMistake;
+
   /// IDs of nodes unlocked after completing this one.
   final List<String> nextIds;
 
@@ -25,6 +28,7 @@ abstract class StageNode implements LearningPathNode {
     required this.id,
     List<String>? nextIds,
     List<String>? dependsOn,
+    this.recoveredFromMistake = false,
   }) : nextIds = nextIds ?? const [],
        dependsOn = dependsOn ?? const [];
 }
@@ -35,7 +39,12 @@ class TrainingStageNode extends StageNode {
     required super.id,
     List<String>? nextIds,
     List<String>? dependsOn,
-  }) : super(nextIds: nextIds, dependsOn: dependsOn);
+    bool recoveredFromMistake = false,
+  }) : super(
+          nextIds: nextIds,
+          dependsOn: dependsOn,
+          recoveredFromMistake: recoveredFromMistake,
+        );
 }
 
 /// Node representing a theory stage.
@@ -44,7 +53,12 @@ class TheoryStageNode extends StageNode {
     required super.id,
     List<String>? nextIds,
     List<String>? dependsOn,
-  }) : super(nextIds: nextIds, dependsOn: dependsOn);
+    bool recoveredFromMistake = false,
+  }) : super(
+          nextIds: nextIds,
+          dependsOn: dependsOn,
+          recoveredFromMistake: recoveredFromMistake,
+        );
 }
 
 /// Service for traversing learning paths defined as graphs.

--- a/lib/services/theory_booster_injector.dart
+++ b/lib/services/theory_booster_injector.dart
@@ -42,6 +42,7 @@ class TheoryBoosterInjector {
           title: n.title,
           content: n.content,
           nextIds: const [],
+          recoveredFromMistake: n.recoveredFromMistake,
         ));
         byId[id] = n; // reserve id
       }
@@ -68,8 +69,18 @@ class TheoryBoosterInjector {
         }
         if (changed) {
           updated[i] = n is TheoryStageNode
-              ? TheoryStageNode(id: n.id, nextIds: next, dependsOn: n.dependsOn)
-              : TrainingStageNode(id: n.id, nextIds: next, dependsOn: n.dependsOn);
+              ? TheoryStageNode(
+                  id: n.id,
+                  nextIds: next,
+                  dependsOn: n.dependsOn,
+                  recoveredFromMistake: n.recoveredFromMistake,
+                )
+              : TrainingStageNode(
+                  id: n.id,
+                  nextIds: next,
+                  dependsOn: n.dependsOn,
+                  recoveredFromMistake: n.recoveredFromMistake,
+                );
         }
       } else if (n is TheoryLessonNode) {
         final next = List<String>.from(n.nextIds);
@@ -87,6 +98,7 @@ class TheoryBoosterInjector {
             title: n.title,
             content: n.content,
             nextIds: next,
+            recoveredFromMistake: n.recoveredFromMistake,
           );
         }
       } else if (n is LearningBranchNode) {
@@ -103,6 +115,7 @@ class TheoryBoosterInjector {
             id: n.id,
             prompt: n.prompt,
             branches: branches,
+            recoveredFromMistake: n.recoveredFromMistake,
           );
         }
       }
@@ -135,18 +148,21 @@ class TheoryBoosterInjector {
         id: node.id,
         prompt: node.prompt,
         branches: Map<String, String>.from(node.branches),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TrainingStageNode) {
       return TrainingStageNode(
         id: node.id,
         nextIds: List<String>.from(node.nextIds),
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryStageNode) {
       return TheoryStageNode(
         id: node.id,
         nextIds: List<String>.from(node.nextIds),
         dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     } else if (node is TheoryLessonNode) {
       return TheoryLessonNode(
@@ -155,6 +171,7 @@ class TheoryBoosterInjector {
         title: node.title,
         content: node.content,
         nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
       );
     }
     return node;

--- a/test/services/learning_path_renderer_test.dart
+++ b/test/services/learning_path_renderer_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mistake_booster_progress_tracker.dart';
+import 'package:poker_analyzer/services/learning_path_renderer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('decorates recovered mini lesson nodes', () async {
+    final tracker = MistakeBoosterProgressTracker.instance;
+    await tracker.resetForTest();
+    await tracker.recordProgress({'push': 0.05});
+    await tracker.recordProgress({'push': 0.05});
+    await tracker.recordProgress({'push': 0.05});
+
+    final nodes = [
+      TheoryMiniLessonNode(id: 'a', title: 'A', content: '', tags: const ['push'], nextIds: const []),
+      TheoryMiniLessonNode(id: 'b', title: 'B', content: '', tags: const ['call'], nextIds: const []),
+    ];
+
+    final renderer = LearningPathRenderer();
+    final result = await renderer.render(nodes);
+
+    expect(result[0].recoveredFromMistake, isTrue);
+    expect(result[1].recoveredFromMistake, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `recoveredFromMistake` property to `LearningPathNode` hierarchy
- implement `MistakeBoosterPathNodeDecorator` and simple `LearningPathRenderer`
- mark nodes recovered from mistake tags
- update graph parsing and clone logic
- add unit test for rendering decorated nodes

## Testing
- `flutter analyze` *(fails: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688bb548eb08832aaf3e323d737be8c9