### PR TITLE
Add DecayBoosterShortcutBanner

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -30,6 +30,7 @@ import '../widgets/continue_training_button.dart';
 import '../widgets/spot_of_the_day_card.dart';
 import '../widgets/decay_booster_dashboard_banner.dart';
 import '../widgets/decay_booster_reminder_banner.dart';
+import '../widgets/decay_booster_shortcut_banner.dart';
 import '../widgets/decay_booster_queue_indicator.dart';
 import '../widgets/decay_boosted_banner.dart';
 import 'streak_history_screen.dart';
@@ -316,6 +317,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
         const DecayBoosterDashboardBanner(),
         const DecayBoostedBanner(),
         const DecayBoosterReminderBanner(),
+        const DecayBoosterShortcutBanner(),
         const GoalReminderBanner(),
         const SmartGoalBanner(),
         const NextBestStepBanner(),

--- a/lib/services/tag_decay_forecast_service.dart
+++ b/lib/services/tag_decay_forecast_service.dart
@@ -92,4 +92,14 @@ class TagDecayForecastService {
     }
     return result;
   }
+
+  /// Returns tags with normalized decay above [threshold], sorted by severity.
+  Future<List<String>> getCriticalTags({double threshold = 0.8}) async {
+    final forecasts = await getAllForecasts();
+    final entries = forecasts.entries
+        .where((e) => e.value > threshold)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return [for (final e in entries) e.key];
+  }
 }

--- a/lib/widgets/decay_booster_shortcut_banner.dart
+++ b/lib/widgets/decay_booster_shortcut_banner.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../services/tag_decay_forecast_service.dart';
+import '../services/decay_spot_booster_engine.dart';
+import '../services/decay_booster_training_launcher.dart';
+
+/// Banner suggesting a quick booster for the most decayed tag.
+class DecayBoosterShortcutBanner extends StatefulWidget {
+  const DecayBoosterShortcutBanner({super.key});
+
+  @override
+  State<DecayBoosterShortcutBanner> createState() =>
+      _DecayBoosterShortcutBannerState();
+}
+
+class _DecayBoosterShortcutBannerState
+    extends State<DecayBoosterShortcutBanner> {
+  bool _loading = true;
+  String? _tag;
+  bool _hidden = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final tags = await const TagDecayForecastService().getCriticalTags();
+    if (!mounted) return;
+    setState(() {
+      _tag = tags.isNotEmpty ? tags.first : null;
+      _loading = false;
+    });
+  }
+
+  Future<void> _start() async {
+    final tag = _tag;
+    if (tag == null) return;
+    await DecaySpotBoosterEngine().enqueueForTag(tag);
+    await const DecayBoosterTrainingLauncher().launch();
+    if (mounted) setState(() => _hidden = true);
+  }
+
+  void _dismiss() {
+    setState(() => _hidden = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _hidden || _tag == null) {
+      return const SizedBox.shrink();
+    }
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🧠', style: TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Ты теряешь знания по теме: $_tag',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.white54),
+                onPressed: _dismiss,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _start,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Повторить'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/test/services/tag_decay_forecast_service_test.dart
+++ b/test/services/tag_decay_forecast_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/tag_decay_forecast_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_success_logger_service.dart';
+import 'package:poker_analyzer/services/inbox_booster_tuner_service.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<double> getDecayScore(String tag, {DateTime? now}) async {
+    return scores[tag] ?? 0.0;
+  }
+}
+
+class _FakeLogger extends RecallSuccessLoggerService {
+  final List<RecallSuccessEntry> entries;
+  _FakeLogger(this.entries) : super._();
+  @override
+  Future<List<RecallSuccessEntry>> getSuccesses({String? tag}) async {
+    if (tag == null) return entries;
+    return entries.where((e) => e.tag == tag).toList();
+  }
+}
+
+class _FakeTuner extends InboxBoosterTunerService {
+  final Map<String, double> map;
+  const _FakeTuner(this.map);
+  @override
+  Future<Map<String, double>> computeTagBoostScores({DateTime? now, int recencyDays = 3}) async {
+    return map;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('getCriticalTags filters by threshold', () async {
+    final service = TagDecayForecastService(
+      retention: const _FakeRetention({'a': 90, 'b': 70}),
+      logger: _FakeLogger([
+        RecallSuccessEntry(tag: 'a', timestamp: DateTime.now()),
+        RecallSuccessEntry(tag: 'b', timestamp: DateTime.now()),
+      ]),
+      tuner: const _FakeTuner({}),
+    );
+
+    final tags = await service.getCriticalTags(threshold: 0.8);
+    expect(tags, ['a']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `getCriticalTags` helper for TagDecayForecastService
- display new `DecayBoosterShortcutBanner` on home screen
- show banner when a tag has decay > 0.8
- include basic unit test for `getCriticalTags`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688c36f89324832aa96e71d4421ede36