### PR TITLE
feat: log skill tree milestones

### DIFF
--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -49,8 +49,8 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
       _progress = await TrainingProgressService.instance
           .getProgress(widget.node.trainingPackId);
     } else {
-      final done =
-          await SkillTreeNodeProgressTracker.instance.isCompleted(widget.node.id);
+      final done = await SkillTreeNodeProgressTracker.instance
+          .isCompleted(widget.node.id);
       if (done) _progress = 1.0;
     }
     if (mounted) setState(() => _loading = false);
@@ -72,16 +72,20 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
         ),
       );
     } else if (widget.node.trainingPackId.isNotEmpty) {
-      final tpl = await PackLibraryService.instance
-          .getById(widget.node.trainingPackId);
+      final tpl =
+          await PackLibraryService.instance.getById(widget.node.trainingPackId);
       if (tpl != null) {
         await const TrainingSessionLauncher().launch(tpl);
       }
     }
     await _load();
     if (mounted && !wasComplete && _progress >= 1.0) {
-      await SkillTreeNodeCelebrationService()
-          .maybeCelebrate(context, widget.node.id);
+      await SkillTreeNodeCelebrationService().maybeCelebrate(
+        context,
+        widget.node.id,
+        trackId: widget.node.category,
+        stage: widget.node.level,
+      );
     }
   }
 
@@ -111,7 +115,8 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                   children: [
                     Row(
                       children: [
-                        Text(visual.emoji, style: const TextStyle(fontSize: 32)),
+                        Text(visual.emoji,
+                            style: const TextStyle(fontSize: 32)),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
@@ -161,8 +166,8 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                     ),
                     const SizedBox(height: 4),
                     Text('$pct%',
-                        style:
-                            const TextStyle(color: Colors.white70, fontSize: 12)),
+                        style: const TextStyle(
+                            color: Colors.white70, fontSize: 12)),
                     const Spacer(),
                     Tooltip(
                       message:
@@ -171,7 +176,8 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                         width: double.infinity,
                         child: ElevatedButton(
                           onPressed: widget.unlocked ? _start : null,
-                          style: ElevatedButton.styleFrom(backgroundColor: accent),
+                          style:
+                              ElevatedButton.styleFrom(backgroundColor: accent),
                           child: const Text('Начать'),
                         ),
                       ),

--- a/lib/services/skill_tree_milestone_analytics_logger.dart
+++ b/lib/services/skill_tree_milestone_analytics_logger.dart
@@ -1,0 +1,44 @@
+import 'user_action_logger.dart';
+
+/// Logs key milestones in the skill tree such as node completions,
+/// stage unlocks and full track completions.
+class SkillTreeMilestoneAnalyticsLogger {
+  SkillTreeMilestoneAnalyticsLogger._();
+  static final instance = SkillTreeMilestoneAnalyticsLogger._();
+
+  Future<void> logNodeCompleted({
+    required String trackId,
+    required int stage,
+    required String nodeId,
+  }) async {
+    await _log('node_completed',
+        trackId: trackId, stage: stage, nodeId: nodeId);
+  }
+
+  Future<void> logStageUnlocked({
+    required String trackId,
+    required int stage,
+  }) async {
+    await _log('stage_unlocked', trackId: trackId, stage: stage);
+  }
+
+  Future<void> logTrackCompleted({required String trackId}) async {
+    await _log('track_completed', trackId: trackId);
+  }
+
+  Future<void> _log(
+    String event, {
+    required String trackId,
+    int? stage,
+    String? nodeId,
+  }) async {
+    final data = <String, dynamic>{
+      'event': event,
+      'trackId': trackId,
+      if (stage != null) 'stage': stage,
+      if (nodeId != null) 'nodeId': nodeId,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    await UserActionLogger.instance.logEvent(data);
+  }
+}

--- a/lib/services/skill_tree_node_celebration_service.dart
+++ b/lib/services/skill_tree_node_celebration_service.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../widgets/skill_tree_node_celebration_overlay.dart';
+import 'skill_tree_milestone_analytics_logger.dart';
 import 'skill_tree_node_progress_tracker.dart';
 
 /// Handles showing a celebration overlay when a skill tree node is completed.
@@ -17,13 +20,23 @@ class SkillTreeNodeCelebrationService {
   static const _prefsPrefix = 'skill_node_celebrated_';
 
   /// Checks completion of [nodeId] and displays celebration once.
-  Future<void> maybeCelebrate(BuildContext context, String nodeId) async {
+  Future<void> maybeCelebrate(
+    BuildContext context,
+    String nodeId, {
+    required String trackId,
+    required int stage,
+  }) async {
     if (!await progress.isCompleted(nodeId)) return;
 
     final prefs = await SharedPreferences.getInstance();
     final key = '$_prefsPrefix$nodeId';
     if (prefs.getBool(key) ?? false) return;
     await prefs.setBool(key, true);
+    unawaited(SkillTreeMilestoneAnalyticsLogger.instance.logNodeCompleted(
+      trackId: trackId,
+      stage: stage,
+      nodeId: nodeId,
+    ));
     final fn = showOverlay ?? showSkillTreeNodeCelebrationOverlay;
     fn(context);
   }

--- a/lib/services/skill_tree_stage_gate_celebration_overlay.dart
+++ b/lib/services/skill_tree_stage_gate_celebration_overlay.dart
@@ -6,6 +6,7 @@ import '../models/skill_tree.dart';
 import 'skill_tree_stage_gate_evaluator.dart';
 import 'skill_tree_node_progress_tracker.dart';
 import '../widgets/skill_tree_stage_gate_celebration_overlay.dart';
+import 'skill_tree_milestone_analytics_logger.dart';
 
 /// Shows a brief overlay when a new skill tree stage becomes unlocked.
 class SkillTreeStageGateCelebrationOverlay {
@@ -19,9 +20,8 @@ class SkillTreeStageGateCelebrationOverlay {
 
   /// Checks [tree] for newly unlocked stages and celebrates each once.
   Future<void> maybeCelebrate(BuildContext context, SkillTree tree) async {
-    final trackId = tree.nodes.values.isNotEmpty
-        ? tree.nodes.values.first.category
-        : '';
+    final trackId =
+        tree.nodes.values.isNotEmpty ? tree.nodes.values.first.category : '';
     if (trackId.isEmpty) return;
 
     await progress.isCompleted('');
@@ -32,7 +32,8 @@ class SkillTreeStageGateCelebrationOverlay {
 
     final prefs = await SharedPreferences.getInstance();
     final prev =
-        prefs.getStringList(_prefsKey(trackId))?.map(int.parse).toSet() ?? <int>{};
+        prefs.getStringList(_prefsKey(trackId))?.map(int.parse).toSet() ??
+            <int>{};
 
     final newStages = unlockedStages.difference(prev).toList()..sort();
 
@@ -41,6 +42,10 @@ class SkillTreeStageGateCelebrationOverlay {
       final title = _firstTitleForStage(tree, level);
       final msg = '🎯 Открыт этап $level${title != null ? ': $title' : ''}!';
       showSkillTreeStageGateCelebrationOverlay(context, msg);
+      unawaited(SkillTreeMilestoneAnalyticsLogger.instance.logStageUnlocked(
+        trackId: trackId,
+        stage: level,
+      ));
       await Future.delayed(const Duration(seconds: 2));
     }
 

--- a/lib/services/skill_tree_track_completion_celebrator.dart
+++ b/lib/services/skill_tree_track_completion_celebrator.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'skill_tree_track_completion_evaluator.dart';
 import '../screens/skill_tree_track_celebration_screen.dart';
+import 'skill_tree_milestone_analytics_logger.dart';
 
 /// Shows a celebration when a skill tree track is fully completed.
 class SkillTreeTrackCompletionCelebrator {
@@ -27,6 +30,8 @@ class SkillTreeTrackCompletionCelebrator {
 
     shown.add(trackId);
     await prefs.setStringList(_prefsKey, shown);
+    unawaited(SkillTreeMilestoneAnalyticsLogger.instance
+        .logTrackCompleted(trackId: trackId));
 
     await Navigator.push(
       context,

--- a/test/services/skill_tree_node_celebration_service_test.dart
+++ b/test/services/skill_tree_node_celebration_service_test.dart
@@ -28,7 +28,12 @@ void main() {
     final service = SkillTreeNodeCelebrationService(showOverlay: overlay.call);
     final key = GlobalKey();
     await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
-    await service.maybeCelebrate(key.currentContext!, 'A');
+    await service.maybeCelebrate(
+      key.currentContext!,
+      'A',
+      trackId: 't1',
+      stage: 1,
+    );
     expect(overlay.calls, 1);
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('skill_node_celebrated_A'), isTrue);
@@ -41,7 +46,12 @@ void main() {
     final service = SkillTreeNodeCelebrationService(showOverlay: overlay.call);
     final key = GlobalKey();
     await tester.pumpWidget(MaterialApp(key: key, home: const SizedBox()));
-    await service.maybeCelebrate(key.currentContext!, 'A');
+    await service.maybeCelebrate(
+      key.currentContext!,
+      'A',
+      trackId: 't1',
+      stage: 1,
+    );
     expect(overlay.calls, 0);
   });
 }


### PR DESCRIPTION
## Summary
- add `SkillTreeMilestoneAnalyticsLogger` to record node, stage and track milestones
- integrate milestone logging with node, stage gate and track celebrations

## Testing
- `/tmp/flutter332/flutter/bin/flutter test` *(failed: Error: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*

------
https://chatgpt.com/codex/tasks/task_e_688d67165244832a9d08b6d228c4c3ba