### PR TITLE
Add ActionEntry extension helpers

### DIFF
--- a/lib/helpers/action_utils.dart
+++ b/lib/helpers/action_utils.dart
@@ -1,19 +1,19 @@
-// Helper utilities for working with ActionEntry lists.
+// Helper utilities and extensions for working with ActionEntry lists.
 import '../models/action_entry.dart';
 
-/// Returns true if [action] was performed by the hero at [heroIndex].
-bool isHeroAction(ActionEntry action, int heroIndex) {
-  return action.playerIndex == heroIndex;
+/// Extension helpers on [ActionEntry] for hero/opponent checks.
+extension ActionEntryX on ActionEntry {
+  /// Returns true if this action was performed by the hero at [heroIndex].
+  bool isHero(int heroIndex) => playerIndex == heroIndex;
+
+  /// Returns true if this action was performed by an opponent of the hero.
+  bool isOpponent(int heroIndex) => playerIndex != heroIndex;
 }
 
-/// Returns true if [action] was performed by an opponent of the hero.
-bool isOpponentAction(ActionEntry action, int heroIndex) {
-  return action.playerIndex != heroIndex;
+/// Provides convenient list helpers for [ActionEntry].
+extension ActionEntryListX on List<ActionEntry> {
+  /// Filters actions to only those taken by opponents of the hero.
+  List<ActionEntry> againstHero(int heroIndex) =>
+      where((a) => a.isOpponent(heroIndex)).toList();
 }
 
-/// Filters [actions] to only those taken by opponents of the hero.
-List<ActionEntry> actionsAgainstHero(List<ActionEntry> actions, int heroIndex) {
-  return actions
-      .where((ActionEntry a) => isOpponentAction(a, heroIndex))
-      .toList();
-}

--- a/lib/screens/training_pack_screen.dart
+++ b/lib/screens/training_pack_screen.dart
@@ -420,7 +420,7 @@ class _TrainingPackScreenState extends State<TrainingPackScreen>
     String userAct = '-';
     if (played != null) {
       for (final a in played.actions) {
-        if (isHeroAction(a, played.heroIndex)) {
+        if (a.isHero(played.heroIndex)) {
           userAct = a.action;
           break;
         }

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -81,8 +81,7 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
         final size = a.amount != null ? ' ${a.amount}' : '';
         final style = TextStyle(
           color: Colors.white,
-          fontWeight:
-              isHeroAction(a, widget.heroIndex) ? FontWeight.bold : null,
+          fontWeight: a.isHero(widget.heroIndex) ? FontWeight.bold : null,
         );
         return Row(
           children: [

--- a/test/helpers/action_utils_test.dart
+++ b/test/helpers/action_utils_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/helpers/action_utils.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+
+void main() {
+  test('ActionEntryX identifies hero and opponent', () {
+    final action = ActionEntry(0, 1, 'call');
+
+    expect(action.isHero(1), isTrue);
+    expect(action.isHero(0), isFalse);
+    expect(action.isOpponent(1), isFalse);
+    expect(action.isOpponent(0), isTrue);
+  });
+
+  test('ActionEntryListX filters opponent actions', () {
+    final actions = [
+      ActionEntry(0, 0, 'fold'),
+      ActionEntry(0, 1, 'call'),
+      ActionEntry(0, 2, 'raise'),
+    ];
+
+    final filtered = actions.againstHero(1);
+
+    expect(filtered.length, 2);
+    expect(filtered.every((a) => a.playerIndex != 1), isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `ActionEntryX` extension with `isHero` and `isOpponent` helpers
- add `ActionEntryListX` extension for filtering actions against hero
- update existing screens to use the new extensions and cover with tests

## Testing
- `flutter test test/helpers/action_utils_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8cc2238832abedd08bb7f5711f7