### PR TITLE
feat: add pinned block tracker service

### DIFF
--- a/lib/services/pinned_block_tracker_service.dart
+++ b/lib/services/pinned_block_tracker_service.dart
@@ -1,0 +1,59 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks pin/unpin actions for theory blocks and exposes basic analytics.
+class PinnedBlockTrackerService {
+  PinnedBlockTrackerService._();
+
+  /// Singleton instance.
+  static final PinnedBlockTrackerService instance =
+      PinnedBlockTrackerService._();
+
+  static String _pinKey(String id) => 'pinned_block_$id';
+  static String _lastPinKey(String id) => 'pinned_block_last_$id';
+
+  /// Records that the block with [blockId] was pinned.
+  Future<void> logPin(String blockId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pinKey(blockId), true);
+    await prefs.setInt(
+      _lastPinKey(blockId),
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  /// Records that the block with [blockId] was unpinned.
+  Future<void> logUnpin(String blockId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_pinKey(blockId));
+  }
+
+  /// Returns the last time the block with [blockId] was pinned.
+  Future<DateTime?> getLastPinTime(String blockId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final millis = prefs.getInt(_lastPinKey(blockId));
+    if (millis == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(millis);
+  }
+
+  /// Whether the block with [blockId] is currently pinned.
+  Future<bool> isPinned(String blockId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_pinKey(blockId)) ?? false;
+  }
+
+  /// Returns all currently pinned block ids.
+  Future<List<String>> getPinnedBlockIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    final prefix = 'pinned_block_';
+    final lastPrefix = 'pinned_block_last_';
+    final ids = <String>[];
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(prefix) && !key.startsWith(lastPrefix)) {
+        if (prefs.getBool(key) ?? false) {
+          ids.add(key.substring(prefix.length));
+        }
+      }
+    }
+    return ids;
+  }
+}

--- a/test/services/pinned_block_tracker_service_test.dart
+++ b/test/services/pinned_block_tracker_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/pinned_block_tracker_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('logs pin and unpin events', () async {
+    final service = PinnedBlockTrackerService.instance;
+
+    await service.logPin('b1');
+    expect(await service.isPinned('b1'), isTrue);
+    final time = await service.getLastPinTime('b1');
+    expect(time, isNotNull);
+
+    await service.logUnpin('b1');
+    expect(await service.isPinned('b1'), isFalse);
+    expect(await service.getLastPinTime('b1'), time);
+  });
+
+  test('returns all pinned block ids', () async {
+    final service = PinnedBlockTrackerService.instance;
+
+    await service.logPin('a');
+    await service.logPin('b');
+    await service.logUnpin('a');
+
+    final ids = await service.getPinnedBlockIds();
+    expect(ids, ['b']);
+  });
+}


### PR DESCRIPTION
## Summary
- track pin and unpin events per theory block
- expose analytics for pinned blocks

## Testing
- `flutter test test/services/pinned_block_tracker_service_test.dart --no-pub`


------
https://chatgpt.com/codex/tasks/task_e_688ebdc05d00832aa933fc943746570d