### PR TITLE
Implement SmartRecapSuggestionBanner

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -884,6 +884,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                     if (!_loadingSuggestions && _goalSuggestions.isNotEmpty)
                       GoalSuggestionRow(recommendations: _goalSuggestions),
                     const GoalReengagementBanner(),
+                    const SmartRecapSuggestionBanner(),
                     const RecoveryPromptBanner(),
                     const RecapBannerWidget(),
                     _buildSuggestedBanner(context),


### PR DESCRIPTION
## Summary
- add `SmartRecapSuggestionBanner` widget to suggest reviewing recently completed goals
- show banner under `GoalReengagementBanner` on the main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cb2a5ac18832aa202b063ad7083a0