### PR TITLE
Implement SkillTreeBlockNodePositioner

### DIFF
--- a/lib/services/skill_tree_block_node_positioner.dart
+++ b/lib/services/skill_tree_block_node_positioner.dart
@@ -1,0 +1,35 @@
+import 'dart:math' as math;
+import 'package:flutter/widgets.dart';
+
+import '../models/skill_tree_node_model.dart';
+
+/// Computes the rectangle positions of nodes inside a level block.
+class SkillTreeBlockNodePositioner {
+  const SkillTreeBlockNodePositioner();
+
+  /// Returns a map of node id to rectangle in the block coordinate space.
+  Map<String, Rect> calculate({
+    required List<SkillTreeNodeModel> nodes,
+    double nodeWidth = 120,
+    double nodeHeight = 80,
+    double spacing = 16,
+    TextDirection direction = TextDirection.ltr,
+    bool center = false,
+  }) {
+    final rects = <String, Rect>{};
+    if (nodes.isEmpty) return rects;
+
+    final totalWidth =
+        nodes.length * nodeWidth + math.max(0, nodes.length - 1) * spacing;
+    var x = center ? -totalWidth / 2 : 0.0;
+    final ordered =
+        direction == TextDirection.ltr ? nodes : nodes.reversed.toList();
+
+    for (final node in ordered) {
+      rects[node.id] = Rect.fromLTWH(x, 0, nodeWidth, nodeHeight);
+      x += nodeWidth + spacing;
+    }
+
+    return rects;
+  }
+}

--- a/test/services/skill_tree_block_node_positioner_test.dart
+++ b/test/services/skill_tree_block_node_positioner_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_block_node_positioner.dart';
+
+SkillTreeNodeModel _node(String id) =>
+    SkillTreeNodeModel(id: id, title: id, category: 'c');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('positions nodes horizontally with spacing', () {
+    final pos = const SkillTreeBlockNodePositioner().calculate(
+      nodes: [_node('a'), _node('b')],
+      nodeWidth: 100,
+      nodeHeight: 50,
+      spacing: 10,
+    );
+    expect(pos['a'], const Rect.fromLTWH(0, 0, 100, 50));
+    expect(pos['b'], const Rect.fromLTWH(110, 0, 100, 50));
+  });
+
+  test('supports RTL direction', () {
+    final pos = const SkillTreeBlockNodePositioner().calculate(
+      nodes: [_node('a'), _node('b')],
+      nodeWidth: 100,
+      nodeHeight: 50,
+      spacing: 10,
+      direction: TextDirection.rtl,
+    );
+    expect(pos['b'], const Rect.fromLTWH(0, 0, 100, 50));
+    expect(pos['a'], const Rect.fromLTWH(110, 0, 100, 50));
+  });
+
+  test('center alignment shifts nodes', () {
+    final pos = const SkillTreeBlockNodePositioner().calculate(
+      nodes: [_node('x')],
+      nodeWidth: 100,
+      nodeHeight: 50,
+      spacing: 10,
+      center: true,
+    );
+    expect(pos['x'], const Rect.fromLTWH(-50, 0, 100, 50));
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeBlockNodePositioner` to compute node layout within a level block
- test horizontal layout, RTL support and centering behavior

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d38816928832a87692012337dd243