### PR TITLE
Add skill tree track state evaluator

### DIFF
--- a/lib/services/skill_tree_track_state_evaluator.dart
+++ b/lib/services/skill_tree_track_state_evaluator.dart
@@ -1,0 +1,61 @@
+import 'skill_tree_track_progress_service.dart';
+
+/// Possible states for a skill tree track.
+enum SkillTreeTrackState { locked, unlocked, inProgress, completed }
+
+/// Pair of a [TrackProgressEntry] with its current [state].
+class TrackStateEntry {
+  final TrackProgressEntry progress;
+  final SkillTreeTrackState state;
+
+  const TrackStateEntry({required this.progress, required this.state});
+}
+
+/// Evaluates the state of each skill tree track based on progress
+/// and optional prerequisites.
+class SkillTreeTrackStateEvaluator {
+  final SkillTreeTrackProgressService progressService;
+  final Map<String, List<String>> _prereq;
+
+  SkillTreeTrackStateEvaluator({
+    SkillTreeTrackProgressService? progressService,
+    Map<String, List<String>>? prerequisites,
+  })  : progressService = progressService ?? SkillTreeTrackProgressService(),
+        _prereq = prerequisites ?? const {};
+
+  /// Returns a list of [TrackStateEntry] describing the state of each track.
+  Future<List<TrackStateEntry>> evaluateStates() async {
+    final list = await progressService.getAllTrackProgress();
+    if (list.isEmpty) return [];
+
+    final completedCats = <String>{};
+    String catOf(TrackProgressEntry e) =>
+        e.tree.nodes.values.first.category;
+
+    for (final e in list) {
+      if (e.isCompleted) completedCats.add(catOf(e));
+    }
+
+    final results = <TrackStateEntry>[];
+    for (final entry in list) {
+      final cat = catOf(entry);
+      final prereq = _prereq[cat] ?? const [];
+      final unlocked = prereq.every(completedCats.contains);
+
+      SkillTreeTrackState state;
+      if (!unlocked) {
+        state = SkillTreeTrackState.locked;
+      } else if (entry.isCompleted) {
+        state = SkillTreeTrackState.completed;
+      } else if (entry.completionRate > 0) {
+        state = SkillTreeTrackState.inProgress;
+      } else {
+        state = SkillTreeTrackState.unlocked;
+      }
+
+      results.add(TrackStateEntry(progress: entry, state: state));
+    }
+
+    return results;
+  }
+}

--- a/test/services/skill_tree_track_state_evaluator_test.dart
+++ b/test/services/skill_tree_track_state_evaluator_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_state_evaluator.dart';
+
+class _FakeProgressService extends SkillTreeTrackProgressService {
+  final List<TrackProgressEntry> entries;
+  const _FakeProgressService(this.entries);
+
+  @override
+  Future<List<TrackProgressEntry>> getAllTrackProgress() async => entries;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, String cat) =>
+      SkillTreeNodeModel(id: id, title: id, category: cat);
+
+  test('computes locked state when prerequisites missing', () async {
+    final treeA = builder.build([node('a1', 'A')]).tree;
+    final treeB = builder.build([node('b1', 'B')]).tree;
+
+    final svc = SkillTreeTrackStateEvaluator(
+      progressService: _FakeProgressService([
+        const TrackProgressEntry(tree: treeA, completionRate: 0.0, isCompleted: false),
+        const TrackProgressEntry(tree: treeB, completionRate: 0.0, isCompleted: false),
+      ]),
+      prerequisites: const {'B': ['A']},
+    );
+
+    final states = await svc.evaluateStates();
+    final map = {for (final e in states) e.progress.tree.nodes.values.first.category: e.state};
+    expect(map['A'], SkillTreeTrackState.unlocked);
+    expect(map['B'], SkillTreeTrackState.locked);
+  });
+
+  test('reports unlocked, inProgress and completed states', () async {
+    final treeA = builder.build([node('a1', 'A')]).tree;
+    final treeB = builder.build([node('b1', 'B')]).tree;
+    final treeC = builder.build([node('c1', 'C')]).tree;
+
+    final svc = SkillTreeTrackStateEvaluator(
+      progressService: _FakeProgressService([
+        const TrackProgressEntry(tree: treeA, completionRate: 1.0, isCompleted: true),
+        const TrackProgressEntry(tree: treeB, completionRate: 0.3, isCompleted: false),
+        const TrackProgressEntry(tree: treeC, completionRate: 0.0, isCompleted: false),
+      ]),
+      prerequisites: const {'B': ['A']},
+    );
+
+    final states = await svc.evaluateStates();
+    final map = {for (final e in states) e.progress.tree.nodes.values.first.category: e.state};
+    expect(map['A'], SkillTreeTrackState.completed);
+    expect(map['B'], SkillTreeTrackState.inProgress);
+    expect(map['C'], SkillTreeTrackState.unlocked);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeTrackStateEvaluator` for track gating
- cover service with unit tests

## Testing
- `flutter test test/services/skill_tree_track_state_evaluator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1ae70b68832aaefaa24143669c51