### PR TITLE
Extract tag preset editor into reusable widget

### DIFF
--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -13,6 +13,7 @@ import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../../services/training_pack_tag_analytics_service.dart';
 import '../../utils/shared_prefs_keys.dart';
+import '../tag_preset_editor.dart';
 
 import '../../models/training_spot.dart';
 import '../../models/training_pack.dart';
@@ -125,8 +126,6 @@ class TrainingSpotListState extends State<TrainingSpotList>
 
   Future<MapEntry<String, List<String>>?> _editTagPreset(
       {String? initialName, List<String>? initialTags}) async {
-    final controller = TextEditingController(text: initialName ?? '');
-    final local = <String>{...(initialTags ?? [])};
     final suggestions = <String>{
       ..._availableTags,
       for (final list in _tagPresets.values) ...list,
@@ -135,70 +134,11 @@ class TrainingSpotListState extends State<TrainingSpotList>
     }..removeWhere((e) => e.isEmpty);
     final result = await showDialog<MapEntry<String, List<String>>>(
       context: context,
-      builder: (context) {
-        return AlertDialog(
-          backgroundColor: AppColors.cardBackground,
-          title: Text(
-            initialName == null ? 'Новый пресет' : 'Редактировать пресет',
-            style: const TextStyle(color: Colors.white),
-          ),
-          content: StatefulBuilder(
-            builder: (context, setStateDialog) {
-              return SizedBox(
-                width: 300,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    TextField(
-                      controller: controller,
-                      style: const TextStyle(color: Colors.white),
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'Название',
-                        labelStyle: TextStyle(color: Colors.white),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Expanded(
-                      child: ListView(
-                        shrinkWrap: true,
-                        children: [
-                          for (final tag in suggestions)
-                            CheckboxListTile(
-                              value: local.contains(tag),
-                              title: Text(tag,
-                                  style: const TextStyle(color: Colors.white)),
-                              onChanged: (v) {
-                                setStateDialog(() {
-                                  if (v ?? false) {
-                                    local.add(tag);
-                                  } else {
-                                    local.remove(tag);
-                                  }
-                                });
-                              },
-                            ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Отмена'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(
-                  context, MapEntry(controller.text.trim(), local.toList())),
-              child: const Text('OK'),
-            ),
-          ],
-        );
-      },
+      builder: (context) => TagPresetEditor(
+        initialName: initialName,
+        initialTags: initialTags,
+        suggestions: suggestions,
+      ),
     );
     if (result == null || result.key.isEmpty) return null;
     return result;

--- a/lib/widgets/tag_preset_editor.dart
+++ b/lib/widgets/tag_preset_editor.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+
+class TagPresetEditor extends StatefulWidget {
+  final String? initialName;
+  final List<String>? initialTags;
+  final Set<String> suggestions;
+
+  const TagPresetEditor({
+    super.key,
+    this.initialName,
+    this.initialTags,
+    required this.suggestions,
+  });
+
+  @override
+  State<TagPresetEditor> createState() => _TagPresetEditorState();
+}
+
+class _TagPresetEditorState extends State<TagPresetEditor> {
+  late final TextEditingController _controller;
+  late final Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName ?? '');
+    _selected = {...(widget.initialTags ?? const [])};
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppColors.cardBackground,
+      title: Text(
+        widget.initialName == null ? 'Новый пресет' : 'Редактировать пресет',
+        style: const TextStyle(color: Colors.white),
+      ),
+      content: SizedBox(
+        width: 300,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _controller,
+              style: const TextStyle(color: Colors.white),
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Название',
+                labelStyle: TextStyle(color: Colors.white),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  for (final tag in widget.suggestions)
+                    CheckboxListTile(
+                      value: _selected.contains(tag),
+                      title: Text(tag, style: const TextStyle(color: Colors.white)),
+                      onChanged: (v) {
+                        setState(() {
+                          if (v ?? false) {
+                            _selected.add(tag);
+                          } else {
+                            _selected.remove(tag);
+                          }
+                        });
+                      },
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Отмена'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(
+            context,
+            MapEntry(_controller.text.trim(), _selected.toList()),
+          ),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- refactor tag preset editing into dedicated `TagPresetEditor` widget
- simplify `_editTagPreset` to show the new dialog

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8c48598832ab0cf69798cf22003