### PR TITLE
feat: prompt sharing after track completion

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -9,6 +9,7 @@ import 'skill_tree_milestone_analytics_logger.dart';
 import 'track_completion_celebration_service.dart';
 import 'track_completion_reward_service.dart';
 import 'track_reward_unlocker_service.dart';
+import '../widgets/track_completion_dialog.dart';
 
 /// Shows a celebratory dialog when a skill tree stage is fully completed.
 class StageCompletionCelebrationService {
@@ -92,6 +93,11 @@ class StageCompletionCelebrationService {
         await TrackCompletionRewardService.instance.grantReward(trackId);
     if (granted) {
       await TrackRewardUnlockerService.instance.unlockReward(trackId);
+    }
+
+    final ctx = navigatorKey.currentState?.context;
+    if (ctx != null && ctx.mounted) {
+      await TrackCompletionDialog.show(ctx, trackId);
     }
 
     await SkillTreeMilestoneAnalyticsLogger.instance

--- a/lib/widgets/track_completion_dialog.dart
+++ b/lib/widgets/track_completion_dialog.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../services/reward_card_renderer_service.dart';
+
+class TrackCompletionDialog extends StatefulWidget {
+  final String trackId;
+  const TrackCompletionDialog({super.key, required this.trackId});
+
+  static Future<void> show(BuildContext context, String trackId) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => TrackCompletionDialog(trackId: trackId),
+    );
+  }
+
+  @override
+  State<TrackCompletionDialog> createState() => _TrackCompletionDialogState();
+}
+
+class _TrackCompletionDialogState extends State<TrackCompletionDialog> {
+  late final Future<RewardCardRendererService> _rendererFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _rendererFuture = RewardCardRendererService.create();
+  }
+
+  Future<void> _share(RewardCardRendererService renderer) async {
+    final bytes = await renderer.exportImage(widget.trackId);
+    if (bytes.isEmpty) return;
+    final file = XFile.fromData(bytes, mimeType: 'image/png', name: 'reward.png');
+    await Share.shareXFiles([file]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<RewardCardRendererService>(
+      future: _rendererFuture,
+      builder: (context, snapshot) {
+        final renderer = snapshot.data;
+        return AlertDialog(
+          content: SizedBox(
+            width: 320,
+            child: snapshot.connectionState == ConnectionState.done && renderer != null
+                ? renderer.buildCard(widget.trackId)
+                : const SizedBox(
+                    height: 200,
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: renderer == null ? null : () => _share(renderer),
+              child: const Text('Поделиться'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Закрыть'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show track completion card with option to share result
- launch sharing dialog after granting track completion reward

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd3380ed0832a92c84b9d074b64a5