### PR TITLE
refactor: extract duplicate spot finder

### DIFF
--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -72,6 +72,7 @@ import '../../models/player_model.dart';
 import 'editor/template_preview_widgets.dart';
 import '../../services/training_pack_stats_service.dart';
 import '../../services/saved_hand_manager_service.dart';
+import '../../services/spot_duplicate_finder.dart';
 
 part 'training_pack_template_editor_screen_old.dart';
 part 'spot_list_section.dart';

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -25,18 +25,6 @@ class _CatStat {
   _CatStat({this.acc = 0, this.ev = 0, this.icm = 0});
 }
 
-List<List<int>> duplicateSpotGroupsStatic(List<TrainingPackSpot> spots) {
-  final map = <String, List<int>>{};
-  for (int i = 0; i < spots.length; i++) {
-    final h = spots[i].hand;
-    final hero = h.heroCards.replaceAll(' ', '');
-    final board = h.board.join();
-    final key = '${h.position.name}-$hero-$board';
-    map.putIfAbsent(key, () => []).add(i);
-  }
-  return [for (final g in map.values) if (g.length > 1) g];
-}
-
 double? averageFocusCoverage(
     Map<String, int> counts, Map<String, int> totals) {
   if (counts.isEmpty) return null;
@@ -5493,18 +5481,6 @@ class _Row {
   const _Row.spot(this.spot)
       : kind = _RowKind.spot,
         tag = '';
-}
-
-List<List<int>> duplicateSpotGroupsStatic(List<TrainingPackSpot> spots) {
-  final map = <String, List<int>>{};
-  for (int i = 0; i < spots.length; i++) {
-    final h = spots[i].hand;
-    final hero = h.heroCards.replaceAll(' ', '');
-    final board = h.board.join();
-    final key = '${h.position.name}-$hero-$board';
-    map.putIfAbsent(key, () => []).add(i);
-  }
-  return [for (final g in map.values) if (g.length > 1) g];
 }
 
 TrainingPackSpot? _copiedSpot;

--- a/lib/services/spot_duplicate_finder.dart
+++ b/lib/services/spot_duplicate_finder.dart
@@ -1,0 +1,13 @@
+import '../models/v2/training_pack_spot.dart';
+
+List<List<int>> duplicateSpotGroupsStatic(List<TrainingPackSpot> spots) {
+  final map = <String, List<int>>{};
+  for (var i = 0; i < spots.length; i++) {
+    final h = spots[i].hand;
+    final hero = h.heroCards.replaceAll(' ', '');
+    final board = h.board.join();
+    final key = '${h.position.name}-$hero-$board';
+    map.putIfAbsent(key, () => []).add(i);
+  }
+  return [for (final g in map.values) if (g.length > 1) g];
+}

--- a/test/duplicate_spot_detection_test.dart
+++ b/test/duplicate_spot_detection_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
 import 'package:poker_analyzer/models/v2/hero_position.dart';
-import 'package:poker_analyzer/screens/v2/training_pack_template_editor_screen.dart';
+import 'package:poker_analyzer/services/spot_duplicate_finder.dart';
 
 HandData _hand(String pos, String hero, String board) {
   final b = <String>[];


### PR DESCRIPTION
## Summary
- move duplicate spot detection to `spot_duplicate_finder.dart`
- reuse helper in template editor
- update tests to use the shared helper

## Testing
- `flutter test test/duplicate_spot_detection_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1d3e254832aaca2fdc8d317dd62