### PR TITLE
Add Stage Gate Evaluator

### DIFF
--- a/lib/services/skill_tree_stage_gate_evaluator.dart
+++ b/lib/services/skill_tree_stage_gate_evaluator.dart
@@ -1,0 +1,47 @@
+import '../models/skill_tree.dart';
+import 'skill_tree_stage_completion_evaluator.dart';
+
+/// Determines whether skill tree stages (levels) are unlocked.
+class SkillTreeStageGateEvaluator {
+  final SkillTreeStageCompletionEvaluator completionEvaluator;
+
+  const SkillTreeStageGateEvaluator({
+    SkillTreeStageCompletionEvaluator? completionEvaluator,
+  }) : completionEvaluator =
+            completionEvaluator ?? const SkillTreeStageCompletionEvaluator();
+
+  /// Returns `true` if [level] is unlocked based on [completedNodeIds].
+  bool isStageUnlocked(
+    SkillTree tree,
+    int level,
+    Set<String> completedNodeIds,
+  ) {
+    if (level == 0) return true;
+    final levels = <int>{for (final n in tree.nodes.values) n.level};
+    final sorted = levels.toList()..sort();
+    for (final lvl in sorted) {
+      if (lvl >= level) break;
+      if (!completionEvaluator.isStageCompleted(
+          tree, lvl, completedNodeIds)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns a sorted list of unlocked levels in [tree].
+  List<int> getUnlockedStages(
+    SkillTree tree,
+    Set<String> completedNodeIds,
+  ) {
+    final levels = <int>{for (final n in tree.nodes.values) n.level};
+    final sorted = levels.toList()..sort();
+    final unlocked = <int>[];
+    for (final lvl in sorted) {
+      if (isStageUnlocked(tree, lvl, completedNodeIds)) {
+        unlocked.add(lvl);
+      }
+    }
+    return unlocked;
+  }
+}

--- a/test/services/skill_tree_stage_gate_evaluator_test.dart
+++ b/test/services/skill_tree_stage_gate_evaluator_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/skill_tree_stage_gate_evaluator.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+  const evaluator = SkillTreeStageGateEvaluator();
+
+  SkillTreeNodeModel node(String id, int level) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'Push/Fold', level: level);
+
+  test('stage 0 always unlocked', () {
+    final tree = builder.build([node('n1', 0)]).tree;
+    expect(evaluator.isStageUnlocked(tree, 0, {}), isTrue);
+  });
+
+  test('requires prior stages to be completed', () {
+    final tree = builder.build([
+      node('n1', 0),
+      node('n2', 1),
+      node('n3', 2),
+    ]).tree;
+    final completed = {'n1'};
+    expect(evaluator.isStageUnlocked(tree, 1, completed), isTrue);
+    expect(evaluator.isStageUnlocked(tree, 2, completed), isFalse);
+    final stages = evaluator.getUnlockedStages(tree, completed);
+    expect(stages, [0, 1]);
+  });
+
+  test('later stages unlock when all previous are completed', () {
+    final tree = builder.build([
+      node('n1', 0),
+      node('n2', 1),
+      node('n3', 2),
+    ]).tree;
+    final completed = {'n1', 'n2', 'n3'};
+    expect(evaluator.isStageUnlocked(tree, 2, completed), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeStageGateEvaluator` for progressive stage unlocking
- test stage gate logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2f3596a0832a8eab3f122ac214e4