### PR TITLE
Add SmartRecallBoosterScheduler

### DIFF
--- a/lib/models/scheduled_booster_entry.dart
+++ b/lib/models/scheduled_booster_entry.dart
@@ -1,0 +1,9 @@
+class ScheduledBoosterEntry {
+  final String tag;
+  final double priorityScore;
+
+  const ScheduledBoosterEntry({
+    required this.tag,
+    required this.priorityScore,
+  });
+}

--- a/lib/services/decay_tag_retention_tracker_service.dart
+++ b/lib/services/decay_tag_retention_tracker_service.dart
@@ -34,4 +34,19 @@ class DecayTagRetentionTrackerService {
     final str = prefs.getString('$_boosterPrefix${tag.toLowerCase()}');
     return str != null ? DateTime.tryParse(str) : null;
   }
+
+  /// Returns days since last review or booster completion for [tag].
+  Future<double> getDecayScore(String tag, {DateTime? now}) async {
+    final review = await getLastTheoryReview(tag);
+    final booster = await getLastBoosterCompletion(tag);
+    DateTime? last;
+    if (review != null && booster != null) {
+      last = review.isAfter(booster) ? review : booster;
+    } else {
+      last = review ?? booster;
+    }
+    if (last == null) return 9999.0;
+    final current = now ?? DateTime.now();
+    return current.difference(last).inDays.toDouble();
+  }
 }

--- a/lib/services/smart_recall_booster_scheduler.dart
+++ b/lib/services/smart_recall_booster_scheduler.dart
@@ -1,0 +1,49 @@
+import '../models/scheduled_booster_entry.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'recall_success_logger_service.dart';
+import 'inbox_booster_tuner_service.dart';
+
+/// Schedules recall boosters based on decay intensity and past effectiveness.
+class SmartRecallBoosterScheduler {
+  final DecayTagRetentionTrackerService retention;
+  final RecallSuccessLoggerService logger;
+  final InboxBoosterTunerService tuner;
+
+  SmartRecallBoosterScheduler({
+    DecayTagRetentionTrackerService? retention,
+    RecallSuccessLoggerService? logger,
+    InboxBoosterTunerService? tuner,
+  })  : retention = retention ?? const DecayTagRetentionTrackerService(),
+        logger = logger ?? RecallSuccessLoggerService.instance,
+        tuner = tuner ?? InboxBoosterTunerService.instance;
+
+  /// Returns upcoming boosters ordered by priority.
+  Future<List<ScheduledBoosterEntry>> getNextBoosters({int max = 5}) async {
+    if (max <= 0) return <ScheduledBoosterEntry>[];
+    final boostScores = await tuner.computeTagBoostScores();
+    final logEntries = await logger.getSuccesses();
+    final successMap = <String, int>{};
+    for (final e in logEntries) {
+      successMap.update(e.tag, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    final tags = <String>{...boostScores.keys, ...successMap.keys};
+    final result = <ScheduledBoosterEntry>[];
+    for (final tag in tags) {
+      final decay = await retention.getDecayScore(tag);
+      final successes = successMap[tag] ?? 0;
+      final weight = boostScores[tag] ?? 1.0;
+
+      double priority = decay * weight / (successes + 1);
+      if (decay > 60 && successes <= 1) {
+        priority += 100;
+      } else if (decay > 30 && successes == 0) {
+        priority += 50;
+      }
+      result.add(ScheduledBoosterEntry(tag: tag, priorityScore: priority));
+    }
+
+    result.sort((a, b) => b.priorityScore.compareTo(a.priorityScore));
+    return result.take(max).toList();
+  }
+}

--- a/test/services/smart_recall_booster_scheduler_test.dart
+++ b/test/services/smart_recall_booster_scheduler_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/smart_recall_booster_scheduler.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_success_logger_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tuner_service.dart';
+import 'package:poker_analyzer/models/scheduled_booster_entry.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<double> getDecayScore(String tag, {DateTime? now}) async {
+    return scores[tag] ?? 0.0;
+  }
+}
+
+class _FakeLogger extends RecallSuccessLoggerService {
+  final Map<String, List<RecallSuccessEntry>> logs;
+  _FakeLogger(this.logs) : super._();
+  @override
+  Future<List<RecallSuccessEntry>> getSuccesses({String? tag}) async {
+    if (tag == null) {
+      return [for (final l in logs.values) ...l];
+    }
+    return List<RecallSuccessEntry>.from(logs[tag] ?? []);
+  }
+}
+
+class _FakeTuner extends InboxBoosterTunerService {
+  final Map<String, double> scores;
+  const _FakeTuner(this.scores);
+  @override
+  Future<Map<String, double>> computeTagBoostScores({DateTime? now, int recencyDays = 3}) async {
+    return scores;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('prioritizes high decay with low success rate', () async {
+    final scheduler = SmartRecallBoosterScheduler(
+      retention: const _FakeRetention({'a': 70, 'b': 65, 'c': 30}),
+      logger: _FakeLogger({'a': [
+        RecallSuccessEntry(tag: 'a', timestamp: DateTime.now()),
+      ]}),
+      tuner: const _FakeTuner({'a': 1.0, 'b': 1.0, 'c': 1.0}),
+    );
+    final list = await scheduler.getNextBoosters();
+    expect(list.length, 3);
+    expect(list.first.tag, 'b');
+  });
+
+  test('limits returned items', () async {
+    final scheduler = SmartRecallBoosterScheduler(
+      retention: const _FakeRetention({'a': 70, 'b': 50, 'c': 45}),
+      logger: _FakeLogger({}),
+      tuner: const _FakeTuner({'a': 1.0, 'b': 1.0, 'c': 1.0}),
+    );
+    final list = await scheduler.getNextBoosters(max: 2);
+    expect(list.length, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add model `ScheduledBoosterEntry`
- extend `DecayTagRetentionTrackerService` with `getDecayScore`
- implement `SmartRecallBoosterScheduler` for dynamic booster ordering
- add unit tests

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bf4a4332c832abdd6a969238132af