### PR TITLE
Add SkillTreeProgressAnalyticsService

### DIFF
--- a/lib/services/skill_tree_progress_analytics_service.dart
+++ b/lib/services/skill_tree_progress_analytics_service.dart
@@ -1,0 +1,57 @@
+import '../models/skill_tree.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Aggregated progress statistics for a skill tree.
+class SkillTreeProgressStats {
+  final int totalNodes;
+  final int completedNodes;
+  final double completionRate;
+  final Map<int, double> completionRateByLevel;
+
+  const SkillTreeProgressStats({
+    required this.totalNodes,
+    required this.completedNodes,
+    required this.completionRate,
+    required this.completionRateByLevel,
+  });
+}
+
+/// Computes progress analytics for a [SkillTree].
+class SkillTreeProgressAnalyticsService {
+  final SkillTreeNodeProgressTracker progress;
+  const SkillTreeProgressAnalyticsService({SkillTreeNodeProgressTracker? progress})
+      : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  /// Returns completion statistics for [tree].
+  Future<SkillTreeProgressStats> getStats(SkillTree tree) async {
+    // Ensure progress is loaded.
+    await progress.isCompleted('');
+
+    final completed = progress.completedNodeIds.value;
+    final total = tree.nodes.length;
+    var completedCount = 0;
+    final levelMap = <int, List<bool>>{};
+
+    for (final node in tree.nodes.values) {
+      final done = completed.contains(node.id);
+      if (done) completedCount++;
+      levelMap.putIfAbsent(node.level, () => []).add(done);
+    }
+
+    final rateByLevel = <int, double>{};
+    for (final e in levelMap.entries) {
+      final done = e.value.where((v) => v).length;
+      rateByLevel[e.key] = e.value.isEmpty ? 0.0 : done / e.value.length;
+    }
+
+    final rate = total > 0 ? completedCount / total : 0.0;
+
+    return SkillTreeProgressStats(
+      totalNodes: total,
+      completedNodes: completedCount,
+      completionRate: rate,
+      completionRateByLevel: rateByLevel,
+    );
+  }
+}
+

--- a/test/services/skill_tree_progress_analytics_service_test.dart
+++ b/test/services/skill_tree_progress_analytics_service_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/skill_tree_progress_analytics_service.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+  const analytics = SkillTreeProgressAnalyticsService();
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs, int level = 0}) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'Push/Fold', prerequisites: prereqs, level: level);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('reports completion stats by level', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+
+    final tree = builder.build([
+      node('n1', level: 0),
+      node('n2', prereqs: ['n1'], level: 0),
+      node('n3', prereqs: ['n2'], level: 1),
+    ]).tree;
+
+    await tracker.markCompleted('n1');
+    await tracker.markCompleted('n2');
+
+    final stats = await analytics.getStats(tree);
+
+    expect(stats.totalNodes, 3);
+    expect(stats.completedNodes, 2);
+    expect(stats.completionRate, closeTo(2 / 3, 1e-6));
+    expect(stats.completionRateByLevel[0], closeTo(1.0, 1e-6));
+    expect(stats.completionRateByLevel[1], closeTo(0.0, 1e-6));
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SkillTreeProgressAnalyticsService` for tracking skill tree progress
- test progress analytics

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc9e7cb2c832a9b7a899ff056fcc3