### PR TITLE
Refactor training filters and file utilities

### DIFF
--- a/lib/utils/training_spot_io.dart
+++ b/lib/utils/training_spot_io.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:csv/csv.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:file_saver/file_saver.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/training_spot.dart';
+
+Future<void> exportPack(BuildContext context, List<TrainingSpot> spots) async {
+  if (spots.isEmpty) return;
+  const encoder = JsonEncoder.withIndent('  ');
+  final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+  final dir = await getTemporaryDirectory();
+  final file = File(
+      '${dir.path}/training_spots_${DateTime.now().millisecondsSinceEpoch}.json');
+  await file.writeAsString(jsonStr);
+  await Share.shareXFiles([XFile(file.path)], text: 'training_spots.json');
+}
+
+Future<void> exportNamedPack(
+    BuildContext context, List<TrainingSpot> spots, String name) async {
+  if (spots.isEmpty) return;
+  const encoder = JsonEncoder.withIndent('  ');
+  final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+  final dir = await getTemporaryDirectory();
+  final safe = name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+  final file = File('${dir.path}/$safe.json');
+  await file.writeAsString(jsonStr);
+  await Share.shareXFiles([XFile(file.path)], text: '$safe.json');
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text('Пакет "$name" создан, спотов: ${spots.length}')),
+  );
+}
+
+Future<void> exportPackSummary(
+    BuildContext context, List<TrainingSpot> spots) async {
+  if (spots.isEmpty) return;
+  final buffer = StringBuffer();
+  for (final spot in spots) {
+    buffer.writeln(
+        'ID: ${spot.tournamentId ?? '-'}, Buy-In: ${spot.buyIn ?? '-'}, Game: ${spot.gameType ?? '-'}, Tags: ${spot.tags.length}');
+  }
+  final dir = await getTemporaryDirectory();
+  final file = File(
+      '${dir.path}/spot_summary_${DateTime.now().millisecondsSinceEpoch}.txt');
+  await file.writeAsString(buffer.toString());
+  await Share.shareXFiles([XFile(file.path)], text: 'spot_summary.txt');
+}
+
+Future<void> exportCsv(BuildContext context, List<TrainingSpot> spots,
+    {String? successMessage}) async {
+  if (spots.isEmpty) return;
+  final rows = <List<dynamic>>[];
+  rows.add(['ID', 'Difficulty', 'Rating', 'Tags', 'Buy-in', 'ICM', 'Date']);
+  final today = DateTime.now();
+  final dateStr =
+      '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+  for (final s in spots) {
+    rows.add([
+      s.tournamentId ?? '',
+      s.difficulty,
+      s.rating,
+      s.tags.join(';'),
+      s.buyIn ?? '',
+      s.tags.contains('ICM') ? '1' : '0',
+      dateStr,
+    ]);
+  }
+  final csvStr = const ListToCsvConverter().convert(rows, eol: '\r\n');
+  final bytes = Uint8List.fromList(utf8.encode(csvStr));
+  final name = 'training_spots_${DateTime.now().millisecondsSinceEpoch}';
+  try {
+    await FileSaver.instance.saveAs(
+      name: name,
+      bytes: bytes,
+      ext: 'csv',
+      mimeType: MimeType.csv,
+    );
+    final msg = successMessage ??
+        'Экспортировано ${spots.length} спотов в CSV';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg)),
+    );
+  } catch (_) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+  }
+}
+
+Future<List<TrainingSpot>> importFromFile(BuildContext context, String path) async {
+  final file = File(path);
+  try {
+    final content = await file.readAsString();
+    final data = jsonDecode(content);
+    if (data is! List) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+      return [];
+    }
+    final spots = <TrainingSpot>[];
+    for (final e in data) {
+      if (e is Map) {
+        try {
+          spots.add(TrainingSpot.fromJson(Map<String, dynamic>.from(e)));
+        } catch (_) {}
+      }
+    }
+    if (spots.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+      return [];
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Импортировано спотов: ${spots.length}')));
+    return spots;
+  } catch (_) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+    return [];
+  }
+}
+
+Future<List<TrainingSpot>> importPack(BuildContext context) async {
+  final result = await FilePicker.platform.pickFiles(
+    type: FileType.custom,
+    allowedExtensions: ['json'],
+  );
+  if (result == null || result.files.isEmpty) return [];
+  final path = result.files.single.path;
+  if (path == null) return [];
+  return await importFromFile(context, path);
+}

--- a/lib/widgets/common/tag_preset_dialog.dart
+++ b/lib/widgets/common/tag_preset_dialog.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import '../../theme/app_colors.dart';
+
+Future<MapEntry<String, List<String>>?> showTagPresetDialog(
+  BuildContext context, {
+  String? initialName,
+  List<String>? initialTags,
+  required Set<String> suggestions,
+}) async {
+  final controller = TextEditingController(text: initialName ?? '');
+  final local = <String>{...(initialTags ?? [])};
+  final result = await showDialog<MapEntry<String, List<String>>>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        backgroundColor: AppColors.cardBackground,
+        title: Text(
+          initialName == null ? 'Новый пресет' : 'Редактировать пресет',
+          style: const TextStyle(color: Colors.white),
+        ),
+        content: StatefulBuilder(
+          builder: (context, setStateDialog) {
+            return SizedBox(
+              width: 300,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: controller,
+                    style: const TextStyle(color: Colors.white),
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Название',
+                      labelStyle: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: [
+                        for (final tag in suggestions)
+                          CheckboxListTile(
+                            value: local.contains(tag),
+                            title: Text(tag,
+                                style: const TextStyle(color: Colors.white)),
+                            onChanged: (v) {
+                              setStateDialog(() {
+                                if (v ?? false) {
+                                  local.add(tag);
+                                } else {
+                                  local.remove(tag);
+                                }
+                              });
+                            },
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(
+                context, MapEntry(controller.text.trim(), local.toList())),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    },
+  );
+  return result;
+}

--- a/lib/widgets/common/training_spot_filters.dart
+++ b/lib/widgets/common/training_spot_filters.dart
@@ -1,0 +1,191 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../utils/shared_prefs_keys.dart';
+import 'training_spot_list_models.dart';
+
+class TrainingSpotFilters {
+  TrainingSpotFilters({
+    this.searchText = '',
+    Set<String>? selectedTags,
+    this.tagFiltersExpanded = true,
+    this.icmOnly = false,
+    this.ratedOnly = false,
+    this.hideCompleted = false,
+    this.listVisible = true,
+    Set<int>? difficultyFilters,
+    Set<int>? ratingFilters,
+    this.ratingSort,
+    this.simpleSortField,
+    this.simpleSortOrder = SimpleSortOrder.ascending,
+    this.listSort,
+    this.quickSort,
+    this.sortOption,
+    this.mistakesOnly = false,
+    this.activeQuickPreset,
+  })  : selectedTags = selectedTags ?? <String>{},
+        difficultyFilters = difficultyFilters ?? <int>{},
+        ratingFilters = ratingFilters ?? <int>{};
+
+  String searchText;
+  final Set<String> selectedTags;
+  bool tagFiltersExpanded;
+  bool icmOnly;
+  bool ratedOnly;
+  bool hideCompleted;
+  bool listVisible;
+  final Set<int> difficultyFilters;
+  final Set<int> ratingFilters;
+  RatingSortOrder? ratingSort;
+  SimpleSortField? simpleSortField;
+  SimpleSortOrder simpleSortOrder;
+  ListSortOption? listSort;
+  QuickSortOption? quickSort;
+  SortOption? sortOption;
+  bool mistakesOnly;
+  String? activeQuickPreset;
+
+  static Future<TrainingSpotFilters> load({required bool defaultIcmOnly}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final tags = prefs.getStringList(SharedPrefsKeys.trainingPresetTags) ?? <String>[];
+    final search = prefs.getString(SharedPrefsKeys.trainingPresetSearch) ?? '';
+    final expanded = prefs.getBool(SharedPrefsKeys.trainingPresetExpanded) ?? true;
+    final listVisible = prefs.getBool(SharedPrefsKeys.trainingSpotListVisible) ?? true;
+    final sortName = prefs.getString(SharedPrefsKeys.trainingPresetSort);
+    final ratingSortName = prefs.getString(SharedPrefsKeys.trainingPresetRatingSort);
+    final simpleFieldName = prefs.getString(SharedPrefsKeys.trainingSimpleSortField);
+    final simpleOrderName = prefs.getString(SharedPrefsKeys.trainingSimpleSortOrder);
+    final listSortName = prefs.getString(SharedPrefsKeys.trainingSpotListSort);
+    final quickSortName = prefs.getString(SharedPrefsKeys.trainingQuickSortOption);
+    final icmOnly = prefs.getBool(SharedPrefsKeys.trainingPresetIcmOnly) ?? defaultIcmOnly;
+    final ratedOnly = prefs.getBool(SharedPrefsKeys.trainingPresetRatedOnly) ?? false;
+    final hideCompleted = prefs.getBool(SharedPrefsKeys.trainingHideCompleted) ?? false;
+    final mistakesOnly = prefs.getBool(SharedPrefsKeys.trainingMistakesOnly) ?? false;
+    final diffs = prefs.getStringList(SharedPrefsKeys.trainingPresetDifficulties);
+    final ratings = prefs.getStringList(SharedPrefsKeys.trainingPresetRatings);
+    final quickPreset = prefs.getString(SharedPrefsKeys.trainingQuickPreset);
+
+    SortOption? sortOption;
+    if (sortName != null && sortName.isNotEmpty) {
+      try {
+        sortOption = SortOption.values.byName(sortName);
+      } catch (_) {}
+    }
+    RatingSortOrder? ratingSort;
+    if (ratingSortName != null && ratingSortName.isNotEmpty) {
+      try {
+        ratingSort = RatingSortOrder.values.byName(ratingSortName);
+      } catch (_) {}
+    }
+    SimpleSortField? simpleField;
+    if (simpleFieldName != null && simpleFieldName.isNotEmpty) {
+      try {
+        simpleField = SimpleSortField.values.byName(simpleFieldName);
+      } catch (_) {}
+    }
+    SimpleSortOrder simpleOrder = SimpleSortOrder.ascending;
+    if (simpleOrderName != null && simpleOrderName.isNotEmpty) {
+      try {
+        simpleOrder = SimpleSortOrder.values.byName(simpleOrderName);
+      } catch (_) {}
+    }
+    ListSortOption? listSort;
+    if (listSortName != null && listSortName.isNotEmpty) {
+      try {
+        listSort = ListSortOption.values.byName(listSortName);
+      } catch (_) {}
+    }
+    QuickSortOption? quickSort;
+    if (quickSortName != null && quickSortName.isNotEmpty) {
+      try {
+        quickSort = QuickSortOption.values.byName(quickSortName);
+      } catch (_) {}
+    }
+
+    final difficultyFilters = <int>{
+      if (diffs != null)
+        for (final d in diffs.map(int.tryParse).whereType<int>().where((d) => d >= 1 && d <= 5)) d,
+    };
+    final ratingFilters = <int>{
+      if (ratings != null)
+        for (final r in ratings.map(int.tryParse).whereType<int>().where((r) => r >= 1 && r <= 5)) r,
+    };
+
+    return TrainingSpotFilters(
+      searchText: search,
+      selectedTags: tags.toSet(),
+      tagFiltersExpanded: expanded,
+      icmOnly: icmOnly,
+      ratedOnly: ratedOnly,
+      hideCompleted: hideCompleted,
+      mistakesOnly: mistakesOnly,
+      listVisible: listVisible,
+      difficultyFilters: difficultyFilters,
+      ratingFilters: ratingFilters,
+      ratingSort: ratingSort,
+      simpleSortField: simpleField,
+      simpleSortOrder: simpleOrder,
+      listSort: listSort,
+      quickSort: quickSort,
+      sortOption: sortOption,
+      activeQuickPreset: quickPreset,
+    );
+  }
+
+  Future<void> save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(SharedPrefsKeys.trainingPresetTags, selectedTags.toList());
+    await prefs.setString(SharedPrefsKeys.trainingPresetSearch, searchText);
+    await prefs.setBool(SharedPrefsKeys.trainingPresetExpanded, tagFiltersExpanded);
+    await prefs.setBool(SharedPrefsKeys.trainingPresetIcmOnly, icmOnly);
+    await prefs.setBool(SharedPrefsKeys.trainingPresetRatedOnly, ratedOnly);
+    await prefs.setBool(SharedPrefsKeys.trainingHideCompleted, hideCompleted);
+    await prefs.setBool(SharedPrefsKeys.trainingMistakesOnly, mistakesOnly);
+    await prefs.setBool(SharedPrefsKeys.trainingSpotListVisible, listVisible);
+    if (difficultyFilters.isNotEmpty) {
+      await prefs.setStringList(
+        SharedPrefsKeys.trainingPresetDifficulties,
+        difficultyFilters.map((e) => e.toString()).toList(),
+      );
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingPresetDifficulties);
+    }
+    if (ratingFilters.isNotEmpty) {
+      await prefs.setStringList(
+        SharedPrefsKeys.trainingPresetRatings,
+        ratingFilters.map((e) => e.toString()).toList(),
+      );
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingPresetRatings);
+    }
+    if (ratingSort != null) {
+      await prefs.setString(SharedPrefsKeys.trainingPresetRatingSort, ratingSort!.name);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingPresetRatingSort);
+    }
+    if (simpleSortField != null) {
+      await prefs.setString(SharedPrefsKeys.trainingSimpleSortField, simpleSortField!.name);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingSimpleSortField);
+    }
+    await prefs.setString(SharedPrefsKeys.trainingSimpleSortOrder, simpleSortOrder.name);
+    if (listSort != null) {
+      await prefs.setString(SharedPrefsKeys.trainingSpotListSort, listSort!.name);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingSpotListSort);
+    }
+    if (quickSort != null) {
+      await prefs.setString(SharedPrefsKeys.trainingQuickSortOption, quickSort!.name);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingQuickSortOption);
+    }
+    if (sortOption != null) {
+      await prefs.setString(SharedPrefsKeys.trainingPresetSort, sortOption!.name);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingPresetSort);
+    }
+    if (activeQuickPreset != null) {
+      await prefs.setString(SharedPrefsKeys.trainingQuickPreset, activeQuickPreset!);
+    } else {
+      await prefs.remove(SharedPrefsKeys.trainingQuickPreset);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- centralize training spot filter state and persistence in new `TrainingSpotFilters`
- extract tag preset dialog builder and file import/export helpers into dedicated modules
- update training spot list to use new utilities

## Testing
- `dart format lib/widgets/common/training_spot_filters.dart lib/utils/training_spot_io.dart lib/widgets/common/tag_preset_dialog.dart lib/widgets/common/training_spot_list.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed8c34fb0832a93ba102ec32f2800