### PR TITLE
feat: auto-scroll to first incomplete stage

### DIFF
--- a/lib/services/stage_auto_scroll_service.dart
+++ b/lib/services/stage_auto_scroll_service.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_track_node_stage_marker_service.dart';
+
+/// Service that scrolls to the first incomplete stage block in a track.
+class StageAutoScrollService {
+  final SkillTreeTrackNodeStageMarkerService stageMarker;
+
+  const StageAutoScrollService({
+    this.stageMarker = const SkillTreeTrackNodeStageMarkerService(),
+  });
+
+  /// Scrolls to the first stage that is not yet completed.
+  Future<void> scrollToFirstIncompleteStage({
+    required BuildContext context,
+    required ScrollController controller,
+    required List<SkillTreeNodeModel> allNodes,
+    required Set<String> completedNodeIds,
+    required Map<int, GlobalKey> stageKeys,
+  }) async {
+    // Wait for the next frame so that widget positions are laid out.
+    await Future<void>.delayed(Duration.zero);
+    if (!context.mounted || !controller.hasClients) return;
+
+    final blocks = stageMarker.build(allNodes);
+    for (final block in blocks) {
+      final nodes = block.nodes;
+      final isCompleted = nodes.every((n) {
+        final opt = (n as dynamic).isOptional == true;
+        return opt || completedNodeIds.contains(n.id);
+      });
+      if (!isCompleted) {
+        final targetContext = stageKeys[block.stageIndex]?.currentContext;
+        if (targetContext != null) {
+          await Scrollable.ensureVisible(
+            targetContext,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        }
+        break;
+      }
+    }
+  }
+}

--- a/lib/widgets/skill_tree_stage_list_builder.dart
+++ b/lib/widgets/skill_tree_stage_list_builder.dart
@@ -22,6 +22,8 @@ class SkillTreeStageListBuilder {
     void Function(SkillTreeNodeModel node)? onNodeTap,
     EdgeInsetsGeometry padding = const EdgeInsets.all(8),
     double spacing = 16,
+    Map<int, GlobalKey>? stageKeys,
+    ScrollController? controller,
   }) {
     final blocks = stageMarker.build(allNodes);
     final children = <Widget>[];
@@ -44,12 +46,18 @@ class SkillTreeStageListBuilder {
         onNodeTap: onNodeTap,
       );
 
+      final key = stageKeys?[lvl];
       children.add(Padding(
+        key: key,
         padding: EdgeInsets.only(bottom: spacing),
         child: stageWidget,
       ));
     }
 
-    return ListView(padding: padding, children: children);
+    return ListView(
+      controller: controller,
+      padding: padding,
+      children: children,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add StageAutoScrollService to navigate to the first incomplete stage when loading a track
- allow SkillTreeStageListBuilder to attach scroll keys and accept a controller
- integrate auto-scroll behavior in SkillTreePathScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ddd6c7e40832aab8f51b2fae9831f