### PR TITLE
Implement DecayBadgeBannerController

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -121,6 +121,7 @@ import 'services/learning_path_reminder_engine.dart';
 import 'services/daily_app_check_service.dart';
 import 'services/skill_loss_overlay_prompt_service.dart';
 import 'services/gift_drop_service.dart';
+import 'services/decay_badge_banner_controller.dart';
 import 'services/session_streak_overlay_prompt_service.dart';
 import 'services/overlay_decay_booster_orchestrator.dart';
 import 'services/smart_recap_auto_injector.dart';
@@ -594,6 +595,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (_) => TheoryInboxBannerController()..start(),
     ),
     Provider(create: (_) => GiftDropService()),
+    Provider(create: (_) => DecayBadgeBannerController()..start()),
     Provider(create: (_) => SessionStreakOverlayPromptService()),
     Provider(create: (_) => OverlayDecayBoosterOrchestrator()),
     Provider(

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -72,6 +72,7 @@ import '../user_preferences.dart';
 import '../services/gift_drop_service.dart';
 import '../services/session_streak_overlay_prompt_service.dart';
 import '../services/overlay_decay_booster_orchestrator.dart';
+import '../services/decay_badge_banner_controller.dart';
 import 'dart:async';
 
 class MainNavigationScreen extends StatefulWidget {
@@ -105,6 +106,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
       _handleDeepLink();
       context.read<GiftDropService>().checkAndDropGift(context: context);
       context.read<SessionStreakOverlayPromptService>().run(context);
+      context.read<DecayBadgeBannerController>().maybeShowStreakBadgeBanner(context);
     });
   }
 

--- a/lib/services/decay_badge_banner_controller.dart
+++ b/lib/services/decay_badge_banner_controller.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+import 'decay_streak_badge_notifier.dart';
+import '../widgets/decay_badge_banner.dart';
+
+/// Shows a temporary banner when a new decay streak milestone is reached.
+class DecayBadgeBannerController with WidgetsBindingObserver {
+  final DecayStreakBadgeNotifier notifier;
+
+  DecayBadgeBannerController({DecayStreakBadgeNotifier? notifier})
+      : notifier = notifier ?? DecayStreakBadgeNotifier();
+
+  bool _shown = false;
+
+  /// Begin listening for app resume events.
+  Future<void> start() async {
+    WidgetsBinding.instance.addObserver(this);
+    final ctx = navigatorKey.currentContext;
+    if (ctx != null) await maybeShowStreakBadgeBanner(ctx);
+  }
+
+  /// Stop listening for lifecycle events.
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      final ctx = navigatorKey.currentContext;
+      if (ctx != null) {
+        // ignore: discarded_futures
+        maybeShowStreakBadgeBanner(ctx);
+      }
+    }
+  }
+
+  /// Checks for a badge and displays a banner if earned.
+  Future<void> maybeShowStreakBadgeBanner(BuildContext context) async {
+    if (_shown) return;
+    final badge = await notifier.checkForBadge();
+    if (badge == null) return;
+    _shown = true;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearMaterialBanners();
+    messenger.showMaterialBanner(
+      DecayBadgeBanner(
+        milestone: badge.milestone,
+        onClose: messenger.hideCurrentMaterialBanner,
+      ),
+    );
+    Future.delayed(const Duration(seconds: 4), () {
+      messenger.hideCurrentMaterialBanner();
+    });
+  }
+
+  /// Resets session state for testing.
+  @visibleForTesting
+  void resetForTest() => _shown = false;
+}

--- a/lib/widgets/decay_badge_banner.dart
+++ b/lib/widgets/decay_badge_banner.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class DecayBadgeBanner extends StatelessWidget {
+  final int milestone;
+  final VoidCallback onClose;
+
+  const DecayBadgeBanner({
+    super.key,
+    required this.milestone,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialBanner(
+      backgroundColor: Colors.grey[850],
+      leading: const Icon(Icons.local_fire_department, color: Colors.orange),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '🔥 \$milestone-day streak!',
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'No critical decay for \$milestone days',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(onPressed: onClose, child: const Text('Close')),
+      ],
+    );
+  }
+}

--- a/test/services/decay_badge_banner_controller_test.dart
+++ b/test/services/decay_badge_banner_controller_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:poker_analyzer/services/decay_badge_banner_controller.dart';
+import 'package:poker_analyzer/services/decay_streak_badge_notifier.dart';
+import 'package:poker_analyzer/services/decay_streak_tracker_service.dart';
+import 'package:poker_analyzer/models/decay_streak_badge.dart';
+
+class _FakeNotifier extends DecayStreakBadgeNotifier {
+  DecayStreakBadge? badge;
+  int calls = 0;
+  _FakeNotifier(this.badge) : super(tracker: const DecayStreakTrackerService());
+
+  @override
+  Future<DecayStreakBadge?> checkForBadge() async {
+    calls++;
+    return badge;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows banner when badge earned', (tester) async {
+    final notifier = _FakeNotifier(const DecayStreakBadge(3));
+    final controller = DecayBadgeBannerController(notifier: notifier);
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [Provider<DecayBadgeBannerController>.value(value: controller)],
+        child: MaterialApp(
+          home: Builder(builder: (context) {
+            return Scaffold(
+              body: TextButton(
+                onPressed: () {
+                  controller.maybeShowStreakBadgeBanner(context);
+                },
+                child: const Text('tap'),
+              ),
+            );
+          }),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('tap'));
+    await tester.pump();
+    expect(find.text('🔥 3-day streak!'), findsOneWidget);
+    expect(notifier.calls, 1);
+  });
+
+  testWidgets('banner not repeated in same session', (tester) async {
+    final notifier = _FakeNotifier(const DecayStreakBadge(3));
+    final controller = DecayBadgeBannerController(notifier: notifier);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(builder: (context) {
+          return Scaffold(
+            body: Column(
+              children: [
+                TextButton(
+                  onPressed: () {
+                    controller.maybeShowStreakBadgeBanner(context);
+                  },
+                  child: const Text('a'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    controller.maybeShowStreakBadgeBanner(context);
+                  },
+                  child: const Text('b'),
+                ),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+
+    await tester.tap(find.text('a'));
+    await tester.pump();
+    expect(find.text('🔥 3-day streak!'), findsOneWidget);
+    await tester.tap(find.text('b'));
+    await tester.pump();
+    expect(notifier.calls, 1);
+  });
+
+  testWidgets('no banner when badge null', (tester) async {
+    final notifier = _FakeNotifier(null);
+    final controller = DecayBadgeBannerController(notifier: notifier);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(builder: (context) {
+          return Scaffold(
+            body: TextButton(
+              onPressed: () {
+                controller.maybeShowStreakBadgeBanner(context);
+              },
+              child: const Text('tap'),
+            ),
+          );
+        }),
+      ),
+    );
+
+    await tester.tap(find.text('tap'));
+    await tester.pump();
+    expect(find.textContaining('streak'), findsNothing);
+    expect(notifier.calls, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- show banner for new decay streak milestones
- add banner widget
- inject new controller via providers
- display badge banner on main navigation screen
- test banner controller logic

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c185163fc832ab6ddab48fcd47d6e