### PR TITLE
feat: track excluded smart boosters

### DIFF
--- a/lib/services/smart_booster_exclusion_tracker_service.dart
+++ b/lib/services/smart_booster_exclusion_tracker_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../utils/shared_prefs_keys.dart';
+
+/// Logs boosters that are excluded from the inbox for diagnostics.
+class SmartBoosterExclusionTrackerService {
+  SmartBoosterExclusionTrackerService();
+
+  static const int _maxEntries = 100;
+
+  /// Records that a booster with [tag] was skipped for [reason].
+  Future<void> logExclusion(String tag, String reason) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = prefs.getStringList(SharedPrefsKeys.boosterExclusionLog) ?? [];
+    entries.add(jsonEncode({
+      'tag': tag,
+      'reason': reason,
+      'timestamp': DateTime.now().toIso8601String(),
+    }));
+    if (entries.length > _maxEntries) {
+      entries.removeRange(0, entries.length - _maxEntries);
+    }
+    await prefs.setStringList(SharedPrefsKeys.boosterExclusionLog, entries);
+  }
+
+  /// Returns the raw exclusion log entries for diagnostics.
+  Future<List<Map<String, dynamic>>> exportLog() async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = prefs.getStringList(SharedPrefsKeys.boosterExclusionLog) ?? [];
+    return entries
+        .map((e) => jsonDecode(e) as Map<String, dynamic>)
+        .toList();
+  }
+
+  /// Clears the stored exclusion log.
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(SharedPrefsKeys.boosterExclusionLog);
+  }
+}
+

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -5,6 +5,7 @@ class SharedPrefsKeys {
   static String boosterInboxLast(String tag) => 'booster_inbox_last_$tag';
   static const String boosterInboxTotalDate = 'booster_inbox_total_date';
   static const String boosterInboxTotalCount = 'booster_inbox_total_count';
+  static const String boosterExclusionLog = 'booster_exclusion_log';
 
   static const String boosterOpenedPrefix = 'booster_opened_';
   static String boosterOpened(String tag) => '${boosterOpenedPrefix}$tag';

--- a/test/services/smart_booster_exclusion_tracker_service_test.dart
+++ b/test/services/smart_booster_exclusion_tracker_service_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/smart_booster_exclusion_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('logs exclusions and exports them', () async {
+    final tracker = SmartBoosterExclusionTrackerService();
+    await tracker.logExclusion('t1', 'rateLimited');
+
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getStringList('booster_exclusion_log');
+    expect(stored, isNotNull);
+    expect(stored!.length, 1);
+
+    final exported = await tracker.exportLog();
+    expect(exported.length, 1);
+    expect(exported.first['tag'], 't1');
+    expect(exported.first['reason'], 'rateLimited');
+    expect(exported.first['timestamp'], isNotNull);
+  });
+
+  test('keeps only last 100 entries', () async {
+    final tracker = SmartBoosterExclusionTrackerService();
+    for (var i = 0; i < 105; i++) {
+      await tracker.logExclusion('t\$i', 'deduplicated');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getStringList('booster_exclusion_log');
+    expect(stored, isNotNull);
+    expect(stored!.length, 100);
+
+    final exported = await tracker.exportLog();
+    expect(exported.first['tag'], 't5');
+  });
+}


### PR DESCRIPTION
## Summary
- add SmartBoosterExclusionTrackerService to log skipped boosters
- track entries in SharedPreferences under `booster_exclusion_log`
- test exclusion logging and entry limit

## Testing
- `flutter format lib/services/smart_booster_exclusion_tracker_service.dart lib/utils/shared_prefs_keys.dart test/services/smart_booster_exclusion_tracker_service_test.dart` *(fails: command not found)*
- `flutter test test/services/smart_booster_exclusion_tracker_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed452d52c832aa3f022f7202a9148