### PR TITLE
feat: celebrate stage completion

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import 'skill_tree_library_service.dart';
+import 'skill_tree_node_progress_tracker.dart';
+import 'skill_tree_stage_completion_evaluator.dart';
+
+/// Shows a celebratory dialog when a skill tree stage is fully completed.
+class StageCompletionCelebrationService {
+  final SkillTreeLibraryService library;
+  final SkillTreeNodeProgressTracker progress;
+  final SkillTreeStageCompletionEvaluator evaluator;
+
+  StageCompletionCelebrationService({
+    SkillTreeLibraryService? library,
+    SkillTreeNodeProgressTracker? progress,
+    SkillTreeStageCompletionEvaluator? evaluator,
+  }) : library = library ?? SkillTreeLibraryService.instance,
+       progress = progress ?? SkillTreeNodeProgressTracker.instance,
+       evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
+
+  static final instance = StageCompletionCelebrationService();
+
+  Future<void> _ensureLoaded() async {
+    if (library.getAllNodes().isEmpty) {
+      await library.reload();
+    }
+    await progress.isCompleted('');
+  }
+
+  /// Checks the highest completed stage in [trackId] and shows a dialog once.
+  Future<void> checkAndCelebrate(String trackId) async {
+    await _ensureLoaded();
+    final tree = library.getTrack(trackId)?.tree;
+    if (tree == null) return;
+    final completed = progress.completedNodeIds.value;
+    final completedStages = evaluator.getCompletedStages(tree, completed);
+    if (completedStages.isEmpty) return;
+    final stageIndex = completedStages.last;
+
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'stage_celebrated_${trackId}_$stageIndex';
+    if (prefs.getBool(key) ?? false) return;
+    await prefs.setBool(key, true);
+
+    final ctx = navigatorKey.currentState?.context;
+    if (ctx == null || !ctx.mounted) return;
+
+    await showDialog<void>(
+      context: ctx,
+      builder: (context) => AlertDialog(
+        title: const Text('Этап завершён'),
+        content: Text('Этап $stageIndex успешно завершён!'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/stage_completion_celebration_service_test.dart
+++ b/test/services/stage_completion_celebration_service_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/stage_completion_celebration_service.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  final Map<String, SkillTreeBuildResult> _trees;
+  final List<SkillTreeNodeModel> _nodes;
+  _FakeLibraryService(this._trees, this._nodes);
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => _trees[category];
+
+  @override
+  SkillTreeBuildResult? getTrack(String trackId) => _trees[trackId];
+
+  @override
+  List<SkillTreeBuildResult> getAllTracks() => _trees.values.toList();
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id, int level) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'T', level: level);
+
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  testWidgets('celebrates newly completed stage', (tester) async {
+    final nodes = [node('a', 0), node('b', 1)];
+    final tree = builder.build(nodes).tree;
+    final lib = _FakeLibraryService({
+      'T': SkillTreeBuildResult(tree: tree),
+    }, nodes);
+
+    await tracker.markCompleted('a');
+
+    final svc = StageCompletionCelebrationService(
+      library: lib,
+      progress: tracker,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.checkAndCelebrate('T');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('stage_celebrated_T_0'), isTrue);
+  });
+
+  testWidgets('does not repeat celebration', (tester) async {
+    SharedPreferences.setMockInitialValues({'stage_celebrated_T_0': true});
+    await tracker.resetForTest();
+    final nodes = [node('a', 0)];
+    final tree = builder.build(nodes).tree;
+    final lib = _FakeLibraryService({
+      'T': SkillTreeBuildResult(tree: tree),
+    }, nodes);
+
+    await tracker.markCompleted('a');
+
+    final svc = StageCompletionCelebrationService(
+      library: lib,
+      progress: tracker,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.checkAndCelebrate('T');
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add StageCompletionCelebrationService to show a dialog when a track stage is fully completed and ensure each stage is celebrated once
- cover stage celebration with widget tests

## Testing
- `flutter test test/services/stage_completion_celebration_service_test.dart` *(fails: the Dart compiler exited unexpectedly)*


------
https://chatgpt.com/codex/tasks/task_e_688d6f4499d0832a93788eeb632633a8