### PR TITLE
feat: add reward preview before starting track

### DIFF
--- a/lib/screens/skill_tree_track_intro_screen.dart
+++ b/lib/screens/skill_tree_track_intro_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import '../services/skill_tree_library_service.dart';
 import '../services/skill_tree_track_progress_service.dart';
+import '../services/track_reward_preview_service.dart';
 import 'skill_tree_path_screen.dart';
 
 class SkillTreeTrackIntroScreen extends StatefulWidget {
@@ -17,10 +18,12 @@ class _SkillTreeTrackIntroScreenState extends State<SkillTreeTrackIntroScreen> {
   String _title = '';
   String _description = '';
   bool _loading = true;
+  late final Future<TrackRewardPreviewService> _previewFuture;
 
   @override
   void initState() {
     super.initState();
+    _previewFuture = TrackRewardPreviewService.create();
     _load();
   }
 
@@ -88,6 +91,20 @@ class _SkillTreeTrackIntroScreenState extends State<SkillTreeTrackIntroScreen> {
                 ),
               ),
               const SizedBox(height: 32),
+              FutureBuilder<TrackRewardPreviewService>(
+                future: _previewFuture,
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const SizedBox.shrink();
+                  }
+                  return Column(
+                    children: [
+                      snapshot.data!.buildPreviewCard(widget.trackId),
+                      const SizedBox(height: 32),
+                    ],
+                  );
+                },
+              ),
               ElevatedButton(
                 onPressed: _start,
                 child: const Text('Начать'),

--- a/lib/services/track_reward_preview_service.dart
+++ b/lib/services/track_reward_preview_service.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'reward_card_renderer_service.dart';
+import 'reward_card_style_tuner_service.dart';
+import 'skill_tree_library_service.dart';
+
+/// Builds a reward card preview for a track before it is completed.
+class TrackRewardPreviewService {
+  final RewardCardRendererService _renderer;
+  final _PreviewPreferences _prefs;
+
+  TrackRewardPreviewService._(this._renderer, this._prefs);
+
+  /// Creates a new instance using [library] and [prefs] or defaults.
+  static Future<TrackRewardPreviewService> create({
+    SkillTreeLibraryService? library,
+    SharedPreferences? prefs,
+    RewardCardStyleTunerService? styleTuner,
+  }) async {
+    final basePrefs = prefs ?? await SharedPreferences.getInstance();
+    final previewPrefs = _PreviewPreferences(basePrefs);
+    final renderer = await RewardCardRendererService.create(
+      library: library,
+      prefs: previewPrefs,
+      styleTuner: styleTuner,
+    );
+    return TrackRewardPreviewService._(renderer, previewPrefs);
+  }
+
+  /// Builds a preview reward card for [trackId] without completion badge.
+  Widget buildPreviewCard(String trackId) {
+    _prefs.trackId = trackId;
+    return _renderer.buildCard(trackId);
+  }
+}
+
+/// Wrapper around [SharedPreferences] that hides reward completion flags.
+class _PreviewPreferences implements SharedPreferences {
+  final SharedPreferences _base;
+  String trackId = '';
+
+  _PreviewPreferences(this._base);
+
+  @override
+  bool? getBool(String key) {
+    if (key == 'reward_granted_$trackId') return false;
+    return _base.getBool(key);
+  }
+
+  @override
+  Set<String> getKeys() => _base.getKeys();
+
+  @override
+  Object? get(String key) => _base.get(key);
+
+  @override
+  bool containsKey(String key) => _base.containsKey(key);
+
+  @override
+  double? getDouble(String key) => _base.getDouble(key);
+
+  @override
+  int? getInt(String key) => _base.getInt(key);
+
+  @override
+  String? getString(String key) => _base.getString(key);
+
+  @override
+  List<String>? getStringList(String key) => _base.getStringList(key);
+
+  @override
+  Future<bool> setBool(String key, bool value) => _base.setBool(key, value);
+
+  @override
+  Future<bool> setDouble(String key, double value) => _base.setDouble(key, value);
+
+  @override
+  Future<bool> setInt(String key, int value) => _base.setInt(key, value);
+
+  @override
+  Future<bool> setString(String key, String value) => _base.setString(key, value);
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) =>
+      _base.setStringList(key, value);
+
+  @override
+  Future<bool> remove(String key) => _base.remove(key);
+
+  @override
+  Future<bool> clear() => _base.clear();
+
+  @override
+  Future<void> reload() => _base.reload();
+}
+

--- a/test/services/track_reward_preview_service_test.dart
+++ b/test/services/track_reward_preview_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/skill_tree_build_result.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/reward_card_style_tuner_service.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_library_service.dart';
+import 'package:poker_analyzer/services/track_reward_preview_service.dart';
+
+class _FakeLibraryService implements SkillTreeLibraryService {
+  final Map<String, SkillTreeBuildResult> _trees;
+  final List<SkillTreeNodeModel> _nodes;
+  _FakeLibraryService(this._trees, this._nodes);
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  SkillTreeBuildResult? getTree(String category) => _trees[category];
+
+  @override
+  SkillTreeBuildResult? getTrack(String trackId) => _trees[trackId];
+
+  @override
+  List<SkillTreeBuildResult> getAllTracks() => _trees.values.toList();
+
+  @override
+  List<SkillTreeNodeModel> getAllNodes() => List.unmodifiable(_nodes);
+}
+
+class _FakeStyleTuner implements RewardCardStyleTunerService {
+  const _FakeStyleTuner();
+
+  @override
+  RewardCardStyle getStyle(String trackId) => const RewardCardStyle(
+        gradient: [Colors.black, Colors.white],
+        icon: Icons.star,
+        badgeText: 'Styled!',
+        badgeColor: Colors.red,
+      );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'reward_granted_T': true});
+  });
+
+  testWidgets('builds preview card without completion badge', (tester) async {
+    final node = SkillTreeNodeModel(
+      id: 'n1',
+      title: 'Test Track',
+      category: 'T',
+      level: 0,
+    );
+    const builder = SkillTreeBuilderService();
+    final tree = builder.build([node]).tree;
+    final lib = _FakeLibraryService(
+      {'T': SkillTreeBuildResult(tree: tree)},
+      [node],
+    );
+    final svc = await TrackRewardPreviewService.create(
+      library: lib,
+      styleTuner: const _FakeStyleTuner(),
+    );
+
+    await tester.pumpWidget(MaterialApp(home: svc.buildPreviewCard('T')));
+
+    expect(find.text('Test Track'), findsOneWidget);
+    expect(find.text('Styled!'), findsNothing);
+    expect(find.byIcon(Icons.star), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TrackRewardPreviewService to render reward card previews without completion badge
- show reward preview card on track intro screen
- cover preview behavior with tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd5b9ceb4832a8722fb7d9d8434a3