### PR TITLE
feat: open next theory step on block tap

### DIFF
--- a/lib/widgets/injected_theory_block_renderer.dart
+++ b/lib/widgets/injected_theory_block_renderer.dart
@@ -55,6 +55,7 @@ class _InjectedTheoryBlockRendererState
       child: TheoryBlockCardWidget(
         block: model,
         evaluator: evaluator,
+        progress: UserProgressService.instance,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- inject UserProgressService into TheoryBlockCardWidget and wire a tap handler that opens the first incomplete lesson or practice pack
- pass progress service to injected theory block renderer

## Testing
- `dart format lib/widgets/theory_block_card_widget.dart lib/widgets/injected_theory_block_renderer.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e53ae9654832a99833d574901e954