### PR TITLE
feat: add skill tree progress indicator

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/skill_tree_stage_header_builder.dart';
 import '../screens/skill_tree_node_detail_screen.dart';
 import '../widgets/skill_tree_node_block_reason_widget.dart';
 import '../widgets/skill_tree_blocked_summary_banner.dart';
+import '../services/skill_tree_progress_service.dart';
 
 class SkillTreeScreen extends StatefulWidget {
   final String category;
@@ -34,6 +35,7 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
   final _headerBuilder = const SkillTreeStageHeaderBuilder();
   final _unlockNotify = SkillTreeUnlockNotificationService();
   final _stageCelebrator = SkillTreeStageGateCelebrationOverlay();
+  final _progressService = const SkillTreeProgressService();
 
   @override
   void initState() {
@@ -176,6 +178,12 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
       for (final n in nodes)
         if (!_completed.contains(n.id) && !_unlocked.contains(n.id)) n,
     ];
+    final unlockedCount = _progressService.getUnlockedNodeCount(
+      tree: tree,
+      unlockedNodeIds: _unlocked,
+      completedNodeIds: _completed,
+    );
+    final totalCount = _progressService.getTotalNodeCount(tree);
     final children = <Widget>[];
     if (lockedNodes.isNotEmpty) {
       children.add(
@@ -184,6 +192,8 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
           child: SkillTreeBlockedSummaryBanner(
             nodes: lockedNodes,
             onShowDetails: _showLockReason,
+            unlockedCount: unlockedCount,
+            totalCount: totalCount,
           ),
         ),
       );

--- a/lib/services/skill_tree_progress_service.dart
+++ b/lib/services/skill_tree_progress_service.dart
@@ -1,0 +1,22 @@
+import '../models/skill_tree.dart';
+
+/// Computes global progress metrics for a skill tree.
+class SkillTreeProgressService {
+  const SkillTreeProgressService();
+
+  /// Returns the total number of nodes in [tree].
+  int getTotalNodeCount(SkillTree tree) => tree.nodes.length;
+
+  /// Returns how many nodes are unlocked or completed in [tree].
+  int getUnlockedNodeCount({
+    required SkillTree tree,
+    required Set<String> unlockedNodeIds,
+    required Set<String> completedNodeIds,
+  }) {
+    final all = unlockedNodeIds.union(
+      completedNodeIds.where(tree.nodes.containsKey).toSet(),
+    );
+    return all.length;
+  }
+}
+

--- a/lib/widgets/skill_tree_blocked_summary_banner.dart
+++ b/lib/widgets/skill_tree_blocked_summary_banner.dart
@@ -7,11 +7,15 @@ import '../services/skill_tree_dependency_link_service.dart';
 class SkillTreeBlockedSummaryBanner extends StatefulWidget {
   final List<SkillTreeNodeModel> nodes;
   final void Function(SkillTreeNodeModel node) onShowDetails;
+  final int unlockedCount;
+  final int totalCount;
 
   const SkillTreeBlockedSummaryBanner({
     super.key,
     required this.nodes,
     required this.onShowDetails,
+    required this.unlockedCount,
+    required this.totalCount,
   });
 
   @override
@@ -98,26 +102,47 @@ class _SkillTreeBlockedSummaryBannerState
           return const SizedBox.shrink();
         }
         final items = snapshot.data!;
-        return SizedBox(
-          height: 90,
-          child: ListView(
-            controller: _scrollController,
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            children: [
-              _LockedCountBadge(count: items.length),
-              for (final item in items)
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 4),
-                  child: _BlockedNodeCard(
-                    key: ValueKey(item.node.id),
-                    data: item,
-                    onTap: () => widget.onShowDetails(item.node),
-                    highlight: _newlyAddedIds.contains(item.node.id),
-                  ),
+        final progressText =
+            '${widget.unlockedCount} of ${widget.totalCount} unlocked';
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Center(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                transitionBuilder: (child, animation) =>
+                    FadeTransition(opacity: animation, child: child),
+                child: Text(
+                  progressText,
+                  key: ValueKey(progressText),
+                  style: const TextStyle(fontSize: 12, color: Colors.grey),
                 ),
-            ],
-          ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            SizedBox(
+              height: 90,
+              child: ListView(
+                controller: _scrollController,
+                scrollDirection: Axis.horizontal,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                children: [
+                  _LockedCountBadge(count: items.length),
+                  for (final item in items)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      child: _BlockedNodeCard(
+                        key: ValueKey(item.node.id),
+                        data: item,
+                        onTap: () => widget.onShowDetails(item.node),
+                        highlight: _newlyAddedIds.contains(item.node.id),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
         );
       },
     );


### PR DESCRIPTION
## Summary
- add SkillTreeProgressService to compute unlocked and total node counts
- display unlocked/total progress above blocked nodes banner with animation
- wire SkillTreeScreen to pass progress counts to banner

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e275e5be4832a964b48a1fef930a6