### PR TITLE
Add BoosterEffectivenessAnalyzer

### DIFF
--- a/lib/services/booster_effectiveness_analyzer.dart
+++ b/lib/services/booster_effectiveness_analyzer.dart
@@ -1,0 +1,52 @@
+import '../models/booster_path_log_entry.dart';
+import 'booster_path_history_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+
+/// Computes average decay improvement after booster repetitions per tag.
+class BoosterEffectivenessAnalyzer {
+  final BoosterPathHistoryService history;
+  final DecayTagRetentionTrackerService retention;
+
+  const BoosterEffectivenessAnalyzer({
+    BoosterPathHistoryService? history,
+    this.retention = const DecayTagRetentionTrackerService(),
+  }) : history = history ?? BoosterPathHistoryService.instance;
+
+  /// Returns average (initialDecay - postBoosterDecay) for each tag.
+  Future<Map<String, double>> computeEffectiveness({DateTime? now}) async {
+    final logs = await history.getHistory();
+    if (logs.isEmpty) return <String, double>{};
+
+    final grouped = <String, List<BoosterPathLogEntry>>{};
+    for (final l in logs) {
+      final tag = l.tag.trim().toLowerCase();
+      if (tag.isEmpty || l.completedAt == null) continue;
+      grouped.putIfAbsent(tag, () => []).add(l);
+    }
+
+    final current = now ?? DateTime.now();
+    final result = <String, double>{};
+
+    for (final entry in grouped.entries) {
+      final events = entry.value
+        ..sort((a, b) => a.completedAt!.compareTo(b.completedAt!));
+      if (events.length < 2) continue;
+      double total = 0.0;
+      for (var i = 1; i < events.length; i++) {
+        final prev = events[i - 1].completedAt!;
+        final cur = events[i].completedAt!;
+        final next = i + 1 < events.length
+            ? events[i + 1].completedAt!
+            : current;
+        final initial = cur.difference(prev).inDays.toDouble();
+        final post = i + 1 < events.length
+            ? next.difference(cur).inDays.toDouble()
+            : await retention.getDecayScore(entry.key, now: current);
+        total += initial - post;
+      }
+      result[entry.key] = total / (events.length - 1);
+    }
+
+    return result;
+  }
+}

--- a/test/services/booster_effectiveness_analyzer_test.dart
+++ b/test/services/booster_effectiveness_analyzer_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/booster_effectiveness_analyzer.dart';
+import 'package:poker_analyzer/services/booster_path_history_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/models/booster_path_log_entry.dart';
+
+class _FakeHistory extends BoosterPathHistoryService {
+  final List<BoosterPathLogEntry> entries;
+  _FakeHistory(this.entries);
+  @override
+  Future<List<BoosterPathLogEntry>> getHistory({String? tag}) async {
+    if (tag == null) return entries;
+    final norm = tag.trim().toLowerCase();
+    return entries.where((e) => e.tag == norm).toList();
+  }
+}
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<double> getDecayScore(String tag, {DateTime? now}) async {
+    return scores[tag] ?? 0.0;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('computes average decay improvement per tag', () async {
+    final now = DateTime(2024, 1, 10);
+    final history = _FakeHistory([
+      BoosterPathLogEntry(
+        lessonId: 'b1',
+        tag: 'icm',
+        shownAt: now.subtract(const Duration(days: 7)),
+        completedAt: now.subtract(const Duration(days: 7)),
+      ),
+      BoosterPathLogEntry(
+        lessonId: 'b2',
+        tag: 'icm',
+        shownAt: now.subtract(const Duration(days: 4)),
+        completedAt: now.subtract(const Duration(days: 4)),
+      ),
+      BoosterPathLogEntry(
+        lessonId: 'b3',
+        tag: 'icm',
+        shownAt: now.subtract(const Duration(days: 1)),
+        completedAt: now.subtract(const Duration(days: 1)),
+      ),
+    ]);
+
+    const retention = _FakeRetention({'icm': 1.0});
+    final analyzer =
+        BoosterEffectivenessAnalyzer(history: history, retention: retention);
+    final result = await analyzer.computeEffectiveness(now: now);
+    expect(result['icm'], closeTo(1.0, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `BoosterEffectivenessAnalyzer` service
- test effectiveness calculation logic

## Testing
- `dart test test/services/booster_effectiveness_analyzer_test.dart` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_688c90467314832ab78660e241d8659b