### PR TITLE
feat: group reward gallery by track

### DIFF
--- a/lib/screens/reward_gallery_screen.dart
+++ b/lib/screens/reward_gallery_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:share_plus/share_plus.dart';
 
-import '../services/skill_tree_library_service.dart';
+import '../services/reward_gallery_group_by_track_service.dart';
 
 class RewardGalleryScreen extends StatefulWidget {
   static const route = '/rewards';
@@ -13,82 +12,57 @@ class RewardGalleryScreen extends StatefulWidget {
 }
 
 class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
-  late Future<List<_RewardItem>> _future;
+  late Future<List<TrackRewardGroup>> _future;
 
   @override
   void initState() {
     super.initState();
-    _future = _loadRewards();
-  }
-
-  Future<List<_RewardItem>> _loadRewards() async {
-    final prefs = await SharedPreferences.getInstance();
-    final keys = prefs.getKeys();
-    final library = SkillTreeLibraryService.instance;
-    if (library.getAllTracks().isEmpty) {
-      await library.reload();
-    }
-    final rewards = <_RewardItem>[];
-    const prefix = 'reward_granted_';
-    for (final k in keys) {
-      if (k.startsWith(prefix) && (prefs.getBool(k) ?? false)) {
-        final id = k.substring(prefix.length);
-        final title = _resolveTrackTitle(library, id);
-        rewards.add(_RewardItem(id: id, title: title));
-      }
-    }
-    rewards.sort((a, b) => a.title.compareTo(b.title));
-    return rewards;
-  }
-
-  String _resolveTrackTitle(SkillTreeLibraryService library, String trackId) {
-    final track = library.getTrack(trackId)?.tree;
-    if (track == null) return trackId;
-    if (track.roots.isNotEmpty) return track.roots.first.title;
-    if (track.nodes.isNotEmpty) return track.nodes.values.first.title;
-    return trackId;
+    _future =
+        RewardGalleryGroupByTrackService.instance.getGroupedRewards();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Награды')),
-      body: FutureBuilder<List<_RewardItem>>(
+      body: FutureBuilder<List<TrackRewardGroup>>(
         future: _future,
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
-          final items = snapshot.data!;
-          if (items.isEmpty) {
+          final groups = snapshot.data!;
+          if (groups.isEmpty) {
             return const Center(child: Text('Вы ещё не получили наград'));
           }
-          return ListView.builder(
+          return ListView(
             padding: const EdgeInsets.all(16),
-            itemCount: items.length,
-            itemBuilder: (context, index) {
-              final r = items[index];
-              return ListTile(
-                leading: const Icon(Icons.card_giftcard, color: Colors.orange),
-                title: Text(r.title),
-                trailing: IconButton(
-                  icon: const Icon(Icons.share),
-                  onPressed: () => Share.share(
-                    'Я только что завершил трек «${r.title}» в Poker Analyzer! 💪 Присоединяйся!',
+            children: [
+              for (final g in groups) ...[
+                ListTile(
+                  leading:
+                      const Icon(Icons.card_giftcard, color: Colors.orange),
+                  title: Text(g.trackTitle),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.share),
+                    onPressed: () => Share.share(
+                      'Я только что завершил трек «${g.trackTitle}» в Poker Analyzer! 💪 Присоединяйся!',
+                    ),
                   ),
                 ),
-              );
-            },
+                for (final r in g.rewards
+                    .where((e) => e.stageIndex != null))
+                  Padding(
+                    padding:
+                        const EdgeInsets.only(left: 72, top: 4, bottom: 8),
+                    child: Text('Этап ${r.stageIndex}'),
+                  ),
+              ]
+            ],
           );
         },
       ),
     );
   }
-}
-
-class _RewardItem {
-  final String id;
-  final String title;
-  const _RewardItem({required this.id, required this.title});
 }
 

--- a/lib/services/reward_gallery_group_by_track_service.dart
+++ b/lib/services/reward_gallery_group_by_track_service.dart
@@ -1,0 +1,84 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'skill_tree_library_service.dart';
+
+/// Item representing a single reward entry, optionally tied to a stage.
+class RewardItem {
+  final String id;
+  final int? stageIndex;
+  const RewardItem({required this.id, this.stageIndex});
+}
+
+/// Group of rewards belonging to a single track.
+class TrackRewardGroup {
+  final String trackId;
+  final String trackTitle;
+  final List<RewardItem> rewards;
+  const TrackRewardGroup({
+    required this.trackId,
+    required this.trackTitle,
+    required this.rewards,
+  });
+}
+
+/// Builds a structured list of earned rewards grouped by track.
+class RewardGalleryGroupByTrackService {
+  RewardGalleryGroupByTrackService._();
+  static final RewardGalleryGroupByTrackService instance =
+      RewardGalleryGroupByTrackService._();
+
+  /// Returns rewards grouped by track, optionally including stage-level info.
+  Future<List<TrackRewardGroup>> getGroupedRewards() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys();
+    final library = SkillTreeLibraryService.instance;
+    if (library.getAllTracks().isEmpty) {
+      await library.reload();
+    }
+
+    const prefix = 'reward_granted_';
+    final Map<String, TrackRewardGroup> groups = {};
+
+    for (final k in keys) {
+      if (!k.startsWith(prefix) || !(prefs.getBool(k) ?? false)) {
+        continue;
+      }
+      var id = k.substring(prefix.length);
+      String trackId = id;
+      int? stageIndex;
+      if (id.contains('_stage_')) {
+        final parts = id.split('_stage_');
+        trackId = parts[0];
+        stageIndex = int.tryParse(parts[1]);
+      }
+      final title = _resolveTrackTitle(library, trackId);
+      final group = groups.putIfAbsent(
+        trackId,
+        () => TrackRewardGroup(trackId: trackId, trackTitle: title, rewards: []),
+      );
+      group.rewards.add(RewardItem(id: id, stageIndex: stageIndex));
+    }
+
+    final trackOrder = library.getAllTracks().map((t) => t.category).toList();
+    final result = groups.values.toList();
+    result.sort((a, b) {
+      final ia = trackOrder.indexOf(a.trackId);
+      final ib = trackOrder.indexOf(b.trackId);
+      if (ia == -1 || ib == -1) {
+        return a.trackTitle.compareTo(b.trackTitle);
+      }
+      return ia.compareTo(ib);
+    });
+    return result;
+  }
+
+  String _resolveTrackTitle(
+      SkillTreeLibraryService library, String trackId) {
+    final track = library.getTrack(trackId)?.tree;
+    if (track == null) return trackId;
+    if (track.roots.isNotEmpty) return track.roots.first.title;
+    if (track.nodes.isNotEmpty) return track.nodes.values.first.title;
+    return trackId;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add RewardGalleryGroupByTrackService for grouping unlocked rewards by track and optional stage
- refactor reward gallery screen to display grouped track rewards with stage entries

## Testing
- `dart format lib/services/reward_gallery_group_by_track_service.dart lib/screens/reward_gallery_screen.dart` *(fails: command not found)*
- `flutter format lib/services/reward_gallery_group_by_track_service.dart lib/screens/reward_gallery_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688dcaa96a7c832a972f56e25f26dc92