### PR TITLE
Implement SkillTreePathProgressOverviewService

### DIFF
--- a/lib/services/skill_tree_path_progress_overview_service.dart
+++ b/lib/services/skill_tree_path_progress_overview_service.dart
@@ -1,0 +1,48 @@
+import 'skill_tree_track_progress_service.dart';
+
+/// Summary information about overall skill tree path progress.
+class PathProgressOverview {
+  final int totalTracks;
+  final int completedTracks;
+  final double averageCompletionRate; // 0.0 - 1.0
+
+  const PathProgressOverview({
+    required this.totalTracks,
+    required this.completedTracks,
+    required this.averageCompletionRate,
+  });
+}
+
+/// Computes aggregated progress across all skill tree tracks.
+class SkillTreePathProgressOverviewService {
+  final SkillTreeTrackProgressService tracks;
+
+  const SkillTreePathProgressOverviewService({
+    SkillTreeTrackProgressService? tracks,
+  }) : tracks = tracks ?? const SkillTreeTrackProgressService();
+
+  /// Returns global progress overview for the skill tree learning path.
+  Future<PathProgressOverview> computeOverview() async {
+    final list = await tracks.getAllTrackProgress();
+    final total = list.length;
+    if (total == 0) {
+      return const PathProgressOverview(
+        totalTracks: 0,
+        completedTracks: 0,
+        averageCompletionRate: 0.0,
+      );
+    }
+    var completed = 0;
+    var sumRate = 0.0;
+    for (final entry in list) {
+      if (entry.isCompleted) completed++;
+      sumRate += entry.completionRate;
+    }
+    final avgRate = sumRate / total;
+    return PathProgressOverview(
+      totalTracks: total,
+      completedTracks: completed,
+      averageCompletionRate: avgRate,
+    );
+  }
+}

--- a/test/services/skill_tree_path_progress_overview_service_test.dart
+++ b/test/services/skill_tree_path_progress_overview_service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+import 'package:poker_analyzer/services/skill_tree_path_progress_overview_service.dart';
+
+class _FakeTrackProgressService extends SkillTreeTrackProgressService {
+  final List<TrackProgressEntry> entries;
+  const _FakeTrackProgressService(this.entries);
+
+  @override
+  Future<List<TrackProgressEntry>> getAllTrackProgress() async => entries;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, String cat) =>
+      SkillTreeNodeModel(id: id, title: id, category: cat);
+
+  test('aggregates overall path progress', () async {
+    final treeA = builder.build([node('a1', 'A')]).tree;
+    final treeB = builder.build([node('b1', 'B')]).tree;
+    final treeC = builder.build([node('c1', 'C')]).tree;
+
+    final svc = SkillTreePathProgressOverviewService(
+      tracks: _FakeTrackProgressService([
+        const TrackProgressEntry(
+            tree: treeA, completionRate: 1.0, isCompleted: true),
+        const TrackProgressEntry(
+            tree: treeB, completionRate: 0.5, isCompleted: false),
+        const TrackProgressEntry(
+            tree: treeC, completionRate: 0.75, isCompleted: true),
+      ]),
+    );
+
+    final overview = await svc.computeOverview();
+    expect(overview.totalTracks, 3);
+    expect(overview.completedTracks, 2);
+    expect(
+        overview.averageCompletionRate,
+        closeTo((1.0 + 0.5 + 0.75) / 3, 1e-6));
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreePathProgressOverviewService` for computing overall skill-tree progress
- verify aggregation logic with unit test

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d10dedd9c832a9d25a47ac4ef71ce