### PR TITLE
feat: add pinned nudge interaction logger

### DIFF
--- a/lib/services/pinned_interaction_logger_service.dart
+++ b/lib/services/pinned_interaction_logger_service.dart
@@ -1,0 +1,72 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/pinned_learning_item.dart';
+
+/// Logs user interactions with pinned comeback nudges and stores simple
+/// counters/timestamps in [SharedPreferences].
+class PinnedInteractionLoggerService {
+  PinnedInteractionLoggerService._();
+
+  /// Singleton instance.
+  static final PinnedInteractionLoggerService instance =
+      PinnedInteractionLoggerService._();
+
+  static String _openKey(String id) => 'pinned_open_$id';
+  static String _seenKey(String id) => 'pinned_seen_$id';
+  static String _dismissKey(String id) => 'pinned_dismiss_$id';
+  static String _lastOpenKey(String id) => 'pinned_open_last_$id';
+
+  /// Records an impression of a pinned nudge.
+  Future<void> logImpression(PinnedLearningItem item) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _seenKey(item.id);
+    final count = (prefs.getInt(key) ?? 0) + 1;
+    await prefs.setInt(key, count);
+  }
+
+  /// Records that the pinned nudge was opened.
+  Future<void> logOpened(PinnedLearningItem item) async {
+    final prefs = await SharedPreferences.getInstance();
+    final openKey = _openKey(item.id);
+    final count = (prefs.getInt(openKey) ?? 0) + 1;
+    await prefs.setInt(openKey, count);
+    await prefs.setInt(
+      _lastOpenKey(item.id),
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  /// Records that the pinned nudge was dismissed without opening.
+  Future<void> logDismissed(PinnedLearningItem item) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _dismissKey(item.id);
+    final count = (prefs.getInt(key) ?? 0) + 1;
+    await prefs.setInt(key, count);
+  }
+
+  /// Returns how many times the pinned nudge for [id] was opened.
+  Future<int> getOpenCount(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_openKey(id)) ?? 0;
+  }
+
+  /// Returns the last time a pinned nudge for [id] was opened.
+  Future<DateTime?> getLastOpened(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final millis = prefs.getInt(_lastOpenKey(id));
+    if (millis == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(millis);
+  }
+
+  /// Returns a raw stats map useful for debugging.
+  Future<Map<String, dynamic>> getStatsFor(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    return {
+      'impressions': prefs.getInt(_seenKey(id)) ?? 0,
+      'opens': prefs.getInt(_openKey(id)) ?? 0,
+      'dismissals': prefs.getInt(_dismissKey(id)) ?? 0,
+      'lastOpened': prefs.getInt(_lastOpenKey(id)),
+    };
+  }
+}
+

--- a/test/services/pinned_interaction_logger_service_test.dart
+++ b/test/services/pinned_interaction_logger_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/pinned_learning_item.dart';
+import 'package:poker_analyzer/services/pinned_interaction_logger_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('records opens and timestamps', () async {
+    final service = PinnedInteractionLoggerService.instance;
+    final item = const PinnedLearningItem(type: 'pack', id: 'p1');
+
+    await service.logOpened(item);
+
+    expect(await service.getOpenCount('p1'), 1);
+    expect(await service.getLastOpened('p1'), isNotNull);
+  });
+
+  test('tracks impressions and dismissals', () async {
+    final service = PinnedInteractionLoggerService.instance;
+    final item = const PinnedLearningItem(type: 'lesson', id: 'l1');
+
+    await service.logImpression(item);
+    await service.logImpression(item);
+    await service.logDismissed(item);
+
+    final stats = await service.getStatsFor('l1');
+    expect(stats['impressions'], 2);
+    expect(stats['dismissals'], 1);
+    expect(stats['opens'], 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- track impressions, opens, and dismissals of pinned comeback nudges
- persist counts and last-open timestamp in shared preferences
- cover logging behavior with unit tests

## Testing
- `flutter test test/services/pinned_interaction_logger_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3f291f8832aa785729819b8f5b8