### PR TITLE
Add skill tree category banner service

### DIFF
--- a/lib/models/skill_tree_category_visual.dart
+++ b/lib/models/skill_tree_category_visual.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// Visual metadata for a skill tree category.
+class SkillTreeCategoryVisual {
+  final String iconAsset;
+  final Color color;
+  final String displayName;
+
+  const SkillTreeCategoryVisual({
+    required this.iconAsset,
+    required this.color,
+    required this.displayName,
+  });
+}

--- a/lib/services/skill_tree_category_banner_service.dart
+++ b/lib/services/skill_tree_category_banner_service.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import '../models/skill_tree_category_visual.dart';
+
+/// Provides visual info for skill tree categories used across the UI.
+class SkillTreeCategoryBannerService {
+  const SkillTreeCategoryBannerService();
+
+  static const Map<String, SkillTreeCategoryVisual> _visuals = {
+    'Push/Fold': SkillTreeCategoryVisual(
+      iconAsset: 'assets/images/red_chip.png',
+      color: Color(0xFFE53935),
+      displayName: 'Push/Fold',
+    ),
+    'Postflop': SkillTreeCategoryVisual(
+      iconAsset: 'assets/images/postflop.png',
+      color: Color(0xFF2196F3),
+      displayName: 'Postflop',
+    ),
+    'ICM': SkillTreeCategoryVisual(
+      iconAsset: 'assets/images/icm.png',
+      color: Color(0xFF8E24AA),
+      displayName: 'ICM',
+    ),
+    '3bet': SkillTreeCategoryVisual(
+      iconAsset: 'assets/images/three_bet.png',
+      color: Color(0xFF3949AB),
+      displayName: '3bet',
+    ),
+  };
+
+  /// Returns visual metadata for [category].
+  /// Falls back to a default if the category is unknown.
+  SkillTreeCategoryVisual getVisual(String category) {
+    return _visuals[category] ??
+        const SkillTreeCategoryVisual(
+          iconAsset: 'assets/images/default.png',
+          color: Colors.grey,
+          displayName: '',
+        );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeCategoryVisual` model
- implement `SkillTreeCategoryBannerService` to map categories to icons and colors

## Testing
- `dart` and `flutter` were not available, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_688d0c892288832a80867017529004f6