### PR TITLE
feat: add reusable duration formatter

### DIFF
--- a/lib/helpers/date_utils.dart
+++ b/lib/helpers/date_utils.dart
@@ -15,3 +15,12 @@ String formatDate(DateTime date) {
 String formatLongDate(DateTime date) {
   return DateFormat('d MMMM y', _currentLocale()).format(date);
 }
+
+String formatDuration(Duration d) {
+  final hours = d.inHours;
+  final minutes = d.inMinutes.remainder(60);
+  final parts = <String>[];
+  if (hours > 0) parts.add('${hours}ч');
+  parts.add('${minutes}м');
+  return parts.join(' ');
+}

--- a/lib/screens/compare_sessions_screen.dart
+++ b/lib/screens/compare_sessions_screen.dart
@@ -42,15 +42,6 @@ class _CompareSessionsScreenState extends State<CompareSessionsScreen> {
     setState(() {});
   }
 
-  String _formatDuration(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60);
-    final parts = <String>[];
-    if (h > 0) parts.add('$hч');
-    parts.add('$mм');
-    return parts.join(' ');
-  }
-
   Widget _buildRow(String label, String left, String right) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -132,7 +123,7 @@ class _CompareSessionsScreenState extends State<CompareSessionsScreen> {
           _buildRow('Споты', _first!.results.length.toString(), _second!.results.length.toString()),
           _buildRow('Верно', firstCorrect.toString(), secondCorrect.toString()),
           _buildRow('Ошибки', firstMistakes.toString(), secondMistakes.toString()),
-          _buildRow('Длительность', _formatDuration(firstDuration), _formatDuration(secondDuration)),
+          _buildRow('Длительность', formatDuration(firstDuration), formatDuration(secondDuration)),
           if (spots.isNotEmpty) ...[
             const SizedBox(height: 16),
             const Text('Совпадающие споты', style: TextStyle(color: Colors.white)),

--- a/lib/screens/pack_history_screen.dart
+++ b/lib/screens/pack_history_screen.dart
@@ -9,15 +9,6 @@ class PackHistoryScreen extends StatelessWidget {
   final String title;
   const PackHistoryScreen({super.key, required this.templateId, required this.title});
 
-  String _formatDuration(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60);
-    final parts = <String>[];
-    if (h > 0) parts.add('$hч');
-    parts.add('$mм');
-    return parts.join(' ');
-  }
-
   @override
   Widget build(BuildContext context) {
     final logs = context
@@ -55,7 +46,7 @@ class PackHistoryScreen extends StatelessWidget {
                     style: const TextStyle(color: Colors.white),
                   ),
                   subtitle: Text(
-                    '${acc.toStringAsFixed(1)}% • ${_formatDuration(duration)}',
+                    '${acc.toStringAsFixed(1)}% • ${formatDuration(duration)}',
                     style: const TextStyle(color: Colors.white70),
                   ),
                 );

--- a/lib/screens/poker_analyzer/playback_controls_widget.dart
+++ b/lib/screens/poker_analyzer/playback_controls_widget.dart
@@ -110,7 +110,7 @@ class _PlaybackControlsSection extends StatelessWidget {
               ),
               const SizedBox(height: 4),
               Text(
-                "Step $playbackIndex / $actionCount${isPlaying ? " - " + _formatDuration(elapsedTime) : ""}",
+                "Step $playbackIndex / $actionCount${isPlaying ? " - " + formatDuration(elapsedTime) : ""}",
                 style: const TextStyle(color: Colors.white),
               ),
             ],
@@ -236,8 +236,4 @@ class PlaybackControls extends StatelessWidget {
     );
   }
 }
-String _formatDuration(Duration d) {
-  final minutes = d.inMinutes.remainder(60).toString().padLeft(2, '0');
-  final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
-  return '$minutes:$seconds';
-}
+

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -63,15 +63,6 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
     return 'Other';
   }
 
-  String _formatDuration(Duration d) {
-    final hours = d.inHours;
-    final minutes = d.inMinutes.remainder(60);
-    final parts = <String>[];
-    if (hours > 0) parts.add('$hoursч');
-    parts.add('$minutesм');
-    return parts.join(' ');
-  }
-
   PageRouteBuilder _buildSwipeRoute(int targetId, {required bool fromRight}) {
     final begin = fromRight ? const Offset(1, 0) : const Offset(-1, 0);
     return PageRouteBuilder(
@@ -126,7 +117,7 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
                   style: const TextStyle(color: Colors.white)),
               Text('Конец: ${formatDateTime(end)}',
                   style: const TextStyle(color: Colors.white)),
-              Text('Длительность: ${_formatDuration(duration)}',
+              Text('Длительность: ${formatDuration(duration)}',
                   style: const TextStyle(color: Colors.white)),
               const SizedBox(height: 4),
               Text('Верно: $correct • Ошибки: $incorrect',

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/common/session_accuracy_distribution_chart.dart';
 import '../widgets/common/mistake_by_street_chart.dart';
 import '../widgets/common/session_volume_accuracy_chart.dart';
 import '../helpers/poker_street_helper.dart';
+import '../helpers/date_utils.dart';
 import 'saved_hands_screen.dart';
 import 'mistake_overview_screen.dart';
 import 'accuracy_mistake_overview_screen.dart';
@@ -92,15 +93,6 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
         .where((h) => _selectedStreets.contains(h.boardStreet.clamp(0, 3)))
         .toList();
     return hands;
-  }
-
-  String _formatDuration(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60);
-    final parts = <String>[];
-    if (h > 0) parts.add('$hч');
-    parts.add('$mм');
-    return parts.join(' ');
   }
 
   List<_WeekData> _weeklyWinrates(Map<int, List<SavedHand>> data) {
@@ -575,7 +567,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
       ..writeln('# Статистика сессий')
       ..writeln('- Всего раздач: ${summary.totalHands}')
       ..writeln(
-          '- Средняя длительность: ${_formatDuration(summary.avgDuration)}');
+          '- Средняя длительность: ${formatDuration(summary.avgDuration)}');
     if (summary.overallAccuracy != null) {
       buffer.writeln(
           '- Точность: ${summary.overallAccuracy!.toStringAsFixed(1)}%');
@@ -671,7 +663,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
             pw.Text('Всего раздач: ${summary.totalHands}',
                 style: pw.TextStyle(font: regularFont)),
             pw.Text(
-                'Средняя длительность: ${_formatDuration(summary.avgDuration)}',
+                'Средняя длительность: ${formatDuration(summary.avgDuration)}',
                 style: pw.TextStyle(font: regularFont)),
             if (summary.overallAccuracy != null)
               pw.Text(
@@ -894,8 +886,8 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
               ),
             ),
           _buildStat('Всего раздач', summary.totalHands.toString(), scale),
-          _buildStat('Сред. длительность', _formatDuration(summary.avgDuration),
-              scale),
+          _buildStat(
+              'Сред. длительность', formatDuration(summary.avgDuration), scale),
           if (summary.overallAccuracy != null)
             _buildStat('Точность',
                 '${summary.overallAccuracy!.toStringAsFixed(1)}%', scale),


### PR DESCRIPTION
## Summary
- add shared `formatDuration` helper
- use `formatDuration` across session and playback screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688edd07026c832a9507d8c7cf6ec9a5