### PR TITLE
feat: parameterize theory pack text

### DIFF
--- a/lib/services/theory_pack_generator.dart
+++ b/lib/services/theory_pack_generator.dart
@@ -9,15 +9,29 @@ import 'booster_thematic_descriptions.dart';
 class TheoryPackGenerator {
   const TheoryPackGenerator();
 
+  /// Default text used when no localized strings are provided.
+  static const String defaultQuestion = 'Question';
+  static const String defaultSolution = 'Solution';
+  static const String defaultExplanation = 'Explanation';
+
   /// Builds a [TrainingPackTemplateV2] with a single theory spot.
-  TrainingPackTemplateV2 generate(String tag, String idPrefix) {
-    final explanation = BoosterThematicDescriptions.get(tag) ?? 'TODO: explanation';
+  TrainingPackTemplateV2 generate(
+    String tag,
+    String idPrefix, {
+    String question = defaultQuestion,
+    String solution = defaultSolution,
+    String? explanation,
+  }) {
+    final resolvedExplanation =
+        explanation ??
+        BoosterThematicDescriptions.get(tag) ??
+        defaultExplanation;
     final spot = TrainingPackSpot(
       id: '${idPrefix}_${tag}_1',
       type: 'theory',
-      title: 'TODO: question',
-      note: 'TODO: solution',
-      explanation: explanation,
+      title: question,
+      note: solution,
+      explanation: resolvedExplanation,
       tags: [tag],
       hand: HandData(),
     );

--- a/test/theory_pack_generator_test.dart
+++ b/test/theory_pack_generator_test.dart
@@ -18,4 +18,29 @@ void main() {
     final tpl = generator.generate('push_sb', 'demo');
     expect(tpl.spots.first.explanation?.isNotEmpty, true);
   });
+
+  test('uses default text when none provided', () {
+    final tpl = generator.generate('unknown', 'demo');
+    final spot = tpl.spots.first;
+    expect(spot.title, TheoryPackGenerator.defaultQuestion);
+    expect(spot.note, TheoryPackGenerator.defaultSolution);
+    expect(spot.explanation, TheoryPackGenerator.defaultExplanation);
+  });
+
+  test('allows localized overrides', () {
+    const q = 'Вопрос';
+    const s = 'Ответ';
+    const e = 'Объяснение';
+    final tpl = generator.generate(
+      'push_sb',
+      'loc',
+      question: q,
+      solution: s,
+      explanation: e,
+    );
+    final spot = tpl.spots.first;
+    expect(spot.title, q);
+    expect(spot.note, s);
+    expect(spot.explanation, e);
+  });
 }


### PR DESCRIPTION
## Summary
- allow callers to provide localized theory pack question, solution, and explanation
- cover defaults and overrides in theory pack generator tests

## Testing
- `flutter test test/theory_pack_generator_test.dart` *(fails: file_picker plugin lacks inline implementation; no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1fd7d90832a9eb806601b207146