### PR TITLE
feat: reward unlocker for completed tracks

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -7,6 +7,7 @@ import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_stage_completion_evaluator.dart';
 import 'skill_tree_milestone_analytics_logger.dart';
 import 'track_completion_celebration_service.dart';
+import 'track_reward_unlocker_service.dart';
 
 /// Shows a celebratory dialog when a skill tree stage is fully completed.
 class StageCompletionCelebrationService {
@@ -18,9 +19,9 @@ class StageCompletionCelebrationService {
     SkillTreeLibraryService? library,
     SkillTreeNodeProgressTracker? progress,
     SkillTreeStageCompletionEvaluator? evaluator,
-  }) : library = library ?? SkillTreeLibraryService.instance,
-       progress = progress ?? SkillTreeNodeProgressTracker.instance,
-       evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
+  })  : library = library ?? SkillTreeLibraryService.instance,
+        progress = progress ?? SkillTreeNodeProgressTracker.instance,
+        evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
 
   static StageCompletionCelebrationService instance =
       StageCompletionCelebrationService();
@@ -84,8 +85,9 @@ class StageCompletionCelebrationService {
     if (await progress.isTrackCompleted(trackId)) return;
     await progress.markTrackCompleted(trackId);
 
-    await TrackCompletionCelebrationService.instance
-        .maybeCelebrate(trackId);
+    await TrackCompletionCelebrationService.instance.maybeCelebrate(trackId);
+
+    await TrackRewardUnlockerService.instance.unlockReward(trackId);
 
     await SkillTreeMilestoneAnalyticsLogger.instance
         .logTrackCompleted(trackId: trackId);

--- a/lib/services/track_reward_unlocker_service.dart
+++ b/lib/services/track_reward_unlocker_service.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import '../screens/player_stats_screen.dart';
+import 'skill_tree_library_service.dart';
+import 'skill_tree_node_progress_tracker.dart';
+
+/// Grants a one-time reward when a track is completed for the first time.
+class TrackRewardUnlockerService {
+  final SkillTreeNodeProgressTracker progress;
+  final SkillTreeLibraryService library;
+
+  TrackRewardUnlockerService({
+    SkillTreeNodeProgressTracker? progress,
+    SkillTreeLibraryService? library,
+  })  : progress = progress ?? SkillTreeNodeProgressTracker.instance,
+        library = library ?? SkillTreeLibraryService.instance;
+
+  /// Singleton instance.
+  static TrackRewardUnlockerService instance = TrackRewardUnlockerService();
+
+  static String _prefsKey(String trackId) => 'reward_granted_$trackId';
+
+  Future<void> _ensureLoaded() async {
+    if (library.getAllTracks().isEmpty) {
+      await library.reload();
+    }
+    await progress.isTrackCompleted('');
+  }
+
+  /// Unlocks reward for [trackId] if the track is completed and not yet granted.
+  Future<void> unlockReward(String trackId) async {
+    await _ensureLoaded();
+    if (!await progress.isTrackCompleted(trackId)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final key = _prefsKey(trackId);
+    if (prefs.getBool(key) ?? false) return;
+    await prefs.setBool(key, true);
+
+    final ctx = navigatorKey.currentState?.context;
+    if (ctx == null || !ctx.mounted) return;
+
+    final title = _resolveTrackTitle(trackId);
+
+    await showDialog<void>(
+      context: ctx,
+      builder: (context) => AlertDialog(
+        title: const Text('Награда за прохождение!'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.card_giftcard, size: 48, color: Colors.orange),
+            const SizedBox(height: 12),
+            Text(title),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              Navigator.of(context).pushNamed(PlayerStatsScreen.route);
+            },
+            child: const Text('Посмотреть награды'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _resolveTrackTitle(String trackId) {
+    final track = library.getTrack(trackId)?.tree;
+    if (track == null) return trackId;
+    if (track.roots.isNotEmpty) return track.roots.first.title;
+    if (track.nodes.isNotEmpty) return track.nodes.values.first.title;
+    return trackId;
+  }
+}

--- a/test/services/track_reward_unlocker_service_test.dart
+++ b/test/services/track_reward_unlocker_service_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/services/track_reward_unlocker_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final tracker = SkillTreeNodeProgressTracker.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await tracker.resetForTest();
+  });
+
+  testWidgets('grants reward once after track completion', (tester) async {
+    await tracker.markTrackCompleted('T');
+    final svc = TrackRewardUnlockerService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.unlockReward('T');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('reward_granted_T'), isTrue);
+  });
+
+  testWidgets('does not repeat reward', (tester) async {
+    SharedPreferences.setMockInitialValues({'reward_granted_T': true});
+    await tracker.resetForTest();
+    await tracker.markTrackCompleted('T');
+    final svc = TrackRewardUnlockerService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.unlockReward('T');
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('skips reward if track incomplete', (tester) async {
+    final svc = TrackRewardUnlockerService(progress: tracker);
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+    );
+
+    await svc.unlockReward('T');
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add TrackRewardUnlockerService to grant one-time reward after track completion
- trigger reward unlocker when a track is finished
- cover reward unlock behavior with widget tests

## Testing
- `flutter test test/services/track_reward_unlocker_service_test.dart` *(fails: Dart SDK 3.1.3; requires >=3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_688d80abb288832a8b375777d87f8e96