### PR TITLE
Add SkillTreeTrainingPackResolver

### DIFF
--- a/lib/services/skill_tree_training_pack_resolver.dart
+++ b/lib/services/skill_tree_training_pack_resolver.dart
@@ -1,0 +1,37 @@
+import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_service.dart';
+import 'skill_tree_unlock_evaluator.dart';
+
+/// Resolves training packs for skill tree nodes using their [trainingPackId].
+class SkillTreeTrainingPackResolver {
+  final PackLibraryService _library;
+  final SkillTreeUnlockEvaluator _unlockEvaluator;
+
+  SkillTreeTrainingPackResolver({
+    PackLibraryService? library,
+    SkillTreeUnlockEvaluator? unlockEvaluator,
+  })  : _library = library ?? PackLibraryService.instance,
+        _unlockEvaluator = unlockEvaluator ?? SkillTreeUnlockEvaluator();
+
+  /// Returns the training pack linked to [node] or `null` if none found.
+  Future<TrainingPackTemplateV2?> getPackForNode(
+    SkillTreeNodeModel node,
+  ) async {
+    final id = node.trainingPackId;
+    if (id.isEmpty) return null;
+    return _library.getById(id);
+  }
+
+  /// Returns a mapping of unlocked nodes in [tree] to their training packs.
+  Future<Map<SkillTreeNodeModel, TrainingPackTemplateV2?>>
+      getPacksForUnlockedNodes(SkillTree tree) async {
+    final nodes = _unlockEvaluator.getUnlockedNodes(tree);
+    final result = <SkillTreeNodeModel, TrainingPackTemplateV2?>{};
+    for (final n in nodes) {
+      result[n] = await getPackForNode(n);
+    }
+    return result;
+  }
+}

--- a/test/services/skill_tree_training_pack_resolver_test.dart
+++ b/test/services/skill_tree_training_pack_resolver_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_training_pack_resolver.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await TrainingPackLibraryV2.instance.reload();
+  });
+
+  test('returns pack for valid trainingPackId', () async {
+    const node = SkillTreeNodeModel(
+      id: 'n1',
+      title: 'CBet IP',
+      category: 'Postflop',
+      trainingPackId: 'cbet_ip',
+    );
+
+    final resolver = SkillTreeTrainingPackResolver();
+    final pack = await resolver.getPackForNode(node);
+    expect(pack, isNotNull);
+    expect(pack!.id, 'cbet_ip');
+  });
+
+  test('returns null when trainingPackId is empty', () async {
+    const node = SkillTreeNodeModel(
+      id: 'n2',
+      title: 'No Pack',
+      category: 'Postflop',
+    );
+
+    final resolver = SkillTreeTrainingPackResolver();
+    final pack = await resolver.getPackForNode(node);
+    expect(pack, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeTrainingPackResolver` service for looking up packs by skill tree node
- test resolver against built-in library

## Testing
- `flutter analyze` *(fails: 6895 issues found)*
- `flutter test test/services/skill_tree_training_pack_resolver_test.dart` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688cbec390ec832aa8fef0a847e3fc30