### PR TITLE
Add skill tree completion badges

### DIFF
--- a/lib/models/skill_tree_completion_badge.dart
+++ b/lib/models/skill_tree_completion_badge.dart
@@ -1,0 +1,11 @@
+class SkillTreeCompletionBadge {
+  final String trackId;
+  final double percentComplete;
+  final bool isComplete;
+
+  const SkillTreeCompletionBadge({
+    required this.trackId,
+    required this.percentComplete,
+    required this.isComplete,
+  });
+}

--- a/lib/screens/skill_tree_track_list_screen.dart
+++ b/lib/screens/skill_tree_track_list_screen.dart
@@ -2,26 +2,38 @@ import 'package:flutter/material.dart';
 
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_state_evaluator.dart';
+import '../services/skill_tree_completion_badge_service.dart';
+import '../models/skill_tree_completion_badge.dart';
 import 'skill_tree_track_launcher.dart';
+
+class _Entry {
+  final TrackStateEntry state;
+  final SkillTreeCompletionBadge badge;
+
+  const _Entry({required this.state, required this.badge});
+}
 
 /// Displays all skill tree tracks with their status and progress.
 class SkillTreeTrackListScreen extends StatefulWidget {
   static const route = '/skill-tree/tracks';
   final SkillTreeTrackStateEvaluator evaluator;
+  final SkillTreeCompletionBadgeService badgeService;
   final bool reloadLibrary;
 
   const SkillTreeTrackListScreen({
     super.key,
     SkillTreeTrackStateEvaluator? evaluator,
+    SkillTreeCompletionBadgeService? badgeService,
     this.reloadLibrary = true,
-  }) : evaluator = evaluator ?? SkillTreeTrackStateEvaluator();
+  })  : evaluator = evaluator ?? SkillTreeTrackStateEvaluator(),
+        badgeService = badgeService ?? const SkillTreeCompletionBadgeService();
 
   @override
   State<SkillTreeTrackListScreen> createState() => _SkillTreeTrackListScreenState();
 }
 
 class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
-  late Future<List<TrackStateEntry>> _future;
+  late Future<List<_Entry>> _future;
 
   @override
   void initState() {
@@ -29,7 +41,7 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
     _future = _load();
   }
 
-  Future<List<TrackStateEntry>> _load() async {
+  Future<List<_Entry>> _load() async {
     if (widget.reloadLibrary) {
       await SkillTreeLibraryService.instance.reload();
     }
@@ -54,7 +66,20 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
       final catB = b.progress.tree.nodes.values.first.category;
       return catA.compareTo(catB);
     });
-    return states;
+    final badges = await widget.badgeService.getBadges();
+    final badgeMap = {for (final b in badges) b.trackId: b};
+    return [
+      for (final s in states)
+        _Entry(
+          state: s,
+          badge: badgeMap[s.progress.tree.nodes.values.first.category] ??
+              SkillTreeCompletionBadge(
+                trackId: s.progress.tree.nodes.values.first.category,
+                percentComplete: s.progress.completionRate,
+                isComplete: s.progress.isCompleted,
+              ),
+        )
+    ];
   }
 
   void _open(String trackId) {
@@ -68,7 +93,7 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<TrackStateEntry>>(
+    return FutureBuilder<List<_Entry>>(
       future: _future,
       builder: (context, snapshot) {
         final list = snapshot.data ?? [];
@@ -90,14 +115,14 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
             separatorBuilder: (_, __) => const Divider(height: 1),
             itemBuilder: (context, index) {
               final entry = list[index];
-              final tree = entry.progress.tree;
+              final tree = entry.state.progress.tree;
               final trackId = tree.nodes.values.first.category;
               final title = tree.roots.isNotEmpty
                   ? tree.roots.first.title
                   : tree.nodes.values.first.title;
-              final pct = (entry.progress.completionRate * 100).round();
+              final pct = (entry.badge.percentComplete * 100).round();
               Widget trailing;
-              switch (entry.state) {
+              switch (entry.state.state) {
                 case SkillTreeTrackState.locked:
                   trailing = const Icon(Icons.lock);
                   break;
@@ -121,11 +146,25 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
                   break;
               }
 
+              final subtitle = entry.badge.isComplete
+                  ? const Text('✅ Completed')
+                  : Row(
+                      children: [
+                        Expanded(
+                          child: LinearProgressIndicator(
+                            value: entry.badge.percentComplete.clamp(0.0, 1.0),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text('$pct%'),
+                      ],
+                    );
+
               return ListTile(
                 title: Text(title),
-                subtitle: Text('$pct%'),
+                subtitle: subtitle,
                 trailing: trailing,
-                onTap: entry.state == SkillTreeTrackState.locked
+                onTap: entry.state.state == SkillTreeTrackState.locked
                     ? null
                     : () => _open(trackId),
               );

--- a/lib/services/skill_tree_completion_badge_service.dart
+++ b/lib/services/skill_tree_completion_badge_service.dart
@@ -1,0 +1,41 @@
+import '../models/skill_tree_completion_badge.dart';
+import 'skill_tree_library_service.dart';
+import 'skill_tree_track_progress_service.dart';
+
+/// Provides completion badge data for skill tree tracks.
+class SkillTreeCompletionBadgeService {
+  final SkillTreeTrackProgressService progressService;
+  final SkillTreeLibraryService libraryService;
+
+  const SkillTreeCompletionBadgeService({
+    SkillTreeTrackProgressService? progressService,
+    SkillTreeLibraryService? libraryService,
+  })  : progressService = progressService ?? SkillTreeTrackProgressService(),
+        libraryService = libraryService ?? SkillTreeLibraryService.instance;
+
+  /// Returns completion badges for all skill tree tracks.
+  Future<List<SkillTreeCompletionBadge>> getBadges() async {
+    if (libraryService.getAllTracks().isEmpty) {
+      await libraryService.reload();
+    }
+    final tracks = libraryService.getAllTracks();
+    final result = <SkillTreeCompletionBadge>[];
+    for (final t in tracks) {
+      final trackId = t.tree.nodes.values.first.category;
+      final nodes = t.tree.nodes.values
+          .where((n) => (n as dynamic).isOptional != true)
+          .toList();
+      final completed = await progressService.getCompletedNodeIds(trackId);
+      final done = completed.length;
+      final total = nodes.length;
+      final percent = total > 0 ? done / total : 0.0;
+      final complete = done >= total && total > 0;
+      result.add(SkillTreeCompletionBadge(
+        trackId: trackId,
+        percentComplete: percent,
+        isComplete: complete,
+      ));
+    }
+    return result;
+  }
+}

--- a/test/widgets/skill_tree_track_list_screen_test.dart
+++ b/test/widgets/skill_tree_track_list_screen_test.dart
@@ -5,6 +5,8 @@ import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
 import 'package:poker_analyzer/services/skill_tree_track_progress_service.dart';
 import 'package:poker_analyzer/services/skill_tree_track_state_evaluator.dart';
 import 'package:poker_analyzer/screens/skill_tree_track_list_screen.dart';
+import 'package:poker_analyzer/models/skill_tree_completion_badge.dart';
+import 'package:poker_analyzer/services/skill_tree_completion_badge_service.dart';
 
 class _FakeEvaluator extends SkillTreeTrackStateEvaluator {
   final List<TrackStateEntry> entries;
@@ -12,6 +14,14 @@ class _FakeEvaluator extends SkillTreeTrackStateEvaluator {
 
   @override
   Future<List<TrackStateEntry>> evaluateStates() async => entries;
+}
+
+class _FakeBadgeService extends SkillTreeCompletionBadgeService {
+  final Map<String, SkillTreeCompletionBadge> map;
+  const _FakeBadgeService(this.map) : super();
+
+  @override
+  Future<List<SkillTreeCompletionBadge>> getBadges() async => map.values.toList();
 }
 
 void main() {
@@ -46,9 +56,17 @@ void main() {
       ),
     ];
 
+    final badgeMap = {
+      'A': const SkillTreeCompletionBadge(trackId: 'A', percentComplete: 1.0, isComplete: true),
+      'B': const SkillTreeCompletionBadge(trackId: 'B', percentComplete: 0.0, isComplete: false),
+      'C': const SkillTreeCompletionBadge(trackId: 'C', percentComplete: 0.0, isComplete: false),
+      'D': const SkillTreeCompletionBadge(trackId: 'D', percentComplete: 0.3, isComplete: false),
+    };
+
     await tester.pumpWidget(MaterialApp(
       home: SkillTreeTrackListScreen(
         evaluator: _FakeEvaluator(entries),
+        badgeService: _FakeBadgeService(badgeMap),
         reloadLibrary: false,
       ),
     ));


### PR DESCRIPTION
## Summary
- implement `SkillTreeCompletionBadgeService` to calculate percent complete per skill track
- display progress badges in `SkillTreeTrackListScreen`
- inject badge service for testing and add fake badge service in tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5dab5fc8832abf25906ef85e2b53