### PR TITLE
Implement skill tree unlock notifications

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -8,6 +8,7 @@ import '../services/skill_tree_unlock_evaluator.dart';
 import '../services/skill_tree_stage_gate_evaluator.dart';
 import '../services/skill_tree_stage_completion_evaluator.dart';
 import '../services/skill_tree_stage_unlock_overlay_builder.dart';
+import '../services/skill_tree_unlock_notification_service.dart';
 import '../widgets/skill_tree_stage_header_builder.dart';
 import '../screens/skill_tree_node_detail_screen.dart';
 
@@ -28,6 +29,7 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
   bool _loading = true;
   final _overlayBuilder = const SkillTreeStageUnlockOverlayBuilder();
   final _headerBuilder = const SkillTreeStageHeaderBuilder();
+  final _unlockNotify = SkillTreeUnlockNotificationService();
 
   @override
   void initState() {
@@ -64,6 +66,9 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
       _completedStages = completedStages;
       _loading = false;
     });
+    if (mounted) {
+      await _unlockNotify.maybeNotify(context, tree);
+    }
   }
 
   Future<void> _openNode(SkillTreeNodeModel node) async {

--- a/lib/services/skill_tree_unlock_notification_service.dart
+++ b/lib/services/skill_tree_unlock_notification_service.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/skill_tree.dart';
+import 'skill_tree_unlock_evaluator.dart';
+import 'skill_tree_stage_gate_evaluator.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Shows a toast when new skill tree nodes or stages become unlocked.
+class SkillTreeUnlockNotificationService {
+  final SkillTreeNodeProgressTracker progress;
+
+  SkillTreeUnlockNotificationService({SkillTreeNodeProgressTracker? progress})
+      : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  static String _nodeKey(String id) => 'skill_tree_unlocked_nodes_' + id;
+  static String _stageKey(String id) => 'skill_tree_unlocked_stages_' + id;
+
+  /// Checks [tree] for newly unlocked nodes or stages and shows notifications.
+  Future<void> maybeNotify(BuildContext context, SkillTree tree) async {
+    final trackId = tree.nodes.values.isNotEmpty
+        ? tree.nodes.values.first.category
+        : '';
+    if (trackId.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+
+    await progress.isCompleted('');
+    final completed = progress.completedNodeIds.value;
+
+    final evaluator = SkillTreeUnlockEvaluator(progress: progress);
+    final unlockedNodes =
+        evaluator.getUnlockedNodes(tree).map((n) => n.id).toSet();
+    final prevNodes = prefs.getStringList(_nodeKey(trackId))?.toSet() ?? <String>{};
+    final newNodes = unlockedNodes.difference(prevNodes);
+
+    const gateEval = SkillTreeStageGateEvaluator();
+    final unlockedStages = gateEval.getUnlockedStages(tree, completed).toSet();
+    final prevStages = prefs
+            .getStringList(_stageKey(trackId))
+            ?.map(int.parse)
+            .toSet() ??
+        <int>{};
+    final newStages = unlockedStages.difference(prevStages);
+
+    for (final level in newStages) {
+      if (!context.mounted) break;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Открыт новый этап: $level')),
+      );
+    }
+
+    for (final id in newNodes) {
+      if (!context.mounted) break;
+      final title = tree.nodes[id]?.title ?? id;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Открыт новый узел: $title')),
+      );
+    }
+
+    await prefs.setStringList(_nodeKey(trackId), unlockedNodes.toList());
+    await prefs.setStringList(
+      _stageKey(trackId),
+      unlockedStages.map((e) => e.toString()).toList(),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `SkillTreeUnlockNotificationService` to show toast when stages or nodes unlock
- trigger notifications after loading skill tree screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5c60ddc0832ab64f36b9386aec77