### PR TITLE
feat: add reward card style tuner

### DIFF
--- a/lib/services/reward_card_renderer_service.dart
+++ b/lib/services/reward_card_renderer_service.dart
@@ -4,36 +4,45 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'png_exporter.dart';
+import 'reward_card_style_tuner_service.dart';
 import 'skill_tree_library_service.dart';
 
 /// Renders a shareable reward card for completed tracks.
 class RewardCardRendererService {
   final SkillTreeLibraryService library;
   final SharedPreferences prefs;
+  final RewardCardStyleTunerService styleTuner;
 
-  RewardCardRendererService._({required this.library, required this.prefs});
+  RewardCardRendererService._({
+    required this.library,
+    required this.prefs,
+    required this.styleTuner,
+  });
 
   /// Creates an instance using [library] and [prefs] or default singletons.
   static Future<RewardCardRendererService> create({
     SkillTreeLibraryService? library,
     SharedPreferences? prefs,
+    RewardCardStyleTunerService? styleTuner,
   }) async {
     final p = prefs ?? await SharedPreferences.getInstance();
     final l = library ?? SkillTreeLibraryService.instance;
-    return RewardCardRendererService._(library: l, prefs: p);
+    final t = styleTuner ?? RewardCardStyleTunerService();
+    return RewardCardRendererService._(library: l, prefs: p, styleTuner: t);
   }
 
   /// Builds a styled reward card widget for [trackId].
   Widget buildCard(String trackId) {
     final title = _resolveTrackTitle(trackId);
     final completed = prefs.getBool('reward_granted_$trackId') ?? false;
+    final style = styleTuner.getStyle(trackId);
 
     return Container(
       width: 300,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [Color(0xFF512DA8), Color(0xFF303F9F)],
+        gradient: LinearGradient(
+          colors: style.gradient,
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
@@ -45,7 +54,7 @@ class RewardCardRendererService {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const Icon(Icons.emoji_events, size: 48, color: Colors.amber),
+              Icon(style.icon, size: 48, color: Colors.amber),
               const SizedBox(height: 12),
               Text(
                 title,
@@ -70,12 +79,12 @@ class RewardCardRendererService {
               child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: Colors.green.shade600,
+                  color: style.badgeColor,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Text(
-                  'Завершено!',
-                  style: TextStyle(color: Colors.white, fontSize: 12),
+                child: Text(
+                  style.badgeText,
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ),
             ),

--- a/lib/services/reward_card_style_tuner_service.dart
+++ b/lib/services/reward_card_style_tuner_service.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class RewardCardStyle {
+  final List<Color> gradient;
+  final IconData icon;
+  final String badgeText;
+  final Color badgeColor;
+
+  const RewardCardStyle({
+    required this.gradient,
+    required this.icon,
+    required this.badgeText,
+    required this.badgeColor,
+  });
+}
+
+/// Provides visual style parameters for reward cards.
+class RewardCardStyleTunerService {
+  RewardCardStyleTunerService({Map<String, RewardCardStyle>? trackStyles})
+      : _trackStyles = trackStyles ?? _defaultTrackStyles;
+
+  final Map<String, RewardCardStyle> _trackStyles;
+
+  static const RewardCardStyle _defaultStyle = RewardCardStyle(
+    gradient: [Color(0xFF512DA8), Color(0xFF303F9F)],
+    icon: Icons.emoji_events,
+    badgeText: 'Завершено!',
+    badgeColor: Color(0xFF2E7D32),
+  );
+
+  static const Map<String, RewardCardStyle> _defaultTrackStyles = {
+    'preflop': RewardCardStyle(
+      gradient: [Color(0xFF1565C0), Color(0xFF0D47A1)],
+      icon: Icons.play_arrow,
+      badgeText: 'Готово',
+      badgeColor: Color(0xFF2E7D32),
+    ),
+    'postflop': RewardCardStyle(
+      gradient: [Color(0xFF00897B), Color(0xFF00695C)],
+      icon: Icons.filter_alt,
+      badgeText: 'Готово',
+      badgeColor: Color(0xFF2E7D32),
+    ),
+  };
+
+  /// Returns a style configuration for a given [trackId].
+  RewardCardStyle getStyle(String trackId) {
+    return _trackStyles[trackId] ?? _defaultStyle;
+  }
+}
+

--- a/test/services/reward_card_renderer_service_test.dart
+++ b/test/services/reward_card_renderer_service_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/models/skill_tree_build_result.dart';
 import 'package:poker_analyzer/models/skill_tree_node_model.dart';
 import 'package:poker_analyzer/services/reward_card_renderer_service.dart';
+import 'package:poker_analyzer/services/reward_card_style_tuner_service.dart';
 import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
 import 'package:poker_analyzer/services/skill_tree_library_service.dart';
 
@@ -27,6 +28,18 @@ class _FakeLibraryService implements SkillTreeLibraryService {
 
   @override
   List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}
+
+class _FakeStyleTuner implements RewardCardStyleTunerService {
+  const _FakeStyleTuner();
+
+  @override
+  RewardCardStyle getStyle(String trackId) => const RewardCardStyle(
+        gradient: [Colors.black, Colors.white],
+        icon: Icons.star,
+        badgeText: 'Styled!',
+        badgeColor: Colors.red,
+      );
 }
 
 void main() {
@@ -53,12 +66,14 @@ void main() {
     final svc = await RewardCardRendererService.create(
       library: lib,
       prefs: prefs,
+      styleTuner: const _FakeStyleTuner(),
     );
 
     await tester.pumpWidget(MaterialApp(home: svc.buildCard('T')));
 
     expect(find.text('Test Track'), findsOneWidget);
-    expect(find.text('Завершено!'), findsOneWidget);
+    expect(find.text('Styled!'), findsOneWidget);
+    expect(find.byIcon(Icons.star), findsOneWidget);
 
     final bytes = await svc.exportImage('T');
     expect(bytes, isNotEmpty);


### PR DESCRIPTION
## Summary
- add `RewardCardStyleTunerService` and `RewardCardStyle` for reward card themes
- use style tuner in `RewardCardRendererService`
- cover renderer with style tuner test

## Testing
- `flutter test test/services/reward_card_renderer_service_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688dd47dec0c832a942bd8cde4cf54f6