### PR TITLE
Implement pack recall logging

### DIFF
--- a/lib/services/pack_recall_stats_service.dart
+++ b/lib/services/pack_recall_stats_service.dart
@@ -1,0 +1,48 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Logs review timestamps for each training pack to analyze recall intervals.
+class PackRecallStatsService {
+  PackRecallStatsService._();
+
+  /// Singleton instance.
+  static final PackRecallStatsService instance = PackRecallStatsService._();
+
+  static const String _prefix = 'pack_recall_history';
+
+  /// Records a review time for [packId].
+  Future<void> recordReview(String packId, DateTime time) async {
+    if (packId.isEmpty) return;
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix.$packId';
+    final list = prefs.getStringList(key) ?? <String>[];
+    list.add(time.toIso8601String());
+    while (list.length > 50) {
+      list.removeAt(0);
+    }
+    await prefs.setStringList(key, list);
+  }
+
+  /// Returns the stored review history for [packId], oldest first.
+  Future<List<DateTime>> getReviewHistory(String packId) async {
+    if (packId.isEmpty) return <DateTime>[];
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefix.$packId';
+    final list = prefs.getStringList(key) ?? <String>[];
+    return [
+      for (final s in list)
+        if (DateTime.tryParse(s) != null) DateTime.parse(s)
+    ];
+  }
+
+  /// Returns the average interval between reviews of [packId].
+  Future<Duration?> averageReviewInterval(String packId) async {
+    final history = await getReviewHistory(packId);
+    if (history.length < 2) return null;
+    history.sort();
+    var total = Duration.zero;
+    for (var i = 1; i < history.length; i++) {
+      total += history[i].difference(history[i - 1]);
+    }
+    return total ~/ (history.length - 1);
+  }
+}

--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -11,6 +11,7 @@ import '../models/theory_mini_lesson_node.dart';
 import 'smart_recap_booster_launcher.dart';
 import 'smart_recap_booster_linker.dart';
 import 'training_pack_template_storage_service.dart';
+import 'pack_recall_stats_service.dart';
 
 /// Helper to start a training session from a pack template.
 class TrainingSessionLauncher {
@@ -22,6 +23,13 @@ class TrainingSessionLauncher {
       {int startIndex = 0, List<String>? sessionTags}) async {
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
+
+    unawaited(
+      PackRecallStatsService.instance.recordReview(
+        template.id,
+        DateTime.now(),
+      ),
+    );
 
     if (template.spots.every((s) => s.type == 'theory')) {
       await Navigator.push(

--- a/test/services/pack_recall_stats_service_test.dart
+++ b/test/services/pack_recall_stats_service_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/pack_recall_stats_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('records review history and computes intervals', () async {
+    final service = PackRecallStatsService.instance;
+    final now = DateTime.now();
+    final t1 = now.subtract(const Duration(days: 2));
+    await service.recordReview('p1', t1);
+    await service.recordReview('p1', now);
+
+    final history = await service.getReviewHistory('p1');
+    expect(history.length, 2);
+    expect(history.first, t1);
+    final avg = await service.averageReviewInterval('p1');
+    expect(avg, const Duration(days: 2));
+  });
+}


### PR DESCRIPTION
## Summary
- add `PackRecallStatsService` for per-pack review analytics
- record review timestamps when launching sessions
- test recall history and interval calculations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bdb4b99e8832a8944adca292efa21