### PR TITLE
Add decay history tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Expose recordToday method on TheoryStreakService and update MiniLessonScreen.
 - Introduce TheoryBoosterSuggestionEngine for recommending lessons when recap tags underperform.
 - Add TheoryReinforcementBannerController for soft theory reminders after recap failures.
+- Persist full decay reinforcement history and expose TagDecayForecastService for spaced repetition analytics.

--- a/lib/services/decay_session_tag_impact_recorder.dart
+++ b/lib/services/decay_session_tag_impact_recorder.dart
@@ -10,6 +10,7 @@ class DecaySessionTagImpactRecorder {
       DecaySessionTagImpactRecorder._();
 
   static const _prefix = 'decay_tag_reinf_';
+  static const _allKey = 'decay_tag_reinf_all';
 
   Future<List<DecayTagReinforcementEvent>> _load(String tag) async {
     final prefs = await SharedPreferences.getInstance();
@@ -36,27 +37,65 @@ class DecaySessionTagImpactRecorder {
         key, jsonEncode([for (final e in list) e.toJson()]));
   }
 
+  Future<List<DecayTagReinforcementEvent>> _loadAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_allKey);
+    if (raw == null) return <DecayTagReinforcementEvent>[];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return [
+          for (final e in data.whereType<Map>())
+            DecayTagReinforcementEvent.fromJson(
+                Map<String, dynamic>.from(e as Map)),
+        ];
+      }
+    } catch (_) {}
+    return <DecayTagReinforcementEvent>[];
+  }
+
+  Future<void> _saveAll(List<DecayTagReinforcementEvent> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        _allKey, jsonEncode([for (final e in list) e.toJson()]));
+  }
+
   Future<void> recordSession(
       Map<String, double> tagDeltas, DateTime timestamp) async {
+    final all = await _loadAll();
     for (final entry in tagDeltas.entries) {
       final tag = entry.key.toLowerCase();
       if (tag.isEmpty) continue;
+      final event = DecayTagReinforcementEvent(
+        tag: tag,
+        delta: entry.value,
+        timestamp: timestamp,
+      );
       final list = await _load(tag);
-      list.insert(
-          0,
-          DecayTagReinforcementEvent(
-            tag: tag,
-            delta: entry.value,
-            timestamp: timestamp,
-          ));
+      list.insert(0, event);
       while (list.length > 100) {
         list.removeLast();
       }
       await _save(tag, list);
+      all.insert(0, event);
     }
+    await _saveAll(all);
   }
 
   Future<List<DecayTagReinforcementEvent>> getRecentReinforcements(String tag) {
     return _load(tag);
+  }
+
+  Future<List<DecayTagReinforcementEvent>> loadAllEvents() {
+    return _loadAll();
+  }
+
+  Future<List<DecayTagReinforcementEvent>> loadByDateRange(
+      DateTime start, DateTime end) async {
+    final all = await _loadAll();
+    return [
+      for (final e in all)
+        if (!e.timestamp.isBefore(start) && !e.timestamp.isAfter(end)) e
+    ];
   }
 }

--- a/lib/services/tag_decay_forecast_service.dart
+++ b/lib/services/tag_decay_forecast_service.dart
@@ -1,0 +1,64 @@
+import 'dart:math' as math;
+
+import '../models/decay_tag_reinforcement_event.dart';
+import 'decay_session_tag_impact_recorder.dart';
+
+class TagDecayStats {
+  final String tag;
+  final DateTime? lastTrained;
+  final Duration timeSinceLast;
+  final Duration averageInterval;
+  final double intervalStd;
+  final DateTime? nextReview;
+
+  const TagDecayStats({
+    required this.tag,
+    this.lastTrained,
+    this.timeSinceLast = Duration.zero,
+    this.averageInterval = Duration.zero,
+    this.intervalStd = 0,
+    this.nextReview,
+  });
+}
+
+class TagDecayForecastService {
+  const TagDecayForecastService();
+
+  Future<Map<String, TagDecayStats>> summarize({DateTime? now}) async {
+    final events = await DecaySessionTagImpactRecorder.instance.loadAllEvents();
+    final current = now ?? DateTime.now();
+    final grouped = <String, List<DateTime>>{};
+    for (final e in events) {
+      grouped.putIfAbsent(e.tag, () => []).add(e.timestamp);
+    }
+    final result = <String, TagDecayStats>{};
+    for (final entry in grouped.entries) {
+      final times = entry.value..sort();
+      final last = times.isNotEmpty ? times.last : null;
+      final intervals = <double>[];
+      for (var i = 1; i < times.length; i++) {
+        intervals.add(times[i].difference(times[i - 1]).inMilliseconds / 86400000);
+      }
+      final avg = intervals.isEmpty
+          ? 0.0
+          : intervals.reduce((a, b) => a + b) / intervals.length;
+      final std = intervals.isEmpty
+          ? 0.0
+          : math.sqrt(intervals
+                  .map((d) => math.pow(d - avg, 2))
+                  .reduce((a, b) => a + b) /
+              intervals.length);
+      final next = last != null ? last.add(Duration(days: avg.round())) : null;
+      final sinceLast = last != null ? current.difference(last) : Duration.zero;
+      result[entry.key] = TagDecayStats(
+        tag: entry.key,
+        lastTrained: last,
+        timeSinceLast: sinceLast,
+        averageInterval: Duration(days: avg.round()),
+        intervalStd: std,
+        nextReview: next,
+      );
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- extend `DecaySessionTagImpactRecorder` to store all reinforcement events
- expose helpers to load all events or a custom date range
- implement `TagDecayForecastService` for spaced repetition analytics
- document feature in CHANGELOG

## Testing
- `flutter analyze` *(fails: Dart SDK version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688bc72642bc832abda1d33e54e6d815