### PR TITLE
Add SkillTreeNodeModel

### DIFF
--- a/lib/models/skill_tree_node_model.dart
+++ b/lib/models/skill_tree_node_model.dart
@@ -1,0 +1,60 @@
+class SkillTreeNodeModel {
+  final String id;
+  final String title;
+  final String category;
+  final List<String> prerequisites;
+  final List<String> unlockedNodeIds;
+  final String trainingPackId;
+  final String theoryLessonId;
+  final int level;
+  final bool isCompleted;
+
+  const SkillTreeNodeModel({
+    required this.id,
+    required this.title,
+    required this.category,
+    List<String>? prerequisites,
+    List<String>? unlockedNodeIds,
+    this.trainingPackId = '',
+    this.theoryLessonId = '',
+    this.level = 0,
+    this.isCompleted = false,
+  })  : prerequisites = prerequisites ?? const [],
+        unlockedNodeIds = unlockedNodeIds ?? const [];
+
+  factory SkillTreeNodeModel.fromJson(Map<String, dynamic> json) {
+    return SkillTreeNodeModel(
+      id: json['id'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      category: json['category'] as String? ?? '',
+      prerequisites: [
+        for (final p in (json['prerequisites'] as List? ?? [])) p.toString()
+      ],
+      unlockedNodeIds: [
+        for (final u in (json['unlockedNodeIds'] as List? ?? [])) u.toString()
+      ],
+      trainingPackId: json['trainingPackId'] as String? ?? '',
+      theoryLessonId: json['theoryLessonId'] as String? ?? '',
+      level: (json['level'] as num?)?.toInt() ?? 0,
+      isCompleted: json['isCompleted'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'category': category,
+        if (prerequisites.isNotEmpty) 'prerequisites': prerequisites,
+        if (unlockedNodeIds.isNotEmpty) 'unlockedNodeIds': unlockedNodeIds,
+        'trainingPackId': trainingPackId,
+        'theoryLessonId': theoryLessonId,
+        'level': level,
+        if (isCompleted) 'isCompleted': true,
+      };
+
+  factory SkillTreeNodeModel.fromYaml(Map yaml) {
+    final map = <String, dynamic>{};
+    yaml.forEach((k, v) => map[k.toString()] = v);
+    return SkillTreeNodeModel.fromJson(map);
+  }
+}

--- a/test/models/skill_tree_node_model_test.dart
+++ b/test/models/skill_tree_node_model_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+
+void main() {
+  test('json round-trip', () {
+    const node = SkillTreeNodeModel(
+      id: 'n1',
+      title: 'Push/Fold EP',
+      category: 'Push/Fold',
+      trainingPackId: 'pack1',
+      theoryLessonId: 'lesson1',
+    );
+    final map = node.toJson();
+    final from = SkillTreeNodeModel.fromJson(map);
+    expect(from.id, 'n1');
+    expect(from.title, 'Push/Fold EP');
+    expect(from.category, 'Push/Fold');
+    expect(from.trainingPackId, 'pack1');
+    expect(from.theoryLessonId, 'lesson1');
+  });
+
+  test('fromYaml matches toJson round-trip', () {
+    const yamlMap = {
+      'id': 'n2',
+      'title': '3-Bet Jam',
+      'category': 'Push/Fold',
+      'trainingPackId': 'pack2',
+      'theoryLessonId': 'lesson2',
+      'level': 1,
+      'prerequisites': ['n1'],
+      'unlockedNodeIds': ['n3'],
+    };
+    final node = SkillTreeNodeModel.fromYaml(yamlMap);
+    expect(node.toJson(), yamlMap);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeNodeModel` for skill tree path items
- test serialization logic for `SkillTreeNodeModel`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb39af8fc832abab91632bce2c917