### PR TITLE
Implement DecayBoostedBanner widget

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -30,6 +30,7 @@ import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/decay_booster_dashboard_banner.dart';
 import '../widgets/decay_booster_reminder_banner.dart';
 import '../widgets/decay_booster_queue_indicator.dart';
+import '../widgets/decay_boosted_banner.dart';
 import 'streak_history_screen.dart';
 import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
@@ -310,6 +311,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
         ),
         const DecayBoosterReminderBanner(),
         const DecayBoosterDashboardBanner(),
+        const DecayBoostedBanner(),
         const GoalReminderBanner(),
         const SmartGoalBanner(),
         const NextBestStepBanner(),

--- a/lib/widgets/decay_boosted_banner.dart
+++ b/lib/widgets/decay_boosted_banner.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../services/decay_boosted_practice_queue.dart';
+import '../services/booster_queue_service.dart';
+import '../services/decay_booster_training_launcher.dart';
+import '../models/v2/training_spot_v2.dart';
+
+/// Banner prompting the user to refresh decayed skills.
+class DecayBoostedBanner extends StatefulWidget {
+  const DecayBoostedBanner({super.key});
+
+  @override
+  State<DecayBoostedBanner> createState() => _DecayBoostedBannerState();
+}
+
+class _DecayBoostedBannerState extends State<DecayBoostedBanner> {
+  bool _loading = true;
+  bool _visible = false;
+  List<TrainingSpotV2> _spots = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final list = await DecayBoostedPracticeQueue().prepareQueue();
+    if (!mounted) return;
+    setState(() {
+      _spots = list;
+      _visible = list.length >= 3;
+      _loading = false;
+    });
+  }
+
+  Future<void> _start() async {
+    if (_spots.isEmpty) return;
+    await BoosterQueueService.instance.addSpots(_spots);
+    await const DecayBoosterTrainingLauncher().launch();
+    if (!mounted) return;
+    setState(() => _visible = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Навык восстановлен')),
+    );
+  }
+
+  void _dismiss() {
+    setState(() => _visible = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || !_visible) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '📉 Подзабытые навыки',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _dismiss,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'Освежи 3+ спота с низким мастерством',
+            style: TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _start,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Тренировать сейчас'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `DecayBoostedBanner` widget to surface decayed skills
- show the banner on the home dashboard

## Testing
- `flutter test` *(fails: requires Dart 3.6 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688bc526ab4c832aa95e2ad37804271b