### PR TITLE
feat: add skill tree node unlock hint widget

### DIFF
--- a/lib/screens/skill_tree_learning_map_screen.dart
+++ b/lib/screens/skill_tree_learning_map_screen.dart
@@ -61,6 +61,9 @@ class _SkillTreeLearningMapScreenState
         builder: (_) => SkillTreeNodeDetailScreen(
           node: node,
           unlocked: _unlocked.contains(node.id),
+          track: _track!,
+          unlockedNodeIds: _unlocked,
+          completedNodeIds: _completed,
         ),
       ),
     );

--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/skill_tree_node_model.dart';
 import '../models/theory_mini_lesson_node.dart';
+import '../models/skill_tree.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
@@ -10,17 +11,24 @@ import '../services/skill_tree_node_progress_tracker.dart';
 import '../services/training_progress_service.dart';
 import '../services/skill_tree_node_celebration_service.dart';
 import '../widgets/tag_badge.dart';
+import '../widgets/skill_tree_node_detail_hint_widget.dart';
 import 'theory_lesson_viewer_screen.dart';
 
 /// Screen showing details for a [SkillTreeNodeModel] before starting it.
 class SkillTreeNodeDetailScreen extends StatefulWidget {
   final SkillTreeNodeModel node;
   final bool unlocked;
+  final SkillTree? track;
+  final Set<String>? unlockedNodeIds;
+  final Set<String>? completedNodeIds;
 
   const SkillTreeNodeDetailScreen({
     super.key,
     required this.node,
     this.unlocked = true,
+    this.track,
+    this.unlockedNodeIds,
+    this.completedNodeIds,
   });
 
   @override
@@ -168,6 +176,16 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                     Text('$pct%',
                         style: const TextStyle(
                             color: Colors.white70, fontSize: 12)),
+                    if (!widget.unlocked &&
+                        widget.track != null &&
+                        widget.unlockedNodeIds != null &&
+                        widget.completedNodeIds != null)
+                      SkillTreeNodeDetailHintWidget(
+                        node: widget.node,
+                        track: widget.track!,
+                        unlocked: widget.unlockedNodeIds!,
+                        completed: widget.completedNodeIds!,
+                      ),
                     const Spacer(),
                     Tooltip(
                       message:

--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -89,6 +89,9 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
         builder: (_) => SkillTreeNodeDetailScreen(
           node: node,
           unlocked: _unlocked.contains(node.id),
+          track: _track!,
+          unlockedNodeIds: _unlocked,
+          completedNodeIds: _completed,
         ),
       ),
     );

--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -80,7 +80,12 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SkillTreeNodeDetailScreen(node: node),
+        builder: (_) => SkillTreeNodeDetailScreen(
+          node: node,
+          track: _tree!,
+          unlockedNodeIds: _unlocked,
+          completedNodeIds: _completed,
+        ),
       ),
     );
     await _load();

--- a/lib/widgets/skill_tree_node_detail_hint_widget.dart
+++ b/lib/widgets/skill_tree_node_detail_hint_widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree.dart';
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_node_detail_unlock_hint_service.dart';
+
+/// Small UI component that shows why a skill tree node is locked.
+class SkillTreeNodeDetailHintWidget extends StatelessWidget {
+  final SkillTreeNodeModel node;
+  final SkillTree track;
+  final Set<String> unlocked;
+  final Set<String> completed;
+
+  const SkillTreeNodeDetailHintWidget({
+    super.key,
+    required this.node,
+    required this.track,
+    required this.unlocked,
+    required this.completed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hint = const SkillTreeNodeDetailUnlockHintService().getUnlockHint(
+      node: node,
+      unlocked: unlocked,
+      completed: completed,
+      track: track,
+    );
+    if (hint == null) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.info_outline, size: 16, color: Colors.grey),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              hint,
+              style: const TextStyle(fontSize: 13, color: Colors.grey),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/test/widgets/skill_tree_node_detail_hint_widget_test.dart
+++ b/test/widgets/skill_tree_node_detail_hint_widget_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/services/skill_tree_builder_service.dart';
+import 'package:poker_analyzer/widgets/skill_tree_node_detail_hint_widget.dart';
+
+void main() {
+  const builder = SkillTreeBuilderService();
+
+  SkillTreeNodeModel node(String id,
+          {List<String>? prerequisites,
+          List<String>? unlocks,
+          int level = 0}) =>
+      SkillTreeNodeModel(
+        id: id,
+        title: id,
+        category: 'cat',
+        prerequisites: prerequisites,
+        unlockedNodeIds: unlocks,
+        level: level,
+      );
+
+  SkillTree buildTree(List<SkillTreeNodeModel> nodes) =>
+      builder.build(nodes).tree;
+
+  testWidgets('renders nothing when no hint', (tester) async {
+    final n1 = node('n1', unlocks: ['n2']);
+    final n2 = node('n2', prerequisites: ['n1']);
+    final tree = buildTree([n1, n2]);
+    await tester.pumpWidget(MaterialApp(
+      home: SkillTreeNodeDetailHintWidget(
+        node: n2,
+        track: tree,
+        unlocked: {'n2'},
+        completed: {'n1'},
+      ),
+    ));
+    expect(find.byIcon(Icons.info_outline), findsNothing);
+  });
+
+  testWidgets('shows hint when locked', (tester) async {
+    final n1 = node('n1', unlocks: ['n2']);
+    final n2 = node('n2', prerequisites: ['n1']);
+    final tree = buildTree([n1, n2]);
+    await tester.pumpWidget(MaterialApp(
+      home: SkillTreeNodeDetailHintWidget(
+        node: n2,
+        track: tree,
+        unlocked: const <String>{},
+        completed: const <String>{},
+      ),
+    ));
+    expect(find.byIcon(Icons.info_outline), findsOneWidget);
+    expect(find.text('Complete n1 to unlock this node'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add SkillTreeNodeDetailHintWidget to surface unlock hints for skill tree nodes
- allow SkillTreeNodeDetailScreen to display these hints when nodes are locked
- cover widget behavior with unit tests

## Testing
- `flutter test` *(failed: It appears that the downloaded file is corrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688e0497c0f4832aa42e4dfab821c7ce