### PR TITLE
feat: add block pinning support

### DIFF
--- a/lib/models/pinned_learning_item.dart
+++ b/lib/models/pinned_learning_item.dart
@@ -1,5 +1,5 @@
 class PinnedLearningItem {
-  final String type; // 'lesson' or 'pack'
+  final String type; // 'lesson', 'pack', or 'block'
   final String id;
   final int? lastPosition;
   final int? lastSeen;

--- a/lib/screens/pinned_hub_screen.dart
+++ b/lib/screens/pinned_hub_screen.dart
@@ -7,6 +7,9 @@ import '../services/mini_lesson_library_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/pinned_learning_service.dart';
 import '../widgets/pinned_learning_tile.dart';
+import '../services/theory_block_library_service.dart';
+import '../services/theory_block_launcher.dart';
+import '../models/theory_block_model.dart';
 
 class PinnedHubScreen extends StatefulWidget {
   const PinnedHubScreen({super.key});
@@ -25,6 +28,7 @@ class _PinnedHubScreenState extends State<PinnedHubScreen> {
     _service.addListener(_reload);
     _service.load();
     MiniLessonLibraryService.instance.loadAll();
+    TheoryBlockLibraryService.instance.loadAll();
   }
 
   void _reload() => setState(() {});
@@ -41,6 +45,8 @@ class _PinnedHubScreenState extends State<PinnedHubScreen> {
         _service.items.where((e) => e.type == 'lesson').toList(growable: false);
     final packs =
         _service.items.where((e) => e.type == 'pack').toList(growable: false);
+    final blocks =
+        _service.items.where((e) => e.type == 'block').toList(growable: false);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Pinned Items'),
@@ -55,6 +61,7 @@ class _PinnedHubScreenState extends State<PinnedHubScreen> {
         children: [
           _buildSection('📘 Lessons', lessons, 'lesson'),
           _buildSection('🎯 Drill Packs', packs, 'pack'),
+          _buildSection('📚 Blocks', blocks, 'block'),
         ],
       ),
     );
@@ -111,6 +118,28 @@ class _PinnedHubScreenState extends State<PinnedHubScreen> {
           context,
           item,
           () => _openLesson(lesson, item),
+        ),
+      );
+    }
+
+    if (type == 'block') {
+      final block = TheoryBlockLibraryService.instance.getById(item.id);
+      if (block == null) return const SizedBox.shrink();
+      return ListTile(
+        key: ValueKey('block:${item.id}'),
+        leading: const Text('📚', style: TextStyle(fontSize: 20)),
+        title: Text(block.title),
+        trailing: _editMode
+            ? ReorderableDragStartListener(
+                index: index,
+                child: const Icon(Icons.drag_handle),
+              )
+            : null,
+        onTap: () => _openBlock(block, item),
+        onLongPress: () => showPinnedLearningMenu(
+          context,
+          item,
+          () => _openBlock(block, item),
         ),
       );
     }
@@ -180,6 +209,10 @@ class _PinnedHubScreenState extends State<PinnedHubScreen> {
         ),
       ),
     );
+  }
+
+  void _openBlock(TheoryBlockModel block, PinnedLearningItem item) {
+    const TheoryBlockLauncher().launch(context: context, block: block);
   }
 }
 

--- a/lib/services/theory_block_launcher.dart
+++ b/lib/services/theory_block_launcher.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_block_model.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/pinned_learning_service.dart';
+import '../services/user_progress_service.dart';
+import '../services/training_session_launcher.dart';
+import '../services/theory_track_resume_service.dart';
+
+/// Launches the next appropriate item within a [TheoryBlockModel].
+class TheoryBlockLauncher {
+  const TheoryBlockLauncher();
+
+  Future<void> launch({
+    required BuildContext context,
+    required TheoryBlockModel block,
+    String? trackId,
+  }) async {
+    if (trackId != null) {
+      await TheoryTrackResumeService.instance
+          .saveLastVisitedBlock(trackId, block.id);
+    }
+    await PinnedLearningService.instance.recordOpen('block', block.id);
+    await MiniLessonLibraryService.instance.loadAll();
+    final progress = UserProgressService.instance;
+    for (final id in block.nodeIds) {
+      final done = await progress.isTheoryLessonCompleted(id);
+      if (!done) {
+        final lesson = MiniLessonLibraryService.instance.getById(id);
+        if (lesson != null) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => MiniLessonScreen(lesson: lesson),
+            ),
+          );
+        }
+        return;
+      }
+    }
+    for (final id in block.practicePackIds) {
+      final done = await progress.isPackCompleted(id);
+      if (!done) {
+        final tpl = await PackLibraryService.instance.getById(id);
+        if (tpl != null) {
+          await const TrainingSessionLauncher().launch(tpl);
+        }
+        return;
+      }
+    }
+    if (context.mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Block Completed')));
+    }
+  }
+}

--- a/lib/widgets/pinned_learning_section.dart
+++ b/lib/widgets/pinned_learning_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/mini_lesson_library_service.dart';
 import 'pinned_learning_tile.dart';
+import '../services/theory_block_library_service.dart';
 
 class PinnedLearningSection extends StatefulWidget {
   const PinnedLearningSection({super.key});
@@ -20,6 +21,7 @@ class _PinnedLearningSectionState extends State<PinnedLearningSection> {
     _service.addListener(_reload);
     _service.load();
     MiniLessonLibraryService.instance.loadAll();
+    TheoryBlockLibraryService.instance.loadAll();
   }
 
   void _reload() => setState(() {});

--- a/lib/widgets/pinned_learning_tile.dart
+++ b/lib/widgets/pinned_learning_tile.dart
@@ -7,6 +7,9 @@ import '../screens/training_pack_screen.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/pinned_learning_service.dart';
+import '../services/theory_block_library_service.dart';
+import '../services/theory_block_launcher.dart';
+import '../models/theory_block_model.dart';
 
 class PinnedLearningTile extends StatelessWidget {
   const PinnedLearningTile({super.key, required this.item});
@@ -31,6 +34,31 @@ class PinnedLearningTile extends StatelessWidget {
           item,
           () => _openLesson(context, lesson),
         ),
+      );
+    }
+
+    if (item.type == 'block') {
+      return FutureBuilder<void>(
+        future: TheoryBlockLibraryService.instance.loadAll(),
+        builder: (context, snapshot) {
+          final block = TheoryBlockLibraryService.instance.getById(item.id);
+          if (block == null) return const SizedBox.shrink();
+          return ListTile(
+            leading: const Text('📚', style: TextStyle(fontSize: 20)),
+            title: Text(block.title),
+            trailing: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () =>
+                  PinnedLearningService.instance.unpin('block', item.id),
+            ),
+            onTap: () => _openBlock(context, block),
+            onLongPress: () => showPinnedLearningMenu(
+              context,
+              item,
+              () => _openBlock(context, block),
+            ),
+          );
+        },
       );
     }
 
@@ -79,6 +107,10 @@ class PinnedLearningTile extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void _openBlock(BuildContext context, TheoryBlockModel block) {
+    const TheoryBlockLauncher().launch(context: context, block: block);
   }
 
 }

--- a/lib/widgets/pinned_top_pick_card.dart
+++ b/lib/widgets/pinned_top_pick_card.dart
@@ -8,6 +8,8 @@ import '../screens/mini_lesson_screen.dart';
 import '../screens/training_pack_screen.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/pinned_learning_item.dart';
+import '../services/theory_block_library_service.dart';
+import '../services/theory_block_launcher.dart';
 
 class PinnedTopPickCard extends StatelessWidget {
   const PinnedTopPickCard({super.key});
@@ -44,6 +46,24 @@ class PinnedTopPickCard extends StatelessWidget {
                           ),
                         ),
                       );
+                    },
+                  );
+                },
+              );
+            }
+            if (item.type == 'block') {
+              return FutureBuilder<void>(
+                future: TheoryBlockLibraryService.instance.loadAll(),
+                builder: (context, snapshot) {
+                  final block =
+                      TheoryBlockLibraryService.instance.getById(item.id);
+                  if (block == null) return const SizedBox.shrink();
+                  return _buildCard(
+                    context,
+                    title: block.title,
+                    onTap: () {
+                      const TheoryBlockLauncher()
+                          .launch(context: context, block: block);
                     },
                   );
                 },

--- a/test/services/pinned_learning_service_block_test.dart
+++ b/test/services/pinned_learning_service_block_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/pinned_learning_service.dart';
+import 'package:poker_analyzer/models/theory_block_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PinnedLearningService block', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await PinnedLearningService.instance.load();
+    });
+
+    test('toggleBlock pins block and removes child pins', () async {
+      final svc = PinnedLearningService.instance;
+      await svc.toggle('lesson', 'l1');
+      expect(svc.items.length, 1);
+      const block = TheoryBlockModel(
+        id: 'b',
+        title: 'B',
+        nodeIds: ['l1'],
+        practicePackIds: ['p1'],
+      );
+      await svc.toggleBlock(block);
+      expect(svc.items.length, 1);
+      expect(svc.items.first.type, 'block');
+      expect(svc.isPinned('lesson', 'l1'), isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('pinned_block_b'), isTrue);
+    });
+
+    test('pinning lesson removes parent block', () async {
+      final svc = PinnedLearningService.instance;
+      const block = TheoryBlockModel(
+        id: 'b',
+        title: 'B',
+        nodeIds: ['l1'],
+        practicePackIds: [],
+      );
+      await svc.toggleBlock(block);
+      expect(svc.items.any((e) => e.type == 'block'), isTrue);
+      await svc.toggle('lesson', 'l1');
+      expect(svc.items.any((e) => e.type == 'block'), isFalse);
+      expect(svc.items.any((e) => e.type == 'lesson'), isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('pinned_block_b'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow pinning entire theory blocks and remove duplicate lesson/pack pins
- surface pinned blocks across widgets and recommendations
- test block pinning and deduplication

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ebb99a590832a939b3a2fa796b788