### PR TITLE
Implement decay review advisor

### DIFF
--- a/lib/services/decay_review_frequency_advisor_service.dart
+++ b/lib/services/decay_review_frequency_advisor_service.dart
@@ -1,0 +1,45 @@
+import 'tag_decay_forecast_service.dart';
+
+class TagReviewAdvice {
+  final String tag;
+  final double decay;
+  final int recommendedDaysUntilReview;
+
+  const TagReviewAdvice({
+    required this.tag,
+    required this.decay,
+    required this.recommendedDaysUntilReview,
+  });
+}
+
+class DecayReviewFrequencyAdvisorService {
+  final TagDecayForecastService forecastService;
+
+  const DecayReviewFrequencyAdvisorService({
+    this.forecastService = const TagDecayForecastService(),
+  });
+
+  Future<List<TagReviewAdvice>> getAdvice() async {
+    final forecasts = await forecastService.getAllForecasts();
+    final result = <TagReviewAdvice>[];
+    for (final entry in forecasts.entries) {
+      final decay = entry.value;
+      if (decay <= 0.5) continue;
+      result.add(
+        TagReviewAdvice(
+          tag: entry.key,
+          decay: decay,
+          recommendedDaysUntilReview: _suggestDays(decay),
+        ),
+      );
+    }
+    result.sort((a, b) => b.decay.compareTo(a.decay));
+    return result;
+  }
+
+  int _suggestDays(double decay) {
+    if (decay >= 0.9) return 0;
+    if (decay >= 0.7) return 1;
+    return 3;
+  }
+}

--- a/test/services/decay_review_frequency_advisor_service_test.dart
+++ b/test/services/decay_review_frequency_advisor_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/services/decay_review_frequency_advisor_service.dart';
+import 'package:poker_analyzer/services/tag_decay_forecast_service.dart';
+
+class _FakeForecast extends TagDecayForecastService {
+  final Map<String, double> map;
+  const _FakeForecast(this.map);
+  @override
+  Future<Map<String, double>> getAllForecasts() async => map;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('returns advice sorted by decay', () async {
+    const service = DecayReviewFrequencyAdvisorService(
+      forecastService: _FakeForecast({'a': 0.6, 'b': 0.8, 'c': 0.4}),
+    );
+    final list = await service.getAdvice();
+    expect(list.length, 2);
+    expect(list.first.tag, 'b');
+    expect(list.first.recommendedDaysUntilReview, 1);
+    expect(list[1].tag, 'a');
+    expect(list[1].recommendedDaysUntilReview, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- add `DecayReviewFrequencyAdvisorService` that suggests review intervals based on decay scores
- test advisory logic and sorting

## Testing
- `flutter pub get` *(warn: plugin warnings)*
- `flutter test` *(fails: MissingPluginException and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c3ec46fe0832a8703882db3abaa1b