### PR TITLE
refactor: extract training spot helpers

### DIFF
--- a/lib/widgets/common/training_spot_filter_widgets.dart
+++ b/lib/widgets/common/training_spot_filter_widgets.dart
@@ -1,0 +1,806 @@
+import 'package:flutter/material.dart';
+
+import '../../models/training_spot.dart';
+import '../../theme/app_colors.dart';
+
+class TagFilterSection extends StatelessWidget {
+  final List<TrainingSpot> filtered;
+  final Set<String> selectedTags;
+  final bool expanded;
+  final String? selectedPreset;
+  final Map<String, List<String>> customPresets;
+  final Map<String, List<String>> defaultPresets;
+  final ValueChanged<bool> onExpanded;
+  final void Function(String tag, bool selected) onTagToggle;
+  final ValueChanged<String?> onPresetSelected;
+  final VoidCallback onClearTags;
+  final VoidCallback onOpenSelector;
+  final VoidCallback onManagePresets;
+
+  const TagFilterSection({
+    super.key,
+    required this.filtered,
+    required this.selectedTags,
+    required this.expanded,
+    required this.selectedPreset,
+    required this.customPresets,
+    required this.defaultPresets,
+    required this.onExpanded,
+    required this.onTagToggle,
+    required this.onPresetSelected,
+    required this.onClearTags,
+    required this.onOpenSelector,
+    required this.onManagePresets,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ExpansionTile(
+          title: const Text(
+            'Фильтры тегов',
+            style: TextStyle(color: Colors.white),
+          ),
+          initiallyExpanded: expanded,
+          onExpansionChanged: onExpanded,
+          iconColor: Colors.white,
+          collapsedIconColor: Colors.white,
+          collapsedTextColor: Colors.white,
+          textColor: Colors.white,
+          childrenPadding:
+              const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
+          children: [
+            _buildTagFilters(),
+            const SizedBox(height: 8),
+            _buildPresetDropdown(),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: ElevatedButton(
+                onPressed: onClearTags,
+                child: const Text('Сбросить теги'),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        _buildTagFilterRow(),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ElevatedButton(
+            onPressed: onManagePresets,
+            child: const Text('Редактировать пресеты'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTagFilterRow() {
+    return SizedBox(
+      height: 40,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        children: [
+          for (final tag in selectedTags)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4.0),
+              child: FilterChip(
+                label: Text(tag),
+                selected: true,
+                onSelected: (selected) => onTagToggle(tag, selected),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTagFilters() {
+    final count = selectedTags.length;
+    final label =
+        count == 0 ? 'Выбрать теги' : 'Выбрано: $count';
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ElevatedButton(
+        onPressed: onOpenSelector,
+        child: Text(label),
+      ),
+    );
+  }
+
+  Widget _buildPresetDropdown() {
+    return Row(
+      children: [
+        const Text('Применить теги ко всем',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<String>(
+          value: selectedPreset,
+          hint: const Text('Выбрать', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: [
+            for (final entry in defaultPresets.entries)
+              DropdownMenuItem(
+                value: entry.key,
+                child: Text(entry.key),
+              ),
+            for (final entry in customPresets.entries)
+              DropdownMenuItem(
+                value: entry.key,
+                child: Text(entry.key),
+              ),
+          ],
+          onChanged: onPresetSelected,
+        ),
+      ],
+    );
+  }
+}
+
+class DifficultyChipRow extends StatelessWidget {
+  final Set<int> selected;
+  final ValueChanged<int> onChanged;
+  final VoidCallback onToggleAll;
+
+  const DifficultyChipRow({
+    required this.selected,
+    required this.onChanged,
+    required this.onToggleAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Сложность', style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        Wrap(
+          spacing: 4,
+          children: [
+            for (int i = 1; i <= 5; i++)
+              FilterChip(
+                label: Text('$i'),
+                selected: selected.contains(i),
+                onSelected: (_) => onChanged(i),
+              ),
+          ],
+        ),
+        const SizedBox(width: 8),
+        TextButton(
+          onPressed: onToggleAll,
+          child: const Text('Выбрать все'),
+        ),
+      ],
+    );
+  }
+}
+
+
+class RatingChipRow extends StatelessWidget {
+  final Set<int> selected;
+  final ValueChanged<int> onChanged;
+  final VoidCallback onToggleAll;
+
+  const RatingChipRow({
+    required this.selected,
+    required this.onChanged,
+    required this.onToggleAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Рейтинг', style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        Wrap(
+          spacing: 4,
+          children: [
+            for (int i = 1; i <= 5; i++)
+              FilterChip(
+                label: Text('$i'),
+                selected: selected.contains(i),
+                onSelected: (_) => onChanged(i),
+              ),
+          ],
+        ),
+        const SizedBox(width: 8),
+        TextButton(
+          onPressed: onToggleAll,
+          child: const Text('Выбрать все'),
+        ),
+      ],
+    );
+  }
+}
+
+class FilterBar extends StatelessWidget {
+  final Set<String> selectedTags;
+  final void Function(String tag, bool selected) onTagToggle;
+  final Set<int> difficultyFilters;
+  final ValueChanged<int> onDifficultyChanged;
+  final VoidCallback onDifficultyToggleAll;
+  final Set<int> ratingFilters;
+  final ValueChanged<int> onRatingChanged;
+  final VoidCallback onRatingToggleAll;
+
+  const FilterBar({
+    required this.selectedTags,
+    required this.onTagToggle,
+    required this.difficultyFilters,
+    required this.onDifficultyChanged,
+    required this.onDifficultyToggleAll,
+    required this.ratingFilters,
+    required this.onRatingChanged,
+    required this.onRatingToggleAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.background,
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 40,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                for (final tag in selectedTags)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                    child: FilterChip(
+                      label: Text(tag),
+                      selected: true,
+                      onSelected: (selected) => onTagToggle(tag, selected),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          DifficultyChipRow(
+            selected: difficultyFilters,
+            onChanged: onDifficultyChanged,
+            onToggleAll: onDifficultyToggleAll,
+          ),
+          const SizedBox(height: 8),
+          RatingChipRow(
+            selected: ratingFilters,
+            onChanged: onRatingChanged,
+            onToggleAll: onRatingToggleAll,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class SliverFilterBarDelegate extends SliverPersistentHeaderDelegate {
+  final double height;
+  final Widget child;
+
+  SliverFilterBarDelegate({required this.height, required this.child});
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return child;
+  }
+
+  @override
+  bool shouldRebuild(covariant SliverFilterBarDelegate oldDelegate) {
+    return oldDelegate.child != child || oldDelegate.height != height;
+  }
+}
+
+class SliverSortHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final double height;
+  final Widget child;
+
+  SliverSortHeaderDelegate({required this.height, required this.child});
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return child;
+  }
+
+  @override
+  bool shouldRebuild(covariant SliverSortHeaderDelegate oldDelegate) {
+    return oldDelegate.child != child || oldDelegate.height != height;
+  }
+}
+
+class ApplyDifficultyDropdown extends StatelessWidget {
+  final ValueChanged<int?> onChanged;
+
+  const ApplyDifficultyDropdown({required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Применить сложность ко всем',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<int?>(
+          hint: const Text('Выбрать', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: [
+            for (int i = 1; i <= 5; i++)
+              DropdownMenuItem(value: i, child: Text('$i')),
+          ],
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class ApplyRatingDropdown extends StatelessWidget {
+  final ValueChanged<int?> onChanged;
+
+  const ApplyRatingDropdown({required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Применить рейтинг ко всем',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<int?>(
+          hint: const Text('Выбрать', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: [
+            for (int i = 1; i <= 5; i++)
+              DropdownMenuItem(value: i, child: Text('$i')),
+          ],
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class SortDropdown extends StatelessWidget {
+  final SortOption? sortOption;
+  final List<TrainingSpot> filtered;
+  final bool manualOrder;
+  final void Function(SortOption? value, List<TrainingSpot> spots) onChanged;
+
+  const SortDropdown({
+    required this.sortOption,
+    required this.filtered,
+    required this.manualOrder,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<SortOption?>(
+      value: sortOption,
+      hint: const Text('Сортировать', style: TextStyle(color: Colors.white60)),
+      dropdownColor: AppColors.cardBackground,
+      style: const TextStyle(color: Colors.white),
+      items: const [
+        DropdownMenuItem(
+          value: null,
+          child: Text('Сбросить сортировку'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.buyInAsc,
+          child: Text('Buy-In ↑'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.buyInDesc,
+          child: Text('Buy-In ↓'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.gameType,
+          child: Text('Тип игры'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.tournamentId,
+          child: Text('ID турнира'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.difficultyAsc,
+          child: Text('Сложность (по возрастанию)'),
+        ),
+        DropdownMenuItem(
+          value: SortOption.difficultyDesc,
+          child: Text('Сложность (по убыванию)'),
+        ),
+      ],
+      onChanged:
+          manualOrder ? null : (value) => onChanged(value, filtered),
+    );
+  }
+}
+
+class ListSortDropdown extends StatelessWidget {
+  final ListSortOption? value;
+  final List<TrainingSpot> filtered;
+  final bool manualOrder;
+  final void Function(ListSortOption? value, List<TrainingSpot> spots) onChanged;
+
+  const ListSortDropdown({
+    required this.value,
+    required this.filtered,
+    required this.manualOrder,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Сортировка', style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<ListSortOption?>(
+          value: value,
+          hint:
+              const Text('Без сортировки', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: const [
+            DropdownMenuItem(value: null, child: Text('Без сортировки')),
+            DropdownMenuItem(
+                value: ListSortOption.dateNew,
+                child: Text('Дата добавления (новые)')),
+            DropdownMenuItem(
+                value: ListSortOption.dateOld,
+                child: Text('Дата добавления (старые)')),
+            DropdownMenuItem(
+                value: ListSortOption.rating, child: Text('Рейтинг')),
+            DropdownMenuItem(
+                value: ListSortOption.difficulty, child: Text('Сложность')),
+            DropdownMenuItem(
+                value: ListSortOption.comment, child: Text('Комментарий')),
+          ],
+          onChanged: manualOrder ? null : (v) => onChanged(v, filtered),
+        ),
+      ],
+    );
+  }
+}
+
+class RatingSortDropdown extends StatelessWidget {
+  final RatingSortOrder? order;
+  final List<TrainingSpot> filtered;
+  final bool manualOrder;
+  final void Function(RatingSortOrder? value, List<TrainingSpot> spots)
+      onChanged;
+
+  const RatingSortDropdown({
+    required this.order,
+    required this.filtered,
+    required this.manualOrder,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text('Сортировать по рейтингу',
+            style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<RatingSortOrder?>(
+          value: order,
+          hint:
+              const Text('Без сортировки', style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: const [
+            DropdownMenuItem(
+              value: null,
+              child: Text('Без сортировки'),
+            ),
+            DropdownMenuItem(
+              value: RatingSortOrder.highFirst,
+              child: Text('Сначала высокий'),
+            ),
+            DropdownMenuItem(
+              value: RatingSortOrder.lowFirst,
+              child: Text('Сначала низкий'),
+            ),
+          ],
+          onChanged: manualOrder ? null : (v) => onChanged(v, filtered),
+        ),
+      ],
+    );
+  }
+}
+
+class QuickSortSegment extends StatelessWidget {
+  final QuickSortOption? value;
+  final ValueChanged<QuickSortOption> onChanged;
+
+  const QuickSortSegment({
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Сортировать по', style: TextStyle(color: Colors.white)),
+        const SizedBox(height: 4),
+        ToggleButtons(
+          isSelected: QuickSortOption.values
+              .map((e) => e == value)
+              .toList(),
+          onPressed: (i) => onChanged(QuickSortOption.values[i]),
+          children: const [
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text('ID'),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text('Сложность'),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text('Рейтинг'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class SimpleSortRow extends StatelessWidget {
+  final SimpleSortField? field;
+  final SimpleSortOrder order;
+  final ValueChanged<SimpleSortField?> onFieldChanged;
+  final ValueChanged<SimpleSortOrder> onOrderChanged;
+
+  const SimpleSortRow({
+    required this.field,
+    required this.order,
+    required this.onFieldChanged,
+    required this.onOrderChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        DropdownButton<SimpleSortField?>(
+          value: field,
+          hint: const Text('Сортировать по',
+              style: TextStyle(color: Colors.white60)),
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: const [
+            DropdownMenuItem(value: null, child: Text('Без сортировки')),
+            DropdownMenuItem(
+                value: SimpleSortField.createdAt, child: Text('Дата')),
+            DropdownMenuItem(
+                value: SimpleSortField.difficulty, child: Text('Сложность')),
+            DropdownMenuItem(
+                value: SimpleSortField.rating, child: Text('Рейтинг')),
+          ],
+          onChanged: onFieldChanged,
+        ),
+        const SizedBox(width: 8),
+        DropdownButton<SimpleSortOrder>(
+          value: order,
+          dropdownColor: AppColors.cardBackground,
+          style: const TextStyle(color: Colors.white),
+          items: const [
+            DropdownMenuItem(
+                value: SimpleSortOrder.ascending,
+                child: Text('По возрастанию')),
+            DropdownMenuItem(
+                value: SimpleSortOrder.descending,
+                child: Text('По убыванию')),
+          ],
+          onChanged: (v) => onOrderChanged(v!),
+        ),
+      ],
+    );
+  }
+}
+
+class SelectionActions extends StatelessWidget {
+  final int selectedCount;
+  final List<TrainingSpot> filtered;
+  final void Function(List<TrainingSpot> spots) onSelectAll;
+  final VoidCallback onClearSelection;
+  final VoidCallback onDeleteSelected;
+  final VoidCallback onExportSelected;
+  final VoidCallback onEditTags;
+
+  const SelectionActions({
+    required this.selectedCount,
+    required this.filtered,
+    required this.onSelectAll,
+    required this.onClearSelection,
+    required this.onDeleteSelected,
+    required this.onExportSelected,
+    required this.onEditTags,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ElevatedButton(
+            onPressed: () => onSelectAll(filtered),
+            child: const Text('Выделить все'),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: selectedCount == 0 ? null : onClearSelection,
+            child: const Text('Снять выделение'),
+          ),
+          const SizedBox(width: 8),
+          Stack(
+            clipBehavior: Clip.none,
+            children: [
+              ElevatedButton(
+                onPressed: selectedCount == 0 ? null : onDeleteSelected,
+                child: const Text('Удалить выбранные'),
+              ),
+              if (selectedCount > 0)
+                Positioned(
+                  right: -6,
+                  top: -6,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Text(
+                      '$selectedCount',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: selectedCount == 0 ? null : onExportSelected,
+            child: const Text('Экспортировать выбранные'),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton.icon(
+            onPressed: selectedCount == 0 ? null : onEditTags,
+            icon: const Icon(Icons.label_outline),
+            label: const Text('Метки'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class BatchFilterActions extends StatelessWidget {
+  final bool disabled;
+  final VoidCallback onApply;
+  final VoidCallback onDelete;
+
+  const BatchFilterActions({
+    required this.disabled,
+    required this.onApply,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ElevatedButton(
+            onPressed: disabled ? null : onApply,
+            child: const Text('Применить фильтры ко всем'),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: disabled ? null : onDelete,
+            child: const Text('Удалить все отфильтрованные'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class QuickPresetRow extends StatelessWidget {
+  final String? active;
+  final Map<String, String> presets;
+  final ValueChanged<String?> onChanged;
+
+  const QuickPresetRow({
+    super.key,
+    required this.active,
+    required this.presets,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 36,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        children: [
+          for (final entry in presets.entries)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4.0),
+              child: ChoiceChip(
+                label: Text(entry.key),
+                selected: active == entry.key,
+                onSelected: (selected) =>
+                    onChanged(selected ? entry.key : null),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class PulsingIndicator extends StatefulWidget {
+  const _PulsingIndicator();
+
+  @override
+  State<PulsingIndicator> createState() => PulsingIndicatorState();
+}
+
+class PulsingIndicatorState extends State<PulsingIndicator> {
+  bool _fadeIn = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: _fadeIn ? 1.0 : 0.4, end: _fadeIn ? 0.4 : 1.0),
+      duration: const Duration(seconds: 1),
+      onEnd: () => setState(() => _fadeIn = !_fadeIn),
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: value,
+          child: child,
+        );
+      },
+      child: const Icon(Icons.circle, size: 8, color: Colors.red),
+    );
+  }
+}

--- a/lib/widgets/common/training_spot_import_export.dart
+++ b/lib/widgets/common/training_spot_import_export.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:csv/csv.dart';
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:file_saver/file_saver.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../models/training_spot.dart';
+
+class TrainingSpotImportExport {
+  const TrainingSpotImportExport._();
+
+  static Future<void> exportPack(List<TrainingSpot> spots) async {
+    if (spots.isEmpty) return;
+    const encoder = JsonEncoder.withIndent('  ');
+    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+    final dir = await getTemporaryDirectory();
+    final file = File(
+        '${dir.path}/training_spots_${DateTime.now().millisecondsSinceEpoch}.json');
+    await file.writeAsString(jsonStr);
+    await Share.shareXFiles([XFile(file.path)], text: 'training_spots.json');
+  }
+
+  static Future<void> exportNamedPack(
+    BuildContext context,
+    List<TrainingSpot> spots,
+    String name,
+  ) async {
+    if (spots.isEmpty) return;
+    const encoder = JsonEncoder.withIndent('  ');
+    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+    final dir = await getTemporaryDirectory();
+    final safe = name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    final file = File('${dir.path}/$safe.json');
+    await file.writeAsString(jsonStr);
+    await Share.shareXFiles([XFile(file.path)], text: '$safe.json');
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Пакет "$name" создан, спотов: ${spots.length}')),
+    );
+  }
+
+  static Future<void> exportPackSummary(List<TrainingSpot> spots) async {
+    if (spots.isEmpty) return;
+    final buffer = StringBuffer();
+    for (final spot in spots) {
+      buffer.writeln(
+          'ID: ${spot.tournamentId ?? '-'}, Buy-In: ${spot.buyIn ?? '-'}, Game: ${spot.gameType ?? '-'}, Tags: ${spot.tags.length}');
+    }
+    final dir = await getTemporaryDirectory();
+    final file = File(
+        '${dir.path}/spot_summary_${DateTime.now().millisecondsSinceEpoch}.txt');
+    await file.writeAsString(buffer.toString());
+    await Share.shareXFiles([XFile(file.path)], text: 'spot_summary.txt');
+  }
+
+  static Future<void> exportCsv(
+    BuildContext context,
+    List<TrainingSpot> spots, {
+    String? successMessage,
+  }) async {
+    if (spots.isEmpty) return;
+
+    final rows = <List<dynamic>>[];
+    rows.add(['ID', 'Difficulty', 'Rating', 'Tags', 'Buy-in', 'ICM', 'Date']);
+    final today = DateTime.now();
+    final dateStr =
+        '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+    for (final s in spots) {
+      rows.add([
+        s.tournamentId ?? '',
+        s.difficulty,
+        s.rating,
+        s.tags.join(';'),
+        s.buyIn ?? '',
+        s.tags.contains('ICM') ? '1' : '0',
+        dateStr,
+      ]);
+    }
+
+    final csvStr = const ListToCsvConverter().convert(rows, eol: '\r\n');
+    final bytes = Uint8List.fromList(utf8.encode(csvStr));
+    final name = 'training_spots_${DateTime.now().millisecondsSinceEpoch}';
+    try {
+      await FileSaver.instance.saveAs(
+        name: name,
+        bytes: bytes,
+        ext: 'csv',
+        mimeType: MimeType.csv,
+      );
+      final msg =
+          successMessage ?? 'Экспортировано ${spots.length} спотов в CSV';
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(msg)));
+    } catch (_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Ошибка экспорта CSV')));
+    }
+  }
+
+  static Future<List<TrainingSpot>?> importFromFile(
+      BuildContext context, String path) async {
+    final file = File(path);
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is! List) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+        return null;
+      }
+      final spots = <TrainingSpot>[];
+      for (final e in data) {
+        if (e is Map) {
+          try {
+            spots.add(TrainingSpot.fromJson(Map<String, dynamic>.from(e)));
+          } catch (_) {}
+        }
+      }
+      if (spots.isEmpty) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+        return null;
+      }
+      return spots;
+    } catch (_) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+      return null;
+    }
+  }
+
+  static Future<List<TrainingSpot>?> pickPack(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final path = result.files.single.path;
+    if (path == null) return null;
+    return importFromFile(context, path);
+  }
+
+  static Future<List<TrainingSpot>> importFromDrop(
+      BuildContext context, DropDoneDetails details) async {
+    final imported = <TrainingSpot>[];
+    for (final item in details.files) {
+      final path = item.path;
+      if (path.toLowerCase().endsWith('.json')) {
+        final spots = await importFromFile(context, path);
+        if (spots != null) {
+          imported.addAll(spots);
+        }
+      }
+    }
+    return imported;
+  }
+}
+


### PR DESCRIPTION
## Summary
- move import/export routines into `TrainingSpotImportExport`
- split tag filter and preset widgets into `training_spot_filter_widgets.dart`
- update `TrainingSpotList` to use new helpers and public presets

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1c87538832abf31bd30ea97c01f