### PR TITLE
Implement DecayStreakTrackerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
 - Add DecayForecastEngine to predict future decay levels by tag.
 - Introduce DecayForecastAlertService for upcoming critical decay warnings.
 - Add DecayDashboardScreen to visualize memory health.
+- Track days without critical decay via DecayStreakTrackerService.

--- a/lib/services/decay_streak_tracker_service.dart
+++ b/lib/services/decay_streak_tracker_service.dart
@@ -1,0 +1,50 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'recall_tag_decay_summary_service.dart';
+
+/// Tracks consecutive days with no critical decay across all tags.
+class DecayStreakTrackerService {
+  final RecallTagDecaySummaryService summary;
+
+  const DecayStreakTrackerService({RecallTagDecaySummaryService? summary})
+      : summary = summary ?? const RecallTagDecaySummaryService();
+
+  static const String _countKey = 'decay_streak_count';
+  static const String _lastCheckKey = 'decay_streak_last_check';
+
+  /// Returns current streak of days without critical decay.
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_countKey) ?? 0;
+  }
+
+  /// Evaluates today's decay summary and updates streak accordingly.
+  Future<void> evaluateToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastCheckKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null &&
+        today.difference(DateTime(last.year, last.month, last.day)).inDays == 0) {
+      return;
+    }
+
+    final summaryResult = await summary.getSummary();
+    var streak = prefs.getInt(_countKey) ?? 0;
+    if (summaryResult.countCritical == 0) {
+      if (last != null &&
+          today.difference(DateTime(last.year, last.month, last.day)).inDays ==
+              1) {
+        streak += 1;
+      } else {
+        streak = 1;
+      }
+    } else {
+      streak = 0;
+    }
+
+    await prefs.setInt(_countKey, streak);
+    await prefs.setString(_lastCheckKey, today.toIso8601String());
+  }
+}

--- a/test/services/decay_streak_tracker_service_test.dart
+++ b/test/services/decay_streak_tracker_service_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/decay_streak_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_tag_decay_summary_service.dart';
+import 'package:poker_analyzer/models/tag_decay_summary.dart';
+
+class _FakeSummaryService extends RecallTagDecaySummaryService {
+  final TagDecaySummary result;
+  const _FakeSummaryService(this.result);
+
+  @override
+  Future<TagDecaySummary> getSummary() async => result;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('streak increments on consecutive zero-critical days', () async {
+    final service = DecayStreakTrackerService(
+      summary: const _FakeSummaryService(
+        TagDecaySummary(
+          avgDecay: 0,
+          countCritical: 0,
+          countWarning: 0,
+          mostDecayedTags: [],
+        ),
+      ),
+    );
+
+    await service.evaluateToday();
+    expect(await service.getCurrentStreak(), 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('decay_streak_last_check', yesterday.toIso8601String());
+    await prefs.setInt('decay_streak_count', 1);
+
+    await service.evaluateToday();
+    expect(await service.getCurrentStreak(), 2);
+  });
+
+  test('streak resets when critical decay present', () async {
+    final service = DecayStreakTrackerService(
+      summary: const _FakeSummaryService(
+        TagDecaySummary(
+          avgDecay: 0,
+          countCritical: 1,
+          countWarning: 0,
+          mostDecayedTags: [],
+        ),
+      ),
+    );
+
+    await service.evaluateToday();
+    expect(await service.getCurrentStreak(), 0);
+  });
+
+  test('streak starts over after gap days even if no critical decay', () async {
+    final service = DecayStreakTrackerService(
+      summary: const _FakeSummaryService(
+        TagDecaySummary(
+          avgDecay: 0,
+          countCritical: 0,
+          countWarning: 0,
+          mostDecayedTags: [],
+        ),
+      ),
+    );
+
+    await service.evaluateToday();
+    expect(await service.getCurrentStreak(), 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    final threeAgo = DateTime.now().subtract(const Duration(days: 3));
+    await prefs.setString('decay_streak_last_check', threeAgo.toIso8601String());
+    await prefs.setInt('decay_streak_count', 5);
+
+    await service.evaluateToday();
+    expect(await service.getCurrentStreak(), 1);
+  });
+}


### PR DESCRIPTION
## Summary
- track consecutive days with no critical decay via new service
- document DecayStreakTrackerService in changelog
- add unit tests for the service

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_688c15a450bc832ab9ad2f4edc08c4da