### PR TITLE
feat: add pinned hub screen with reorderable items

### DIFF
--- a/lib/screens/pinned_hub_screen.dart
+++ b/lib/screens/pinned_hub_screen.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+
+import '../models/pinned_learning_item.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../screens/training_pack_screen.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/pinned_learning_service.dart';
+import '../widgets/pinned_learning_tile.dart';
+
+class PinnedHubScreen extends StatefulWidget {
+  const PinnedHubScreen({super.key});
+
+  @override
+  State<PinnedHubScreen> createState() => _PinnedHubScreenState();
+}
+
+class _PinnedHubScreenState extends State<PinnedHubScreen> {
+  final _service = PinnedLearningService.instance;
+  bool _editMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.addListener(_reload);
+    _service.load();
+    MiniLessonLibraryService.instance.loadAll();
+  }
+
+  void _reload() => setState(() {});
+
+  @override
+  void dispose() {
+    _service.removeListener(_reload);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lessons =
+        _service.items.where((e) => e.type == 'lesson').toList(growable: false);
+    final packs =
+        _service.items.where((e) => e.type == 'pack').toList(growable: false);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pinned Items'),
+        actions: [
+          IconButton(
+            icon: Icon(_editMode ? Icons.check : Icons.edit),
+            onPressed: () => setState(() => _editMode = !_editMode),
+          ),
+        ],
+      ),
+      body: ListView(
+        children: [
+          _buildSection('📘 Lessons', lessons, 'lesson'),
+          _buildSection('🎯 Drill Packs', packs, 'pack'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection(String title, List<PinnedLearningItem> items, String type) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+          ),
+          ReorderableListView(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            onReorder: (oldIndex, newIndex) async {
+              if (newIndex > oldIndex) newIndex--;
+              await _reorder(type, oldIndex, newIndex);
+            },
+            children: [
+              for (var i = 0; i < items.length; i++)
+                _buildItem(type, items[i], i),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItem(String type, PinnedLearningItem item, int index) {
+    if (type == 'lesson') {
+      final lesson = MiniLessonLibraryService.instance.getById(item.id);
+      if (lesson == null) return const SizedBox.shrink();
+      return ListTile(
+        key: ValueKey('lesson:${item.id}'),
+        leading: const Text('📘', style: TextStyle(fontSize: 20)),
+        title: Text(lesson.title),
+        trailing: _editMode
+            ? ReorderableDragStartListener(
+                index: index,
+                child: const Icon(Icons.drag_handle),
+              )
+            : null,
+        onTap: () => _openLesson(lesson, item),
+        onLongPress: () => showPinnedLearningMenu(
+          context,
+          item,
+          () => _openLesson(lesson, item),
+        ),
+      );
+    }
+
+    return FutureBuilder<TrainingPackTemplateV2?>(
+      key: ValueKey('pack:${item.id}'),
+      future: PackLibraryService.instance.getById(item.id),
+      builder: (context, snapshot) {
+        final tpl = snapshot.data;
+        if (tpl == null) return const SizedBox.shrink();
+        return ListTile(
+          leading: const Text('🎯', style: TextStyle(fontSize: 20)),
+          title: Text(tpl.name),
+          trailing: _editMode
+              ? ReorderableDragStartListener(
+                  index: index,
+                  child: const Icon(Icons.drag_handle),
+                )
+              : null,
+          onTap: () => _openPack(tpl, item),
+          onLongPress: () => showPinnedLearningMenu(
+            context,
+            item,
+            () => _openPack(tpl, item),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _reorder(String type, int oldIndex, int newIndex) async {
+    final indices = <int>[];
+    for (var i = 0; i < _service.items.length; i++) {
+      if (_service.items[i].type == type) indices.add(i);
+    }
+    final oldGlobal = indices[oldIndex];
+    int newGlobal;
+    if (newIndex >= indices.length) {
+      newGlobal = indices.last + 1;
+    } else if (newIndex > oldIndex) {
+      newGlobal = indices[newIndex] + 1;
+    } else {
+      newGlobal = indices[newIndex];
+    }
+    await _service.reorder(oldGlobal, newGlobal);
+  }
+
+  void _openLesson(dynamic lesson, PinnedLearningItem item) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MiniLessonScreen(
+          lesson: lesson,
+          initialPosition: item.lastPosition,
+        ),
+      ),
+    );
+  }
+
+  void _openPack(TrainingPackTemplateV2 tpl, PinnedLearningItem item) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackScreen(
+          pack: tpl,
+          initialPosition: item.lastPosition,
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/pinned_learning_tile.dart
+++ b/lib/widgets/pinned_learning_tile.dart
@@ -26,7 +26,11 @@ class PinnedLearningTile extends StatelessWidget {
           onPressed: () => PinnedLearningService.instance.unpin('lesson', item.id),
         ),
         onTap: () => _openLesson(context, lesson),
-        onLongPress: () => _showMenu(context, () => _openLesson(context, lesson)),
+        onLongPress: () => showPinnedLearningMenu(
+          context,
+          item,
+          () => _openLesson(context, lesson),
+        ),
       );
     }
 
@@ -43,7 +47,11 @@ class PinnedLearningTile extends StatelessWidget {
             onPressed: () => PinnedLearningService.instance.unpin('pack', item.id),
           ),
           onTap: () => _openPack(context, tpl),
-          onLongPress: () => _showMenu(context, () => _openPack(context, tpl)),
+          onLongPress: () => showPinnedLearningMenu(
+            context,
+            item,
+            () => _openPack(context, tpl),
+          ),
         );
       },
     );
@@ -73,47 +81,53 @@ class PinnedLearningTile extends StatelessWidget {
     );
   }
 
-  Future<void> _showMenu(BuildContext context, VoidCallback open) async {
-    final service = PinnedLearningService.instance;
-    final hasMultiple = service.items.length > 1;
-    final result = await showModalBottomSheet<String>(
-      context: context,
-      builder: (context) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.open_in_new),
-              title: const Text('Open'),
-              onTap: () => Navigator.pop(context, 'open'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.push_pin_outlined),
-              title: const Text('Unpin'),
-              onTap: () => Navigator.pop(context, 'unpin'),
-            ),
-            if (hasMultiple)
-              ListTile(
-                leading: const Icon(Icons.vertical_align_top),
-                title: const Text('Move to Top'),
-                onTap: () => Navigator.pop(context, 'top'),
-              ),
-          ],
-        ),
-      ),
-    );
+}
 
-    switch (result) {
-      case 'open':
-        open();
-        break;
-      case 'unpin':
-        await service.unpin(item.type, item.id);
-        break;
-      case 'top':
-        await service.moveToTop(item.type, item.id);
-        break;
-    }
+Future<void> showPinnedLearningMenu(
+  BuildContext context,
+  PinnedLearningItem item,
+  VoidCallback open,
+) async {
+  final service = PinnedLearningService.instance;
+  final hasMultiple = service.items.length > 1;
+  final result = await showModalBottomSheet<String>(
+    context: context,
+    builder: (context) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.open_in_new),
+            title: const Text('Open'),
+            onTap: () => Navigator.pop(context, 'open'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.push_pin_outlined),
+            title: const Text('Unpin'),
+            onTap: () => Navigator.pop(context, 'unpin'),
+          ),
+          if (hasMultiple)
+            ListTile(
+              leading: const Icon(Icons.vertical_align_top),
+              title: const Text('Move to Top'),
+              onTap: () => Navigator.pop(context, 'top'),
+            ),
+        ],
+      ),
+    ),
+  );
+
+  switch (result) {
+    case 'open':
+      open();
+      break;
+    case 'unpin':
+      await service.unpin(item.type, item.id);
+      break;
+    case 'top':
+      await service.moveToTop(item.type, item.id);
+      break;
   }
 }
+
 


### PR DESCRIPTION
## Summary
- add PinnedHubScreen to access pinned lessons and packs with drag-and-drop reordering
- expose pinned menu utility and enable manual reordering in service

## Testing
- `flutter format lib/services/pinned_learning_service.dart lib/widgets/pinned_learning_tile.dart lib/screens/pinned_hub_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eae3b7c2c832aba28a45aed38ac1d