### PR TITLE
feat: add track unlock reason service

### DIFF
--- a/lib/screens/lesson_track_library_screen.dart
+++ b/lib/screens/lesson_track_library_screen.dart
@@ -51,7 +51,8 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
       final ok = await LearningPathUnlockEngine.instance.canUnlockTrack(t.id);
       unlocked[t.id] = ok;
       if (!ok) {
-        reasons[t.id] = await TrackUnlockReasonService.instance.getReason(t.id);
+        reasons[t.id] =
+            await TrackUnlockReasonService.instance.getUnlockReason(t.id);
       }
     }
     _unlocked
@@ -183,9 +184,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
                     );
                     return TrackLockOverlay(
                       locked: _unlocked[track.id] != true,
-                      reason: _reasons[track.id] == null
-                          ? null
-                          : 'Unlock by ${_reasons[track.id]}',
+                      reason: _reasons[track.id],
                       onTap: () => _showUnlockHint(track.id),
                       child: card,
                     );

--- a/lib/services/learning_track_engine.dart
+++ b/lib/services/learning_track_engine.dart
@@ -30,6 +30,14 @@ class LearningTrackEngine {
 
   List<LessonTrack> getTracks() => List.unmodifiable(_tracks);
 
+  /// Returns the track with the given [id] or `null` if not found.
+  LessonTrack? getTrackById(String id) {
+    for (final t in _tracks) {
+      if (t.id == id) return t;
+    }
+    return null;
+  }
+
   /// Builds the current learning track based on [allPacks] and [stats].
   ///
   /// Returns a [LearningTrack] containing unlocked packs in their original

--- a/lib/services/track_unlock_reason_service.dart
+++ b/lib/services/track_unlock_reason_service.dart
@@ -1,12 +1,33 @@
-import 'learning_path_unlock_engine.dart';
+import 'learning_track_engine.dart';
+import 'track_lock_evaluator.dart';
 
-/// Convenience service that delegates to [LearningPathUnlockEngine]
-/// to fetch textual explanations for locked tracks.
+/// Provides textual explanations for why learning tracks are locked.
 class TrackUnlockReasonService {
-  TrackUnlockReasonService._();
-  static final instance = TrackUnlockReasonService._();
+  final TrackLockEvaluator lockEvaluator;
+  final LearningTrackEngine trackEngine;
 
-  Future<String?> getReason(String trackId) {
-    return LearningPathUnlockEngine.instance.getUnlockReason(trackId);
+  TrackUnlockReasonService({
+    TrackLockEvaluator? lockEvaluator,
+    LearningTrackEngine trackEngine = const LearningTrackEngine(),
+  })  : lockEvaluator = lockEvaluator ??
+            TrackLockEvaluator(
+              prerequisites: const {
+                'live_exploit': 'mtt_pro',
+                'leak_fixer': 'live_exploit',
+              },
+            ),
+        trackEngine = trackEngine;
+
+  static final TrackUnlockReasonService instance = TrackUnlockReasonService();
+
+  /// Returns `null` if [trackId] is unlocked, otherwise a message explaining
+  /// which prerequisite track must be completed.
+  Future<String?> getUnlockReason(String trackId) async {
+    if (!await lockEvaluator.isLocked(trackId)) return null;
+    final prereqId = lockEvaluator.prerequisites[trackId];
+    if (prereqId == null) return null;
+    final prereqTrack = trackEngine.getTrackById(prereqId);
+    final prereqName = prereqTrack?.title ?? prereqId;
+    return "Чтобы разблокировать этот трек, завершите трек '$prereqName'.";
   }
 }

--- a/test/services/track_unlock_reason_service_test.dart
+++ b/test/services/track_unlock_reason_service_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/track_unlock_reason_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final tracker = SkillTreeNodeProgressTracker.instance;
+  final service = TrackUnlockReasonService.instance;
+
+  setUp(() async {
+    await tracker.resetForTest();
+  });
+
+  test('returns message when track is locked', () async {
+    final reason = await service.getUnlockReason('live_exploit');
+    expect(reason, isNotNull);
+    expect(reason, contains('MTT Pro Track'));
+  });
+
+  test('returns null when prerequisite completed', () async {
+    await tracker.markTrackCompleted('mtt_pro');
+    final reason = await service.getUnlockReason('live_exploit');
+    expect(reason, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- explain locked tracks via TrackUnlockReasonService
- display unlock reasons in TrackLockOverlay on selector and library screens
- support track lookup by id and add regression tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7aad80e8832ab9854406749a4992