### PR TITLE
feat: show prerequisite progress summary

### DIFF
--- a/lib/widgets/skill_tree_node_block_reason_widget.dart
+++ b/lib/widgets/skill_tree_node_block_reason_widget.dart
@@ -119,6 +119,9 @@ class _DependencyItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final total = prereqs.length;
+    final done =
+        prereqs.where((p) => p.status == _PrereqStatus.completed).length;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -127,6 +130,14 @@ class _DependencyItem extends StatelessWidget {
           title,
           style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
         ),
+        if (prereqs.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              '✅ $done of $total prerequisites complete',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+          ),
         if (prereqs.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(top: 2),


### PR DESCRIPTION
## Summary
- show completed prerequisite count above each dependency chain

## Testing
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e0f451e74832a8c2727cc3298494d