### PR TITLE
feat: celebrate track completion

### DIFF
--- a/lib/services/skill_tree_node_progress_tracker.dart
+++ b/lib/services/skill_tree_node_progress_tracker.dart
@@ -50,6 +50,8 @@ class SkillTreeNodeProgressTracker {
         if (trackId != null && trackId.isNotEmpty) {
           await StageCompletionCelebrationService.instance
               .checkAndCelebrate(trackId);
+          await StageCompletionCelebrationService.instance
+              .checkAndCelebrateTrackCompletion(trackId);
         }
       } catch (_) {}
     }


### PR DESCRIPTION
## Summary
- extend StageCompletionCelebrationService to honor full track completion with dialog and analytics
- invoke track celebration after node completion
- cover track celebration with tests

## Testing
- `flutter test test/services/stage_completion_celebration_service_test.dart test/services/skill_tree_node_progress_tracker_test.dart` *(fails: command not found)*
- `flutter --version` *(installation attempted, but flutter tool setup failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d74855bc4832aa1ee896d6f1356b1