### PR TITLE
Improve SkillTreeBlockedSummaryBanner robustness

### DIFF
--- a/lib/widgets/skill_tree_blocked_summary_banner.dart
+++ b/lib/widgets/skill_tree_blocked_summary_banner.dart
@@ -39,9 +39,13 @@ class _SkillTreeBlockedSummaryBannerState
   Future<List<_LockedNodeData>> _load() async {
     final result = <_LockedNodeData>[];
     for (final node in widget.nodes) {
-      final deps = await _linkService.getDependencies(node.id);
-      final hint = deps.isNotEmpty ? deps.first.hint : '';
-      result.add(_LockedNodeData(node: node, hint: hint));
+      try {
+        final deps = await _linkService.getDependencies(node.id);
+        final hint = deps.isNotEmpty ? deps.first.hint : '';
+        result.add(_LockedNodeData(node: node, hint: hint));
+      } catch (_) {
+        result.add(_LockedNodeData(node: node, hint: ''));
+      }
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- gracefully handle errors when fetching dependency hints for locked nodes

## Testing
- `flutter test` *(fails: the Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688e1c007c7c832a9e9ca5b0ef02ddb2