### PR TITLE
Add TrackUnlockHintDialog modal

### DIFF
--- a/lib/screens/lesson_track_library_screen.dart
+++ b/lib/screens/lesson_track_library_screen.dart
@@ -71,7 +71,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
   }
 
   void _showUnlockHint(String trackId) {
-    showTrackUnlockHintDialog(context, trackId);
+    TrackUnlockHintDialog.show(context, trackId);
   }
 
   Future<void> _select(LessonTrack track, String? currentId) async {

--- a/lib/widgets/dialogs/track_unlock_hint_dialog.dart
+++ b/lib/widgets/dialogs/track_unlock_hint_dialog.dart
@@ -1,89 +1,41 @@
 import 'package:flutter/material.dart';
 
-import '../../models/v3/lesson_track.dart';
-import '../../models/track_unlock_requirement_progress.dart';
-import '../../services/learning_track_engine.dart';
-import '../../services/yaml_lesson_track_loader.dart';
-import '../../services/lesson_track_unlock_engine.dart';
+import '../../services/track_unlock_reason_service.dart';
 
+/// A simple modal that explains how to unlock a learning track.
 class TrackUnlockHintDialog extends StatelessWidget {
-  final LessonTrack track;
-  final List<TrackUnlockRequirementProgress> requirements;
-  const TrackUnlockHintDialog({
-    super.key,
-    required this.track,
-    required this.requirements,
-  });
+  final String message;
+
+  const TrackUnlockHintDialog({super.key, required this.message});
+
+  /// Shows the dialog for the given [trackId].
+  static Future<void> show(BuildContext context, String trackId) async {
+    final reason =
+        await TrackUnlockReasonService.instance.getUnlockReason(trackId);
+    if (reason == null) return;
+    final match = RegExp("завершите трек '(.+)'", caseSensitive: false)
+        .firstMatch(reason);
+    final cta =
+        match != null ? "Завершите '${match.group(1)}', чтобы открыть" : null;
+    final message = cta == null ? reason : "$reason\n\n$cta";
+    await showDialog<void>(
+      context: context,
+      builder: (_) => TrackUnlockHintDialog(message: message),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    final allMet = requirements.isNotEmpty &&
-        requirements.every((r) => r.met);
     return AlertDialog(
       backgroundColor: const Color(0xFF1E1E1E),
-      title: Text(track.title),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(track.description,
-              style: const TextStyle(color: Colors.white70)),
-          const SizedBox(height: 8),
-          for (final r in requirements)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Row(
-                children: [
-                  Text(r.icon, style: const TextStyle(fontSize: 20)),
-                  const SizedBox(width: 8),
-                  Expanded(child: Text(r.label)),
-                  Text(
-                    '${r.current}/${r.required}',
-                    style: TextStyle(
-                        color: r.met ? Colors.green : Colors.red),
-                  ),
-                  const SizedBox(width: 4),
-                  Icon(
-                    r.met ? Icons.check_circle : Icons.cancel,
-                    color: r.met ? Colors.green : Colors.red,
-                    size: 16,
-                  ),
-                ],
-              ),
-            ),
-          if (allMet) ...[
-            const SizedBox(height: 8),
-            const Text('\uD83D\uDD13 Track will unlock soon!',
-                style: TextStyle(color: Colors.greenAccent)),
-          ],
-        ],
-      ),
+      title: const Text('Трек заблокирован'),
+      content: Text(message),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('OK'),
         ),
       ],
-    );
-  }
-}
-
-Future<void> showTrackUnlockHintDialog(
-    BuildContext context, String trackId) async {
-  final builtIn = const LearningTrackEngine().getTracks();
-  final yaml = await YamlLessonTrackLoader.instance.loadTracksFromAssets();
-  final tracks = [...builtIn, ...yaml];
-  final track = tracks.firstWhere(
-    (t) => t.id == trackId,
-    orElse: () =>
-        const LessonTrack(id: '', title: '', description: '', stepIds: []),
-  );
-  final reqs =
-      await LessonTrackUnlockEngine.instance.getRequirementProgress(trackId);
-  if (context.mounted) {
-    await showDialog(
-      context: context,
-      builder: (_) => TrackUnlockHintDialog(track: track, requirements: reqs),
     );
   }
 }


### PR DESCRIPTION
## Summary
- introduce reusable TrackUnlockHintDialog to display lock reason and next step
- hook LessonTrackLibraryScreen up to new dialog

## Testing
- `flutter test` *(fails: Building flutter tool...)*

------
https://chatgpt.com/codex/tasks/task_e_688d7c2c3190832aa45bfd77d42b291d