### PR TITLE
Implement ReviewStreakEvaluatorService

### DIFF
--- a/lib/services/review_streak_evaluator_service.dart
+++ b/lib/services/review_streak_evaluator_service.dart
@@ -1,0 +1,79 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'pack_recall_stats_service.dart';
+
+/// Evaluates review streaks for training packs.
+///
+/// A streak consists of at least two consecutive reviews where each
+/// review occurs within [maxGap] of the previous one. The streak is
+/// considered active only if the latest review is also within [maxGap]
+/// from now.
+class ReviewStreakEvaluatorService {
+  const ReviewStreakEvaluatorService({this.recallStats});
+
+  /// Service used to read review history. Defaults to
+  /// [PackRecallStatsService.instance].
+  final PackRecallStatsService? recallStats;
+
+  /// Maximum allowed gap between consecutive reviews to keep a streak.
+  static const Duration maxGap = Duration(days: 3);
+
+  PackRecallStatsService get _stats =>
+      recallStats ?? PackRecallStatsService.instance;
+
+  /// Returns `true` if [packId] currently has an active review streak.
+  Future<bool> isStreakActive(String packId) async {
+    final history = await _stats.getReviewHistory(packId);
+    if (history.length < 2) return false;
+    history.sort();
+    var last = history.last;
+    var streak = 1;
+    for (var i = history.length - 2; i >= 0; i--) {
+      final diff = last.difference(history[i]);
+      if (diff <= maxGap) {
+        streak += 1;
+        last = history[i];
+      } else {
+        break;
+      }
+    }
+    if (streak < 2) return false;
+    if (DateTime.now().difference(history.last) > maxGap) return false;
+    return true;
+  }
+
+  /// Returns the date when the last review streak was broken for [packId].
+  /// Returns `null` if the streak is still active or never existed.
+  Future<DateTime?> streakBreakDate(String packId) async {
+    final history = await _stats.getReviewHistory(packId);
+    if (history.length < 2) return null;
+    history.sort();
+    DateTime? breakDate;
+    for (var i = 1; i < history.length; i++) {
+      final prev = history[i - 1];
+      final diff = history[i].difference(prev);
+      if (diff > maxGap) {
+        breakDate = prev.add(maxGap);
+      }
+    }
+    final last = history.last;
+    if (DateTime.now().difference(last) > maxGap) {
+      breakDate = last.add(maxGap);
+    }
+    return breakDate;
+  }
+
+  /// Returns ids of packs with broken review streaks.
+  Future<List<String>> packsWithBrokenStreaks() async {
+    final prefs = await SharedPreferences.getInstance();
+    const prefix = 'pack_recall_history.';
+    final ids = <String>[];
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(prefix)) {
+        final id = key.substring(prefix.length);
+        if (await streakBreakDate(id) != null) ids.add(id);
+      }
+    }
+    return ids;
+  }
+}

--- a/test/services/review_streak_evaluator_service_test.dart
+++ b/test/services/review_streak_evaluator_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/pack_recall_stats_service.dart';
+import 'package:poker_analyzer/services/review_streak_evaluator_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('detects active review streak', () async {
+    final service = PackRecallStatsService.instance;
+    final now = DateTime.now();
+    await service.recordReview('p1', now.subtract(const Duration(days: 2)));
+    await service.recordReview('p1', now);
+
+    const eval = ReviewStreakEvaluatorService();
+    expect(await eval.isStreakActive('p1'), isTrue);
+    expect(await eval.streakBreakDate('p1'), isNull);
+  });
+
+  test('detects broken streak and break date', () async {
+    final service = PackRecallStatsService.instance;
+    final now = DateTime.now();
+    final fiveDaysAgo = now.subtract(const Duration(days: 5));
+    await service.recordReview('p2', fiveDaysAgo);
+    await service.recordReview('p2', now);
+
+    const eval = ReviewStreakEvaluatorService();
+    expect(await eval.isStreakActive('p2'), isFalse);
+    final breakDate = await eval.streakBreakDate('p2');
+    expect(breakDate, isNotNull);
+    expect(breakDate!.difference(fiveDaysAgo), const Duration(days: 3));
+  });
+
+  test('lists packs with broken streaks', () async {
+    final service = PackRecallStatsService.instance;
+    final now = DateTime.now();
+    await service.recordReview('p3', now.subtract(const Duration(days: 5)));
+    await service.recordReview('p3', now);
+
+    const eval = ReviewStreakEvaluatorService();
+    final broken = await eval.packsWithBrokenStreaks();
+    expect(broken, contains('p3'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `ReviewStreakEvaluatorService` to track timely pack reviews
- provide helper to detect broken streaks across packs
- test review streak detection logic

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: command not found)*
- `flutter test test/services/review_streak_evaluator_service_test.dart -j 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bdcbec990832a8b7914468a43023c