### PR TITLE
Cache locale for date format helpers

### DIFF
--- a/lib/helpers/date_utils.dart
+++ b/lib/helpers/date_utils.dart
@@ -1,16 +1,17 @@
 import 'package:intl/intl.dart';
 
+String? _locale;
+
+String _currentLocale() => _locale ??= Intl.getCurrentLocale();
+
 String formatDateTime(DateTime date) {
-  final locale = Intl.getCurrentLocale();
-  return DateFormat('dd.MM.yyyy HH:mm', locale).format(date);
+  return DateFormat('dd.MM.yyyy HH:mm', _currentLocale()).format(date);
 }
 
 String formatDate(DateTime date) {
-  final locale = Intl.getCurrentLocale();
-  return DateFormat('dd.MM.yyyy', locale).format(date);
+  return DateFormat('dd.MM.yyyy', _currentLocale()).format(date);
 }
 
 String formatLongDate(DateTime date) {
-  final locale = Intl.getCurrentLocale();
-  return DateFormat('d MMMM y', locale).format(date);
+  return DateFormat('d MMMM y', _currentLocale()).format(date);
 }


### PR DESCRIPTION
## Summary
- cache the current locale in a private helper
- refactor date format helpers to reuse the cached locale

## Testing
- `flutter test test/date_utils_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8c1299c832a9d6f80ce2535965c