### PR TITLE
Implement BoosterInboxDeliveryService

### DIFF
--- a/lib/services/booster_inbox_delivery_service.dart
+++ b/lib/services/booster_inbox_delivery_service.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/scheduled_booster_entry.dart';
+import 'smart_recall_booster_scheduler.dart';
+
+/// Delivers top priority booster tags while respecting cooldown and
+/// avoiding recent repeats.
+class BoosterInboxDeliveryService {
+  final SmartRecallBoosterScheduler scheduler;
+  final Duration cooldown;
+
+  BoosterInboxDeliveryService({
+    SmartRecallBoosterScheduler? scheduler,
+    this.cooldown = const Duration(hours: 12),
+  }) : scheduler = scheduler ?? SmartRecallBoosterScheduler();
+
+  static final BoosterInboxDeliveryService instance =
+      BoosterInboxDeliveryService();
+
+  static const String _prefsKey = 'delivered_booster_tags';
+
+  Map<String, DateTime> _history = {};
+  bool _loaded = false;
+
+  /// Loads cached delivery history.
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final data = jsonDecode(raw);
+        if (data is Map) {
+          _history = {
+            for (final e in data.entries)
+              if (e.value is String)
+                e.key.toString():
+                    DateTime.tryParse(e.value as String) ?? DateTime.now()
+          };
+        }
+      } catch (_) {}
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode({for (final e in _history.entries) e.key: e.value.toIso8601String()}),
+    );
+  }
+
+  /// Returns the next tag that can be delivered, or null if none.
+  Future<String?> getNextDeliverableTag({int maxCandidates = 5}) async {
+    await _load();
+    final list = await scheduler.getNextBoosters(max: maxCandidates);
+    if (list.isEmpty) return null;
+    final now = DateTime.now();
+    for (final ScheduledBoosterEntry e in list) {
+      final ts = _history[e.tag];
+      if (ts == null || now.difference(ts) >= cooldown) {
+        return e.tag;
+      }
+    }
+    return null;
+  }
+
+  /// Records that [tag] was delivered now.
+  Future<void> markDelivered(String tag) async {
+    await _load();
+    _history[tag] = DateTime.now();
+    await _save();
+  }
+
+  /// Clears cached state for testing.
+  void resetForTest() {
+    _loaded = false;
+    _history = {};
+  }
+}

--- a/test/services/booster_inbox_delivery_service_test.dart
+++ b/test/services/booster_inbox_delivery_service_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/booster_inbox_delivery_service.dart';
+import 'package:poker_analyzer/services/smart_recall_booster_scheduler.dart';
+import 'package:poker_analyzer/models/scheduled_booster_entry.dart';
+
+class _FakeScheduler extends SmartRecallBoosterScheduler {
+  final List<ScheduledBoosterEntry> items;
+  _FakeScheduler(this.items);
+
+  @override
+  Future<List<ScheduledBoosterEntry>> getNextBoosters({int max = 5}) async {
+    return items.take(max).toList();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns next deliverable tag', () async {
+    final scheduler = _FakeScheduler([
+      const ScheduledBoosterEntry(tag: 'a', priorityScore: 2),
+      const ScheduledBoosterEntry(tag: 'b', priorityScore: 1),
+    ]);
+    final service = BoosterInboxDeliveryService(
+      scheduler: scheduler,
+      cooldown: Duration(hours: 12),
+    );
+
+    final tag1 = await service.getNextDeliverableTag();
+    expect(tag1, 'a');
+    await service.markDelivered(tag1!);
+
+    final tag2 = await service.getNextDeliverableTag();
+    expect(tag2, 'b');
+  });
+
+  test('respects cooldown window', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'delivered_booster_tags': jsonEncode({'a': now.toIso8601String()}),
+    });
+    final scheduler = _FakeScheduler([
+      const ScheduledBoosterEntry(tag: 'a', priorityScore: 2),
+    ]);
+    final service = BoosterInboxDeliveryService(
+      scheduler: scheduler,
+      cooldown: Duration(hours: 12),
+    );
+
+    final tag = await service.getNextDeliverableTag();
+    expect(tag, isNull);
+  });
+
+  test('allows delivery after cooldown expires', () async {
+    final old = DateTime.now().subtract(const Duration(hours: 13));
+    SharedPreferences.setMockInitialValues({
+      'delivered_booster_tags': jsonEncode({'a': old.toIso8601String()}),
+    });
+    final scheduler = _FakeScheduler([
+      const ScheduledBoosterEntry(tag: 'a', priorityScore: 2),
+    ]);
+    final service = BoosterInboxDeliveryService(
+      scheduler: scheduler,
+      cooldown: Duration(hours: 12),
+    );
+
+    final tag = await service.getNextDeliverableTag();
+    expect(tag, 'a');
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoosterInboxDeliveryService` for prioritized booster delivery
- add corresponding unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bf853a5e4832ab1dcda91403e30ae