### PR TITLE
Add skill tree grid block widget

### DIFF
--- a/lib/widgets/skill_tree_grid_block_builder.dart
+++ b/lib/widgets/skill_tree_grid_block_builder.dart
@@ -1,0 +1,89 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_block_node_positioner.dart';
+import '../services/skill_tree_path_connector_builder.dart';
+import 'skill_tree_stage_header_builder.dart';
+import 'skill_tree_node_card.dart';
+
+/// Builds a complete visual block for a single skill tree level.
+class SkillTreeGridBlockBuilder {
+  final SkillTreeBlockNodePositioner positioner;
+  final SkillTreePathConnectorBuilder connectorBuilder;
+  final SkillTreeStageHeaderBuilder headerBuilder;
+
+  const SkillTreeGridBlockBuilder({
+    this.positioner = const SkillTreeBlockNodePositioner(),
+    this.connectorBuilder = const SkillTreePathConnectorBuilder(),
+    this.headerBuilder = const SkillTreeStageHeaderBuilder(),
+  });
+
+  /// Renders [nodes] of a level inside a column with header and connectors.
+  Widget build({
+    required int level,
+    required List<SkillTreeNodeModel> nodes,
+    required Set<String> unlockedNodeIds,
+    required Set<String> completedNodeIds,
+    double nodeWidth = 120,
+    double nodeHeight = 80,
+    double spacing = 16,
+  }) {
+    final bounds = positioner.calculate(
+      nodes: nodes,
+      nodeWidth: nodeWidth,
+      nodeHeight: nodeHeight,
+      spacing: spacing,
+      center: true,
+    );
+
+    final connectors = connectorBuilder.build(
+      nodes: nodes,
+      bounds: bounds,
+      unlockedNodeIds: unlockedNodeIds,
+    );
+
+    final nodeWidgets = <Widget>[];
+    for (final node in nodes) {
+      final rect = bounds[node.id];
+      if (rect == null) continue;
+      nodeWidgets.add(Positioned(
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        child: SkillTreeNodeCard(
+          node: node,
+          unlocked: unlockedNodeIds.contains(node.id),
+          completed: completedNodeIds.contains(node.id),
+        ),
+      ));
+    }
+
+    final contentHeight = bounds.values
+        .map((r) => r.bottom)
+        .fold<double>(0, (prev, b) => math.max(prev, b));
+
+    final header = headerBuilder.buildHeader(
+      level: level,
+      nodes: nodes,
+      completedNodeIds: completedNodeIds,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        header,
+        const SizedBox(height: 8),
+        SizedBox(
+          height: contentHeight,
+          child: Stack(children: [
+            ...connectors,
+            ...nodeWidgets,
+          ]),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/skill_tree_node_card.dart
+++ b/lib/widgets/skill_tree_node_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../models/node_gate_status.dart';
+import '../services/skill_tree_lesson_state_overlay_builder.dart';
+import '../models/node_completion_status.dart';
+
+/// Simple card widget representing a skill tree node with completion overlay.
+class SkillTreeNodeCard extends StatelessWidget {
+  final SkillTreeNodeModel node;
+  final bool unlocked;
+  final bool completed;
+  final VoidCallback? onTap;
+
+  const SkillTreeNodeCard({
+    super.key,
+    required this.node,
+    required this.unlocked,
+    required this.completed,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final overlay = const SkillTreeLessonStateOverlayBuilder().build(
+      const NodeGateStatus(isVisible: true, isEnabled: true),
+      completed ? NodeCompletionStatus.completed : NodeCompletionStatus.notStarted,
+    );
+    Color borderColor;
+    if (completed) {
+      borderColor = Colors.green;
+    } else if (unlocked) {
+      borderColor = Theme.of(context).colorScheme.secondary;
+    } else {
+      borderColor = Colors.grey;
+    }
+
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: borderColor),
+        ),
+        padding: const EdgeInsets.all(8),
+        child: Stack(
+          children: [
+            Center(
+              child: Text(
+                node.title,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+            Positioned(right: 0, top: 0, child: overlay),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/skill_tree_grid_block_builder_test.dart
+++ b/test/services/skill_tree_grid_block_builder_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/widgets/skill_tree_grid_block_builder.dart';
+import 'package:poker_analyzer/widgets/skill_tree_node_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'PF', level: 1);
+
+  testWidgets('builds grid block with nodes and connectors', (tester) async {
+    final builder = const SkillTreeGridBlockBuilder();
+    final widget = builder.build(
+      level: 1,
+      nodes: [node('a'), node('b')],
+      unlockedNodeIds: {'a', 'b'},
+      completedNodeIds: {'a'},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byType(SkillTreeNodeCard), findsNWidgets(2));
+    // Only one connector between two nodes
+    expect(find.byType(CustomPaint), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeNodeCard` widget to show a node with progress overlay
- implement `SkillTreeGridBlockBuilder` for level layout
- add unit test for the new builder

## Testing
- `flutter test test/services/skill_tree_grid_block_builder_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d39cea7d8832aa09270d63075e953