### PR TITLE
Implement daily review booster launcher

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,6 +63,8 @@ import 'services/overlay_decay_booster_orchestrator.dart';
 import 'services/decay_streak_overlay_prompt_service.dart';
 import 'screens/training_session_screen.dart';
 import 'screens/empty_training_screen.dart';
+import 'models/v2/training_pack_v2.dart';
+import 'models/v2/training_pack_template_v2.dart';
 import 'services/app_init_service.dart';
 import 'services/suggested_pack_push_service.dart';
 import 'services/lesson_path_reminder_scheduler.dart';
@@ -317,6 +319,23 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
     );
   }
 
+  Route<dynamic>? _onGenerateRoute(RouteSettings settings) {
+    if (settings.name == TrainingSessionScreen.route) {
+      final arg = settings.arguments;
+      if (arg is TrainingPackV2) {
+        return MaterialPageRoute(
+          builder: (_) => TrainingSessionScreen(pack: arg),
+        );
+      } else if (arg is TrainingPackTemplateV2) {
+        final pack = TrainingPackV2.fromTemplate(arg, arg.id);
+        return MaterialPageRoute(
+          builder: (_) => TrainingSessionScreen(pack: pack),
+        );
+      }
+    }
+    return null;
+  }
+
   @override
   void dispose() {
     AppBootstrap.dispose();
@@ -353,6 +372,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               Locale('pt'),
               Locale('de'),
             ],
+            onGenerateRoute: _onGenerateRoute,
             routes: {
               WeaknessOverviewScreen.route: (_) =>
                   const WeaknessOverviewScreen(),

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -77,6 +77,7 @@ class _EndlessStats {
 }
 
 class TrainingSessionScreen extends StatefulWidget {
+  static const route = '/training_session';
   final VoidCallback? onSessionEnd;
   final TrainingSession? session;
   final TrainingPackV2? pack;

--- a/lib/services/booster_pack_factory.dart
+++ b/lib/services/booster_pack_factory.dart
@@ -1,0 +1,51 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../models/game_type.dart';
+import 'training_spot_library.dart';
+
+/// Builds ad-hoc booster packs from existing spots filtered by tags.
+class BoosterPackFactory {
+  const BoosterPackFactory();
+
+  /// Returns a training pack containing spots matching [tags].
+  /// The result may be `null` if no suitable spots are found.
+  static Future<TrainingPackTemplateV2?> buildFromTags(List<String> tags,
+      {int spotsPerTag = 3}) async {
+    final lib = TrainingSpotLibrary();
+    final spots = <TrainingPackSpot>[];
+    final used = <String>{};
+
+    for (final tag in tags) {
+      final list = await lib.indexByTag(tag);
+      for (final spot in list) {
+        if (used.add(spot.id)) {
+          spots.add(TrainingPackSpot.fromJson(spot.toJson()));
+          if (spots.length >= spotsPerTag * tags.length) break;
+        }
+      }
+      if (spots.length >= spotsPerTag * tags.length) break;
+    }
+
+    if (spots.isEmpty) return null;
+
+    final positions = <HeroPosition>{for (final s in spots) s.hand.position};
+
+    final tpl = TrainingPackTemplateV2(
+      id: const Uuid().v4(),
+      name: 'Daily Review',
+      tags: List<String>.from(tags),
+      trainingType: TrainingType.pushFold,
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      positions: [for (final p in positions) p.name],
+    );
+    tpl.trainingType = const TrainingTypeEngine().detectTrainingType(tpl);
+    return tpl;
+  }
+}

--- a/lib/services/daily_review_booster_launcher.dart
+++ b/lib/services/daily_review_booster_launcher.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'decay_smart_scheduler_service.dart';
+import 'booster_pack_factory.dart';
+import '../screens/training_session_screen.dart';
+
+/// Starts a review session for decayed tags.
+class DailyReviewBoosterLauncher {
+  const DailyReviewBoosterLauncher();
+
+  /// Builds today's booster pack and opens the training screen.
+  Future<void> launch(BuildContext context) async {
+    final plan = await const DecaySmartSchedulerService().generateTodayPlan();
+    final tags = plan.tags;
+    if (tags.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Сегодня ничего не забыто!')),
+      );
+      return;
+    }
+
+    final pack = await BoosterPackFactory.buildFromTags(tags);
+    if (pack == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Сегодня ничего не забыто!')),
+      );
+      return;
+    }
+
+    Navigator.pushNamed(
+      context,
+      TrainingSessionScreen.route,
+      arguments: pack,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `BoosterPackFactory` to build packs from decayed tags
- implement `DailyReviewBoosterLauncher` service
- expose named route for `TrainingSessionScreen`
- add `onGenerateRoute` handler in `main.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c898ece4c832aa81a223a69e46fc1