### PR TITLE
feat: show skill tree track progress in header

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,7 @@ import 'services/decay_booster_notification_service.dart';
 import 'services/decay_booster_cron_job.dart';
 import 'services/theory_lesson_notification_scheduler.dart';
 import 'services/booster_recall_decay_cleaner.dart';
+import 'route_observer.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -365,6 +366,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
           final theme = context.watch<ThemeService>().mode;
           return MaterialApp(
             navigatorKey: navigatorKey,
+            navigatorObservers: [routeObserver],
             title: 'Poker AI Analyzer',
             debugShowCheckedModeBanner: false,
             themeMode: theme,

--- a/lib/route_observer.dart
+++ b/lib/route_observer.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+/// Global route observer for monitoring navigation events.
+final RouteObserver<PageRoute<dynamic>> routeObserver =
+    RouteObserver<PageRoute<dynamic>>();

--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -6,7 +6,7 @@ import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_progress_service.dart';
 import '../services/skill_tree_track_celebration_service.dart';
 import '../widgets/skill_tree_stage_list_builder.dart';
-import '../widgets/skill_tree_progress_header.dart';
+import '../widgets/skill_tree_track_overview_header.dart';
 import 'skill_tree_node_detail_screen.dart';
 
 /// Renders the full learning path for a skill track.
@@ -100,7 +100,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
 
     final header = Padding(
       padding: const EdgeInsets.all(12),
-      child: SkillTreeProgressHeader(trackId: widget.trackId),
+      child: SkillTreeTrackOverviewHeader(trackId: widget.trackId),
     );
 
     return Scaffold(

--- a/lib/widgets/skill_tree_track_overview_header.dart
+++ b/lib/widgets/skill_tree_track_overview_header.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../services/skill_tree_library_service.dart';
+import '../services/skill_tree_path_progress_estimator.dart';
+import '../route_observer.dart';
+
+/// Displays track title with overall completion percentage.
+class SkillTreeTrackOverviewHeader extends StatefulWidget {
+  final String trackId;
+
+  const SkillTreeTrackOverviewHeader({super.key, required this.trackId});
+
+  @override
+  State<SkillTreeTrackOverviewHeader> createState() =>
+      _SkillTreeTrackOverviewHeaderState();
+}
+
+class _SkillTreeTrackOverviewHeaderState extends State<SkillTreeTrackOverviewHeader>
+    with RouteAware {
+  String _title = '';
+  int _percent = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final library = SkillTreeLibraryService.instance;
+    await library.reload();
+    final track = library.getTrack(widget.trackId)?.tree;
+    String title;
+    if (track != null && track.nodes.isNotEmpty) {
+      title = track.roots.isNotEmpty
+          ? track.roots.first.title
+          : track.nodes.values.first.title;
+    } else {
+      title = widget.trackId;
+    }
+    final estimator = SkillTreePathProgressEstimator(library: library);
+    final pct = await estimator.getProgressPercent(widget.trackId);
+    if (!mounted) return;
+    setState(() {
+      _title = title;
+      _percent = pct;
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route is PageRoute) {
+      routeObserver.subscribe(this, route);
+    }
+  }
+
+  @override
+  void dispose() {
+    routeObserver.unsubscribe(this);
+    super.dispose();
+  }
+
+  @override
+  void didPopNext() {
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          _title,
+          style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text('Прогресс: $_percent%'),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- integrate route observer and navigator observers to track navigation
- show skill tree track completion percent via new track overview header

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6bcd5a20832aaaf9bbac631af4ed