### PR TITLE
feat: add inbox delivery rule simulator

### DIFF
--- a/lib/services/inbox_delivery_rule_simulator_service.dart
+++ b/lib/services/inbox_delivery_rule_simulator_service.dart
@@ -1,0 +1,85 @@
+import 'smart_booster_exclusion_tracker_service.dart';
+import 'smart_booster_inbox_limiter_service.dart';
+import 'smart_inbox_heuristic_tuning_service.dart';
+
+class InboxSimulationResult {
+  final String tag;
+  final bool wouldShow;
+  final String reasonIfExcluded;
+
+  const InboxSimulationResult({
+    required this.tag,
+    required this.wouldShow,
+    required this.reasonIfExcluded,
+  });
+}
+
+/// Simulates Smart Inbox delivery decisions for debugging and tuning.
+class InboxDeliveryRuleSimulatorService {
+  InboxDeliveryRuleSimulatorService({
+    SmartInboxHeuristicTuningService? tuning,
+    SmartBoosterExclusionTrackerService? tracker,
+  })  : tuning = tuning ?? SmartInboxHeuristicTuningService(),
+        tracker = tracker ?? SmartBoosterExclusionTrackerService();
+
+  final SmartInboxHeuristicTuningService tuning;
+  final SmartBoosterExclusionTrackerService tracker;
+
+  /// Simulates whether each [tags] would be shown given current heuristics
+  /// and exclusion history.
+  Future<List<InboxSimulationResult>> simulate(List<String> tags) async {
+    await tuning.tuneHeuristics();
+    final log = await tracker.exportLog();
+    final now = DateTime.now();
+
+    final results = <InboxSimulationResult>[];
+    for (final tag in tags) {
+      final cooldown =
+          tuning.cooldownOverrides[tag] ?? SmartBoosterInboxLimiterService.tagCooldown;
+      final dailyLimit = SmartBoosterInboxLimiterService.maxPerDay +
+          (tuning.dailyLimitAdjustments[tag] ?? 0);
+
+      DateTime? lastRateLimited;
+      var rateLimitedCount = 0;
+      for (final entry in log) {
+        if (entry['tag'] != tag) continue;
+        final reason = entry['reason'] as String? ?? '';
+        if (reason != 'rateLimited') continue;
+        final tsStr = entry['timestamp'] as String?;
+        if (tsStr == null) continue;
+        final ts = DateTime.tryParse(tsStr);
+        if (ts == null) continue;
+        if (lastRateLimited == null || ts.isAfter(lastRateLimited)) {
+          lastRateLimited = ts;
+        }
+        if (now.difference(ts) < const Duration(hours: 24)) {
+          rateLimitedCount++;
+        }
+      }
+
+      var wouldShow = true;
+      var reason = '';
+      if (lastRateLimited != null && now.difference(lastRateLimited) < cooldown) {
+        wouldShow = false;
+        reason = 'cooldown';
+      } else if (rateLimitedCount >= dailyLimit) {
+        wouldShow = false;
+        reason = 'rateLimited';
+      }
+
+      results.add(InboxSimulationResult(
+          tag: tag, wouldShow: wouldShow, reasonIfExcluded: reason));
+    }
+    return results;
+  }
+
+  /// Prints a simple report for [results] to the console.
+  void printSimulationReport(List<InboxSimulationResult> results) {
+    for (final r in results) {
+      final status = r.wouldShow ? 'SHOW' : 'EXCLUDED (${r.reasonIfExcluded})';
+      // ignore: avoid_print
+      print('${r.tag}: $status');
+    }
+  }
+}
+

--- a/test/services/inbox_delivery_rule_simulator_service_test.dart
+++ b/test/services/inbox_delivery_rule_simulator_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/inbox_delivery_rule_simulator_service.dart';
+import 'package:poker_analyzer/services/smart_booster_exclusion_tracker_service.dart';
+import 'package:poker_analyzer/services/smart_inbox_heuristic_tuning_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('returns show when no history', () async {
+    final sim = InboxDeliveryRuleSimulatorService(
+      tuning: SmartInboxHeuristicTuningService(),
+      tracker: SmartBoosterExclusionTrackerService(),
+    );
+    final results = await sim.simulate(['t1']);
+    expect(results.single.wouldShow, true);
+  });
+
+  test('detects cooldown and rate limit with adjustments', () async {
+    final tracker = SmartBoosterExclusionTrackerService();
+    final tuning = SmartInboxHeuristicTuningService();
+    final sim = InboxDeliveryRuleSimulatorService(tuning: tuning, tracker: tracker);
+
+    // first exclusion triggers cooldown
+    await tracker.logExclusion('t1', 'rateLimited');
+    var results = await sim.simulate(['t1']);
+    expect(results.single.wouldShow, false);
+    expect(results.single.reasonIfExcluded, 'cooldown');
+
+    // override cooldown and hit rate limit
+    tuning.cooldownOverrides['t1'] = Duration.zero;
+    await tracker.logExclusion('t1', 'rateLimited');
+    results = await sim.simulate(['t1']);
+    expect(results.single.wouldShow, false);
+    expect(results.single.reasonIfExcluded, 'rateLimited');
+
+    // increase daily limit so tag would show
+    tuning.dailyLimitAdjustments['t1'] = 1;
+    results = await sim.simulate(['t1']);
+    expect(results.single.wouldShow, true);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add InboxDeliveryRuleSimulatorService to simulate Smart Inbox rule outcomes
- support reporting results with InboxSimulationResult
- test delivery rule simulator for cooldown and rate limit scenarios

## Testing
- `flutter test test/services/inbox_delivery_rule_simulator_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688edd024d04832a8c1df6b77c8fcdb9