### PR TITLE
Implement DecayHeatmapTileGenerator

### DIFF
--- a/lib/services/decay_heatmap_tile_generator.dart
+++ b/lib/services/decay_heatmap_tile_generator.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'tag_decay_forecast_service.dart';
+
+class DecayHeatmapTile {
+  final String tag;
+  final double urgency; // 0.0 = fresh, 1.0 = decayed
+  final Color color;
+
+  const DecayHeatmapTile({
+    required this.tag,
+    required this.urgency,
+    required this.color,
+  });
+}
+
+class DecayHeatmapTileGenerator {
+  final TagDecayForecastService service;
+
+  const DecayHeatmapTileGenerator({this.service = const TagDecayForecastService()});
+
+  Color _colorForUrgency(double u) {
+    if (u <= 0.5) {
+      return Color.lerp(Colors.green, Colors.yellow, u * 2) ?? Colors.green;
+    }
+    return Color.lerp(Colors.yellow, Colors.red, (u - 0.5) * 2) ?? Colors.red;
+  }
+
+  Future<List<DecayHeatmapTile>> generate() async {
+    final forecasts = await service.getAllForecasts();
+    final result = <DecayHeatmapTile>[];
+    for (final entry in forecasts.entries) {
+      final urgency = entry.value.clamp(0.0, 1.0);
+      result.add(DecayHeatmapTile(
+        tag: entry.key,
+        urgency: urgency,
+        color: _colorForUrgency(urgency),
+      ));
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- extend `TagDecayForecastService` with retention/tuner/logger fields
- add `getAllForecasts` to provide normalized decay data
- create `DecayHeatmapTileGenerator` for converting forecasts to colored tiles

## Testing
- `flutter analyze` *(fails: dart-sdk missing)*

------
https://chatgpt.com/codex/tasks/task_e_688c32f5acfc832aa10287d9498d78c7