### PR TITLE
Implement stage block builder

### DIFF
--- a/lib/widgets/skill_tree_stage_block_builder.dart
+++ b/lib/widgets/skill_tree_stage_block_builder.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_stage_unlock_overlay_builder.dart';
+import 'skill_tree_grid_block_builder.dart';
+import 'skill_tree_stage_header_builder.dart';
+
+/// Builds a full visual block for a single skill tree stage (level).
+class SkillTreeStageBlockBuilder {
+  final SkillTreeGridBlockBuilder gridBuilder;
+  final SkillTreeStageHeaderBuilder headerBuilder;
+  final SkillTreeStageUnlockOverlayBuilder overlayBuilder;
+
+  const SkillTreeStageBlockBuilder({
+    this.gridBuilder = const SkillTreeGridBlockBuilder(),
+    this.headerBuilder = const SkillTreeStageHeaderBuilder(),
+    this.overlayBuilder = const SkillTreeStageUnlockOverlayBuilder(),
+  });
+
+  /// Returns a widget displaying [nodes] for a stage with header and overlay.
+  Widget build({
+    required int level,
+    required List<SkillTreeNodeModel> nodes,
+    required Set<String> unlockedNodeIds,
+    required Set<String> completedNodeIds,
+    required bool isStageUnlocked,
+    required bool isStageCompleted,
+  }) {
+    final header = headerBuilder.buildHeader(
+      level: level,
+      nodes: nodes,
+      completedNodeIds: completedNodeIds,
+      overlay: overlayBuilder.buildOverlay(
+        level: level,
+        isUnlocked: isStageUnlocked,
+        isCompleted: isStageCompleted,
+      ),
+    );
+
+    final grid = SkillTreeGridBlockBuilder(
+      positioner: gridBuilder.positioner,
+      connectorBuilder: gridBuilder.connectorBuilder,
+      headerBuilder: const _EmptyHeaderBuilder(),
+    ).build(
+      level: level,
+      nodes: isStageUnlocked ? nodes : const [],
+      unlockedNodeIds: unlockedNodeIds,
+      completedNodeIds: completedNodeIds,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        header,
+        if (isStageUnlocked) ...[
+          const SizedBox(height: 8),
+          grid,
+        ],
+      ],
+    );
+  }
+}
+
+class _EmptyHeaderBuilder extends SkillTreeStageHeaderBuilder {
+  const _EmptyHeaderBuilder();
+
+  @override
+  Widget buildHeader({
+    required int level,
+    required List<SkillTreeNodeModel> nodes,
+    required Set<String> completedNodeIds,
+    Widget? overlay,
+  }) {
+    return const SizedBox.shrink();
+  }
+}

--- a/test/services/skill_tree_stage_block_builder_test.dart
+++ b/test/services/skill_tree_stage_block_builder_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/widgets/skill_tree_node_card.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_block_builder.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'PF', level: 1);
+
+  testWidgets('locked stage hides nodes and shows lock overlay', (tester) async {
+    const builder = SkillTreeStageBlockBuilder();
+    final widget = builder.build(
+      level: 1,
+      nodes: [node('a')],
+      unlockedNodeIds: {},
+      completedNodeIds: {},
+      isStageUnlocked: false,
+      isStageCompleted: false,
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byType(SkillTreeNodeCard), findsNothing);
+    expect(find.byIcon(Icons.lock), findsOneWidget);
+  });
+
+  testWidgets('completed stage shows check overlay', (tester) async {
+    const builder = SkillTreeStageBlockBuilder();
+    final widget = builder.build(
+      level: 1,
+      nodes: [node('a')],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {'a'},
+      isStageUnlocked: true,
+      isStageCompleted: true,
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byType(SkillTreeNodeCard), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeStageBlockBuilder` for composing a stage header, grid and unlock overlay
- test new builder behaviour

## Testing
- `flutter test test/services/skill_tree_stage_block_builder_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3b24ae64832a8c44b8f317c026e8