### PR TITLE
Add decay streak badge notifier

### DIFF
--- a/lib/models/decay_streak_badge.dart
+++ b/lib/models/decay_streak_badge.dart
@@ -1,0 +1,5 @@
+class DecayStreakBadge {
+  final int milestone;
+
+  const DecayStreakBadge(this.milestone);
+}

--- a/lib/services/decay_streak_badge_notifier.dart
+++ b/lib/services/decay_streak_badge_notifier.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'decay_streak_tracker_service.dart';
+import '../models/decay_streak_badge.dart';
+
+/// Detects when the user reaches a new decay streak milestone.
+class DecayStreakBadgeNotifier {
+  final DecayStreakTrackerService tracker;
+
+  DecayStreakBadgeNotifier({DecayStreakTrackerService? tracker})
+      : tracker = tracker ?? const DecayStreakTrackerService();
+
+  static const _milestones = [3, 7, 14, 30];
+  static const _key = 'decay_streak_last_milestone';
+
+  /// Returns a badge for a newly reached milestone or `null`.
+  Future<DecayStreakBadge?> checkForBadge() async {
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getInt(_key) ?? 0;
+    final streak = await tracker.getCurrentStreak();
+    for (final m in _milestones) {
+      if (streak >= m && m > last) {
+        await prefs.setInt(_key, m);
+        return DecayStreakBadge(m);
+      }
+    }
+    return null;
+  }
+}

--- a/test/services/decay_streak_badge_notifier_test.dart
+++ b/test/services/decay_streak_badge_notifier_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/decay_streak_badge_notifier.dart';
+import 'package:poker_analyzer/services/decay_streak_tracker_service.dart';
+import 'package:poker_analyzer/models/decay_streak_badge.dart';
+
+class _FakeTracker extends DecayStreakTrackerService {
+  final int streak;
+  const _FakeTracker(this.streak);
+
+  @override
+  Future<int> getCurrentStreak() async => streak;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('emits badge when milestone reached', () async {
+    final notifier = DecayStreakBadgeNotifier(tracker: const _FakeTracker(3));
+    final badge = await notifier.checkForBadge();
+    expect(badge?.milestone, 3);
+  });
+
+  test('skips when milestone already awarded', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('decay_streak_last_milestone', 3);
+    final notifier = DecayStreakBadgeNotifier(tracker: const _FakeTracker(5));
+    final badge = await notifier.checkForBadge();
+    expect(badge, isNull);
+  });
+
+  test('returns next milestone when surpassed', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('decay_streak_last_milestone', 7);
+    final notifier = DecayStreakBadgeNotifier(tracker: const _FakeTracker(30));
+    final badge = await notifier.checkForBadge();
+    expect(badge?.milestone, 14);
+  });
+}


### PR DESCRIPTION
## Summary
- model DecayStreakBadge
- service DecayStreakBadgeNotifier to detect streak milestones
- tests for DecayStreakBadgeNotifier

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c16fe530c832a8d6ec956650bc393