### PR TITLE
Use ErrorLogger for validation and parser warnings

### DIFF
--- a/lib/services/graph_path_template_parser.dart
+++ b/lib/services/graph_path_template_parser.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:yaml/yaml.dart';
 
+import '../core/error_logger.dart';
 import '../models/learning_branch_node.dart';
 import '../models/learning_path_node.dart';
 import '../models/stage_type.dart';
@@ -190,9 +191,8 @@ class GraphPathTemplateParser {
     }
 
     if (warnings.isNotEmpty) {
-      // ignore: avoid_print
       for (final w in warnings) {
-        print('GraphPathTemplateParser: $w');
+        ErrorLogger.instance.logError('GraphPathTemplateParser: $w');
       }
     }
 

--- a/lib/services/learning_path_registry_service.dart
+++ b/lib/services/learning_path_registry_service.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:yaml/yaml.dart';
 
+import '../core/error_logger.dart';
 import '../models/learning_path_template_v2.dart';
 
 class LearningPathRegistryService {
@@ -94,7 +95,7 @@ class LearningPathRegistryService {
       ];
 
   /// Validates that all stage references and prerequisites are valid.
-  /// Prints errors to the console and returns the list of messages.
+  /// Logs errors and returns the list of messages.
   Future<List<String>> validateAll() async {
     await loadAll();
     final errors = <String>[];
@@ -120,8 +121,7 @@ class LearningPathRegistryService {
       }
     }
     for (final e in errors) {
-      // ignore: avoid_print
-      print('LearningPath validation: $e');
+      ErrorLogger.instance.logError('LearningPath validation: $e');
     }
     return errors;
   }


### PR DESCRIPTION
## Summary
- replace direct prints with ErrorLogger for validation and graph parser warnings
- document validation method now logs through ErrorLogger

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1ce4dd4832a8bcf871512a48eed