### PR TITLE
feat: add pinned block inbox provider

### DIFF
--- a/lib/models/inbox_card_model.dart
+++ b/lib/models/inbox_card_model.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+
+/// Represents a simple card entry in the user's inbox.
+class InboxCardModel {
+  final String id;
+  final String title;
+  final String subtitle;
+  final void Function(BuildContext) onTap;
+
+  InboxCardModel({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+}
+

--- a/lib/services/smart_pinned_block_inbox_provider.dart
+++ b/lib/services/smart_pinned_block_inbox_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../models/inbox_card_model.dart';
+import '../services/pinned_block_tracker_service.dart';
+import '../services/theory_block_library_service.dart';
+import '../widgets/theory_block_context_sheet.dart';
+
+/// Generates inbox cards for pinned theory blocks for quick access.
+class SmartPinnedBlockInboxProvider {
+  SmartPinnedBlockInboxProvider({
+    PinnedBlockTrackerService? tracker,
+    TheoryBlockLibraryService? library,
+  })  : tracker = tracker ?? PinnedBlockTrackerService.instance,
+        library = library ?? TheoryBlockLibraryService.instance;
+
+  final PinnedBlockTrackerService tracker;
+  final TheoryBlockLibraryService library;
+
+  /// Returns a list of [InboxCardModel]s representing pinned blocks.
+  Future<List<InboxCardModel>> getCards() async {
+    final ids = await tracker.getPinnedBlockIds();
+    if (ids.isEmpty) return [];
+    await library.loadAll();
+
+    final cards = <InboxCardModel>[];
+    for (final id in ids) {
+      final block = library.getById(id);
+      if (block == null) continue;
+      cards.add(
+        InboxCardModel(
+          id: block.id,
+          title: block.title,
+          subtitle: 'You pinned this for later',
+          onTap: (context) => showTheoryBlockContextSheet(context, block),
+        ),
+      );
+    }
+    return cards;
+  }
+}
+

--- a/lib/widgets/theory_block_context_sheet.dart
+++ b/lib/widgets/theory_block_context_sheet.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_block_model.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../screens/training_pack_screen.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../services/pinned_learning_service.dart';
+import '../services/user_progress_service.dart';
+
+/// Displays the same options sheet used by [TheoryBlockCardWidget] when long
+/// pressed. Allows pin/unpin and quick navigation to lessons or packs.
+Future<void> showTheoryBlockContextSheet(
+    BuildContext context, TheoryBlockModel block) async {
+  await MiniLessonLibraryService.instance.loadAll();
+  final progress = UserProgressService.instance;
+  var pinned = PinnedLearningService.instance.isPinned('block', block.id);
+
+  final lessons = <_LessonEntry>[];
+  for (final id in block.nodeIds) {
+    final lesson = MiniLessonLibraryService.instance.getById(id);
+    if (lesson == null) continue;
+    final done = await progress.isTheoryLessonCompleted(id);
+    lessons.add(_LessonEntry(lesson, done));
+  }
+
+  final packs = <_PackEntry>[];
+  for (final id in block.practicePackIds) {
+    final tpl = await PackLibraryService.instance.getById(id);
+    if (tpl == null) continue;
+    final done = await progress.isPackCompleted(id);
+    packs.add(_PackEntry(tpl, done));
+  }
+
+  await showModalBottomSheet(
+    context: context,
+    builder: (ctx) {
+      return SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              leading: Icon(
+                  pinned ? Icons.push_pin : Icons.push_pin_outlined),
+              title: Text(pinned ? 'Unpin Block' : 'Pin Block'),
+              onTap: () async {
+                Navigator.pop(ctx);
+                await PinnedLearningService.instance.toggleBlock(block);
+                pinned =
+                    PinnedLearningService.instance.isPinned('block', block.id);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(pinned ? 'Pinned' : 'Unpinned')),
+                );
+              },
+            ),
+            if (lessons.isNotEmpty)
+              const ListTile(title: Text('Lessons')),
+            for (final e in lessons)
+              ListTile(
+                leading: const Icon(Icons.menu_book),
+                title: Text(e.lesson.title),
+                trailing: Icon(
+                  e.done ? Icons.check_circle : Icons.cancel,
+                  color: e.done ? Colors.green : Colors.red,
+                ),
+                onTap: () async {
+                  Navigator.pop(ctx);
+                  await Navigator.push(
+                    ctx,
+                    MaterialPageRoute(
+                      builder: (_) => MiniLessonScreen(lesson: e.lesson),
+                    ),
+                  );
+                },
+              ),
+            if (packs.isNotEmpty) const ListTile(title: Text('Drill Packs')),
+            for (final e in packs)
+              ListTile(
+                leading: const Icon(Icons.fitness_center),
+                title: Text(e.pack.name),
+                trailing: Icon(
+                  e.done ? Icons.check_circle : Icons.cancel,
+                  color: e.done ? Colors.green : Colors.red,
+                ),
+                onTap: () async {
+                  Navigator.pop(ctx);
+                  await Navigator.push(
+                    ctx,
+                    MaterialPageRoute(
+                      builder: (_) => TrainingPackScreen(pack: e.pack),
+                    ),
+                  );
+                },
+              ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+class _LessonEntry {
+  final TheoryMiniLessonNode lesson;
+  final bool done;
+  _LessonEntry(this.lesson, this.done);
+}
+
+class _PackEntry {
+  final TrainingPackTemplateV2 pack;
+  final bool done;
+  _PackEntry(this.pack, this.done);
+}
+

--- a/test/services/smart_pinned_block_inbox_provider_test.dart
+++ b/test/services/smart_pinned_block_inbox_provider_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_block_model.dart';
+import 'package:poker_analyzer/models/inbox_card_model.dart';
+import 'package:poker_analyzer/services/pinned_block_tracker_service.dart';
+import 'package:poker_analyzer/services/smart_pinned_block_inbox_provider.dart';
+import 'package:poker_analyzer/services/theory_block_library_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('creates inbox cards for pinned blocks', () async {
+    final tracker = PinnedBlockTrackerService.instance;
+    await tracker.logPin('b1');
+    const block = TheoryBlockModel(
+      id: 'b1',
+      title: 'Block One',
+      nodeIds: [],
+      practicePackIds: [],
+    );
+    final library = _FakeBlockLibrary({block.id: block});
+    final provider = SmartPinnedBlockInboxProvider(
+      tracker: tracker,
+      library: library,
+    );
+    final cards = await provider.getCards();
+    expect(cards.length, 1);
+    final InboxCardModel card = cards.first;
+    expect(card.title, 'Block One');
+    expect(card.subtitle, 'You pinned this for later');
+  });
+}
+
+class _FakeBlockLibrary implements TheoryBlockLibraryService {
+  _FakeBlockLibrary(this._map);
+  final Map<String, TheoryBlockModel> _map;
+
+  @override
+  List<TheoryBlockModel> get all => _map.values.toList();
+
+  @override
+  TheoryBlockModel? getById(String id) => _map[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+}
+


### PR DESCRIPTION
## Summary
- add `InboxCardModel` and provider to surface pinned theory blocks as inbox cards
- extract theory block long-press sheet for reuse
- add tests for pinned block inbox provider

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ec107f96c832ab2c8c9af6faab50e