### PR TITLE
Implement RecallTagDecaySummaryService

### DIFF
--- a/lib/models/tag_decay_summary.dart
+++ b/lib/models/tag_decay_summary.dart
@@ -1,0 +1,13 @@
+class TagDecaySummary {
+  final double avgDecay;
+  final int countCritical;
+  final int countWarning;
+  final List<String> mostDecayedTags;
+
+  const TagDecaySummary({
+    required this.avgDecay,
+    required this.countCritical,
+    required this.countWarning,
+    required this.mostDecayedTags,
+  });
+}

--- a/lib/services/recall_tag_decay_summary_service.dart
+++ b/lib/services/recall_tag_decay_summary_service.dart
@@ -1,0 +1,57 @@
+import '../models/tag_decay_summary.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'recall_success_logger_service.dart';
+import 'inbox_booster_tuner_service.dart';
+
+/// Provides aggregated decay diagnostics across all known tags.
+class RecallTagDecaySummaryService {
+  final DecayTagRetentionTrackerService retention;
+  final RecallSuccessLoggerService logger;
+  final InboxBoosterTunerService tuner;
+
+  const RecallTagDecaySummaryService({
+    DecayTagRetentionTrackerService? retention,
+    RecallSuccessLoggerService? logger,
+    InboxBoosterTunerService? tuner,
+  })  : retention = retention ?? const DecayTagRetentionTrackerService(),
+        logger = logger ?? RecallSuccessLoggerService.instance,
+        tuner = tuner ?? InboxBoosterTunerService.instance;
+
+  /// Returns summary metrics for all known tags.
+  Future<TagDecaySummary> getSummary() async {
+    final successes = await logger.getSuccesses();
+    final fromLogs = successes
+        .map((e) => e.tag.trim().toLowerCase())
+        .where((t) => t.isNotEmpty);
+    final boostScores = await tuner.computeTagBoostScores();
+    final fromBoost = boostScores.keys
+        .map((e) => e.trim().toLowerCase())
+        .where((t) => t.isNotEmpty);
+
+    final allTags = {...fromLogs, ...fromBoost};
+    final scores = <String, double>{};
+    double total = 0.0;
+    int countCritical = 0;
+    int countWarning = 0;
+
+    for (final tag in allTags) {
+      final score = await retention.getDecayScore(tag);
+      scores[tag] = score;
+      total += score;
+      if (score > 60) countCritical++;
+      if (score > 30) countWarning++;
+    }
+
+    final avg = allTags.isNotEmpty ? total / allTags.length : 0.0;
+    final sorted = scores.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final mostDecayed = [for (final e in sorted.take(5)) e.key];
+
+    return TagDecaySummary(
+      avgDecay: avg,
+      countCritical: countCritical,
+      countWarning: countWarning,
+      mostDecayedTags: mostDecayed,
+    );
+  }
+}

--- a/test/services/recall_tag_decay_summary_service_test.dart
+++ b/test/services/recall_tag_decay_summary_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/recall_tag_decay_summary_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_success_logger_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tuner_service.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<double> getDecayScore(String tag, {DateTime? now}) async {
+    return scores[tag] ?? 0.0;
+  }
+}
+
+class _FakeLogger extends RecallSuccessLoggerService {
+  final List<RecallSuccessEntry> entries;
+  _FakeLogger(this.entries) : super._();
+  @override
+  Future<List<RecallSuccessEntry>> getSuccesses({String? tag}) async {
+    if (tag == null) return entries;
+    return entries.where((e) => e.tag == tag).toList();
+  }
+}
+
+class _FakeTuner extends InboxBoosterTunerService {
+  final Map<String, double> map;
+  const _FakeTuner(this.map);
+  @override
+  Future<Map<String, double>> computeTagBoostScores({DateTime? now, int recencyDays = 3}) async {
+    return map;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('getSummary aggregates decay metrics', () async {
+    final service = RecallTagDecaySummaryService(
+      retention: const _FakeRetention({'a': 10, 'b': 40, 'c': 70}),
+      logger: _FakeLogger([
+        RecallSuccessEntry(tag: 'a', timestamp: DateTime.now()),
+        RecallSuccessEntry(tag: 'b', timestamp: DateTime.now()),
+      ]),
+      tuner: const _FakeTuner({'b': 1.0, 'c': 1.0}),
+    );
+
+    final summary = await service.getSummary();
+    expect(summary.avgDecay, closeTo(40.0, 0.01));
+    expect(summary.countCritical, 1);
+    expect(summary.countWarning, 2);
+    expect(summary.mostDecayedTags.first, 'c');
+  });
+
+  test('getSummary handles no tags', () async {
+    final service = RecallTagDecaySummaryService(
+      retention: const _FakeRetention({}),
+      logger: _FakeLogger([]),
+      tuner: const _FakeTuner({}),
+    );
+
+    final summary = await service.getSummary();
+    expect(summary.avgDecay, 0.0);
+    expect(summary.countCritical, 0);
+    expect(summary.countWarning, 0);
+    expect(summary.mostDecayedTags, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TagDecaySummary` data model
- implement `RecallTagDecaySummaryService` to aggregate decay data
- test summary metrics for decay diagnostics

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bfc39b8ec832a8745c247dfe25833