### PR TITLE
refactor hand type label matching

### DIFF
--- a/lib/helpers/hand_type_utils.dart
+++ b/lib/helpers/hand_type_utils.dart
@@ -1,5 +1,62 @@
-
 const _ranks = '23456789TJQKA';
+
+final Map<String, bool Function(String)> _labelMatchers = {
+  'PAIRS': (code) => code.length == 2,
+  'SMALL PAIRS': (code) {
+    final hi = code[0];
+    return code.length == 2 && _ranks.indexOf(hi) <= _ranks.indexOf('6');
+  },
+  'LOW PAIRS': (code) {
+    final hi = code[0];
+    return code.length == 2 && _ranks.indexOf(hi) <= _ranks.indexOf('6');
+  },
+  'MID PAIRS': (code) {
+    final hi = code[0];
+    return code.length == 2 &&
+        _ranks.indexOf(hi) > _ranks.indexOf('6') &&
+        _ranks.indexOf(hi) <= _ranks.indexOf('T');
+  },
+  'BIG PAIRS': (code) {
+    final hi = code[0];
+    return code.length == 2 && _ranks.indexOf(hi) > _ranks.indexOf('T');
+  },
+  'HIGH PAIRS': (code) {
+    final hi = code[0];
+    return code.length == 2 && _ranks.indexOf(hi) > _ranks.indexOf('T');
+  },
+  'SUITED CONNECTORS': (code) {
+    final hi = code[0];
+    final lo = code.length > 1 ? code[1] : '';
+    return code.endsWith('S') && _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  },
+  'OFFSUIT CONNECTORS': (code) {
+    final hi = code[0];
+    final lo = code.length > 1 ? code[1] : '';
+    return !code.endsWith('S') &&
+        _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  },
+  'CONNECTORS': (code) {
+    final hi = code[0];
+    final lo = code.length > 1 ? code[1] : '';
+    return _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
+  },
+  'SUITED AX': (code) {
+    final hi = code[0];
+    final lo = code.length > 1 ? code[1] : '';
+    return code.startsWith('A') &&
+        code.endsWith('S') &&
+        code.length == 3 &&
+        hi != lo;
+  },
+  'OFFSUIT AX': (code) {
+    final hi = code[0];
+    final lo = code.length > 1 ? code[1] : '';
+    return code.startsWith('A') &&
+        !code.endsWith('S') &&
+        code.length == 3 &&
+        hi != lo;
+  },
+};
 
 String? handTypeLabelError(String label) {
   final l = label.trim().toUpperCase();
@@ -20,71 +77,65 @@ String? handTypeLabelError(String label) {
     return null;
   }
   if (RegExp(r'^[2-9TJQKA]X[so]?$').hasMatch(l)) return null;
-  if (RegExp(r'^[2-9TJQKA]{2}(?:[so](?:\+)?|\+)?$').hasMatch(l)) return null;
+  if (RegExp(r'^[2-9TJQKA]{2}(?:[so](?:\\+)?|\\+)?$').hasMatch(l)) return null;
   return 'Invalid hand type (e.g. JXs, 76s+, suited connectors)';
 }
-
 
 bool matchHandTypeLabel(String label, String handCode) {
   final l = label.trim().toUpperCase();
   final code = handCode.toUpperCase();
-  final hi = code[0];
-  final lo = code.length > 1 ? code[1] : '';
-  final suited = code.endsWith('S');
-  if (l == 'PAIRS') return code.length == 2;
-  if (l == 'SMALL PAIRS' || l == 'LOW PAIRS') {
-    return code.length == 2 && _ranks.indexOf(hi) <= _ranks.indexOf('6');
-  }
-  if (l == 'MID PAIRS') {
-    return code.length == 2 &&
-        _ranks.indexOf(hi) > _ranks.indexOf('6') &&
-        _ranks.indexOf(hi) <= _ranks.indexOf('T');
-  }
-  if (l == 'BIG PAIRS' || l == 'HIGH PAIRS') {
-    return code.length == 2 && _ranks.indexOf(hi) > _ranks.indexOf('T');
-  }
-  if (l == 'SUITED CONNECTORS') {
-    return suited && _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
-  }
-  if (l == 'OFFSUIT CONNECTORS') {
-    return !suited && _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
-  }
-  if (l == 'CONNECTORS') {
-    return _ranks.indexOf(hi) - _ranks.indexOf(lo) == 1;
-  }
-  if (l == 'SUITED AX') {
-    return code.startsWith('A') && suited && code.length == 3 && hi != lo;
-  }
-  if (l == 'OFFSUIT AX') {
-    return code.startsWith('A') && !suited && code.length == 3 && hi != lo;
-  }
+  final matcher = _labelMatchers[l];
+  if (matcher != null) return matcher(code);
+
   final m1 = RegExp(r'^([2-9TJQKA])X([so])?$').firstMatch(l);
   if (m1 != null) {
     final r = m1.group(1)!;
     final s = m1.group(2);
-    if (code.length != 3 || code[0] != r || hi == lo) return false;
-    if (s == 'S' && !suited) return false;
-    if (s == 'O' && suited) return false;
-    return true;
+    bool fn(String c) {
+      final hi = c[0];
+      final lo = c.length > 1 ? c[1] : '';
+      final suited = c.endsWith('S');
+      if (c.length != 3 || hi != r || hi == lo) return false;
+      if (s == 'S' && !suited) return false;
+      if (s == 'O' && suited) return false;
+      return true;
+    }
+
+    _labelMatchers[l] = fn;
+    return fn(code);
   }
-  final m2 = RegExp(r'^([2-9TJQKA])([2-9TJQKA])([so](?:\+)?|\+)?$').firstMatch(l);
+
+  final m2 =
+      RegExp(r'^([2-9TJQKA])([2-9TJQKA])([so](?:\\+)?|\\+)?$').firstMatch(l);
   if (m2 != null) {
     final h = m2.group(1)!;
     final lw = m2.group(2)!;
     final s = m2.group(3);
     final plus = s?.contains('+') == true;
-    final hiIdx = _ranks.indexOf(hi);
-    final loIdx = _ranks.indexOf(lo);
     final hIdx = _ranks.indexOf(h);
     final lwIdx = _ranks.indexOf(lw);
-    final diff = hiIdx - loIdx;
     final baseDiff = hIdx - lwIdx;
-    if (s == 'S' && !suited) return false;
-    if (s == 'O' && suited) return false;
-    if (plus) {
-      return diff == baseDiff && hiIdx >= hIdx && loIdx >= lwIdx;
+    bool fn(String c) {
+      final hi = c[0];
+      final lo = c.length > 1 ? c[1] : '';
+      final suited = c.endsWith('S');
+      final hiIdx = _ranks.indexOf(hi);
+      final loIdx = _ranks.indexOf(lo);
+      final diff = hiIdx - loIdx;
+      if (s == 'S' && !suited) return false;
+      if (s == 'O' && suited) return false;
+      if (plus) {
+        return diff == baseDiff && hiIdx >= hIdx && loIdx >= lwIdx;
+      }
+      return c.startsWith('$h$lw') &&
+          diff == baseDiff &&
+          (s == null || (s == 'S' ? suited : !suited));
     }
-    return code.startsWith('$h$lw') && diff == baseDiff && (s == null || (s == 'S' ? suited : !suited));
+
+    _labelMatchers[l] = fn;
+    return fn(code);
   }
+
   return false;
 }
+


### PR DESCRIPTION
## Summary
- centralize hand label logic in `_labelMatchers`
- simplify `matchHandTypeLabel` by delegating to cached matcher functions

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ed8c87d08832ab09da482cd74c74f