### PR TITLE
refactor: use GoalType enum

### DIFF
--- a/lib/models/goal.dart
+++ b/lib/models/goal.dart
@@ -1,7 +1,9 @@
+enum GoalType { daily, weekly, progressive }
+
 class Goal {
   final String id;
   final String title;
-  final String type;
+  final GoalType type;
   final int targetXP;
   int currentXP;
   final DateTime deadline;
@@ -22,7 +24,7 @@ class Goal {
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
-        'type': type,
+        'type': type.name,
         'targetXP': targetXP,
         'currentXP': currentXP,
         'deadline': deadline.toIso8601String(),
@@ -33,7 +35,10 @@ class Goal {
   factory Goal.fromJson(Map<String, dynamic> json) => Goal(
         id: json['id'] as String,
         title: json['title'] as String,
-        type: json['type'] as String,
+        type: GoalType.values.firstWhere(
+          (e) => e.name == json['type'],
+          orElse: () => GoalType.daily,
+        ),
         targetXP: json['targetXP'] as int,
         currentXP: json['currentXP'] as int? ?? 0,
         deadline: DateTime.tryParse(json['deadline'] as String? ?? '') ?? DateTime.now(),

--- a/lib/services/goal_engine.dart
+++ b/lib/services/goal_engine.dart
@@ -38,7 +38,7 @@ class GoalEngine extends ChangeNotifier {
       Goal(
         id: 'daily',
         title: 'Earn 200 XP today',
-        type: 'daily',
+        type: GoalType.daily,
         targetXP: 200,
         currentXP: 0,
         deadline: DateTime(now.year, now.month, now.day).add(const Duration(days: 1)),
@@ -46,7 +46,7 @@ class GoalEngine extends ChangeNotifier {
       Goal(
         id: 'weekly',
         title: 'Reach level 10 this week',
-        type: 'weekly',
+        type: GoalType.weekly,
         targetXP: 1000,
         currentXP: 0,
         deadline: DateTime(now.year, now.month, now.day).add(Duration(days: 8 - now.weekday)),
@@ -54,7 +54,7 @@ class GoalEngine extends ChangeNotifier {
       Goal(
         id: 'progress',
         title: 'Earn 10K XP all-time',
-        type: 'progressive',
+        type: GoalType.progressive,
         targetXP: 10000,
         currentXP: 0,
         deadline: DateTime.now().add(const Duration(days: 3650)),


### PR DESCRIPTION
## Summary
- introduce `GoalType` enum to categorize goals
- switch `Goal.type` to use `GoalType` with updated JSON serialization
- update `GoalEngine` defaults to reference `GoalType` values

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8bf7674832abe31fd92284f4421