### PR TITLE
Refactor coverage recount to return summary

### DIFF
--- a/lib/core/training/generation/push_fold_pack_generator.dart
+++ b/lib/core/training/generation/push_fold_pack_generator.dart
@@ -65,7 +65,7 @@ class PushFoldPackGenerator {
       createdAt: now,
       lastGeneratedAt: now,
     );
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     return tpl;
   }
 

--- a/lib/helpers/training_pack_storage.dart
+++ b/lib/helpers/training_pack_storage.dart
@@ -42,7 +42,7 @@ class TrainingPackStorage {
     bool changed = false;
     for (final t in templates) {
       if (!t.meta.containsKey('evCovered') || !t.meta.containsKey('icmCovered')) {
-        TemplateCoverageUtils.recountAll(t);
+        TemplateCoverageUtils.recountAll(t).applyTo(t.meta);
         changed = true;
       }
     }
@@ -52,7 +52,7 @@ class TrainingPackStorage {
 
   static Future<void> save(List<TrainingPackTemplate> t) async {
     for (final tpl in t) {
-      TemplateCoverageUtils.recountAll(tpl);
+      TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, jsonEncode([for (final x in t) x.toJson()]));

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -91,7 +91,7 @@ class TrainingPackTemplate {
         playerStacksBb = playerStacksBb ?? const [10, 10],
         meta = meta ?? {},
         createdAt = createdAt ?? DateTime.now() {
-    TemplateCoverageUtils.recountAll(this);
+    TemplateCoverageUtils.recountAll(this).applyTo(this.meta);
   }
 
   TrainingPackTemplate copyWith({
@@ -231,7 +231,7 @@ class TrainingPackTemplate {
     );
     if (!tpl.meta.containsKey('evCovered') ||
         !tpl.meta.containsKey('icmCovered')) {
-      TemplateCoverageUtils.recountAll(tpl);
+      TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     }
     return tpl;
   }
@@ -322,7 +322,7 @@ class TrainingPackTemplate {
   }
 
   void recountCoverage([List<TrainingPackSpot>? all]) {
-    TemplateCoverageUtils.recountAll(this);
+    TemplateCoverageUtils.recountAll(this).applyTo(this.meta);
   }
 
   Future<List<TrainingPackSpot>> generateSpots() async {

--- a/lib/screens/global_evaluation_screen.dart
+++ b/lib/screens/global_evaluation_screen.dart
@@ -56,7 +56,7 @@ class _GlobalEvaluationScreenState extends State<GlobalEvaluationScreen> {
       if (!mounted) return;
       if (_cancelRequested) break;
       for (var j = 0; j < batch.length; j++) {
-        if (results[j] > 0) TemplateCoverageUtils.recountAll(batch[j]);
+        if (results[j] > 0) TemplateCoverageUtils.recountAll(batch[j]).applyTo(batch[j].meta);
       }
       setState(() => _progress = (i + batch.length) / total);
     }

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -413,7 +413,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
       s.dirty = false;
     }
     pack.lastTrainedAt = null;
-    TemplateCoverageUtils.recountAll(pack);
+    TemplateCoverageUtils.recountAll(pack).applyTo(pack.meta);
     final list = await TrainingPackStorage.load();
     final idx = list.indexWhere((e) => e.id == pack.id);
     if (idx != -1) list[idx] = pack;

--- a/lib/screens/template_library_screen.dart
+++ b/lib/screens/template_library_screen.dart
@@ -1624,7 +1624,7 @@ class _TemplateLibraryScreenState extends State<TemplateLibraryScreen> {
                       await TrainingPackTemplateService.generateFromPreset(p);
                   tpl.isBuiltIn = true;
                   await BulkEvaluatorService().generateMissing(tpl);
-                  TemplateCoverageUtils.recountAll(tpl);
+                  TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
                   service.addTemplate(tpl);
                   added++;
                 }

--- a/lib/screens/v2/spot_list_section.dart
+++ b/lib/screens/v2/spot_list_section.dart
@@ -268,7 +268,7 @@ part of 'training_pack_template_editor_screen.dart';
   Future<void> _persist() async {
     if (widget.readOnly) return;
     widget.template.isDraft = true;
-    TemplateCoverageUtils.recountAll(widget.template);
+    TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
     context.read<TemplateStorageService>().updateTemplate(widget.template);
     setState(() {});
     await TrainingPackStorage.save(widget.templates);

--- a/lib/screens/v2/training_pack_template_editor_screen_old.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen_old.dart
@@ -343,7 +343,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       BulkEvaluatorService()
           .generateMissing(widget.template, onProgress: null)
           .then((_) {
-        TemplateCoverageUtils.recountAll(widget.template);
+        TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
         if (mounted) setState(() => _loadingEval = false);
       });
     }
@@ -487,7 +487,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     }
     final ready = validateTrainingPackTemplate(widget.template).isEmpty;
     widget.template.isDraft = !ready;
-    TemplateCoverageUtils.recountAll(widget.template);
+    TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
     TrainingPackStorage.save(widget.templates);
     unawaited(
       BulkEvaluatorService()
@@ -1471,7 +1471,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroEv == null) {
                       await const PushFoldEvService()
                           .evaluate(s, anteBb: widget.template.anteBb);
-                      TemplateCoverageUtils.recountAll(widget.template);
+                      TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();
@@ -1539,7 +1539,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroIcmEv == null) {
                       await const PushFoldEvService()
                           .evaluateIcm(s, anteBb: widget.template.anteBb);
-                      TemplateCoverageUtils.recountAll(widget.template);
+                      TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();
@@ -1632,7 +1632,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     await BulkEvaluatorService()
         .generateMissingForTemplate(widget.template, onProgress: null)
         .catchError((_) {});
-    TemplateCoverageUtils.recountAll(widget.template);
+    TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
     if (mounted) setState(() => _loadingEval = false);
   }
 
@@ -5779,7 +5779,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
       BulkEvaluatorService()
           .generateMissing(widget.template, onProgress: null)
           .then((_) {
-        TemplateCoverageUtils.recountAll(widget.template);
+        TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
         if (mounted) setState(() => _loadingEval = false);
       });
     }
@@ -5922,7 +5922,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     }
     final ready = validateTrainingPackTemplate(widget.template).isEmpty;
     widget.template.isDraft = !ready;
-    TemplateCoverageUtils.recountAll(widget.template);
+    TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
     TrainingPackStorage.save(widget.templates);
     unawaited(
       BulkEvaluatorService()
@@ -6914,7 +6914,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroEv == null) {
                       await const PushFoldEvService()
                           .evaluate(s, anteBb: widget.template.anteBb);
-                      TemplateCoverageUtils.recountAll(widget.template);
+                      TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();
@@ -6982,7 +6982,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
                     if (s.heroIcmEv == null) {
                       await const PushFoldEvService()
                           .evaluateIcm(s, anteBb: widget.template.anteBb);
-                      TemplateCoverageUtils.recountAll(widget.template);
+                      TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
                       if (!mounted) return;
                       setState(() {
                         if (_autoSortEv) _sortSpots();
@@ -7075,7 +7075,7 @@ class _TrainingPackTemplateEditorScreenState extends State<TrainingPackTemplateE
     await BulkEvaluatorService()
         .generateMissingForTemplate(widget.template, onProgress: null)
         .catchError((_) {});
-    TemplateCoverageUtils.recountAll(widget.template);
+    TemplateCoverageUtils.recountAll(widget.template).applyTo(widget.template.meta);
     if (mounted) setState(() => _loadingEval = false);
   }
 

--- a/lib/screens/v2/training_pack_template_list_screen.dart
+++ b/lib/screens/v2/training_pack_template_list_screen.dart
@@ -920,7 +920,7 @@ class _TrainingPackTemplateListScreenState
             .generateMissingForTemplate(t, onProgress: null)
             .catchError((_) => 0);
         if (!mounted) return;
-        TemplateCoverageUtils.recountAll(t);
+        TemplateCoverageUtils.recountAll(t).applyTo(t.meta);
         refreshed += n;
       }
       if (refreshed > 0) {
@@ -2595,7 +2595,7 @@ class _TrainingPackTemplateListScreenState
                       if (mounted) setDialog(() {});
                     },
                   );
-                  TemplateCoverageUtils.recountAll(tpl);
+                  TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
                 }
                 await TrainingPackStorage.save(_templates);
                 if (Navigator.canPop(ctx)) Navigator.pop(ctx);

--- a/lib/services/bulk_evaluator_service.dart
+++ b/lib/services/bulk_evaluator_service.dart
@@ -47,7 +47,7 @@ class BulkEvaluatorService {
         }
       }
       if (next <= 1) onProgress?.call(1.0);
-      TemplateCoverageUtils.recountAll(template);
+      TemplateCoverageUtils.recountAll(template).applyTo(template.meta);
       return updated;
     } else if (target is TrainingPackSpot) {
       final spot = target;

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -559,7 +559,7 @@ class EvaluationExecutorService implements EvaluationExecutor {
         ? '+${(heroPushEv - foldEv).toStringAsFixed(2)} BB vs fold'
         : '${(foldEv - heroPushEv).toStringAsFixed(2)} BB better to fold';
     if (template != null) {
-      TemplateCoverageUtils.recountAll(template);
+      TemplateCoverageUtils.recountAll(template).applyTo(template.meta);
       final changed = prev == null ||
           !const DeepCollectionEquality().equals(
             prev.toJson(),

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -171,7 +171,7 @@ class PackGeneratorService {
       lastGeneratedAt: DateTime.now(),
       isBuiltIn: true,
     );
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     return tpl;
   }
 
@@ -244,7 +244,7 @@ class PackGeneratorService {
       createdAt: createdAt,
       lastGeneratedAt: DateTime.now(),
     );
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     return tpl;
   }
 
@@ -296,7 +296,7 @@ class PackGeneratorService {
       lastGeneratedAt: DateTime.now(),
       meta: {'maxStack': maxBb},
     );
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     return tpl;
   }
 
@@ -422,7 +422,7 @@ class PackGeneratorService {
       spots: spots,
       createdAt: createdAt,
     );
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     return tpl;
   }
 

--- a/lib/services/training_pack_template_ui_service.dart
+++ b/lib/services/training_pack_template_ui_service.dart
@@ -112,7 +112,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    TemplateCoverageUtils.recountAll(template);
+    TemplateCoverageUtils.recountAll(template).applyTo(template.meta);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }
@@ -224,7 +224,7 @@ class TrainingPackTemplateUiService {
         );
       },
     );
-    TemplateCoverageUtils.recountAll(template);
+    TemplateCoverageUtils.recountAll(template).applyTo(template.meta);
     template.lastGeneratedAt = DateTime.now();
     return generated;
   }

--- a/lib/utils/template_coverage_utils.dart
+++ b/lib/utils/template_coverage_utils.dart
@@ -1,8 +1,22 @@
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_spot.dart';
 
+class CoverageSummary {
+  final int ev;
+  final int icm;
+  final int total;
+
+  const CoverageSummary({required this.ev, required this.icm, required this.total});
+
+  void applyTo(Map<String, dynamic> meta) {
+    meta['evCovered'] = ev;
+    meta['icmCovered'] = icm;
+    meta['totalWeight'] = total;
+  }
+}
+
 class TemplateCoverageUtils {
-  static void recountAll(TrainingPackTemplateV2 template) {
+  static CoverageSummary recountAll(TrainingPackTemplateV2 template) {
     final List<TrainingPackSpot> list = template.spots;
     int ev = 0;
     int icm = 0;
@@ -13,8 +27,6 @@ class TemplateCoverageUtils {
       if (!s.dirty && s.heroEv != null) ev += w;
       if (!s.dirty && s.heroIcmEv != null) icm += w;
     }
-    template.meta['evCovered'] = ev;
-    template.meta['icmCovered'] = icm;
-    template.meta['totalWeight'] = total;
+    return CoverageSummary(ev: ev, icm: icm, total: total);
   }
 }

--- a/test/coverage_summary_test.dart
+++ b/test/coverage_summary_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/utils/template_coverage_utils.dart';
+
+void main() {
+  test('CoverageSummary calculates and applies meta', () {
+    final spots = <TrainingPackSpot>[
+      TrainingPackSpot(
+        id: 's1',
+        hand: HandData(
+          heroCards: '',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: const {'0': 10, '1': 10},
+          actions: {
+            0: [ActionEntry(0, 0, 'push', amount: 10, ev: 1.0)],
+          },
+        ),
+        priority: 2,
+      ),
+      TrainingPackSpot(
+        id: 's2',
+        hand: HandData(
+          heroCards: '',
+          position: HeroPosition.sb,
+          heroIndex: 0,
+          playerCount: 2,
+          stacks: const {'0': 10, '1': 10},
+          actions: {
+            0: [ActionEntry(0, 0, 'push', amount: 10)],
+          },
+        ),
+        priority: 3,
+      ),
+    ];
+    final tpl = TrainingPackTemplate(
+      id: 't',
+      name: 't',
+      spotCount: 2,
+      playerStacksBb: const [10, 10],
+      heroPos: HeroPosition.sb,
+      heroRange: const [],
+      spots: spots,
+    );
+    final summary = TemplateCoverageUtils.recountAll(tpl);
+    expect(summary.ev, 2);
+    expect(summary.icm, 0);
+    expect(summary.total, 5);
+    summary.applyTo(tpl.meta);
+    expect(tpl.evCovered, 2);
+    expect(tpl.icmCovered, 0);
+    expect(tpl.totalWeight, 5);
+  });
+}

--- a/test/template_ev_cache_test.dart
+++ b/test/template_ev_cache_test.dart
@@ -52,7 +52,7 @@ void main() {
     const service = TrainingPackTemplateUiService();
     final generated = await service.generateMissingSpotsWithProgress(ctx, tpl);
     tpl.spots.addAll(generated);
-    TemplateCoverageUtils.recountAll(tpl);
+    TemplateCoverageUtils.recountAll(tpl).applyTo(tpl.meta);
     expect(tpl.evCovered, 4 + generated.length);
   });
 }


### PR DESCRIPTION
## Summary
- refactor TemplateCoverageUtils.recountAll to return a CoverageSummary and remove side effects
- update all callers to apply the returned summary to template metadata
- add unit test for CoverageSummary and adjust existing tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1f88450832a8712ba36b3011415