### PR TITLE
feat: add smart pinned recommender

### DIFF
--- a/lib/services/smart_pinned_recommender_service.dart
+++ b/lib/services/smart_pinned_recommender_service.dart
@@ -1,0 +1,91 @@
+import '../models/pinned_learning_item.dart';
+import 'pinned_learning_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'training_progress_service.dart';
+import 'lesson_progress_service.dart';
+import 'mini_lesson_library_service.dart';
+import 'pack_library_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Chooses the best pinned item to resume next based on simple heuristics.
+class SmartPinnedRecommenderService {
+  SmartPinnedRecommenderService({
+    PinnedLearningService? pinned,
+    DecayTagRetentionTrackerService? retention,
+    TrainingProgressService? training,
+    LessonProgressService? lessons,
+  })  : _pinned = pinned ?? PinnedLearningService.instance,
+        _retention = retention ?? const DecayTagRetentionTrackerService(),
+        _training = training ?? TrainingProgressService.instance,
+        _lessons = lessons ?? LessonProgressService.instance;
+
+  final PinnedLearningService _pinned;
+  final DecayTagRetentionTrackerService _retention;
+  final TrainingProgressService _training;
+  final LessonProgressService _lessons;
+
+  /// Returns the most relevant [PinnedLearningItem] to continue, or `null`
+  /// if no item stands out.
+  Future<PinnedLearningItem?> recommendNext() async {
+    final items = _pinned.items;
+    if (items.isEmpty) return null;
+
+    PinnedLearningItem? best;
+    var bestScore = double.negativeInfinity;
+
+    for (final item in items) {
+      var score = 0.0;
+      final tags = <String>[];
+
+      if (item.type == 'pack') {
+        final TrainingPackTemplateV2? tpl =
+            await PackLibraryService.instance.getById(item.id);
+        if (tpl != null) {
+          tags.addAll(tpl.tags.map((e) => e.trim().toLowerCase()));
+          final prog = await _training.getProgress(item.id);
+          score += (1 - prog) * 6; // Low completion => higher weight
+        }
+      } else if (item.type == 'lesson') {
+        await MiniLessonLibraryService.instance.loadAll();
+        final TheoryMiniLessonNode? lesson =
+            MiniLessonLibraryService.instance.getById(item.id);
+        if (lesson != null) {
+          tags.addAll(lesson.tags.map((e) => e.trim().toLowerCase()));
+          final completed = await _lessons.isCompleted(item.id);
+          if (!completed) score += 6; // Incomplete lesson
+        }
+      }
+
+      // High decay urgency for any associated tag.
+      for (final t in tags) {
+        final days = await _retention.getDecayScore(t);
+        if (days > 30) { // Consider tags older than 30 days as high decay
+          score += 10;
+          break;
+        }
+      }
+
+      // Not seen recently
+      if (item.lastSeen == null ||
+          DateTime.now()
+                  .difference(DateTime.fromMillisecondsSinceEpoch(item.lastSeen!)) >
+              const Duration(days: 7)) {
+        score += 3;
+      }
+
+      // Penalize if opened many times already
+      if (item.openCount >= 5) score -= 3;
+
+      if (score > bestScore) {
+        bestScore = score;
+        best = item;
+      }
+    }
+
+    // Only return a recommendation if the best item has a positive score.
+    if (bestScore <= 0) return null;
+    return best;
+  }
+}
+

--- a/lib/widgets/pinned_top_pick_card.dart
+++ b/lib/widgets/pinned_top_pick_card.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../services/pack_library_service.dart';
+import '../services/smart_pinned_recommender_service.dart';
 import '../screens/mini_lesson_screen.dart';
 import '../screens/training_pack_screen.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../models/pinned_learning_item.dart';
 
 class PinnedTopPickCard extends StatelessWidget {
   const PinnedTopPickCard({super.key});
@@ -18,49 +20,54 @@ class PinnedTopPickCard extends StatelessWidget {
       builder: (context, _) {
         final items = service.items;
         if (items.isEmpty) return const SizedBox.shrink();
-        final item = items.first;
-        if (item.type == 'lesson') {
-          return FutureBuilder<void>(
-            future: MiniLessonLibraryService.instance.loadAll(),
-            builder: (context, snapshot) {
-              final lesson =
-                  MiniLessonLibraryService.instance.getById(item.id);
-              if (lesson == null) return const SizedBox.shrink();
-              return _buildCard(
-                context,
-                title: lesson.title,
-                onTap: () {
-                  Navigator.push(
+        return FutureBuilder<PinnedLearningItem?>(
+          future: SmartPinnedRecommenderService().recommendNext(),
+          builder: (context, snapshot) {
+            final item = snapshot.data ?? items.first;
+            if (item.type == 'lesson') {
+              return FutureBuilder<void>(
+                future: MiniLessonLibraryService.instance.loadAll(),
+                builder: (context, snapshot) {
+                  final lesson =
+                      MiniLessonLibraryService.instance.getById(item.id);
+                  if (lesson == null) return const SizedBox.shrink();
+                  return _buildCard(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => MiniLessonScreen(
-                        lesson: lesson,
-                        initialPosition: item.lastPosition,
-                      ),
-                    ),
+                    title: lesson.title,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MiniLessonScreen(
+                            lesson: lesson,
+                            initialPosition: item.lastPosition,
+                          ),
+                        ),
+                      );
+                    },
                   );
                 },
               );
-            },
-          );
-        }
-        return FutureBuilder<TrainingPackTemplateV2?>(
-          future: PackLibraryService.instance.getById(item.id),
-          builder: (context, snapshot) {
-            final tpl = snapshot.data;
-            if (tpl == null) return const SizedBox.shrink();
-            return _buildCard(
-              context,
-              title: tpl.name,
-              onTap: () {
-                Navigator.push(
+            }
+            return FutureBuilder<TrainingPackTemplateV2?>(
+              future: PackLibraryService.instance.getById(item.id),
+              builder: (context, snapshot) {
+                final tpl = snapshot.data;
+                if (tpl == null) return const SizedBox.shrink();
+                return _buildCard(
                   context,
-                  MaterialPageRoute(
-                    builder: (_) => TrainingPackScreen(
-                      pack: tpl,
-                      initialPosition: item.lastPosition,
-                    ),
-                  ),
+                  title: tpl.name,
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TrainingPackScreen(
+                          pack: tpl,
+                          initialPosition: item.lastPosition,
+                        ),
+                      ),
+                    );
+                  },
                 );
               },
             );


### PR DESCRIPTION
## Summary
- add SmartPinnedRecommenderService to choose next pinned item using decay, completion, recency, and usage heuristics
- use SmartPinnedRecommenderService in PinnedTopPickCard as a smarter fallback to the first pinned item

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb177f594832ab863fab0033aec3d