### PR TITLE
Add skill tree completion banner composer

### DIFF
--- a/lib/models/skill_tree_category_visual.dart
+++ b/lib/models/skill_tree_category_visual.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// Visual metadata for a skill tree category.
+class SkillTreeCategoryVisual {
+  final String category;
+  final String emoji;
+  final Color color;
+
+  const SkillTreeCategoryVisual({
+    required this.category,
+    required this.emoji,
+    required this.color,
+  });
+}

--- a/lib/models/skill_tree_completion_banner_model.dart
+++ b/lib/models/skill_tree_completion_banner_model.dart
@@ -1,0 +1,16 @@
+import '../services/skill_tree_track_progress_service.dart';
+import 'skill_tree_category_visual.dart';
+import 'skill_tree_track_summary.dart';
+
+/// Combined data for a skill tree completion banner.
+class SkillTreeCompletionBannerModel {
+  final SkillTreeCategoryVisual visual;
+  final SkillTreeTrackSummary summary;
+  final TrackProgressEntry? nextTrack;
+
+  const SkillTreeCompletionBannerModel({
+    required this.visual,
+    required this.summary,
+    required this.nextTrack,
+  });
+}

--- a/lib/services/skill_tree_category_banner_service.dart
+++ b/lib/services/skill_tree_category_banner_service.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_category_visual.dart';
+
+/// Provides visual metadata for skill tree categories.
+class SkillTreeCategoryBannerService {
+  const SkillTreeCategoryBannerService();
+
+  /// Returns visuals for [category].
+  SkillTreeCategoryVisual getVisual(String category) {
+    switch (category) {
+      case 'Push/Fold':
+        return SkillTreeCategoryVisual(
+          category: category,
+          emoji: '💥',
+          color: Colors.redAccent,
+        );
+      case 'Postflop':
+        return SkillTreeCategoryVisual(
+          category: category,
+          emoji: '♠️',
+          color: Colors.blueAccent,
+        );
+      case 'ICM':
+        return SkillTreeCategoryVisual(
+          category: category,
+          emoji: '🏆',
+          color: Colors.orangeAccent,
+        );
+      case '3bet':
+        return SkillTreeCategoryVisual(
+          category: category,
+          emoji: '🎯',
+          color: Colors.purpleAccent,
+        );
+      default:
+        return SkillTreeCategoryVisual(
+          category: category,
+          emoji: '🃏',
+          color: Colors.grey,
+        );
+    }
+  }
+}

--- a/lib/services/skill_tree_completion_banner_composer.dart
+++ b/lib/services/skill_tree_completion_banner_composer.dart
@@ -1,0 +1,32 @@
+import '../models/skill_tree.dart';
+import '../models/skill_tree_completion_banner_model.dart';
+import 'skill_tree_category_banner_service.dart';
+import 'skill_tree_track_progress_service.dart';
+import 'skill_tree_track_summary_builder.dart';
+
+/// Assembles final UI data for a completed skill tree track.
+class SkillTreeCompletionBannerComposer {
+  final SkillTreeTrackSummaryBuilder summaryBuilder;
+  final SkillTreeCategoryBannerService bannerService;
+  final SkillTreeTrackProgressService progressService;
+
+  const SkillTreeCompletionBannerComposer({
+    SkillTreeTrackSummaryBuilder? summaryBuilder,
+    SkillTreeCategoryBannerService? bannerService,
+    SkillTreeTrackProgressService? progressService,
+  })  : summaryBuilder = summaryBuilder ?? const SkillTreeTrackSummaryBuilder(),
+        bannerService = bannerService ?? const SkillTreeCategoryBannerService(),
+        progressService = progressService ?? const SkillTreeTrackProgressService();
+
+  /// Builds the completion banner model for [tree].
+  Future<SkillTreeCompletionBannerModel> compose(SkillTree tree) async {
+    final summary = await summaryBuilder.build(tree);
+    final visual = bannerService.getVisual(summary.title);
+    final nextTrack = await progressService.getNextTrack();
+    return SkillTreeCompletionBannerModel(
+      visual: visual,
+      summary: summary,
+      nextTrack: nextTrack,
+    );
+  }
+}

--- a/test/services/skill_tree_completion_banner_composer_test.dart
+++ b/test/services/skill_tree_completion_banner_composer_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_summary_builder.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+import 'package:poker_analyzer/services/skill_tree_completion_banner_composer.dart';
+import 'package:poker_analyzer/services/skill_tree_category_banner_service.dart';
+import 'package:poker_analyzer/models/skill_tree_track_summary.dart';
+import 'package:poker_analyzer/models/skill_tree_category_visual.dart';
+
+class _FakeSummaryBuilder extends SkillTreeTrackSummaryBuilder {
+  final SkillTreeTrackSummary summary;
+  const _FakeSummaryBuilder(this.summary);
+  @override
+  Future<SkillTreeTrackSummary> build(tree) async => summary;
+}
+
+class _FakeBannerService extends SkillTreeCategoryBannerService {
+  final SkillTreeCategoryVisual visual;
+  const _FakeBannerService(this.visual);
+  @override
+  SkillTreeCategoryVisual getVisual(String category) => visual;
+}
+
+class _FakeProgressService extends SkillTreeTrackProgressService {
+  final TrackProgressEntry? next;
+  const _FakeProgressService(this.next) : super();
+  @override
+  Future<TrackProgressEntry?> getNextTrack() async => next;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, String cat) =>
+      SkillTreeNodeModel(id: id, title: id, category: cat);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('composes completion banner', () async {
+    final tree = builder.build([node('a', 'A')]).tree;
+    final nextTree = builder.build([node('b', 'B')]).tree;
+    const summary = SkillTreeTrackSummary(
+      title: 'A',
+      completedCount: 1,
+      avgEvLoss: null,
+      motivationalLine: 'Good job!',
+    );
+    const visual = SkillTreeCategoryVisual(
+      category: 'A',
+      emoji: '🎉',
+      color: Colors.red,
+    );
+    final model = await SkillTreeCompletionBannerComposer(
+      summaryBuilder: const _FakeSummaryBuilder(summary),
+      bannerService: const _FakeBannerService(visual),
+      progressService: _FakeProgressService(
+        TrackProgressEntry(tree: nextTree, completionRate: 0.0, isCompleted: false),
+      ),
+    ).compose(tree);
+    expect(model.summary.title, 'A');
+    expect(model.visual.emoji, '🎉');
+    expect(model.nextTrack?.tree.nodes.containsKey('b'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add model for skill tree category visuals
- add model for completion banner data
- add service to provide visuals for categories
- add `SkillTreeCompletionBannerComposer` to combine summary, visuals, and next track
- test banner composer

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0f5a9f0c832a86619c2b8387ccb4