### PR TITLE
feat: add pinned block booster inbox banner

### DIFF
--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+
+import '../widgets/inbox_pinned_block_booster_banner.dart';
+import 'smart_pinned_block_booster_provider.dart';
+
+/// Aggregates smart inbox items for the user.
+class SmartInboxController {
+  SmartInboxController({SmartPinnedBlockBoosterProvider? boosterProvider})
+    : boosterProvider = boosterProvider ?? SmartPinnedBlockBoosterProvider();
+
+  final SmartPinnedBlockBoosterProvider boosterProvider;
+
+  /// Returns widgets to display in the smart inbox.
+  Future<List<Widget>> getInboxItems() async {
+    final items = <Widget>[];
+    final boosters = await boosterProvider.getBoosters();
+    if (boosters.isNotEmpty) {
+      items.add(
+        InboxPinnedBlockBoosterBanner(suggestions: boosters.take(2).toList()),
+      );
+    }
+    return items;
+  }
+}

--- a/lib/widgets/inbox_pinned_block_booster_banner.dart
+++ b/lib/widgets/inbox_pinned_block_booster_banner.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../services/smart_pinned_block_booster_provider.dart';
+import '../services/pack_library_service.dart';
+import '../services/theory_block_library_service.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+import '../screens/mini_lesson_screen.dart';
+
+/// Banner that surfaces booster suggestions from pinned theory blocks with
+/// decayed tags.
+class InboxPinnedBlockBoosterBanner extends StatelessWidget {
+  final List<PinnedBlockBoosterSuggestion> suggestions;
+
+  const InboxPinnedBlockBoosterBanner({super.key, required this.suggestions});
+
+  Future<void> _open(
+    BuildContext context,
+    PinnedBlockBoosterSuggestion s,
+  ) async {
+    if (s.action == 'resumePack' && s.packId != null) {
+      final tpl = await PackLibraryService.instance.getById(s.packId!);
+      if (tpl == null) return;
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TrainingPackPlayScreen(template: tpl),
+        ),
+      );
+      return;
+    }
+    await TheoryBlockLibraryService.instance.loadAll();
+    await MiniLessonLibraryService.instance.loadAll();
+    final block = TheoryBlockLibraryService.instance.getById(s.blockId);
+    final firstId = block?.nodeIds.isNotEmpty == true
+        ? block!.nodeIds.first
+        : null;
+    if (firstId == null) return;
+    final lesson = MiniLessonLibraryService.instance.getById(firstId);
+    if (lesson == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (suggestions.isEmpty) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Column(
+      children: [
+        for (final s in suggestions)
+          Container(
+            margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[850],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        s.blockTitle,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        s.tag,
+                        style: const TextStyle(color: Colors.white70),
+                      ),
+                    ],
+                  ),
+                ),
+                ActionChip(
+                  label: Text(
+                    s.action == 'resumePack' ? '🎯 Drill' : '📘 Review',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  backgroundColor: accent,
+                  onPressed: () => _open(context, s),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `InboxPinnedBlockBoosterBanner` widget to show decayed pinned block boosters
- expose banner via `SmartInboxController.getInboxItems`

## Testing
- `flutter test` *(fails: file_picker plugin lacks inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_688ec62574f0832a96d71f720bacc2d7