### PR TITLE
Add SkillTreeMotivationalHintEngine

### DIFF
--- a/lib/services/skill_tree_motivational_hint_engine.dart
+++ b/lib/services/skill_tree_motivational_hint_engine.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'skill_tree_progress_analytics_service.dart';
+
+/// Provides motivational messages based on skill tree progress.
+class SkillTreeMotivationalHintEngine {
+  /// Creates an engine with optional [cooldown].
+  SkillTreeMotivationalHintEngine({Duration? cooldown})
+      : cooldown = cooldown ?? defaultCooldown;
+
+  /// Singleton instance with default cooldown.
+  static final SkillTreeMotivationalHintEngine instance =
+      SkillTreeMotivationalHintEngine();
+
+  /// Default cooldown between messages.
+  static Duration defaultCooldown = const Duration(hours: 6);
+
+  final Duration cooldown;
+
+  static const String _lastKey = 'skill_tree_hint_last';
+  static const String _levelsKey = 'skill_tree_hint_levels';
+
+  DateTime _lastShown = DateTime.fromMillisecondsSinceEpoch(0);
+  Set<int> _shownLevels = {};
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastKey);
+    if (lastStr != null) {
+      _lastShown = DateTime.tryParse(lastStr) ?? _lastShown;
+    }
+    final list = prefs.getStringList(_levelsKey);
+    if (list != null) {
+      _shownLevels = {
+        for (final s in list)
+          if (int.tryParse(s) != null) int.parse(s)
+      };
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastKey, _lastShown.toIso8601String());
+    await prefs.setStringList(
+      _levelsKey,
+      _shownLevels.map((e) => e.toString()).toList(),
+    );
+  }
+
+  /// Clears stored state for testing purposes.
+  @visibleForTesting
+  Future<void> resetForTest() async {
+    _loaded = false;
+    _lastShown = DateTime.fromMillisecondsSinceEpoch(0);
+    _shownLevels.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastKey);
+    await prefs.remove(_levelsKey);
+  }
+
+  /// Returns a motivational message if a milestone is achieved.
+  Future<String?> getMotivationalMessage(SkillTreeProgressStats stats) async {
+    await _load();
+    final now = DateTime.now();
+    if (now.difference(_lastShown) < cooldown) return null;
+
+    final levels = stats.completionRateByLevel.keys.toList()..sort();
+    for (final level in levels) {
+      final rate = stats.completionRateByLevel[level] ?? 0.0;
+      if (rate == 1.0 && !_shownLevels.contains(level)) {
+        _shownLevels.add(level);
+        _lastShown = now;
+        await _save();
+        return 'Level $level complete!';
+      }
+    }
+
+    if (stats.completionRate > 0.75) {
+      _lastShown = now;
+      await _save();
+      return 'Almost there!';
+    }
+
+    return null;
+  }
+}
+

--- a/test/skill_tree_motivational_hint_engine_test.dart
+++ b/test/skill_tree_motivational_hint_engine_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/skill_tree_motivational_hint_engine.dart';
+import 'package:poker_analyzer/services/skill_tree_progress_analytics_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  SkillTreeProgressStats stats({double rate = 1.0, int level = 1}) =>
+      SkillTreeProgressStats(
+        totalNodes: 1,
+        completedNodes: rate == 1.0 ? 1 : 0,
+        completionRate: rate,
+        completionRateByLevel: {level: rate},
+      );
+
+  test('level completion message shown once per level', () async {
+    final engine = SkillTreeMotivationalHintEngine(cooldown: Duration.zero);
+    await engine.resetForTest();
+    final msg1 = await engine.getMotivationalMessage(stats());
+    expect(msg1, 'Level 1 complete!');
+    final msg2 = await engine.getMotivationalMessage(stats());
+    expect(msg2, isNull);
+  });
+
+  test('progress message triggered near completion', () async {
+    final engine = SkillTreeMotivationalHintEngine(cooldown: Duration.zero);
+    await engine.resetForTest();
+    final msg = await engine.getMotivationalMessage(stats(rate: 0.8));
+    expect(msg, 'Almost there!');
+  });
+
+  test('cooldown prevents repeated messages', () async {
+    final engine = SkillTreeMotivationalHintEngine(cooldown: Duration(seconds: 5));
+    await engine.resetForTest();
+    final first = await engine.getMotivationalMessage(stats(rate: 0.8));
+    expect(first, isNotNull);
+    final second = await engine.getMotivationalMessage(stats(rate: 0.8));
+    expect(second, isNull);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add SkillTreeMotivationalHintEngine for motivational progress hints
- test motivational hint engine behavior

## Testing
- `flutter test test/skill_tree_motivational_hint_engine_test.dart` *(fails: Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ccb29a964832a962824c578c81aa2