### PR TITLE
feat: add booster exclusion analytics dashboard service

### DIFF
--- a/lib/services/booster_exclusion_analytics_dashboard_service.dart
+++ b/lib/services/booster_exclusion_analytics_dashboard_service.dart
@@ -1,0 +1,61 @@
+import 'package:poker_analyzer/services/smart_booster_exclusion_tracker_service.dart';
+
+class BoosterExclusionAnalytics {
+  final Map<String, int> exclusionsByReason;
+  final Map<String, int> exclusionsByTag;
+  final Map<String, Map<String, int>> exclusionsByTagAndReason;
+
+  const BoosterExclusionAnalytics({
+    required this.exclusionsByReason,
+    required this.exclusionsByTag,
+    required this.exclusionsByTagAndReason,
+  });
+}
+
+class BoosterExclusionAnalyticsDashboardService {
+  const BoosterExclusionAnalyticsDashboardService();
+
+  Future<BoosterExclusionAnalytics> getDashboardData() async {
+    final log = await SmartBoosterExclusionTrackerService().exportLog();
+    final Map<String, int> byReason = {};
+    final Map<String, int> byTag = {};
+    final Map<String, Map<String, int>> byTagAndReason = {};
+
+    for (final entry in log) {
+      final tag = (entry['tag'] ?? '') as String;
+      final reason = (entry['reason'] ?? '') as String;
+
+      byReason[reason] = (byReason[reason] ?? 0) + 1;
+      byTag[tag] = (byTag[tag] ?? 0) + 1;
+
+      final reasonMap = byTagAndReason.putIfAbsent(tag, () => {});
+      reasonMap[reason] = (reasonMap[reason] ?? 0) + 1;
+    }
+
+    return BoosterExclusionAnalytics(
+      exclusionsByReason: byReason,
+      exclusionsByTag: byTag,
+      exclusionsByTagAndReason: byTagAndReason,
+    );
+  }
+
+  Future<void> printSummary() async {
+    final data = await getDashboardData();
+    final reasons = data.exclusionsByReason.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final tags = data.exclusionsByTag.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    print('Top exclusion reasons:');
+    for (int i = 0; i < reasons.length && i < 5; i++) {
+      final r = reasons[i];
+      print('${r.key}: ${r.value}');
+    }
+
+    print('Top exclusion tags:');
+    for (int i = 0; i < tags.length && i < 5; i++) {
+      final t = tags[i];
+      print('${t.key}: ${t.value}');
+    }
+  }
+}

--- a/test/services/booster_exclusion_analytics_dashboard_service_test.dart
+++ b/test/services/booster_exclusion_analytics_dashboard_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/booster_exclusion_analytics_dashboard_service.dart';
+import 'package:poker_analyzer/services/smart_booster_exclusion_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('aggregates exclusion statistics', () async {
+    final tracker = SmartBoosterExclusionTrackerService();
+    await tracker.logExclusion('t1', 'reasonA');
+    await tracker.logExclusion('t2', 'reasonA');
+    await tracker.logExclusion('t1', 'reasonB');
+
+    final service = BoosterExclusionAnalyticsDashboardService();
+    final data = await service.getDashboardData();
+
+    expect(data.exclusionsByReason['reasonA'], 2);
+    expect(data.exclusionsByReason['reasonB'], 1);
+
+    expect(data.exclusionsByTag['t1'], 2);
+    expect(data.exclusionsByTag['t2'], 1);
+
+    expect(data.exclusionsByTagAndReason['t1']?['reasonA'], 1);
+    expect(data.exclusionsByTagAndReason['t1']?['reasonB'], 1);
+    expect(data.exclusionsByTagAndReason['t2']?['reasonA'], 1);
+
+    await service.printSummary();
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterExclusionAnalyticsDashboardService to summarize exclusion reasons and tags
- cover analytics aggregation with unit test

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart': No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688ed7b276f0832abd39b4dc21f89797