### PR TITLE
Add skill tree node completion celebration

### DIFF
--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -8,6 +8,7 @@ import '../services/training_session_launcher.dart';
 import '../services/skill_tree_category_banner_service.dart';
 import '../services/skill_tree_node_progress_tracker.dart';
 import '../services/training_progress_service.dart';
+import '../services/skill_tree_node_celebration_service.dart';
 import '../widgets/tag_badge.dart';
 import 'theory_lesson_viewer_screen.dart';
 
@@ -56,6 +57,7 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
   }
 
   Future<void> _start() async {
+    final wasComplete = _progress >= 1.0;
     if (widget.node.theoryLessonId.isNotEmpty) {
       final lesson = _lesson;
       if (lesson == null) return;
@@ -75,6 +77,11 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
       if (tpl != null) {
         await const TrainingSessionLauncher().launch(tpl);
       }
+    }
+    await _load();
+    if (mounted && !wasComplete && _progress >= 1.0) {
+      await SkillTreeNodeCelebrationService()
+          .maybeCelebrate(context, widget.node.id);
     }
   }
 

--- a/lib/services/skill_tree_node_celebration_service.dart
+++ b/lib/services/skill_tree_node_celebration_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../widgets/skill_tree_node_celebration_overlay.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Handles showing a celebration overlay when a skill tree node is completed.
+class SkillTreeNodeCelebrationService {
+  final SkillTreeNodeProgressTracker progress;
+  final void Function(BuildContext context)? showOverlay;
+
+  SkillTreeNodeCelebrationService({
+    SkillTreeNodeProgressTracker? progress,
+    this.showOverlay,
+  }) : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  static const _prefsPrefix = 'skill_node_celebrated_';
+
+  /// Checks completion of [nodeId] and displays celebration once.
+  Future<void> maybeCelebrate(BuildContext context, String nodeId) async {
+    if (!await progress.isCompleted(nodeId)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_prefsPrefix$nodeId';
+    if (prefs.getBool(key) ?? false) return;
+    await prefs.setBool(key, true);
+    final fn = showOverlay ?? showSkillTreeNodeCelebrationOverlay;
+    fn(context);
+  }
+}

--- a/lib/widgets/skill_tree_node_celebration_overlay.dart
+++ b/lib/widgets/skill_tree_node_celebration_overlay.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'confetti_overlay.dart';
+
+/// Brief overlay celebrating completion of a skill tree node.
+class SkillTreeNodeCelebrationOverlay extends StatefulWidget {
+  final VoidCallback onClose;
+  const SkillTreeNodeCelebrationOverlay({super.key, required this.onClose});
+
+  @override
+  State<SkillTreeNodeCelebrationOverlay> createState() =>
+      _SkillTreeNodeCelebrationOverlayState();
+}
+
+class _SkillTreeNodeCelebrationOverlayState
+    extends State<SkillTreeNodeCelebrationOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+    Future.delayed(const Duration(milliseconds: 1500), widget.onClose);
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: FadeTransition(
+        opacity: CurvedAnimation(parent: _anim, curve: Curves.easeInOut),
+        child: const Center(
+          child: Text('🎯', style: TextStyle(fontSize: 72)),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows [SkillTreeNodeCelebrationOverlay] above the current screen.
+void showSkillTreeNodeCelebrationOverlay(BuildContext context) {
+  final overlay = Overlay.of(context);
+  if (overlay == null) return;
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => SkillTreeNodeCelebrationOverlay(onClose: () {
+      entry.remove();
+    }),
+  );
+  overlay.insert(entry);
+}

--- a/test/services/skill_tree_node_celebration_service_test.dart
+++ b/test/services/skill_tree_node_celebration_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/skill_tree_node_celebration_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+class _FakeOverlay {
+  int calls = 0;
+  void call(BuildContext context) {
+    calls++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  testWidgets('celebrates when node completed', (tester) async {
+    await tracker.markCompleted('A');
+    final overlay = _FakeOverlay();
+    final service = SkillTreeNodeCelebrationService(showOverlay: overlay.call);
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
+    await service.maybeCelebrate(key.currentContext!, 'A');
+    expect(overlay.calls, 1);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('skill_node_celebrated_A'), isTrue);
+  });
+
+  testWidgets('does not repeat celebration', (tester) async {
+    await tracker.markCompleted('A');
+    SharedPreferences.setMockInitialValues({'skill_node_celebrated_A': true});
+    final overlay = _FakeOverlay();
+    final service = SkillTreeNodeCelebrationService(showOverlay: overlay.call);
+    final key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
+    await service.maybeCelebrate(key.currentContext!, 'A');
+    expect(overlay.calls, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTreeNodeCelebrationOverlay` widget for short confetti/emoji animation
- add `SkillTreeNodeCelebrationService` to show overlay once per node
- trigger celebration on node completion in `SkillTreeNodeDetailScreen`
- test celebration service logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d60ed0010832aaa907015a56ccb6b