### PR TITLE
feat: add level II open-fold BTN vs BB mini lesson

### DIFF
--- a/assets/mini_lesson_library.yaml
+++ b/assets/mini_lesson_library.yaml
@@ -1,0 +1,34 @@
+lessons:
+  - id: bubble_fold
+    title: 'Bubble Folds'
+    content: 'Fold marginal hands near the money.'
+    tags: [bubble_fold]
+    type: mini
+  - id: iso_vs_limp
+    title: 'Isolate Limpers'
+    content: 'Raise bigger to isolate limpers.'
+    tags: [iso_vs_limp]
+    type: mini
+  - id: theory_open_fold_btn_vs_bb_15bb
+    title: 'Open/Fold BTN vs BB 15bb'
+    tags:
+      - openfold
+      - btn
+      - bb
+      - 15bb
+      - level2
+      - preflop
+    parts:
+      - title: 'Why BTN opens wide vs BB'
+        content: |
+          With only the blinds left to act, the Button can profitably open a wide range.
+          Holding position postflop lets us pressure the Big Blind and leverage antes
+          with minimal risk.
+      - title: 'Fold equity and punishability from BB'
+        content: |
+          At 15bb effective, the Big Blind must defend carefully. Many hands cannot
+          call or 3-bet shove profitably, giving our opens immediate fold equity.
+          Only strong reshove or defend ranges punish overly loose opens.
+    type: mini
+    next:
+      - theory_open_call_bb_vs_btn

--- a/assets/mini_lessons/level_2_open_fold_btn_vs_bb.yaml
+++ b/assets/mini_lessons/level_2_open_fold_btn_vs_bb.yaml
@@ -1,0 +1,23 @@
+id: theory_open_fold_btn_vs_bb_15bb
+title: 'Open/Fold BTN vs BB 15bb'
+tags:
+  - openfold
+  - btn
+  - bb
+  - 15bb
+  - level2
+  - preflop
+parts:
+  - title: 'Why BTN opens wide vs BB'
+    content: |
+      With only the blinds left to act, the Button can profitably open a wide range.
+      Holding position postflop lets us pressure the Big Blind and leverage antes
+      with minimal risk.
+  - title: 'Fold equity and punishability from BB'
+    content: |
+      At 15bb effective, the Big Blind must defend carefully. Many hands cannot
+      call or 3-bet shove profitably, giving our opens immediate fold equity.
+      Only strong reshove or defend ranges punish overly loose opens.
+next:
+  - theory_open_call_bb_vs_btn
+type: mini

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,6 +111,7 @@ flutter:
     - assets/theory_blocks/
     - assets/theory_tracks/
     - assets/mini_lessons/
+    - assets/mini_lesson_library.yaml
     - assets/lessons/
     - assets/lesson_tracks/
     - assets/pack_matrix.json


### PR DESCRIPTION
## Summary
- add Level II mini-lesson for BTN vs BB 15bb open/fold with multi-part theory content
- catalog new lesson in `mini_lesson_library.yaml`
- expose mini lesson library as asset in pubspec

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y dart-sdk` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688e48e2f678832aa8a64d9d4200336c