### PR TITLE
feat: track booster banner interactions

### DIFF
--- a/lib/services/booster_interaction_tracker_service.dart
+++ b/lib/services/booster_interaction_tracker_service.dart
@@ -1,0 +1,76 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'user_action_logger.dart';
+
+/// Records when booster banners are opened or dismissed per tag.
+class BoosterInteractionTrackerService {
+  BoosterInteractionTrackerService._();
+  static final BoosterInteractionTrackerService instance =
+      BoosterInteractionTrackerService._();
+
+  static const String _openedPrefix = 'booster_opened_';
+  static const String _dismissedPrefix = 'booster_dismissed_';
+
+  Future<void> logOpened(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      '$_openedPrefix$tag',
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    await UserActionLogger.instance.logEvent({
+      'event': 'booster_banner.opened',
+      'tag': tag,
+    });
+  }
+
+  Future<void> logDismissed(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      '$_dismissedPrefix$tag',
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    await UserActionLogger.instance.logEvent({
+      'event': 'booster_banner.dismissed',
+      'tag': tag,
+    });
+  }
+
+  Future<DateTime?> getLastOpened(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final ts = prefs.getInt('$_openedPrefix$tag');
+    if (ts == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(ts);
+  }
+
+  Future<DateTime?> getLastDismissed(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final ts = prefs.getInt('$_dismissedPrefix$tag');
+    if (ts == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(ts);
+  }
+
+  /// Returns summary analytics keyed by tag with last open/dismiss times.
+  Future<Map<String, Map<String, DateTime?>>> getSummary() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, Map<String, DateTime?>>{};
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(_openedPrefix)) {
+        final tag = key.substring(_openedPrefix.length);
+        final ts = prefs.getInt(key);
+        final map = result.putIfAbsent(tag, () => {});
+        if (ts != null) {
+          map['opened'] = DateTime.fromMillisecondsSinceEpoch(ts);
+        }
+      } else if (key.startsWith(_dismissedPrefix)) {
+        final tag = key.substring(_dismissedPrefix.length);
+        final ts = prefs.getInt(key);
+        final map = result.putIfAbsent(tag, () => {});
+        if (ts != null) {
+          map['dismissed'] = DateTime.fromMillisecondsSinceEpoch(ts);
+        }
+      }
+    }
+    return result;
+  }
+}
+

--- a/lib/widgets/inbox_pinned_block_booster_banner.dart
+++ b/lib/widgets/inbox_pinned_block_booster_banner.dart
@@ -6,6 +6,7 @@ import '../services/theory_block_library_service.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../screens/v2/training_pack_play_screen.dart';
 import '../screens/mini_lesson_screen.dart';
+import '../services/booster_interaction_tracker_service.dart';
 
 /// Banner that surfaces booster suggestions from pinned theory blocks with
 /// decayed tags.
@@ -86,7 +87,17 @@ class InboxPinnedBlockBoosterBanner extends StatelessWidget {
                     style: const TextStyle(color: Colors.white),
                   ),
                   backgroundColor: accent,
-                  onPressed: () => _open(context, s),
+                  onPressed: () async {
+                    await BoosterInteractionTrackerService.instance
+                        .logOpened(s.tag);
+                    await _open(context, s);
+                  },
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 20),
+                  color: Colors.white70,
+                  onPressed: () => BoosterInteractionTrackerService.instance
+                      .logDismissed(s.tag),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- add BoosterInteractionTrackerService to log open and dismiss events for booster banners
- integrate tracker with InboxPinnedBlockBoosterBanner's open and dismiss actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ecb64d24c832aa8775f9ce24e3077