### PR TITLE
feat: add reward gallery screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'screens/decay_adaptation_insight_screen.dart';
 import 'screens/skill_tree_learning_map_screen.dart';
 import 'screens/skill_tree_track_map_screen.dart';
 import 'screens/skill_tree_track_list_screen.dart';
+import 'screens/reward_gallery_screen.dart';
 import 'services/training_pack_storage_service.dart';
 import 'services/training_pack_cloud_sync_service.dart';
 import 'services/mistake_pack_cloud_service.dart';
@@ -407,6 +408,7 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
                   const SkillTreeTrackMapScreen(),
               SkillTreeTrackListScreen.route: (_) =>
                   const SkillTreeTrackListScreen(),
+              RewardGalleryScreen.route: (_) => const RewardGalleryScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -28,6 +28,7 @@ import 'screens/goal_center_screen.dart';
 import 'screens/goal_insights_screen.dart';
 import 'screens/memory_insights_screen.dart';
 import 'screens/decay_heatmap_screen.dart';
+import 'screens/reward_gallery_screen.dart';
 
 final GlobalKey analyzerKey = GlobalKey();
 
@@ -180,6 +181,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                   GoalInsightsScreen.route: (_) => const GoalInsightsScreen(),
                   MemoryInsightsScreen.route: (_) => const MemoryInsightsScreen(),
                   DecayHeatmapScreen.route: (_) => const DecayHeatmapScreen(),
+                  RewardGalleryScreen.route: (_) => const RewardGalleryScreen(),
                 },
                 builder: (context, child) {
                   return Stack(

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -52,6 +52,7 @@ import 'mistake_repeat_screen.dart';
 import 'quick_hand_analysis_screen.dart';
 import 'hand_analysis_history_screen.dart';
 import 'achievements_screen.dart';
+import 'reward_gallery_screen.dart';
 import '../services/goals_service.dart';
 import '../widgets/focus_of_the_week_card.dart';
 import '../widgets/sync_status_widget.dart';
@@ -717,6 +718,13 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         label: 'Decay Adaptation',
         onTap: () {
           Navigator.pushNamed(context, DecayAdaptationInsightScreen.route);
+        },
+      ),
+      _MenuItem(
+        icon: Icons.card_giftcard,
+        label: 'Награды',
+        onTap: () {
+          Navigator.pushNamed(context, RewardGalleryScreen.route);
         },
       ),
       _MenuItem(

--- a/lib/screens/reward_gallery_screen.dart
+++ b/lib/screens/reward_gallery_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/skill_tree_library_service.dart';
+
+class RewardGalleryScreen extends StatefulWidget {
+  static const route = '/rewards';
+  const RewardGalleryScreen({super.key});
+
+  @override
+  State<RewardGalleryScreen> createState() => _RewardGalleryScreenState();
+}
+
+class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
+  late Future<List<_RewardItem>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadRewards();
+  }
+
+  Future<List<_RewardItem>> _loadRewards() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys();
+    final library = SkillTreeLibraryService.instance;
+    if (library.getAllTracks().isEmpty) {
+      await library.reload();
+    }
+    final rewards = <_RewardItem>[];
+    const prefix = 'reward_granted_';
+    for (final k in keys) {
+      if (k.startsWith(prefix) && (prefs.getBool(k) ?? false)) {
+        final id = k.substring(prefix.length);
+        final title = _resolveTrackTitle(library, id);
+        rewards.add(_RewardItem(id: id, title: title));
+      }
+    }
+    rewards.sort((a, b) => a.title.compareTo(b.title));
+    return rewards;
+  }
+
+  String _resolveTrackTitle(SkillTreeLibraryService library, String trackId) {
+    final track = library.getTrack(trackId)?.tree;
+    if (track == null) return trackId;
+    if (track.roots.isNotEmpty) return track.roots.first.title;
+    if (track.nodes.isNotEmpty) return track.nodes.values.first.title;
+    return trackId;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Награды')),
+      body: FutureBuilder<List<_RewardItem>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final items = snapshot.data!;
+          if (items.isEmpty) {
+            return const Center(child: Text('Вы ещё не получили наград'));
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final r = items[index];
+              return ListTile(
+                leading: const Icon(Icons.card_giftcard, color: Colors.orange),
+                title: Text(r.title),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RewardItem {
+  final String id;
+  final String title;
+  const _RewardItem({required this.id, required this.title});
+}
+


### PR DESCRIPTION
## Summary
- add RewardGalleryScreen to showcase unlocked track rewards
- link reward gallery from main menu and register route

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d82f69c58832a88ea507cbb5b3a91