### PR TITLE
Implement unified memory reminder banner

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -282,8 +282,9 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
       AppUsageTracker.instance.markActive();
       _maybeShowTrainingReminder();
       _maybeLaunchScheduledTraining();
-      unawaited(
-          context.read<OverlayDecayBoosterOrchestrator>().maybeShowIfIdle(context));
+      unawaited(context
+          .read<OverlayDecayBoosterOrchestrator>()
+          .maybeShowIfIdle(context));
     }
   }
 
@@ -310,15 +311,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
             ),
           ],
         ),
-        const DecayBoosterReminderBanner(),
         const DecayBoosterDashboardBanner(),
         const DecayBoostedBanner(),
+        const DecayBoosterReminderBanner(),
         const GoalReminderBanner(),
         const SmartGoalBanner(),
         const NextBestStepBanner(),
         const SpotOfTheDayCard(),
         const PackSuggestionBanner(),
-        const BrokenStreakBanner(),
         const StreakChart(),
         const TodayProgressBanner(),
         const StreakMiniCard(),

--- a/lib/services/decay_booster_reminder_orchestrator.dart
+++ b/lib/services/decay_booster_reminder_orchestrator.dart
@@ -28,15 +28,13 @@ class DecayBoosterReminderOrchestrator {
   }
 
   /// Whether to show a broken streak banner.
-  Future<bool> shouldShowBrokenStreakBanner() async {
-    final ids = await streak.packsWithBrokenStreaks();
-    return ids.isNotEmpty;
+  Future<List<String>> brokenStreakPacks() async {
+    return streak.packsWithBrokenStreaks();
   }
 
   /// Whether to show upcoming review banner.
-  Future<bool> shouldShowUpcomingReviewBanner() async {
-    final ids = await recall.upcomingReviewPacks();
-    return ids.isNotEmpty;
+  Future<List<String>> upcomingReviewPacks() async {
+    return recall.upcomingReviewPacks();
   }
 
   /// Returns ranked memory reminders.
@@ -48,14 +46,20 @@ class DecayBoosterReminderOrchestrator {
           type: MemoryReminderType.decayBooster, priority: 3));
     }
 
-    if (await shouldShowBrokenStreakBanner()) {
-      list.add(const MemoryReminder(
-          type: MemoryReminderType.brokenStreak, priority: 2));
+    final broken = await brokenStreakPacks();
+    if (broken.isNotEmpty) {
+      list.add(MemoryReminder(
+          type: MemoryReminderType.brokenStreak,
+          priority: 2,
+          packId: broken.first));
     }
 
-    if (await shouldShowUpcomingReviewBanner()) {
-      list.add(const MemoryReminder(
-          type: MemoryReminderType.upcomingReview, priority: 1));
+    final upcoming = await upcomingReviewPacks();
+    if (upcoming.isNotEmpty) {
+      list.add(MemoryReminder(
+          type: MemoryReminderType.upcomingReview,
+          priority: 1,
+          packId: upcoming.first));
     }
 
     list.sort((a, b) => b.priority.compareTo(a.priority));


### PR DESCRIPTION
## Summary
- update `DecayBoosterReminderBanner` to show the highest-priority memory reminder
- attach pack ids in `DecayBoosterReminderOrchestrator`
- allow `BrokenStreakBanner` to filter by pack
- insert banner before goal reminders and remove old streak banner

## Testing
- `flutter analyze` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_688be1ecce98832aad43479e5cdfbaa4