### PR TITLE
feat: prioritize pinned blocks in smart resume

### DIFF
--- a/lib/models/resume_target.dart
+++ b/lib/models/resume_target.dart
@@ -1,0 +1,7 @@
+enum ResumeType { lesson, pack, block }
+
+class ResumeTarget {
+  final String id;
+  final ResumeType type;
+  const ResumeTarget(this.id, this.type);
+}

--- a/lib/services/pinned_block_resume_strategy.dart
+++ b/lib/services/pinned_block_resume_strategy.dart
@@ -1,0 +1,50 @@
+import '../models/resume_target.dart';
+import '../models/theory_block_model.dart';
+import 'pinned_block_tracker_service.dart';
+import 'theory_block_library_service.dart';
+import 'theory_path_completion_evaluator_service.dart';
+import 'user_progress_service.dart';
+import 'resume_strategy.dart';
+
+class PinnedBlockResumeStrategy implements ResumeStrategy {
+  PinnedBlockResumeStrategy({
+    PinnedBlockTrackerService? tracker,
+    TheoryBlockLibraryService? library,
+    TheoryPathCompletionEvaluatorService? evaluator,
+  })  : tracker = tracker ?? PinnedBlockTrackerService.instance,
+        library = library ?? TheoryBlockLibraryService.instance,
+        evaluator = evaluator ??
+            TheoryPathCompletionEvaluatorService(
+              userProgress: UserProgressService.instance,
+            );
+
+  final PinnedBlockTrackerService tracker;
+  final TheoryBlockLibraryService library;
+  final TheoryPathCompletionEvaluatorService evaluator;
+
+  @override
+  Future<ResumeTarget?> getResumeTarget() async {
+    final ids = await tracker.getPinnedBlockIds();
+    if (ids.isEmpty) return null;
+    await library.loadAll();
+
+    final entries = <_Entry>[];
+    for (final id in ids) {
+      final TheoryBlockModel? block = library.getById(id);
+      if (block == null) continue;
+      if (await evaluator.isBlockCompleted(block)) continue;
+      final time = await tracker.getLastPinTime(id);
+      if (time == null) continue;
+      entries.add(_Entry(block.id, time));
+    }
+    if (entries.isEmpty) return null;
+    entries.sort((a, b) => b.time.compareTo(a.time));
+    return ResumeTarget(entries.first.id, ResumeType.block);
+  }
+}
+
+class _Entry {
+  _Entry(this.id, this.time);
+  final String id;
+  final DateTime time;
+}

--- a/lib/services/resume_strategy.dart
+++ b/lib/services/resume_strategy.dart
@@ -1,0 +1,5 @@
+import '../models/resume_target.dart';
+
+abstract class ResumeStrategy {
+  Future<ResumeTarget?> getResumeTarget();
+}

--- a/lib/services/smart_resume_engine.dart
+++ b/lib/services/smart_resume_engine.dart
@@ -1,6 +1,10 @@
 import 'package:shared_preferences/shared_preferences.dart';
+
 import '../helpers/training_pack_storage.dart';
+import '../models/resume_target.dart';
 import '../models/v2/training_pack_template.dart';
+import 'pinned_block_resume_strategy.dart';
+import 'resume_strategy.dart';
 
 class UnfinishedPack {
   final TrainingPackTemplate template;
@@ -12,8 +16,20 @@ class UnfinishedPack {
 }
 
 class SmartResumeEngine {
-  SmartResumeEngine._();
-  static final instance = SmartResumeEngine._();
+  SmartResumeEngine({List<ResumeStrategy>? strategies})
+      : _strategies = strategies ?? [PinnedBlockResumeStrategy()];
+
+  static final SmartResumeEngine instance = SmartResumeEngine();
+
+  final List<ResumeStrategy> _strategies;
+
+  Future<ResumeTarget?> getResumeTarget() async {
+    for (final strategy in _strategies) {
+      final target = await strategy.getResumeTarget();
+      if (target != null) return target;
+    }
+    return null;
+  }
 
   static const _playPrefix = 'tpl_prog_';
   static const _playTsPrefix = 'tpl_ts_';

--- a/test/services/pinned_block_resume_strategy_test.dart
+++ b/test/services/pinned_block_resume_strategy_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_block_model.dart';
+import 'package:poker_analyzer/models/resume_target.dart';
+import 'package:poker_analyzer/services/pinned_block_resume_strategy.dart';
+import 'package:poker_analyzer/services/pinned_block_tracker_service.dart';
+import 'package:poker_analyzer/services/smart_resume_engine.dart';
+import 'package:poker_analyzer/services/theory_block_library_service.dart';
+import 'package:poker_analyzer/services/theory_path_completion_evaluator_service.dart';
+import 'package:poker_analyzer/services/user_progress_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns most recent pinned incomplete block', () async {
+    final tracker = PinnedBlockTrackerService.instance;
+    await tracker.logPin('a');
+    await Future.delayed(const Duration(milliseconds: 1));
+    await tracker.logPin('b');
+    await Future.delayed(const Duration(milliseconds: 1));
+    await tracker.logPin('c');
+
+    final blocks = {
+      'a': const TheoryBlockModel(id: 'a', title: 'A', nodeIds: [], practicePackIds: []),
+      'b': const TheoryBlockModel(id: 'b', title: 'B', nodeIds: [], practicePackIds: []),
+      'c': const TheoryBlockModel(id: 'c', title: 'C', nodeIds: [], practicePackIds: []),
+    };
+
+    final library = _FakeBlockLibrary(blocks);
+    final evaluator = _FakeEvaluator({'b': true}); // mark b completed
+
+    final strategy = PinnedBlockResumeStrategy(
+      tracker: tracker,
+      library: library,
+      evaluator: evaluator,
+    );
+
+    final engine = SmartResumeEngine(strategies: [strategy]);
+
+    final target = await engine.getResumeTarget();
+    expect(target, isNotNull);
+    expect(target!.id, 'c');
+    expect(target.type, ResumeType.block);
+  });
+}
+
+class _FakeBlockLibrary implements TheoryBlockLibraryService {
+  _FakeBlockLibrary(this._map);
+  final Map<String, TheoryBlockModel> _map;
+
+  @override
+  List<TheoryBlockModel> get all => _map.values.toList();
+
+  @override
+  TheoryBlockModel? getById(String id) => _map[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+}
+
+class _FakeEvaluator extends TheoryPathCompletionEvaluatorService {
+  _FakeEvaluator(this._completed)
+      : super(userProgress: _FakeProgressService());
+  final Map<String, bool> _completed;
+
+  @override
+  Future<bool> isBlockCompleted(TheoryBlockModel block) async {
+    return _completed[block.id] ?? false;
+  }
+}
+
+class _FakeProgressService implements UserProgressService {
+  @override
+  Future<bool> isPackCompleted(String id) async => false;
+
+  @override
+  Future<bool> isTheoryLessonCompleted(String id) async => false;
+}


### PR DESCRIPTION
## Summary
- extend smart resume engine with strategy-based resume target selection
- implement pinned block resume strategy to pick most recently pinned incomplete blocks
- add model for resume targets and unit test for pinned block selection

## Testing
- `flutter test test/services/pinned_block_resume_strategy_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688ec2b5aa24832ab32ba24eeb6597b6