### PR TITLE
feat: trigger stage celebration automatically

### DIFF
--- a/lib/services/skill_tree_node_progress_tracker.dart
+++ b/lib/services/skill_tree_node_progress_tracker.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'stage_completion_celebration_service.dart';
+import 'skill_tree_track_resolver.dart';
+
 /// Tracks completion status for skill tree nodes.
 class SkillTreeNodeProgressTracker {
   SkillTreeNodeProgressTracker._();
@@ -41,6 +44,14 @@ class SkillTreeNodeProgressTracker {
     if (set.add(nodeId)) {
       completedNodeIds.value = Set<String>.from(set);
       await _save();
+      try {
+        final trackId =
+            await SkillTreeTrackResolver.instance.getTrackIdForNode(nodeId);
+        if (trackId != null && trackId.isNotEmpty) {
+          await StageCompletionCelebrationService.instance
+              .checkAndCelebrate(trackId);
+        }
+      } catch (_) {}
     }
   }
 

--- a/lib/services/skill_tree_track_resolver.dart
+++ b/lib/services/skill_tree_track_resolver.dart
@@ -1,0 +1,27 @@
+import 'skill_tree_library_service.dart';
+
+/// Resolves the track id for a given skill tree node.
+class SkillTreeTrackResolver {
+  SkillTreeTrackResolver({SkillTreeLibraryService? library})
+      : _library = library ?? SkillTreeLibraryService.instance;
+
+  final SkillTreeLibraryService _library;
+
+  static SkillTreeTrackResolver instance = SkillTreeTrackResolver();
+
+  Future<void> _ensureLoaded() async {
+    if (_library.getAllNodes().isEmpty) {
+      await _library.reload();
+    }
+  }
+
+  /// Returns the track id that contains [nodeId], or `null` if not found.
+  Future<String?> getTrackIdForNode(String nodeId) async {
+    if (nodeId.isEmpty) return null;
+    await _ensureLoaded();
+    for (final node in _library.getAllNodes()) {
+      if (node.id == nodeId) return node.category;
+    }
+    return null;
+  }
+}

--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -21,7 +21,8 @@ class StageCompletionCelebrationService {
        progress = progress ?? SkillTreeNodeProgressTracker.instance,
        evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
 
-  static final instance = StageCompletionCelebrationService();
+  static StageCompletionCelebrationService instance =
+      StageCompletionCelebrationService();
 
   Future<void> _ensureLoaded() async {
     if (library.getAllNodes().isEmpty) {


### PR DESCRIPTION
## Summary
- trigger stage completion celebration when a node is marked complete
- allow swapping StageCompletionCelebrationService instance for testing
- add SkillTreeTrackResolver to map node ids to track ids

## Testing
- `dart test test/services/skill_tree_node_progress_tracker_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688d73147e44832abcc4946bea960afc