### PR TITLE
refactor: centralize shared preferences access

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,7 +53,6 @@ import 'app_bootstrap.dart';
 import 'app_providers.dart';
 import 'l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
 import 'helpers/training_pack_storage.dart';
 import 'screens/v2/training_pack_play_screen.dart';
@@ -81,6 +80,7 @@ import 'services/theory_lesson_notification_scheduler.dart';
 import 'services/booster_recall_decay_cleaner.dart';
 import 'services/pinned_comeback_nudge_service.dart';
 import 'route_observer.dart';
+import 'services/shared_preferences_service.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -95,8 +95,9 @@ Future<void> main() async {
     if (!auth.isSignedIn) {
       final uid = await auth.signInAnonymously();
       if (uid != null) {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('anon_uid_log', uid);
+        await SharedPreferencesService.instance.init();
+        await SharedPreferencesService.instance
+            .setString('anon_uid_log', uid);
       }
     }
   }

--- a/lib/services/shared_preferences_service.dart
+++ b/lib/services/shared_preferences_service.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesService {
+  SharedPreferencesService._();
+  static final SharedPreferencesService instance = SharedPreferencesService._();
+
+  SharedPreferences? _prefs;
+
+  Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  SharedPreferences get _sp => _prefs!;
+  SharedPreferences get prefs => _sp;
+
+  String? getString(String key) => _sp.getString(key);
+  Future<bool> setString(String key, String value) => _sp.setString(key, value);
+
+  bool? getBool(String key) => _sp.getBool(key);
+  Future<bool> setBool(String key, bool value) => _sp.setBool(key, value);
+
+  int? getInt(String key) => _sp.getInt(key);
+  Future<bool> setInt(String key, int value) => _sp.setInt(key, value);
+
+  double? getDouble(String key) => _sp.getDouble(key);
+  Future<bool> setDouble(String key, double value) => _sp.setDouble(key, value);
+
+  List<String>? getStringList(String key) => _sp.getStringList(key);
+  Future<bool> setStringList(String key, List<String> value) =>
+      _sp.setStringList(key, value);
+
+  bool containsKey(String key) => _sp.containsKey(key);
+  Future<bool> remove(String key) => _sp.remove(key);
+}

--- a/lib/widgets/booster_suggestion_block.dart
+++ b/lib/widgets/booster_suggestion_block.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
+import '../services/shared_preferences_service.dart';
 
 import '../models/mistake_tag.dart';
 import '../models/mistake_tag_cluster.dart';
@@ -33,7 +33,8 @@ class _BoosterSuggestionBlockState extends State<BoosterSuggestionBlock> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final cacheTimeStr = prefs.getString(_cacheTimeKey);
     final cacheId = prefs.getString(_cacheKey);
     final now = DateTime.now();

--- a/lib/widgets/category_drill_card.dart
+++ b/lib/widgets/category_drill_card.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
 import '../helpers/category_translations.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class CategoryDrillCard extends StatefulWidget {
   const CategoryDrillCard({super.key});
@@ -22,7 +22,8 @@ class _CategoryDrillCardState extends State<CategoryDrillCard> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    SharedPreferencesService.instance.init().then((_) {
+      final p = SharedPreferencesService.instance;
       final done = p.getBool(_key) ?? false;
       final ts = p.getInt(_tsKey);
       final hide = ts != null &&
@@ -84,7 +85,8 @@ class _CategoryDrillCardState extends State<CategoryDrillCard> {
                   context, entry.key);
               if (tpl == null) return;
               await context.read<TrainingSessionService>().startSession(tpl);
-              final p = await SharedPreferences.getInstance();
+              await SharedPreferencesService.instance.init();
+              final p = SharedPreferencesService.instance;
               await p.setInt(
                   _tsKey, DateTime.now().millisecondsSinceEpoch);
               if (mounted) setState(() => _done = false);

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -8,10 +8,10 @@ import 'package:file_picker/file_picker.dart';
 import 'package:csv/csv.dart';
 import 'package:file_saver/file_saver.dart';
 import 'package:desktop_drop/desktop_drop.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../../services/training_pack_tag_analytics_service.dart';
+import '../../services/shared_preferences_service.dart';
 
 import '../../models/training_spot.dart';
 import '../../models/training_pack.dart';
@@ -528,8 +528,9 @@ class TrainingSpotListState extends State<TrainingSpotList>
   }
 
   Future<void> _loadPresets() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    await _restoreOrderFromPrefs(prefs);
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
+    await _restoreOrderFromPrefs(prefs.prefs);
     final List<String> tags = prefs.getStringList(_prefsTagsKey) ?? <String>[];
     final String search = prefs.getString(_prefsSearchKey) ?? '';
     final bool expanded = prefs.getBool(_prefsExpandedKey) ?? true;
@@ -669,7 +670,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
 
   Future<void> _savePresets() async {
     if (!_presetsLoaded) return;
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setStringList(_prefsTagsKey, _selectedTags.toList());
     await prefs.setString(_prefsSearchKey, _searchController.text);
     await prefs.setBool(_prefsExpandedKey, _tagFiltersExpanded);
@@ -727,7 +729,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
 
   Future<void> _saveOrderToPrefs() async {
     if (!_presetsLoaded) return;
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setStringList(
       _prefsOrderKey,
       [for (final s in widget.spots) jsonEncode(s.toJson())],
@@ -735,7 +738,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
   }
 
   Future<void> _saveSearchHistory() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setStringList(_prefsSearchHistoryKey, _searchHistory);
   }
 
@@ -752,7 +756,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
 
   Future<void> _clearSearchHistory() async {
     _searchHistory.clear();
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.remove(_prefsSearchHistoryKey);
   }
 
@@ -2201,7 +2206,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
   void didUpdateWidget(covariant TrainingSpotList oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!_orderRestored && widget.spots.isNotEmpty && _presetsLoaded) {
-      SharedPreferences.getInstance().then(_restoreOrderFromPrefs);
+      SharedPreferencesService.instance.init().then(
+          (_) => _restoreOrderFromPrefs(SharedPreferencesService.instance.prefs));
     }
   }
 

--- a/lib/widgets/daily_spotlight_card.dart
+++ b/lib/widgets/daily_spotlight_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../services/daily_spotlight_service.dart';
 import '../screens/v2/training_pack_play_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class DailySpotlightCard extends StatefulWidget {
   const DailySpotlightCard({super.key});
@@ -17,14 +17,16 @@ class _DailySpotlightCardState extends State<DailySpotlightCard> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    SharedPreferencesService.instance.init().then((_) {
+      final p = SharedPreferencesService.instance;
       if (!mounted) return;
       setState(() => _hidden = p.getBool('hide_today_card') ?? false);
     });
   }
 
   Future<void> _hide() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setBool('hide_today_card', true);
     if (mounted) setState(() => _hidden = true);
   }

--- a/lib/widgets/dialogs/track_unlock_hint_dialog.dart
+++ b/lib/widgets/dialogs/track_unlock_hint_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../screens/lesson_path_screen.dart';
 import '../../services/track_unlock_reason_service.dart';
+import '../../services/shared_preferences_service.dart';
 
 /// A simple modal that explains how to unlock a learning track.
 class TrackUnlockHintDialog extends StatelessWidget {
@@ -53,7 +53,8 @@ class TrackUnlockHintDialog extends StatelessWidget {
         if (prerequisiteId != null && prerequisiteTitle != null)
           TextButton(
             onPressed: () async {
-              final prefs = await SharedPreferences.getInstance();
+              await SharedPreferencesService.instance.init();
+              final prefs = SharedPreferencesService.instance;
               await prefs.setString(
                   'lesson_selected_track', prerequisiteId!);
               Navigator.pushReplacement(

--- a/lib/widgets/dormant_tag_reminder_banner.dart
+++ b/lib/widgets/dormant_tag_reminder_banner.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/training_gap_detector_service.dart';
 import '../services/pack_library_loader_service.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../services/user_action_logger.dart';
 import '../screens/v2/training_pack_play_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class DormantTagReminderBanner extends StatefulWidget {
   const DormantTagReminderBanner({super.key});
@@ -29,7 +29,8 @@ class _DormantTagReminderBannerState extends State<DormantTagReminderBanner> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final hideStr = prefs.getString(_hideKey);
     final now = DateTime.now();
     if (hideStr != null) {
@@ -77,7 +78,8 @@ class _DormantTagReminderBannerState extends State<DormantTagReminderBanner> {
   }
 
   Future<void> _hide() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final until = DateTime.now().add(const Duration(days: 1));
     await prefs.setString(_hideKey, until.toIso8601String());
     if (mounted) setState(() => _pack = null);

--- a/lib/widgets/first_launch_tutorial.dart
+++ b/lib/widgets/first_launch_tutorial.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../theme/app_colors.dart';
+import '../services/shared_preferences_service.dart';
 
 class FirstLaunchTutorial extends StatefulWidget {
   final VoidCallback onComplete;
@@ -19,7 +19,8 @@ class _FirstLaunchTutorialState extends State<FirstLaunchTutorial> {
   int _index = 0;
 
   Future<void> _next() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setBool('intro_step_$_index', true);
     if (_index == _steps.length - 1) {
       widget.onComplete();
@@ -29,7 +30,8 @@ class _FirstLaunchTutorialState extends State<FirstLaunchTutorial> {
   }
 
   Future<void> _skip() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     for (int i = 0; i < _steps.length; i++) {
       await prefs.setBool('intro_step_$i', true);
     }

--- a/lib/widgets/last_mistake_drill_card.dart
+++ b/lib/widgets/last_mistake_drill_card.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class LastMistakeDrillCard extends StatefulWidget {
   const LastMistakeDrillCard({super.key});
@@ -22,13 +22,15 @@ class _LastMistakeDrillCardState extends State<LastMistakeDrillCard> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    SharedPreferencesService.instance.init().then((_) {
+      final p = SharedPreferencesService.instance;
       if (mounted) setState(() => _ts = p.getInt(_key));
     });
   }
 
   Future<void> _mark(int ts) async {
-    final p = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final p = SharedPreferencesService.instance;
     await p.setInt(_key, ts);
     if (mounted) setState(() => _ts = ts);
   }

--- a/lib/widgets/next_steps_modal.dart
+++ b/lib/widgets/next_steps_modal.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/learning_path_template_v2.dart';
 import '../models/v2/training_pack_template.dart';
@@ -10,6 +9,7 @@ import '../services/weak_spot_recommendation_service.dart';
 import '../services/training_session_service.dart';
 import '../screens/learning_path_screen_v2.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class NextStepsModal extends StatefulWidget {
   final String completedPathId;
@@ -52,7 +52,8 @@ class _NextStepsModalState extends State<NextStepsModal> {
     final paths = unlocked.take(2).toList();
 
     TrainingPackTemplate? booster;
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     if (prefs.getBool('showWeaknessOverlay') ?? true) {
       final mastery = context.read<TagMasteryService>();
       final weak = await mastery.findWeakTags(threshold: 0.6);

--- a/lib/widgets/recovery_prompt_banner.dart
+++ b/lib/widgets/recovery_prompt_banner.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/skill_recovery_pack_engine.dart';
 import '../services/training_history_service_v2.dart';
@@ -11,6 +10,7 @@ import '../services/suggested_training_packs_history_service.dart';
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../screens/v2/training_pack_play_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class RecoveryPromptBanner extends StatefulWidget {
   const RecoveryPromptBanner({super.key});
@@ -33,7 +33,8 @@ class _RecoveryPromptBannerState extends State<RecoveryPromptBanner> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final now = DateTime.now();
     final hideStr = prefs.getString(_hideKey);
     if (hideStr != null) {
@@ -68,7 +69,8 @@ class _RecoveryPromptBannerState extends State<RecoveryPromptBanner> {
   }
 
   Future<void> _dismiss() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setString(
       _hideKey,
       DateTime.now().add(const Duration(hours: 48)).toIso8601String(),

--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -7,7 +7,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/saved_hand.dart';
 import '../theme/constants.dart';
@@ -16,6 +15,7 @@ import '../helpers/mistake_advice.dart';
 import 'saved_hand_tile.dart';
 import '../helpers/date_utils.dart';
 import 'package:sticky_headers/sticky_headers.dart';
+import '../services/shared_preferences_service.dart';
 
 /// Internal enum for accuracy filter options.
 enum _AccuracyFilter { all, errors, correct }
@@ -72,7 +72,8 @@ class _SavedHandListViewState extends State<SavedHandListView> {
   }
 
   Future<void> _loadAccuracy() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final stored = prefs.getString(_prefsAccuracyKey);
     if (stored != null && mounted) {
       setState(() => _accuracy = _parseAccuracy(stored));
@@ -80,7 +81,8 @@ class _SavedHandListViewState extends State<SavedHandListView> {
   }
 
   Future<void> _saveAccuracy(_AccuracyFilter value) async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.setString(_prefsAccuracyKey, _accuracyToString(value));
   }
 

--- a/lib/widgets/smart_suggestion_banner.dart
+++ b/lib/widgets/smart_suggestion_banner.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
 
 import '../models/training_pack_template.dart';
@@ -8,6 +7,7 @@ import '../services/template_storage_service.dart';
 import '../services/training_session_service.dart';
 import '../services/training_topic_suggestion_engine.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class SmartSuggestionBanner extends StatefulWidget {
   final Set<String> selectedTags;
@@ -34,7 +34,8 @@ class _SmartSuggestionBannerState extends State<SmartSuggestionBanner> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final hideStr = prefs.getString(_hideKey);
     final now = DateTime.now();
     if (hideStr != null) {
@@ -81,7 +82,8 @@ class _SmartSuggestionBannerState extends State<SmartSuggestionBanner> {
     }
     await prefs.setString(_packKey, tpl.id);
     await prefs.setString(_tagKey, tag);
-    await prefs.setString(_dateKey, DateTime(now.year, now.month, now.day).toIso8601String());
+    await prefs.setString(
+        _dateKey, DateTime(now.year, now.month, now.day).toIso8601String());
     if (mounted) {
       setState(() {
         _pack = tpl;
@@ -92,7 +94,8 @@ class _SmartSuggestionBannerState extends State<SmartSuggestionBanner> {
   }
 
   Future<void> _hide() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final until = DateTime.now().add(const Duration(days: 1));
     await prefs.setString(_hideKey, until.toIso8601String());
     if (mounted) setState(() => _pack = null);

--- a/lib/widgets/streak_banner_widget.dart
+++ b/lib/widgets/streak_banner_widget.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/lesson_streak_engine.dart';
 import 'confetti_overlay.dart';
+import '../services/shared_preferences_service.dart';
 
 /// Banner displaying current lesson streak.
 class StreakBannerWidget extends StatefulWidget {
@@ -36,7 +36,8 @@ class _StreakBannerWidgetState extends State<StreakBannerWidget>
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final disabled = prefs.getBool(_disabledKey) ?? false;
     final trackId = prefs.getString('lesson_selected_track');
     final value = await LessonStreakEngine.instance.getCurrentStreak();

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../services/streak_counter_service.dart';
 import 'package:intl/intl.dart';
 import 'confetti_overlay.dart';
+import '../services/shared_preferences_service.dart';
 
 class TodayProgressBanner extends StatefulWidget {
   const TodayProgressBanner({super.key});
@@ -58,7 +58,8 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
         ),
       );
     });
-    SharedPreferences.getInstance().then((prefs) {
+    SharedPreferencesService.instance.init().then((_) {
+      final prefs = SharedPreferencesService.instance;
       final str = prefs.getString(_prefKey);
       if (str != null) {
         _lastCelebration = DateTime.tryParse(str);
@@ -80,9 +81,9 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
       if (_lastCelebration == null || !_isSameDay(_lastCelebration!, today)) {
         _celebrated = true;
         _lastCelebration = today;
-        SharedPreferences.getInstance().then(
-          (p) => p.setString(_prefKey, today.toIso8601String()),
-        );
+        SharedPreferencesService.instance.init().then((_) =>
+            SharedPreferencesService.instance.setString(
+                _prefKey, today.toIso8601String()));
         _controller.forward(from: 0);
         HapticFeedback.mediumImpact();
         showConfettiOverlay(context);

--- a/lib/widgets/top_mistake_drill_card.dart
+++ b/lib/widgets/top_mistake_drill_card.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 class TopMistakeDrillCard extends StatefulWidget {
   const TopMistakeDrillCard({super.key});
@@ -20,13 +20,15 @@ class _TopMistakeDrillCardState extends State<TopMistakeDrillCard> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    SharedPreferencesService.instance.init().then((_) {
+      final p = SharedPreferencesService.instance;
       if (mounted) setState(() => _done = p.getBool(_key) ?? false);
     });
   }
 
   Future<void> _mark() async {
-    final p = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final p = SharedPreferencesService.instance;
     await p.setBool(_key, true);
     if (mounted) setState(() => _done = true);
   }

--- a/lib/widgets/training_pack_card.dart
+++ b/lib/widgets/training_pack_card.dart
@@ -5,10 +5,10 @@ import '../services/pinned_pack_service.dart';
 import '../theme/app_colors.dart';
 import '../helpers/mistake_category_translations.dart';
 import 'coverage_meter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/date_utils.dart';
 import '../services/training_pack_stats_service.dart';
 import 'package:intl/intl.dart';
+import '../services/shared_preferences_service.dart';
 
 class TrainingPackCard extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -54,7 +54,8 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
   }
 
   Future<void> _resetProgress() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     await prefs.remove('progress_tpl_${widget.template.id}');
     await prefs.remove('completed_tpl_${widget.template.id}');
     await prefs.remove('completed_at_tpl_${widget.template.id}');
@@ -138,7 +139,8 @@ class _TrainingPackCardState extends State<TrainingPackCard> {
   }
 
   Future<void> _loadStats() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final ts = DateTime.tryParse(
       prefs.getString('completed_at_tpl_${widget.template.id}') ?? '',
     );

--- a/lib/widgets/training_type_gap_prompt_banner.dart
+++ b/lib/widgets/training_type_gap_prompt_banner.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_template.dart';
@@ -9,6 +8,7 @@ import '../services/pack_library_loader_service.dart';
 import '../services/training_session_service.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../screens/training_session_screen.dart';
+import '../services/shared_preferences_service.dart';
 
 /// Banner prompting the user to train the weakest [TrainingType].
 ///
@@ -46,7 +46,8 @@ class _TrainingTypeGapPromptBannerState extends State<TrainingTypeGapPromptBanne
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final hideStr = prefs.getString(_hideKey);
     final now = DateTime.now();
     if (hideStr != null) {
@@ -95,7 +96,8 @@ class _TrainingTypeGapPromptBannerState extends State<TrainingTypeGapPromptBanne
   }
 
   Future<void> _hide() async {
-    final prefs = await SharedPreferences.getInstance();
+    await SharedPreferencesService.instance.init();
+    final prefs = SharedPreferencesService.instance;
     final until = DateTime.now().add(const Duration(days: 1));
     await prefs.setString(_hideKey, until.toIso8601String());
     if (mounted) setState(() => _pack = null);


### PR DESCRIPTION
## Summary
- add `SharedPreferencesService` with async init and typed helpers
- use `SharedPreferencesService` in `main.dart`
- migrate booster and various widgets to the new service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1e58f88832ab540c6f67dbc116e