### PR TITLE
Add SmartMistakeGoalBanner

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -60,6 +60,7 @@ import 'training_home_screen.dart';
 import 'ready_to_train_screen.dart';
 import '../widgets/lesson_suggestion_banner.dart';
 import '../widgets/smart_decay_goal_banner.dart';
+import '../widgets/smart_mistake_goal_banner.dart';
 import '../widgets/recovery_prompt_banner.dart';
 import '../widgets/goal_reengagement_banner.dart';
 import '../widgets/smart_recap_suggestion_banner.dart';
@@ -863,6 +864,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                   children: [
                     const LessonSuggestionBanner(),
                     const SmartDecayGoalBanner(),
+                    const SmartMistakeGoalBanner(),
                     const GoalReengagementBannerWidget(),
                     const RecoveryPromptBanner(),
                     const RecapBannerWidget(),

--- a/lib/widgets/smart_mistake_goal_banner.dart
+++ b/lib/widgets/smart_mistake_goal_banner.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/goal_recommendation.dart';
+import '../models/user_goal.dart';
+import '../services/smart_mistake_goal_generator.dart';
+import '../services/user_goal_engine.dart';
+
+class SmartMistakeGoalBanner extends StatefulWidget {
+  const SmartMistakeGoalBanner({super.key});
+
+  @override
+  State<SmartMistakeGoalBanner> createState() => _SmartMistakeGoalBannerState();
+}
+
+class _SmartMistakeGoalBannerState extends State<SmartMistakeGoalBanner> {
+  bool _loading = true;
+  GoalRecommendation? _rec;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final generator = SmartMistakeGoalGenerator();
+    final list = await generator.recommendMistakeRecoveryGoals();
+    if (!mounted) return;
+    setState(() {
+      _rec = list.isNotEmpty ? list.first : null;
+      _loading = false;
+    });
+  }
+
+  Future<void> _addGoal() async {
+    final rec = _rec;
+    if (rec == null) return;
+    final now = DateTime.now();
+    final goal = UserGoal(
+      id: 'mistake_${rec.tag}_${now.millisecondsSinceEpoch}',
+      title: 'Исправить ошибку ${rec.tag}',
+      type: 'tag',
+      target: 90,
+      base: 0,
+      createdAt: now,
+      tag: rec.tag,
+      targetAccuracy: 90.0,
+    );
+    await context.read<UserGoalEngine>().addGoal(goal);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Цель добавлена!')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _rec == null) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    final rec = _rec!;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('⚠️', style: TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '#${rec.tag}',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            rec.reason,
+            style: const TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _addGoal,
+              style: ElevatedButton.styleFrom(backgroundColor: accent),
+              child: const Text('Исправить ошибку'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- suggest high-value mistake goals from SmartMistakeGoalGenerator
- show SmartMistakeGoalBanner in the main menu

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ca6de42b0832abb6558b2f4bbb11c