### PR TITLE
Add DecayHeatmapScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Add DecayHeatmapUISurface widget for visualizing memory decay.
+- Add DecayHeatmapScreen to review tag decay as a heatmap.
 - Fix training resume dialog to load packs before showing confirmation.
 - Remove unused spot storage field from app state.
 - Add "Select All" toggle in the My Packs selection toolbar.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'screens/achievements_dashboard_screen.dart';
 import 'screens/goal_insights_screen.dart';
 import 'screens/memory_insights_screen.dart';
 import 'screens/decay_dashboard_screen.dart';
+import 'screens/decay_heatmap_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -361,6 +362,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
               MemoryInsightsScreen.route: (_) => const MemoryInsightsScreen(),
               DecayDashboardScreen.route: (_) => const DecayDashboardScreen(),
+              DecayHeatmapScreen.route: (_) => const DecayHeatmapScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -27,6 +27,7 @@ import 'screens/master_mode_screen.dart';
 import 'screens/goal_center_screen.dart';
 import 'screens/goal_insights_screen.dart';
 import 'screens/memory_insights_screen.dart';
+import 'screens/decay_heatmap_screen.dart';
 
 final GlobalKey analyzerKey = GlobalKey();
 
@@ -178,6 +179,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                   GoalCenterScreen.route: (_) => const GoalCenterScreen(),
                   GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
                   MemoryInsightsScreen.route: (_) => const MemoryInsightsScreen(),
+                  DecayHeatmapScreen.route: (_) => const DecayHeatmapScreen(),
                 },
                 builder: (context, child) {
                   return Stack(

--- a/lib/screens/decay_heatmap_screen.dart
+++ b/lib/screens/decay_heatmap_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../services/decay_heatmap_tile_generator.dart';
+import '../utils/responsive.dart';
+
+class DecayHeatmapScreen extends StatefulWidget {
+  static const route = '/decay_heatmap';
+  const DecayHeatmapScreen({super.key});
+
+  @override
+  State<DecayHeatmapScreen> createState() => _DecayHeatmapScreenState();
+}
+
+class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
+  bool _loading = true;
+  List<DecayHeatmapTile> _tiles = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final generator = const DecayHeatmapTileGenerator();
+    final tiles = await generator.generate();
+    tiles.sort((a, b) => b.urgency.compareTo(a.urgency));
+    if (!mounted) return;
+    setState(() {
+      _tiles = tiles;
+      _loading = false;
+    });
+  }
+
+  Color _textColor(Color bg) {
+    return ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
+        ? Colors.white
+        : Colors.black;
+  }
+
+  Widget _buildTile(DecayHeatmapTile tile) {
+    final textColor = _textColor(tile.color);
+    return Container(
+      decoration: BoxDecoration(
+        color: tile.color,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            tile.tag,
+            style: TextStyle(
+              color: textColor,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${(tile.urgency * 100).toStringAsFixed(0)}%',
+            style: TextStyle(color: textColor),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final count = isLandscape(context) ? 4 : 3;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Decay Heatmap'),
+        actions: [
+          IconButton(onPressed: _load, icon: const Icon(Icons.refresh)),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _tiles.isEmpty
+              ? const Center(child: Text('No tags'))
+              : GridView.count(
+                  padding: const EdgeInsets.all(16),
+                  crossAxisCount: count,
+                  crossAxisSpacing: 8,
+                  mainAxisSpacing: 8,
+                  childAspectRatio: 1,
+                  children: _tiles.map(_buildTile).toList(),
+                ),
+    );
+  }
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -43,6 +43,7 @@ import 'progress_history_screen.dart';
 import 'drill_history_screen.dart';
 import 'memory_insights_screen.dart';
 import 'decay_dashboard_screen.dart';
+import 'decay_heatmap_screen.dart';
 import '../services/streak_service.dart';
 import 'goals_overview_screen.dart';
 import 'mistake_repeat_screen.dart';
@@ -674,6 +675,13 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         label: 'Memory Health',
         onTap: () {
           Navigator.pushNamed(context, DecayDashboardScreen.route);
+        },
+      ),
+      _MenuItem(
+        icon: Icons.grid_view,
+        label: 'Decay Heatmap',
+        onTap: () {
+          Navigator.pushNamed(context, DecayHeatmapScreen.route);
         },
       ),
       _MenuItem(


### PR DESCRIPTION
## Summary
- introduce `DecayHeatmapScreen` to visualize decay-tag urgency
- expose the new screen via routes and main menu
- document the feature in the changelog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3524b464832a972cd5176cef5762