### PR TITLE
feat: add booster logger utility

### DIFF
--- a/lib/services/booster_interaction_tracker_service.dart
+++ b/lib/services/booster_interaction_tracker_service.dart
@@ -1,6 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'user_action_logger.dart';
+import '../utils/booster_logger.dart';
 
 /// Records when booster banners are opened or dismissed per tag.
 class BoosterInteractionTrackerService {
@@ -17,10 +17,7 @@ class BoosterInteractionTrackerService {
       '$_openedPrefix$tag',
       DateTime.now().millisecondsSinceEpoch,
     );
-    await UserActionLogger.instance.logEvent({
-      'event': 'booster_banner.opened',
-      'tag': tag,
-    });
+    await BoosterLogger.log('booster_banner.opened:$tag');
   }
 
   Future<void> logDismissed(String tag) async {
@@ -29,10 +26,7 @@ class BoosterInteractionTrackerService {
       '$_dismissedPrefix$tag',
       DateTime.now().millisecondsSinceEpoch,
     );
-    await UserActionLogger.instance.logEvent({
-      'event': 'booster_banner.dismissed',
-      'tag': tag,
-    });
+    await BoosterLogger.log('booster_banner.dismissed:$tag');
   }
 
   Future<DateTime?> getLastOpened(String tag) async {

--- a/lib/services/smart_booster_diversity_scheduler_service.dart
+++ b/lib/services/smart_booster_diversity_scheduler_service.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import '../utils/booster_logger.dart';
 import 'booster_interaction_tracker_service.dart';
 import 'smart_pinned_block_booster_provider.dart';
 
@@ -68,7 +69,8 @@ class SmartBoosterDiversitySchedulerService {
       // shuffle tags each round to enhance diversity
       tags.shuffle(rnd);
     }
-
+    await BoosterLogger.log(
+        'schedule: input=${all.length}, output=${result.length}');
     return result;
   }
 }

--- a/lib/utils/booster_logger.dart
+++ b/lib/utils/booster_logger.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../services/user_action_logger.dart';
+
+/// Utility for booster-related debugging and analytics logs.
+class BoosterLogger {
+  BoosterLogger._();
+
+  /// Prints [message] with a booster prefix and logs it as an event.
+  static Future<void> log(String message) async {
+    debugPrint('[Booster] $message');
+    await UserActionLogger.instance.logEvent({
+      'event': 'booster.log',
+      'message': message,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add BoosterLogger for unified booster debugging and analytics logging
- replace scattered prints/events in booster services with BoosterLogger

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ece33d668832ab966ae2f573c23f1