### PR TITLE
Implement DecayTagRetentionTrackerService

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -98,6 +98,7 @@ import 'services/user_action_logger.dart';
 import 'services/hand_analyzer_service.dart';
 import 'services/tag_mastery_service.dart';
 import 'services/tag_retention_tracker.dart';
+import 'services/decay_tag_retention_tracker_service.dart';
 import 'services/goal_suggestion_engine.dart';
 import 'services/goal_sync_service.dart';
 import 'services/tag_coverage_service.dart';
@@ -501,6 +502,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) =>
           TagRetentionTracker(mastery: context.read<TagMasteryService>()),
     ),
+    Provider(create: (_) => const DecayTagRetentionTrackerService()),
     Provider(create: (_) => LearningPathPrefs()..load()),
     Provider(create: (_) => TagCoverageService()),
     Provider(create: (_) => TagMasteryHistoryService()),

--- a/lib/services/decay_booster_training_launcher.dart
+++ b/lib/services/decay_booster_training_launcher.dart
@@ -5,21 +5,29 @@ import '../core/training/engine/training_type_engine.dart';
 import 'training_session_launcher.dart';
 import 'booster_queue_service.dart';
 import 'user_action_logger.dart';
+import 'decay_tag_retention_tracker_service.dart';
 
 /// Launches queued decay booster spots as a training session.
 class DecayBoosterTrainingLauncher {
   final BoosterQueueService queue;
   final TrainingSessionLauncher launcher;
+  final DecayTagRetentionTrackerService retention;
 
   const DecayBoosterTrainingLauncher({
     this.queue = BoosterQueueService.instance,
     this.launcher = const TrainingSessionLauncher(),
+    this.retention = const DecayTagRetentionTrackerService(),
   });
 
   /// Builds a temporary pack from queued spots and launches it.
   Future<void> launch() async {
     final spots = queue.getQueue();
     if (spots.isEmpty) return;
+
+    final tags = <String>{};
+    for (final s in spots) {
+      tags.addAll(s.tags.map((t) => t.trim().toLowerCase()));
+    }
 
     final tpl = TrainingPackTemplateV2(
       id: const Uuid().v4(),
@@ -33,6 +41,9 @@ class DecayBoosterTrainingLauncher {
     await launcher.launch(tpl);
     queue.clear();
     await queue.markUsed();
+    for (final tag in tags) {
+      await retention.markBoosterCompleted(tag);
+    }
     await UserActionLogger.instance
         .logEvent({'event': 'decay_booster_completed'});
   }

--- a/lib/services/decay_tag_retention_tracker_service.dart
+++ b/lib/services/decay_tag_retention_tracker_service.dart
@@ -1,0 +1,37 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks reinforcement events for decayed theory tags.
+class DecayTagRetentionTrackerService {
+  const DecayTagRetentionTrackerService();
+
+  static const String _theoryPrefix = 'retention.theoryReviewed.';
+  static const String _boosterPrefix = 'retention.boosterCompleted.';
+
+  Future<void> markTheoryReviewed(String tag, {DateTime? time}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      '$_theoryPrefix${tag.toLowerCase()}',
+      (time ?? DateTime.now()).toIso8601String(),
+    );
+  }
+
+  Future<void> markBoosterCompleted(String tag, {DateTime? time}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      '$_boosterPrefix${tag.toLowerCase()}',
+      (time ?? DateTime.now()).toIso8601String(),
+    );
+  }
+
+  Future<DateTime?> getLastTheoryReview(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('$_theoryPrefix${tag.toLowerCase()}');
+    return str != null ? DateTime.tryParse(str) : null;
+  }
+
+  Future<DateTime?> getLastBoosterCompletion(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('$_boosterPrefix${tag.toLowerCase()}');
+    return str != null ? DateTime.tryParse(str) : null;
+  }
+}

--- a/lib/services/theory_booster_injection_service.dart
+++ b/lib/services/theory_booster_injection_service.dart
@@ -3,19 +3,24 @@ import 'package:collection/collection.dart';
 import '../models/theory_mini_lesson_node.dart';
 import 'decay_booster_reminder_engine.dart';
 import 'mini_lesson_library_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
 
 /// Injects a short theory reminder before launching a decay booster.
 class TheoryBoosterInjectionService {
   final DecayBoosterReminderEngine engine;
   final MiniLessonLibraryService library;
+  final DecayTagRetentionTrackerService retention;
 
   TheoryBoosterInjectionService({
     DecayBoosterReminderEngine? engine,
     MiniLessonLibraryService? library,
+    DecayTagRetentionTrackerService? retention,
   })  : engine = engine ?? DecayBoosterReminderEngine(),
-        library = library ?? MiniLessonLibraryService.instance;
+        library = library ?? MiniLessonLibraryService.instance,
+        retention = retention ?? const DecayTagRetentionTrackerService();
 
   TheoryMiniLessonNode? _cached;
+  String? _tag;
 
   /// Returns a lesson for the most decayed tag or `null`.
   Future<TheoryMiniLessonNode?> getLesson({DateTime? now}) async {
@@ -24,12 +29,19 @@ class TheoryBoosterInjectionService {
     if (tag == null) return null;
     await library.loadAll();
     final lesson = library.findByTags([tag]).firstOrNull;
-    if (lesson != null) _cached = lesson;
+    if (lesson != null) {
+      _cached = lesson;
+      _tag = tag;
+    }
     return lesson;
   }
 
   /// Clears previously returned lesson so it can be injected again later.
   void reset() {
     _cached = null;
+    _tag = null;
   }
+
+  /// Tag associated with the last returned lesson.
+  String? get currentTag => _tag;
 }

--- a/lib/widgets/decay_booster_reminder_banner.dart
+++ b/lib/widgets/decay_booster_reminder_banner.dart
@@ -7,6 +7,7 @@ import '../services/decay_booster_reminder_orchestrator.dart';
 import '../services/decay_booster_training_launcher.dart';
 import '../services/theory_booster_injection_service.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../services/decay_tag_retention_tracker_service.dart';
 import 'broken_streak_banner.dart';
 import 'theory_modal_viewer.dart';
 
@@ -26,6 +27,7 @@ class _DecayBoosterReminderBannerState
   TheoryMiniLessonNode? _lesson;
   bool _loading = true;
   bool _hidden = false;
+  final TheoryBoosterInjectionService _injection = TheoryBoosterInjectionService();
 
   @override
   void initState() {
@@ -45,7 +47,7 @@ class _DecayBoosterReminderBannerState
       title = tpl?.name;
     }
     if (r?.type == MemoryReminderType.decayBooster) {
-      lesson = await TheoryBoosterInjectionService().getLesson();
+      lesson = await _injection.getLesson();
     }
     if (!mounted) return;
     setState(() {
@@ -64,6 +66,12 @@ class _DecayBoosterReminderBannerState
   void _openLesson() {
     final lesson = _lesson;
     if (lesson == null) return;
+    final tag = _injection.currentTag;
+    if (tag != null) {
+      context
+          .read<DecayTagRetentionTrackerService>()
+          .markTheoryReviewed(tag);
+    }
     TheoryModalViewer.show(context, lesson);
   }
 

--- a/test/services/decay_tag_retention_tracker_service_test.dart
+++ b/test/services/decay_tag_retention_tracker_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('stores and retrieves theory review', () async {
+    final tracker = const DecayTagRetentionTrackerService();
+    expect(await tracker.getLastTheoryReview('push'), isNull);
+    await tracker.markTheoryReviewed('push');
+    final ts = await tracker.getLastTheoryReview('push');
+    expect(ts, isNotNull);
+  });
+
+  test('stores and retrieves booster completion', () async {
+    final tracker = const DecayTagRetentionTrackerService();
+    expect(await tracker.getLastBoosterCompletion('call'), isNull);
+    await tracker.markBoosterCompleted('call');
+    final ts = await tracker.getLastBoosterCompletion('call');
+    expect(ts, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add DecayTagRetentionTrackerService to record reinforcement timestamps
- integrate retention tracking with theory booster injection and booster launch
- expose DecayTagRetentionTrackerService via providers
- log theory reviews and booster completions
- test the new tracker

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688beb5855c0832ab27d6b75a910bfe9