### PR TITLE
feat: centralize shared preferences access

### DIFF
--- a/lib/services/goal_engine.dart
+++ b/lib/services/goal_engine.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'preferences_service.dart';
 import '../models/goal.dart';
 
 class GoalEngine extends ChangeNotifier {
@@ -17,7 +17,7 @@ class GoalEngine extends ChangeNotifier {
   List<Goal> get goals => List.unmodifiable(_goals);
 
   Future<void> _init() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final raw = prefs.getString(_prefsKey);
     if (raw != null) {
       try {
@@ -63,7 +63,7 @@ class GoalEngine extends ChangeNotifier {
   }
 
   Future<void> _save() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_prefsKey, jsonEncode([for (final g in _goals) g.toJson()]));
   }
 

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -1,0 +1,23 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../utils/shared_prefs_keys.dart';
+
+/// Provides a cached [SharedPreferences] instance and exports preference keys.
+class PreferencesService {
+  PreferencesService._();
+
+  static SharedPreferences? _prefs;
+
+  /// Returns the cached [SharedPreferences] instance, initializing it if necessary.
+  static Future<SharedPreferences> getInstance() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Accessor for the cached [SharedPreferences] instance.
+  ///
+  /// Ensure [getInstance] is called at least once before using this getter.
+  static SharedPreferences get instance => _prefs!;
+}
+
+// Re-export keys so consumers only need to import this service.
+export '../utils/shared_prefs_keys.dart';

--- a/lib/services/user_goal_engine.dart
+++ b/lib/services/user_goal_engine.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'preferences_service.dart';
 import '../models/user_goal.dart';
 import '../widgets/confetti_overlay.dart';
 import '../main.dart';
@@ -38,7 +38,7 @@ class UserGoalEngine extends ChangeNotifier {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final raw = prefs.getString(_prefsKey);
     if (raw != null) {
       _goals
@@ -48,7 +48,7 @@ class UserGoalEngine extends ChangeNotifier {
   }
 
   Future<void> _save() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_prefsKey, UserGoal.encode(_goals));
     unawaited(sync?.upload(_goals));
   }

--- a/lib/widgets/daily_spotlight_card.dart
+++ b/lib/widgets/daily_spotlight_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../services/preferences_service.dart';
 import '../services/daily_spotlight_service.dart';
 import '../screens/v2/training_pack_play_screen.dart';
 
@@ -17,14 +17,14 @@ class _DailySpotlightCardState extends State<DailySpotlightCard> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    PreferencesService.getInstance().then((p) {
       if (!mounted) return;
       setState(() => _hidden = p.getBool('hide_today_card') ?? false);
     });
   }
 
   Future<void> _hide() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = PreferencesService.instance;
     await prefs.setBool('hide_today_card', true);
     if (mounted) setState(() => _hidden = true);
   }


### PR DESCRIPTION
## Summary
- add PreferencesService singleton exposing cached SharedPreferences and SharedPrefsKeys
- use PreferencesService in GoalEngine, UserGoalEngine and DailySpotlightCard

## Testing
- `dart format lib/services/preferences_service.dart lib/services/goal_engine.dart lib/services/user_goal_engine.dart lib/widgets/daily_spotlight_card.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8bdba0c832a8c23253af9b1670e