### PR TITLE
Implement SkillTreeTrackLauncher

### DIFF
--- a/lib/screens/skill_tree_track_launcher.dart
+++ b/lib/screens/skill_tree_track_launcher.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../services/skill_tree_track_progress_service.dart';
+import 'skill_tree_track_intro_screen.dart';
+import 'skill_tree_path_screen.dart';
+
+/// Decides whether to show [SkillTreeTrackIntroScreen] or
+/// [SkillTreePathScreen] based on whether the user has already
+/// started the track.
+class SkillTreeTrackLauncher extends StatelessWidget {
+  final String trackId;
+  const SkillTreeTrackLauncher({super.key, required this.trackId});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: SkillTreeTrackProgressService().isStarted(trackId),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final started = snapshot.data!;
+        return started
+            ? SkillTreePathScreen(trackId: trackId)
+            : SkillTreeTrackIntroScreen(trackId: trackId);
+      },
+    );
+  }
+}

--- a/test/widgets/skill_tree_track_launcher_test.dart
+++ b/test/widgets/skill_tree_track_launcher_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/screens/skill_tree_track_launcher.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('shows intro when track not started', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: SkillTreeTrackLauncher(trackId: 't1'),
+    ));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.pump();
+    // After future completes, should show intro screen widget
+    expect(find.byType(SkillTreeTrackLauncher), findsOneWidget);
+    expect(find.text('Начать'), findsOneWidget);
+  });
+
+  testWidgets('shows path when track started', (tester) async {
+    SharedPreferences.setMockInitialValues({'skill_track_started_t2': true});
+    await tester.pumpWidget(const MaterialApp(
+      home: SkillTreeTrackLauncher(trackId: 't2'),
+    ));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(SkillTreeTrackLauncher), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `SkillTreeTrackLauncher` widget which routes the user to either the intro or path screen
- test the widget's logic

## Testing
- `flutter analyze` *(fails: many issues in repo)*
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688d44fc1508832ab2f397d470e6baa7