### PR TITLE
feat: add theory block review streak evaluator

### DIFF
--- a/lib/services/theory_block_review_streak_evaluator.dart
+++ b/lib/services/theory_block_review_streak_evaluator.dart
@@ -1,0 +1,68 @@
+import '../models/theory_block_model.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'theory_block_library_service.dart';
+
+/// Evaluates review streaks for theory blocks based on recorded tag reviews.
+class TheoryBlockReviewStreakEvaluator {
+  TheoryBlockReviewStreakEvaluator({
+    DecayTagRetentionTrackerService? retention,
+    TheoryBlockLibraryService? library,
+  })  : retention = retention ?? const DecayTagRetentionTrackerService(),
+        library = library ?? TheoryBlockLibraryService.instance;
+
+  final DecayTagRetentionTrackerService retention;
+  final TheoryBlockLibraryService library;
+
+  /// Returns all unique UTC dates when any theory tag was reviewed.
+  Future<List<DateTime>> getStreakDays() async {
+    await library.loadAll();
+    final tags = <String>{};
+    for (final TheoryBlockModel block in library.all) {
+      tags.addAll(block.tags.map((e) => e.toLowerCase()));
+    }
+    final days = <DateTime>{};
+    for (final tag in tags) {
+      final last = await retention.getLastTheoryReview(tag);
+      if (last != null) {
+        final utc = last.toUtc();
+        days.add(DateTime.utc(utc.year, utc.month, utc.day));
+      }
+    }
+    final list = days.toList()..sort();
+    return list;
+  }
+
+  /// Current streak of consecutive days with at least one review.
+  Future<int> getCurrentStreak() async {
+    final days = await getStreakDays();
+    if (days.isEmpty) return 0;
+    final set = days.toSet();
+    var day = DateTime.now().toUtc();
+    day = DateTime.utc(day.year, day.month, day.day);
+    var streak = 0;
+    while (set.contains(day)) {
+      streak += 1;
+      day = day.subtract(const Duration(days: 1));
+    }
+    return streak;
+  }
+
+  /// Historical maximum streak length.
+  Future<int> getMaxStreak() async {
+    final days = await getStreakDays();
+    if (days.isEmpty) return 0;
+    var best = 1;
+    var current = 1;
+    for (var i = 1; i < days.length; i++) {
+      final diff = days[i].difference(days[i - 1]).inDays;
+      if (diff == 1) {
+        current += 1;
+      } else if (diff > 1) {
+        if (current > best) best = current;
+        current = 1;
+      }
+    }
+    if (current > best) best = current;
+    return best;
+  }
+}

--- a/test/services/theory_block_review_streak_evaluator_test.dart
+++ b/test/services/theory_block_review_streak_evaluator_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_block_model.dart';
+import 'package:poker_analyzer/services/theory_block_review_streak_evaluator.dart';
+import 'package:poker_analyzer/services/theory_block_library_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('streak days aggregated and deduped', () async {
+    final now = DateTime.now().toUtc();
+    SharedPreferences.setMockInitialValues({
+      'retention.theoryReviewed.a': now.toIso8601String(),
+      'retention.theoryReviewed.b': now.toIso8601String(),
+      'retention.theoryReviewed.c':
+          now.subtract(const Duration(days: 2)).toIso8601String(),
+    });
+
+    final library = _FakeLibrary({
+      '1': const TheoryBlockModel(
+        id: '1',
+        title: 'b1',
+        nodeIds: [],
+        practicePackIds: [],
+        tags: ['a', 'b'],
+      ),
+      '2': const TheoryBlockModel(
+        id: '2',
+        title: 'b2',
+        nodeIds: [],
+        practicePackIds: [],
+        tags: ['c'],
+      ),
+    });
+
+    final evaluator =
+        TheoryBlockReviewStreakEvaluator(library: library);
+    final days = await evaluator.getStreakDays();
+    final today = DateTime.utc(now.year, now.month, now.day);
+    final twoAgo = today.subtract(const Duration(days: 2));
+    expect(days, [twoAgo, today]);
+  });
+
+  test('current and max streak computed', () async {
+    final now = DateTime.now().toUtc();
+    SharedPreferences.setMockInitialValues({
+      'retention.theoryReviewed.t1': now.toIso8601String(),
+      'retention.theoryReviewed.t2':
+          now.subtract(const Duration(days: 1)).toIso8601String(),
+      'retention.theoryReviewed.t3':
+          now.subtract(const Duration(days: 3)).toIso8601String(),
+    });
+
+    final library = _FakeLibrary({
+      'b': const TheoryBlockModel(
+        id: 'b',
+        title: 'b',
+        nodeIds: [],
+        practicePackIds: [],
+        tags: ['t1', 't2', 't3'],
+      ),
+    });
+
+    final evaluator =
+        TheoryBlockReviewStreakEvaluator(library: library);
+    expect(await evaluator.getCurrentStreak(), 2);
+    expect(await evaluator.getMaxStreak(), 2);
+  });
+}
+
+class _FakeLibrary implements TheoryBlockLibraryService {
+  _FakeLibrary(this._map);
+  final Map<String, TheoryBlockModel> _map;
+
+  @override
+  List<TheoryBlockModel> get all => _map.values.toList();
+
+  @override
+  TheoryBlockModel? getById(String id) => _map[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+}


### PR DESCRIPTION
## Summary
- add TheoryBlockReviewStreakEvaluator to compute current and max streaks from tag review dates
- cover streak day aggregation and streak calculation with tests

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install dart` *(fails: Unable to locate package dart)*
- `apt-get install flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688ec87dec14832a8cf99f0f7041b92e