### PR TITLE
Add pinned comeback nudge service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,6 +79,7 @@ import 'services/decay_booster_notification_service.dart';
 import 'services/decay_booster_cron_job.dart';
 import 'services/theory_lesson_notification_scheduler.dart';
 import 'services/booster_recall_decay_cleaner.dart';
+import 'services/pinned_comeback_nudge_service.dart';
 import 'route_observer.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -136,6 +137,7 @@ Future<void> main() async {
   unawaited(DecayReminderScheduler.instance.register());
   unawaited(DecayReminderScheduler.instance.runIfNeeded());
   unawaited(DecayBoosterCronJob.instance.start());
+  unawaited(PinnedComebackNudgeService.instance.start());
   await BoosterRecallDecayCleaner.instance.init();
   await AppInitService.instance.init();
   runApp(

--- a/lib/services/in_app_nudge_service.dart
+++ b/lib/services/in_app_nudge_service.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+/// Simple helper to display lightweight in-app nudges.
+class InAppNudgeService {
+  /// Shows a snackbar style nudge with [title] and [message].
+  /// Returns `true` if displayed, otherwise `false`.
+  static Future<bool> show({
+    required String title,
+    required String message,
+    VoidCallback? onTap,
+  }) async {
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return false;
+    final messenger = ScaffoldMessenger.maybeOf(ctx);
+    if (messenger == null) return false;
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text('$title\n$message'),
+        action: onTap != null
+            ? SnackBarAction(label: 'Open', onPressed: onTap)
+            : null,
+      ),
+    );
+    return true;
+  }
+}

--- a/lib/services/pinned_comeback_nudge_service.dart
+++ b/lib/services/pinned_comeback_nudge_service.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/pinned_learning_item.dart';
+import 'smart_pinned_recommender_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'mini_lesson_library_service.dart';
+import 'pack_library_service.dart';
+import 'in_app_nudge_service.dart';
+
+/// Periodically nudges the user to resume decayed pinned content when the app
+/// is resumed after being idle.
+class PinnedComebackNudgeService with WidgetsBindingObserver {
+  PinnedComebackNudgeService({
+    SmartPinnedRecommenderService? recommender,
+    DecayTagRetentionTrackerService? retention,
+  })  : _recommender = recommender ?? SmartPinnedRecommenderService(),
+        _retention = retention ?? const DecayTagRetentionTrackerService();
+
+  static final PinnedComebackNudgeService instance =
+      PinnedComebackNudgeService();
+
+  final SmartPinnedRecommenderService _recommender;
+  final DecayTagRetentionTrackerService _retention;
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+  bool _pluginInitialized = false;
+  bool _checking = false;
+  static const _lastKey = 'pinned_comeback_nudge_last';
+
+  Future<void> start() async {
+    WidgetsBinding.instance.addObserver(this);
+    if (WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed) {
+      _scheduleCheck();
+    }
+  }
+
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _scheduleCheck();
+    }
+  }
+
+  void _scheduleCheck() {
+    Future.delayed(const Duration(seconds: 5), _maybeNudge);
+  }
+
+  Future<void> _maybeNudge() async {
+    if (_checking) return;
+    _checking = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final lastMillis = prefs.getInt(_lastKey);
+      if (lastMillis != null &&
+          DateTime.now()
+                  .difference(DateTime.fromMillisecondsSinceEpoch(lastMillis)) <
+              const Duration(hours: 24)) {
+        return;
+      }
+
+      final item = await _recommender.recommendNext();
+      if (item == null) return;
+      if (!await _shouldNudge(item)) return;
+
+      final shown = await InAppNudgeService.show(
+        title: 'Continue learning',
+        message: 'You have pinned content waiting to review.',
+      );
+      if (!shown) {
+        await _showNotification();
+      }
+      await prefs.setInt(_lastKey, DateTime.now().millisecondsSinceEpoch);
+    } finally {
+      _checking = false;
+    }
+  }
+
+  Future<bool> _shouldNudge(PinnedLearningItem item) async {
+    if (item.lastSeen != null &&
+        DateTime.now()
+                .difference(DateTime.fromMillisecondsSinceEpoch(item.lastSeen!)) <=
+            const Duration(days: 7)) {
+      return false;
+    }
+    if (!await _hasHighDecay(item)) return false;
+    return true;
+  }
+
+  Future<bool> _hasHighDecay(PinnedLearningItem item) async {
+    final tags = <String>[];
+    if (item.type == 'pack') {
+      final tpl = await PackLibraryService.instance.getById(item.id);
+      if (tpl != null) {
+        tags.addAll(tpl.tags.map((e) => e.trim().toLowerCase()));
+      }
+    } else if (item.type == 'lesson') {
+      await MiniLessonLibraryService.instance.loadAll();
+      final lesson = MiniLessonLibraryService.instance.getById(item.id);
+      if (lesson != null) {
+        tags.addAll(lesson.tags.map((e) => e.trim().toLowerCase()));
+      }
+    }
+    for (final t in tags) {
+      final days = await _retention.getDecayScore(t);
+      if (days > 30) return true;
+    }
+    return false;
+  }
+
+  Future<void> _showNotification() async {
+    if (!_pluginInitialized) {
+      const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+      const ios = DarwinInitializationSettings();
+      await _plugin.initialize(
+        const InitializationSettings(android: android, iOS: ios),
+      );
+      _pluginInitialized = true;
+    }
+    await _plugin.show(
+      904,
+      'Come back to training',
+      'You have pinned content getting rusty.',
+      const NotificationDetails(
+        android: AndroidNotificationDetails('pinned_comeback', 'Pinned Comeback'),
+        iOS: DarwinNotificationDetails(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create in-app nudge service
- add comeback nudge service that surfaces decayed pinned content on resume and falls back to local notifications
- hook comeback nudge service into app startup

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688eb26de780832aafb22b94e12ed76a