### PR TITLE
feat: prioritize pinned items by recent activity

### DIFF
--- a/lib/models/pinned_learning_item.dart
+++ b/lib/models/pinned_learning_item.dart
@@ -2,18 +2,30 @@ class PinnedLearningItem {
   final String type; // 'lesson' or 'pack'
   final String id;
   final int? lastPosition;
+  final int? lastSeen;
+  final int openCount;
 
   const PinnedLearningItem({
     required this.type,
     required this.id,
     this.lastPosition,
+    this.lastSeen,
+    this.openCount = 0,
   });
 
-  PinnedLearningItem copyWith({String? type, String? id, int? lastPosition}) =>
+  PinnedLearningItem copyWith({
+    String? type,
+    String? id,
+    int? lastPosition,
+    int? lastSeen,
+    int? openCount,
+  }) =>
       PinnedLearningItem(
         type: type ?? this.type,
         id: id ?? this.id,
         lastPosition: lastPosition ?? this.lastPosition,
+        lastSeen: lastSeen ?? this.lastSeen,
+        openCount: openCount ?? this.openCount,
       );
 
   factory PinnedLearningItem.fromJson(Map<String, dynamic> json) =>
@@ -21,11 +33,15 @@ class PinnedLearningItem {
         type: json['type'] as String? ?? '',
         id: json['id'] as String? ?? '',
         lastPosition: json['lastPosition'] as int?,
+        lastSeen: json['lastSeen'] as int?,
+        openCount: json['openCount'] as int? ?? 0,
       );
 
   Map<String, dynamic> toJson() => {
         'type': type,
         'id': id,
         if (lastPosition != null) 'lastPosition': lastPosition,
+        if (lastSeen != null) 'lastSeen': lastSeen,
+        'openCount': openCount,
       };
 }

--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -37,6 +37,9 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
       initialScrollOffset: (widget.initialPosition ?? 0).toDouble(),
     );
     unawaited(
+      PinnedLearningService.instance.recordOpen('lesson', widget.lesson.id),
+    );
+    unawaited(
       TheoryBoosterRecallEngine.instance.recordLaunch(widget.lesson.id),
     );
   }

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -170,6 +170,9 @@ class _TrainingPackScreenState extends State<TrainingPackScreen>
       cloud: context.read<CloudSyncService>(),
     );
     _pack = widget.pack;
+    unawaited(
+      PinnedLearningService.instance.recordOpen('pack', _pack.id),
+    );
     _allHands = widget.hands ?? _pack.hands;
     _sessionHands = List.from(_allHands);
     _allSpots = List.from(_pack.spots);

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -102,6 +102,9 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   @override
   void initState() {
     super.initState();
+    unawaited(
+      PinnedLearningService.instance.recordOpen('pack', widget.template.id),
+    );
     _prepare();
   }
 

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -110,6 +110,9 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
   @override
   void initState() {
     super.initState();
+    unawaited(
+      PinnedLearningService.instance.recordOpen('pack', widget.template.id),
+    );
     _prepare();
   }
 


### PR DESCRIPTION
## Summary
- track `lastSeen` and `openCount` for pinned learning items
- sort pinned items by recent activity and record opens
- update lesson and pack screens to record pinned item usage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ea3c38980832a8d9a4d539de7d0f1