### PR TITLE
Implement SkillTreeNodeProgressTracker service

### DIFF
--- a/lib/services/skill_tree_node_progress_tracker.dart
+++ b/lib/services/skill_tree_node_progress_tracker.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks completion status for skill tree nodes.
+class SkillTreeNodeProgressTracker {
+  SkillTreeNodeProgressTracker._();
+  static final SkillTreeNodeProgressTracker instance =
+      SkillTreeNodeProgressTracker._();
+
+  static const String _prefsKey = 'skill_node_progress';
+
+  final ValueNotifier<Set<String>> completedNodeIds =
+      ValueNotifier(<String>{});
+
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    completedNodeIds.value =
+        (prefs.getStringList(_prefsKey)?.toSet() ?? <String>{});
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, completedNodeIds.value.toList());
+  }
+
+  /// Whether [nodeId] has been marked as completed.
+  Future<bool> isCompleted(String nodeId) async {
+    await _load();
+    return completedNodeIds.value.contains(nodeId);
+  }
+
+  /// Marks [nodeId] as completed and notifies listeners.
+  Future<void> markCompleted(String nodeId) async {
+    if (nodeId.isEmpty) return;
+    await _load();
+    final set = completedNodeIds.value;
+    if (set.add(nodeId)) {
+      completedNodeIds.value = Set<String>.from(set);
+      await _save();
+    }
+  }
+
+  /// Clears stored progress for tests.
+  Future<void> resetForTest() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+    completedNodeIds.value = <String>{};
+    _loaded = false;
+  }
+}

--- a/test/services/skill_tree_node_progress_tracker_test.dart
+++ b/test/services/skill_tree_node_progress_tracker_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('markCompleted persists and reports completion', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+
+    expect(await tracker.isCompleted('n1'), isFalse);
+    await tracker.markCompleted('n1');
+    expect(await tracker.isCompleted('n1'), isTrue);
+  });
+
+  test('completedNodeIds notifies on updates', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+
+    final changes = <Set<String>>[];
+    tracker.completedNodeIds.addListener(() {
+      changes.add(tracker.completedNodeIds.value);
+    });
+
+    await tracker.markCompleted('a');
+    await tracker.markCompleted('b');
+
+    expect(changes.length, 2);
+    expect(changes.last.contains('b'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeNodeProgressTracker` for tracking completed skill tree nodes
- notify listeners with `ValueNotifier` of completed node IDs
- add unit tests for progress tracking

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/skill_tree_node_progress_tracker_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbbb0361c832abe507e4c51cc91f4