### PR TITLE
feat: add skill tree badge legend

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -9,6 +9,7 @@ import '../services/track_milestone_unlocker_service.dart';
 import '../services/stage_auto_scroll_service.dart';
 import '../widgets/skill_tree_stage_list_builder.dart';
 import '../widgets/skill_tree_track_overview_header.dart';
+import '../widgets/skill_tree_stage_badge_legend_widget.dart';
 import 'skill_tree_node_detail_screen.dart';
 
 /// Renders the full learning path for a skill track.
@@ -138,8 +139,10 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
     return Scaffold(
       appBar: AppBar(title: Text(title)),
       body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           header,
+          const SkillTreeStageBadgeLegendWidget(),
           Expanded(child: list),
         ],
       ),

--- a/lib/widgets/skill_tree_stage_badge_legend_widget.dart
+++ b/lib/widgets/skill_tree_stage_badge_legend_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import 'skill_tree_stage_badge_icon.dart';
+
+/// Displays legend for stage badges with icons and explanations.
+class SkillTreeStageBadgeLegendWidget extends StatelessWidget {
+  const SkillTreeStageBadgeLegendWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _LegendItem(badge: 'locked', text: 'Stage locked'),
+          SizedBox(height: 4),
+          _LegendItem(badge: 'in_progress', text: 'Stage in progress'),
+          SizedBox(height: 4),
+          _LegendItem(badge: 'perfect', text: 'Perfect completion'),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegendItem extends StatelessWidget {
+  final String badge;
+  final String text;
+
+  const _LegendItem({required this.badge, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SkillTreeStageBadgeIcon(badge: badge),
+        const SizedBox(width: 8),
+        Text(text),
+      ],
+    );
+  }
+}

--- a/test/widgets/skill_tree_stage_badge_legend_widget_test.dart
+++ b/test/widgets/skill_tree_stage_badge_legend_widget_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_badge_icon.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_badge_legend_widget.dart';
+
+void main() {
+  testWidgets('displays legend items', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SkillTreeStageBadgeLegendWidget()),
+    );
+
+    expect(find.text('Stage locked'), findsOneWidget);
+    expect(find.text('Stage in progress'), findsOneWidget);
+    expect(find.text('Perfect completion'), findsOneWidget);
+    expect(find.byType(SkillTreeStageBadgeIcon), findsNWidgets(3));
+  });
+}


### PR DESCRIPTION
## Summary
- add SkillTreeStageBadgeLegendWidget to explain badge meanings
- show badge legend on SkillTreePathScreen
- cover badge legend with widget tests

## Testing
- `flutter test` *(fails: Because poker_analyzer requires SDK version >=3.6.0 <4.0.0, version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e00efa2ac832aa9c633395371c5ce