### PR TITLE
Implement interactive DecayHeatmap

### DIFF
--- a/lib/models/tag_decay_entry.dart
+++ b/lib/models/tag_decay_entry.dart
@@ -1,0 +1,11 @@
+class TagDecayEntry {
+  final String tag;
+  final double decay;
+  final int boosters;
+
+  const TagDecayEntry({
+    required this.tag,
+    required this.decay,
+    this.boosters = 0,
+  });
+}

--- a/lib/screens/decay_heatmap_screen.dart
+++ b/lib/screens/decay_heatmap_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
-import '../services/decay_heatmap_tile_generator.dart';
+import '../models/tag_decay_entry.dart';
+import '../services/booster_path_history_service.dart';
+import '../services/decay_tag_retention_tracker_service.dart';
 import '../utils/responsive.dart';
 
 class DecayHeatmapScreen extends StatefulWidget {
@@ -11,9 +13,12 @@ class DecayHeatmapScreen extends StatefulWidget {
   State<DecayHeatmapScreen> createState() => _DecayHeatmapScreenState();
 }
 
+enum _Sort { decay, alphabet, boosters }
+
 class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
   bool _loading = true;
-  List<DecayHeatmapTile> _tiles = [];
+  List<TagDecayEntry> _entries = [];
+  _Sort _sort = _Sort.decay;
 
   @override
   void initState() {
@@ -23,14 +28,40 @@ class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final generator = const DecayHeatmapTileGenerator();
-    final tiles = await generator.generate();
-    tiles.sort((a, b) => b.urgency.compareTo(a.urgency));
+    final scores = await const DecayTagRetentionTrackerService().getAllDecayScores();
+    final boosterStats = await BoosterPathHistoryService.instance.getTagStats();
+    final list = <TagDecayEntry>[];
+    scores.forEach((tag, score) {
+      final boosters = boosterStats[tag]?.completedCount ?? 0;
+      list.add(TagDecayEntry(tag: tag, decay: score, boosters: boosters));
+    });
+    _sortEntries(list);
     if (!mounted) return;
     setState(() {
-      _tiles = tiles;
+      _entries = list;
       _loading = false;
     });
+  }
+
+  void _sortEntries(List<TagDecayEntry> list) {
+    switch (_sort) {
+      case _Sort.alphabet:
+        list.sort((a, b) => a.tag.compareTo(b.tag));
+        break;
+      case _Sort.boosters:
+        list.sort((a, b) => b.boosters.compareTo(a.boosters));
+        break;
+      case _Sort.decay:
+      default:
+        list.sort((a, b) => b.decay.compareTo(a.decay));
+    }
+  }
+
+  Color _colorFor(double u) {
+    if (u <= 0.5) {
+      return Color.lerp(Colors.green, Colors.yellow, u * 2) ?? Colors.green;
+    }
+    return Color.lerp(Colors.yellow, Colors.red, (u - 0.5) * 2) ?? Colors.red;
   }
 
   Color _textColor(Color bg) {
@@ -39,31 +70,40 @@ class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
         : Colors.black;
   }
 
-  Widget _buildTile(DecayHeatmapTile tile) {
-    final textColor = _textColor(tile.color);
-    return Container(
-      decoration: BoxDecoration(
-        color: tile.color,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      alignment: Alignment.center,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            tile.tag,
-            style: TextStyle(
-              color: textColor,
-              fontWeight: FontWeight.bold,
+  Widget _buildTile(TagDecayEntry e) {
+    final color = _colorFor(e.decay);
+    final textColor = _textColor(color);
+    return GestureDetector(
+      onTap: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Selected ${e.tag}')),
+        );
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.center,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              e.tag,
+              style: TextStyle(
+                color: textColor,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
             ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 4),
-          Text(
-            '${(tile.urgency * 100).toStringAsFixed(0)}%',
-            style: TextStyle(color: textColor),
-          ),
-        ],
+            const SizedBox(height: 4),
+            Text('${(e.decay * 100).toStringAsFixed(0)}%',
+                style: TextStyle(color: textColor)),
+            if (e.boosters > 0)
+              Text('x${e.boosters}',
+                  style: TextStyle(color: textColor, fontSize: 10)),
+          ],
+        ),
       ),
     );
   }
@@ -76,11 +116,25 @@ class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
         title: const Text('Decay Heatmap'),
         actions: [
           IconButton(onPressed: _load, icon: const Icon(Icons.refresh)),
+          PopupMenuButton<_Sort>(
+            icon: const Icon(Icons.sort),
+            onSelected: (v) {
+              setState(() {
+                _sort = v;
+                _sortEntries(_entries);
+              });
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: _Sort.decay, child: Text('By decay')),
+              PopupMenuItem(value: _Sort.alphabet, child: Text('Alphabetical')),
+              PopupMenuItem(value: _Sort.boosters, child: Text('By boosters')),
+            ],
+          ),
         ],
       ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : _tiles.isEmpty
+          : _entries.isEmpty
               ? const Center(child: Text('No tags'))
               : GridView.count(
                   padding: const EdgeInsets.all(16),
@@ -88,7 +142,7 @@ class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
                   crossAxisSpacing: 8,
                   mainAxisSpacing: 8,
                   childAspectRatio: 1,
-                  children: _tiles.map(_buildTile).toList(),
+                  children: _entries.map(_buildTile).toList(),
                 ),
     );
   }

--- a/lib/services/decay_tag_retention_tracker_service.dart
+++ b/lib/services/decay_tag_retention_tracker_service.dart
@@ -49,4 +49,39 @@ class DecayTagRetentionTrackerService {
     final current = now ?? DateTime.now();
     return current.difference(last).inDays.toDouble();
   }
+
+  /// Returns normalized decay scores for all tracked tags.
+  Future<Map<String, double>> getAllDecayScores({DateTime? now}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final tags = <String>{};
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(_theoryPrefix)) {
+        tags.add(key.substring(_theoryPrefix.length));
+      } else if (key.startsWith(_boosterPrefix)) {
+        tags.add(key.substring(_boosterPrefix.length));
+      }
+    }
+
+    final current = now ?? DateTime.now();
+    final result = <String, double>{};
+    for (final tag in tags) {
+      final reviewStr = prefs.getString('$_theoryPrefix$tag');
+      final boosterStr = prefs.getString('$_boosterPrefix$tag');
+      final review = reviewStr != null ? DateTime.tryParse(reviewStr) : null;
+      final booster = boosterStr != null ? DateTime.tryParse(boosterStr) : null;
+      DateTime? last;
+      if (review != null && booster != null) {
+        last = review.isAfter(booster) ? review : booster;
+      } else {
+        last = review ?? booster;
+      }
+      if (last == null) {
+        result[tag] = 1.0;
+      } else {
+        final days = current.difference(last).inDays.toDouble();
+        result[tag] = (days / 100).clamp(0.0, 1.0);
+      }
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
## Summary
- add `TagDecayEntry` model for heatmap data
- expose `getAllDecayScores` in `DecayTagRetentionTrackerService`
- rebuild `DecayHeatmapScreen` with sorting and booster stats

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c8e84d928832aacd54159c78f9e1b