### PR TITLE
Add DecayRewardDropEngine

### DIFF
--- a/lib/services/decay_booster_training_launcher.dart
+++ b/lib/services/decay_booster_training_launcher.dart
@@ -6,6 +6,8 @@ import 'training_session_launcher.dart';
 import 'booster_queue_service.dart';
 import 'user_action_logger.dart';
 import 'decay_tag_retention_tracker_service.dart';
+import 'decay_reward_drop_engine.dart';
+import '../main.dart';
 
 /// Launches queued decay booster spots as a training session.
 class DecayBoosterTrainingLauncher {
@@ -43,6 +45,10 @@ class DecayBoosterTrainingLauncher {
     await queue.markUsed();
     for (final tag in tags) {
       await retention.markBoosterCompleted(tag);
+    }
+    final ctx = navigatorKey.currentContext;
+    if (ctx != null) {
+      await DecayRewardDropEngine.instance.maybeTriggerReward(ctx);
     }
     await UserActionLogger.instance
         .logEvent({'event': 'decay_booster_completed'});

--- a/lib/services/decay_reward_drop_engine.dart
+++ b/lib/services/decay_reward_drop_engine.dart
@@ -1,0 +1,63 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import '../widgets/confetti_overlay.dart';
+import 'coins_service.dart';
+import 'decay_streak_tracker_service.dart';
+import 'motivation_service.dart';
+
+/// Randomly shows a small reward after finishing decay boosters.
+class DecayRewardDropEngine {
+  DecayRewardDropEngine._({
+    DecayStreakTrackerService? streaks,
+    Random? random,
+  })  : streaks = streaks ?? const DecayStreakTrackerService(),
+        _random = random ?? Random();
+
+  /// Singleton instance.
+  static final DecayRewardDropEngine instance = DecayRewardDropEngine._();
+
+  final DecayStreakTrackerService streaks;
+  final Random _random;
+
+  static const double minChance = 0.10;
+  static const double maxChance = 0.20;
+  static const _countKey = 'decay_reward_drop_count';
+  static const _lastKey = 'decay_reward_drop_last';
+
+  /// Triggers a surprise reward with 10-20% chance when on a decay streak.
+  Future<void> maybeTriggerReward(BuildContext context) async {
+    final streak = await streaks.getCurrentStreak();
+    if (streak <= 0) return;
+
+    final chance = minChance + _random.nextDouble() * (maxChance - minChance);
+    if (_random.nextDouble() > chance) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_countKey, (prefs.getInt(_countKey) ?? 0) + 1);
+    await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+
+    final rewardType = _random.nextInt(3); // 0: confetti, 1: quote, 2: coins
+    switch (rewardType) {
+      case 0:
+        showConfettiOverlay(context);
+        break;
+      case 1:
+        final quote = await MotivationService.getDailyQuote();
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text('⭐ $quote')));
+        }
+        break;
+      default:
+        const amount = 5;
+        await CoinsService.instance.addCoins(amount);
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('🪙 +5 coins!')));
+        }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `DecayRewardDropEngine` for random confetti/coin/quote rewards
- trigger new reward engine after decay booster completion

## Testing
- `dart tools/validate_training_content.dart --ci`
- `flutter analyze lib/services/decay_reward_drop_engine.dart lib/services/decay_booster_training_launcher.dart`

------
https://chatgpt.com/codex/tasks/task_e_688c246c7c40832ab505c3e7a405dc57