### PR TITLE
feat: add fade-in animation for locked node cards

### DIFF
--- a/lib/widgets/skill_tree_blocked_summary_banner.dart
+++ b/lib/widgets/skill_tree_blocked_summary_banner.dart
@@ -69,6 +69,7 @@ class _SkillTreeBlockedSummaryBannerState
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 4),
                   child: _BlockedNodeCard(
+                    key: ValueKey(item.node.id),
                     data: item,
                     onTap: () => widget.onShowDetails(item.node),
                   ),
@@ -81,47 +82,81 @@ class _SkillTreeBlockedSummaryBannerState
   }
 }
 
-class _BlockedNodeCard extends StatelessWidget {
+class _BlockedNodeCard extends StatefulWidget {
   final _LockedNodeData data;
   final VoidCallback onTap;
 
-  const _BlockedNodeCard({required this.data, required this.onTap});
+  const _BlockedNodeCard({
+    super.key,
+    required this.data,
+    required this.onTap,
+  });
+
+  @override
+  State<_BlockedNodeCard> createState() => _BlockedNodeCardState();
+}
+
+class _BlockedNodeCardState extends State<_BlockedNodeCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 350),
+    );
+    _opacity = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 200,
-      child: Card(
-        child: InkWell(
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.all(8),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    const Icon(Icons.lock, size: 16, color: Colors.grey),
-                    const SizedBox(width: 4),
-                    Expanded(
-                      child: Text(
-                        data.node.title,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                        overflow: TextOverflow.ellipsis,
+    final data = widget.data;
+    return FadeTransition(
+      opacity: _opacity,
+      child: SizedBox(
+        width: 200,
+        child: Card(
+          child: InkWell(
+            onTap: widget.onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.lock, size: 16, color: Colors.grey),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          data.node.title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  data.hint.isNotEmpty
-                      ? data.hint
-                      : 'No unlock requirements available',
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 12, color: Colors.grey),
-                ),
-              ],
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    data.hint.isNotEmpty
+                        ? data.hint
+                        : 'No unlock requirements available',
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- animate locked node cards with a fade-in effect when they appear
- assign stable keys to each card to ensure transitions are animated properly

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688e1ee1c060832a89da90e27fab0e9f