### PR TITLE
refactor: extract date key formatter

### DIFF
--- a/lib/services/smart_booster_inbox_limiter_service.dart
+++ b/lib/services/smart_booster_inbox_limiter_service.dart
@@ -1,5 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../utils/date_key_formatter.dart';
+
 /// Limits how often booster inbox banners can be shown per tag and per day.
 class SmartBoosterInboxLimiterService {
   SmartBoosterInboxLimiterService();
@@ -11,15 +13,12 @@ class SmartBoosterInboxLimiterService {
   static const String _totalDateKey = 'booster_inbox_total_date';
   static const String _totalCountKey = 'booster_inbox_total_count';
 
-  String _todayKey(DateTime dt) =>
-      '${dt.year.toString().padLeft(4, '0')}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
-
   /// Whether a booster banner for [tag] can be shown now.
   Future<bool> canShow(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     final now = DateTime.now();
 
-    final dateKey = _todayKey(now);
+    final dateKey = DateKeyFormatter.format(now);
     final storedDate = prefs.getString(_totalDateKey);
     var count = prefs.getInt(_totalCountKey) ?? 0;
     if (storedDate != dateKey) {
@@ -43,7 +42,7 @@ class SmartBoosterInboxLimiterService {
     final now = DateTime.now();
     await prefs.setInt(_tagKey(tag), now.millisecondsSinceEpoch);
 
-    final dateKey = _todayKey(now);
+    final dateKey = DateKeyFormatter.format(now);
     final storedDate = prefs.getString(_totalDateKey);
     var count = prefs.getInt(_totalCountKey) ?? 0;
     if (storedDate != dateKey) {
@@ -57,7 +56,7 @@ class SmartBoosterInboxLimiterService {
   /// Returns total boosters shown today.
   Future<int> getTotalBoostersShownToday() async {
     final prefs = await SharedPreferences.getInstance();
-    final dateKey = _todayKey(DateTime.now());
+    final dateKey = DateKeyFormatter.format(DateTime.now());
     final storedDate = prefs.getString(_totalDateKey);
     if (storedDate != dateKey) return 0;
     return prefs.getInt(_totalCountKey) ?? 0;

--- a/lib/utils/date_key_formatter.dart
+++ b/lib/utils/date_key_formatter.dart
@@ -1,0 +1,10 @@
+class DateKeyFormatter {
+  const DateKeyFormatter._();
+
+  static String format(DateTime date) {
+    final year = date.year.toString().padLeft(4, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}

--- a/test/services/lesson_goal_engine_test.dart
+++ b/test/services/lesson_goal_engine_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_goal_engine.dart';
+import 'package:poker_analyzer/utils/date_key_formatter.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -17,8 +18,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
-    final yStr =
-        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    final yStr = DateKeyFormatter.format(yesterday);
     await prefs.setString('goal_daily_date', yStr);
     await prefs.setInt('goal_daily_count', 3);
 
@@ -28,8 +28,7 @@ void main() {
     final lastWeek = DateTime.now().subtract(const Duration(days: 7));
     final lwStart = DateTime(lastWeek.year, lastWeek.month, lastWeek.day)
         .subtract(Duration(days: lastWeek.weekday - 1));
-    final lwStr =
-        '${lwStart.year.toString().padLeft(4, '0')}-${lwStart.month.toString().padLeft(2, '0')}-${lwStart.day.toString().padLeft(2, '0')}';
+    final lwStr = DateKeyFormatter.format(lwStart);
     await prefs.setString('goal_weekly_start', lwStr);
     await prefs.setInt('goal_weekly_count', 10);
 

--- a/test/services/lesson_goal_streak_engine_test.dart
+++ b/test/services/lesson_goal_streak_engine_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_goal_streak_engine.dart';
+import 'package:poker_analyzer/utils/date_key_formatter.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -16,8 +17,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
-    final yStr =
-        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    final yStr = DateKeyFormatter.format(yesterday);
     await prefs.setString('goal_streak_last_date', yStr);
     await prefs.setInt('goal_streak_count', 1);
     await prefs.setInt('goal_streak_best', 3);
@@ -29,8 +29,7 @@ void main() {
     expect(best, 3);
 
     final old = DateTime.now().subtract(const Duration(days: 3));
-    final oStr =
-        '${old.year.toString().padLeft(4, '0')}-${old.month.toString().padLeft(2, '0')}-${old.day.toString().padLeft(2, '0')}';
+    final oStr = DateKeyFormatter.format(old);
     await prefs.setString('goal_streak_last_date', oStr);
     await prefs.setInt('goal_streak_count', 2);
     await prefs.setInt('goal_streak_best', 3);

--- a/test/services/lesson_streak_engine_test.dart
+++ b/test/services/lesson_streak_engine_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/lesson_streak_engine.dart';
+import 'package:poker_analyzer/utils/date_key_formatter.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,8 +14,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
-    final yStr =
-        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    final yStr = DateKeyFormatter.format(yesterday);
     await prefs.setString('lesson_streak_last_day', yStr);
     await prefs.setInt('lesson_streak_count', 1);
 
@@ -23,8 +23,7 @@ void main() {
     expect(streak, 2);
 
     final old = DateTime.now().subtract(const Duration(days: 3));
-    final oStr =
-        '${old.year.toString().padLeft(4, '0')}-${old.month.toString().padLeft(2, '0')}-${old.day.toString().padLeft(2, '0')}';
+    final oStr = DateKeyFormatter.format(old);
     await prefs.setString('lesson_streak_last_day', oStr);
     await prefs.setInt('lesson_streak_count', 2);
 

--- a/test/services/smart_booster_inbox_limiter_service_test.dart
+++ b/test/services/smart_booster_inbox_limiter_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/smart_booster_inbox_limiter_service.dart';
+import 'package:poker_analyzer/utils/date_key_formatter.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -30,8 +31,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     // Simulate yesterday to reset daily count
     final yesterday = DateTime.now().subtract(const Duration(days: 1));
-    final dateKey =
-        '${yesterday.year.toString().padLeft(4, '0')}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')}';
+    final dateKey = DateKeyFormatter.format(yesterday);
     await prefs.setString('booster_inbox_total_date', dateKey);
     await prefs.setInt('booster_inbox_last_t1',
         DateTime.now().subtract(const Duration(hours: 49)).millisecondsSinceEpoch);


### PR DESCRIPTION
## Summary
- add DateKeyFormatter utility for YYYY-MM-DD keys
- use formatter in SmartBoosterInboxLimiterService
- update tests to rely on DateKeyFormatter

## Testing
- `flutter test test/services/smart_booster_inbox_limiter_service_test.dart` *(fails: command not found)*
- `dart test test/services/smart_booster_inbox_limiter_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ece3b1fbc832a9d08b04bea61cc44