### PR TITLE
Implement decay booster reminder scheduler

### DIFF
--- a/lib/services/decay_reminder_scheduler_service.dart
+++ b/lib/services/decay_reminder_scheduler_service.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+import 'booster_inbox_delivery_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'notification_service.dart';
+
+/// Schedules a daily reminder if no decay booster was completed today.
+class DecayReminderSchedulerService with WidgetsBindingObserver {
+  final BoosterInboxDeliveryService inbox;
+  final DecayTagRetentionTrackerService retention;
+
+  DecayReminderSchedulerService({
+    BoosterInboxDeliveryService? inbox,
+    DecayTagRetentionTrackerService? retention,
+  })  : inbox = inbox ?? BoosterInboxDeliveryService.instance,
+        retention = retention ?? const DecayTagRetentionTrackerService();
+
+  static const _prefsKey = 'decay_reminder_last';
+  static const _id = 425;
+
+  Future<void> init() async {
+    WidgetsBinding.instance.addObserver(this);
+    await scheduleReminderIfNeeded();
+  }
+
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      scheduleReminderIfNeeded();
+    }
+  }
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  /// Schedules the reminder notification for 19:00 if conditions allow.
+  Future<void> scheduleReminderIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final lastStr = prefs.getString(_prefsKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    if (last != null && _sameDay(last, now)) return;
+
+    final tag = await inbox.getNextDeliverableTag();
+    if (tag == null) return;
+    final completed = await retention.getLastBoosterCompletion(tag);
+    if (completed != null && _sameDay(completed, now)) return;
+
+    var when = tz.TZDateTime(tz.local, now.year, now.month, now.day, 19);
+    if (!when.isAfter(tz.TZDateTime.now(tz.local))) {
+      when = when.add(const Duration(days: 1));
+    }
+
+    await NotificationService.schedule(
+      id: _id,
+      when: when,
+      body: '🔥 Не забудь повторить: streak под угрозой',
+    );
+
+    await prefs.setString(_prefsKey, now.toIso8601String());
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -53,7 +53,8 @@ class NotificationService {
     return TimeOfDay(hour: m ~/ 60, minute: m % 60);
   }
 
-  static Future<void> updateReminderTime(BuildContext context, TimeOfDay t) async {
+  static Future<void> updateReminderTime(
+      BuildContext context, TimeOfDay t) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_timeKey, t.hour * 60 + t.minute);
     await cancel(101);
@@ -85,14 +86,16 @@ class NotificationService {
         iOS: DarwinNotificationDetails(),
       ),
       androidAllowWhileIdle: true,
-      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,
     );
   }
 
   static Future<void> scheduleDailyProgress(BuildContext context) async {
     final stats = context.read<TrainingStatsService>();
-    final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+    final today =
+        DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
     final sessions = stats.sessionsDaily(1);
     if (sessions.isNotEmpty && sessions.first.value > 0) return;
     final rec = context.read<PersonalRecommendationService>();
@@ -120,7 +123,31 @@ class NotificationService {
       ),
       payload: 'progress',
       androidAllowWhileIdle: true,
-      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  /// Schedules a simple notification [body] at the given [when].
+  static Future<void> schedule({
+    required int id,
+    required DateTime when,
+    required String body,
+    String title = 'Poker Analyzer',
+  }) async {
+    await _plugin.zonedSchedule(
+      id,
+      title,
+      body,
+      tz.TZDateTime.from(when, tz.local),
+      const NotificationDetails(
+        android: AndroidNotificationDetails('generic', 'Generic'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,
     );
   }
@@ -146,5 +173,6 @@ class NotificationService {
     });
   }
 
-  static String _fmt(DateTime d) => '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  static String _fmt(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 }


### PR DESCRIPTION
## Summary
- add a generic `NotificationService.schedule` helper
- create `DecayReminderSchedulerService` to notify if no decay booster was completed

## Testing
- `dart format lib/services/notification_service.dart lib/services/decay_reminder_scheduler_service.dart`
- `flutter analyze` *(fails: The current Dart SDK version is 3.1.5; requires >=3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_688c21c310a0832a8f4a103f9da035c3