### PR TITLE
Add initial block navigation for learning track

### DIFF
--- a/lib/screens/learning_track_screen.dart
+++ b/lib/screens/learning_track_screen.dart
@@ -11,7 +11,12 @@ import '../widgets/theory_block_card_widget.dart';
 /// Displays blocks of a [TheoryTrackModel] respecting progression rules.
 class LearningTrackScreen extends StatefulWidget {
   final TheoryTrackModel track;
-  const LearningTrackScreen({super.key, required this.track});
+  final String? initialBlockId;
+  const LearningTrackScreen({
+    super.key,
+    required this.track,
+    this.initialBlockId,
+  });
 
   @override
   State<LearningTrackScreen> createState() => _LearningTrackScreenState();
@@ -35,8 +40,9 @@ class _LearningTrackScreenState extends State<LearningTrackScreen> {
 
   Future<void> _load() async {
     final unlocked = await _progression.getUnlockedBlocks(widget.track);
-    final last = await TheoryTrackResumeService.instance
-        .getLastVisitedBlock(widget.track.id);
+    final last = widget.initialBlockId ??
+        await TheoryTrackResumeService.instance
+            .getLastVisitedBlock(widget.track.id);
     if (mounted) {
       setState(() => _unlocked = unlocked);
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/widgets/continue_learning_card.dart
+++ b/lib/widgets/continue_learning_card.dart
@@ -63,7 +63,10 @@ class ContinueLearningCard extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => LearningTrackScreen(track: data.track),
+                        builder: (_) => LearningTrackScreen(
+                          track: data.track,
+                          initialBlockId: data.blockId,
+                        ),
                       ),
                     );
                   },


### PR DESCRIPTION
## Summary
- open learning track at a specific block when resuming from home card
- wire ContinueLearningCard to provide last visited block

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e9e2259d8832ab8567e7f865acdba