### PR TITLE
feat: queue skill tree unlock banners

### DIFF
--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/skill_tree_stage_list_builder.dart';
 import '../widgets/skill_tree_track_overview_header.dart';
 import '../widgets/skill_tree_stage_badge_legend_widget.dart';
 import 'skill_tree_node_detail_screen.dart';
+import '../services/banner_queue_service.dart';
 
 /// Renders the full learning path for a skill track.
 class SkillTreePathScreen extends StatefulWidget {
@@ -119,8 +120,6 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
   }
 
   void _showTheoryUnlockBanner() {
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.clearMaterialBanners();
     final banner = MaterialBanner(
       backgroundColor: Colors.blue,
       content: const Text(
@@ -130,7 +129,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
       actions: [
         TextButton(
           onPressed: () async {
-            messenger.clearMaterialBanners();
+            BannerQueueService.instance.dismissCurrent();
             final nodeId =
                 _newTheoryNodeIds.isNotEmpty ? _newTheoryNodeIds.first : null;
             final node = nodeId != null ? _track?.nodes[nodeId] : null;
@@ -145,15 +144,10 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
         ),
       ],
     );
-    messenger.showMaterialBanner(banner);
-    Future.delayed(const Duration(seconds: 3), () {
-      messenger.clearMaterialBanners();
-    });
+    BannerQueueService.instance.queue(banner);
   }
 
   void _showPracticeUnlockBanner() {
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.clearMaterialBanners();
     final banner = MaterialBanner(
       backgroundColor: Colors.blue,
       content: const Text(
@@ -163,7 +157,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
       actions: [
         TextButton(
           onPressed: () async {
-            messenger.clearMaterialBanners();
+            BannerQueueService.instance.dismissCurrent();
             final nodeId =
                 _newPracticeNodeIds.isNotEmpty ? _newPracticeNodeIds.first : null;
             final node = nodeId != null ? _track?.nodes[nodeId] : null;
@@ -178,10 +172,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
         ),
       ],
     );
-    messenger.showMaterialBanner(banner);
-    Future.delayed(const Duration(seconds: 3), () {
-      messenger.clearMaterialBanners();
-    });
+    BannerQueueService.instance.queue(banner);
   }
 
   Future<void> _openNode(SkillTreeNodeModel node) async {

--- a/lib/services/banner_queue_service.dart
+++ b/lib/services/banner_queue_service.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+/// Queues [MaterialBanner] widgets to show one at a time.
+class BannerQueueService {
+  BannerQueueService._();
+  static final BannerQueueService instance = BannerQueueService._();
+
+  final List<MaterialBanner> _queue = [];
+  bool _isShowing = false;
+
+  /// Adds [banner] to the queue and displays it when possible.
+  void queue(MaterialBanner banner) {
+    _queue.add(banner);
+    _processQueue();
+  }
+
+  /// Dismisses the current banner and shows the next one if available.
+  void dismissCurrent() {
+    final ctx = navigatorKey.currentContext;
+    if (ctx != null) {
+      ScaffoldMessenger.of(ctx).clearMaterialBanners();
+    }
+    _isShowing = false;
+    _processQueue();
+  }
+
+  void _processQueue() {
+    if (_isShowing || _queue.isEmpty) return;
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null || !ctx.mounted) return;
+    final messenger = ScaffoldMessenger.of(ctx);
+    final banner = _queue.removeAt(0);
+    _isShowing = true;
+    messenger.clearMaterialBanners();
+    messenger.showMaterialBanner(banner);
+    Future.delayed(const Duration(seconds: 3), dismissCurrent);
+  }
+}


### PR DESCRIPTION
## Summary
- add BannerQueueService to sequence MaterialBanners
- use BannerQueueService for theory and practice unlock banners in SkillTreePathScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e37b617a0832aa56ba3007659475b