### PR TITLE
Add DecayAnalyticsExporterService

### DIFF
--- a/lib/models/decay_analytics_export.dart
+++ b/lib/models/decay_analytics_export.dart
@@ -1,0 +1,48 @@
+import "../services/booster_adaptation_tuner.dart";
+
+class DecayAnalyticsExport {
+  final String tag;
+  final double decay;
+  final BoosterAdaptation adaptation;
+  final DateTime? lastInteraction;
+  final int recommendedDaysUntilReview;
+
+  const DecayAnalyticsExport({
+    required this.tag,
+    required this.decay,
+    required this.adaptation,
+    this.lastInteraction,
+    required this.recommendedDaysUntilReview,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'decay': decay,
+        'adaptation': adaptation.name,
+        if (lastInteraction != null)
+          'lastInteraction': lastInteraction!.toIso8601String(),
+        'recommendedDaysUntilReview': recommendedDaysUntilReview,
+      };
+
+  factory DecayAnalyticsExport.fromJson(Map<String, dynamic> json) =>
+      DecayAnalyticsExport(
+        tag: json['tag'] as String? ?? '',
+        decay: (json['decay'] as num?)?.toDouble() ?? 0.0,
+        adaptation: _parseAdaptation(json['adaptation'] as String?),
+        lastInteraction:
+            DateTime.tryParse(json['lastInteraction'] as String? ?? ''),
+        recommendedDaysUntilReview:
+            (json['recommendedDaysUntilReview'] as num?)?.toInt() ?? 0,
+      );
+
+  static BoosterAdaptation _parseAdaptation(String? value) {
+    switch (value) {
+      case 'increase':
+        return BoosterAdaptation.increase;
+      case 'reduce':
+        return BoosterAdaptation.reduce;
+      default:
+        return BoosterAdaptation.keep;
+    }
+  }
+}

--- a/lib/services/decay_analytics_exporter_service.dart
+++ b/lib/services/decay_analytics_exporter_service.dart
@@ -1,0 +1,51 @@
+import '../models/decay_analytics_export.dart';
+import 'booster_adaptation_tuner.dart';
+import 'decay_review_frequency_advisor_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'review_streak_evaluator_service.dart';
+
+class DecayAnalyticsExporterService {
+  final DecayTagRetentionTrackerService retention;
+  final BoosterAdaptationTuner tuner;
+  final ReviewStreakEvaluatorService streak;
+  final DecayReviewFrequencyAdvisorService advisor;
+
+  const DecayAnalyticsExporterService({
+    this.retention = const DecayTagRetentionTrackerService(),
+    BoosterAdaptationTuner? tuner,
+    this.streak = const ReviewStreakEvaluatorService(),
+    this.advisor = const DecayReviewFrequencyAdvisorService(),
+  }) : tuner = tuner ?? BoosterAdaptationTuner();
+
+  Future<List<DecayAnalyticsExport>> exportAnalytics() async {
+    final decayScores = await retention.getAllDecayScores();
+    final adaptations = await tuner.loadAdaptations();
+    final tagStats = await streak.getTagStats();
+    final adviceList = await advisor.getAdvice();
+    final adviceMap = {for (final a in adviceList) a.tag: a};
+
+    final tags = <String>{
+      ...decayScores.keys,
+      ...adaptations.keys,
+      ...tagStats.keys,
+      ...adviceMap.keys,
+    }..removeWhere((t) => t.isEmpty);
+
+    final exports = <DecayAnalyticsExport>[];
+    for (final tag in tags) {
+      exports.add(
+        DecayAnalyticsExport(
+          tag: tag,
+          decay: decayScores[tag] ?? 0.0,
+          adaptation: adaptations[tag] ?? BoosterAdaptation.keep,
+          lastInteraction: tagStats[tag]?.lastInteraction,
+          recommendedDaysUntilReview:
+              adviceMap[tag]?.recommendedDaysUntilReview ?? 0,
+        ),
+      );
+    }
+
+    exports.sort((a, b) => b.decay.compareTo(a.decay));
+    return exports;
+  }
+}

--- a/test/services/decay_analytics_exporter_service_test.dart
+++ b/test/services/decay_analytics_exporter_service_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/booster_tag_history.dart';
+import 'package:poker_analyzer/services/booster_adaptation_tuner.dart';
+import 'package:poker_analyzer/services/decay_analytics_exporter_service.dart';
+import 'package:poker_analyzer/services/decay_review_frequency_advisor_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/review_streak_evaluator_service.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> map;
+  const _FakeRetention(this.map);
+  @override
+  Future<Map<String, double>> getAllDecayScores({DateTime? now}) async => map;
+}
+
+class _FakeTuner extends BoosterAdaptationTuner {
+  final Map<String, BoosterAdaptation> map;
+  const _FakeTuner(this.map);
+  @override
+  Future<Map<String, BoosterAdaptation>> loadAdaptations() async => map;
+}
+
+class _FakeStreak extends ReviewStreakEvaluatorService {
+  final Map<String, BoosterTagHistory> map;
+  const _FakeStreak(this.map);
+  @override
+  Future<Map<String, BoosterTagHistory>> getTagStats() async => map;
+}
+
+class _FakeAdvisor extends DecayReviewFrequencyAdvisorService {
+  final List<TagReviewAdvice> list;
+  const _FakeAdvisor(this.list);
+  @override
+  Future<List<TagReviewAdvice>> getAdvice() async => list;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exports analytics sorted by decay', () async {
+    final now = DateTime.now();
+    final service = DecayAnalyticsExporterService(
+      retention: const _FakeRetention({'a': 0.6, 'b': 0.9}),
+      tuner: const _FakeTuner({'a': BoosterAdaptation.increase}),
+      streak: _FakeStreak({
+        'a': BoosterTagHistory(
+          tag: 'a',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 1,
+          lastInteraction: now.subtract(const Duration(days: 1)),
+        ),
+      }),
+      advisor: const _FakeAdvisor([
+        TagReviewAdvice(tag: 'a', decay: 0.6, recommendedDaysUntilReview: 2),
+        TagReviewAdvice(tag: 'b', decay: 0.9, recommendedDaysUntilReview: 1),
+      ]),
+    );
+
+    final list = await service.exportAnalytics();
+    expect(list.length, 2);
+    expect(list.first.tag, 'b');
+    expect(list.first.decay, 0.9);
+    expect(list[1].tag, 'a');
+    expect(list[1].adaptation, BoosterAdaptation.increase);
+    expect(list[1].recommendedDaysUntilReview, 2);
+    expect(list[1].lastInteraction, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add data model `DecayAnalyticsExport`
- implement `DecayAnalyticsExporterService` to gather decay analytics
- unit test `DecayAnalyticsExporterService`

## Testing
- `flutter test test/services/decay_analytics_exporter_service_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c985366b4832a8d9285b968363721