### PR TITLE
refactor: add player zone config and registry

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -38,6 +38,7 @@ import 'services/daily_hand_service.dart';
 import 'services/daily_target_service.dart';
 import 'services/daily_tip_service.dart';
 import 'services/xp_tracker_service.dart';
+import 'widgets/player_zone_widget.dart';
 import 'services/reward_service.dart';
 import 'services/reward_system_service.dart';
 import 'services/coins_service.dart';
@@ -157,6 +158,7 @@ List<SingleChildWidget> buildCoreProviders(CloudSyncService cloud) {
     ChangeNotifierProvider<AbTestEngine>.value(value: ab),
     ChangeNotifierProvider(create: (_) => ThemeService()..load()),
     Provider<CloudSyncService>.value(value: cloud),
+    Provider(create: (_) => PlayerZoneRegistry()),
   ];
 }
 

--- a/lib/models/player_zone_config.dart
+++ b/lib/models/player_zone_config.dart
@@ -1,0 +1,65 @@
+import "package:flutter/material.dart";
+import "card_model.dart";
+import "player_model.dart";
+
+class PlayerZoneConfig {
+  final String playerName;
+  final String street;
+  final String? position;
+  final List<CardModel> cards;
+  final bool isHero;
+  final bool isFolded;
+  final bool isShowdownLoser;
+  final int currentBet;
+  final int? stackSize;
+  final Map<int, int>? stackSizes;
+  final int? playerIndex;
+  final PlayerType playerType;
+  final ValueChanged<PlayerType>? onPlayerTypeChanged;
+  final bool isActive;
+  final bool highlightLastAction;
+  final bool showHint;
+  final bool showPlayerTypeLabel;
+  final int? remainingStack;
+  final String? actionTagText;
+  final void Function(int, CardModel) onCardsSelected;
+  final int maxStackSize;
+  final double scale;
+  final Set<String> usedCards;
+  final bool editMode;
+  final PlayerModel player;
+  final ValueChanged<int>? onStackChanged;
+  final ValueChanged<int>? onBetChanged;
+  final ValueChanged<String>? onRevealRequest;
+
+  const PlayerZoneConfig({
+    required this.player,
+    required this.playerName,
+    required this.street,
+    this.position,
+    required this.cards,
+    required this.isHero,
+    required this.isFolded,
+    this.isShowdownLoser = false,
+    this.currentBet = 0,
+    this.stackSize,
+    this.stackSizes,
+    this.playerIndex,
+    this.playerType = PlayerType.unknown,
+    this.onPlayerTypeChanged,
+    required this.onCardsSelected,
+    this.isActive = false,
+    this.highlightLastAction = false,
+    this.showHint = false,
+    this.showPlayerTypeLabel = false,
+    this.remainingStack,
+    this.actionTagText,
+    this.maxStackSize = 100,
+    this.scale = 1.0,
+    this.usedCards = const {},
+    this.editMode = false,
+    this.onStackChanged,
+    this.onBetChanged,
+    this.onRevealRequest,
+  });
+}

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -1192,7 +1192,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     Future.delayed(const Duration(milliseconds: 1500), () {
       if (!mounted) return;
       for (final i in _bustedPlayers) {
-        fadeOutBustedPlayerZone(players[i].name);
+        fadeOutBustedPlayerZone(
+            context.read<PlayerZoneRegistry>(), players[i].name);
       }
     });
     if (widget.demoMode) {
@@ -1269,16 +1270,18 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         .where((e) => e.value > 0)
         .map((e) => e.key)
         .toSet();
+    final registry = context.read<PlayerZoneRegistry>();
     for (int i = 0; i < numberOfPlayers; i++) {
       final name = players[i].name;
       if (!_actionTagService.tags.containsKey(i)) {
-        setPlayerLastActionOutcome(name, ActionOutcome.neutral);
+        setPlayerLastActionOutcome(
+            registry, name, ActionOutcome.neutral);
       } else if (winnerSet.contains(i)) {
-        setPlayerLastActionOutcome(name, ActionOutcome.win);
-        setPlayerShowdownStatus(name, 'W');
+        setPlayerLastActionOutcome(registry, name, ActionOutcome.win);
+        setPlayerShowdownStatus(registry, name, 'W');
       } else {
-        setPlayerLastActionOutcome(name, ActionOutcome.lose);
-        setPlayerShowdownStatus(name, 'L');
+        setPlayerLastActionOutcome(registry, name, ActionOutcome.lose);
+        setPlayerShowdownStatus(registry, name, 'L');
       }
     }
   }
@@ -1305,9 +1308,11 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       payouts[winner] = pot - returnTotal;
     }
     final resultSidePots = List<int>.from(_sidePots);
-    await triggerWinnerAnimation(winner, pot - returnTotal);
+    await triggerWinnerAnimation(
+        context.read<PlayerZoneRegistry>(), winner, pot - returnTotal);
     if (!_returnsAnimated) {
-      await _potAnimations.triggerRefundAnimations(returns);
+      await _potAnimations.triggerRefundAnimations(
+          returns, context.read<PlayerZoneRegistry>());
     }
     await Future.delayed(const Duration(milliseconds: 500));
     if (!mounted) return;
@@ -1421,6 +1426,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     final end = Offset(centerX + dx, centerY + dy + bias + 92 * scale);
     _registerResetAnimation();
     playRefundToPlayer(
+      context.read<PlayerZoneRegistry>(),
       playerIndex,
       amount,
       startPosition: start,
@@ -1474,6 +1480,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
         if (!mounted) return;
         _registerResetAnimation();
         playRefundToPlayer(
+          context.read<PlayerZoneRegistry>(),
           playerIndex,
           amount,
           startPosition: start,
@@ -1504,7 +1511,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
   void _notifyShowdownResults() {
     for (int i = 0; i < numberOfPlayers; i++) {
-      onShowdownResult(players[i].name);
+      onShowdownResult(
+          context.read<PlayerZoneRegistry>(), players[i].name);
     }
   }
 
@@ -1863,7 +1871,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     for (final p in winners) {
       showWinnerHighlight(context, players[p].name);
       if (prefs.showWinnerCelebration) {
-        showWinnerCelebration(context, players[p].name);
+        showWinnerCelebration(
+            context, context.read<PlayerZoneRegistry>(), players[p].name);
       }
       if (widget.demoMode) {
         _demoAnimations.showWinnerZoneOverlay(context, players[p].name);
@@ -2343,7 +2352,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       );
       final name = players[playerIndex].name;
       showWinnerHighlight(context, name);
-      showWinnerZoneOverlay(context, name);
+      showWinnerZoneOverlay(
+          context, context.read<PlayerZoneRegistry>(), name);
       showPotCollectionChips(
         context: context,
         start: start,
@@ -3490,6 +3500,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
       playerManager: _playerManager,
       triggerCenterChip: _triggerCenterChip,
       playChipAnimation: _handleBetAction,
+      playerZoneRegistry: context.read<PlayerZoneRegistry>(),
     ));
     _actionEditing = _serviceRegistry.get<ActionEditingService>();
     Future(() => _initializeDebugPreferences());
@@ -3810,7 +3821,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     _winnerIndex = activePlayers.first;
     final winnerName = players[_winnerIndex!].name;
     showWinnerHighlight(context, winnerName);
-    showWinnerZoneOverlay(context, winnerName);
+    showWinnerZoneOverlay(
+        context, context.read<PlayerZoneRegistry>(), winnerName);
     _returns = _calculateUncalledReturns();
     _playPotWinAnimation();
     _scheduleAutoReset();
@@ -5102,7 +5114,8 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
     const color = Colors.red;
     for (int i = 0; i < numberOfPlayers; i++) {
       if (i == heroIndex) continue;
-      setPlayerLastAction(players[i].name, 'Fold', color, 'fold');
+      setPlayerLastAction(context.read<PlayerZoneRegistry>(),
+          players[i].name, 'Fold', color, 'fold');
     }
   }
 

--- a/lib/services/action_editing_service.dart
+++ b/lib/services/action_editing_service.dart
@@ -28,6 +28,7 @@ class ActionEditingService {
   final PlayerManagerService playerManager;
   final void Function(ActionEntry entry)? triggerCenterChip;
   final void Function(ActionEntry entry)? playChipAnimation;
+  final PlayerZoneRegistry playerZoneRegistry;
 
   ActionEditingService({
     required this.actionSync,
@@ -42,6 +43,7 @@ class ActionEditingService {
     required this.playerManager,
     this.triggerCenterChip,
     this.playChipAnimation,
+    required this.playerZoneRegistry,
   });
 
   List<ActionEntry> get actions => actionSync.analyzerActions;
@@ -80,6 +82,7 @@ class ActionEditingService {
         visibleCount: playbackManager.playbackIndex);
     actionTag.updateForAction(entry);
     setPlayerLastAction(
+      playerZoneRegistry,
       players[entry.playerIndex].name,
       ActionFormattingHelper.formatLastAction(entry),
       ActionFormattingHelper.actionColor(entry.action),
@@ -122,6 +125,7 @@ class ActionEditingService {
     actionSync.notifyListeners();
     actionTag.updateForAction(entry);
     setPlayerLastAction(
+      playerZoneRegistry,
       players[entry.playerIndex].name,
       ActionFormattingHelper.formatLastAction(entry),
       ActionFormattingHelper.actionColor(entry.action),

--- a/lib/services/demo_animation_manager.dart
+++ b/lib/services/demo_animation_manager.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../helpers/table_geometry_helper.dart';
 import '../widgets/pot_collection_chips.dart' as chips;
 import '../widgets/player_zone_widget.dart' as pzw;
+import 'package:provider/provider.dart';
 import '../widgets/winner_glow_widget.dart';
 import '../widgets/chip_stack_moving_widget.dart';
 
@@ -32,7 +33,9 @@ class DemoAnimationManager {
 
   /// Display an overlay glow around the given winner's zone.
   void showWinnerZoneOverlay(BuildContext context, String playerName) {
-    pzw.showWinnerZoneOverlay(context, playerName);
+    final registry =
+        Provider.of<pzw.PlayerZoneRegistry>(context, listen: false);
+    pzw.showWinnerZoneOverlay(context, registry, playerName);
   }
 
   /// Show chips flying from the pot to the winner's stack.

--- a/lib/services/pot_animation_service.dart
+++ b/lib/services/pot_animation_service.dart
@@ -34,10 +34,11 @@ class PotAnimationService {
   String? _highlightedPlayer;
 
   void showWinnerHighlight(BuildContext context, String playerName) {
-    final state = playerZoneRegistry[playerName];
+    final registry = Provider.of<PlayerZoneRegistry>(context, listen: false);
+    final state = registry[playerName];
     if (state == null) return;
     if (_highlightedPlayer != null && _highlightedPlayer != playerName) {
-      final prev = playerZoneRegistry[_highlightedPlayer!];
+      final prev = registry[_highlightedPlayer!];
       prev?.clearWinnerHighlight();
     }
     _highlightedPlayer = playerName;
@@ -245,13 +246,14 @@ class PotAnimationService {
     });
   }
 
-  Future<void> triggerRefundAnimations(Map<int, int> refunds) async {
+  Future<void> triggerRefundAnimations(
+      Map<int, int> refunds, PlayerZoneRegistry registry) async {
     for (final entry in refunds.entries) {
       final playerIndex = entry.key;
       final amount = entry.value;
       if (amount <= 0) continue;
       dynamic state;
-      for (final s in playerZoneRegistry.values) {
+      for (final s in registry.values) {
         if (s.widget.playerIndex == playerIndex) {
           state = s;
           break;


### PR DESCRIPTION
## Summary
- add PlayerZoneConfig to bundle player zone settings
- manage PlayerZoneWidget state via PlayerZoneRegistry provider
- update services and screens to look up player zones using provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1e0fa90832aab38770c21701266