### PR TITLE
feat: add reward card renderer service

### DIFF
--- a/lib/services/reward_card_renderer_service.dart
+++ b/lib/services/reward_card_renderer_service.dart
@@ -1,0 +1,100 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'png_exporter.dart';
+import 'skill_tree_library_service.dart';
+
+/// Renders a shareable reward card for completed tracks.
+class RewardCardRendererService {
+  final SkillTreeLibraryService library;
+  final SharedPreferences prefs;
+
+  RewardCardRendererService._({required this.library, required this.prefs});
+
+  /// Creates an instance using [library] and [prefs] or default singletons.
+  static Future<RewardCardRendererService> create({
+    SkillTreeLibraryService? library,
+    SharedPreferences? prefs,
+  }) async {
+    final p = prefs ?? await SharedPreferences.getInstance();
+    final l = library ?? SkillTreeLibraryService.instance;
+    return RewardCardRendererService._(library: l, prefs: p);
+  }
+
+  /// Builds a styled reward card widget for [trackId].
+  Widget buildCard(String trackId) {
+    final title = _resolveTrackTitle(trackId);
+    final completed = prefs.getBool('reward_granted_$trackId') ?? false;
+
+    return Container(
+      width: 300,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [Color(0xFF512DA8), Color(0xFF303F9F)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Stack(
+        children: [
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Icon(Icons.emoji_events, size: 48, color: Colors.amber),
+              const SizedBox(height: 12),
+              Text(
+                title,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                'Poker Analyzer',
+                style: TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ],
+          ),
+          if (completed)
+            Positioned(
+              right: 0,
+              top: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.green.shade600,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Text(
+                  'Завершено!',
+                  style: TextStyle(color: Colors.white, fontSize: 12),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Exports the reward card for [trackId] as a PNG image.
+  Future<Uint8List> exportImage(String trackId) async {
+    final img = await PngExporter.exportWidget(buildCard(trackId));
+    return img ?? Uint8List(0);
+  }
+
+  String _resolveTrackTitle(String trackId) {
+    final track = library.getTrack(trackId)?.tree;
+    if (track == null) return trackId;
+    if (track.roots.isNotEmpty) return track.roots.first.title;
+    if (track.nodes.isNotEmpty) return track.nodes.values.first.title;
+    return trackId;
+  }
+}

--- a/test/services/reward_card_renderer_service_test.dart
+++ b/test/services/reward_card_renderer_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/reward_card_renderer_service.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  final Map<String, SkillTreeBuildResult> _trees;
+  final List<SkillTreeNodeModel> _nodes;
+  _FakeLibraryService(this._trees, this._nodes);
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => _trees[category];
+
+  @override
+  SkillTreeBuildResult? getTrack(String trackId) => _trees[trackId];
+
+  @override
+  List<SkillTreeBuildResult> getAllTracks() => _trees.values.toList();
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'reward_granted_T': true});
+  });
+
+  testWidgets('builds card with title and completion badge', (tester) async {
+    final node = SkillTreeNodeModel(
+      id: 'n1',
+      title: 'Test Track',
+      category: 'T',
+      level: 0,
+    );
+    const builder = SkillTreeBuilderService();
+    final tree = builder.build([node]).tree;
+    final lib = _FakeLibraryService(
+      {'T': SkillTreeBuildResult(tree: tree)},
+      [node],
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final svc = await RewardCardRendererService.create(
+      library: lib,
+      prefs: prefs,
+    );
+
+    await tester.pumpWidget(MaterialApp(home: svc.buildCard('T')));
+
+    expect(find.text('Test Track'), findsOneWidget);
+    expect(find.text('Завершено!'), findsOneWidget);
+
+    final bytes = await svc.exportImage('T');
+    expect(bytes, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add RewardCardRendererService to render and export styled reward cards
- cover service with widget test for track title and completion badge

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*
- `flutter test test/services/reward_card_renderer_service_test.dart` *(fails: Type 'TrainingPackTemplate' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dcc25c150832a952552f27add2922