### PR TITLE
feat: open theory lesson from unlock banner

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -31,6 +31,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
   Set<String> _unlocked = {};
   Set<String> _completed = {};
   final Set<String> _justUnlocked = {};
+  List<String> _newTheoryNodeIds = [];
   bool _loading = true;
 
   @override
@@ -58,9 +59,10 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
     final completed = await progress.getCompletedNodeIds(widget.trackId);
 
     final newlyUnlocked = unlocked.difference(_unlocked);
-    final hasNewTheory = newlyUnlocked.any(
-      (id) => tree.nodes[id]?.theoryLessonId.isNotEmpty ?? false,
-    );
+    final newTheoryNodeIds = newlyUnlocked
+        .where((id) => tree.nodes[id]?.theoryLessonId.isNotEmpty ?? false)
+        .toList();
+    final hasNewTheory = newTheoryNodeIds.isNotEmpty;
 
     final blocks = _listBuilder.stageMarker.build(nodes);
     for (final block in blocks) {
@@ -73,6 +75,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
       _unlocked = unlocked;
       _completed = completed;
       _loading = false;
+      _newTheoryNodeIds = newTheoryNodeIds;
       if (hadPrev) {
         _justUnlocked.addAll(newlyUnlocked);
       }
@@ -115,7 +118,23 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
         '📘 New Theory Available!',
         style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
       ),
-      actions: const [SizedBox.shrink()],
+      actions: [
+        TextButton(
+          onPressed: () async {
+            messenger.clearMaterialBanners();
+            final nodeId =
+                _newTheoryNodeIds.isNotEmpty ? _newTheoryNodeIds.first : null;
+            final node = nodeId != null ? _track?.nodes[nodeId] : null;
+            if (node != null) {
+              await _openNode(node);
+            }
+          },
+          child: const Text(
+            'View Theory',
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+      ],
     );
     messenger.showMaterialBanner(banner);
     Future.delayed(const Duration(seconds: 3), () {


### PR DESCRIPTION
## Summary
- track newly unlocked theory node IDs when loading skill tree path
- add a `View Theory` button to the "New Theory Available!" banner
- navigate to the first new theory lesson and reload the path after viewing

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e3521c9e4832aad094696ae1dbe53