### PR TITLE
Add Smart Inbox debug banner

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -12,6 +12,7 @@ import '../services/training_pack_cloud_sync_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
+import '../services/smart_inbox_debug_service.dart';
 import 'basic_achievements_screen.dart';
 import 'booster_library_screen.dart';
 import 'booster_archive_screen.dart';
@@ -27,6 +28,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   late int _evaluated;
   late int _correct;
   final List<MapEntry<TrainingPackStat, String>> _stats = [];
+  static const String _appVersion = '1.0.0+1';
 
   void _load() {
     final service = EvaluationExecutorService();
@@ -338,6 +340,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 ],
               );
             },
+          ),
+          const Spacer(),
+          GestureDetector(
+            onLongPress: SmartInboxDebugService.instance.toggle,
+            child: Text(
+              'v$_appVersion',
+              style: const TextStyle(color: Colors.white54, fontSize: 12),
+            ),
           ),
         ],
       ),

--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/widgets.dart';
 
 import '../widgets/inbox_pinned_block_booster_banner.dart';
+import '../widgets/smart_inbox_debug_banner_widget.dart';
 import 'smart_booster_diversity_scheduler_service.dart';
 import 'smart_booster_inbox_limiter_service.dart';
+import 'smart_inbox_debug_service.dart';
 import 'smart_pinned_block_booster_provider.dart';
 import 'smart_inbox_item_deduplication_service.dart';
 import 'smart_inbox_priority_scorer_service.dart';
@@ -33,21 +35,35 @@ class SmartInboxController {
   /// Returns widgets to display in the smart inbox.
   Future<List<Widget>> getInboxItems() async {
     final items = <Widget>[];
-    final boosters = await boosterProvider.getBoosters();
-    if (boosters.isNotEmpty) {
-      final scheduled = await diversityScheduler.schedule(boosters);
+    final raw = await boosterProvider.getBoosters();
+    if (raw.isNotEmpty) {
+      final scheduled = await diversityScheduler.schedule(raw);
       final deduped = await deduplicator.deduplicate(scheduled);
       final sorted = await priorityScorer.sort(deduped);
-      final allowed = <PinnedBlockBoosterSuggestion>[];
+      final limited = <PinnedBlockBoosterSuggestion>[];
       for (final b in sorted) {
         if (await inboxLimiter.canShow(b.tag)) {
           await inboxLimiter.recordShown(b.tag);
-          allowed.add(b);
+          limited.add(b);
         }
-        if (allowed.length >= SmartBoosterInboxLimiterService.maxPerDay) break;
+        if (limited.length >= SmartBoosterInboxLimiterService.maxPerDay) break;
       }
-      if (allowed.isNotEmpty) {
-        items.add(InboxPinnedBlockBoosterBanner(suggestions: allowed));
+      if (limited.isNotEmpty) {
+        items.add(InboxPinnedBlockBoosterBanner(suggestions: limited));
+      }
+      if (SmartInboxDebugService.instance.enabled.value) {
+        items.add(
+          SmartInboxDebugBannerWidget(
+            info: SmartInboxDebugInfo(
+              raw: raw,
+              scheduled: scheduled,
+              deduplicated: deduped,
+              sorted: sorted,
+              limited: limited,
+              rendered: limited,
+            ),
+          ),
+        );
       }
     }
     return items;

--- a/lib/services/smart_inbox_debug_service.dart
+++ b/lib/services/smart_inbox_debug_service.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+import 'smart_pinned_block_booster_provider.dart';
+
+class SmartInboxDebugService {
+  SmartInboxDebugService._();
+
+  static final SmartInboxDebugService instance = SmartInboxDebugService._();
+
+  final ValueNotifier<bool> enabled = ValueNotifier(false);
+
+  void toggle() => enabled.value = !enabled.value;
+}
+
+class SmartInboxDebugInfo {
+  SmartInboxDebugInfo({
+    required this.raw,
+    required this.scheduled,
+    required this.deduplicated,
+    required this.sorted,
+    required this.limited,
+    required this.rendered,
+  });
+
+  final List<PinnedBlockBoosterSuggestion> raw;
+  final List<PinnedBlockBoosterSuggestion> scheduled;
+  final List<PinnedBlockBoosterSuggestion> deduplicated;
+  final List<PinnedBlockBoosterSuggestion> sorted;
+  final List<PinnedBlockBoosterSuggestion> limited;
+  final List<PinnedBlockBoosterSuggestion> rendered;
+}

--- a/lib/widgets/smart_inbox_debug_banner_widget.dart
+++ b/lib/widgets/smart_inbox_debug_banner_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../services/smart_inbox_debug_service.dart';
+import '../services/smart_pinned_block_booster_provider.dart';
+
+class SmartInboxDebugBannerWidget extends StatelessWidget {
+  const SmartInboxDebugBannerWidget({super.key, required this.info});
+
+  final SmartInboxDebugInfo info;
+
+  Widget _buildStage(String name, List<PinnedBlockBoosterSuggestion> list) {
+    return ExpansionTile(
+      title: Text('$name (${list.length})'),
+      children: [
+        for (final b in list)
+          ListTile(
+            dense: true,
+            title: Text('${b.tag} - ${b.action}'),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: Text(
+              'Smart Inbox Debug',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          _buildStage('raw', info.raw),
+          _buildStage('scheduled', info.scheduled),
+          _buildStage('deduplicated', info.deduplicated),
+          _buildStage('sorted', info.sorted),
+          _buildStage('limited', info.limited),
+          _buildStage('rendered', info.rendered),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add SmartInboxDebugService and info model
- show SmartInboxDebugBannerWidget with pipeline stage counts
- long-press app version on profile screen to toggle debug banner

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688ed0d619d0832a8c981da7aa26e8fc