### PR TITLE
Implement SkillTreeLibraryService

### DIFF
--- a/assets/skills/cash/postflop.yaml
+++ b/assets/skills/cash/postflop.yaml
@@ -1,0 +1,4 @@
+- id: post1
+  title: Postflop Basics
+  category: Postflop
+  level: 0

--- a/assets/skills/cash/push_fold.yaml
+++ b/assets/skills/cash/push_fold.yaml
@@ -1,0 +1,15 @@
+- id: pf1
+  title: Push/Fold Basics
+  category: Push/Fold
+  trainingPackId: push_fold_basics
+  theoryLessonId: lesson_pf1
+  level: 0
+  prerequisites: []
+  unlockedNodeIds: [pf2]
+- id: pf2
+  title: Push/Fold Advanced
+  category: Push/Fold
+  trainingPackId: push_fold_adv
+  theoryLessonId: lesson_pf2
+  level: 1
+  prerequisites: [pf1]

--- a/lib/services/skill_tree_library_service.dart
+++ b/lib/services/skill_tree_library_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:yaml/yaml.dart';
+
+import '../asset_manifest.dart';
+import '../models/skill_tree_node_model.dart';
+import '../models/skill_tree_build_result.dart';
+import 'skill_tree_builder_service.dart';
+
+/// Loads skill tree node definitions from YAML assets and exposes built trees.
+class SkillTreeLibraryService {
+  SkillTreeLibraryService._();
+
+  static final instance = SkillTreeLibraryService._();
+
+  static const _dir = 'assets/skills/cash/';
+
+  final _builder = const SkillTreeBuilderService();
+
+  final Map<String, SkillTreeBuildResult> _trees = {};
+  final List<SkillTreeNodeModel> _nodes = [];
+
+  /// Loads all skill tree YAML files from the assets directory.
+  Future<void> reload() async {
+    _trees.clear();
+    _nodes.clear();
+    final manifest = await AssetManifest.instance;
+    final paths =
+        manifest.keys
+            .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+            .toList()
+          ..sort();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final doc = loadYaml(raw);
+        if (doc is List) {
+          final nodes = <SkillTreeNodeModel>[];
+          for (final item in doc) {
+            if (item is Map) {
+              try {
+                final node = SkillTreeNodeModel.fromYaml(
+                  Map<String, dynamic>.from(item),
+                );
+                if (node.id.isEmpty) continue;
+                nodes.add(node);
+              } catch (_) {}
+            }
+          }
+          if (nodes.isNotEmpty) {
+            final res = _builder.build(nodes);
+            final category = nodes.first.category;
+            _trees[category] = res;
+            _nodes.addAll(nodes);
+          }
+        }
+      } catch (_) {}
+    }
+  }
+
+  /// Returns the skill tree for [category], or `null` if not found.
+  SkillTreeBuildResult? getTree(String category) => _trees[category];
+
+  /// Returns all loaded nodes across categories in insertion order.
+  List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -121,6 +121,7 @@ flutter:
     - assets/learning_path_tracks.yaml
     - assets/animations/congrats.json
     - assets/images/
+    - assets/skills/cash/
     - assets/paths/
 
 # Release build configuration for the demo entry point. Run


### PR DESCRIPTION
## Summary
- load cash skill trees from YAML
- expose built trees and nodes via a new service
- register assets path for new skill trees
- add sample cash node trees

## Testing
- `flutter analyze --no-pub` *(fails: Undefined name 'AppLocalizations', ...)*
- `flutter test` *(fails: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688cb6c8383c832a8135b38fd40a24a1