### PR TITLE
Add BB vs BTN 15bb defense theory mini-lesson

### DIFF
--- a/assets/mini_lesson_library.yaml
+++ b/assets/mini_lesson_library.yaml
@@ -32,3 +32,27 @@ lessons:
     type: mini
     next:
       - theory_open_call_bb_vs_btn
+  - id: theory_open_call_bb_vs_btn
+    title: 'Defending BB vs BTN Open 15bb'
+    tags:
+      - openfold
+      - bb
+      - btn
+      - 15bb
+      - level2
+      - preflop
+      - defense
+    parts:
+      - title: 'When to call vs BTN open at 15bb'
+        content: |
+          Despite being out of position, the Big Blind gets excellent pot odds.
+          Call with value hands and playable suited or connected holdings that
+          can realize equity postflop without committing your stack.
+      - title: 'When to reshove'
+        content: |
+          Take advantage of fold equity by 3-bet shoving hands with high-card blockers
+          or poor postflop playability. These shoves punish wide Button opens and
+          deny them the chance to see cheap flops.
+    type: mini
+    prev:
+      - theory_open_fold_btn_vs_bb_15bb

--- a/assets/mini_lessons/level_2_bb_defense_vs_btn_open.yaml
+++ b/assets/mini_lessons/level_2_bb_defense_vs_btn_open.yaml
@@ -1,0 +1,24 @@
+id: theory_open_call_bb_vs_btn
+title: 'Defending BB vs BTN Open 15bb'
+tags:
+  - openfold
+  - bb
+  - btn
+  - 15bb
+  - level2
+  - preflop
+  - defense
+parts:
+  - title: 'When to call vs BTN open at 15bb'
+    content: |
+      Despite being out of position, the Big Blind gets excellent pot odds.
+      Call with value hands and playable suited or connected holdings that
+      can realize equity postflop without committing your stack.
+  - title: 'When to reshove'
+    content: |
+      Take advantage of fold equity by 3-bet shoving hands with high-card blockers
+      or poor postflop playability. These shoves punish wide Button opens and
+      deny them the chance to see cheap flops.
+prev:
+  - theory_open_fold_btn_vs_bb_15bb
+type: mini


### PR DESCRIPTION
## Summary
- add mini lesson explaining how the big blind defends versus a 15bb button open
- register lesson in the mini-lesson library and link it to the preceding BTN open lesson

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a737070832ab40ef66ed096367e