### PR TITLE
Add SkillTreeNodeDetailScreen

### DIFF
--- a/lib/screens/skill_tree_learning_map_screen.dart
+++ b/lib/screens/skill_tree_learning_map_screen.dart
@@ -6,7 +6,7 @@ import '../models/skill_tree_node_model.dart';
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_node_progress_tracker.dart';
 import '../services/skill_tree_unlock_evaluator.dart';
-import 'skill_tree_node_detail_view.dart';
+import 'skill_tree_node_detail_screen.dart';
 
 /// Visual map of all nodes in a skill tree track.
 class SkillTreeLearningMapScreen extends StatefulWidget {
@@ -58,7 +58,7 @@ class _SkillTreeLearningMapScreenState
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SkillTreeNodeDetailView(
+        builder: (_) => SkillTreeNodeDetailScreen(
           node: node,
           unlocked: _unlocked.contains(node.id),
         ),

--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/training_session_launcher.dart';
+import '../services/skill_tree_category_banner_service.dart';
+import '../services/skill_tree_node_progress_tracker.dart';
+import '../services/training_progress_service.dart';
+import '../widgets/tag_badge.dart';
+import 'theory_lesson_viewer_screen.dart';
+
+/// Screen showing details for a [SkillTreeNodeModel] before starting it.
+class SkillTreeNodeDetailScreen extends StatefulWidget {
+  final SkillTreeNodeModel node;
+  final bool unlocked;
+
+  const SkillTreeNodeDetailScreen({
+    super.key,
+    required this.node,
+    this.unlocked = true,
+  });
+
+  @override
+  State<SkillTreeNodeDetailScreen> createState() =>
+      _SkillTreeNodeDetailScreenState();
+}
+
+class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
+  TheoryMiniLessonNode? _lesson;
+  double _progress = 0.0;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    if (widget.node.theoryLessonId.isNotEmpty) {
+      await MiniLessonLibraryService.instance.loadAll();
+      _lesson =
+          MiniLessonLibraryService.instance.getById(widget.node.theoryLessonId);
+    }
+    if (widget.node.trainingPackId.isNotEmpty) {
+      _progress = await TrainingProgressService.instance
+          .getProgress(widget.node.trainingPackId);
+    } else {
+      final done =
+          await SkillTreeNodeProgressTracker.instance.isCompleted(widget.node.id);
+      if (done) _progress = 1.0;
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  Future<void> _start() async {
+    if (widget.node.theoryLessonId.isNotEmpty) {
+      final lesson = _lesson;
+      if (lesson == null) return;
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TheoryLessonViewerScreen(
+            lesson: lesson,
+            currentIndex: 1,
+            totalCount: 1,
+          ),
+        ),
+      );
+    } else if (widget.node.trainingPackId.isNotEmpty) {
+      final tpl = await PackLibraryService.instance
+          .getById(widget.node.trainingPackId);
+      if (tpl != null) {
+        await const TrainingSessionLauncher().launch(tpl);
+      }
+    }
+  }
+
+  String _shortDescription(String text, {int max = 160}) {
+    final clean = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (clean.length <= max) return clean;
+    return '${clean.substring(0, max)}…';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visual =
+        const SkillTreeCategoryBannerService().getVisual(widget.node.category);
+    final accent = visual.color;
+    final pct = (_progress.clamp(0.0, 1.0) * 100).round();
+
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.node.title)),
+      backgroundColor: const Color(0xFF121212),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(visual.emoji, style: const TextStyle(fontSize: 32)),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            widget.node.title,
+                            style: const TextStyle(
+                                fontSize: 20, fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (_lesson != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        _lesson!.resolvedTitle,
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold),
+                      ),
+                      if (_lesson!.tags.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Wrap(
+                            spacing: 4,
+                            runSpacing: -4,
+                            children: [
+                              for (final t in _lesson!.tags.take(3)) TagBadge(t)
+                            ],
+                          ),
+                        ),
+                      if (_lesson!.resolvedContent.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: Text(
+                            _shortDescription(_lesson!.resolvedContent),
+                            style: const TextStyle(color: Colors.white70),
+                          ),
+                        ),
+                    ],
+                    const SizedBox(height: 16),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: _progress.clamp(0.0, 1.0),
+                        backgroundColor: Colors.white24,
+                        valueColor: AlwaysStoppedAnimation<Color>(accent),
+                        minHeight: 6,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text('$pct%',
+                        style:
+                            const TextStyle(color: Colors.white70, fontSize: 12)),
+                    const Spacer(),
+                    Tooltip(
+                      message:
+                          widget.unlocked ? '' : 'Этап ещё не разблокирован',
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: widget.unlocked ? _start : null,
+                          style: ElevatedButton.styleFrom(backgroundColor: accent),
+                          child: const Text('Начать'),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -5,7 +5,7 @@ import '../models/skill_tree_node_model.dart';
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_progress_service.dart';
 import '../widgets/skill_tree_stage_list_builder.dart';
-import 'skill_tree_node_detail_view.dart';
+import 'skill_tree_node_detail_screen.dart';
 
 /// Renders the full learning path for a skill track.
 class SkillTreePathScreen extends StatefulWidget {
@@ -54,7 +54,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SkillTreeNodeDetailView(
+        builder: (_) => SkillTreeNodeDetailScreen(
           node: node,
           unlocked: _unlocked.contains(node.id),
         ),

--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -9,7 +9,7 @@ import '../services/skill_tree_stage_gate_evaluator.dart';
 import '../services/skill_tree_stage_completion_evaluator.dart';
 import '../services/skill_tree_stage_unlock_overlay_builder.dart';
 import '../widgets/skill_tree_stage_header_builder.dart';
-import '../screens/skill_tree_node_detail_view.dart';
+import '../screens/skill_tree_node_detail_screen.dart';
 
 class SkillTreeScreen extends StatefulWidget {
   final String category;
@@ -71,7 +71,7 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SkillTreeNodeDetailView(node: node),
+        builder: (_) => SkillTreeNodeDetailScreen(node: node),
       ),
     );
     await _load();


### PR DESCRIPTION
## Summary
- add screen to show detailed info for skill tree nodes
- use new screen from skill tree map and list views

## Testing
- `apt-get install -y dart-sdk` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688d4ee48eb0832aaaaef184c744be85