### PR TITLE
Add stage gate celebration overlay

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -8,6 +8,7 @@ import '../services/skill_tree_unlock_evaluator.dart';
 import '../services/skill_tree_stage_gate_evaluator.dart';
 import '../services/skill_tree_stage_completion_evaluator.dart';
 import '../services/skill_tree_stage_unlock_overlay_builder.dart';
+import '../services/skill_tree_stage_gate_celebration_overlay.dart';
 import '../services/skill_tree_unlock_notification_service.dart';
 import '../widgets/skill_tree_stage_header_builder.dart';
 import '../screens/skill_tree_node_detail_screen.dart';
@@ -30,6 +31,7 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
   final _overlayBuilder = const SkillTreeStageUnlockOverlayBuilder();
   final _headerBuilder = const SkillTreeStageHeaderBuilder();
   final _unlockNotify = SkillTreeUnlockNotificationService();
+  final _stageCelebrator = SkillTreeStageGateCelebrationOverlay();
 
   @override
   void initState() {
@@ -68,6 +70,8 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     });
     if (mounted) {
       await _unlockNotify.maybeNotify(context, tree);
+      if (!mounted) return;
+      await _stageCelebrator.maybeCelebrate(context, tree);
     }
   }
 

--- a/lib/services/skill_tree_stage_gate_celebration_overlay.dart
+++ b/lib/services/skill_tree_stage_gate_celebration_overlay.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/skill_tree.dart';
+import 'skill_tree_stage_gate_evaluator.dart';
+import 'skill_tree_node_progress_tracker.dart';
+import '../widgets/skill_tree_stage_gate_celebration_overlay.dart';
+
+/// Shows a brief overlay when a new skill tree stage becomes unlocked.
+class SkillTreeStageGateCelebrationOverlay {
+  final SkillTreeNodeProgressTracker progress;
+
+  SkillTreeStageGateCelebrationOverlay({
+    SkillTreeNodeProgressTracker? progress,
+  }) : progress = progress ?? SkillTreeNodeProgressTracker.instance;
+
+  static String _prefsKey(String id) => 'skill_tree_stage_celebrations_$id';
+
+  /// Checks [tree] for newly unlocked stages and celebrates each once.
+  Future<void> maybeCelebrate(BuildContext context, SkillTree tree) async {
+    final trackId = tree.nodes.values.isNotEmpty
+        ? tree.nodes.values.first.category
+        : '';
+    if (trackId.isEmpty) return;
+
+    await progress.isCompleted('');
+    final completed = progress.completedNodeIds.value;
+
+    const gateEval = SkillTreeStageGateEvaluator();
+    final unlockedStages = gateEval.getUnlockedStages(tree, completed).toSet();
+
+    final prefs = await SharedPreferences.getInstance();
+    final prev =
+        prefs.getStringList(_prefsKey(trackId))?.map(int.parse).toSet() ?? <int>{};
+
+    final newStages = unlockedStages.difference(prev).toList()..sort();
+
+    for (final level in newStages) {
+      if (!context.mounted) break;
+      final title = _firstTitleForStage(tree, level);
+      final msg = '🎯 Открыт этап $level${title != null ? ': $title' : ''}!';
+      showSkillTreeStageGateCelebrationOverlay(context, msg);
+      await Future.delayed(const Duration(seconds: 2));
+    }
+
+    await prefs.setStringList(
+      _prefsKey(trackId),
+      unlockedStages.map((e) => e.toString()).toList(),
+    );
+  }
+
+  String? _firstTitleForStage(SkillTree tree, int level) {
+    for (final node in tree.nodes.values) {
+      if (node.level == level) return node.title;
+    }
+    return null;
+  }
+}

--- a/lib/widgets/skill_tree_stage_gate_celebration_overlay.dart
+++ b/lib/widgets/skill_tree_stage_gate_celebration_overlay.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'confetti_overlay.dart';
+
+/// Overlay shown when a new skill tree stage is unlocked.
+class SkillTreeStageGateCelebrationOverlay extends StatefulWidget {
+  final String message;
+  final VoidCallback onClose;
+  const SkillTreeStageGateCelebrationOverlay({
+    super.key,
+    required this.message,
+    required this.onClose,
+  });
+
+  @override
+  State<SkillTreeStageGateCelebrationOverlay> createState() =>
+      _SkillTreeStageGateCelebrationOverlayState();
+}
+
+class _SkillTreeStageGateCelebrationOverlayState
+    extends State<SkillTreeStageGateCelebrationOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+    Future.delayed(const Duration(milliseconds: 1500), widget.onClose);
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: FadeTransition(
+        opacity: CurvedAnimation(parent: _anim, curve: Curves.easeInOut),
+        child: Center(
+          child: ScaleTransition(
+            scale: CurvedAnimation(parent: _anim, curve: Curves.easeIn),
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.black87,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                widget.message,
+                style: const TextStyle(color: Colors.white, fontSize: 20),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays [SkillTreeStageGateCelebrationOverlay] above the current screen.
+void showSkillTreeStageGateCelebrationOverlay(BuildContext context, String message) {
+  final overlay = Overlay.of(context);
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => SkillTreeStageGateCelebrationOverlay(
+      message: message,
+      onClose: () {
+        entry.remove();
+      },
+    ),
+  );
+  overlay.insert(entry);
+}


### PR DESCRIPTION
## Summary
- celebrate stage unlocks with confetti overlay
- track which stages were already celebrated
- trigger overlay in SkillTreeScreen after new stages become available

## Testing
- `dart analyze lib/services/skill_tree_stage_gate_celebration_overlay.dart lib/widgets/skill_tree_stage_gate_celebration_overlay.dart lib/screens/skill_tree_screen.dart`

------
https://chatgpt.com/codex/tasks/task_e_688d62a998a4832a98837f3fdd3aaca5