### PR TITLE
feat: prioritize smart inbox boosters by urgency

### DIFF
--- a/lib/services/smart_inbox_priority_scorer_service.dart
+++ b/lib/services/smart_inbox_priority_scorer_service.dart
@@ -1,0 +1,55 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../utils/shared_prefs_keys.dart';
+import 'smart_pinned_block_booster_provider.dart';
+
+/// Scores and sorts booster suggestions by urgency for the smart inbox.
+class SmartInboxPriorityScorerService {
+  /// Returns [input] sorted by urgency and recency.
+  Future<List<PinnedBlockBoosterSuggestion>> sort(
+      List<PinnedBlockBoosterSuggestion> input) async {
+    if (input.isEmpty) return [];
+
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final scored = <_ScoredSuggestion>[];
+    for (final s in input) {
+      final base = _scoreForAction(s.action);
+      final lastMillis =
+          prefs.getInt(SharedPrefsKeys.boosterInboxLast(s.tag));
+      final last = lastMillis == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(lastMillis);
+      final ageMs =
+          last == null ? double.infinity : now.difference(last).inMilliseconds.toDouble();
+      scored.add(_ScoredSuggestion(s, base, ageMs));
+    }
+
+    scored.sort((a, b) {
+      final cmp = b.base.compareTo(a.base);
+      if (cmp != 0) return cmp;
+      return b.ageMs.compareTo(a.ageMs); // older first
+    });
+
+    return scored.map((s) => s.suggestion).toList();
+  }
+
+  int _scoreForAction(String action) {
+    switch (action) {
+      case 'decayBooster':
+        return 3;
+      case 'reviewTheory':
+        return 2;
+      case 'resumePack':
+      default:
+        return 1;
+    }
+  }
+}
+
+class _ScoredSuggestion {
+  final PinnedBlockBoosterSuggestion suggestion;
+  final int base;
+  final double ageMs;
+  _ScoredSuggestion(this.suggestion, this.base, this.ageMs);
+}

--- a/test/services/smart_inbox_priority_scorer_service_test.dart
+++ b/test/services/smart_inbox_priority_scorer_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_inbox_priority_scorer_service.dart';
+import 'package:poker_analyzer/services/smart_pinned_block_booster_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('sorts by action priority', () async {
+    final service = SmartInboxPriorityScorerService();
+    final input = [
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'a',
+          action: 'resumePack'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '2',
+          blockTitle: 'b2',
+          tag: 'b',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '3',
+          blockTitle: 'b3',
+          tag: 'c',
+          action: 'decayBooster'),
+    ];
+    final result = await service.sort(input);
+    expect(result.map((e) => e.blockId).toList(), ['3', '2', '1']);
+  });
+
+  test('older last shown wins tie', () async {
+    final now = DateTime.now();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+        'booster_inbox_last_a', now.subtract(const Duration(days: 1)).millisecondsSinceEpoch);
+    await prefs.setInt(
+        'booster_inbox_last_b', now.subtract(const Duration(days: 3)).millisecondsSinceEpoch);
+
+    final service = SmartInboxPriorityScorerService();
+    final input = [
+      const PinnedBlockBoosterSuggestion(
+          blockId: '1',
+          blockTitle: 'b1',
+          tag: 'a',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '2',
+          blockTitle: 'b2',
+          tag: 'b',
+          action: 'reviewTheory'),
+      const PinnedBlockBoosterSuggestion(
+          blockId: '3',
+          blockTitle: 'b3',
+          tag: 'c',
+          action: 'reviewTheory'),
+    ];
+    final result = await service.sort(input);
+    expect(result.map((e) => e.blockId).toList(), ['3', '2', '1']);
+  });
+}


### PR DESCRIPTION
## Summary
- score smart inbox boosters by urgency and recency
- sort boosters before limiting for display
- test priority scoring and age tie-breakers

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ecfe1a610832aaf2085bb7b0ec984