### PR TITLE
Add SkillTreePathScreen for interactive learning path

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_library_service.dart';
+import '../services/skill_tree_track_progress_service.dart';
+import '../widgets/skill_tree_stage_list_builder.dart';
+import 'skill_tree_node_detail_view.dart';
+
+/// Renders the full learning path for a skill track.
+class SkillTreePathScreen extends StatefulWidget {
+  final String trackId;
+  const SkillTreePathScreen({super.key, required this.trackId});
+
+  @override
+  State<SkillTreePathScreen> createState() => _SkillTreePathScreenState();
+}
+
+class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
+  final _listBuilder = const SkillTreeStageListBuilder();
+
+  SkillTree? _track;
+  Set<String> _unlocked = {};
+  Set<String> _completed = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await SkillTreeLibraryService.instance.reload();
+    final res = SkillTreeLibraryService.instance.getTrack(widget.trackId);
+    final tree = res?.tree;
+    if (tree == null) {
+      setState(() => _loading = false);
+      return;
+    }
+    final progress = SkillTreeTrackProgressService();
+    final unlocked = await progress.getUnlockedNodeIds(widget.trackId);
+    final completed = await progress.getCompletedNodeIds(widget.trackId);
+    if (!mounted) return;
+    setState(() {
+      _track = tree;
+      _unlocked = unlocked;
+      _completed = completed;
+      _loading = false;
+    });
+  }
+
+  Future<void> _openNode(SkillTreeNodeModel node) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SkillTreeNodeDetailView(
+          node: node,
+          unlocked: _unlocked.contains(node.id),
+        ),
+      ),
+    );
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    final tree = _track;
+    if (tree == null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(widget.trackId)),
+        body: const Center(child: Text('Track not found')),
+      );
+    }
+    final nodes = tree.nodes.values.toList()
+      ..sort((a, b) => a.level.compareTo(b.level));
+
+    final list = _listBuilder.build(
+      allNodes: nodes,
+      unlockedNodeIds: _unlocked,
+      completedNodeIds: _completed,
+      padding: const EdgeInsets.all(12),
+      spacing: 20,
+      onNodeTap: _openNode,
+    );
+
+    final title = tree.roots.isNotEmpty
+        ? tree.roots.first.title
+        : widget.trackId;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: list,
+    );
+  }
+}

--- a/lib/services/skill_tree_library_service.dart
+++ b/lib/services/skill_tree_library_service.dart
@@ -60,6 +60,11 @@ class SkillTreeLibraryService {
   /// Returns the skill tree for [category], or `null` if not found.
   SkillTreeBuildResult? getTree(String category) => _trees[category];
 
+  /// Returns the skill track for [trackId].
+  ///
+  /// This is an alias for [getTree] to allow referencing tracks by id.
+  SkillTreeBuildResult? getTrack(String trackId) => getTree(trackId);
+
   /// Returns all loaded nodes across categories in insertion order.
   List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
 }

--- a/lib/services/skill_tree_track_progress_service.dart
+++ b/lib/services/skill_tree_track_progress_service.dart
@@ -4,6 +4,7 @@ import 'skill_tree_builder_service.dart';
 import 'skill_tree_library_service.dart';
 import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_final_node_completion_detector.dart';
+import 'skill_tree_unlock_evaluator.dart';
 
 /// Progress information for a single skill tree track.
 class TrackProgressEntry {
@@ -89,6 +90,25 @@ class SkillTreeTrackProgressService {
       }
     }
     return null;
+  }
+
+  /// Returns ids of nodes unlocked in [trackId].
+  Future<Set<String>> getUnlockedNodeIds(String trackId) async {
+    await _ensureLoaded();
+    final tree = library.getTrack(trackId)?.tree;
+    if (tree == null) return <String>{};
+    final evaluator = SkillTreeUnlockEvaluator(progress: progress);
+    final unlocked = evaluator.getUnlockedNodes(tree);
+    return unlocked.map((n) => n.id).toSet();
+  }
+
+  /// Returns ids of completed nodes in [trackId].
+  Future<Set<String>> getCompletedNodeIds(String trackId) async {
+    await _ensureLoaded();
+    final tree = library.getTrack(trackId)?.tree;
+    if (tree == null) return <String>{};
+    final completed = progress.completedNodeIds.value;
+    return completed.where(tree.nodes.containsKey).toSet();
   }
 }
 

--- a/lib/widgets/skill_tree_grid_block_builder.dart
+++ b/lib/widgets/skill_tree_grid_block_builder.dart
@@ -26,6 +26,7 @@ class SkillTreeGridBlockBuilder {
     required List<SkillTreeNodeModel> nodes,
     required Set<String> unlockedNodeIds,
     required Set<String> completedNodeIds,
+    void Function(SkillTreeNodeModel node)? onNodeTap,
     double nodeWidth = 120,
     double nodeHeight = 80,
     double spacing = 16,
@@ -57,6 +58,7 @@ class SkillTreeGridBlockBuilder {
           node: node,
           unlocked: unlockedNodeIds.contains(node.id),
           completed: completedNodeIds.contains(node.id),
+          onTap: onNodeTap == null ? null : () => onNodeTap(node),
         ),
       ));
     }

--- a/lib/widgets/skill_tree_stage_block_builder.dart
+++ b/lib/widgets/skill_tree_stage_block_builder.dart
@@ -25,6 +25,7 @@ class SkillTreeStageBlockBuilder {
     required Set<String> completedNodeIds,
     required bool isStageUnlocked,
     required bool isStageCompleted,
+    void Function(SkillTreeNodeModel node)? onNodeTap,
   }) {
     final header = headerBuilder.buildHeader(
       level: level,
@@ -46,6 +47,7 @@ class SkillTreeStageBlockBuilder {
       nodes: isStageUnlocked ? nodes : const [],
       unlockedNodeIds: unlockedNodeIds,
       completedNodeIds: completedNodeIds,
+      onNodeTap: onNodeTap,
     );
 
     return Column(

--- a/lib/widgets/skill_tree_stage_list_builder.dart
+++ b/lib/widgets/skill_tree_stage_list_builder.dart
@@ -16,6 +16,7 @@ class SkillTreeStageListBuilder {
     required List<SkillTreeNodeModel> allNodes,
     required Set<String> unlockedNodeIds,
     required Set<String> completedNodeIds,
+    void Function(SkillTreeNodeModel node)? onNodeTap,
     EdgeInsetsGeometry padding = const EdgeInsets.all(8),
     double spacing = 16,
   }) {
@@ -41,6 +42,7 @@ class SkillTreeStageListBuilder {
         completedNodeIds: completedNodeIds,
         isStageUnlocked: isUnlocked,
         isStageCompleted: isCompleted,
+        onNodeTap: onNodeTap,
       );
 
       children.add(Padding(


### PR DESCRIPTION
## Summary
- expose `getTrack` in `SkillTreeLibraryService`
- add `getUnlockedNodeIds` and `getCompletedNodeIds` helpers in `SkillTreeTrackProgressService`
- allow node tap handling in skill tree builders
- implement `SkillTreePathScreen` to display a full track path

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3ff8ef48832abe3aca35aeabeaeb