### PR TITLE
feat: resume theory track from home

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -73,6 +73,7 @@ import '../tutorial/tutorial_flow.dart';
 import '../widgets/suggestion_card_weak_spots.dart';
 import '../widgets/tag_progress_card.dart';
 import '../widgets/weekly_summary_card.dart';
+import '../widgets/continue_learning_card.dart';
 
 class TrainingHomeScreen extends StatefulWidget {
   final TutorialFlow? tutorial;
@@ -157,6 +158,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const RecommendedNextPackCard(),
           const AdaptiveTheoryReminderBanner(),
           const NextLearningStepCard(),
+          const ContinueLearningCard(),
           const ResumeLessonCard(),
           const DecayMemoryHealthBanner(),
           const StreakBannerWidget(),

--- a/lib/services/theory_track_library_service.dart
+++ b/lib/services/theory_track_library_service.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/services.dart' show rootBundle;
+import '../asset_manifest.dart';
+import '../core/training/generation/yaml_reader.dart';
+import '../models/theory_track_model.dart';
+import '../models/theory_block_model.dart';
+
+/// Loads and indexes theory tracks from bundled YAML files.
+class TheoryTrackLibraryService {
+  TheoryTrackLibraryService._();
+  static final TheoryTrackLibraryService instance = TheoryTrackLibraryService._();
+
+  static const String _trackDir = 'assets/theory_tracks/';
+  static const String _blockDir = 'assets/theory_blocks/';
+
+  final List<TheoryTrackModel> _tracks = [];
+  final Map<String, TheoryTrackModel> _index = {};
+
+  List<TheoryTrackModel> get all => List.unmodifiable(_tracks);
+
+  Future<void> loadAll() async {
+    if (_tracks.isNotEmpty) return;
+    await reload();
+  }
+
+  Future<void> reload() async {
+    _tracks.clear();
+    _index.clear();
+    final manifest = await AssetManifest.instance;
+    final trackPaths = manifest.keys
+        .where((p) => p.startsWith(_trackDir) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in trackPaths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        final map = const YamlReader().read(raw);
+        final id = map['id']?.toString() ??
+            path.split('/').last.replaceAll('.yaml', '');
+        final title = map['title']?.toString() ?? '';
+        final blockYaml = map['blocks'];
+        final blockIds = <String>[];
+        if (blockYaml is List) {
+          for (final b in blockYaml) {
+            blockIds.add(b.toString());
+          }
+        }
+        final blocks = <TheoryBlockModel>[];
+        for (final bid in blockIds) {
+          try {
+            final bRaw = await rootBundle.loadString('$_blockDir$bid.yaml');
+            final bMap = const YamlReader().read(bRaw);
+            blocks.add(TheoryBlockModel.fromYaml(
+                Map<String, dynamic>.from(bMap)));
+          } catch (_) {}
+        }
+        final track = TheoryTrackModel(id: id, title: title, blocks: blocks);
+        _tracks.add(track);
+        _index[id] = track;
+      } catch (_) {}
+    }
+  }
+
+  TheoryTrackModel? getById(String id) => _index[id];
+}

--- a/lib/services/theory_track_resume_service.dart
+++ b/lib/services/theory_track_resume_service.dart
@@ -6,15 +6,22 @@ class TheoryTrackResumeService {
   static final instance = TheoryTrackResumeService._();
 
   static const _keyPrefix = 'theory_track_last_block_';
+  static const _trackKey = 'theory_track_last_id';
 
   Future<void> saveLastVisitedBlock(String trackId, String blockId) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('$_keyPrefix$trackId', blockId);
+    await prefs.setString(_trackKey, trackId);
   }
 
   Future<String?> getLastVisitedBlock(String trackId) async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString('$_keyPrefix$trackId');
+  }
+
+  Future<String?> getLastVisitedTrackId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_trackKey);
   }
 }
 

--- a/lib/widgets/continue_learning_card.dart
+++ b/lib/widgets/continue_learning_card.dart
@@ -1,0 +1,85 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import '../services/theory_track_resume_service.dart';
+import '../services/theory_track_library_service.dart';
+import '../screens/learning_track_screen.dart';
+import '../models/theory_track_model.dart';
+
+class ContinueLearningCard extends StatelessWidget {
+  const ContinueLearningCard({super.key});
+
+  Future<_ResumeData?> _load() async {
+    final trackId =
+        await TheoryTrackResumeService.instance.getLastVisitedTrackId();
+    if (trackId == null) return null;
+    final blockId =
+        await TheoryTrackResumeService.instance.getLastVisitedBlock(trackId);
+    if (blockId == null) return null;
+    await TheoryTrackLibraryService.instance.loadAll();
+    final track = TheoryTrackLibraryService.instance.getById(trackId);
+    if (track == null) return null;
+    return _ResumeData(track, blockId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    return FutureBuilder<_ResumeData?>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final data = snapshot.data;
+        if (data == null) return const SizedBox.shrink();
+        final block =
+            data.track.blocks.firstWhereOrNull((b) => b.id == data.blockId);
+        return Container(
+          margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '📚 Continue learning',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(data.track.title,
+                  style: const TextStyle(color: Colors.white)),
+              if (block != null)
+                Text(block.title,
+                    style: const TextStyle(color: Colors.white70)),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(backgroundColor: accent),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => LearningTrackScreen(track: data.track),
+                      ),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ResumeData {
+  final TheoryTrackModel track;
+  final String blockId;
+  const _ResumeData(this.track, this.blockId);
+}


### PR DESCRIPTION
## Summary
- persist last visited theory track and block
- load theory tracks and blocks via new library service
- add Continue Learning card to home screen to reopen last track

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e59caa18c832ab0e0ef30485bd27b