### PR TITLE
feat: add pinned item context menu

### DIFF
--- a/lib/services/pinned_learning_service.dart
+++ b/lib/services/pinned_learning_service.dart
@@ -79,6 +79,20 @@ class PinnedLearningService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> moveToTop(String type, String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (var i = 0; i < _items.length; i++) {
+      final e = _items[i];
+      if (e.type == type && e.id == id) {
+        _items[i] = e.copyWith(lastSeen: now);
+        _sort();
+        await _save();
+        notifyListeners();
+        break;
+      }
+    }
+  }
+
   int? lastPosition(String type, String id) => _find(type, id)?.lastPosition;
 
   Future<void> setLastPosition(String type, String id, int position) async {

--- a/lib/widgets/pinned_learning_section.dart
+++ b/lib/widgets/pinned_learning_section.dart
@@ -2,11 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../services/pinned_learning_service.dart';
 import '../services/mini_lesson_library_service.dart';
-import '../services/pack_library_service.dart';
-import '../screens/mini_lesson_screen.dart';
-import '../screens/training_pack_screen.dart';
-import '../models/pinned_learning_item.dart';
-import '../models/v2/training_pack_template_v2.dart';
+import 'pinned_learning_tile.dart';
 
 class PinnedLearningSection extends StatefulWidget {
   const PinnedLearningSection({super.key});
@@ -48,61 +44,8 @@ class _PinnedLearningSectionState extends State<PinnedLearningSection> {
             style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),
         ),
-        for (final item in items) _buildTile(item),
+        for (final item in items) PinnedLearningTile(item: item),
       ],
     );
-  }
-
-  Widget _buildTile(PinnedLearningItem item) {
-    if (item.type == 'lesson') {
-      final lesson = MiniLessonLibraryService.instance.getById(item.id);
-      if (lesson == null) return const SizedBox.shrink();
-      return ListTile(
-        leading: const Text('📘', style: TextStyle(fontSize: 20)),
-        title: Text(lesson.title),
-        trailing: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () => _service.unpin('lesson', item.id),
-        ),
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => MiniLessonScreen(
-                lesson: lesson,
-                initialPosition: item.lastPosition,
-              ),
-            ),
-          );
-        },
-      );
-    } else {
-      return FutureBuilder<TrainingPackTemplateV2?>(
-        future: PackLibraryService.instance.getById(item.id),
-        builder: (context, snapshot) {
-          final tpl = snapshot.data;
-          if (tpl == null) return const SizedBox.shrink();
-          return ListTile(
-            leading: const Text('🎯', style: TextStyle(fontSize: 20)),
-            title: Text(tpl.name),
-            trailing: IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: () => _service.unpin('pack', item.id),
-            ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => TrainingPackScreen(
-                    pack: tpl,
-                    initialPosition: item.lastPosition,
-                  ),
-                ),
-              );
-            },
-          );
-        },
-      );
-    }
   }
 }

--- a/lib/widgets/pinned_learning_tile.dart
+++ b/lib/widgets/pinned_learning_tile.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../models/pinned_learning_item.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../screens/training_pack_screen.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/pinned_learning_service.dart';
+
+class PinnedLearningTile extends StatelessWidget {
+  const PinnedLearningTile({super.key, required this.item});
+
+  final PinnedLearningItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    if (item.type == 'lesson') {
+      final lesson = MiniLessonLibraryService.instance.getById(item.id);
+      if (lesson == null) return const SizedBox.shrink();
+      return ListTile(
+        leading: const Text('📘', style: TextStyle(fontSize: 20)),
+        title: Text(lesson.title),
+        trailing: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => PinnedLearningService.instance.unpin('lesson', item.id),
+        ),
+        onTap: () => _openLesson(context, lesson),
+        onLongPress: () => _showMenu(context, () => _openLesson(context, lesson)),
+      );
+    }
+
+    return FutureBuilder<TrainingPackTemplateV2?>(
+      future: PackLibraryService.instance.getById(item.id),
+      builder: (context, snapshot) {
+        final tpl = snapshot.data;
+        if (tpl == null) return const SizedBox.shrink();
+        return ListTile(
+          leading: const Text('🎯', style: TextStyle(fontSize: 20)),
+          title: Text(tpl.name),
+          trailing: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => PinnedLearningService.instance.unpin('pack', item.id),
+          ),
+          onTap: () => _openPack(context, tpl),
+          onLongPress: () => _showMenu(context, () => _openPack(context, tpl)),
+        );
+      },
+    );
+  }
+
+  void _openLesson(BuildContext context, dynamic lesson) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MiniLessonScreen(
+          lesson: lesson,
+          initialPosition: item.lastPosition,
+        ),
+      ),
+    );
+  }
+
+  void _openPack(BuildContext context, TrainingPackTemplateV2 tpl) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackScreen(
+          pack: tpl,
+          initialPosition: item.lastPosition,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showMenu(BuildContext context, VoidCallback open) async {
+    final service = PinnedLearningService.instance;
+    final hasMultiple = service.items.length > 1;
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.open_in_new),
+              title: const Text('Open'),
+              onTap: () => Navigator.pop(context, 'open'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.push_pin_outlined),
+              title: const Text('Unpin'),
+              onTap: () => Navigator.pop(context, 'unpin'),
+            ),
+            if (hasMultiple)
+              ListTile(
+                leading: const Icon(Icons.vertical_align_top),
+                title: const Text('Move to Top'),
+                onTap: () => Navigator.pop(context, 'top'),
+              ),
+          ],
+        ),
+      ),
+    );
+
+    switch (result) {
+      case 'open':
+        open();
+        break;
+      case 'unpin':
+        await service.unpin(item.type, item.id);
+        break;
+      case 'top':
+        await service.moveToTop(item.type, item.id);
+        break;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add PinnedLearningTile with long-press menu for managing pinned entries
- wire PinnedLearningSection to use new tile
- support manual item reordering via moveToTop in PinnedLearningService

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ea671a0d8832aa9df7220401dcad7