### PR TITLE
feat: show banner on stage unlock

### DIFF
--- a/lib/screens/skill_tree_screen.dart
+++ b/lib/screens/skill_tree_screen.dart
@@ -82,7 +82,10 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
       _loading = false;
     });
 
-    if (shouldCelebrate) _showStageUnlockConfetti();
+    if (shouldCelebrate) {
+      _showStageUnlockConfetti();
+      _showStageUnlockBanner();
+    }
 
     _previousUnlockedStages = unlockedStages;
 
@@ -122,6 +125,23 @@ class _SkillTreeScreenState extends State<SkillTreeScreen> {
     Future.delayed(const Duration(milliseconds: 1500), () {
       controller.dispose();
       entry.remove();
+    });
+  }
+
+  void _showStageUnlockBanner() {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearMaterialBanners();
+    final banner = MaterialBanner(
+      backgroundColor: Colors.green,
+      content: const Text(
+        '⭐ New Stage Unlocked!',
+        style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+      ),
+      actions: const [SizedBox.shrink()],
+    );
+    messenger.showMaterialBanner(banner);
+    Future.delayed(const Duration(seconds: 3), () {
+      messenger.clearMaterialBanners();
     });
   }
 


### PR DESCRIPTION
## Summary
- display a green "New Stage Unlocked" banner when a skill tree stage unlocks

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e314701f8832a9cad68f3095226fd