### PR TITLE
feat: add smart pinned block booster provider

### DIFF
--- a/lib/services/smart_pinned_block_booster_provider.dart
+++ b/lib/services/smart_pinned_block_booster_provider.dart
@@ -1,0 +1,62 @@
+import 'pinned_block_tracker_service.dart';
+import 'theory_block_library_service.dart';
+import 'decay_recall_evaluator_service.dart';
+import '../models/theory_block_model.dart';
+
+/// Suggests booster drills for pinned blocks with decayed tags.
+class PinnedBlockBoosterSuggestion {
+  final String blockId;
+  final String blockTitle;
+  final String tag;
+  final String action; // 'resumePack' or 'reviewTheory'
+  final String? packId;
+
+  const PinnedBlockBoosterSuggestion({
+    required this.blockId,
+    required this.blockTitle,
+    required this.tag,
+    required this.action,
+    this.packId,
+  });
+}
+
+class SmartPinnedBlockBoosterProvider {
+  SmartPinnedBlockBoosterProvider({
+    PinnedBlockTrackerService? tracker,
+    TheoryBlockLibraryService? library,
+    DecayRecallEvaluatorService? evaluator,
+  })  : tracker = tracker ?? PinnedBlockTrackerService.instance,
+        library = library ?? TheoryBlockLibraryService.instance,
+        evaluator = evaluator ?? const DecayRecallEvaluatorService();
+
+  final PinnedBlockTrackerService tracker;
+  final TheoryBlockLibraryService library;
+  final DecayRecallEvaluatorService evaluator;
+
+  /// Returns booster suggestions for pinned blocks with decayed tags.
+  Future<List<PinnedBlockBoosterSuggestion>> getBoosters() async {
+    final ids = await tracker.getPinnedBlockIds();
+    if (ids.isEmpty) return [];
+    await library.loadAll();
+    final suggestions = <PinnedBlockBoosterSuggestion>[];
+    for (final id in ids) {
+      final block = library.getById(id);
+      if (block == null) continue;
+      final decayed = await evaluator.getDecayedTags(block);
+      if (decayed.isEmpty) continue;
+      for (final tag in decayed) {
+        final hasPack = block.practicePackIds.isNotEmpty;
+        suggestions.add(
+          PinnedBlockBoosterSuggestion(
+            blockId: block.id,
+            blockTitle: block.title,
+            tag: tag,
+            action: hasPack ? 'resumePack' : 'reviewTheory',
+            packId: hasPack ? block.practicePackIds.first : null,
+          ),
+        );
+      }
+    }
+    return suggestions;
+  }
+}

--- a/test/services/smart_pinned_block_booster_provider_test.dart
+++ b/test/services/smart_pinned_block_booster_provider_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_block_model.dart';
+import 'package:poker_analyzer/services/pinned_block_tracker_service.dart';
+import 'package:poker_analyzer/services/smart_pinned_block_booster_provider.dart';
+import 'package:poker_analyzer/services/theory_block_library_service.dart';
+import 'package:poker_analyzer/services/decay_recall_evaluator_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('suggests boosters for pinned blocks with decayed tags', () async {
+    final tracker = PinnedBlockTrackerService.instance;
+    await tracker.logPin('b1');
+    await tracker.logPin('b2');
+
+    const block1 = TheoryBlockModel(
+      id: 'b1',
+      title: 'Block 1',
+      nodeIds: [],
+      practicePackIds: ['p1'],
+      tags: ['t1'],
+    );
+
+    const block2 = TheoryBlockModel(
+      id: 'b2',
+      title: 'Block 2',
+      nodeIds: [],
+      practicePackIds: [],
+      tags: ['t2'],
+    );
+
+    final library = _FakeBlockLibrary({block1.id: block1, block2.id: block2});
+    final evaluator = _FakeEvaluator({'b1': ['t1'], 'b2': ['t2']});
+
+    final provider = SmartPinnedBlockBoosterProvider(
+      tracker: tracker,
+      library: library,
+      evaluator: evaluator,
+    );
+
+    final boosters = await provider.getBoosters();
+    expect(boosters.length, 2);
+    final first = boosters.firstWhere((b) => b.blockId == 'b1');
+    expect(first.tag, 't1');
+    expect(first.action, 'resumePack');
+    expect(first.packId, 'p1');
+
+    final second = boosters.firstWhere((b) => b.blockId == 'b2');
+    expect(second.tag, 't2');
+    expect(second.action, 'reviewTheory');
+    expect(second.packId, isNull);
+  });
+}
+
+class _FakeBlockLibrary implements TheoryBlockLibraryService {
+  _FakeBlockLibrary(this._map);
+  final Map<String, TheoryBlockModel> _map;
+
+  @override
+  List<TheoryBlockModel> get all => _map.values.toList();
+
+  @override
+  TheoryBlockModel? getById(String id) => _map[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+}
+
+class _FakeEvaluator extends DecayRecallEvaluatorService {
+  final Map<String, List<String>> _map;
+  const _FakeEvaluator(this._map);
+
+  @override
+  Future<List<String>> getDecayedTags(TheoryBlockModel block,
+      {double threshold = 30}) async {
+    return _map[block.id] ?? [];
+  }
+
+  @override
+  Future<bool> hasDecayedTags(TheoryBlockModel block,
+      {double threshold = 30}) async {
+    return (await getDecayedTags(block, threshold: threshold)).isNotEmpty;
+  }
+}


### PR DESCRIPTION
## Summary
- extend decay evaluator with ability to detect decayed tags in a theory block
- add SmartPinnedBlockBoosterProvider to suggest boosters for pinned decayed content
- cover provider with unit test

## Testing
- `flutter test test/services/smart_pinned_block_booster_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ec49eec88832aa33ca3f02e11b76b