### PR TITLE
Add Smart Inbox debug banner widget

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -38,6 +38,8 @@ import '../services/user_action_logger.dart';
 import '../services/daily_target_service.dart';
 import '../widgets/streak_widget.dart';
 import '../services/app_usage_tracker.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import '../services/smart_inbox_debug_service.dart';
 import '../widgets/resume_training_card.dart';
 import '../services/ab_test_engine.dart';
 import '../services/daily_training_reminder_service.dart';
@@ -359,6 +361,37 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
     );
   }
 
+  Future<void> _showAboutDialog() async {
+    final info = await PackageInfo.fromPlatform();
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('About'),
+        content: GestureDetector(
+          onLongPress: () {
+            SmartInboxDebugService.instance.toggle();
+            Navigator.of(context).pop();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  'Smart Inbox debug '
+                  '${SmartInboxDebugService.instance.enabled ? 'enabled' : 'disabled'}',
+                ),
+              ),
+            );
+          },
+          child: Text('Version ${info.version}'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   void _onTap(int index) {
     UserActionLogger.instance.log('nav_$index');
     setState(() => _currentIndex = index);
@@ -487,7 +520,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
                   );
                   break;
                 case 'about':
-                  showAboutDialog(context: context);
+                  _showAboutDialog();
                   break;
               }
             },

--- a/lib/services/smart_inbox_controller.dart
+++ b/lib/services/smart_inbox_controller.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/widgets.dart';
 
 import '../widgets/inbox_pinned_block_booster_banner.dart';
+import '../widgets/smart_inbox_debug_banner_widget.dart';
+import 'smart_inbox_debug_service.dart';
 import 'smart_booster_diversity_scheduler_service.dart';
 import 'smart_booster_inbox_limiter_service.dart';
 import 'smart_pinned_block_booster_provider.dart';
@@ -34,14 +36,32 @@ class SmartInboxController {
   Future<List<Widget>> getInboxItems() async {
     final items = <Widget>[];
     final boosters = await boosterProvider.getBoosters();
+    var scheduled = <PinnedBlockBoosterSuggestion>[];
+    var deduped = <PinnedBlockBoosterSuggestion>[];
+    var sorted = <PinnedBlockBoosterSuggestion>[];
+    var allowed = <PinnedBlockBoosterSuggestion>[];
+
     if (boosters.isNotEmpty) {
-      final scheduled = await diversityScheduler.schedule(boosters);
-      final deduped = await deduplicator.deduplicate(scheduled);
-      final sorted = await priorityScorer.sort(deduped);
-      final allowed = await _buildAllowedInboxBoosters(sorted);
+      scheduled = await diversityScheduler.schedule(boosters);
+      deduped = await deduplicator.deduplicate(scheduled);
+      sorted = await priorityScorer.sort(deduped);
+      allowed = await _buildAllowedInboxBoosters(sorted);
       if (allowed.isNotEmpty) {
         items.add(InboxPinnedBlockBoosterBanner(suggestions: allowed));
       }
+    }
+
+    final debugSvc = SmartInboxDebugService.instance;
+    debugSvc.update(SmartInboxDebugInfo(
+      raw: boosters,
+      scheduled: scheduled,
+      deduplicated: deduped,
+      sorted: sorted,
+      limited: allowed,
+      rendered: allowed,
+    ));
+    if (debugSvc.enabled) {
+      items.insert(0, const SmartInboxDebugBannerWidget());
     }
     return items;
   }

--- a/lib/services/smart_inbox_debug_service.dart
+++ b/lib/services/smart_inbox_debug_service.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+
+import 'smart_pinned_block_booster_provider.dart';
+
+/// Holds debug information for the Smart Inbox pipeline stages.
+class SmartInboxDebugInfo {
+  final List<PinnedBlockBoosterSuggestion> raw;
+  final List<PinnedBlockBoosterSuggestion> scheduled;
+  final List<PinnedBlockBoosterSuggestion> deduplicated;
+  final List<PinnedBlockBoosterSuggestion> sorted;
+  final List<PinnedBlockBoosterSuggestion> limited;
+  final List<PinnedBlockBoosterSuggestion> rendered;
+
+  const SmartInboxDebugInfo({
+    required this.raw,
+    required this.scheduled,
+    required this.deduplicated,
+    required this.sorted,
+    required this.limited,
+    required this.rendered,
+  });
+}
+
+/// Global service storing Smart Inbox debug state.
+class SmartInboxDebugService extends ChangeNotifier {
+  SmartInboxDebugService._();
+
+  /// Singleton instance.
+  static final SmartInboxDebugService instance = SmartInboxDebugService._();
+
+  /// Latest debug info from the controller.
+  SmartInboxDebugInfo? info;
+
+  /// Whether the debug banner should be shown.
+  bool enabled = false;
+
+  /// Updates [info] and notifies listeners.
+  void update(SmartInboxDebugInfo data) {
+    info = data;
+    notifyListeners();
+  }
+
+  /// Toggles the debug banner visibility.
+  void toggle() {
+    enabled = !enabled;
+    notifyListeners();
+  }
+}
+

--- a/lib/widgets/smart_inbox_debug_banner_widget.dart
+++ b/lib/widgets/smart_inbox_debug_banner_widget.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../services/smart_inbox_debug_service.dart';
+import '../services/smart_pinned_block_booster_provider.dart';
+
+/// Debug banner displaying Smart Inbox pipeline stages and retained boosters.
+class SmartInboxDebugBannerWidget extends StatefulWidget {
+  const SmartInboxDebugBannerWidget({super.key});
+
+  @override
+  State<SmartInboxDebugBannerWidget> createState() =>
+      _SmartInboxDebugBannerWidgetState();
+}
+
+class _SmartInboxDebugBannerWidgetState
+    extends State<SmartInboxDebugBannerWidget> {
+  final _service = SmartInboxDebugService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _service.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  void _onChanged() => setState(() {});
+
+  Widget _stageTile(String label, List<PinnedBlockBoosterSuggestion> list) {
+    return ExpansionTile(
+      title: Text('$label (${list.length})'),
+      children: [
+        for (final b in list)
+          ListTile(
+            dense: true,
+            title: Text(b.tag),
+            subtitle: Text(b.action),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_service.enabled || _service.info == null) {
+      return const SizedBox.shrink();
+    }
+    final info = _service.info!;
+    return Container(
+      margin: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: ExpansionTile(
+        title: const Text('Smart Inbox Debug'),
+        children: [
+          _stageTile('raw', info.raw),
+          _stageTile('scheduled', info.scheduled),
+          _stageTile('deduplicated', info.deduplicated),
+          _stageTile('sorted', info.sorted),
+          _stageTile('limited', info.limited),
+          _stageTile('rendered', info.rendered),
+        ],
+      ),
+    );
+  }
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -949,6 +949,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   lottie: ^3.3.1
   workmanager: ^0.5.1
   graphview: ^1.2.0
+  package_info_plus: ^8.3.0
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- add SmartInboxDebugService and SmartInboxDebugBannerWidget for viewing booster pipeline stages
- wire SmartInboxController to populate debug info and show banner when enabled
- allow toggling banner via long press on version in About dialog

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed28d4434832a81dc042aa43523d8