### PR TITLE
feat: share rewards

### DIFF
--- a/lib/screens/reward_gallery_screen.dart
+++ b/lib/screens/reward_gallery_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../services/skill_tree_library_service.dart';
 
@@ -70,6 +71,12 @@ class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
               return ListTile(
                 leading: const Icon(Icons.card_giftcard, color: Colors.orange),
                 title: Text(r.title),
+                trailing: IconButton(
+                  icon: const Icon(Icons.share),
+                  onPressed: () => Share.share(
+                    'Я только что завершил трек «${r.title}» в Poker Analyzer! 💪 Присоединяйся!',
+                  ),
+                ),
               );
             },
           );

--- a/test/widgets/reward_gallery_screen_test.dart
+++ b/test/widgets/reward_gallery_screen_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:poker_analyzer/screens/reward_gallery_screen.dart';
+
+class _FakeSharePlatform extends SharePlatform {
+  bool shared = false;
+  @override
+  Future<void> share(String? text,
+      {String? subject, ShareOptions? sharePositionOrigin}) async {
+    shared = true;
+  }
+
+  @override
+  Future<void> shareXFiles(List<XFile> files,
+      {String? text, String? subject, ShareOptions? sharePositionOrigin}) async {
+    shared = true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Share button shares reward', (tester) async {
+    SharedPreferences.setMockInitialValues({'reward_granted_test': true});
+    final share = _FakeSharePlatform();
+    SharePlatform.instance = share;
+
+    await tester.pumpWidget(const MaterialApp(home: RewardGalleryScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.share), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.share));
+    await tester.pumpAndSettle();
+    expect(share.shared, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add share button to reward gallery items
- test reward sharing displays share button and triggers share platform

## Testing
- `flutter test test/widgets/reward_gallery_screen_test.dart` *(fails: command not found: flutter)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688dc8487ffc832a989863c0ce9749c4