### PR TITLE
Implement SkillTreeTrackHeaderBuilder

### DIFF
--- a/lib/widgets/skill_tree_track_header_builder.dart
+++ b/lib/widgets/skill_tree_track_header_builder.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_track_progress_service.dart';
+import '../services/skill_tree_category_banner_service.dart';
+
+/// Builds a header widget with metadata for a skill tree track.
+class SkillTreeTrackHeaderBuilder {
+  final SkillTreeCategoryBannerService bannerService;
+
+  const SkillTreeTrackHeaderBuilder({
+    SkillTreeCategoryBannerService? bannerService,
+  }) : bannerService = bannerService ?? const SkillTreeCategoryBannerService();
+
+  /// Returns a widget displaying [root] info and [progress].
+  Widget build({
+    required SkillTreeNodeModel root,
+    required TrackProgressEntry progress,
+    Map<String, Widget>? iconMap,
+    bool compact = false,
+  }) {
+    final visual = bannerService.getVisual(root.category);
+    final accent = visual.color;
+    final iconWidget = iconMap?[root.category] ??
+        Text(visual.emoji, style: const TextStyle(fontSize: 20));
+    final pct = (progress.completionRate.clamp(0.0, 1.0) * 100).round();
+
+    final progressBar = ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: LinearProgressIndicator(
+        value: progress.completionRate.clamp(0.0, 1.0),
+        backgroundColor: Colors.white24,
+        valueColor: AlwaysStoppedAnimation<Color>(accent),
+        minHeight: 6,
+      ),
+    );
+
+    final status = progress.isCompleted
+        ? const Icon(Icons.check_circle, color: Colors.green)
+        : Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              progressBar,
+              const SizedBox(height: 4),
+              Text(
+                '$pct%',
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ],
+          );
+
+    if (compact) {
+      return Row(
+        children: [
+          CircleAvatar(backgroundColor: accent, child: iconWidget),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  root.title,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                if (!progress.isCompleted) ...[
+                  const SizedBox(height: 4),
+                  progressBar,
+                  const SizedBox(height: 4),
+                  Text('$pct%',
+                      style:
+                          const TextStyle(color: Colors.white70, fontSize: 12)),
+                ] else
+                  const Padding(
+                    padding: EdgeInsets.only(top: 4),
+                    child: Icon(Icons.check_circle,
+                        color: Colors.green, size: 16),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CircleAvatar(backgroundColor: accent, child: iconWidget),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    root.title,
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    root.category,
+                    style: const TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+            status,
+          ],
+        ),
+        if (!progress.isCompleted) ...[
+          const SizedBox(height: 8),
+          progressBar,
+        ],
+      ],
+    );
+  }
+}

--- a/test/widgets/skill_tree_track_header_builder_test.dart
+++ b/test/widgets/skill_tree_track_header_builder_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
+import 'package:poker_analyzer/widgets/skill_tree_track_header_builder.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: 'Title', category: 'Push/Fold');
+
+  testWidgets('builds header with progress', (WidgetTester tester) async {
+    final tree = builder.build([node('a')]).tree;
+    final progress = TrackProgressEntry(
+      tree: tree,
+      completionRate: 0.3,
+      isCompleted: false,
+    );
+    final header = const SkillTreeTrackHeaderBuilder().build(
+      root: node('a'),
+      progress: progress,
+    );
+    await tester.pumpWidget(MaterialApp(home: header));
+
+    expect(find.text('Title'), findsOneWidget);
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byType(LinearProgressIndicator),
+    );
+    expect(bar.value, closeTo(0.3, 0.001));
+    expect(find.text('30%'), findsOneWidget);
+  });
+
+  testWidgets('shows completed status', (WidgetTester tester) async {
+    final tree = builder.build([node('b')]).tree;
+    final progress = TrackProgressEntry(
+      tree: tree,
+      completionRate: 1.0,
+      isCompleted: true,
+    );
+    final header = const SkillTreeTrackHeaderBuilder().build(
+      root: node('b'),
+      progress: progress,
+    );
+    await tester.pumpWidget(MaterialApp(home: header));
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeTrackHeaderBuilder` for building UI widgets for track headers
- test header output for progress and completion

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2164fe80832aaaf7f04f0cf86860