### PR TITLE
Add Level II open vs BB theory practice pack

### DIFF
--- a/assets/theory_blocks/block_open_vs_bb_15bb.yaml
+++ b/assets/theory_blocks/block_open_vs_bb_15bb.yaml
@@ -3,6 +3,8 @@ title: 'BTN vs BB at 15bb'
 nodeIds:
   - theory_open_fold_btn_vs_bb_15bb
   - theory_open_call_bb_vs_btn
+practicePackIds:
+  - theory_pack_open_vs_bb_15bb
 tags:
   - level2
   - btn

--- a/assets/theory_packs/level_2_open_vs_bb_15bb.yaml
+++ b/assets/theory_packs/level_2_open_vs_bb_15bb.yaml
@@ -1,0 +1,17 @@
+id: theory_pack_open_vs_bb_15bb
+title: 'Open vs BB 15bb'
+type: theory_drill
+tags:
+  - level2
+  - btn
+  - bb
+  - openfold
+  - preflop
+references:
+  - theory_open_fold_btn_vs_bb_15bb
+  - theory_open_call_bb_vs_btn
+spots:
+  - open_vs_bb_15bb_spot_1
+  - open_vs_bb_15bb_spot_2
+  - open_vs_bb_15bb_spot_3
+  - open_vs_bb_15bb_spot_4


### PR DESCRIPTION
## Summary
- add Level II `Open vs BB 15bb` theory drill pack with mini-lesson references
- link practice pack into existing block `block_open_vs_bb_15bb`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688e4d49ad08832a99e802daecf84b22