### PR TITLE
test: add banner queue service tests

### DIFF
--- a/lib/services/banner_queue_service.dart
+++ b/lib/services/banner_queue_service.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../main.dart';
-
 /// Queues [MaterialBanner] widgets to show one at a time.
 class BannerQueueService {
   BannerQueueService._();
@@ -9,6 +7,7 @@ class BannerQueueService {
 
   final List<MaterialBanner> _queue = [];
   bool _isShowing = false;
+  GlobalKey<NavigatorState>? navigatorKey;
 
   /// Adds [banner] to the queue and displays it when possible.
   void queue(MaterialBanner banner) {
@@ -18,7 +17,7 @@ class BannerQueueService {
 
   /// Dismisses the current banner and shows the next one if available.
   void dismissCurrent() {
-    final ctx = navigatorKey.currentContext;
+    final ctx = navigatorKey?.currentContext;
     if (ctx != null) {
       ScaffoldMessenger.of(ctx).clearMaterialBanners();
     }
@@ -28,7 +27,7 @@ class BannerQueueService {
 
   void _processQueue() {
     if (_isShowing || _queue.isEmpty) return;
-    final ctx = navigatorKey.currentContext;
+    final ctx = navigatorKey?.currentContext;
     if (ctx == null || !ctx.mounted) return;
     final messenger = ScaffoldMessenger.of(ctx);
     final banner = _queue.removeAt(0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,10 +113,10 @@ flutter:
     - assets/mini_lessons/
     - assets/lessons/
     - assets/lesson_tracks/
-      - assets/pack_matrix.json
-      - assets/learning_intro.svg
-      - assets/training_paths.yaml
-      - assets/learning_paths/
+    - assets/pack_matrix.json
+    - assets/learning_intro.svg
+    - assets/training_paths.yaml
+    - assets/learning_paths/
     - assets/learning_tracks/
     - assets/learning_path_tracks.yaml
     - assets/animations/congrats.json

--- a/test/services/banner_queue_service_test.dart
+++ b/test/services/banner_queue_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/services/banner_queue_service.dart';
+
+MaterialBanner _banner(String text) {
+  return MaterialBanner(
+    content: Text(text),
+    actions: [
+      TextButton(onPressed: () {}, child: const Text('OK')),
+    ],
+  );
+}
+
+void main() {
+  testWidgets('displays banners sequentially with auto dismiss', (tester) async {
+    final key = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: key,
+      home: const Scaffold(),
+    ));
+
+    final service = BannerQueueService.instance;
+    service.navigatorKey = key;
+    service.queue(_banner('first'));
+    service.queue(_banner('second'));
+    service.queue(_banner('third'));
+
+    await tester.pump();
+    expect(find.text('first'), findsOneWidget);
+    expect(find.text('second'), findsNothing);
+    expect(find.text('third'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+    expect(find.text('first'), findsNothing);
+    expect(find.text('second'), findsOneWidget);
+    expect(find.text('third'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+    expect(find.text('second'), findsNothing);
+    expect(find.text('third'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+    expect(find.text('third'), findsNothing);
+  });
+
+  testWidgets('dismissCurrent skips to next banner immediately', (tester) async {
+    final key = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: key,
+      home: const Scaffold(),
+    ));
+
+    final service = BannerQueueService.instance;
+    service.navigatorKey = key;
+    service.queue(_banner('one'));
+    service.queue(_banner('two'));
+
+    await tester.pump();
+    expect(find.text('one'), findsOneWidget);
+    expect(find.text('two'), findsNothing);
+
+    service.dismissCurrent();
+    await tester.pump();
+    expect(find.text('one'), findsNothing);
+    expect(find.text('two'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+  });
+}
+


### PR DESCRIPTION
## Summary
- allow BannerQueueService to accept an injected navigator key for easier testing
- cover banner queueing, auto dismiss, and manual dismissal with widget tests
- fix asset entries in pubspec so flutter tests can run

## Testing
- `flutter test test/services/banner_queue_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688e3f1fc174832a8ab3ee86eda54649