### PR TITLE
Add navigation button to TrackUnlockHintDialog

### DIFF
--- a/lib/widgets/dialogs/track_unlock_hint_dialog.dart
+++ b/lib/widgets/dialogs/track_unlock_hint_dialog.dart
@@ -1,26 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../screens/lesson_path_screen.dart';
 import '../../services/track_unlock_reason_service.dart';
 
 /// A simple modal that explains how to unlock a learning track.
 class TrackUnlockHintDialog extends StatelessWidget {
   final String message;
+  final String? prerequisiteId;
+  final String? prerequisiteTitle;
 
-  const TrackUnlockHintDialog({super.key, required this.message});
+  const TrackUnlockHintDialog({
+    super.key,
+    required this.message,
+    this.prerequisiteId,
+    this.prerequisiteTitle,
+  });
 
   /// Shows the dialog for the given [trackId].
   static Future<void> show(BuildContext context, String trackId) async {
-    final reason =
-        await TrackUnlockReasonService.instance.getUnlockReason(trackId);
+    final reasonService = TrackUnlockReasonService.instance;
+    final reason = await reasonService.getUnlockReason(trackId);
     if (reason == null) return;
-    final match = RegExp("завершите трек '(.+)'", caseSensitive: false)
-        .firstMatch(reason);
+    final prereqId = reasonService.lockEvaluator.prerequisites[trackId];
+    String? prereqTitle;
+    if (prereqId != null) {
+      prereqTitle =
+          reasonService.trackEngine.getTrackById(prereqId)?.title ?? prereqId;
+    }
+    final match =
+        RegExp("завершите трек '(.+)'", caseSensitive: false).firstMatch(reason);
     final cta =
         match != null ? "Завершите '${match.group(1)}', чтобы открыть" : null;
     final message = cta == null ? reason : "$reason\n\n$cta";
     await showDialog<void>(
       context: context,
-      builder: (_) => TrackUnlockHintDialog(message: message),
+      builder: (_) => TrackUnlockHintDialog(
+        message: message,
+        prerequisiteId: prereqId,
+        prerequisiteTitle: prereqTitle,
+      ),
     );
   }
 
@@ -31,6 +50,22 @@ class TrackUnlockHintDialog extends StatelessWidget {
       title: const Text('Трек заблокирован'),
       content: Text(message),
       actions: [
+        if (prerequisiteId != null && prerequisiteTitle != null)
+          TextButton(
+            onPressed: () async {
+              final prefs = await SharedPreferences.getInstance();
+              await prefs.setString(
+                  'lesson_selected_track', prerequisiteId!);
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const LessonPathScreen(),
+                ),
+              );
+            },
+            child:
+                Text("Перейти к треку '$prerequisiteTitle'"),
+          ),
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('OK'),


### PR DESCRIPTION
## Summary
- add button in TrackUnlockHintDialog to jump directly to prerequisite track
- persist selected track and navigate to LessonPathScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7e161b78832aa3c11d7601f6277b