### PR TITLE
Add skill tree track celebration service

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -4,7 +4,7 @@ import '../models/skill_tree.dart';
 import '../models/skill_tree_node_model.dart';
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_progress_service.dart';
-import '../services/track_completion_celebration_service.dart';
+import '../services/skill_tree_track_celebration_service.dart';
 import '../widgets/skill_tree_stage_list_builder.dart';
 import '../widgets/skill_tree_progress_header.dart';
 import 'skill_tree_node_detail_screen.dart';
@@ -51,7 +51,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
       _loading = false;
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      TrackCompletionCelebrationService.instance
+      SkillTreeTrackCelebrationService.instance
           .maybeCelebrate(context, widget.trackId);
     });
   }

--- a/lib/screens/skill_tree_track_celebration_screen.dart
+++ b/lib/screens/skill_tree_track_celebration_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+
+import '../widgets/confetti_overlay.dart';
+
+/// Fullscreen celebration shown when a skill tree track is completed.
+class SkillTreeTrackCelebrationScreen extends StatefulWidget {
+  final String trackId;
+  final VoidCallback? onNext;
+  const SkillTreeTrackCelebrationScreen({
+    super.key,
+    required this.trackId,
+    this.onNext,
+  });
+
+  @override
+  State<SkillTreeTrackCelebrationScreen> createState() =>
+      _SkillTreeTrackCelebrationScreenState();
+}
+
+class _SkillTreeTrackCelebrationScreenState
+    extends State<SkillTreeTrackCelebrationScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  void _finish() {
+    if (widget.onNext != null) {
+      widget.onNext!();
+    } else {
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Center(
+          child: FadeTransition(
+            opacity: CurvedAnimation(parent: _anim, curve: Curves.easeIn),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ScaleTransition(
+                  scale: CurvedAnimation(parent: _anim, curve: Curves.elasticOut),
+                  child: Lottie.asset(
+                    'assets/animations/congrats.json',
+                    width: 160,
+                    repeat: false,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                const Text(
+                  'Трек завершён!',
+                  style: TextStyle(fontSize: 28),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  widget.trackId,
+                  style: const TextStyle(fontSize: 20),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                ElevatedButton(
+                  onPressed: _finish,
+                  child: Text(widget.onNext == null ? 'Готово' : 'Следующий трек'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/skill_tree_track_celebration_service.dart
+++ b/lib/services/skill_tree_track_celebration_service.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../screens/skill_tree_track_celebration_screen.dart';
+import '../screens/skill_tree_track_launcher.dart';
+import 'skill_tree_track_completion_evaluator.dart';
+import 'skill_tree_track_progress_service.dart';
+
+/// Triggers a celebratory screen when a skill tree track is completed.
+class SkillTreeTrackCelebrationService {
+  final SkillTreeTrackCompletionEvaluator evaluator;
+  final SkillTreeTrackProgressService progress;
+
+  SkillTreeTrackCelebrationService({
+    SkillTreeTrackCompletionEvaluator? evaluator,
+    SkillTreeTrackProgressService? progress,
+  })  : evaluator = evaluator ?? SkillTreeTrackCompletionEvaluator(),
+        progress = progress ?? SkillTreeTrackProgressService();
+
+  /// Singleton instance.
+  static final instance = SkillTreeTrackCelebrationService();
+
+  static const _prefsKey = 'skill_tree_track_celebrations';
+
+  /// Checks completion of [trackId] and shows celebration once.
+  Future<void> maybeCelebrate(BuildContext context, String trackId) async {
+    if (!await evaluator.isCompleted(trackId)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final done = prefs.getStringList(_prefsKey) ?? <String>[];
+    if (done.contains(trackId)) return;
+
+    done.add(trackId);
+    await prefs.setStringList(_prefsKey, done);
+
+    final next = await progress.getNextTrack();
+    final nextId = next?.tree.nodes.values.isNotEmpty == true
+        ? next!.tree.nodes.values.first.category
+        : null;
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => SkillTreeTrackCelebrationScreen(
+          trackId: trackId,
+          onNext: nextId == null
+              ? null
+              : () {
+                  Navigator.pop(context);
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SkillTreeTrackLauncher(trackId: nextId),
+                    ),
+                  );
+                },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeTrackCelebrationScreen` with confetti animation
- implement `SkillTreeTrackCelebrationService` to show the screen once per track
- trigger the new celebration service from `SkillTreePathScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5b24edfc832a974a07384e0b428c