### PR TITLE
Add skill tree completion celebration

### DIFF
--- a/lib/services/skill_tree_celebration_trigger_service.dart
+++ b/lib/services/skill_tree_celebration_trigger_service.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/skill_tree.dart';
+import 'skill_tree_final_node_completion_detector.dart';
+import 'skill_tree_milestone_overlay_service.dart';
+import 'skill_tree_motivational_hint_engine.dart';
+import 'skill_tree_progress_analytics_service.dart';
+
+/// Detects full skill tree completion and shows a celebration overlay.
+class SkillTreeCelebrationTriggerService {
+  final SkillTreeFinalNodeCompletionDetector detector;
+  final SkillTreeProgressAnalyticsService analytics;
+  final SkillTreeMilestoneOverlayService overlay;
+
+  SkillTreeCelebrationTriggerService({
+    SkillTreeFinalNodeCompletionDetector? detector,
+    SkillTreeProgressAnalyticsService? analytics,
+    SkillTreeMilestoneOverlayService? overlay,
+  })  : detector = detector ?? const SkillTreeFinalNodeCompletionDetector(),
+        analytics = analytics ?? const SkillTreeProgressAnalyticsService(),
+        overlay = overlay ??
+            SkillTreeMilestoneOverlayService(
+              engine: const _CompletionMessageEngine(),
+            );
+
+  static const _prefix = 'celebration_done_';
+
+  /// Checks [tree] completion and shows celebration once per tree.
+  Future<void> maybeCelebrate(BuildContext context, SkillTree tree) async {
+    final id = tree.nodes.values.isNotEmpty ? tree.nodes.values.first.category : '';
+    final key = '$_prefix$id';
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(key) ?? false) return;
+    if (!await detector.isTreeCompleted(tree)) return;
+    await prefs.setBool(key, true);
+    final stats = await analytics.getStats(tree);
+    await overlay.maybeShow(context, stats);
+  }
+}
+
+class _CompletionMessageEngine extends SkillTreeMotivationalHintEngine {
+  const _CompletionMessageEngine();
+
+  @override
+  Future<String?> getMotivationalMessage(SkillTreeProgressStats stats) async {
+    return "You've completed this track!";
+  }
+}

--- a/test/services/skill_tree_celebration_trigger_service_test.dart
+++ b/test/services/skill_tree_celebration_trigger_service_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/skill_tree_progress_analytics_service.dart';
+import 'package:poker_analyzer/services/skill_tree_final_node_completion_detector.dart';
+import 'package:poker_analyzer/services/skill_tree_celebration_trigger_service.dart';
+import 'package:poker_analyzer/services/skill_tree_milestone_overlay_service.dart';
+import 'package:poker_analyzer/services/skill_tree_motivational_hint_engine.dart';
+
+class _FakeOverlay extends SkillTreeMilestoneOverlayService {
+  int calls = 0;
+  _FakeOverlay() : super(engine: const SkillTreeMotivationalHintEngine());
+
+  @override
+  Future<void> maybeShow(BuildContext context, SkillTreeProgressStats stats) async {
+    calls++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final builder = const SkillTreeBuilderService();
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs}) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'PF', prerequisites: prereqs);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  testWidgets('celebrates when tree completed', (tester) async {
+    final tree = builder.build([node('a'), node('b', prereqs: ['a'])]).tree;
+    await tracker.markCompleted('a');
+    await tracker.markCompleted('b');
+    final overlay = _FakeOverlay();
+    final service = SkillTreeCelebrationTriggerService(overlay: overlay);
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
+    await service.maybeCelebrate(key.currentContext!, tree);
+    expect(overlay.calls, 1);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('celebration_done_PF'), isTrue);
+  });
+
+  testWidgets('does not repeat celebration', (tester) async {
+    final tree = builder.build([node('a')]).tree;
+    await tracker.markCompleted('a');
+    SharedPreferences.setMockInitialValues({'celebration_done_PF': true});
+    final overlay = _FakeOverlay();
+    final service = SkillTreeCelebrationTriggerService(overlay: overlay);
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
+    await service.maybeCelebrate(key.currentContext!, tree);
+    expect(overlay.calls, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeCelebrationTriggerService` to show final milestone overlay when a tree is completed
- test celebration trigger behavior

## Testing
- `flutter test test/services/skill_tree_celebration_trigger_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d026172e0832a97b847980098680f