### PR TITLE
Add skill tree layout service

### DIFF
--- a/lib/services/skill_tree_celebration_trigger_service.dart
+++ b/lib/services/skill_tree_celebration_trigger_service.dart
@@ -17,11 +17,11 @@ class SkillTreeCelebrationTriggerService {
     SkillTreeFinalNodeCompletionDetector? detector,
     SkillTreeProgressAnalyticsService? analytics,
     SkillTreeMilestoneOverlayService? overlay,
-  })  : detector = detector ?? const SkillTreeFinalNodeCompletionDetector(),
-        analytics = analytics ?? const SkillTreeProgressAnalyticsService(),
+  })  : detector = detector ?? SkillTreeFinalNodeCompletionDetector(),
+        analytics = analytics ?? SkillTreeProgressAnalyticsService(),
         overlay = overlay ??
             SkillTreeMilestoneOverlayService(
-              engine: const _CompletionMessageEngine(),
+              engine: _CompletionMessageEngine(),
             );
 
   static const _prefix = 'celebration_done_';
@@ -40,7 +40,7 @@ class SkillTreeCelebrationTriggerService {
 }
 
 class _CompletionMessageEngine extends SkillTreeMotivationalHintEngine {
-  const _CompletionMessageEngine();
+  _CompletionMessageEngine();
 
   @override
   Future<String?> getMotivationalMessage(SkillTreeProgressStats stats) async {

--- a/lib/services/skill_tree_completion_banner_composer.dart
+++ b/lib/services/skill_tree_completion_banner_composer.dart
@@ -10,13 +10,13 @@ class SkillTreeCompletionBannerComposer {
   final SkillTreeCategoryBannerService bannerService;
   final SkillTreeTrackProgressService progressService;
 
-  const SkillTreeCompletionBannerComposer({
+  SkillTreeCompletionBannerComposer({
     SkillTreeTrackSummaryBuilder? summaryBuilder,
     SkillTreeCategoryBannerService? bannerService,
     SkillTreeTrackProgressService? progressService,
-  })  : summaryBuilder = summaryBuilder ?? const SkillTreeTrackSummaryBuilder(),
+  })  : summaryBuilder = summaryBuilder ?? SkillTreeTrackSummaryBuilder(),
         bannerService = bannerService ?? const SkillTreeCategoryBannerService(),
-        progressService = progressService ?? const SkillTreeTrackProgressService();
+        progressService = progressService ?? SkillTreeTrackProgressService();
 
   /// Builds the completion banner model for [tree].
   Future<SkillTreeCompletionBannerModel> compose(SkillTree tree) async {

--- a/lib/services/skill_tree_final_node_completion_detector.dart
+++ b/lib/services/skill_tree_final_node_completion_detector.dart
@@ -5,7 +5,7 @@ import 'skill_tree_node_progress_tracker.dart';
 class SkillTreeFinalNodeCompletionDetector {
   final SkillTreeNodeProgressTracker progress;
 
-  const SkillTreeFinalNodeCompletionDetector({SkillTreeNodeProgressTracker? progress})
+  SkillTreeFinalNodeCompletionDetector({SkillTreeNodeProgressTracker? progress})
       : progress = progress ?? SkillTreeNodeProgressTracker.instance;
 
   /// Returns `true` if all non-optional nodes in [tree] are completed.

--- a/lib/services/skill_tree_learning_map_layout_service.dart
+++ b/lib/services/skill_tree_learning_map_layout_service.dart
@@ -1,0 +1,34 @@
+import 'skill_tree_track_progress_service.dart';
+
+/// Arranges skill tree tracks into a 2D grid layout for the learning map.
+class SkillTreeLearningMapLayoutService {
+  final SkillTreeTrackProgressService tracks;
+
+  SkillTreeLearningMapLayoutService({
+    SkillTreeTrackProgressService? tracks,
+  }) : tracks = tracks ?? SkillTreeTrackProgressService();
+
+  /// Returns a grid of [TrackProgressEntry] items laid out in [columns] per row.
+  Future<List<List<TrackProgressEntry>>> buildLayout({int columns = 2}) async {
+    if (columns <= 0) return [];
+    final list = await tracks.getAllTrackProgress();
+    if (list.isEmpty) return [];
+
+    // Incomplete tracks first, then alphabetical by category.
+    list.sort((a, b) {
+      if (a.isCompleted != b.isCompleted) {
+        return a.isCompleted ? 1 : -1;
+      }
+      final catA = a.tree.nodes.values.first.category;
+      final catB = b.tree.nodes.values.first.category;
+      return catA.compareTo(catB);
+    });
+
+    final grid = <List<TrackProgressEntry>>[];
+    for (var i = 0; i < list.length; i += columns) {
+      final end = i + columns < list.length ? i + columns : list.length;
+      grid.add(list.sublist(i, end));
+    }
+    return grid;
+  }
+}

--- a/lib/services/skill_tree_path_progress_overview_service.dart
+++ b/lib/services/skill_tree_path_progress_overview_service.dart
@@ -17,9 +17,9 @@ class PathProgressOverview {
 class SkillTreePathProgressOverviewService {
   final SkillTreeTrackProgressService tracks;
 
-  const SkillTreePathProgressOverviewService({
+  SkillTreePathProgressOverviewService({
     SkillTreeTrackProgressService? tracks,
-  }) : tracks = tracks ?? const SkillTreeTrackProgressService();
+  }) : tracks = tracks ?? SkillTreeTrackProgressService();
 
   /// Returns global progress overview for the skill tree learning path.
   Future<PathProgressOverview> computeOverview() async {

--- a/lib/services/skill_tree_progress_analytics_service.dart
+++ b/lib/services/skill_tree_progress_analytics_service.dart
@@ -19,7 +19,7 @@ class SkillTreeProgressStats {
 /// Computes progress analytics for a [SkillTree].
 class SkillTreeProgressAnalyticsService {
   final SkillTreeNodeProgressTracker progress;
-  const SkillTreeProgressAnalyticsService({SkillTreeNodeProgressTracker? progress})
+  SkillTreeProgressAnalyticsService({SkillTreeNodeProgressTracker? progress})
       : progress = progress ?? SkillTreeNodeProgressTracker.instance;
 
   /// Returns completion statistics for [tree].

--- a/lib/services/skill_tree_track_progress_service.dart
+++ b/lib/services/skill_tree_track_progress_service.dart
@@ -24,13 +24,13 @@ class SkillTreeTrackProgressService {
   final SkillTreeNodeProgressTracker progress;
   final SkillTreeFinalNodeCompletionDetector detector;
 
-  const SkillTreeTrackProgressService({
+  SkillTreeTrackProgressService({
     SkillTreeLibraryService? library,
     SkillTreeNodeProgressTracker? progress,
     SkillTreeFinalNodeCompletionDetector? detector,
   })  : library = library ?? SkillTreeLibraryService.instance,
         progress = progress ?? SkillTreeNodeProgressTracker.instance,
-        detector = detector ?? const SkillTreeFinalNodeCompletionDetector();
+        detector = detector ?? SkillTreeFinalNodeCompletionDetector();
 
   Future<void> _ensureLoaded() async {
     if (library.getAllNodes().isEmpty) {

--- a/test/services/skill_tree_final_node_completion_detector_test.dart
+++ b/test/services/skill_tree_final_node_completion_detector_test.dart
@@ -21,7 +21,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const builder = SkillTreeBuilderService();
-  const detector = SkillTreeFinalNodeCompletionDetector();
+  final detector = SkillTreeFinalNodeCompletionDetector();
 
   SkillTreeNodeModel node(String id, {List<String>? prereqs}) => SkillTreeNodeModel(
         id: id,

--- a/test/services/skill_tree_learning_map_layout_service_test.dart
+++ b/test/services/skill_tree_learning_map_layout_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_learning_map_layout_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+
+class _FakeTrackProgressService extends SkillTreeTrackProgressService {
+  final List<TrackProgressEntry> entries;
+  _FakeTrackProgressService(this.entries);
+
+  @override
+  Future<List<TrackProgressEntry>> getAllTrackProgress() async => entries;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, String cat) =>
+      SkillTreeNodeModel(id: id, title: id, category: cat);
+
+  test('builds grid layout with 2 columns', () async {
+    final treeA = builder.build([node('a1', 'A')]).tree;
+    final treeB = builder.build([node('b1', 'B')]).tree;
+    final treeC = builder.build([node('c1', 'C')]).tree;
+
+    final svc = SkillTreeLearningMapLayoutService(
+      tracks: _FakeTrackProgressService([
+        TrackProgressEntry(
+            tree: treeA, completionRate: 0.1, isCompleted: false),
+        TrackProgressEntry(
+            tree: treeB, completionRate: 0.2, isCompleted: false),
+        TrackProgressEntry(
+            tree: treeC, completionRate: 0.3, isCompleted: true),
+      ]),
+    );
+
+    final grid = await svc.buildLayout(columns: 2);
+    expect(grid.length, 2);
+    expect(grid[0].length, 2);
+    expect(grid[1].length, 1);
+  });
+}

--- a/test/services/skill_tree_progress_analytics_service_test.dart
+++ b/test/services/skill_tree_progress_analytics_service_test.dart
@@ -9,7 +9,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const builder = SkillTreeBuilderService();
-  const analytics = SkillTreeProgressAnalyticsService();
+  final analytics = SkillTreeProgressAnalyticsService();
 
   SkillTreeNodeModel node(String id, {List<String>? prereqs, int level = 0}) =>
       SkillTreeNodeModel(id: id, title: id, category: 'Push/Fold', prerequisites: prereqs, level: level);

--- a/test/services/skill_tree_track_progress_service_test.dart
+++ b/test/services/skill_tree_track_progress_service_test.dart
@@ -57,7 +57,7 @@ void main() {
     final svc = SkillTreeTrackProgressService(
       library: lib,
       progress: tracker,
-      detector: const SkillTreeFinalNodeCompletionDetector(progress: tracker),
+      detector: SkillTreeFinalNodeCompletionDetector(progress: tracker),
     );
 
     final all = await svc.getAllTrackProgress();
@@ -83,7 +83,7 @@ void main() {
     final svc = SkillTreeTrackProgressService(
       library: lib,
       progress: tracker,
-      detector: const SkillTreeFinalNodeCompletionDetector(progress: tracker),
+      detector: SkillTreeFinalNodeCompletionDetector(progress: tracker),
     );
 
     var current = await svc.getCurrentTrack();


### PR DESCRIPTION
## Summary
- implement `SkillTreeLearningMapLayoutService` for arranging skill tree tracks on a grid
- add unit test for layout service
- make related constructors non-const to avoid invalid constants

## Testing
- `flutter analyze lib/services/skill_tree_learning_map_layout_service.dart test/services/skill_tree_learning_map_layout_service_test.dart lib/services/skill_tree_track_progress_service.dart lib/services/skill_tree_path_progress_overview_service.dart lib/services/skill_tree_completion_banner_composer.dart lib/services/skill_tree_final_node_completion_detector.dart lib/services/skill_tree_celebration_trigger_service.dart lib/services/skill_tree_progress_analytics_service.dart test/services/skill_tree_track_progress_service_test.dart test/services/skill_tree_final_node_completion_detector_test.dart test/services/skill_tree_progress_analytics_service_test.dart`
- `flutter test test/services/skill_tree_learning_map_layout_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688d121e7b90832aa39258fc3e3eb9b0