### PR TITLE
feat: add node completion state service

### DIFF
--- a/lib/services/skill_tree_node_completion_state_service.dart
+++ b/lib/services/skill_tree_node_completion_state_service.dart
@@ -1,0 +1,31 @@
+import '../models/skill_tree_node_model.dart';
+
+/// Represents the normalized completion state of a skill tree node.
+enum SkillTreeNodeState { locked, unlocked, completed, optional }
+
+/// Determines the [SkillTreeNodeState] for a given [SkillTreeNodeModel].
+///
+/// The evaluation is based on node metadata and player progress:
+/// - [SkillTreeNodeState.optional] if the node is marked optional.
+/// - [SkillTreeNodeState.completed] if the node has been completed or is
+///   implicitly completed by being optional.
+/// - [SkillTreeNodeState.unlocked] if the node is unlocked but not completed.
+/// - [SkillTreeNodeState.locked] otherwise.
+class SkillTreeNodeCompletionStateService {
+  const SkillTreeNodeCompletionStateService();
+
+  SkillTreeNodeState getNodeState({
+    required SkillTreeNodeModel node,
+    required Set<String> unlocked,
+    required Set<String> completed,
+  }) {
+    final isOptional = (node as dynamic).isOptional == true;
+    final isCompleted = isOptional || completed.contains(node.id);
+
+    if (isOptional) return SkillTreeNodeState.optional;
+    if (isCompleted) return SkillTreeNodeState.completed;
+    if (unlocked.contains(node.id)) return SkillTreeNodeState.unlocked;
+    return SkillTreeNodeState.locked;
+  }
+}
+

--- a/test/services/skill_tree_node_completion_state_service_test.dart
+++ b/test/services/skill_tree_node_completion_state_service_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_node_completion_state_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const service = SkillTreeNodeCompletionStateService();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'cat');
+
+  class OptionalNode extends SkillTreeNodeModel {
+    final bool isOptional;
+    const OptionalNode(String id)
+        : isOptional = true,
+          super(id: id, title: id, category: 'cat');
+  }
+
+  test('detects locked and unlocked nodes', () {
+    const u = {'n1'};
+    const c = <String>{};
+    expect(
+      service.getNodeState(node: node('n0'), unlocked: u, completed: c),
+      SkillTreeNodeState.locked,
+    );
+    expect(
+      service.getNodeState(node: node('n1'), unlocked: u, completed: c),
+      SkillTreeNodeState.unlocked,
+    );
+  });
+
+  test('detects completed nodes', () {
+    const u = {'n1'};
+    const c = {'n1'};
+    expect(
+      service.getNodeState(node: node('n1'), unlocked: u, completed: c),
+      SkillTreeNodeState.completed,
+    );
+  });
+
+  test('treats optional nodes as optional and completed', () {
+    const u = <String>{};
+    const c = <String>{};
+    final n = OptionalNode('opt');
+    expect(
+      service.getNodeState(node: n, unlocked: u, completed: c),
+      SkillTreeNodeState.optional,
+    );
+    // Optional nodes are also considered completed for progress.
+    expect(
+      service.getNodeState(node: n, unlocked: u, completed: {'opt'}),
+      SkillTreeNodeState.optional,
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `SkillTreeNodeCompletionStateService` to normalize node completion states
- cover node state logic with unit tests

## Testing
- `flutter test test/services/skill_tree_node_completion_state_service_test.dart` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688ddfe482b8832abc44268bcf2a6ba0