### PR TITLE
feat: sync skill tree prereq setting to cloud

### DIFF
--- a/lib/services/cloud_preferences_service.dart
+++ b/lib/services/cloud_preferences_service.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'cloud_retry_policy.dart';
+
+class CloudPreferencesService {
+  CloudPreferencesService._();
+  static final CloudPreferencesService instance =
+      CloudPreferencesService._();
+
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  String? get _uid => _auth.currentUser?.uid;
+
+  Future<bool?> getBool(String key) async {
+    if (_uid == null) return null;
+    try {
+      final snap = await _db
+          .collection('users')
+          .doc(_uid)
+          .collection('preferences')
+          .doc('main')
+          .get();
+      final data = snap.data();
+      return data?[key] as bool?;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> setBool(String key, bool value) async {
+    if (_uid == null) return;
+    await CloudRetryPolicy.execute(() async {
+      await _db
+          .collection('users')
+          .doc(_uid)
+          .collection('preferences')
+          .doc('main')
+          .set({
+        key: value,
+        'updatedAt': DateTime.now().toIso8601String(),
+      }, SetOptions(merge: true));
+    });
+  }
+}
+

--- a/lib/services/skill_tree_settings_service.dart
+++ b/lib/services/skill_tree_settings_service.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'cloud_preferences_service.dart';
+
 class SkillTreeSettingsService {
   SkillTreeSettingsService._();
   static final SkillTreeSettingsService instance = SkillTreeSettingsService._();
@@ -13,7 +15,12 @@ class SkillTreeSettingsService {
   Future<void> load() async {
     if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
-    hideCompletedPrereqs.value = prefs.getBool(_hideCompletedKey) ?? false;
+    final cloudVal =
+        await CloudPreferencesService.instance.getBool(_hideCompletedKey);
+    final localVal = prefs.getBool(_hideCompletedKey);
+    final value = cloudVal ?? localVal ?? false;
+    hideCompletedPrereqs.value = value;
+    await prefs.setBool(_hideCompletedKey, value);
     _loaded = true;
   }
 
@@ -21,6 +28,7 @@ class SkillTreeSettingsService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_hideCompletedKey, value);
     hideCompletedPrereqs.value = value;
+    await CloudPreferencesService.instance.setBool(_hideCompletedKey, value);
   }
 }
 


### PR DESCRIPTION
## Summary
- add CloudPreferencesService to store preferences in Firestore
- sync hide-completed-prerequisites setting with cloud preferences

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e16fcaba0832a84597ccaba2957d5