### PR TITLE
Implement SkillTreeStageListBuilder

### DIFF
--- a/lib/widgets/skill_tree_stage_list_builder.dart
+++ b/lib/widgets/skill_tree_stage_list_builder.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_stage_block_builder.dart';
+
+/// Builds a scrollable list of skill tree stages.
+class SkillTreeStageListBuilder {
+  final SkillTreeStageBlockBuilder blockBuilder;
+
+  const SkillTreeStageListBuilder({
+    this.blockBuilder = const SkillTreeStageBlockBuilder(),
+  });
+
+  /// Returns a [ListView] of stage blocks grouped by level.
+  Widget build({
+    required List<SkillTreeNodeModel> allNodes,
+    required Set<String> unlockedNodeIds,
+    required Set<String> completedNodeIds,
+    EdgeInsetsGeometry padding = const EdgeInsets.all(8),
+    double spacing = 16,
+  }) {
+    final levels = <int, List<SkillTreeNodeModel>>{};
+    for (final node in allNodes) {
+      levels.putIfAbsent(node.level, () => []).add(node);
+    }
+
+    final sortedLevels = levels.keys.toList()..sort();
+    final children = <Widget>[];
+    for (final lvl in sortedLevels) {
+      final nodes = levels[lvl]!;
+      final isUnlocked = nodes.any((n) => unlockedNodeIds.contains(n.id));
+      final isCompleted = nodes.every((n) {
+        final opt = (n as dynamic).isOptional == true;
+        return opt || completedNodeIds.contains(n.id);
+      });
+
+      final block = blockBuilder.build(
+        level: lvl,
+        nodes: nodes,
+        unlockedNodeIds: unlockedNodeIds,
+        completedNodeIds: completedNodeIds,
+        isStageUnlocked: isUnlocked,
+        isStageCompleted: isCompleted,
+      );
+
+      children.add(Padding(
+        padding: EdgeInsets.only(bottom: spacing),
+        child: block,
+      ));
+    }
+
+    return ListView(padding: padding, children: children);
+  }
+}

--- a/test/services/skill_tree_stage_list_builder_test.dart
+++ b/test/services/skill_tree_stage_list_builder_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/widgets/skill_tree_node_card.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_list_builder.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SkillTreeNodeModel node(String id, int level) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'PF', level: level);
+
+  testWidgets('renders locked and unlocked stages', (tester) async {
+    const builder = SkillTreeStageListBuilder();
+    final widget = builder.build(
+      allNodes: [node('a', 0), node('b', 1)],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byType(SkillTreeNodeCard), findsOneWidget);
+    expect(find.byIcon(Icons.lock), findsOneWidget);
+  });
+
+  testWidgets('completed stage shows check icon', (tester) async {
+    const builder = SkillTreeStageListBuilder();
+    final widget = builder.build(
+      allNodes: [node('a', 0)],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {'a'},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeStageListBuilder` widget to render multiple stages vertically
- test list builder behavior for locked/unlocked and completed stages

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3e696b30832a93813374f4af778b