### PR TITLE
feat(skill-tree): add node detail unlock hints

### DIFF
--- a/lib/services/skill_tree_node_detail_unlock_hint_service.dart
+++ b/lib/services/skill_tree_node_detail_unlock_hint_service.dart
@@ -1,0 +1,63 @@
+import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_stage_gate_evaluator.dart';
+
+/// Provides hints explaining how to unlock a skill tree node on the detail page.
+class SkillTreeNodeDetailUnlockHintService {
+  const SkillTreeNodeDetailUnlockHintService({
+    this.stageEvaluator = const SkillTreeStageGateEvaluator(),
+  });
+
+  final SkillTreeStageGateEvaluator stageEvaluator;
+
+  /// Returns a human‑readable hint describing how to unlock [node].
+  ///
+  /// If the node is already unlocked, `null` is returned.
+  /// Otherwise the method inspects the track's edges and stage gates to
+  /// determine which prerequisite nodes must be completed.
+  String? getUnlockHint({
+    required SkillTreeNodeModel node,
+    required Set<String> unlocked,
+    required Set<String> completed,
+    required SkillTree track,
+  }) {
+    if (unlocked.contains(node.id)) return null;
+
+    // Stage gating: check if the node's stage is unlocked.
+    if (!stageEvaluator.isStageUnlocked(track, node.level, completed)) {
+      final blockers = stageEvaluator.getBlockingNodes(track, node.level, completed);
+      if (blockers.isNotEmpty) {
+        final names = _formatNames(blockers.map((n) => n.title).toList());
+        return 'Complete $names to unlock this node';
+      }
+      return 'Complete previous stages to unlock this node';
+    }
+
+    // Determine parent nodes from track edges that are not yet completed.
+    final parentNodeIds = <String>[
+      for (final n in track.nodes.values)
+        if (n.unlockedNodeIds.contains(node.id)) n.id,
+    ];
+
+    final blocking = <SkillTreeNodeModel>[
+      for (final id in parentNodeIds)
+        if (!completed.contains(id)) track.nodes[id]!,
+    ];
+
+    if (blocking.isEmpty) return null;
+
+    final names = _formatNames(blocking.map((n) => n.title).toList());
+    return 'Complete $names to unlock this node';
+  }
+
+  String _formatNames(List<String> titles) {
+    if (titles.isEmpty) return '';
+    if (titles.length == 1) return titles.first;
+    if (titles.length == 2) return '${titles[0]} or ${titles[1]}';
+    if (titles.length == 3) {
+      return '${titles[0]}, ${titles[1]} or ${titles[2]}';
+    }
+    return titles.first;
+  }
+}
+

--- a/test/services/skill_tree_node_detail_unlock_hint_service_test.dart
+++ b/test/services/skill_tree_node_detail_unlock_hint_service_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/services/skill_tree_node_detail_unlock_hint_service.dart';
+
+void main() {
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id,
+          {List<String>? prerequisites,
+          List<String>? unlocks,
+          int level = 0}) =>
+      SkillTreeNodeModel(
+        id: id,
+        title: id,
+        category: 'cat',
+        prerequisites: prerequisites,
+        unlockedNodeIds: unlocks,
+        level: level,
+      );
+
+  SkillTree buildTree(List<SkillTreeNodeModel> nodes) =>
+      builder.build(nodes).tree;
+
+  test('returns null for unlocked node', () {
+    final n1 = node('n1', unlocks: ['n2']);
+    final n2 = node('n2', prerequisites: ['n1']);
+    final tree = buildTree([n1, n2]);
+    final svc = const SkillTreeNodeDetailUnlockHintService();
+    final hint = svc.getUnlockHint(
+      node: n2,
+      unlocked: {'n2'},
+      completed: {'n1'},
+      track: tree,
+    );
+    expect(hint, isNull);
+  });
+
+  test('reports missing prerequisite', () {
+    final n1 = node('n1', unlocks: ['n2']);
+    final n2 = node('n2', prerequisites: ['n1']);
+    final tree = buildTree([n1, n2]);
+    final svc = const SkillTreeNodeDetailUnlockHintService();
+    final hint = svc.getUnlockHint(
+      node: n2,
+      unlocked: {},
+      completed: {},
+      track: tree,
+    );
+    expect(hint, 'Complete n1 to unlock this node');
+  });
+
+  test('reports locked stage', () {
+    final n1 = node('n1', unlocks: ['n2'], level: 0);
+    final n2 = node('n2', unlocks: ['n3'], level: 1);
+    final n3 = node('n3', prerequisites: ['n2'], level: 2);
+    final tree = buildTree([n1, n2, n3]);
+    final svc = const SkillTreeNodeDetailUnlockHintService();
+    final hint = svc.getUnlockHint(
+      node: n3,
+      unlocked: {},
+      completed: {'n1'},
+      track: tree,
+    );
+    expect(hint, 'Complete n2 to unlock this node');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add service providing unlock hints for skill tree nodes
- cover unlock hint logic with tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e03599288832aad531ddf582640aa