### PR TITLE
Implement smart inbox item deduplication

### DIFF
--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -4,6 +4,7 @@ import '../widgets/inbox_pinned_block_booster_banner.dart';
 import 'smart_booster_diversity_scheduler_service.dart';
 import 'smart_booster_inbox_limiter_service.dart';
 import 'smart_pinned_block_booster_provider.dart';
+import 'smart_inbox_item_deduplication_service.dart';
 
 /// Aggregates smart inbox items for the user.
 class SmartInboxController {
@@ -11,14 +12,18 @@ class SmartInboxController {
     SmartPinnedBlockBoosterProvider? boosterProvider,
     SmartBoosterInboxLimiterService? inboxLimiter,
     SmartBoosterDiversitySchedulerService? diversityScheduler,
+    SmartInboxItemDeduplicationService? deduplicator,
   })  : boosterProvider = boosterProvider ?? SmartPinnedBlockBoosterProvider(),
         inboxLimiter = inboxLimiter ?? SmartBoosterInboxLimiterService(),
         diversityScheduler =
-            diversityScheduler ?? SmartBoosterDiversitySchedulerService();
+            diversityScheduler ?? SmartBoosterDiversitySchedulerService(),
+        deduplicator =
+            deduplicator ?? SmartInboxItemDeduplicationService();
 
   final SmartPinnedBlockBoosterProvider boosterProvider;
   final SmartBoosterInboxLimiterService inboxLimiter;
   final SmartBoosterDiversitySchedulerService diversityScheduler;
+  final SmartInboxItemDeduplicationService deduplicator;
 
   /// Returns widgets to display in the smart inbox.
   Future<List<Widget>> getInboxItems() async {
@@ -26,8 +31,9 @@ class SmartInboxController {
     final boosters = await boosterProvider.getBoosters();
     if (boosters.isNotEmpty) {
       final scheduled = await diversityScheduler.schedule(boosters);
+      final deduped = await deduplicator.deduplicate(scheduled);
       final allowed = <PinnedBlockBoosterSuggestion>[];
-      for (final b in scheduled) {
+      for (final b in deduped) {
         if (await inboxLimiter.canShow(b.tag)) {
           await inboxLimiter.recordShown(b.tag);
           allowed.add(b);

--- a/lib/services/smart_inbox_item_deduplication_service.dart
+++ b/lib/services/smart_inbox_item_deduplication_service.dart
@@ -1,0 +1,70 @@
+import 'booster_interaction_tracker_service.dart';
+import 'smart_pinned_block_booster_provider.dart';
+
+/// Removes redundant smart inbox boosters targeting the same tag or block.
+class SmartInboxItemDeduplicationService {
+  SmartInboxItemDeduplicationService({
+    BoosterInteractionTrackerService? interactions,
+  }) : interactions = interactions ?? BoosterInteractionTrackerService.instance;
+
+  final BoosterInteractionTrackerService interactions;
+
+  /// Filters [input] keeping the highest priority suggestion per tag and block.
+  /// Priority is determined by how long ago the booster was shown and preferring
+  /// `resumePack` over `reviewTheory` when ties occur.
+  Future<List<PinnedBlockBoosterSuggestion>> deduplicate(
+      List<PinnedBlockBoosterSuggestion> input) async {
+    if (input.isEmpty) return [];
+
+    final now = DateTime.now();
+    final summary = await interactions.getSummary();
+
+    final scored = <_ScoredSuggestion>[];
+    for (final s in input) {
+      final info = summary[s.tag];
+      DateTime? last;
+      if (info != null) {
+        final opened = info['opened'];
+        final dismissed = info['dismissed'];
+        if (opened != null && dismissed != null) {
+          last = opened.isAfter(dismissed) ? opened : dismissed;
+        } else {
+          last = opened ?? dismissed;
+        }
+      }
+      final ageMs =
+          last == null ? double.infinity : now.difference(last).inMilliseconds.toDouble();
+      final isResumePack = s.action == 'resumePack';
+      scored.add(_ScoredSuggestion(s, ageMs, isResumePack));
+    }
+
+    scored.sort((a, b) {
+      final cmp = b.ageMs.compareTo(a.ageMs);
+      if (cmp != 0) return cmp;
+      if (a.isResumePack == b.isResumePack) return 0;
+      return b.isResumePack ? 1 : -1; // resumePack preferred
+    });
+
+    final byTag = <String, PinnedBlockBoosterSuggestion>{};
+    final byBlock = <String, PinnedBlockBoosterSuggestion>{};
+    final result = <PinnedBlockBoosterSuggestion>[];
+    for (final s in scored) {
+      final tag = s.suggestion.tag;
+      final block = s.suggestion.blockId;
+      if (byTag.containsKey(tag) || byBlock.containsKey(block)) {
+        continue;
+      }
+      byTag[tag] = s.suggestion;
+      byBlock[block] = s.suggestion;
+      result.add(s.suggestion);
+    }
+    return result;
+  }
+}
+
+class _ScoredSuggestion {
+  final PinnedBlockBoosterSuggestion suggestion;
+  final double ageMs;
+  final bool isResumePack;
+  _ScoredSuggestion(this.suggestion, this.ageMs, this.isResumePack);
+}

--- a/test/services/smart_inbox_item_deduplication_service_test.dart
+++ b/test/services/smart_inbox_item_deduplication_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_inbox_item_deduplication_service.dart';
+import 'package:poker_analyzer/services/smart_pinned_block_booster_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('keeps booster not shown recently for same tag', () async {
+    final now = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('booster_opened_a',
+        now.subtract(const Duration(days: 1)).millisecondsSinceEpoch);
+
+    final service = SmartInboxItemDeduplicationService();
+    final input = [
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'a',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '2',
+          blockTitle: 'b2',
+          tag: 'a',
+          action: 'reviewTheory'),
+    ];
+    final result = await service.deduplicate(input);
+    expect(result.length, 1);
+    expect(result.first.blockId, '2');
+  });
+
+  test('prefers resumePack for same block', () async {
+    final service = SmartInboxItemDeduplicationService();
+    final input = [
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'a',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'b',
+          action: 'resumePack'),
+    ];
+    final result = await service.deduplicate(input);
+    expect(result.length, 1);
+    expect(result.first.tag, 'b');
+  });
+}


### PR DESCRIPTION
## Summary
- add SmartInboxItemDeduplicationService to remove duplicate boosters by tag or block
- wire deduplication into SmartInboxController ahead of inbox limiter
- cover dedup logic with unit tests

## Testing
- `flutter test test/services/smart_inbox_item_deduplication_service_test.dart test/services/smart_booster_diversity_scheduler_service_test.dart` *(fails: command not found)*
- `dart test test/services/smart_inbox_item_deduplication_service_test.dart test/services/smart_booster_diversity_scheduler_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_688eceb7fdc8832a8694e5b4e8f886d9