### PR TITLE
Implement memory reminder orchestrator

### DIFF
--- a/lib/models/memory_reminder.dart
+++ b/lib/models/memory_reminder.dart
@@ -1,0 +1,13 @@
+enum MemoryReminderType { decayBooster, brokenStreak, upcomingReview }
+
+class MemoryReminder {
+  final MemoryReminderType type;
+  final int priority;
+  final String? packId;
+
+  const MemoryReminder({
+    required this.type,
+    required this.priority,
+    this.packId,
+  });
+}

--- a/lib/services/decay_booster_reminder_orchestrator.dart
+++ b/lib/services/decay_booster_reminder_orchestrator.dart
@@ -1,0 +1,64 @@
+import '../models/memory_reminder.dart';
+import 'booster_queue_service.dart';
+import 'decay_booster_reminder_engine.dart';
+import 'review_streak_evaluator_service.dart';
+import 'pack_recall_stats_service.dart';
+
+/// Coordinates multiple memory reminder signals and ranks them by priority.
+class DecayBoosterReminderOrchestrator {
+  final BoosterQueueService queue;
+  final DecayBoosterReminderEngine boosterEngine;
+  final ReviewStreakEvaluatorService streak;
+  final PackRecallStatsService recall;
+
+  DecayBoosterReminderOrchestrator({
+    BoosterQueueService? queue,
+    DecayBoosterReminderEngine? boosterEngine,
+    ReviewStreakEvaluatorService? streak,
+    PackRecallStatsService? recall,
+  })  : queue = queue ?? BoosterQueueService.instance,
+        boosterEngine = boosterEngine ?? DecayBoosterReminderEngine(),
+        streak = streak ?? const ReviewStreakEvaluatorService(),
+        recall = recall ?? PackRecallStatsService.instance;
+
+  /// Whether a decay booster banner should be shown.
+  Future<bool> shouldShowDecayBoosterBanner() async {
+    if (queue.getQueue().isNotEmpty) return true;
+    return boosterEngine.shouldShowReminder();
+  }
+
+  /// Whether to show a broken streak banner.
+  Future<bool> shouldShowBrokenStreakBanner() async {
+    final ids = await streak.packsWithBrokenStreaks();
+    return ids.isNotEmpty;
+  }
+
+  /// Whether to show upcoming review banner.
+  Future<bool> shouldShowUpcomingReviewBanner() async {
+    final ids = await recall.upcomingReviewPacks();
+    return ids.isNotEmpty;
+  }
+
+  /// Returns ranked memory reminders.
+  Future<List<MemoryReminder>> getRankedReminders() async {
+    final list = <MemoryReminder>[];
+
+    if (await shouldShowDecayBoosterBanner()) {
+      list.add(const MemoryReminder(
+          type: MemoryReminderType.decayBooster, priority: 3));
+    }
+
+    if (await shouldShowBrokenStreakBanner()) {
+      list.add(const MemoryReminder(
+          type: MemoryReminderType.brokenStreak, priority: 2));
+    }
+
+    if (await shouldShowUpcomingReviewBanner()) {
+      list.add(const MemoryReminder(
+          type: MemoryReminderType.upcomingReview, priority: 1));
+    }
+
+    list.sort((a, b) => b.priority.compareTo(a.priority));
+    return list;
+  }
+}

--- a/test/services/decay_booster_reminder_orchestrator_test.dart
+++ b/test/services/decay_booster_reminder_orchestrator_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/booster_queue_service.dart';
+import 'package:poker_analyzer/services/decay_booster_reminder_orchestrator.dart';
+import 'package:poker_analyzer/services/decay_booster_reminder_engine.dart';
+import 'package:poker_analyzer/services/review_streak_evaluator_service.dart';
+import 'package:poker_analyzer/services/pack_recall_stats_service.dart';
+import 'package:poker_analyzer/models/memory_reminder.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+class _StubDecayEngine extends DecayBoosterReminderEngine {
+  final bool result;
+  _StubDecayEngine(this.result);
+  @override
+  Future<bool> shouldShowReminder({DateTime? now}) async => result;
+}
+
+class _FakeStreak extends ReviewStreakEvaluatorService {
+  final List<String> ids;
+  const _FakeStreak(this.ids);
+  @override
+  Future<List<String>> packsWithBrokenStreaks() async => ids;
+}
+
+class _FakeStats extends PackRecallStatsService {
+  final List<String> upcoming;
+  _FakeStats(this.upcoming);
+  @override
+  Future<List<String>> upcomingReviewPacks({Duration leadTime = const Duration(days: 3)}) async => upcoming;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BoosterQueueService.instance.clear();
+  });
+
+  test('returns decay booster reminder when queue not empty', () async {
+    await BoosterQueueService.instance.addSpots([TrainingPackSpot(id: 's1')]);
+    final orch = DecayBoosterReminderOrchestrator(
+      boosterEngine: _StubDecayEngine(false),
+      streak: const _FakeStreak([]),
+      recall: _FakeStats([]),
+      queue: BoosterQueueService.instance,
+    );
+    final reminders = await orch.getRankedReminders();
+    expect(reminders.first.type, MemoryReminderType.decayBooster);
+  });
+
+  test('orders reminders by priority', () async {
+    final orch = DecayBoosterReminderOrchestrator(
+      boosterEngine: _StubDecayEngine(false),
+      streak: const _FakeStreak(['p1']),
+      recall: _FakeStats(['p2']),
+      queue: BoosterQueueService.instance,
+    );
+    final reminders = await orch.getRankedReminders();
+    expect(reminders.map((e) => e.type).toList(),
+        [MemoryReminderType.brokenStreak, MemoryReminderType.upcomingReview]);
+  });
+}

--- a/test/services/pack_recall_stats_service_test.dart
+++ b/test/services/pack_recall_stats_service_test.dart
@@ -22,4 +22,18 @@ void main() {
     final avg = await service.averageReviewInterval('p1');
     expect(avg, const Duration(days: 2));
   });
+
+  test('detects upcoming review packs', () async {
+    final service = PackRecallStatsService.instance;
+    final now = DateTime.now();
+    await service.recordReview('p2', now.subtract(const Duration(days: 6)));
+    await service.recordReview('p2', now.subtract(const Duration(days: 2)));
+
+    await service.recordReview('p3', now.subtract(const Duration(days: 4)));
+    await service.recordReview('p3', now);
+
+    final upcoming = await service.upcomingReviewPacks();
+    expect(upcoming, contains('p2'));
+    expect(upcoming, isNot(contains('p3')));
+  });
 }


### PR DESCRIPTION
## Summary
- add `MemoryReminder` model and types
- expose `upcomingReviewPacks` in `PackRecallStatsService`
- add `DecayBoosterReminderOrchestrator` for ranking memory reminders
- test upcoming review logic and orchestrator behaviour

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*


------
https://chatgpt.com/codex/tasks/task_e_688be0bc937c832a8dbc1568d3e0d48e