### PR TITLE
Add track completion celebrator

### DIFF
--- a/lib/screens/skill_tree_track_list_screen.dart
+++ b/lib/screens/skill_tree_track_list_screen.dart
@@ -5,6 +5,7 @@ import '../services/skill_tree_track_state_evaluator.dart';
 import '../services/skill_tree_completion_badge_service.dart';
 import '../models/skill_tree_completion_badge.dart';
 import 'skill_tree_track_launcher.dart';
+import '../services/skill_tree_track_completion_celebrator.dart';
 
 class _Entry {
   final TrackStateEntry state;
@@ -82,12 +83,18 @@ class _SkillTreeTrackListScreenState extends State<SkillTreeTrackListScreen> {
     ];
   }
 
-  void _open(String trackId) {
-    Navigator.push(
+  Future<void> _open(String trackId) async {
+    await Navigator.push(
       context,
       MaterialPageRoute(
         builder: (_) => SkillTreeTrackLauncher(trackId: trackId),
       ),
+    );
+    if (!mounted) return;
+    setState(() => _future = _load());
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => SkillTreeTrackCompletionCelebrator.instance
+          .maybeCelebrate(context, trackId),
     );
   }
 

--- a/lib/services/skill_tree_track_completion_celebrator.dart
+++ b/lib/services/skill_tree_track_completion_celebrator.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'skill_tree_track_completion_evaluator.dart';
+import '../screens/skill_tree_track_celebration_screen.dart';
+
+/// Shows a celebration when a skill tree track is fully completed.
+class SkillTreeTrackCompletionCelebrator {
+  final SkillTreeTrackCompletionEvaluator evaluator;
+
+  SkillTreeTrackCompletionCelebrator({
+    SkillTreeTrackCompletionEvaluator? evaluator,
+  }) : evaluator = evaluator ?? SkillTreeTrackCompletionEvaluator();
+
+  static const _prefsKey = 'shown_track_celebrations';
+
+  /// Singleton instance.
+  static final instance = SkillTreeTrackCompletionCelebrator();
+
+  /// Checks [trackId] completion and shows celebration once.
+  Future<void> maybeCelebrate(BuildContext context, String trackId) async {
+    if (!await evaluator.isCompleted(trackId)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final shown = prefs.getStringList(_prefsKey) ?? <String>[];
+    if (shown.contains(trackId)) return;
+
+    shown.add(trackId);
+    await prefs.setStringList(_prefsKey, shown);
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => SkillTreeTrackCelebrationScreen(trackId: trackId),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- celebrate skill tree track completion with a new `SkillTreeTrackCompletionCelebrator`
- launch the celebrator when returning from a track in the track list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5fa89af4832aaf734d57fbaa3c56