### PR TITLE
Add SkillTreeUnlockEvaluator service

### DIFF
--- a/lib/services/skill_tree_unlock_evaluator.dart
+++ b/lib/services/skill_tree_unlock_evaluator.dart
@@ -1,0 +1,25 @@
+import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Determines which skill tree nodes are currently unlocked based on progress.
+class SkillTreeUnlockEvaluator {
+  final SkillTreeNodeProgressTracker progress;
+
+  const SkillTreeUnlockEvaluator({SkillTreeNodeProgressTracker? progress})
+      : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  /// Returns nodes that are unlocked and not yet completed in [tree].
+  List<SkillTreeNodeModel> getUnlockedNodes(SkillTree tree) {
+    final completed = progress.completedNodeIds.value;
+    final unlocked = <SkillTreeNodeModel>[];
+    for (final node in tree.nodes.values) {
+      if (completed.contains(node.id)) continue;
+      if (node.prerequisites.isEmpty ||
+          node.prerequisites.every(completed.contains)) {
+        unlocked.add(node);
+      }
+    }
+    return unlocked;
+  }
+}

--- a/test/services/skill_tree_unlock_evaluator_test.dart
+++ b/test/services/skill_tree_unlock_evaluator_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/skill_tree_unlock_evaluator.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+  const evaluator = SkillTreeUnlockEvaluator();
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs}) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'Push/Fold', prerequisites: prereqs);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns root nodes when no progress', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    final tree = builder.build([
+      node('n1'),
+      node('n2', prereqs: ['n1']),
+    ]).tree;
+
+    final unlocked = evaluator.getUnlockedNodes(tree);
+    expect(unlocked.map((n) => n.id), ['n1']);
+  });
+
+  test('returns next nodes after completing prerequisites', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    final tree = builder.build([
+      node('n1'),
+      node('n2', prereqs: ['n1']),
+      node('n3', prereqs: ['n1']),
+      node('n4', prereqs: ['n2', 'n3']),
+    ]).tree;
+
+    var unlocked = evaluator.getUnlockedNodes(tree);
+    expect(unlocked.map((n) => n.id).toSet(), {'n1'});
+
+    await tracker.markCompleted('n1');
+    unlocked = evaluator.getUnlockedNodes(tree);
+    expect(unlocked.map((n) => n.id).toSet(), {'n2', 'n3'});
+
+    await tracker.markCompleted('n2');
+    await tracker.markCompleted('n3');
+    unlocked = evaluator.getUnlockedNodes(tree);
+    expect(unlocked.map((n) => n.id), ['n4']);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SkillTreeUnlockEvaluator` for determining unlocked skill tree nodes
- add unit tests covering unlock logic

## Testing
- `dart test test/services/skill_tree_unlock_evaluator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbd5b21a4832a9726914561368919