### PR TITLE
Add skill tree completion detector service

### DIFF
--- a/lib/services/skill_tree_final_node_completion_detector.dart
+++ b/lib/services/skill_tree_final_node_completion_detector.dart
@@ -1,0 +1,22 @@
+import '../models/skill_tree.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Detects whether all required nodes in a skill tree are completed.
+class SkillTreeFinalNodeCompletionDetector {
+  final SkillTreeNodeProgressTracker progress;
+
+  const SkillTreeFinalNodeCompletionDetector({SkillTreeNodeProgressTracker? progress})
+      : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  /// Returns `true` if all non-optional nodes in [tree] are completed.
+  Future<bool> isTreeCompleted(SkillTree tree) async {
+    await progress.isCompleted('');
+    final completed = progress.completedNodeIds.value;
+    for (final node in tree.nodes.values) {
+      final opt = (node as dynamic).isOptional;
+      if (opt == true) continue;
+      if (!completed.contains(node.id)) return false;
+    }
+    return true;
+  }
+}

--- a/test/services/skill_tree_final_node_completion_detector_test.dart
+++ b/test/services/skill_tree_final_node_completion_detector_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_final_node_completion_detector.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+class OptionalNode extends SkillTreeNodeModel {
+  final bool isOptional;
+  const OptionalNode({required String id, List<String>? prerequisites})
+      : isOptional = true,
+        super(
+          id: id,
+          title: id,
+          category: 'Push/Fold',
+          prerequisites: prerequisites,
+        );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+  const detector = SkillTreeFinalNodeCompletionDetector();
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs}) => SkillTreeNodeModel(
+        id: id,
+        title: id,
+        category: 'Push/Fold',
+        prerequisites: prereqs,
+      );
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('tree completed after all required nodes done', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+
+    final tree = builder.build([
+      node('n1'),
+      node('n2', prereqs: ['n1']),
+      OptionalNode(id: 'opt', prerequisites: ['n2']),
+    ]).tree;
+
+    expect(await detector.isTreeCompleted(tree), isFalse);
+
+    await tracker.markCompleted('n1');
+    expect(await detector.isTreeCompleted(tree), isFalse);
+
+    await tracker.markCompleted('n2');
+    expect(await detector.isTreeCompleted(tree), isTrue);
+
+    await tracker.markCompleted('opt');
+    expect(await detector.isTreeCompleted(tree), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeFinalNodeCompletionDetector` service
- check if all required nodes in a tree are completed
- unit test for detector

## Testing
- `flutter test test/services/skill_tree_final_node_completion_detector_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d01033088832a9e4c353ff12422ff