### PR TITLE
refactor: centralize shared prefs keys

### DIFF
--- a/lib/services/booster_interaction_tracker_service.dart
+++ b/lib/services/booster_interaction_tracker_service.dart
@@ -1,6 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'user_action_logger.dart';
+import '../utils/shared_prefs_keys.dart';
 
 /// Records when booster banners are opened or dismissed per tag.
 class BoosterInteractionTrackerService {
@@ -8,13 +9,10 @@ class BoosterInteractionTrackerService {
   static final BoosterInteractionTrackerService instance =
       BoosterInteractionTrackerService._();
 
-  static const String _openedPrefix = 'booster_opened_';
-  static const String _dismissedPrefix = 'booster_dismissed_';
-
   Future<void> logOpened(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(
-      '$_openedPrefix$tag',
+      SharedPrefsKeys.boosterOpened(tag),
       DateTime.now().millisecondsSinceEpoch,
     );
     await UserActionLogger.instance.logEvent({
@@ -26,7 +24,7 @@ class BoosterInteractionTrackerService {
   Future<void> logDismissed(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(
-      '$_dismissedPrefix$tag',
+      SharedPrefsKeys.boosterDismissed(tag),
       DateTime.now().millisecondsSinceEpoch,
     );
     await UserActionLogger.instance.logEvent({
@@ -37,14 +35,14 @@ class BoosterInteractionTrackerService {
 
   Future<DateTime?> getLastOpened(String tag) async {
     final prefs = await SharedPreferences.getInstance();
-    final ts = prefs.getInt('$_openedPrefix$tag');
+    final ts = prefs.getInt(SharedPrefsKeys.boosterOpened(tag));
     if (ts == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(ts);
   }
 
   Future<DateTime?> getLastDismissed(String tag) async {
     final prefs = await SharedPreferences.getInstance();
-    final ts = prefs.getInt('$_dismissedPrefix$tag');
+    final ts = prefs.getInt(SharedPrefsKeys.boosterDismissed(tag));
     if (ts == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(ts);
   }
@@ -54,15 +52,16 @@ class BoosterInteractionTrackerService {
     final prefs = await SharedPreferences.getInstance();
     final result = <String, Map<String, DateTime?>>{};
     for (final key in prefs.getKeys()) {
-      if (key.startsWith(_openedPrefix)) {
-        final tag = key.substring(_openedPrefix.length);
+      if (key.startsWith(SharedPrefsKeys.boosterOpenedPrefix)) {
+        final tag = key.substring(SharedPrefsKeys.boosterOpenedPrefix.length);
         final ts = prefs.getInt(key);
         final map = result.putIfAbsent(tag, () => {});
         if (ts != null) {
           map['opened'] = DateTime.fromMillisecondsSinceEpoch(ts);
         }
-      } else if (key.startsWith(_dismissedPrefix)) {
-        final tag = key.substring(_dismissedPrefix.length);
+      } else if (key.startsWith(SharedPrefsKeys.boosterDismissedPrefix)) {
+        final tag =
+            key.substring(SharedPrefsKeys.boosterDismissedPrefix.length);
         final ts = prefs.getInt(key);
         final map = result.putIfAbsent(tag, () => {});
         if (ts != null) {
@@ -73,4 +72,3 @@ class BoosterInteractionTrackerService {
     return result;
   }
 }
-

--- a/lib/services/smart_booster_inbox_limiter_service.dart
+++ b/lib/services/smart_booster_inbox_limiter_service.dart
@@ -1,15 +1,15 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../utils/shared_prefs_keys.dart';
+
 /// Limits how often booster inbox banners can be shown per tag and per day.
 class SmartBoosterInboxLimiterService {
   SmartBoosterInboxLimiterService();
 
   static const int maxPerDay = 2;
   static const Duration tagCooldown = Duration(hours: 48);
-
-  static String _tagKey(String tag) => 'booster_inbox_last_$tag';
-  static const String _totalDateKey = 'booster_inbox_total_date';
-  static const String _totalCountKey = 'booster_inbox_total_count';
+  static const String _totalDateKey = SharedPrefsKeys.boosterInboxTotalDate;
+  static const String _totalCountKey = SharedPrefsKeys.boosterInboxTotalCount;
 
   String _todayKey(DateTime dt) =>
       '${dt.year.toString().padLeft(4, '0')}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
@@ -27,7 +27,8 @@ class SmartBoosterInboxLimiterService {
     }
     if (count >= maxPerDay) return false;
 
-    final lastMillis = prefs.getInt(_tagKey(tag));
+    final lastMillis =
+        prefs.getInt(SharedPrefsKeys.boosterInboxLast(tag));
     if (lastMillis != null) {
       final last = DateTime.fromMillisecondsSinceEpoch(lastMillis);
       if (now.difference(last) < tagCooldown) {
@@ -41,7 +42,10 @@ class SmartBoosterInboxLimiterService {
   Future<void> recordShown(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     final now = DateTime.now();
-    await prefs.setInt(_tagKey(tag), now.millisecondsSinceEpoch);
+    await prefs.setInt(
+      SharedPrefsKeys.boosterInboxLast(tag),
+      now.millisecondsSinceEpoch,
+    );
 
     final dateKey = _todayKey(now);
     final storedDate = prefs.getString(_totalDateKey);

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -1,0 +1,14 @@
+/// Centralized SharedPreferences keys used across the app.
+class SharedPrefsKeys {
+  SharedPrefsKeys._();
+
+  static String boosterInboxLast(String tag) => 'booster_inbox_last_$tag';
+  static const String boosterInboxTotalDate = 'booster_inbox_total_date';
+  static const String boosterInboxTotalCount = 'booster_inbox_total_count';
+
+  static const String boosterOpenedPrefix = 'booster_opened_';
+  static String boosterOpened(String tag) => '${boosterOpenedPrefix}$tag';
+
+  static const String boosterDismissedPrefix = 'booster_dismissed_';
+  static String boosterDismissed(String tag) => '${boosterDismissedPrefix}$tag';
+}


### PR DESCRIPTION
## Summary
- centralize SharedPreferences keys in SharedPrefsKeys utility
- use SharedPrefsKeys in SmartBoosterInboxLimiterService and BoosterInteractionTrackerService

## Testing
- `flutter format lib/utils/shared_prefs_keys.dart lib/services/smart_booster_inbox_limiter_service.dart lib/services/booster_interaction_tracker_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ece21a258832a8119f7504b1895fb