### PR TITLE
refactor: rename inbox method for booster clarity

### DIFF
--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -20,8 +20,8 @@ class SmartInboxController {
   final SmartBoosterInboxLimiterService inboxLimiter;
   final SmartBoosterDiversitySchedulerService diversityScheduler;
 
-  /// Returns widgets to display in the smart inbox.
-  Future<List<Widget>> getInboxItems() async {
+  /// Builds booster widgets to display in the smart inbox.
+  Future<List<Widget>> buildBoosterInbox() async {
     final items = <Widget>[];
     final boosters = await boosterProvider.getBoosters();
     if (boosters.isNotEmpty) {


### PR DESCRIPTION
## Summary
- rename `getInboxItems` to `buildBoosterInbox` in `SmartInboxController`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ece2c8188832a88d7238cfc2f632f