### PR TITLE
feat: add theory block completion evaluator

### DIFF
--- a/lib/models/theory_block_model.dart
+++ b/lib/models/theory_block_model.dart
@@ -1,0 +1,46 @@
+class TheoryBlockModel {
+  final String id;
+  final String title;
+  final List<String> nodeIds;
+  final List<String> practicePackIds;
+  final List<String> tags;
+
+  const TheoryBlockModel({
+    required this.id,
+    required this.title,
+    required this.nodeIds,
+    required this.practicePackIds,
+    List<String>? tags,
+  }) : tags = tags ?? const [];
+
+  factory TheoryBlockModel.fromYaml(Map yaml) {
+    final nodeYaml = yaml['nodeIds'];
+    final nodes = <String>[];
+    if (nodeYaml is List) {
+      for (final n in nodeYaml) {
+        nodes.add(n.toString());
+      }
+    }
+    final packYaml = yaml['practicePackIds'];
+    final packs = <String>[];
+    if (packYaml is List) {
+      for (final p in packYaml) {
+        packs.add(p.toString());
+      }
+    }
+    final tagYaml = yaml['tags'];
+    final tags = <String>[];
+    if (tagYaml is List) {
+      for (final t in tagYaml) {
+        tags.add(t.toString());
+      }
+    }
+    return TheoryBlockModel(
+      id: yaml['id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      nodeIds: nodes,
+      practicePackIds: packs,
+      tags: tags,
+    );
+  }
+}

--- a/lib/services/theory_path_completion_evaluator_service.dart
+++ b/lib/services/theory_path_completion_evaluator_service.dart
@@ -1,0 +1,45 @@
+import '../models/theory_block_model.dart';
+import 'user_progress_service.dart';
+
+/// Possible completion states for a theory block.
+enum CompletionStatus { notStarted, inProgress, completed }
+
+/// Evaluates completion of theory blocks based on lesson and pack progress.
+class TheoryPathCompletionEvaluatorService {
+  final UserProgressService userProgress;
+
+  const TheoryPathCompletionEvaluatorService({
+    required this.userProgress,
+  });
+
+  /// Returns true if all lessons and packs in [block] are completed.
+  Future<bool> isBlockCompleted(TheoryBlockModel block) async {
+    return (await getBlockStatus(block)) == CompletionStatus.completed;
+  }
+
+  /// Computes completion percentage for [block] (0.0–1.0).
+  Future<double> getBlockCompletionPercent(TheoryBlockModel block) async {
+    final total = block.nodeIds.length + block.practicePackIds.length;
+    if (total == 0) return 0.0;
+    var done = 0;
+    for (final id in block.nodeIds) {
+      if (await userProgress.isTheoryLessonCompleted(id)) {
+        done++;
+      }
+    }
+    for (final id in block.practicePackIds) {
+      if (await userProgress.isPackCompleted(id)) {
+        done++;
+      }
+    }
+    return done / total;
+  }
+
+  /// Derives high-level status for [block].
+  Future<CompletionStatus> getBlockStatus(TheoryBlockModel block) async {
+    final percent = await getBlockCompletionPercent(block);
+    if (percent == 0) return CompletionStatus.notStarted;
+    if (percent >= 1.0) return CompletionStatus.completed;
+    return CompletionStatus.inProgress;
+  }
+}

--- a/lib/services/user_progress_service.dart
+++ b/lib/services/user_progress_service.dart
@@ -1,0 +1,17 @@
+import 'mini_lesson_progress_tracker.dart';
+import 'pack_library_completion_service.dart';
+
+/// Provides completion lookups for theory lessons and training packs.
+class UserProgressService {
+  UserProgressService._();
+  static final instance = UserProgressService._();
+
+  Future<bool> isTheoryLessonCompleted(String id) {
+    return MiniLessonProgressTracker.instance.isCompleted(id);
+  }
+
+  Future<bool> isPackCompleted(String id) async {
+    final data = await PackLibraryCompletionService.instance.getCompletion(id);
+    return data != null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TheoryBlockModel` for parsing theory block metadata
- create `UserProgressService` to check lesson and pack completion
- implement `TheoryPathCompletionEvaluatorService` with percent and status helpers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e4e8d553c832abfe137eb4bd80115