### PR TITLE
Implement DecayForecastAlertService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - Add TheoryReinforcementBannerController for soft theory reminders after recap failures.
 - Persist full decay reinforcement history and expose TagDecayForecastService for spaced repetition analytics.
 - Add DecayForecastEngine to predict future decay levels by tag.
+- Introduce DecayForecastAlertService for upcoming critical decay warnings.

--- a/lib/models/decay_forecast_alert.dart
+++ b/lib/models/decay_forecast_alert.dart
@@ -1,0 +1,11 @@
+class DecayForecastAlert {
+  final String tag;
+  final int daysToCritical; // 7 or 14
+  final double projectedDecay;
+
+  const DecayForecastAlert({
+    required this.tag,
+    required this.daysToCritical,
+    required this.projectedDecay,
+  });
+}

--- a/lib/services/decay_forecast_alert_service.dart
+++ b/lib/services/decay_forecast_alert_service.dart
@@ -1,0 +1,36 @@
+import '../models/decay_forecast_alert.dart';
+import '../services/decay_forecast_engine.dart';
+
+/// Scans decay forecasts and returns upcoming critical tags.
+class DecayForecastAlertService {
+  final DecayForecastEngine engine;
+  final double threshold;
+
+  const DecayForecastAlertService({
+    DecayForecastEngine? engine,
+    this.threshold = 60,
+  }) : engine = engine ?? const DecayForecastEngine();
+
+  /// Returns tags predicted to exceed [threshold] decay soon.
+  Future<List<DecayForecastAlert>> getUpcomingCriticalTags(
+      List<String> tags) async {
+    final forecasts = await engine.forecast(tags);
+    final result = <DecayForecastAlert>[];
+    for (final f in forecasts) {
+      if (f.in7days > threshold) {
+        result.add(DecayForecastAlert(
+          tag: f.tag,
+          daysToCritical: 7,
+          projectedDecay: f.in7days,
+        ));
+      } else if (f.in14days > threshold) {
+        result.add(DecayForecastAlert(
+          tag: f.tag,
+          daysToCritical: 14,
+          projectedDecay: f.in14days,
+        ));
+      }
+    }
+    return result;
+  }
+}

--- a/test/services/decay_forecast_alert_service_test.dart
+++ b/test/services/decay_forecast_alert_service_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/tag_decay_forecast.dart';
+import 'package:poker_analyzer/services/decay_forecast_alert_service.dart';
+import 'package:poker_analyzer/services/decay_forecast_engine.dart';
+
+class _FakeEngine extends DecayForecastEngine {
+  final List<TagDecayForecast> forecasts;
+  const _FakeEngine(this.forecasts);
+
+  @override
+  Future<List<TagDecayForecast>> forecast(List<String> tags, {int horizonDays = 30}) async {
+    return forecasts;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('detects upcoming critical tags', () async {
+    final service = DecayForecastAlertService(
+      engine: _FakeEngine([
+        const TagDecayForecast(tag: 'a', current: 50, in7days: 70, in14days: 80, in30days: 90),
+        const TagDecayForecast(tag: 'b', current: 40, in7days: 50, in14days: 65, in30days: 70),
+        const TagDecayForecast(tag: 'c', current: 10, in7days: 20, in14days: 30, in30days: 40),
+      ]),
+    );
+
+    final alerts = await service.getUpcomingCriticalTags(['a', 'b', 'c']);
+    expect(alerts.length, 2);
+
+    final a = alerts.firstWhere((e) => e.tag == 'a');
+    expect(a.daysToCritical, 7);
+    expect(a.projectedDecay, 70);
+
+    final b = alerts.firstWhere((e) => e.tag == 'b');
+    expect(b.daysToCritical, 14);
+    expect(b.projectedDecay, 65);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `DecayForecastAlert` model
- implement `DecayForecastAlertService` for early decay warnings
- test alert logic
- document new feature in CHANGELOG

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c1067fbe4832aa89024b11219b4e4