### PR TITLE
feat: add theory track progression service

### DIFF
--- a/lib/models/theory_track_model.dart
+++ b/lib/models/theory_track_model.dart
@@ -1,0 +1,31 @@
+import 'theory_block_model.dart';
+
+/// Represents a linear collection of [TheoryBlockModel]s.
+class TheoryTrackModel {
+  final String id;
+  final String title;
+  final List<TheoryBlockModel> blocks;
+
+  const TheoryTrackModel({
+    required this.id,
+    required this.title,
+    required this.blocks,
+  });
+
+  factory TheoryTrackModel.fromYaml(Map yaml) {
+    final list = yaml['blocks'];
+    final blocks = <TheoryBlockModel>[];
+    if (list is List) {
+      for (final v in list) {
+        if (v is Map) {
+          blocks.add(TheoryBlockModel.fromYaml(Map<String, dynamic>.from(v)));
+        }
+      }
+    }
+    return TheoryTrackModel(
+      id: yaml['id']?.toString() ?? '',
+      title: yaml['title']?.toString() ?? '',
+      blocks: blocks,
+    );
+  }
+}

--- a/lib/screens/learning_track_screen.dart
+++ b/lib/screens/learning_track_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_block_model.dart';
+import '../models/theory_track_model.dart';
+import '../services/theory_track_progression_service.dart';
+import '../services/theory_path_completion_evaluator_service.dart';
+import '../services/user_progress_service.dart';
+import '../widgets/theory_block_card_widget.dart';
+
+/// Displays blocks of a [TheoryTrackModel] respecting progression rules.
+class LearningTrackScreen extends StatefulWidget {
+  final TheoryTrackModel track;
+  const LearningTrackScreen({super.key, required this.track});
+
+  @override
+  State<LearningTrackScreen> createState() => _LearningTrackScreenState();
+}
+
+class _LearningTrackScreenState extends State<LearningTrackScreen> {
+  late final TheoryPathCompletionEvaluatorService _evaluator;
+  late final TheoryTrackProgressionService _progression;
+  List<TheoryBlockModel>? _unlocked;
+
+  @override
+  void initState() {
+    super.initState();
+    _evaluator = TheoryPathCompletionEvaluatorService(
+      userProgress: UserProgressService.instance,
+    );
+    _progression = TheoryTrackProgressionService(evaluator: _evaluator);
+    _load();
+  }
+
+  Future<void> _load() async {
+    final unlocked = await _progression.getUnlockedBlocks(widget.track);
+    if (mounted) {
+      setState(() => _unlocked = unlocked);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final unlocked = _unlocked;
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.track.title)),
+      backgroundColor: const Color(0xFF121212),
+      body: unlocked == null
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: widget.track.blocks.length,
+              itemBuilder: (context, index) {
+                final block = widget.track.blocks[index];
+                final isUnlocked =
+                    unlocked.any((b) => b.id == block.id);
+                final card = TheoryBlockCardWidget(
+                  block: block,
+                  evaluator: _evaluator,
+                  progress: UserProgressService.instance,
+                );
+                return isUnlocked
+                    ? card
+                    : Opacity(
+                        opacity: 0.5,
+                        child: IgnorePointer(child: card),
+                      );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/theory_block_library_service.dart
+++ b/lib/services/theory_block_library_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/theory_block_model.dart';
+
+/// Loads [TheoryBlockModel] definitions from YAML files.
+class TheoryBlockLibraryService {
+  TheoryBlockLibraryService._();
+  static final TheoryBlockLibraryService instance = TheoryBlockLibraryService._();
+
+  static const String _dir = 'assets/theory_blocks/';
+
+  final List<TheoryBlockModel> _blocks = [];
+  final Map<String, TheoryBlockModel> _byId = {};
+
+  List<TheoryBlockModel> get all => List.unmodifiable(_blocks);
+  TheoryBlockModel? getById(String id) => _byId[id];
+
+  Future<void> loadAll() async {
+    if (_blocks.isNotEmpty) return;
+    await reload();
+  }
+
+  Future<void> reload() async {
+    _blocks.clear();
+    _byId.clear();
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        final block = TheoryBlockModel.fromYaml(Map<String, dynamic>.from(map));
+        if (block.id.isEmpty) continue;
+        _blocks.add(block);
+        _byId[block.id] = block;
+      } catch (_) {}
+    }
+  }
+}

--- a/lib/services/theory_track_progression_service.dart
+++ b/lib/services/theory_track_progression_service.dart
@@ -1,0 +1,36 @@
+import '../models/theory_block_model.dart';
+import '../models/theory_track_model.dart';
+import 'theory_path_completion_evaluator_service.dart';
+
+/// Determines which blocks of a [TheoryTrackModel] are currently unlocked.
+class TheoryTrackProgressionService {
+  final TheoryPathCompletionEvaluatorService evaluator;
+
+  const TheoryTrackProgressionService({required this.evaluator});
+
+  /// Returns blocks that are unlocked based on sequential completion.
+  Future<List<TheoryBlockModel>> getUnlockedBlocks(TheoryTrackModel track) async {
+    final unlocked = <TheoryBlockModel>[];
+    for (var i = 0; i < track.blocks.length; i++) {
+      final block = track.blocks[i];
+      if (i == 0) {
+        unlocked.add(block);
+        continue;
+      }
+      final prev = track.blocks[i - 1];
+      final done = await evaluator.isBlockCompleted(prev);
+      if (done) {
+        unlocked.add(block);
+      } else {
+        break;
+      }
+    }
+    return unlocked;
+  }
+
+  /// Returns true if [block] is unlocked within [track].
+  Future<bool> isBlockUnlocked(TheoryTrackModel track, TheoryBlockModel block) async {
+    final unlocked = await getUnlockedBlocks(track);
+    return unlocked.any((b) => b.id == block.id);
+  }
+}


### PR DESCRIPTION
## Summary
- add TheoryTrackModel for representing linear theory tracks
- support loading block models and determining unlocked blocks
- display tracks with locked blocks dimmed and non-interactive

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e571366b0832aa8da3028688b8527