### PR TITLE
Implement SkillTree track summary builder

### DIFF
--- a/lib/models/skill_tree_track_summary.dart
+++ b/lib/models/skill_tree_track_summary.dart
@@ -1,0 +1,13 @@
+class SkillTreeTrackSummary {
+  final String title;
+  final int completedCount;
+  final double? avgEvLoss;
+  final String motivationalLine;
+
+  const SkillTreeTrackSummary({
+    required this.title,
+    required this.completedCount,
+    this.avgEvLoss,
+    required this.motivationalLine,
+  });
+}

--- a/lib/services/skill_tree_track_summary_builder.dart
+++ b/lib/services/skill_tree_track_summary_builder.dart
@@ -1,0 +1,60 @@
+import '../models/skill_tree.dart';
+import '../models/skill_tree_track_summary.dart';
+import 'skill_tree_node_progress_tracker.dart';
+import 'training_stats_service.dart';
+
+/// Builds user-facing summaries for skill tree tracks.
+class SkillTreeTrackSummaryBuilder {
+  final SkillTreeNodeProgressTracker progress;
+  final TrainingStatsService? stats;
+
+  const SkillTreeTrackSummaryBuilder({
+    SkillTreeNodeProgressTracker? progress,
+    this.stats,
+  }) : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  /// Generates a [SkillTreeTrackSummary] for [tree].
+  Future<SkillTreeTrackSummary> build(SkillTree tree) async {
+    // Ensure progress is loaded
+    await progress.isCompleted('');
+    final completedIds = progress.completedNodeIds.value;
+
+    var total = 0;
+    var completed = 0;
+    for (final node in tree.nodes.values) {
+      final opt = (node as dynamic).isOptional == true;
+      if (opt) continue;
+      total++;
+      if (completedIds.contains(node.id)) {
+        completed++;
+      }
+    }
+
+    final category =
+        tree.nodes.values.isNotEmpty ? tree.nodes.values.first.category : '';
+
+    double? avgEvLoss;
+    final svc = stats ?? TrainingStatsService.instance;
+    if (svc != null) {
+      final stat = svc.skillStats[category];
+      if (stat != null && stat.handsPlayed > 0) {
+        avgEvLoss = stat.evAvg;
+      }
+    }
+
+    String line;
+    if (total > 0 && completed >= total) {
+      line = 'Nice! You crushed all $category drills.';
+    } else {
+      final pct = total > 0 ? (completed / total * 100).round() : 0;
+      line = 'Great progress! $pct% complete.';
+    }
+
+    return SkillTreeTrackSummary(
+      title: category,
+      completedCount: completed,
+      avgEvLoss: avgEvLoss,
+      motivationalLine: line,
+    );
+  }
+}

--- a/test/services/skill_tree_track_summary_builder_test.dart
+++ b/test/services/skill_tree_track_summary_builder_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/skill_tree_track_summary_builder.dart';
+import 'package:poker_analyzer/services/training_stats_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs}) => SkillTreeNodeModel(
+        id: id,
+        title: id,
+        category: 'Push/Fold',
+        prerequisites: prereqs,
+      );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  test('builds summary with ev loss stats', () async {
+    final tree = builder.build([node('a'), node('b')]).tree;
+    await tracker.markCompleted('a');
+    final stats = TrainingStatsService();
+    await stats.updateSkill('Push/Fold', -0.5, true);
+    final summary = await SkillTreeTrackSummaryBuilder(
+      progress: tracker,
+      stats: stats,
+    ).build(tree);
+    expect(summary.title, 'Push/Fold');
+    expect(summary.completedCount, 1);
+    expect(summary.avgEvLoss, closeTo(-0.5, 0.0001));
+    expect(summary.motivationalLine.isNotEmpty, isTrue);
+  });
+
+  test('generates completion message when all done', () async {
+    final tree = builder.build([node('c')]).tree;
+    await tracker.markCompleted('c');
+    final summary = await SkillTreeTrackSummaryBuilder(progress: tracker).build(tree);
+    expect(summary.completedCount, 1);
+    expect(summary.motivationalLine.toLowerCase(), contains('crushed'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeTrackSummary` model
- implement `SkillTreeTrackSummaryBuilder` service
- unit tests for summary builder

## Testing
- `dart format lib/models/skill_tree_track_summary.dart lib/services/skill_tree_track_summary_builder.dart test/services/skill_tree_track_summary_builder_test.dart` *(fails: command not found)*
- `flutter test test/services/skill_tree_track_summary_builder_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0da0ced0832a8445f8f0941f97ad