### PR TITLE
feat: add track lock evaluator

### DIFF
--- a/lib/screens/track_selector_screen.dart
+++ b/lib/screens/track_selector_screen.dart
@@ -1,11 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import '../models/v3/lesson_track.dart';
 import '../services/learning_track_engine.dart';
+import '../services/track_lock_evaluator.dart';
+import '../widgets/track_lock_overlay.dart';
 import 'lesson_path_screen.dart';
 
-class TrackSelectorScreen extends StatelessWidget {
+class TrackSelectorScreen extends StatefulWidget {
   const TrackSelectorScreen({super.key});
+
+  @override
+  State<TrackSelectorScreen> createState() => _TrackSelectorScreenState();
+}
+
+class _TrackSelectorScreenState extends State<TrackSelectorScreen> {
+  late Future<Map<String, dynamic>> _future;
+  final TrackLockEvaluator _lockEvaluator = TrackLockEvaluator(
+    prerequisites: const {
+      'live_exploit': 'mtt_pro',
+      'leak_fixer': 'live_exploit',
+    },
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<Map<String, dynamic>> _load() async {
+    final tracks = const LearningTrackEngine().getTracks();
+    final Map<String, bool> locked = {};
+    for (final t in tracks) {
+      locked[t.id] = await _lockEvaluator.isLocked(t.id);
+    }
+    return {'tracks': tracks, 'locked': locked};
+  }
 
   Future<void> _select(BuildContext context, LessonTrack track) async {
     final prefs = await SharedPreferences.getInstance();
@@ -20,31 +51,45 @@ class TrackSelectorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tracks = const LearningTrackEngine().getTracks();
-    return Scaffold(
-      appBar: AppBar(title: const Text('Выбор трека')),
-      backgroundColor: const Color(0xFF121212),
-      body: ListView.builder(
-        itemCount: tracks.length,
-        itemBuilder: (context, index) {
-          final track = tracks[index];
-          return Card(
-            color: const Color(0xFF1E1E1E),
-            margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: ListTile(
-              title: Text(track.title),
-              subtitle: Text(
-                track.description,
-                style: const TextStyle(color: Colors.white70),
-              ),
-              trailing: ElevatedButton(
-                onPressed: () => _select(context, track),
-                child: const Text('Выбрать'),
-              ),
-            ),
-          );
-        },
-      ),
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _future,
+      builder: (context, snapshot) {
+        final tracks = snapshot.data?['tracks'] as List<LessonTrack>? ?? [];
+        final locked = snapshot.data?['locked'] as Map<String, bool>? ?? {};
+        return Scaffold(
+          appBar: AppBar(title: const Text('Выбор трека')),
+          backgroundColor: const Color(0xFF121212),
+          body: ListView.builder(
+            itemCount: tracks.length,
+            itemBuilder: (context, index) {
+              final track = tracks[index];
+              final isLocked = locked[track.id] == true;
+              final card = Card(
+                color: const Color(0xFF1E1E1E),
+                margin:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ListTile(
+                  title: Text(track.title),
+                  subtitle: Text(
+                    track.description,
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                  trailing: isLocked
+                      ? const Icon(Icons.lock)
+                      : ElevatedButton(
+                          onPressed: () => _select(context, track),
+                          child: const Text('Выбрать'),
+                        ),
+                ),
+              );
+              return TrackLockOverlay(
+                locked: isLocked,
+                child: card,
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/services/track_lock_evaluator.dart
+++ b/lib/services/track_lock_evaluator.dart
@@ -1,0 +1,33 @@
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Evaluates whether a track is locked based on prerequisite completion.
+class TrackLockEvaluator {
+  final SkillTreeNodeProgressTracker progress;
+  final Map<String, String> prerequisites;
+
+  TrackLockEvaluator({
+    SkillTreeNodeProgressTracker? progress,
+    Map<String, String>? prerequisites,
+  })  : progress = progress ?? SkillTreeNodeProgressTracker.instance,
+        prerequisites = prerequisites ?? const {};
+
+  /// Returns `true` if [trackId] has a prerequisite that is not yet completed.
+  Future<bool> isLocked(String trackId) async {
+    final prereq = prerequisites[trackId];
+    if (prereq == null) return false;
+    return !(await progress.isTrackCompleted(prereq));
+  }
+
+  /// Returns all track IDs that are currently unlocked.
+  Future<List<String>> getUnlockedTracks() async {
+    final ids = <String>{...prerequisites.keys, ...prerequisites.values};
+    final unlocked = <String>[];
+    for (final id in ids) {
+      if (!await isLocked(id)) {
+        unlocked.add(id);
+      }
+    }
+    return unlocked;
+  }
+}
+

--- a/test/services/track_lock_evaluator_test.dart
+++ b/test/services/track_lock_evaluator_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/track_lock_evaluator.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  setUp(() async {
+    await tracker.resetForTest();
+  });
+
+  test('detects locked tracks based on prerequisites', () async {
+    final eval = TrackLockEvaluator(prerequisites: const {'b': 'a'});
+    expect(await eval.isLocked('a'), isFalse);
+    expect(await eval.isLocked('b'), isTrue);
+    await tracker.markTrackCompleted('a');
+    expect(await eval.isLocked('b'), isFalse);
+  });
+
+  test('getUnlockedTracks returns only unlocked ids', () async {
+    final eval = TrackLockEvaluator(prerequisites: const {'b': 'a', 'c': 'b'});
+    await tracker.markTrackCompleted('a');
+    final unlocked = await eval.getUnlockedTracks();
+    expect(unlocked.contains('a'), isTrue);
+    expect(unlocked.contains('b'), isTrue);
+    expect(unlocked.contains('c'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add TrackLockEvaluator to determine if a track is locked based on prerequisites
- integrate lock evaluator into track selector UI with lock overlay
- cover new logic with unit tests

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688d7955fc90832ab520a60fc717e00e