### PR TITLE
feat: add reusable stage badge icon

### DIFF
--- a/lib/widgets/skill_tree_stage_badge_icon.dart
+++ b/lib/widgets/skill_tree_stage_badge_icon.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Displays a badge icon for a skill tree stage based on [badge].
+///
+/// The [badge] parameter accepts `locked`, `in_progress`, or `perfect` and
+/// renders the appropriate icon with a tooltip. Unknown values render nothing.
+class SkillTreeStageBadgeIcon extends StatelessWidget {
+  final String badge;
+
+  const SkillTreeStageBadgeIcon({super.key, required this.badge});
+
+  @override
+  Widget build(BuildContext context) {
+    IconData? icon;
+    Color? color;
+    String? tooltip;
+
+    switch (badge) {
+      case 'locked':
+        icon = Icons.lock_outline;
+        color = Colors.grey;
+        tooltip = 'Stage locked';
+        break;
+      case 'in_progress':
+        icon = Icons.hourglass_bottom;
+        color = Colors.amber;
+        tooltip = 'In progress';
+        break;
+      case 'perfect':
+        icon = Icons.verified;
+        color = Colors.green;
+        tooltip = 'Perfect';
+        break;
+    }
+
+    if (icon == null || tooltip == null) return const SizedBox.shrink();
+
+    return Tooltip(
+      message: tooltip,
+      child: Icon(icon, color: color, size: 20),
+    );
+  }
+}

--- a/lib/widgets/skill_tree_stage_header_builder.dart
+++ b/lib/widgets/skill_tree_stage_header_builder.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/skill_tree_node_model.dart';
 import '../services/skill_tree_stage_badge_evaluator_service.dart';
+import 'skill_tree_stage_badge_icon.dart';
 
 /// Builds a header widget describing a skill tree stage (level).
 class SkillTreeStageHeaderBuilder {
@@ -45,36 +46,11 @@ class SkillTreeStageHeaderBuilder {
         unlocked: unlockedNodeIds,
         completed: completedNodeIds,
       );
-      IconData? icon;
-      Color? color;
-      String? tooltip;
-      switch (badgeType) {
-        case 'locked':
-          icon = Icons.lock_outline;
-          color = Colors.grey;
-          tooltip = 'Stage locked';
-          break;
-        case 'in_progress':
-          icon = Icons.hourglass_bottom;
-          color = Colors.amber;
-          tooltip = 'In progress';
-          break;
-        case 'perfect':
-          icon = Icons.verified;
-          color = Colors.green;
-          tooltip = 'Perfect';
-          break;
-      }
-      if (icon != null && tooltip != null) {
-        badge = Positioned(
-          right: 0,
-          top: 0,
-          child: Tooltip(
-            message: tooltip,
-            child: Icon(icon, color: color, size: 20),
-          ),
-        );
-      }
+      badge = Positioned(
+        right: 0,
+        top: 0,
+        child: SkillTreeStageBadgeIcon(badge: badgeType),
+      );
     }
 
     return SizedBox(

--- a/test/widgets/skill_tree_stage_badge_icon_test.dart
+++ b/test/widgets/skill_tree_stage_badge_icon_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_badge_icon.dart';
+
+void main() {
+  testWidgets('renders locked badge', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SkillTreeStageBadgeIcon(badge: 'locked')),
+    );
+    expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+  });
+
+  testWidgets('renders in progress badge', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SkillTreeStageBadgeIcon(badge: 'in_progress')),
+    );
+    expect(find.byIcon(Icons.hourglass_bottom), findsOneWidget);
+  });
+
+  testWidgets('renders perfect badge', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SkillTreeStageBadgeIcon(badge: 'perfect')),
+    );
+    expect(find.byIcon(Icons.verified), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- extract SkillTreeStageBadgeIcon widget for consistent badge visuals
- use SkillTreeStageBadgeIcon in SkillTreeStageHeaderBuilder
- cover badge icon with widget tests

## Testing
- `dart test test/widgets/skill_tree_stage_badge_icon_test.dart test/widgets/skill_tree_stage_header_builder_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_688de768c1e4832a9714accd4593b1da