### PR TITLE
Implement SmartDecayGoalGenerator

### DIFF
--- a/lib/models/goal_recommendation.dart
+++ b/lib/models/goal_recommendation.dart
@@ -1,0 +1,7 @@
+class GoalRecommendation {
+  final String tag;
+  final String reason;
+
+  const GoalRecommendation({required this.tag, required this.reason});
+}
+

--- a/lib/services/smart_decay_goal_generator.dart
+++ b/lib/services/smart_decay_goal_generator.dart
@@ -1,0 +1,65 @@
+import '../models/goal_recommendation.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'recall_success_logger_service.dart';
+import 'review_streak_evaluator_service.dart';
+
+/// Generates goal recommendations for decayed theory tags.
+class SmartDecayGoalGenerator {
+  final DecayTagRetentionTrackerService retention;
+  final RecallSuccessLoggerService logger;
+  final ReviewStreakEvaluatorService streak;
+
+  SmartDecayGoalGenerator({
+    DecayTagRetentionTrackerService? retention,
+    RecallSuccessLoggerService? logger,
+    ReviewStreakEvaluatorService? streak,
+  })  : retention = retention ?? const DecayTagRetentionTrackerService(),
+        logger = logger ?? RecallSuccessLoggerService.instance,
+        streak = streak ?? const ReviewStreakEvaluatorService();
+
+  /// Returns recommended recovery goals for highly decayed tags.
+  Future<List<GoalRecommendation>> recommendDecayRecoveryGoals({int max = 5}) async {
+    if (max <= 0) return <GoalRecommendation>[];
+    final decayScores = await retention.getAllDecayScores();
+    final successLogs = await logger.getSuccesses();
+    final tagStats = await streak.getTagStats();
+
+    final successMap = <String, int>{};
+    for (final log in successLogs) {
+      final tag = log.tag.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      successMap.update(tag, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    final entries = decayScores.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final now = DateTime.now();
+    final recommendations = <GoalRecommendation>[];
+
+    for (final e in entries) {
+      if (recommendations.length >= max) break;
+      final tag = e.key;
+      final decayPct = (e.value * 100).clamp(0.0, 100.0);
+      if (decayPct <= 60) continue;
+
+      final stats = tagStats[tag];
+      final daysSince = stats != null
+          ? now.difference(stats.lastInteraction).inDays
+          : (decayPct).round();
+      if (daysSince <= 7) continue;
+
+      final successes = successMap[tag] ?? 0;
+      final completed = stats?.completedCount ?? 0;
+      final successRate =
+          completed > 0 ? successes * 100 / completed : (successes > 0 ? 100 : 0);
+      if (successRate > 90) continue;
+
+      final reason =
+          'Decay ${decayPct.round()}%, last review $daysSince days ago';
+      recommendations.add(GoalRecommendation(tag: tag, reason: reason));
+    }
+
+    return recommendations;
+  }
+}
+

--- a/test/services/smart_decay_goal_generator_test.dart
+++ b/test/services/smart_decay_goal_generator_test.dart
@@ -1,0 +1,104 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/smart_decay_goal_generator.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/recall_success_logger_service.dart';
+import 'package:poker_analyzer/services/review_streak_evaluator_service.dart';
+import 'package:poker_analyzer/models/goal_recommendation.dart';
+import 'package:poker_analyzer/models/booster_tag_history.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final Map<String, double> scores;
+  const _FakeRetention(this.scores);
+  @override
+  Future<Map<String, double>> getAllDecayScores({DateTime? now}) async => scores;
+}
+
+class _FakeLogger extends RecallSuccessLoggerService {
+  final List<RecallSuccessEntry> entries;
+  _FakeLogger(this.entries) : super._();
+  @override
+  Future<List<RecallSuccessEntry>> getSuccesses({String? tag}) async {
+    if (tag == null) return entries;
+    return entries.where((e) => e.tag == tag).toList();
+  }
+}
+
+class _FakeStreak extends ReviewStreakEvaluatorService {
+  final Map<String, BoosterTagHistory> stats;
+  const _FakeStreak(this.stats);
+  @override
+  Future<Map<String, BoosterTagHistory>> getTagStats() async => stats;
+}
+
+void main() {
+
+  test('recommends top decayed tags', () async {
+    final now = DateTime.now();
+    final service = SmartDecayGoalGenerator(
+      retention: const _FakeRetention({'a': 0.8, 'b': 0.7, 'c': 0.5}),
+      logger: _FakeLogger([]),
+      streak: _FakeStreak({
+        'a': BoosterTagHistory(
+          tag: 'a',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 1,
+          lastInteraction: now.subtract(const Duration(days: 10)),
+        ),
+        'b': BoosterTagHistory(
+          tag: 'b',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 1,
+          lastInteraction: now.subtract(const Duration(days: 8)),
+        ),
+        'c': BoosterTagHistory(
+          tag: 'c',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 1,
+          lastInteraction: now.subtract(const Duration(days: 15)),
+        ),
+      }),
+    );
+
+    final List<GoalRecommendation> list =
+        await service.recommendDecayRecoveryGoals();
+    expect(list.length, 2);
+    expect(list.first.tag, 'a');
+    expect(list.last.tag, 'b');
+  });
+
+  test('filters high success rate tags', () async {
+    final now = DateTime.now();
+    final service = SmartDecayGoalGenerator(
+      retention: const _FakeRetention({'a': 0.8, 'b': 0.7}),
+      logger: _FakeLogger([
+        RecallSuccessEntry(tag: 'a', timestamp: DateTime.now()),
+      ]),
+      streak: _FakeStreak({
+        'a': BoosterTagHistory(
+          tag: 'a',
+          shownCount: 1,
+          startedCount: 0,
+          completedCount: 1,
+          lastInteraction: now.subtract(const Duration(days: 10)),
+        ),
+        'b': BoosterTagHistory(
+          tag: 'b',
+          shownCount: 5,
+          startedCount: 5,
+          completedCount: 5,
+          lastInteraction: now.subtract(const Duration(days: 10)),
+        ),
+      }),
+    );
+
+    final list = await service.recommendDecayRecoveryGoals();
+    expect(list.length, 1);
+    expect(list.first.tag, 'b');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `GoalRecommendation` model
- implement `SmartDecayGoalGenerator` service to suggest goals for decayed tags
- test recommendation logic

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688c9ed05790832abe6481801a8a0f7a