### PR TITLE
Add decay smart scheduler

### DIFF
--- a/lib/models/daily_review_plan.dart
+++ b/lib/models/daily_review_plan.dart
@@ -1,0 +1,9 @@
+class DailyReviewPlan {
+  final DateTime date;
+  final List<String> tags;
+
+  const DailyReviewPlan({
+    required this.date,
+    required this.tags,
+  });
+}

--- a/lib/services/decay_smart_scheduler_service.dart
+++ b/lib/services/decay_smart_scheduler_service.dart
@@ -1,0 +1,48 @@
+import '../models/daily_review_plan.dart';
+import 'tag_decay_forecast_service.dart';
+import 'decay_review_frequency_advisor_service.dart';
+
+/// Generates a prioritized list of tags to review each day.
+class DecaySmartSchedulerService {
+  final TagDecayForecastService forecastService;
+  final DecayReviewFrequencyAdvisorService advisor;
+
+  const DecaySmartSchedulerService({
+    TagDecayForecastService? forecastService,
+    DecayReviewFrequencyAdvisorService? advisor,
+  })  : forecastService = forecastService ?? const TagDecayForecastService(),
+        advisor = advisor ?? const DecayReviewFrequencyAdvisorService();
+
+  /// Builds today\'s review plan using decay analytics.
+  Future<DailyReviewPlan> generateTodayPlan() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    final forecasts = await forecastService.getAllForecasts();
+    final critical = forecasts.entries
+        .where((e) => e.value > 0.8)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final criticalTags = [for (final e in critical) e.key];
+
+    final advice = await advisor.getAdvice();
+    final soon = advice
+        .where((a) => a.recommendedDaysUntilReview <= 1)
+        .map((a) => a.tag)
+        .toList();
+
+    final tags = <String>[];
+    for (final t in criticalTags) {
+      if (tags.length >= 10) break;
+      tags.add(t);
+    }
+    for (final t in soon) {
+      if (tags.length >= 10) break;
+      if (!tags.contains(t)) {
+        tags.add(t);
+      }
+    }
+
+    return DailyReviewPlan(date: today, tags: tags);
+  }
+}

--- a/test/services/decay_smart_scheduler_service_test.dart
+++ b/test/services/decay_smart_scheduler_service_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/services/decay_smart_scheduler_service.dart';
+import 'package:poker_analyzer/services/tag_decay_forecast_service.dart';
+import 'package:poker_analyzer/services/decay_review_frequency_advisor_service.dart';
+import 'package:poker_analyzer/models/daily_review_plan.dart';
+
+class _FakeForecast extends TagDecayForecastService {
+  final Map<String, double> map;
+  const _FakeForecast(this.map);
+  @override
+  Future<Map<String, double>> getAllForecasts() async => map;
+}
+
+class _FakeAdvisor extends DecayReviewFrequencyAdvisorService {
+  final List<TagReviewAdvice> list;
+  const _FakeAdvisor(this.list);
+  @override
+  Future<List<TagReviewAdvice>> getAdvice() async => list;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('combines critical and soon advice', () async {
+    const service = DecaySmartSchedulerService(
+      forecastService: _FakeForecast({'a': 0.9, 'b': 0.85, 'c': 0.75}),
+      advisor: _FakeAdvisor([
+        TagReviewAdvice(tag: 'c', decay: 0.75, recommendedDaysUntilReview: 0),
+        TagReviewAdvice(tag: 'd', decay: 0.65, recommendedDaysUntilReview: 1),
+        TagReviewAdvice(tag: 'a', decay: 0.9, recommendedDaysUntilReview: 0),
+      ]),
+    );
+
+    final DailyReviewPlan plan = await service.generateTodayPlan();
+    expect(plan.tags, ['a', 'b', 'c', 'd']);
+  });
+
+  test('limits to 10 tags', () async {
+    final map = <String, double>{};
+    for (var i = 0; i < 12; i++) {
+      map['t\\$i'] = 0.9 - i * 0.01;
+    }
+    const advisor = DecayReviewFrequencyAdvisorService();
+    final service = DecaySmartSchedulerService(
+      forecastService: _FakeForecast(map),
+      advisor: advisor,
+    );
+    final plan = await service.generateTodayPlan();
+    expect(plan.tags.length, 10);
+  });
+}


### PR DESCRIPTION
## Summary
- create `DailyReviewPlan` model
- add `DecaySmartSchedulerService` to build daily review plan
- test scheduler logic

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c86b68644832a9f68eecd9daefc7a