### PR TITLE
feat: add decay-based smart inbox boosters

### DIFF
--- a/lib/models/smart_inbox_item.dart
+++ b/lib/models/smart_inbox_item.dart
@@ -1,0 +1,13 @@
+class SmartInboxItem {
+  final String type;
+  final String tag;
+  final String source;
+  final double? urgency;
+
+  const SmartInboxItem({
+    required this.type,
+    required this.tag,
+    required this.source,
+    this.urgency,
+  });
+}

--- a/lib/services/decay_tag_retention_tracker_service.dart
+++ b/lib/services/decay_tag_retention_tracker_service.dart
@@ -84,4 +84,20 @@ class DecayTagRetentionTrackerService {
     }
     return result;
   }
+
+  /// Returns top decayed tags sorted by severity.
+  ///
+  /// Each entry contains the tag and its normalized decay score
+  /// (0-1 range where higher means more decayed).
+  Future<List<MapEntry<String, double>>> getMostDecayedTags(int limit,
+      {DateTime? now}) async {
+    if (limit <= 0) return [];
+    final scores = await getAllDecayScores(now: now);
+    final entries = scores.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    if (entries.length > limit) {
+      return entries.sublist(0, limit);
+    }
+    return entries;
+  }
 }

--- a/lib/services/smart_decay_inbox_booster_service.dart
+++ b/lib/services/smart_decay_inbox_booster_service.dart
@@ -1,0 +1,25 @@
+import '../models/smart_inbox_item.dart';
+import 'decay_tag_retention_tracker_service.dart';
+
+/// Surfaces booster inbox items for highly decayed tags.
+class SmartDecayInboxBoosterService {
+  final DecayTagRetentionTrackerService retention;
+
+  const SmartDecayInboxBoosterService({
+    DecayTagRetentionTrackerService? retention,
+  }) : retention = retention ?? const DecayTagRetentionTrackerService();
+
+  /// Returns [limit] top decayed tags as inbox booster items ordered by severity.
+  Future<List<SmartInboxItem>> getItems({int limit = 5}) async {
+    final entries = await retention.getMostDecayedTags(limit);
+    return [
+      for (final e in entries)
+        SmartInboxItem(
+          type: 'booster',
+          tag: e.key,
+          source: 'decayRecovery',
+          urgency: e.value,
+        ),
+    ];
+  }
+}

--- a/lib/widgets/inbox_pinned_block_booster_banner.dart
+++ b/lib/widgets/inbox_pinned_block_booster_banner.dart
@@ -7,6 +7,7 @@ import '../services/mini_lesson_library_service.dart';
 import '../screens/v2/training_pack_play_screen.dart';
 import '../screens/mini_lesson_screen.dart';
 import '../services/booster_interaction_tracker_service.dart';
+import '../services/decay_booster_training_launcher.dart';
 
 /// Banner that surfaces booster suggestions from pinned theory blocks with
 /// decayed tags.
@@ -19,6 +20,10 @@ class InboxPinnedBlockBoosterBanner extends StatelessWidget {
     BuildContext context,
     PinnedBlockBoosterSuggestion s,
   ) async {
+    if (s.action == 'decayBooster') {
+      await const DecayBoosterTrainingLauncher().launch();
+      return;
+    }
     if (s.action == 'resumePack' && s.packId != null) {
       final tpl = await PackLibraryService.instance.getById(s.packId!);
       if (tpl == null) return;
@@ -83,7 +88,11 @@ class InboxPinnedBlockBoosterBanner extends StatelessWidget {
                 ),
                 ActionChip(
                   label: Text(
-                    s.action == 'resumePack' ? '🎯 Drill' : '📘 Review',
+                    s.action == 'resumePack'
+                        ? '🎯 Drill'
+                        : s.action == 'decayBooster'
+                            ? '⚡ Boost'
+                            : '📘 Review',
                     style: const TextStyle(color: Colors.white),
                   ),
                   backgroundColor: accent,

--- a/test/services/decay_tag_retention_tracker_service_test.dart
+++ b/test/services/decay_tag_retention_tracker_service_test.dart
@@ -25,4 +25,15 @@ void main() {
     final ts = await tracker.getLastBoosterCompletion('call');
     expect(ts, isNotNull);
   });
+
+  test('returns most decayed tags', () async {
+    final tracker = const DecayTagRetentionTrackerService();
+    final now = DateTime.now();
+    await tracker.markBoosterCompleted('a', time: now.subtract(const Duration(days: 30)));
+    await tracker.markBoosterCompleted('b', time: now.subtract(const Duration(days: 10)));
+    final result = await tracker.getMostDecayedTags(2, now: now);
+    expect(result.length, 2);
+    expect(result.first.key, 'a');
+    expect(result.first.value, greaterThan(result.last.value));
+  });
 }

--- a/test/services/smart_decay_inbox_booster_service_test.dart
+++ b/test/services/smart_decay_inbox_booster_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/smart_decay_inbox_booster_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('builds inbox items for decayed tags', () async {
+    final retention = const DecayTagRetentionTrackerService();
+    final now = DateTime.now();
+    await retention.markBoosterCompleted('alpha',
+        time: now.subtract(const Duration(days: 40)));
+    await retention.markBoosterCompleted('beta',
+        time: now.subtract(const Duration(days: 20)));
+
+    final service = SmartDecayInboxBoosterService(retention: retention);
+    final items = await service.getItems(limit: 1);
+    expect(items.length, 1);
+    expect(items.first.tag, 'alpha');
+    expect(items.first.type, 'booster');
+    expect(items.first.source, 'decayRecovery');
+    expect(items.first.urgency, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- track and return most decayed tags
- surface decay-recovery boosters for Smart Inbox
- support launching decay boosters from inbox banner

## Testing
- `flutter test test/services/decay_tag_retention_tracker_service_test.dart test/services/smart_decay_inbox_booster_service_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688edd729594832aaf95c2668ec890d5