### PR TITLE
Add skill tree milestone overlay service

### DIFF
--- a/lib/services/skill_tree_milestone_overlay_service.dart
+++ b/lib/services/skill_tree_milestone_overlay_service.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'skill_tree_motivational_hint_engine.dart';
+import 'skill_tree_progress_analytics_service.dart';
+import '../widgets/skill_tree_milestone_overlay.dart';
+
+/// Listens for motivational events and displays celebration overlays.
+class SkillTreeMilestoneOverlayService {
+  final SkillTreeMotivationalHintEngine engine;
+
+  SkillTreeMilestoneOverlayService({SkillTreeMotivationalHintEngine? engine})
+      : engine = engine ?? SkillTreeMotivationalHintEngine.instance;
+
+  OverlayEntry? _entry;
+
+  bool get isShowing => _entry != null;
+
+  /// Checks [stats] and shows an overlay if a milestone message is returned.
+  Future<void> maybeShow(
+    BuildContext context,
+    SkillTreeProgressStats stats,
+  ) async {
+    if (isShowing) return;
+    final message = await engine.getMotivationalMessage(stats);
+    if (message == null) return;
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (_) => SkillTreeMilestoneOverlay(
+        message: message,
+        onClose: () {
+          entry.remove();
+          _entry = null;
+        },
+      ),
+    );
+    _entry = entry;
+    overlay.insert(entry);
+  }
+}

--- a/lib/widgets/skill_tree_milestone_overlay.dart
+++ b/lib/widgets/skill_tree_milestone_overlay.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+import 'confetti_overlay.dart';
+
+/// Fullscreen overlay celebrating skill tree milestones.
+class SkillTreeMilestoneOverlay extends StatefulWidget {
+  final String message;
+  final VoidCallback onClose;
+  const SkillTreeMilestoneOverlay({
+    super.key,
+    required this.message,
+    required this.onClose,
+  });
+
+  @override
+  State<SkillTreeMilestoneOverlay> createState() => _SkillTreeMilestoneOverlayState();
+}
+
+class _SkillTreeMilestoneOverlayState extends State<SkillTreeMilestoneOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+    Future.delayed(const Duration(seconds: 3), widget.onClose);
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black87,
+      body: Center(
+        child: FadeTransition(
+          opacity: CurvedAnimation(parent: _anim, curve: Curves.easeIn),
+          child: ScaleTransition(
+            scale: CurvedAnimation(parent: _anim, curve: Curves.elasticOut),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Lottie.asset(
+                  'assets/animations/congrats.json',
+                  width: 160,
+                  repeat: false,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  widget.message,
+                  style: const TextStyle(color: Colors.white, fontSize: 24),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows [SkillTreeMilestoneOverlay] above the current screen.
+Future<void> showSkillTreeMilestoneOverlay(BuildContext context, String message) {
+  return showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => SkillTreeMilestoneOverlay(
+      message: message,
+      onClose: () => Navigator.pop(context),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add UI overlay widget for skill tree milestones
- implement service that checks motivational hints and shows overlay

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ccddbe054832aad352b2752b70640