### PR TITLE
feat: diversify booster scheduling

### DIFF
--- a/lib/services/smart_booster_diversity_scheduler_service.dart
+++ b/lib/services/smart_booster_diversity_scheduler_service.dart
@@ -1,0 +1,81 @@
+import 'dart:math';
+
+import 'booster_interaction_tracker_service.dart';
+import 'smart_pinned_block_booster_provider.dart';
+
+/// Schedules booster suggestions to maximize variety and penalize recent repeats.
+class SmartBoosterDiversitySchedulerService {
+  SmartBoosterDiversitySchedulerService({
+    BoosterInteractionTrackerService? interactions,
+  }) : interactions = interactions ?? BoosterInteractionTrackerService.instance;
+
+  final BoosterInteractionTrackerService interactions;
+
+  /// Returns [all] suggestions ordered to avoid repetitive nudges.
+  Future<List<PinnedBlockBoosterSuggestion>> schedule(
+      List<PinnedBlockBoosterSuggestion> all) async {
+    if (all.isEmpty) return [];
+
+    final now = DateTime.now();
+    final uniqueTags = all.map((s) => s.tag).toSet();
+    final tagTimes = <String, DateTime?>{};
+    for (final tag in uniqueTags) {
+      final opened = await interactions.getLastOpened(tag);
+      final dismissed = await interactions.getLastDismissed(tag);
+      DateTime? last;
+      if (opened != null && dismissed != null) {
+        last = opened.isAfter(dismissed) ? opened : dismissed;
+      } else {
+        last = opened ?? dismissed;
+      }
+      tagTimes[tag] = last;
+    }
+
+    final byTag = <String, List<_ScoredSuggestion>>{};
+    for (final s in all) {
+      final last = tagTimes[s.tag];
+      double score;
+      if (last == null) {
+        score = 1000; // never shown
+      } else {
+        final age = now.difference(last).inDays.toDouble();
+        score = age >= 7 ? age : age - 7; // penalize recent (<7 days)
+      }
+      byTag.putIfAbsent(s.tag, () => []).add(_ScoredSuggestion(s, score));
+    }
+
+    for (final list in byTag.values) {
+      list.sort((a, b) => b.score.compareTo(a.score));
+    }
+
+    final tags = byTag.keys.toList()
+      ..sort((a, b) => byTag[b]![0].score.compareTo(byTag[a]![0].score));
+
+    final rnd = Random();
+    final result = <PinnedBlockBoosterSuggestion>[];
+    var added = true;
+    while (added) {
+      added = false;
+      for (final tag in tags) {
+        final list = byTag[tag]!;
+        if (list.isNotEmpty) {
+          // add slight randomness to avoid deterministic ordering within same score
+          final next = list.removeAt(0);
+          result.add(next.suggestion);
+          added = true;
+        }
+      }
+      // shuffle tags each round to enhance diversity
+      tags.shuffle(rnd);
+    }
+
+    return result;
+  }
+}
+
+class _ScoredSuggestion {
+  final PinnedBlockBoosterSuggestion suggestion;
+  final double score;
+  _ScoredSuggestion(this.suggestion, this.score);
+}
+

--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../widgets/inbox_pinned_block_booster_banner.dart';
+import 'smart_booster_diversity_scheduler_service.dart';
 import 'smart_booster_inbox_limiter_service.dart';
 import 'smart_pinned_block_booster_provider.dart';
 
@@ -9,19 +10,24 @@ class SmartInboxController {
   SmartInboxController({
     SmartPinnedBlockBoosterProvider? boosterProvider,
     SmartBoosterInboxLimiterService? inboxLimiter,
+    SmartBoosterDiversitySchedulerService? diversityScheduler,
   })  : boosterProvider = boosterProvider ?? SmartPinnedBlockBoosterProvider(),
-        inboxLimiter = inboxLimiter ?? SmartBoosterInboxLimiterService();
+        inboxLimiter = inboxLimiter ?? SmartBoosterInboxLimiterService(),
+        diversityScheduler =
+            diversityScheduler ?? SmartBoosterDiversitySchedulerService();
 
   final SmartPinnedBlockBoosterProvider boosterProvider;
   final SmartBoosterInboxLimiterService inboxLimiter;
+  final SmartBoosterDiversitySchedulerService diversityScheduler;
 
   /// Returns widgets to display in the smart inbox.
   Future<List<Widget>> getInboxItems() async {
     final items = <Widget>[];
     final boosters = await boosterProvider.getBoosters();
     if (boosters.isNotEmpty) {
+      final scheduled = await diversityScheduler.schedule(boosters);
       final allowed = <PinnedBlockBoosterSuggestion>[];
-      for (final b in boosters) {
+      for (final b in scheduled) {
         if (await inboxLimiter.canShow(b.tag)) {
           await inboxLimiter.recordShown(b.tag);
           allowed.add(b);

--- a/test/services/smart_booster_diversity_scheduler_service_test.dart
+++ b/test/services/smart_booster_diversity_scheduler_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_booster_diversity_scheduler_service.dart';
+import 'package:poker_analyzer/services/smart_pinned_block_booster_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('prioritizes old or unseen boosters and mixes tags', () async {
+    final now = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    // Tag B shown yesterday
+    await prefs.setInt('booster_opened_b',
+        now.subtract(const Duration(days: 1)).millisecondsSinceEpoch);
+    // Tag A shown 10 days ago
+    await prefs.setInt('booster_opened_a',
+        now.subtract(const Duration(days: 10)).millisecondsSinceEpoch);
+
+    final scheduler = SmartBoosterDiversitySchedulerService();
+    final suggestions = [
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'a',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '2',
+          blockTitle: 'b2',
+          tag: 'a',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '3',
+          blockTitle: 'b3',
+          tag: 'b',
+          action: 'reviewTheory'),
+    ];
+
+    final scheduled = await scheduler.schedule(suggestions);
+    expect(scheduled.map((s) => s.tag).toList(), ['a', 'b', 'a']);
+  });
+}


### PR DESCRIPTION
## Summary
- schedule booster prompts with recency-aware diversity to prevent repetition
- incorporate scheduler into SmartInboxController before limiter filtering
- test scheduler ensuring tag rotation and recency bias

## Testing
- `flutter test test/services/smart_booster_diversity_scheduler_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ecc74dd98832abedd410ce9e428b7