### PR TITLE
Add Skill Tree Learning Map Screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'screens/decay_heatmap_screen.dart';
 import 'screens/decay_stats_dashboard_screen.dart';
 import 'screens/decay_analytics_screen.dart';
 import 'screens/decay_adaptation_insight_screen.dart';
+import 'screens/skill_tree_learning_map_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -391,6 +392,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               DecayAnalyticsScreen.route: (_) => const DecayAnalyticsScreen(),
               DecayAdaptationInsightScreen.route: (_) =>
                   const DecayAdaptationInsightScreen(),
+              SkillTreeLearningMapScreen.route: (_) =>
+                  const SkillTreeLearningMapScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/screens/skill_tree_learning_map_screen.dart
+++ b/lib/screens/skill_tree_learning_map_screen.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import '../services/skill_tree_learning_map_layout_service.dart';
+import '../services/skill_tree_track_progress_service.dart';
+import 'skill_tree_screen.dart';
+import '../utils/responsive.dart';
+
+/// Displays all skill tree tracks in a scrollable grid layout.
+class SkillTreeLearningMapScreen extends StatefulWidget {
+  static const route = '/learning-map';
+  const SkillTreeLearningMapScreen({super.key});
+
+  @override
+  State<SkillTreeLearningMapScreen> createState() => _SkillTreeLearningMapScreenState();
+}
+
+class _SkillTreeLearningMapScreenState extends State<SkillTreeLearningMapScreen> {
+  late Future<List<List<TrackProgressEntry>>> _future;
+  late int _columns;
+
+  @override
+  void initState() {
+    super.initState();
+    // columns computed later in didChangeDependencies
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _columns = isLandscape(context)
+        ? (isCompactWidth(context) ? 2 : 3)
+        : (isCompactWidth(context) ? 1 : 2);
+    _future = SkillTreeLearningMapLayoutService().buildLayout(columns: _columns);
+  }
+
+  void _openTrack(TrackProgressEntry entry) {
+    final category = entry.tree.nodes.values.first.category;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => SkillTreeScreen(category: category)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<List<List<TrackProgressEntry>>>(
+      future: _future,
+      builder: (context, snapshot) {
+        final grid = snapshot.data ?? const <List<TrackProgressEntry>>[];
+        final list = [for (final row in grid) ...row];
+        return Scaffold(
+          appBar: AppBar(title: const Text('Карта обучения')),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : list.isEmpty
+                  ? const Center(child: Text('Нет треков'))
+                  : GridView.builder(
+                      padding: const EdgeInsets.all(12),
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: _columns,
+                        mainAxisSpacing: 12,
+                        crossAxisSpacing: 12,
+                        childAspectRatio: 1.1,
+                      ),
+                      itemCount: list.length,
+                      itemBuilder: (context, index) {
+                        final entry = list[index];
+                        final title = entry.tree.roots.isNotEmpty
+                            ? entry.tree.roots.first.title
+                            : entry.tree.nodes.values.first.title;
+                        final pct = entry.completionRate.clamp(0.0, 1.0);
+                        return GestureDetector(
+                          onTap: () => _openTrack(entry),
+                          child: Card(
+                            child: Padding(
+                              padding: const EdgeInsets.all(8),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    title,
+                                    style: const TextStyle(
+                                        fontSize: 14, fontWeight: FontWeight.bold),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  ClipRRect(
+                                    borderRadius: BorderRadius.circular(4),
+                                    child: LinearProgressIndicator(
+                                      value: pct,
+                                      backgroundColor: Colors.white24,
+                                      valueColor: AlwaysStoppedAnimation<Color>(accent),
+                                      minHeight: 6,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Row(
+                                    children: [
+                                      Text('${(pct * 100).round()}%',
+                                          style: const TextStyle(fontSize: 12)),
+                                      if (entry.isCompleted)
+                                        const Padding(
+                                          padding: EdgeInsets.only(left: 4),
+                                          child: Icon(Icons.check, color: Colors.green, size: 16),
+                                        ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `SkillTreeLearningMapScreen` which lays out skill tracks from `SkillTreeLearningMapLayoutService`
- add new route to `MaterialApp`

## Testing
- `flutter pub get`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_688d162c9db0832a92c99ded36ea1124