### PR TITLE
Add lock reason service

### DIFF
--- a/lib/services/skill_tree_node_lock_reason_service.dart
+++ b/lib/services/skill_tree_node_lock_reason_service.dart
@@ -1,0 +1,57 @@
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_library_service.dart';
+import 'skill_tree_node_progress_tracker.dart';
+import 'skill_tree_stage_gate_evaluator.dart';
+import 'skill_tree_unlock_evaluator.dart';
+
+/// Provides explanations for why a skill tree node is locked.
+class SkillTreeNodeLockReasonService {
+  final SkillTreeLibraryService _library;
+  final SkillTreeNodeProgressTracker _progress;
+  final SkillTreeStageGateEvaluator _stageEval;
+  final SkillTreeUnlockEvaluator _unlockEval;
+
+  SkillTreeNodeLockReasonService({
+    SkillTreeLibraryService? library,
+    SkillTreeNodeProgressTracker? progress,
+    SkillTreeStageGateEvaluator? stageEvaluator,
+    SkillTreeUnlockEvaluator? unlockEvaluator,
+  })  : _library = library ?? SkillTreeLibraryService.instance,
+        _progress = progress ?? SkillTreeNodeProgressTracker.instance,
+        _stageEval = stageEvaluator ?? const SkillTreeStageGateEvaluator(),
+        _unlockEval =
+            unlockEvaluator ?? SkillTreeUnlockEvaluator(progress: progress ?? SkillTreeNodeProgressTracker.instance);
+
+  Future<String?> getLockReason(SkillTreeNodeModel node) async {
+    final res = _library.getTree(node.category);
+    final tree = res?.tree;
+    if (tree == null) return null;
+
+    await _progress.isCompleted('');
+    final completed = _progress.completedNodeIds.value;
+
+    final unlockedIds =
+        _unlockEval.getUnlockedNodes(tree).map((n) => n.id).toSet();
+    if (unlockedIds.contains(node.id)) return null;
+
+    if (!_stageEval.isStageUnlocked(tree, node.level, completed)) {
+      final blockers =
+          _stageEval.getBlockingNodes(tree, node.level, completed);
+      if (blockers.isNotEmpty) {
+        blockers.sort((a, b) => b.level.compareTo(a.level));
+        final b = blockers.first;
+        return 'Завершите этап ${b.level}: ${b.title}';
+      }
+      return 'Завершите предыдущие этапы';
+    }
+
+    for (final id in node.prerequisites) {
+      if (!completed.contains(id)) {
+        final b = tree.nodes[id];
+        final title = b?.title ?? id;
+        return 'Завершите узел: $title';
+      }
+    }
+    return null;
+  }
+}

--- a/lib/services/skill_tree_stage_gate_evaluator.dart
+++ b/lib/services/skill_tree_stage_gate_evaluator.dart
@@ -1,4 +1,5 @@
 import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
 import 'skill_tree_stage_completion_evaluator.dart';
 
 /// Determines whether skill tree stages (levels) are unlocked.
@@ -43,5 +44,24 @@ class SkillTreeStageGateEvaluator {
       }
     }
     return unlocked;
+  }
+
+  /// Returns nodes from earlier stages that block unlocking of [level].
+  List<SkillTreeNodeModel> getBlockingNodes(
+    SkillTree tree,
+    int level,
+    Set<String> completedNodeIds,
+  ) {
+    final blocking = <SkillTreeNodeModel>[];
+    for (final node in tree.nodes.values) {
+      if (node.level >= level) continue;
+      final opt = (node as dynamic).isOptional == true;
+      if (opt) continue;
+      if (!completedNodeIds.contains(node.id)) {
+        blocking.add(node);
+      }
+    }
+    blocking.sort((a, b) => a.level.compareTo(b.level));
+    return blocking;
   }
 }

--- a/test/services/skill_tree_node_lock_reason_service_test.dart
+++ b/test/services/skill_tree_node_lock_reason_service_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_lock_reason_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/skill_tree_stage_gate_evaluator.dart';
+import 'package:poker_analyzer/services/skill_tree_unlock_evaluator.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  final SkillTreeBuildResult result;
+  _FakeLibraryService(this.result);
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => result;
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => result.tree.nodes.values.toList();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id,
+          {List<String>? prereqs, int level = 0}) =>
+      SkillTreeNodeModel(
+          id: id,
+          title: id,
+          category: 'Push/Fold',
+          prerequisites: prereqs,
+          level: level);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns null when node is unlocked', () async {
+    final nodes = [node('n1'), node('n2', prereqs: ['n1'])];
+    final tree = builder.build(nodes).tree;
+    final lib = _FakeLibraryService(SkillTreeBuildResult(tree: tree));
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    await tracker.markCompleted('n1');
+    final svc = SkillTreeNodeLockReasonService(
+      library: lib,
+      progress: tracker,
+      stageEvaluator: const SkillTreeStageGateEvaluator(),
+      unlockEvaluator: SkillTreeUnlockEvaluator(progress: tracker),
+    );
+    final reason = await svc.getLockReason(nodes[1]);
+    expect(reason, isNull);
+  });
+
+  test('reports missing prerequisite node', () async {
+    final nodes = [node('n1'), node('n2', prereqs: ['n1'])];
+    final tree = builder.build(nodes).tree;
+    final lib = _FakeLibraryService(SkillTreeBuildResult(tree: tree));
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    final svc = SkillTreeNodeLockReasonService(
+      library: lib,
+      progress: tracker,
+      stageEvaluator: const SkillTreeStageGateEvaluator(),
+      unlockEvaluator: SkillTreeUnlockEvaluator(progress: tracker),
+    );
+    final reason = await svc.getLockReason(nodes[1]);
+    expect(reason, startsWith('Завершите узел'));
+  });
+
+  test('reports locked stage', () async {
+    final nodes = [
+      node('n1', level: 0),
+      node('n2', level: 1),
+      node('n3', level: 2),
+    ];
+    final tree = builder.build(nodes).tree;
+    final lib = _FakeLibraryService(SkillTreeBuildResult(tree: tree));
+    final tracker = SkillTreeNodeProgressTracker.instance;
+    await tracker.resetForTest();
+    await tracker.markCompleted('n1');
+    final svc = SkillTreeNodeLockReasonService(
+      library: lib,
+      progress: tracker,
+      stageEvaluator: const SkillTreeStageGateEvaluator(),
+      unlockEvaluator: SkillTreeUnlockEvaluator(progress: tracker),
+    );
+    final reason = await svc.getLockReason(nodes[2]);
+    expect(reason, startsWith('Завершите этап'));
+  });
+}

--- a/test/services/skill_tree_stage_gate_evaluator_test.dart
+++ b/test/services/skill_tree_stage_gate_evaluator_test.dart
@@ -39,4 +39,15 @@ void main() {
     final completed = {'n1', 'n2', 'n3'};
     expect(evaluator.isStageUnlocked(tree, 2, completed), isTrue);
   });
+
+  test('getBlockingNodes returns incomplete prior stage nodes', () {
+    final tree = builder.build([
+      node('n1', 0),
+      node('n2', 1),
+      node('n3', 2),
+    ]).tree;
+    final completed = {'n1'};
+    final blocking = evaluator.getBlockingNodes(tree, 2, completed);
+    expect(blocking.map((n) => n.id), ['n2']);
+  });
 }


### PR DESCRIPTION
## Summary
- expose blocking nodes from `SkillTreeStageGateEvaluator`
- add `SkillTreeNodeLockReasonService` to explain locked nodes
- test new helper and service

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d56fc234c832a9a053ae88ffcb44e