### PR TITLE
feat: add stage marker service for track nodes

### DIFF
--- a/lib/services/skill_tree_track_node_stage_marker_service.dart
+++ b/lib/services/skill_tree_track_node_stage_marker_service.dart
@@ -1,0 +1,28 @@
+import '../models/skill_tree_node_model.dart';
+
+/// Helper service that groups nodes into visual stage blocks based on level.
+class SkillTreeTrackNodeStageMarkerService {
+  const SkillTreeTrackNodeStageMarkerService();
+
+  /// Groups [nodes] by their level and returns ordered stage blocks.
+  List<StageBlock> build(List<SkillTreeNodeModel> nodes) {
+    final levels = <int, List<SkillTreeNodeModel>>{};
+    for (final node in nodes) {
+      levels.putIfAbsent(node.level, () => []).add(node);
+    }
+
+    final sortedLevels = levels.keys.toList()..sort();
+    return [
+      for (final lvl in sortedLevels)
+        StageBlock(stageIndex: lvl, nodes: List.unmodifiable(levels[lvl]!)),
+    ];
+  }
+}
+
+/// Container for nodes belonging to the same stage.
+class StageBlock {
+  final int stageIndex;
+  final List<SkillTreeNodeModel> nodes;
+
+  const StageBlock({required this.stageIndex, required this.nodes});
+}

--- a/lib/widgets/skill_tree_stage_list_builder.dart
+++ b/lib/widgets/skill_tree_stage_list_builder.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 
 import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_track_node_stage_marker_service.dart';
 import 'skill_tree_stage_block_builder.dart';
 
 /// Builds a scrollable list of skill tree stages.
 class SkillTreeStageListBuilder {
   final SkillTreeStageBlockBuilder blockBuilder;
+  final SkillTreeTrackNodeStageMarkerService stageMarker;
 
   const SkillTreeStageListBuilder({
     this.blockBuilder = const SkillTreeStageBlockBuilder(),
+    this.stageMarker = const SkillTreeTrackNodeStageMarkerService(),
   });
 
   /// Returns a [ListView] of stage blocks grouped by level.
@@ -20,22 +23,18 @@ class SkillTreeStageListBuilder {
     EdgeInsetsGeometry padding = const EdgeInsets.all(8),
     double spacing = 16,
   }) {
-    final levels = <int, List<SkillTreeNodeModel>>{};
-    for (final node in allNodes) {
-      levels.putIfAbsent(node.level, () => []).add(node);
-    }
-
-    final sortedLevels = levels.keys.toList()..sort();
+    final blocks = stageMarker.build(allNodes);
     final children = <Widget>[];
-    for (final lvl in sortedLevels) {
-      final nodes = levels[lvl]!;
+    for (final block in blocks) {
+      final nodes = block.nodes;
+      final lvl = block.stageIndex;
       final isUnlocked = nodes.any((n) => unlockedNodeIds.contains(n.id));
       final isCompleted = nodes.every((n) {
         final opt = (n as dynamic).isOptional == true;
         return opt || completedNodeIds.contains(n.id);
       });
 
-      final block = blockBuilder.build(
+      final stageWidget = this.blockBuilder.build(
         level: lvl,
         nodes: nodes,
         unlockedNodeIds: unlockedNodeIds,
@@ -47,7 +46,7 @@ class SkillTreeStageListBuilder {
 
       children.add(Padding(
         padding: EdgeInsets.only(bottom: spacing),
-        child: block,
+        child: stageWidget,
       ));
     }
 

--- a/test/services/skill_tree_track_node_stage_marker_service_test.dart
+++ b/test/services/skill_tree_track_node_stage_marker_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_track_node_stage_marker_service.dart';
+
+void main() {
+  final svc = SkillTreeTrackNodeStageMarkerService();
+
+  SkillTreeNodeModel node(String id, int level) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'PF', level: level);
+
+  test('groups nodes by level into stage blocks', () {
+    final nodes = [node('a', 0), node('b', 1), node('c', 1)];
+    final blocks = svc.build(nodes);
+    expect(blocks.length, 2);
+    expect(blocks.first.stageIndex, 0);
+    expect(blocks.first.nodes.map((n) => n.id), ['a']);
+    expect(blocks[1].stageIndex, 1);
+    expect(blocks[1].nodes.map((n) => n.id), ['b', 'c']);
+  });
+}


### PR DESCRIPTION
## Summary
- group track nodes by level using `SkillTreeTrackNodeStageMarkerService`
- use stage grouping service in `SkillTreeStageListBuilder`
- test stage marker service

## Testing
- `dart test test/services/skill_tree_track_node_stage_marker_service_test.dart` *(fails: command not found)*
- `flutter test test/services/skill_tree_track_node_stage_marker_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ddc37e400832ab8bbad959fa799f4