### PR TITLE
Implement SkillTreeTrackIntroScreen

### DIFF
--- a/lib/screens/skill_tree_track_intro_screen.dart
+++ b/lib/screens/skill_tree_track_intro_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../services/skill_tree_library_service.dart';
+import '../services/skill_tree_track_progress_service.dart';
+import 'skill_tree_path_screen.dart';
+
+class SkillTreeTrackIntroScreen extends StatefulWidget {
+  final String trackId;
+  const SkillTreeTrackIntroScreen({super.key, required this.trackId});
+
+  @override
+  State<SkillTreeTrackIntroScreen> createState() => _SkillTreeTrackIntroScreenState();
+}
+
+class _SkillTreeTrackIntroScreenState extends State<SkillTreeTrackIntroScreen> {
+  String _title = '';
+  String _description = '';
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await SkillTreeLibraryService.instance.reload();
+    final res = SkillTreeLibraryService.instance.getTrack(widget.trackId);
+    final tree = res?.tree;
+    if (tree != null && tree.nodes.isNotEmpty) {
+      _title = tree.roots.isNotEmpty
+          ? tree.roots.first.title
+          : tree.nodes.values.first.title;
+    } else {
+      _title = widget.trackId;
+    }
+    // Placeholder description until YAML provides it
+    _description = 'Пройдите этапы, чтобы освоить навык.';
+    if (mounted) {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _start() async {
+    await SkillTreeTrackProgressService().markStarted(widget.trackId);
+    if (!mounted) return;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SkillTreePathScreen(trackId: widget.trackId),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: Text(_title)),
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                'assets/learning_intro.svg',
+                width: 200,
+                height: 200,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                _title,
+                style: const TextStyle(fontSize: 24),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Text(
+                  _description,
+                  style: const TextStyle(color: Colors.white70),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: _start,
+                child: const Text('Начать'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/skill_tree_track_progress_service.dart
+++ b/lib/services/skill_tree_track_progress_service.dart
@@ -5,6 +5,7 @@ import 'skill_tree_library_service.dart';
 import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_final_node_completion_detector.dart';
 import 'skill_tree_unlock_evaluator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Progress information for a single skill tree track.
 class TrackProgressEntry {
@@ -109,6 +110,20 @@ class SkillTreeTrackProgressService {
     if (tree == null) return <String>{};
     final completed = progress.completedNodeIds.value;
     return completed.where(tree.nodes.containsKey).toSet();
+  }
+
+  static String _startedKey(String id) => 'skill_track_started_' + id;
+
+  /// Marks [trackId] as started.
+  Future<void> markStarted(String trackId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_startedKey(trackId), true);
+  }
+
+  /// Whether [trackId] has been started previously.
+  Future<bool> isStarted(String trackId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_startedKey(trackId)) ?? false;
   }
 }
 


### PR DESCRIPTION
## Summary
- add SkillTreeTrackIntroScreen with basic layout and start action
- persist track start flag in SkillTreeTrackProgressService

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688d4392d5f4832a9d589b4faa083527