### PR TITLE
Add Level II BTN vs BB theory block

### DIFF
--- a/assets/theory_blocks/block_open_vs_bb_15bb.yaml
+++ b/assets/theory_blocks/block_open_vs_bb_15bb.yaml
@@ -1,0 +1,11 @@
+id: block_open_vs_bb_15bb
+title: 'BTN vs BB at 15bb'
+nodeIds:
+  - theory_open_fold_btn_vs_bb_15bb
+  - theory_open_call_bb_vs_btn
+tags:
+  - level2
+  - btn
+  - bb
+  - openfold
+  - preflop

--- a/assets/theory_tracks/track_level_2_opening.yaml
+++ b/assets/theory_tracks/track_level_2_opening.yaml
@@ -1,0 +1,4 @@
+id: track_level_2_opening
+title: 'Level II - BTN vs BB 15bb'
+blocks:
+  - block_open_vs_bb_15bb


### PR DESCRIPTION
## Summary
- Add theory block `block_open_vs_bb_15bb` linking BTN open and BB defend mini lessons
- Register new Level II theory track referencing the BTN vs BB block

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688e4b716b08832a9bf76008d96d7def