### PR TITLE
Implement AdaptivePackInboxNotifier

### DIFF
--- a/lib/services/adaptive_pack_inbox_notifier.dart
+++ b/lib/services/adaptive_pack_inbox_notifier.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/memory_reminder.dart';
+import 'adaptive_pack_recommender_service.dart';
+import 'decay_booster_reminder_orchestrator.dart';
+import 'inbox_booster_tracker_service.dart';
+
+/// Background notifier that posts high urgency adaptive pack suggestions
+/// to the theory inbox when no memory banners are visible.
+class AdaptivePackInboxNotifier with WidgetsBindingObserver {
+  final AdaptivePackRecommenderService recommender;
+  final DecayBoosterReminderOrchestrator orchestrator;
+  final InboxBoosterTrackerService inbox;
+  final Duration cooldown;
+
+  AdaptivePackInboxNotifier({
+    required this.recommender,
+    DecayBoosterReminderOrchestrator? orchestrator,
+    InboxBoosterTrackerService? inbox,
+    this.cooldown = const Duration(hours: 6),
+  })  : orchestrator = orchestrator ?? DecayBoosterReminderOrchestrator(),
+        inbox = inbox ?? InboxBoosterTrackerService.instance;
+
+  static const String _lastKey = 'adaptive_pack_inbox_last';
+
+  /// Begin observing lifecycle events.
+  Future<void> start() async {
+    WidgetsBinding.instance.addObserver(this);
+    await _maybeNotify();
+  }
+
+  /// Stop observing lifecycle events.
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _maybeNotify();
+    }
+  }
+
+  Future<DateTime?> _lastRun() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_lastKey);
+    return str == null ? null : DateTime.tryParse(str);
+  }
+
+  Future<void> _setLastRun(DateTime time) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastKey, time.toIso8601String());
+  }
+
+  Future<void> _maybeNotify() async {
+    final last = await _lastRun();
+    final now = DateTime.now();
+    if (last != null && now.difference(last) < cooldown) return;
+
+    final memory = await orchestrator.getRankedReminders();
+    if (memory.isNotEmpty) return;
+
+    final recs = await recommender.recommend(count: 1);
+    if (recs.isEmpty) return;
+    final AdaptivePackRecommendation top = recs.first;
+    if (top.score < 4.0) return;
+
+    final id = 'pack:${top.pack.id}';
+    if (await inbox.wasRecentlyShown(id)) return;
+    await inbox.addToInbox(id);
+    await _setLastRun(now);
+  }
+}

--- a/test/services/adaptive_pack_inbox_notifier_test.dart
+++ b/test/services/adaptive_pack_inbox_notifier_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/memory_reminder.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/adaptive_pack_inbox_notifier.dart';
+import 'package:poker_analyzer/services/adaptive_pack_recommender_service.dart';
+import 'package:poker_analyzer/services/decay_booster_reminder_orchestrator.dart';
+import 'package:poker_analyzer/services/inbox_booster_tracker_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeOrchestrator extends DecayBoosterReminderOrchestrator {
+  final List<MemoryReminder> reminders;
+  _FakeOrchestrator(this.reminders);
+  @override
+  Future<List<MemoryReminder>> getRankedReminders() async => reminders;
+}
+
+class _FakeRecommender extends AdaptivePackRecommenderService {
+  final List<AdaptivePackRecommendation> recs;
+  _FakeRecommender(this.recs)
+      : super(masteryService: _FakeMastery());
+  @override
+  Future<List<AdaptivePackRecommendation>> recommend({int count = 3, DateTime? now}) async => recs.take(count).toList();
+}
+
+class _FakeMastery extends TagMasteryService {
+  _FakeMastery() : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<Map<String, double>> computeMastery({bool force = false}) async => {};
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    InboxBoosterTrackerService.instance.resetForTest();
+  });
+
+  TrainingPackTemplateV2 _pack(String id) => TrainingPackTemplateV2(
+        id: id,
+        name: id,
+        trainingType: TrainingType.pushFold,
+      );
+
+  test('adds high score pack to inbox', () async {
+    final recs = [
+      AdaptivePackRecommendation(pack: _pack('p1'), score: 4.5),
+    ];
+    final notifier = AdaptivePackInboxNotifier(
+      recommender: _FakeRecommender(recs),
+      orchestrator: _FakeOrchestrator([]),
+      inbox: InboxBoosterTrackerService.instance,
+      cooldown: Duration.zero,
+    );
+    await notifier.start();
+    final queue = await InboxBoosterTrackerService.instance.getInbox();
+    expect(queue, contains('pack:p1'));
+  });
+
+  test('skips when memory reminders exist', () async {
+    final recs = [
+      AdaptivePackRecommendation(pack: _pack('p1'), score: 4.5),
+    ];
+    final notifier = AdaptivePackInboxNotifier(
+      recommender: _FakeRecommender(recs),
+      orchestrator: _FakeOrchestrator([
+        const MemoryReminder(type: MemoryReminderType.decayBooster, priority: 3),
+      ]),
+      inbox: InboxBoosterTrackerService.instance,
+      cooldown: Duration.zero,
+    );
+    await notifier.start();
+    final queue = await InboxBoosterTrackerService.instance.getInbox();
+    expect(queue, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `AdaptivePackInboxNotifier` service for pack suggestions
- add tests covering inbox logic

## Testing
- `flutter test test/services/adaptive_pack_inbox_notifier_test.dart` *(fails: command not found)*
- `dart test test/services/adaptive_pack_inbox_notifier_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be5b31374832a93ab2af13d0d521e