### PR TITLE
Add track completion celebration dialog

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -4,6 +4,7 @@ import '../models/skill_tree.dart';
 import '../models/skill_tree_node_model.dart';
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_progress_service.dart';
+import '../services/track_completion_celebration_service.dart';
 import '../widgets/skill_tree_stage_list_builder.dart';
 import 'skill_tree_node_detail_screen.dart';
 
@@ -47,6 +48,10 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
       _unlocked = unlocked;
       _completed = completed;
       _loading = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      TrackCompletionCelebrationService.instance
+          .maybeCelebrate(context, widget.trackId);
     });
   }
 

--- a/lib/services/track_completion_celebration_service.dart
+++ b/lib/services/track_completion_celebration_service.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'skill_tree_track_completion_evaluator.dart';
+import 'skill_tree_track_progress_service.dart';
+import '../widgets/track_celebration_dialog.dart';
+import '../screens/skill_tree_track_launcher.dart';
+
+/// Detects when a skill tree track is completed for the first time and
+/// shows a celebration dialog with an option to open the next track.
+class TrackCompletionCelebrationService {
+  final SkillTreeTrackCompletionEvaluator evaluator;
+  final SkillTreeTrackProgressService progress;
+
+  TrackCompletionCelebrationService({
+    SkillTreeTrackCompletionEvaluator? evaluator,
+    SkillTreeTrackProgressService? progress,
+  })  : evaluator = evaluator ?? SkillTreeTrackCompletionEvaluator(),
+        progress = progress ?? SkillTreeTrackProgressService();
+
+  static final instance = TrackCompletionCelebrationService();
+
+  static const _prefsKey = 'celebrated_track_ids';
+
+  /// Checks completion of [trackId] and displays celebration once.
+  Future<void> maybeCelebrate(BuildContext context, String trackId) async {
+    if (!await evaluator.isCompleted(trackId)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final celebrated = prefs.getStringList(_prefsKey) ?? <String>[];
+    if (celebrated.contains(trackId)) return;
+
+    celebrated.add(trackId);
+    await prefs.setStringList(_prefsKey, celebrated);
+
+    final next = await progress.getNextTrack();
+    final nextId = next?.tree.nodes.values.isNotEmpty == true
+        ? next!.tree.nodes.values.first.category
+        : null;
+
+    await showTrackCelebrationDialog(
+      context,
+      trackId,
+      onNext: nextId == null
+          ? null
+          : () {
+              Navigator.pop(context);
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SkillTreeTrackLauncher(trackId: nextId),
+                ),
+              );
+            },
+    );
+  }
+}

--- a/lib/widgets/track_celebration_dialog.dart
+++ b/lib/widgets/track_celebration_dialog.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'confetti_overlay.dart';
+
+/// Simple dialog displayed when a skill track is completed.
+class TrackCelebrationDialog extends StatelessWidget {
+  final String trackId;
+  final VoidCallback? onNext;
+  const TrackCelebrationDialog({super.key, required this.trackId, this.onNext});
+
+  @override
+  Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+    return AlertDialog(
+      backgroundColor: Colors.grey[900],
+      title: const Text('🎉 Трек завершён!',
+          style: TextStyle(color: Colors.white)),
+      content: Text(
+        trackId,
+        style: const TextStyle(color: Colors.white70),
+      ),
+      actions: [
+        if (onNext != null)
+          TextButton(
+            onPressed: onNext,
+            child: const Text('Открыть следующий трек'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showTrackCelebrationDialog(BuildContext context, String trackId,
+    {VoidCallback? onNext}) {
+  return showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => TrackCelebrationDialog(trackId: trackId, onNext: onNext),
+  );
+}


### PR DESCRIPTION
## Summary
- implement `TrackCompletionCelebrationService` to show a celebration when a skill tree track is finished for the first time
- create `TrackCelebrationDialog` with confetti and action to open the next track
- trigger this celebration when loading a track in `SkillTreePathScreen`

## Testing
- `flutter analyze` *(fails: Flutter SDK 0.0.0-unknown; requires 3.32.8)*

------
https://chatgpt.com/codex/tasks/task_e_688d54a29cec832a8d23638a7d79a8f4