### PR TITLE
Implement TheoryBoosterInjectionService

### DIFF
--- a/lib/services/decay_booster_reminder_engine.dart
+++ b/lib/services/decay_booster_reminder_engine.dart
@@ -47,4 +47,16 @@ class DecayBoosterReminderEngine {
     await logger.log('decay_reminder_shown');
     return true;
   }
+
+  /// Returns the tag with the highest decay score above [decayThreshold].
+  Future<String?> getTopDecayTag({DateTime? now}) async {
+    final current = now ?? DateTime.now();
+    final scores = await decay.computeDecayScores(now: current);
+    final entries = scores.entries
+        .where((e) => e.value > decayThreshold)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    if (entries.isEmpty) return null;
+    return entries.first.key;
+  }
 }

--- a/lib/services/theory_booster_injection_service.dart
+++ b/lib/services/theory_booster_injection_service.dart
@@ -1,0 +1,35 @@
+import 'package:collection/collection.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import 'decay_booster_reminder_engine.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Injects a short theory reminder before launching a decay booster.
+class TheoryBoosterInjectionService {
+  final DecayBoosterReminderEngine engine;
+  final MiniLessonLibraryService library;
+
+  TheoryBoosterInjectionService({
+    DecayBoosterReminderEngine? engine,
+    MiniLessonLibraryService? library,
+  })  : engine = engine ?? DecayBoosterReminderEngine(),
+        library = library ?? MiniLessonLibraryService.instance;
+
+  TheoryMiniLessonNode? _cached;
+
+  /// Returns a lesson for the most decayed tag or `null`.
+  Future<TheoryMiniLessonNode?> getLesson({DateTime? now}) async {
+    if (_cached != null) return _cached;
+    final tag = await engine.getTopDecayTag(now: now);
+    if (tag == null) return null;
+    await library.loadAll();
+    final lesson = library.findByTags([tag]).firstOrNull;
+    if (lesson != null) _cached = lesson;
+    return lesson;
+  }
+
+  /// Clears previously returned lesson so it can be injected again later.
+  void reset() {
+    _cached = null;
+  }
+}

--- a/lib/widgets/decay_booster_reminder_banner.dart
+++ b/lib/widgets/decay_booster_reminder_banner.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/memory_reminder.dart';
+import '../models/theory_mini_lesson_node.dart';
 import '../services/decay_booster_reminder_orchestrator.dart';
 import '../services/decay_booster_training_launcher.dart';
+import '../services/theory_booster_injection_service.dart';
 import '../services/training_pack_template_storage_service.dart';
 import 'broken_streak_banner.dart';
+import 'theory_modal_viewer.dart';
 
 /// Displays the highest-priority memory reminder.
 class DecayBoosterReminderBanner extends StatefulWidget {
@@ -20,6 +23,7 @@ class _DecayBoosterReminderBannerState
     extends State<DecayBoosterReminderBanner> {
   MemoryReminder? _reminder;
   String? _packTitle;
+  TheoryMiniLessonNode? _lesson;
   bool _loading = true;
   bool _hidden = false;
 
@@ -33,16 +37,21 @@ class _DecayBoosterReminderBannerState
     final list = await DecayBoosterReminderOrchestrator().getRankedReminders();
     MemoryReminder? r = list.isNotEmpty ? list.first : null;
     String? title;
+    TheoryMiniLessonNode? lesson;
     if (r?.packId != null) {
       final tpl = await context
           .read<TrainingPackTemplateStorageService>()
           .loadById(r!.packId!);
       title = tpl?.name;
     }
+    if (r?.type == MemoryReminderType.decayBooster) {
+      lesson = await TheoryBoosterInjectionService().getLesson();
+    }
     if (!mounted) return;
     setState(() {
       _reminder = r;
       _packTitle = title;
+      _lesson = lesson;
       _loading = false;
     });
   }
@@ -50,6 +59,12 @@ class _DecayBoosterReminderBannerState
   Future<void> _startBooster() async {
     await const DecayBoosterTrainingLauncher().launch();
     if (mounted) setState(() => _hidden = true);
+  }
+
+  void _openLesson() {
+    final lesson = _lesson;
+    if (lesson == null) return;
+    TheoryModalViewer.show(context, lesson);
   }
 
   void _dismiss() {
@@ -83,6 +98,29 @@ class _DecayBoosterReminderBannerState
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (_lesson != null) ...[
+            Text(
+              _lesson!.resolvedTitle,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _summary(_lesson!.resolvedContent),
+              style: const TextStyle(color: Colors.white70),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _openLesson,
+                child: const Text('Review Theory'),
+              ),
+            ),
+            const Divider(color: Colors.white30),
+          ],
           Row(
             children: [
               const Expanded(
@@ -114,6 +152,17 @@ class _DecayBoosterReminderBannerState
     );
   }
 
+  String _summary(String text) {
+    final cleaned = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    final reg = RegExp(r'^(.+?[.!?])\s+(.+?[.!?])');
+    final m = reg.firstMatch(cleaned);
+    var result = m != null ? '${m.group(1)} ${m.group(2)}' : cleaned;
+    if (result.length > 160) {
+      result = '${result.substring(0, 157)}...';
+    }
+    return result;
+  }
+
   Widget _buildUpcomingBanner(BuildContext context) {
     final title = _packTitle ?? '';
     return Container(
@@ -143,3 +192,4 @@ class _DecayBoosterReminderBannerState
     );
   }
 }
+

--- a/lib/widgets/theory_modal_viewer.dart
+++ b/lib/widgets/theory_modal_viewer.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+
+/// Simple modal viewer for [TheoryMiniLessonNode] content.
+class TheoryModalViewer extends StatelessWidget {
+  final TheoryMiniLessonNode lesson;
+  const TheoryModalViewer({super.key, required this.lesson});
+
+  static Future<void> show(BuildContext context, TheoryMiniLessonNode lesson) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.grey[900],
+      builder: (_) => FractionallySizedBox(
+        heightFactor: 0.9,
+        child: TheoryModalViewer(lesson: lesson),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final style = MarkdownStyleSheet.fromTheme(theme);
+    return SafeArea(
+      child: Column(
+        children: [
+          AppBar(
+            title: Text(lesson.resolvedTitle),
+          ),
+          Expanded(
+            child: Markdown(
+              data: lesson.resolvedContent,
+              styleSheet: style,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/theory_booster_injection_service_test.dart
+++ b/test/services/theory_booster_injection_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/decay_booster_reminder_engine.dart';
+import 'package:poker_analyzer/services/theory_booster_injection_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeEngine extends DecayBoosterReminderEngine {
+  final String? tag;
+  _FakeEngine(this.tag);
+  @override
+  Future<String?> getTopDecayTag({DateTime? now}) async => tag;
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, List<TheoryMiniLessonNode>> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => [for (final l in lessons.values) ...l];
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      all.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final result = <TheoryMiniLessonNode>[];
+    for (final t in tags) {
+      result.addAll(lessons[t] ?? const []);
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('returns lesson for decayed tag', () async {
+    const lesson = TheoryMiniLessonNode(id: 'l1', title: 'T', content: '', tags: ['a']);
+    final service = TheoryBoosterInjectionService(
+      engine: _FakeEngine('a'),
+      library: _FakeLibrary({'a': [lesson]}),
+    );
+    final result = await service.getLesson();
+    expect(result?.id, 'l1');
+  });
+
+  test('returns null when no tag', () async {
+    final service = TheoryBoosterInjectionService(
+      engine: _FakeEngine(null),
+      library: _FakeLibrary(const {}),
+    );
+    final result = await service.getLesson();
+    expect(result, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- surface decaying tag theory using TheoryBoosterInjectionService
- add modal viewer for mini lessons
- inject short theory snippet in decay booster banner
- expose top decay tag from DecayBoosterReminderEngine
- test TheoryBoosterInjectionService

## Testing
- `flutter test test/services/theory_booster_injection_service_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688be7f6adac832ab1ce4b732aa1427b