### PR TITLE
feat: add stage badge icon rendering

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -109,14 +109,19 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     final children = <Widget>[];
     final sortedLevels = levels.keys.toList()..sort();
     for (final lvl in sortedLevels) {
-      final overlay = _overlayBuilder.buildOverlay(
-        level: lvl,
-        isUnlocked: _unlockedStages.contains(lvl),
-        isCompleted: _completedStages.contains(lvl),
-      );
+      final isUnlockedStage = _unlockedStages.contains(lvl);
+      Widget? overlay;
+      if (!isUnlockedStage) {
+        overlay = _overlayBuilder.buildOverlay(
+          level: lvl,
+          isUnlocked: isUnlockedStage,
+          isCompleted: _completedStages.contains(lvl),
+        );
+      }
       final header = _headerBuilder.buildHeader(
         level: lvl,
         nodes: levels[lvl]!,
+        unlockedNodeIds: _unlocked,
         completedNodeIds: _completed,
         overlay: overlay,
       );

--- a/lib/widgets/skill_tree_grid_block_builder.dart
+++ b/lib/widgets/skill_tree_grid_block_builder.dart
@@ -70,6 +70,7 @@ class SkillTreeGridBlockBuilder {
     final header = headerBuilder.buildHeader(
       level: level,
       nodes: nodes,
+      unlockedNodeIds: unlockedNodeIds,
       completedNodeIds: completedNodeIds,
     );
 

--- a/lib/widgets/skill_tree_stage_block_builder.dart
+++ b/lib/widgets/skill_tree_stage_block_builder.dart
@@ -34,16 +34,20 @@ class SkillTreeStageBlockBuilder {
       completed: completedNodeIds,
     );
     final isStageUnlocked = stageState != SkillTreeStageState.locked;
-    final isStageCompleted = stageState == SkillTreeStageState.completed;
+    Widget? overlay;
+    if (!isStageUnlocked) {
+      overlay = overlayBuilder.buildOverlay(
+        level: level,
+        isUnlocked: isStageUnlocked,
+        isCompleted: false,
+      );
+    }
     final header = headerBuilder.buildHeader(
       level: level,
       nodes: nodes,
+      unlockedNodeIds: unlockedNodeIds,
       completedNodeIds: completedNodeIds,
-      overlay: overlayBuilder.buildOverlay(
-        level: level,
-        isUnlocked: isStageUnlocked,
-        isCompleted: isStageCompleted,
-      ),
+      overlay: overlay,
     );
 
     final grid = SkillTreeGridBlockBuilder(
@@ -78,6 +82,7 @@ class _EmptyHeaderBuilder extends SkillTreeStageHeaderBuilder {
   Widget buildHeader({
     required int level,
     required List<SkillTreeNodeModel> nodes,
+    required Set<String> unlockedNodeIds,
     required Set<String> completedNodeIds,
     Widget? overlay,
   }) {

--- a/lib/widgets/skill_tree_stage_header_builder.dart
+++ b/lib/widgets/skill_tree_stage_header_builder.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/material.dart';
 
 import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_stage_badge_evaluator_service.dart';
 
 /// Builds a header widget describing a skill tree stage (level).
 class SkillTreeStageHeaderBuilder {
-  const SkillTreeStageHeaderBuilder();
+  final SkillTreeStageBadgeEvaluatorService badgeEvaluator;
+
+  const SkillTreeStageHeaderBuilder({
+    this.badgeEvaluator = const SkillTreeStageBadgeEvaluatorService(),
+  });
 
   /// Returns a widget displaying metadata for a stage.
   Widget buildHeader({
     required int level,
     required List<SkillTreeNodeModel> nodes,
+    required Set<String> unlockedNodeIds,
     required Set<String> completedNodeIds,
     Widget? overlay,
   }) {
@@ -31,6 +37,45 @@ class SkillTreeStageHeaderBuilder {
       '$done of $total completed • $pct%',
       style: const TextStyle(fontSize: 12, color: Colors.white70),
     );
+
+    Widget? badge;
+    if (overlay == null) {
+      final badgeType = badgeEvaluator.getBadge(
+        nodes: nodes,
+        unlocked: unlockedNodeIds,
+        completed: completedNodeIds,
+      );
+      IconData? icon;
+      Color? color;
+      String? tooltip;
+      switch (badgeType) {
+        case 'locked':
+          icon = Icons.lock_outline;
+          color = Colors.grey;
+          tooltip = 'Stage locked';
+          break;
+        case 'in_progress':
+          icon = Icons.hourglass_bottom;
+          color = Colors.amber;
+          tooltip = 'In progress';
+          break;
+        case 'perfect':
+          icon = Icons.verified;
+          color = Colors.green;
+          tooltip = 'Perfect';
+          break;
+      }
+      if (icon != null && tooltip != null) {
+        badge = Positioned(
+          right: 0,
+          top: 0,
+          child: Tooltip(
+            message: tooltip,
+            child: Icon(icon, color: color, size: 20),
+          ),
+        );
+      }
+    }
 
     return SizedBox(
       height: 52,
@@ -54,6 +99,7 @@ class SkillTreeStageHeaderBuilder {
             ),
           ),
           if (overlay != null) overlay,
+          if (badge != null) badge,
         ],
       ),
     );

--- a/test/widgets/skill_tree_stage_header_builder_test.dart
+++ b/test/widgets/skill_tree_stage_header_builder_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_header_builder.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'cat', level: 1);
+
+  testWidgets('shows hourglass badge when stage in progress', (tester) async {
+    const builder = SkillTreeStageHeaderBuilder();
+    final header = builder.buildHeader(
+      level: 1,
+      nodes: [node('a')],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {},
+    );
+    await tester.pumpWidget(MaterialApp(home: header));
+    expect(find.byIcon(Icons.hourglass_bottom), findsOneWidget);
+  });
+
+  testWidgets('shows verified badge when stage perfect', (tester) async {
+    const builder = SkillTreeStageHeaderBuilder();
+    final header = builder.buildHeader(
+      level: 1,
+      nodes: [node('a')],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {'a'},
+    );
+    await tester.pumpWidget(MaterialApp(home: header));
+    expect(find.byIcon(Icons.verified), findsOneWidget);
+  });
+
+  testWidgets('no badge when overlay provided', (tester) async {
+    const builder = SkillTreeStageHeaderBuilder();
+    final overlay = const Positioned(right: 0, top: 0, child: Icon(Icons.lock));
+    final header = builder.buildHeader(
+      level: 1,
+      nodes: [node('a')],
+      unlockedNodeIds: {'a'},
+      completedNodeIds: {},
+      overlay: overlay,
+    );
+    await tester.pumpWidget(MaterialApp(home: header));
+    expect(find.byIcon(Icons.hourglass_bottom), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- render stage status badge icons in headers using SkillTreeStageBadgeEvaluatorService
- avoid overlay duplication and pass unlocked node data to header builders
- add tests for badge rendering behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de5cb2610832a8a5fd9b0472e527e