### PR TITLE
feat: celebrate track completion

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -6,8 +6,7 @@ import 'skill_tree_library_service.dart';
 import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_stage_completion_evaluator.dart';
 import 'skill_tree_milestone_analytics_logger.dart';
-import 'track_recommendation_engine.dart';
-import 'skill_tree_navigator.dart';
+import 'track_completion_celebration_service.dart';
 
 /// Shows a celebratory dialog when a skill tree stage is fully completed.
 class StageCompletionCelebrationService {
@@ -85,32 +84,8 @@ class StageCompletionCelebrationService {
     if (await progress.isTrackCompleted(trackId)) return;
     await progress.markTrackCompleted(trackId);
 
-    final ctx = navigatorKey.currentState?.context;
-    if (ctx == null || !ctx.mounted) return;
-
-    final nextTrackId = TrackRecommendationEngine.getNextTrack(trackId);
-
-    await showDialog<void>(
-      context: ctx,
-      builder: (context) => AlertDialog(
-        title: const Text('Трек завершён'),
-        content: const Text('Вы прошли весь трек!'),
-        actions: [
-          if (nextTrackId != null)
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-                SkillTreeNavigator.instance.openTrack(nextTrackId);
-              },
-              child: const Text('Следующий трек'),
-            ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
+    await TrackCompletionCelebrationService.instance
+        .maybeCelebrate(trackId);
 
     await SkillTreeMilestoneAnalyticsLogger.instance
         .logTrackCompleted(trackId: trackId);

--- a/test/services/stage_completion_celebration_service_test.dart
+++ b/test/services/stage_completion_celebration_service_test.dart
@@ -9,8 +9,6 @@ import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
 import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
 import 'package:poker_analyzer/services/stage_completion_celebration_service.dart';
 import 'package:poker_analyzer/services/skill_tree_library_service.dart';
-import 'package:poker_analyzer/services/track_recommendation_engine.dart';
-import 'package:poker_analyzer/services/skill_tree_navigator.dart';
 
 class _FakeLibraryService implements SkillTreeLibraryService {
   final Map<String, SkillTreeBuildResult> _trees;
@@ -99,108 +97,4 @@ void main() {
 
     expect(find.byType(AlertDialog), findsNothing);
   });
-
-  testWidgets('celebrates track completion', (tester) async {
-    final nodes = [node('a', 0), node('b', 1)];
-    final tree = builder.build(nodes).tree;
-    final lib = _FakeLibraryService({
-      'T': SkillTreeBuildResult(tree: tree),
-    }, nodes);
-
-    await tracker.markCompleted('a');
-    await tracker.markCompleted('b');
-
-    final svc = StageCompletionCelebrationService(
-      library: lib,
-      progress: tracker,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
-    );
-
-    await svc.checkAndCelebrateTrackCompletion('T');
-    await tester.pumpAndSettle();
-
-    expect(find.byType(AlertDialog), findsOneWidget);
-    expect(await tracker.isTrackCompleted('T'), isTrue);
-  });
-
-  testWidgets('does not repeat track celebration', (tester) async {
-    final nodes = [node('a', 0), node('b', 1)];
-    final tree = builder.build(nodes).tree;
-    final lib = _FakeLibraryService({
-      'T': SkillTreeBuildResult(tree: tree),
-    }, nodes);
-
-    await tracker.markCompleted('a');
-    await tracker.markCompleted('b');
-    await tracker.markTrackCompleted('T');
-
-    final svc = StageCompletionCelebrationService(
-      library: lib,
-      progress: tracker,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
-    );
-
-    await svc.checkAndCelebrateTrackCompletion('T');
-    await tester.pump();
-
-    expect(find.byType(AlertDialog), findsNothing);
-  });
-
-  testWidgets('offers next track recommendation', (tester) async {
-    final nodes1 = [node('a', 0)];
-    final nodes2 = [node('b', 0)];
-    final tree1 = builder.build(nodes1).tree;
-    final tree2 = builder.build(nodes2).tree;
-    final lib = _FakeLibraryService({
-      'T1': SkillTreeBuildResult(tree: tree1),
-      'T2': SkillTreeBuildResult(tree: tree2),
-    }, [...nodes1, ...nodes2]);
-
-    await tracker.markCompleted('a');
-
-    TrackRecommendationEngine.instance =
-        TrackRecommendationEngine(library: lib);
-    String opened = '';
-    SkillTreeNavigator.instance = _RecordingSkillTreeNavigator((id) {
-      opened = id;
-    });
-
-    final svc = StageCompletionCelebrationService(
-      library: lib,
-      progress: tracker,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
-    );
-
-    await svc.checkAndCelebrateTrackCompletion('T1');
-    await tester.pumpAndSettle();
-
-    expect(find.text('Следующий трек'), findsOneWidget);
-
-    await tester.tap(find.text('Следующий трек'));
-    await tester.pumpAndSettle();
-
-    expect(opened, 'T2');
-
-    TrackRecommendationEngine.instance = TrackRecommendationEngine();
-    SkillTreeNavigator.instance = const SkillTreeNavigator();
-  });
-}
-
-class _RecordingSkillTreeNavigator extends SkillTreeNavigator {
-  final void Function(String) onOpen;
-  const _RecordingSkillTreeNavigator(this.onOpen);
-
-  @override
-  Future<void> openTrack(String trackId) async {
-    onOpen(trackId);
-  }
 }

--- a/test/services/track_completion_celebration_service_test.dart
+++ b/test/services/track_completion_celebration_service_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+import 'package:poker_analyzer/services/track_completion_celebration_service.dart';
+import 'package:poker_analyzer/services/track_recommendation_engine.dart';
+import 'package:poker_analyzer/services/skill_tree_navigator.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  final Map<String, SkillTreeBuildResult> _trees;
+  final List<SkillTreeNodeModel> _nodes;
+  _FakeLibraryService(this._trees, this._nodes);
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => _trees[category];
+
+  @override
+  SkillTreeBuildResult? getTrack(String trackId) => _trees[trackId];
+
+  @override
+  List<SkillTreeBuildResult> getAllTracks() => _trees.values.toList();
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  testWidgets('celebrates completed track', (tester) async {
+    await tracker.markTrackCompleted('T');
+
+    final svc = TrackCompletionCelebrationService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.maybeCelebrate('T');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('track_completion_shown_T'), isTrue);
+  });
+
+  testWidgets('does not repeat celebration', (tester) async {
+    SharedPreferences.setMockInitialValues({'track_completion_shown_T': true});
+    await tracker.resetForTest();
+    await tracker.markTrackCompleted('T');
+
+    final svc = TrackCompletionCelebrationService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.maybeCelebrate('T');
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('offers next track navigation', (tester) async {
+    final node1 = SkillTreeNodeModel(id: 'a', title: 'A', category: 'T1', level: 0);
+    final node2 = SkillTreeNodeModel(id: 'b', title: 'B', category: 'T2', level: 0);
+    const builder = SkillTreeBuilderService();
+    final tree1 = builder.build([node1]).tree;
+    final tree2 = builder.build([node2]).tree;
+    final lib = _FakeLibraryService({
+      'T1': SkillTreeBuildResult(tree: tree1),
+      'T2': SkillTreeBuildResult(tree: tree2),
+    }, [node1, node2]);
+
+    TrackRecommendationEngine.instance = TrackRecommendationEngine(library: lib);
+    String opened = '';
+    SkillTreeNavigator.instance = _RecordingSkillTreeNavigator((id) {
+      opened = id;
+    });
+
+    await tracker.markTrackCompleted('T1');
+
+    final svc = TrackCompletionCelebrationService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.maybeCelebrate('T1');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Открыть следующий трек'), findsOneWidget);
+
+    await tester.tap(find.text('Открыть следующий трек'));
+    await tester.pumpAndSettle();
+
+    expect(opened, 'T2');
+
+    TrackRecommendationEngine.instance = TrackRecommendationEngine();
+    SkillTreeNavigator.instance = const SkillTreeNavigator();
+  });
+}
+
+class _RecordingSkillTreeNavigator extends SkillTreeNavigator {
+  final void Function(String) onOpen;
+  const _RecordingSkillTreeNavigator(this.onOpen);
+
+  @override
+  Future<void> openTrack(String trackId) async {
+    onOpen(trackId);
+  }
+}


### PR DESCRIPTION
## Summary
- add TrackCompletionCelebrationService to show celebratory modal on track completion
- delegate track completion handling in StageCompletionCelebrationService to new service
- cover track completion celebration with widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7f0ee528832aa5afaea9a436f8d4