### PR TITLE
Add SkillTreeLessonGatingService

### DIFF
--- a/lib/models/node_gate_status.dart
+++ b/lib/models/node_gate_status.dart
@@ -1,0 +1,6 @@
+class NodeGateStatus {
+  final bool isVisible;
+  final bool isEnabled;
+
+  const NodeGateStatus({required this.isVisible, required this.isEnabled});
+}

--- a/lib/services/skill_tree_lesson_gating_service.dart
+++ b/lib/services/skill_tree_lesson_gating_service.dart
@@ -1,0 +1,47 @@
+import '../models/skill_tree.dart';
+import '../models/node_gate_status.dart';
+import 'skill_tree_track_progress_service.dart';
+
+/// Determines visibility and enablement of nodes in a [SkillTree].
+class SkillTreeLessonGatingService {
+  final SkillTreeTrackProgressService progressService;
+
+  SkillTreeLessonGatingService({SkillTreeTrackProgressService? progressService})
+      : progressService = progressService ?? SkillTreeTrackProgressService();
+
+  /// Returns a mapping of node id to its [NodeGateStatus].
+  Future<Map<String, NodeGateStatus>> evaluate(SkillTree tree) async {
+    final tracker = progressService.progress;
+    // Ensure progress is loaded.
+    await tracker.isCompleted('');
+    final completed = tracker.completedNodeIds.value;
+
+    final result = <String, NodeGateStatus>{};
+
+    NodeGateStatus computeStatus(String id) {
+      final cached = result[id];
+      if (cached != null) return cached;
+      final node = tree.nodes[id];
+      if (node == null) {
+        return const NodeGateStatus(isVisible: false, isEnabled: false);
+      }
+      if (node.prerequisites.isEmpty) {
+        final status = const NodeGateStatus(isVisible: true, isEnabled: true);
+        result[id] = status;
+        return status;
+      }
+      final visible = tree.ancestorsOf(id)
+          .every((a) => computeStatus(a.id).isVisible);
+      final enabled = node.prerequisites.every(completed.contains);
+      final status = NodeGateStatus(isVisible: visible, isEnabled: enabled);
+      result[id] = status;
+      return status;
+    }
+
+    for (final id in tree.nodes.keys) {
+      computeStatus(id);
+    }
+
+    return result;
+  }
+}

--- a/test/services/skill_tree_lesson_gating_service_test.dart
+++ b/test/services/skill_tree_lesson_gating_service_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_final_node_completion_detector.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+import 'package:poker_analyzer/services/skill_tree_lesson_gating_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => null;
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, {List<String>? prereqs}) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'Push/Fold', prerequisites: prereqs);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('computes visibility and enablement for nodes', () async {
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    final tree = builder.build([
+      node('n1'),
+      node('n2', prereqs: ['n1']),
+      node('n3', prereqs: ['n1']),
+      node('n4', prereqs: ['n2', 'n3']),
+    ]).tree;
+
+    final progressService = SkillTreeTrackProgressService(
+      library: _FakeLibraryService(),
+      progress: tracker,
+      detector: SkillTreeFinalNodeCompletionDetector(progress: tracker),
+    );
+    final gating = SkillTreeLessonGatingService(progressService: progressService);
+
+    var map = await gating.evaluate(tree);
+    expect(map['n1']!.isVisible, isTrue);
+    expect(map['n1']!.isEnabled, isTrue);
+    expect(map['n2']!.isVisible, isTrue);
+    expect(map['n2']!.isEnabled, isFalse);
+    expect(map['n4']!.isVisible, isTrue);
+    expect(map['n4']!.isEnabled, isFalse);
+
+    await tracker.markCompleted('n1');
+    map = await gating.evaluate(tree);
+    expect(map['n2']!.isEnabled, isTrue);
+    expect(map['n3']!.isEnabled, isTrue);
+    expect(map['n4']!.isEnabled, isFalse);
+
+    await tracker.markCompleted('n2');
+    await tracker.markCompleted('n3');
+    map = await gating.evaluate(tree);
+    expect(map['n4']!.isEnabled, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `NodeGateStatus` model
- implement `SkillTreeLessonGatingService` to compute node visibility and enablement
- test gating logic with `SkillTreeLessonGatingService`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1c66ef08832a99961433ccd53122