### PR TITLE
Add DecayDashboardScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 - Persist full decay reinforcement history and expose TagDecayForecastService for spaced repetition analytics.
 - Add DecayForecastEngine to predict future decay levels by tag.
 - Introduce DecayForecastAlertService for upcoming critical decay warnings.
+- Add DecayDashboardScreen to visualize memory health.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'screens/goal_center_screen.dart';
 import 'screens/achievements_dashboard_screen.dart';
 import 'screens/goal_insights_screen.dart';
 import 'screens/memory_insights_screen.dart';
+import 'screens/decay_dashboard_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -110,8 +111,8 @@ Future<void> main() async {
   await packCloud.syncUpTemplates(templateStorage);
   unawaited(
     AssetSyncService.instance.syncIfNeeded().catchError(
-      (e, st) => ErrorLogger.instance.logError('Asset sync failed', e, st),
-    ),
+          (e, st) => ErrorLogger.instance.logError('Asset sync failed', e, st),
+        ),
   );
   await EvaluationSettingsService.instance.load();
   await MistakeHintService.instance.load();
@@ -245,8 +246,9 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
       sessions: context.read<TrainingSessionService>(),
     ));
     unawaited(context.read<SkillLossOverlayPromptService>().run(context));
-    unawaited(
-        context.read<OverlayDecayBoosterOrchestrator>().maybeShowIfIdle(context));
+    unawaited(context
+        .read<OverlayDecayBoosterOrchestrator>()
+        .maybeShowIfIdle(context));
     unawaited(context.read<OverlayBoosterManager>().onAfterXpScreen());
     unawaited(
       TheoryLessonNotificationScheduler.instance.scheduleReminderIfNeeded(),
@@ -281,9 +283,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     final stat = await TrainingPackStatsService.getStats(pinned.id);
     final idx = stat?.lastIndex ?? 0;
     if (completed && idx >= pinned.spots.length - 1) {
-      final rec = await ctx
-          .read<PersonalRecommendationService>()
-          .getTopRecommended();
+      final rec =
+          await ctx.read<PersonalRecommendationService>().getTopRecommended();
       if (rec == null) return;
       await ctx.read<TrainingSessionService>().startSession(rec);
     } else {
@@ -354,6 +355,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
                   const AchievementsDashboardScreen(),
               GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
               MemoryInsightsScreen.route: (_) => const MemoryInsightsScreen(),
+              DecayDashboardScreen.route: (_) => const DecayDashboardScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/screens/decay_dashboard_screen.dart
+++ b/lib/screens/decay_dashboard_screen.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/decay_forecast_alert.dart';
+import '../models/tag_decay_summary.dart';
+import '../services/decay_forecast_alert_service.dart';
+import '../services/decay_heatmap_model_generator.dart';
+import '../services/decay_tag_retention_tracker_service.dart';
+import '../services/inbox_booster_delivery_controller.dart';
+import '../services/inbox_booster_tuner_service.dart';
+import '../services/recall_success_logger_service.dart';
+import '../services/recall_tag_decay_summary_service.dart';
+import '../widgets/decay_heatmap_ui_surface.dart';
+
+class DecayDashboardScreen extends StatefulWidget {
+  static const route = '/decay_dashboard';
+  const DecayDashboardScreen({super.key});
+
+  @override
+  State<DecayDashboardScreen> createState() => _DecayDashboardScreenState();
+}
+
+class _DecayDashboardScreenState extends State<DecayDashboardScreen> {
+  bool _loading = true;
+  TagDecaySummary? _summary;
+  List<DecayHeatmapEntry> _heatmap = [];
+  List<DecayForecastAlert> _alerts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    final summaryService = RecallTagDecaySummaryService();
+    final recallSummary = await summaryService.getSummary();
+
+    final logger = RecallSuccessLoggerService.instance;
+    final tuner = InboxBoosterTunerService.instance;
+    final retention = const DecayTagRetentionTrackerService();
+
+    final successes = await logger.getSuccesses();
+    final fromLogs = successes
+        .map((e) => e.tag.trim().toLowerCase())
+        .where((t) => t.isNotEmpty);
+    final boostScores = await tuner.computeTagBoostScores();
+    final fromBoost = boostScores.keys
+        .map((e) => e.trim().toLowerCase())
+        .where((t) => t.isNotEmpty);
+    final tags = {...fromLogs, ...fromBoost};
+
+    final scores = <String, double>{};
+    for (final tag in tags) {
+      scores[tag] = await retention.getDecayScore(tag);
+    }
+
+    final generator = DecayHeatmapModelGenerator();
+    final heatmap = generator.generate(scores);
+
+    final alerts = await const DecayForecastAlertService()
+        .getUpcomingCriticalTags(tags.toList());
+
+    if (!mounted) return;
+    setState(() {
+      _summary = recallSummary;
+      _heatmap = heatmap;
+      _alerts = alerts;
+      _loading = false;
+    });
+  }
+
+  Future<void> _reviewNow() async {
+    await InboxBoosterDeliveryController().maybeTriggerBoosterInbox();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Review triggered')),
+    );
+  }
+
+  Widget _summarySection() {
+    final s = _summary;
+    if (s == null) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Avg Decay: ${s.avgDecay.toStringAsFixed(0)}',
+              style: const TextStyle(color: Colors.white)),
+          const SizedBox(height: 4),
+          Text('Critical: ${s.countCritical} · Warning: ${s.countWarning}',
+              style: const TextStyle(color: Colors.white70)),
+          if (s.mostDecayedTags.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text('Most at risk: ${s.mostDecayedTags.join(', ')}',
+                style: const TextStyle(color: Colors.white70)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _alertsSection() {
+    if (_alerts.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Upcoming Risk',
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (final a in _alerts)
+          Text(
+            '${a.tag} → ${a.projectedDecay.toStringAsFixed(0)} in ${a.daysToCritical}d',
+            style: const TextStyle(color: Colors.white70),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Memory Health')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _heatmap.isEmpty && _alerts.isEmpty
+              ? const Center(
+                  child:
+                      Text('No tags', style: TextStyle(color: Colors.white70)),
+                )
+              : ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    _summarySection(),
+                    const SizedBox(height: 16),
+                    if (_heatmap.isNotEmpty)
+                      DecayHeatmapUISurface(data: _heatmap),
+                    const SizedBox(height: 16),
+                    _alertsSection(),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: _reviewNow,
+                      child: const Text('Review Now'),
+                    ),
+                  ],
+                ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -42,6 +42,7 @@ import 'progress_overview_screen.dart';
 import 'progress_history_screen.dart';
 import 'drill_history_screen.dart';
 import 'memory_insights_screen.dart';
+import 'decay_dashboard_screen.dart';
 import '../services/streak_service.dart';
 import 'goals_overview_screen.dart';
 import 'mistake_repeat_screen.dart';
@@ -666,6 +667,13 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         label: 'Memory Insights',
         onTap: () {
           Navigator.pushNamed(context, MemoryInsightsScreen.route);
+        },
+      ),
+      _MenuItem(
+        icon: Icons.monitor_heart,
+        label: 'Memory Health',
+        onTap: () {
+          Navigator.pushNamed(context, DecayDashboardScreen.route);
         },
       ),
       _MenuItem(


### PR DESCRIPTION
## Summary
- introduce `DecayDashboardScreen` to view memory health
- register dashboard route and menu entry
- mention new feature in changelog

## Testing
- `flutter analyze` *(fails: Dart SDK version solving failed)*
- `flutter test` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_688c1314b284832a953010009f462fb6