### PR TITLE
Implement DecayBoostedPracticeQueue

### DIFF
--- a/lib/services/decay_boosted_practice_queue.dart
+++ b/lib/services/decay_boosted_practice_queue.dart
@@ -1,0 +1,36 @@
+import '../models/v2/training_spot_v2.dart';
+import 'auto_decay_spot_generator.dart';
+import 'recent_spot_history_service.dart';
+
+/// Builds a queue of practice spots boosted by decay urgency.
+class DecayBoostedPracticeQueue {
+  final AutoDecaySpotGenerator generator;
+  final RecentSpotHistoryService history;
+
+  DecayBoostedPracticeQueue({
+    AutoDecaySpotGenerator? generator,
+    RecentSpotHistoryService? history,
+  })  : generator = generator ?? const AutoDecaySpotGenerator(),
+        history = history ?? RecentSpotHistoryService.instance;
+
+  /// Generates up to 5 spots prioritized by decay and filtered against
+  /// the most recent session.
+  Future<List<TrainingSpotV2>> prepareQueue({int limit = 5}) async {
+    if (limit <= 0) return <TrainingSpotV2>[];
+    final spots = await generator.generate(limit: limit);
+    if (spots.isEmpty) return <TrainingSpotV2>[];
+    final recentIds = await history.load();
+    final filtered = <TrainingSpotV2>[];
+    for (final s in spots) {
+      if (!recentIds.contains(s.id)) {
+        final spot = TrainingSpotV2.fromJson(s.toJson());
+        spot.meta['origin'] = 'decayBoost';
+        filtered.add(spot);
+        if (filtered.length >= 5) break;
+      }
+    }
+    if (filtered.length > 5) filtered.length = 5;
+    if (filtered.length < 3) return filtered;
+    return filtered;
+  }
+}

--- a/lib/services/recent_spot_history_service.dart
+++ b/lib/services/recent_spot_history_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists IDs of practice spots from the last completed session.
+class RecentSpotHistoryService {
+  RecentSpotHistoryService._();
+  static final RecentSpotHistoryService instance = RecentSpotHistoryService._();
+
+  static const _prefsKey = 'recent_spot_history';
+
+  /// Returns stored spot IDs from the last session.
+  Future<List<String>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return <String>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [for (final id in data) if (id is String) id];
+      }
+    } catch (_) {}
+    return <String>[];
+  }
+
+  /// Stores [spotIds] as the most recent session history.
+  Future<void> save(List<String> spotIds) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(spotIds));
+  }
+}


### PR DESCRIPTION
## Summary
- add `RecentSpotHistoryService` for tracking recently practiced spots
- add `DecayBoostedPracticeQueue` service to build decay-driven practice queues

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc36c15d0832aa2429edb49b747da