### PR TITLE
feat: add drill navigation in theory block menu

### DIFF
--- a/lib/widgets/theory_block_card_widget.dart
+++ b/lib/widgets/theory_block_card_widget.dart
@@ -8,6 +8,7 @@ import '../services/pack_library_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/theory_track_resume_service.dart';
 import '../screens/mini_lesson_screen.dart';
+import '../screens/training_pack_screen.dart';
 
 /// Card widget displaying a [TheoryBlockModel] with completion progress.
 class TheoryBlockCardWidget extends StatefulWidget {
@@ -158,7 +159,12 @@ class _TheoryBlockCardWidgetState extends State<TheoryBlockCardWidget> {
           ),
           onTap: () async {
             Navigator.pop(context);
-            await const TrainingSessionLauncher().launch(tpl);
+            await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => TrainingPackScreen(pack: tpl),
+              ),
+            );
           },
         ),
       );


### PR DESCRIPTION
## Summary
- allow long-press on a theory block to jump into any lesson or drill pack in the block

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e9f492ce4832ab8f11aa7df7e6726