### PR TITLE
feat: add stage header badge widget

### DIFF
--- a/lib/widgets/skill_tree_stage_header_badge_widget.dart
+++ b/lib/widgets/skill_tree_stage_header_badge_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_tree_stage_badge_evaluator_service.dart';
+
+/// Displays a small badge next to the stage header describing its state.
+///
+/// It evaluates the stage using [SkillTreeStageBadgeEvaluatorService] and
+/// renders one of three icons:
+/// - `locked` ➜ grey lock
+/// - `in_progress` ➜ amber hourglass
+/// - `perfect` ➜ green check circle
+class SkillTreeStageHeaderBadgeWidget extends StatelessWidget {
+  final List<SkillTreeNodeModel> nodes;
+  final Set<String> unlocked;
+  final Set<String> completed;
+
+  const SkillTreeStageHeaderBadgeWidget({
+    super.key,
+    required this.nodes,
+    required this.unlocked,
+    required this.completed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const evaluator = SkillTreeStageBadgeEvaluatorService();
+    final badge = evaluator.getBadge(
+      nodes: nodes,
+      unlocked: unlocked,
+      completed: completed,
+    );
+
+    Icon? icon;
+    switch (badge) {
+      case 'locked':
+        icon = const Icon(Icons.lock, color: Colors.grey, size: 18);
+        break;
+      case 'in_progress':
+        icon = const Icon(Icons.hourglass_bottom, color: Colors.amber, size: 18);
+        break;
+      case 'perfect':
+        icon = const Icon(Icons.check_circle, color: Colors.green, size: 18);
+        break;
+    }
+
+    if (icon == null) return const SizedBox.shrink();
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(width: 4),
+        icon,
+      ],
+    );
+  }
+}

--- a/lib/widgets/skill_tree_stage_header_builder.dart
+++ b/lib/widgets/skill_tree_stage_header_builder.dart
@@ -1,16 +1,11 @@
 import 'package:flutter/material.dart';
 
 import '../models/skill_tree_node_model.dart';
-import '../services/skill_tree_stage_badge_evaluator_service.dart';
-import 'skill_tree_stage_badge_icon.dart';
+import 'skill_tree_stage_header_widget.dart';
 
 /// Builds a header widget describing a skill tree stage (level).
 class SkillTreeStageHeaderBuilder {
-  final SkillTreeStageBadgeEvaluatorService badgeEvaluator;
-
-  const SkillTreeStageHeaderBuilder({
-    this.badgeEvaluator = const SkillTreeStageBadgeEvaluatorService(),
-  });
+  const SkillTreeStageHeaderBuilder();
 
   /// Returns a widget displaying metadata for a stage.
   Widget buildHeader({
@@ -20,64 +15,12 @@ class SkillTreeStageHeaderBuilder {
     required Set<String> completedNodeIds,
     Widget? overlay,
   }) {
-    final filtered = nodes
-        .where((n) => (n as dynamic).isOptional != true)
-        .toList();
-    final total = filtered.length;
-    final done = filtered.where((n) => completedNodeIds.contains(n.id)).length;
-    final pct = total > 0 ? ((done / total) * 100).round() : 0;
-    final progress = total > 0 ? done / total : 0.0;
-
-    final progressBar = LinearProgressIndicator(
-      value: progress,
-      backgroundColor: Colors.white24,
-      minHeight: 6,
-    );
-
-    final subtitle = Text(
-      '$done of $total completed • $pct%',
-      style: const TextStyle(fontSize: 12, color: Colors.white70),
-    );
-
-    Widget? badge;
-    if (overlay == null) {
-      final badgeType = badgeEvaluator.getBadge(
-        nodes: nodes,
-        unlocked: unlockedNodeIds,
-        completed: completedNodeIds,
-      );
-      badge = Positioned(
-        right: 0,
-        top: 0,
-        child: SkillTreeStageBadgeIcon(badge: badgeType),
-      );
-    }
-
-    return SizedBox(
-      height: 52,
-      child: Stack(
-        children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  'Level $level',
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 4),
-                progressBar,
-                const SizedBox(height: 4),
-                subtitle,
-              ],
-            ),
-          ),
-          if (overlay != null) overlay,
-          if (badge != null) badge,
-        ],
-      ),
+    return SkillTreeStageHeaderWidget(
+      level: level,
+      nodes: nodes,
+      unlockedNodeIds: unlockedNodeIds,
+      completedNodeIds: completedNodeIds,
+      overlay: overlay,
     );
   }
 }

--- a/lib/widgets/skill_tree_stage_header_widget.dart
+++ b/lib/widgets/skill_tree_stage_header_widget.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../models/skill_tree_node_model.dart';
+import 'skill_tree_stage_header_badge_widget.dart';
+
+/// Displays metadata for a skill tree stage including progress and badge.
+class SkillTreeStageHeaderWidget extends StatelessWidget {
+  final int level;
+  final List<SkillTreeNodeModel> nodes;
+  final Set<String> unlockedNodeIds;
+  final Set<String> completedNodeIds;
+  final Widget? overlay;
+
+  const SkillTreeStageHeaderWidget({
+    super.key,
+    required this.level,
+    required this.nodes,
+    required this.unlockedNodeIds,
+    required this.completedNodeIds,
+    this.overlay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered =
+        nodes.where((n) => (n as dynamic).isOptional != true).toList();
+    final total = filtered.length;
+    final done = filtered.where((n) => completedNodeIds.contains(n.id)).length;
+    final pct = total > 0 ? ((done / total) * 100).round() : 0;
+    final progress = total > 0 ? done / total : 0.0;
+
+    final progressBar = LinearProgressIndicator(
+      value: progress,
+      backgroundColor: Colors.white24,
+      minHeight: 6,
+    );
+
+    final subtitle = Text(
+      '$done of $total completed • $pct%',
+      style: const TextStyle(fontSize: 12, color: Colors.white70),
+    );
+
+    final badge = overlay == null
+        ? SkillTreeStageHeaderBadgeWidget(
+            nodes: nodes,
+            unlocked: unlockedNodeIds,
+            completed: completedNodeIds,
+          )
+        : null;
+
+    return SizedBox(
+      height: 52,
+      child: Stack(
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Level $level',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    if (badge != null) badge,
+                  ],
+                ),
+                const SizedBox(height: 4),
+                progressBar,
+                const SizedBox(height: 4),
+                subtitle,
+              ],
+            ),
+          ),
+          if (overlay != null) overlay!,
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/skill_tree_stage_header_badge_widget_test.dart
+++ b/test/widgets/skill_tree_stage_header_badge_widget_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/widgets/skill_tree_stage_header_badge_widget.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SkillTreeNodeModel node(String id) =>
+      SkillTreeNodeModel(id: id, title: id, category: 'cat', level: 1);
+
+  testWidgets('shows lock icon when stage locked', (tester) async {
+    final widget = SkillTreeStageHeaderBadgeWidget(
+      nodes: [node('a')],
+      unlocked: const {},
+      completed: const {},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byIcon(Icons.lock), findsOneWidget);
+  });
+
+  testWidgets('shows hourglass when stage in progress', (tester) async {
+    final widget = SkillTreeStageHeaderBadgeWidget(
+      nodes: [node('a')],
+      unlocked: const {'a'},
+      completed: const {},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byIcon(Icons.hourglass_bottom), findsOneWidget);
+  });
+
+  testWidgets('shows check when stage perfect', (tester) async {
+    final widget = SkillTreeStageHeaderBadgeWidget(
+      nodes: [node('a')],
+      unlocked: const {'a'},
+      completed: const {'a'},
+    );
+    await tester.pumpWidget(MaterialApp(home: widget));
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}

--- a/test/widgets/skill_tree_stage_header_builder_test.dart
+++ b/test/widgets/skill_tree_stage_header_builder_test.dart
@@ -21,7 +21,7 @@ void main() {
     expect(find.byIcon(Icons.hourglass_bottom), findsOneWidget);
   });
 
-  testWidgets('shows verified badge when stage perfect', (tester) async {
+  testWidgets('shows check badge when stage perfect', (tester) async {
     const builder = SkillTreeStageHeaderBuilder();
     final header = builder.buildHeader(
       level: 1,
@@ -30,7 +30,7 @@ void main() {
       completedNodeIds: {'a'},
     );
     await tester.pumpWidget(MaterialApp(home: header));
-    expect(find.byIcon(Icons.verified), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
   });
 
   testWidgets('no badge when overlay provided', (tester) async {


### PR DESCRIPTION
## Summary
- add `SkillTreeStageHeaderBadgeWidget` to render stage status icons
- introduce `SkillTreeStageHeaderWidget` and use it in the header builder
- cover header badge logic with widget tests

## Testing
- `flutter test test/widgets/skill_tree_stage_header_builder_test.dart test/widgets/skill_tree_stage_header_badge_widget_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688e068d9008832a8946fc06b56aa740