### PR TITLE
Implement decay recall tuner

### DIFF
--- a/lib/services/booster_adaptation_tuner.dart
+++ b/lib/services/booster_adaptation_tuner.dart
@@ -87,4 +87,13 @@ class BoosterAdaptationTuner {
     await _save();
     return result;
   }
+
+  /// Saves [adaptation] for [tag] overriding any cached value.
+  Future<void> saveAdaptation(String tag, BoosterAdaptation adaptation) async {
+    final key = tag.trim().toLowerCase();
+    if (key.isEmpty) return;
+    await _load();
+    _cache[key] = adaptation;
+    await _save();
+  }
 }

--- a/lib/services/decay_recall_tuner_engine.dart
+++ b/lib/services/decay_recall_tuner_engine.dart
@@ -1,0 +1,74 @@
+import 'booster_adaptation_tuner.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'recall_success_logger_service.dart';
+import 'review_streak_evaluator_service.dart';
+
+/// Tunes decay speed per tag based on recall success and review frequency.
+class DecayRecallTunerEngine {
+  final RecallSuccessLoggerService logger;
+  final ReviewStreakEvaluatorService streak;
+  final DecayTagRetentionTrackerService retention;
+  final BoosterAdaptationTuner tuner;
+
+  DecayRecallTunerEngine({
+    RecallSuccessLoggerService? logger,
+    ReviewStreakEvaluatorService? streak,
+    DecayTagRetentionTrackerService? retention,
+    BoosterAdaptationTuner? tuner,
+  })  : logger = logger ?? RecallSuccessLoggerService.instance,
+        streak = streak ?? const ReviewStreakEvaluatorService(),
+        retention = retention ?? const DecayTagRetentionTrackerService(),
+        tuner = tuner ?? BoosterAdaptationTuner.instance;
+
+  /// Minimum gap considered over-review.
+  static const Duration _frequentGap = Duration(days: 2);
+
+  /// Gap indicating tag was neglected for too long.
+  static const Duration _longGap = Duration(days: 14);
+
+  /// Computes adaptations and persists them via [BoosterAdaptationTuner].
+  Future<void> tune() async {
+    final successLogs = await logger.getSuccesses();
+    final tagStats = await streak.getTagStats();
+    final decayScores = await retention.getAllDecayScores();
+
+    final successMap = <String, int>{};
+    for (final e in successLogs) {
+      final tag = e.tag.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      successMap.update(tag, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    final tags = <String>{
+      ...successMap.keys,
+      ...tagStats.keys,
+      ...decayScores.keys,
+    }..removeWhere((t) => t.isEmpty);
+
+    final now = DateTime.now();
+
+    for (final tag in tags) {
+      final stats = tagStats[tag];
+      final completed = stats?.completedCount ?? 0;
+      final successes = successMap[tag] ?? 0;
+      final successRate =
+          completed > 0 ? successes * 100 / completed : (successes > 0 ? 100 : 0);
+
+      final last = stats?.lastInteraction;
+      final daysSince = last != null ? now.difference(last).inDays : 999;
+      final decay = decayScores[tag] ?? 0.0;
+
+      final tooFrequent = daysSince <= _frequentGap.inDays && decay < 30;
+      final longDelay = daysSince >= _longGap.inDays || decay > 60;
+
+      BoosterAdaptation adaptation = BoosterAdaptation.keep;
+      if (successRate > 90 && tooFrequent) {
+        adaptation = BoosterAdaptation.reduce;
+      } else if (successRate < 60 || longDelay) {
+        adaptation = BoosterAdaptation.increase;
+      }
+
+      await tuner.saveAdaptation(tag, adaptation);
+    }
+  }
+}

--- a/test/services/decay_recall_tuner_engine_test.dart
+++ b/test/services/decay_recall_tuner_engine_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/booster_tag_history.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+import 'package:poker_analyzer/services/booster_adaptation_tuner.dart';
+import 'package:poker_analyzer/services/decay_recall_tuner_engine.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_success_logger_service.dart';
+import 'package:poker_analyzer/services/review_streak_evaluator_service.dart';
+
+class _FakeLogger extends RecallSuccessLoggerService {
+  final List<RecallSuccessEntry> list;
+  _FakeLogger(this.list) : super._();
+  @override
+  Future<List<RecallSuccessEntry>> getSuccesses({String? tag}) async {
+    if (tag == null) return list;
+    return list.where((e) => e.tag == tag).toList();
+  }
+}
+
+class _FakeStreak extends ReviewStreakEvaluatorService {
+  final Map<String, BoosterTagHistory> map;
+  const _FakeStreak(this.map);
+  @override
+  Future<Map<String, BoosterTagHistory>> getTagStats() async => map;
+}
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<Map<String, double>> getAllDecayScores({DateTime? now}) async => scores;
+}
+
+class _RecordingTuner extends BoosterAdaptationTuner {
+  final Map<String, BoosterAdaptation> saved = {};
+  @override
+  Future<void> saveAdaptation(String tag, BoosterAdaptation adaptation) async {
+    saved[tag] = adaptation;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('tune adjusts adaptations per heuristics', () async {
+    final now = DateTime.now();
+    final tuner = _RecordingTuner();
+    final engine = DecayRecallTunerEngine(
+      logger: _FakeLogger([
+        RecallSuccessEntry(tag: 'a', timestamp: now),
+        RecallSuccessEntry(tag: 'a', timestamp: now),
+        RecallSuccessEntry(tag: 'b', timestamp: now),
+      ]),
+      streak: _FakeStreak({
+        'a': BoosterTagHistory(
+          tag: 'a',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 2,
+          lastInteraction: now.subtract(const Duration(days: 1)),
+        ),
+        'b': BoosterTagHistory(
+          tag: 'b',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 2,
+          lastInteraction: now.subtract(const Duration(days: 20)),
+        ),
+        'c': BoosterTagHistory(
+          tag: 'c',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 2,
+          lastInteraction: now.subtract(const Duration(days: 5)),
+        ),
+      }),
+      retention: _FakeRetention({'a': 10, 'b': 70, 'c': 40}),
+      tuner: tuner,
+    );
+
+    await engine.tune();
+
+    expect(tuner.saved['a'], BoosterAdaptation.reduce);
+    expect(tuner.saved['b'], BoosterAdaptation.increase);
+    expect(tuner.saved['c'], BoosterAdaptation.keep);
+  });
+}


### PR DESCRIPTION
## Summary
- add `DecayRecallTunerEngine` for dynamic decay adjustments
- allow saving of individual adaptations in `BoosterAdaptationTuner`
- test new tuning logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c9b161a3c832abb78d7b64840e41b