### PR TITLE
feat: implement nudge fatigue cooldown

### DIFF
--- a/test/services/nudge_fatigue_detector_service_test.dart
+++ b/test/services/nudge_fatigue_detector_service_test.dart
@@ -30,6 +30,14 @@ void main() {
         await logger.logImpression(item);
       }
       await logger.logOpened(item);
+      // simulate open happened more than a week ago
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(
+        'pinned_open_last_b',
+        DateTime.now()
+            .subtract(const Duration(days: 8))
+            .millisecondsSinceEpoch,
+      );
       for (var i = 0; i < 6; i++) {
         await logger.logDismissed(item);
       }
@@ -47,6 +55,34 @@ void main() {
     for (var i = 0; i < 5; i++) {
       await logger.logDismissed(item);
     }
+    expect(await detector.isFatigued(item), false);
+  });
+
+  test('re-engagement removes fatigue', () async {
+    const item = PinnedLearningItem(type: 'lesson', id: 'd');
+    for (var i = 0; i < 3; i++) {
+      await logger.logDismissed(item);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      'pinned_open_last_d',
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(await detector.isFatigued(item), false);
+  });
+
+  test('fatigue resets after cooldown', () async {
+    const item = PinnedLearningItem(type: 'lesson', id: 'e');
+    for (var i = 0; i < 3; i++) {
+      await logger.logDismissed(item);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      'pinned_dismiss_last_e',
+      DateTime.now()
+          .subtract(const Duration(days: 8))
+          .millisecondsSinceEpoch,
+    );
     expect(await detector.isFatigued(item), false);
   });
 }

--- a/test/services/pinned_interaction_logger_service_test.dart
+++ b/test/services/pinned_interaction_logger_service_test.dart
@@ -33,5 +33,20 @@ void main() {
     expect(stats['dismissals'], 1);
     expect(stats['opens'], 0);
   });
+
+  test('records dismissal time and clears fatigue', () async {
+    final service = PinnedInteractionLoggerService.instance;
+    const item = PinnedLearningItem(type: 'lesson', id: 'l2');
+
+    await service.logDismissed(item);
+
+    expect(await service.getLastDismissed('l2'), isNotNull);
+
+    await service.clearFatigueFor('l2');
+
+    final stats = await service.getStatsFor('l2');
+    expect(stats['dismissals'], 0);
+    expect(stats['lastDismissed'], isNull);
+  });
 }
 


### PR DESCRIPTION
## Summary
- track last dismiss times and allow clearing fatigue data
- use time-based cooldowns in fatigue detector and expose clearFatigueFor
- expand tests for dismissal timestamps and fatigue cooldown recovery

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb8392db8832aa9ec0cfe9b5f9860