### PR TITLE
refactor: extract goal streak helpers

### DIFF
--- a/lib/services/goal_streak_tracker_service.dart
+++ b/lib/services/goal_streak_tracker_service.dart
@@ -34,44 +34,70 @@ class GoalStreakTrackerService {
     final lastStr = prefs.getString(_lastKey);
     var current = prefs.getInt(_currentKey) ?? 0;
     var longest = prefs.getInt(_longestKey) ?? current;
-    DateTime? lastDay =
-        lastStr != null ? DateTime.tryParse(lastStr) : null;
+    DateTime? lastDay = lastStr != null ? DateTime.tryParse(lastStr) : null;
 
-    final logs = await GoalProgressPersistenceService.instance.getAllLogs();
-    if (logs.isNotEmpty) {
-      final days = <DateTime>[];
-      for (final l in logs..sort((a, b) => a.completedAt.compareTo(b.completedAt))) {
-        final d = DateTime(l.completedAt.year, l.completedAt.month, l.completedAt.day);
-        if (days.isEmpty || days.last != d) {
-          days.add(d);
-        }
-      }
-
-      int best = 1;
-      int count = 1;
-      for (var i = 1; i < days.length; i++) {
-        final diff = days[i].difference(days[i - 1]).inDays;
-        if (diff == 1) {
-          count += 1;
-        } else if (diff > 1) {
-          if (count > best) best = count;
-          count = 1;
-        }
-      }
-      if (count > best) best = count;
-      longest = best;
-      lastDay = days.last;
-      current = count;
-      final today = DateTime.now();
-      final diff = DateTime(today.year, today.month, today.day)
-          .difference(lastDay)
-          .inDays;
-      if (diff > 1) current = 0;
+    final days = await _loadLogs();
+    if (days.isNotEmpty) {
+      final result = _calculateStreak(days);
+      current = result.current;
+      longest = result.longest;
+      lastDay = result.lastDay;
     } else {
       current = 0;
       lastDay = null;
     }
 
+    await _persistStreak(prefs, current, longest, lastDay);
+
+    return GoalStreakInfo(
+      currentStreak: current,
+      longestStreak: longest,
+      lastCompletedDay: lastDay ?? DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  Future<List<DateTime>> _loadLogs() async {
+    final logs = await GoalProgressPersistenceService.instance.getAllLogs();
+    final days = <DateTime>[];
+    for (final l in logs) {
+      final d = DateTime(l.completedAt.year, l.completedAt.month, l.completedAt.day);
+      if (days.isEmpty || days.last != d) {
+        days.add(d);
+      }
+    }
+    return days;
+  }
+
+  ({int current, int longest, DateTime? lastDay}) _calculateStreak(
+      List<DateTime> days) {
+    if (days.isEmpty) {
+      return (current: 0, longest: 0, lastDay: null);
+    }
+
+    int best = 1;
+    int count = 1;
+    for (var i = 1; i < days.length; i++) {
+      final diff = days[i].difference(days[i - 1]).inDays;
+      if (diff == 1) {
+        count += 1;
+      } else if (diff > 1) {
+        if (count > best) best = count;
+        count = 1;
+      }
+    }
+    if (count > best) best = count;
+
+    final lastDay = days.last;
+    final today = DateTime.now();
+    final diff = DateTime(today.year, today.month, today.day)
+        .difference(lastDay)
+        .inDays;
+    final current = diff > 1 ? 0 : count;
+    return (current: current, longest: best, lastDay: lastDay);
+  }
+
+  Future<void> _persistStreak(SharedPreferences prefs, int current, int longest,
+      DateTime? lastDay) async {
     await prefs.setInt(_currentKey, current);
     await prefs.setInt(_longestKey, longest);
     if (lastDay != null) {
@@ -79,11 +105,5 @@ class GoalStreakTrackerService {
     } else {
       await prefs.remove(_lastKey);
     }
-
-    return GoalStreakInfo(
-      currentStreak: current,
-      longestStreak: longest,
-      lastCompletedDay: lastDay ?? DateTime.fromMillisecondsSinceEpoch(0),
-    );
   }
 }


### PR DESCRIPTION
## Summary
- add helper methods for loading logs, calculating streaks, and persisting state
- simplify `getStreakInfo` to orchestrate new helpers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8c62728832ab3f35f11d3fd7474