### PR TITLE
feat: add skill tree progress bar

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -184,6 +184,7 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
       completedNodeIds: _completed,
     );
     final totalCount = _progressService.getTotalNodeCount(tree);
+    final progress = totalCount == 0 ? 0.0 : unlockedCount / totalCount;
     final children = <Widget>[];
     if (lockedNodes.isNotEmpty) {
       children.add(
@@ -248,7 +249,20 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     }
     return Scaffold(
       appBar: AppBar(title: Text(widget.category)),
-      body: ListView(children: children),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TweenAnimationBuilder<double>(
+              tween: Tween(begin: 0, end: progress),
+              duration: const Duration(milliseconds: 300),
+              builder: (context, value, child) =>
+                  LinearProgressIndicator(value: value, minHeight: 4),
+            ),
+          ),
+          Expanded(child: ListView(children: children)),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- visualize skill tree progress with animated LinearProgressIndicator under the header

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e28b41b0c832a9077f2174b6f8274