### PR TITLE
feat: grant track completion reward

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -7,6 +7,7 @@ import 'skill_tree_node_progress_tracker.dart';
 import 'skill_tree_stage_completion_evaluator.dart';
 import 'skill_tree_milestone_analytics_logger.dart';
 import 'track_completion_celebration_service.dart';
+import 'track_completion_reward_service.dart';
 import 'track_reward_unlocker_service.dart';
 
 /// Shows a celebratory dialog when a skill tree stage is fully completed.
@@ -87,7 +88,11 @@ class StageCompletionCelebrationService {
 
     await TrackCompletionCelebrationService.instance.maybeCelebrate(trackId);
 
-    await TrackRewardUnlockerService.instance.unlockReward(trackId);
+    final granted =
+        await TrackCompletionRewardService.instance.grantReward(trackId);
+    if (granted) {
+      await TrackRewardUnlockerService.instance.unlockReward(trackId);
+    }
 
     await SkillTreeMilestoneAnalyticsLogger.instance
         .logTrackCompleted(trackId: trackId);

--- a/lib/services/track_completion_reward_service.dart
+++ b/lib/services/track_completion_reward_service.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists a flag that a track completion reward has been granted.
+class TrackCompletionRewardService {
+  TrackCompletionRewardService._();
+  static final TrackCompletionRewardService instance =
+      TrackCompletionRewardService._();
+
+  /// Grants reward for [trackId].
+  /// Returns `true` if the reward was granted for the first time.
+  Future<bool> grantReward(String trackId) async {
+    if (trackId.isEmpty) return false;
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'reward_granted_$trackId';
+    if (prefs.getBool(key) ?? false) return false;
+    await prefs.setBool(key, true);
+    return true;
+  }
+}

--- a/lib/services/track_reward_unlocker_service.dart
+++ b/lib/services/track_reward_unlocker_service.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
 import '../screens/player_stats_screen.dart';
@@ -20,8 +19,6 @@ class TrackRewardUnlockerService {
   /// Singleton instance.
   static TrackRewardUnlockerService instance = TrackRewardUnlockerService();
 
-  static String _prefsKey(String trackId) => 'reward_granted_$trackId';
-
   Future<void> _ensureLoaded() async {
     if (library.getAllTracks().isEmpty) {
       await library.reload();
@@ -29,16 +26,10 @@ class TrackRewardUnlockerService {
     await progress.isTrackCompleted('');
   }
 
-  /// Unlocks reward for [trackId] if the track is completed and not yet granted.
+  /// Displays a reward dialog for [trackId] if it is completed.
   Future<void> unlockReward(String trackId) async {
     await _ensureLoaded();
     if (!await progress.isTrackCompleted(trackId)) return;
-
-    final prefs = await SharedPreferences.getInstance();
-    final key = _prefsKey(trackId);
-    if (prefs.getBool(key) ?? false) return;
-    await prefs.setBool(key, true);
-
     final ctx = navigatorKey.currentState?.context;
     if (ctx == null || !ctx.mounted) return;
 

--- a/test/services/track_completion_reward_service_test.dart
+++ b/test/services/track_completion_reward_service_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/track_completion_reward_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('grants reward only once', () async {
+    final svc = TrackCompletionRewardService.instance;
+    final first = await svc.grantReward('T');
+    expect(first, isTrue);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('reward_granted_T'), isTrue);
+    final second = await svc.grantReward('T');
+    expect(second, isFalse);
+  });
+}

--- a/test/services/track_reward_unlocker_service_test.dart
+++ b/test/services/track_reward_unlocker_service_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/services/track_completion_reward_service.dart';
 import 'package:poker_analyzer/services/track_reward_unlocker_service.dart';
 import 'package:poker_analyzer/services/skill_tree_node_progress_tracker.dart';
 
@@ -16,36 +17,22 @@ void main() {
     await tracker.resetForTest();
   });
 
-  testWidgets('grants reward once after track completion', (tester) async {
+  testWidgets('shows reward dialog after track completion', (tester) async {
     await tracker.markTrackCompleted('T');
+    final granted =
+        await TrackCompletionRewardService.instance.grantReward('T');
     final svc = TrackRewardUnlockerService(progress: tracker);
 
     await tester.pumpWidget(
       MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
     );
 
-    await svc.unlockReward('T');
+    if (granted) {
+      await svc.unlockReward('T');
+    }
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsOneWidget);
-    final prefs = await SharedPreferences.getInstance();
-    expect(prefs.getBool('reward_granted_T'), isTrue);
-  });
-
-  testWidgets('does not repeat reward', (tester) async {
-    SharedPreferences.setMockInitialValues({'reward_granted_T': true});
-    await tracker.resetForTest();
-    await tracker.markTrackCompleted('T');
-    final svc = TrackRewardUnlockerService(progress: tracker);
-
-    await tester.pumpWidget(
-      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
-    );
-
-    await svc.unlockReward('T');
-    await tester.pump();
-
-    expect(find.byType(AlertDialog), findsNothing);
   });
 
   testWidgets('skips reward if track incomplete', (tester) async {


### PR DESCRIPTION
## Summary
- Persist track completion rewards in SharedPreferences via new TrackCompletionRewardService
- Grant reward on track completion and show unlock dialog only once
- Cover reward granting and unlocker behavior with tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc937aa7c832a8c23de34109cbacd