### PR TITLE
feat: log skill tree stage completion

### DIFF
--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,16 @@
+import 'user_action_logger.dart';
+
+/// Provides a simple interface for logging analytics events.
+class AnalyticsService {
+  AnalyticsService._();
+
+  static final instance = AnalyticsService._();
+
+  Future<void> logEvent(String event, Map<String, dynamic> params) async {
+    await UserActionLogger.instance.logEvent({
+      'event': event,
+      ...params,
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+  }
+}

--- a/lib/services/skill_tree_milestone_analytics_logger.dart
+++ b/lib/services/skill_tree_milestone_analytics_logger.dart
@@ -1,10 +1,12 @@
-import 'user_action_logger.dart';
+import 'analytics_service.dart';
 
 /// Logs key milestones in the skill tree such as node completions,
-/// stage unlocks and full track completions.
+/// stage unlocks, stage completions and full track completions.
 class SkillTreeMilestoneAnalyticsLogger {
   SkillTreeMilestoneAnalyticsLogger._();
   static final instance = SkillTreeMilestoneAnalyticsLogger._();
+
+  final AnalyticsService _analytics = AnalyticsService.instance;
 
   Future<void> logNodeCompleted({
     required String trackId,
@@ -26,19 +28,28 @@ class SkillTreeMilestoneAnalyticsLogger {
     await _log('track_completed', trackId: trackId);
   }
 
+  Future<void> logStageCompleted({
+    required String trackId,
+    required int stageIndex,
+    required int totalStages,
+  }) async {
+    await _analytics.logEvent('skill_tree_stage_completed', {
+      'trackId': trackId,
+      'stageIndex': stageIndex,
+      'totalStages': totalStages,
+    });
+  }
+
   Future<void> _log(
     String event, {
     required String trackId,
     int? stage,
     String? nodeId,
   }) async {
-    final data = <String, dynamic>{
-      'event': event,
+    await _analytics.logEvent(event, {
       'trackId': trackId,
       if (stage != null) 'stage': stage,
       if (nodeId != null) 'nodeId': nodeId,
-      'timestamp': DateTime.now().toIso8601String(),
-    };
-    await UserActionLogger.instance.logEvent(data);
+    });
   }
 }

--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -5,6 +5,7 @@ import '../main.dart';
 import 'skill_tree_library_service.dart';
 import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_stage_completion_evaluator.dart';
+import 'skill_tree_milestone_analytics_logger.dart';
 
 /// Shows a celebratory dialog when a skill tree stage is fully completed.
 class StageCompletionCelebrationService {
@@ -38,6 +39,7 @@ class StageCompletionCelebrationService {
     final completedStages = evaluator.getCompletedStages(tree, completed);
     if (completedStages.isEmpty) return;
     final stageIndex = completedStages.last;
+    final totalStages = tree.nodes.values.map((n) => n.level).toSet().length;
 
     final prefs = await SharedPreferences.getInstance();
     final key = 'stage_celebrated_${trackId}_$stageIndex';
@@ -59,6 +61,12 @@ class StageCompletionCelebrationService {
           ),
         ],
       ),
+    );
+
+    await SkillTreeMilestoneAnalyticsLogger.instance.logStageCompleted(
+      trackId: trackId,
+      stageIndex: stageIndex,
+      totalStages: totalStages,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add analytics service abstraction for logging
- extend milestone analytics logger with stage completion tracking
- report stage completion analytics after celebration dialog

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688d719ba780832a804e876681e16317