### PR TITLE
Refactor training spot list and library

### DIFF
--- a/lib/services/training_spot_file_service.dart
+++ b/lib/services/training_spot_file_service.dart
@@ -1,8 +1,13 @@
 import 'dart:io';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:csv/csv.dart';
+import 'package:file_saver/file_saver.dart';
 
 import '../models/training_spot.dart';
 import 'training_import_export_service.dart';
@@ -63,5 +68,162 @@ class TrainingSpotFileService {
       );
     }
     return file.path;
+  }
+
+  Future<void> exportSpotsCsv(BuildContext context, List<TrainingSpot> spots,
+      {String? successMessage}) async {
+    if (spots.isEmpty) return;
+    final rows = <List<dynamic>>[];
+    rows.add(['ID', 'Difficulty', 'Rating', 'Tags', 'Buy-in', 'ICM', 'Date']);
+    final today = DateTime.now();
+    final dateStr =
+        '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+    for (final s in spots) {
+      rows.add([
+        s.tournamentId ?? '',
+        s.difficulty,
+        s.rating,
+        s.tags.join(';'),
+        s.buyIn ?? '',
+        s.tags.contains('ICM') ? '1' : '0',
+        dateStr,
+      ]);
+    }
+
+    final csvStr = const ListToCsvConverter().convert(rows, eol: '\r\n');
+    final bytes = Uint8List.fromList(utf8.encode(csvStr));
+    final name = 'training_spots_${DateTime.now().millisecondsSinceEpoch}';
+    try {
+      await FileSaver.instance.saveAs(
+        name: name,
+        bytes: bytes,
+        ext: 'csv',
+        mimeType: MimeType.csv,
+      );
+      if (context.mounted) {
+        final msg = successMessage ??
+            'Экспортировано ${spots.length} спотов в CSV';
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(msg)));
+      }
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+      }
+    }
+  }
+
+  Future<List<TrainingSpot>> importSpotsJson(
+      BuildContext context, String path) async {
+    final file = File(path);
+    try {
+      final content = await file.readAsString();
+      final data = jsonDecode(content);
+      if (data is! List) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+        }
+        return [];
+      }
+      final spots = <TrainingSpot>[];
+      for (final e in data) {
+        if (e is Map) {
+          try {
+            spots.add(TrainingSpot.fromJson(Map<String, dynamic>.from(e)));
+          } catch (_) {}
+        }
+      }
+      if (spots.isEmpty) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+        }
+        return [];
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(
+                SnackBar(content: Text('Импортировано спотов: ${spots.length}')));
+      }
+      return spots;
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+      }
+      return [];
+    }
+  }
+
+  Future<List<TrainingSpot>> pickAndImportSpots(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.isEmpty) return [];
+    final path = result.files.single.path;
+    if (path == null) return [];
+    return importSpotsJson(context, path);
+  }
+
+  Future<void> exportPack(List<TrainingSpot> spots) async {
+    if (spots.isEmpty) return;
+    const encoder = JsonEncoder.withIndent('  ');
+    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+    final dir = await getTemporaryDirectory();
+    final file = File(
+        '${dir.path}/training_spots_${DateTime.now().millisecondsSinceEpoch}.json');
+    await file.writeAsString(jsonStr);
+    await Share.shareXFiles([XFile(file.path)], text: 'training_spots.json');
+  }
+
+  Future<void> exportNamedPack(
+      BuildContext context, List<TrainingSpot> spots, String name) async {
+    if (spots.isEmpty) return;
+    const encoder = JsonEncoder.withIndent('  ');
+    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
+    final dir = await getTemporaryDirectory();
+    final safe = name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    final file = File('${dir.path}/$safe.json');
+    await file.writeAsString(jsonStr);
+    await Share.shareXFiles([XFile(file.path)], text: '$safe.json');
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Пакет "$name" создан, спотов: ${spots.length}')),
+      );
+    }
+  }
+
+  Future<void> exportPackSummary(List<TrainingSpot> spots) async {
+    if (spots.isEmpty) return;
+    final buffer = StringBuffer();
+    for (final spot in spots) {
+      buffer.writeln(
+          'ID: ${spot.tournamentId ?? '-'}, Buy-In: ${spot.buyIn ?? '-'}, Game: ${spot.gameType ?? '-'}, Tags: ${spot.tags.length}');
+    }
+    final dir = await getTemporaryDirectory();
+    final file = File(
+        '${dir.path}/spot_summary_${DateTime.now().millisecondsSinceEpoch}.txt');
+    await file.writeAsString(buffer.toString());
+    await Share.shareXFiles([XFile(file.path)], text: 'spot_summary.txt');
+  }
+
+  Future<void> shareSpotsCsv(List<TrainingSpot> spots) async {
+    if (spots.isEmpty) return;
+    final rows = <List<String>>[];
+    rows.add(['date', 'position', 'stackChips', 'tags']);
+    for (final s in spots) {
+      final pos = s.positions.isNotEmpty ? s.positions[s.heroIndex] : '';
+      final stack = s.stacks.isNotEmpty ? s.stacks[s.heroIndex].toString() : '';
+      final date = s.createdAt.toIso8601String();
+      rows.add([date, pos, stack, s.tags.join(';')]);
+    }
+    final csv = const ListToCsvConverter().convert(rows);
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/spots_${DateTime.now().millisecondsSinceEpoch}.csv');
+    await file.writeAsString(csv);
+    await Share.shareXFiles([XFile(file.path)]);
   }
 }

--- a/lib/widgets/common/training_spot_filters.dart
+++ b/lib/widgets/common/training_spot_filters.dart
@@ -1,0 +1,23 @@
+const List<String> kAvailableTags = [
+  '3бет пот',
+  'Фиш',
+  'Рег',
+  'ICM',
+  'vs агро',
+];
+
+const Map<String, List<String>> kTagPresets = {
+  '3бет пот': ['3бет пот'],
+  'Фиш': ['Фиш'],
+  'Рег': ['Рег'],
+  'ICM': ['ICM'],
+  'vs агро': ['vs агро'],
+};
+
+const Map<String, String> kQuickFilterPresets = {
+  'ICM': 'ICM',
+  'Push/Fold': 'Push/Fold',
+  'Postflop': 'Postflop',
+  '3-bet': '3-bet',
+  'Bubble': 'Bubble',
+};

--- a/lib/widgets/common/training_spot_list.dart
+++ b/lib/widgets/common/training_spot_list.dart
@@ -1,19 +1,17 @@
 import 'package:flutter/material.dart';
 import 'dart:math';
 import 'dart:convert';
-import 'dart:io';
-import 'package:path_provider/path_provider.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:file_picker/file_picker.dart';
-import 'package:csv/csv.dart';
-import 'package:file_saver/file_saver.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
+import 'package:path_provider/path_provider.dart';
 import '../../services/training_pack_tag_analytics_service.dart';
 import '../../utils/shared_prefs_keys.dart';
 import '../tag_preset_editor.dart';
+import 'training_spot_filters.dart';
+import '../../services/training_spot_file_service.dart';
+import 'dart:io';
 
 import '../../models/training_spot.dart';
 import '../../models/training_pack.dart';
@@ -46,32 +44,10 @@ class TrainingSpotList extends StatefulWidget {
 class TrainingSpotListState extends State<TrainingSpotList>
     with TickerProviderStateMixin {
   final TextEditingController _searchController = TextEditingController();
+  final TrainingSpotFileService _fileService = const TrainingSpotFileService();
 
   bool _presetsLoaded = false;
   bool _orderRestored = false;
-  static const List<String> _availableTags = [
-    '3бет пот',
-    'Фиш',
-    'Рег',
-    'ICM',
-    'vs агро',
-  ];
-
-  static const Map<String, List<String>> _tagPresets = {
-    '3бет пот': ['3бет пот'],
-    'Фиш': ['Фиш'],
-    'Рег': ['Рег'],
-    'ICM': ['ICM'],
-    'vs агро': ['vs агро'],
-  };
-
-  static const Map<String, String> _quickFilterPresets = {
-    'ICM': 'ICM',
-    'Push/Fold': 'Push/Fold',
-    'Postflop': 'Postflop',
-    '3-bet': '3-bet',
-    'Bubble': 'Bubble',
-  };
 
   Map<String, List<String>> _customTagPresets = {};
 
@@ -127,8 +103,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
   Future<MapEntry<String, List<String>>?> _editTagPreset(
       {String? initialName, List<String>? initialTags}) async {
     final suggestions = <String>{
-      ..._availableTags,
-      for (final list in _tagPresets.values) ...list,
+      ...kAvailableTags,
+      for (final list in kTagPresets.values) ...list,
       for (final list in _customTagPresets.values) ...list,
       for (final s in widget.spots) ...s.tags,
     }..removeWhere((e) => e.isEmpty);
@@ -150,7 +126,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
       builder: (context) {
         return StatefulBuilder(
           builder: (context, setStateDialog) {
-            final staticEntries = _tagPresets.entries.toList();
+            final staticEntries = kTagPresets.entries.toList();
             final customEntries = _customTagPresets.entries.toList();
             return AlertDialog(
               backgroundColor: AppColors.cardBackground,
@@ -445,7 +421,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
     _activeQuickPreset = quickPreset;
     if (_activeQuickPreset != null) {
       _prevQuickTags = Set<String>.from(_selectedTags);
-      final tag = _quickFilterPresets[_activeQuickPreset!];
+      final tag = kQuickFilterPresets[_activeQuickPreset!];
       if (tag != null) {
         _selectedTags
           ..clear()
@@ -779,7 +755,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                     Wrap(
                       spacing: 4,
                       children: [
-                        for (final tag in _availableTags)
+                        for (final tag in kAvailableTags)
                           FilterChip(
                             label: Text(tag),
                             selected: localTags.contains(tag),
@@ -1109,7 +1085,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                 child: ListView(
                   shrinkWrap: true,
                   children: [
-                    for (final tag in _availableTags)
+                    for (final tag in kAvailableTags)
                       CheckboxListTile(
                         value: localTags.contains(tag),
                         title:
@@ -1159,8 +1135,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
 
   Future<void> _quickAddTagsForSpot(TrainingSpot spot) async {
     final suggestions = <String>{
-      ...TrainingSpotListState._availableTags,
-      for (final list in TrainingSpotListState._tagPresets.values) ...list,
+      ...kAvailableTags,
+      for (final list in kTagPresets.values) ...list,
       for (final list in _customTagPresets.values) ...list,
       for (final s in widget.spots) ...s.tags,
     }..removeWhere((e) => e.isEmpty);
@@ -1381,8 +1357,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
     if (count == 0) return;
 
     final suggestions = <String>{
-      ...TrainingSpotListState._availableTags,
-      for (final list in TrainingSpotListState._tagPresets.values) ...list,
+      ...kAvailableTags,
+      for (final list in kTagPresets.values) ...list,
       for (final list in _customTagPresets.values) ...list,
       for (final s in widget.spots) ...s.tags,
     }..removeWhere((e) => e.isEmpty);
@@ -1926,8 +1902,8 @@ class TrainingSpotListState extends State<TrainingSpotList>
     }
 
     final suggestions = <String>{
-      ...TrainingSpotListState._availableTags,
-      for (final list in TrainingSpotListState._tagPresets.values) ...list,
+      ...kAvailableTags,
+      for (final list in kTagPresets.values) ...list,
       for (final list in _customTagPresets.values) ...list,
       for (final s in widget.spots) ...s.tags,
     }..removeWhere((e) => e.isEmpty);
@@ -2118,7 +2094,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                           _prevQuickTags = Set<String>.from(_selectedTags);
                         }
                         _activeQuickPreset = value;
-                        final tag = _quickFilterPresets[value];
+                        final tag = kQuickFilterPresets[value];
                         if (tag != null) {
                           _selectedTags
                             ..clear()
@@ -2241,7 +2217,7 @@ class TrainingSpotListState extends State<TrainingSpotList>
                     },
                     onPresetSelected: (value) {
                       if (value == null) return;
-                      final tags = TrainingSpotListState._tagPresets[value] ??
+                      final tags = kTagPresets[value] ??
                           _customTagPresets[value];
                       if (tags == null) return;
                       setState(() {
@@ -3815,9 +3791,9 @@ class TrainingSpotListState extends State<TrainingSpotList>
     final popular = [for (final a in analytics.getPopularTags()) a.tag];
     final tags = [
       for (final t in popular)
-        if (_availableTags.contains(t)) t,
+        if (kAvailableTags.contains(t)) t,
       ...[
-        for (final t in _availableTags)
+        for (final t in kAvailableTags)
           if (!popular.contains(t)) t
       ]
     ];
@@ -4090,150 +4066,36 @@ class TrainingSpotListState extends State<TrainingSpotList>
   }
 
   Future<void> _exportPack(List<TrainingSpot> spots) async {
-    if (spots.isEmpty) return;
-    const encoder = JsonEncoder.withIndent('  ');
-    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
-    final dir = await getTemporaryDirectory();
-    final file = File(
-        '${dir.path}/training_spots_${DateTime.now().millisecondsSinceEpoch}.json');
-    await file.writeAsString(jsonStr);
-    await Share.shareXFiles([XFile(file.path)], text: 'training_spots.json');
+    await _fileService.exportPack(spots);
   }
 
   Future<void> _exportNamedPack(List<TrainingSpot> spots, String name) async {
-    if (spots.isEmpty) return;
-    const encoder = JsonEncoder.withIndent('  ');
-    final jsonStr = encoder.convert([for (final s in spots) s.toJson()]);
-    final dir = await getTemporaryDirectory();
-    final safe = name.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
-    final file = File('${dir.path}/$safe.json');
-    await file.writeAsString(jsonStr);
-    await Share.shareXFiles([XFile(file.path)], text: '$safe.json');
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Пакет "$name" создан, спотов: ${spots.length}')),
-      );
-    }
+    await _fileService.exportNamedPack(context, spots, name);
   }
 
   Future<void> _exportPackSummary(List<TrainingSpot> spots) async {
-    if (spots.isEmpty) return;
-    final buffer = StringBuffer();
-    for (final spot in spots) {
-      buffer.writeln(
-          'ID: ${spot.tournamentId ?? '-'}, Buy-In: ${spot.buyIn ?? '-'}, Game: ${spot.gameType ?? '-'}, Tags: ${spot.tags.length}');
-    }
-    final dir = await getTemporaryDirectory();
-    final file = File(
-        '${dir.path}/spot_summary_${DateTime.now().millisecondsSinceEpoch}.txt');
-    await file.writeAsString(buffer.toString());
-    await Share.shareXFiles([XFile(file.path)], text: 'spot_summary.txt');
+    await _fileService.exportPackSummary(spots);
   }
 
   Future<void> _exportCsv(List<TrainingSpot> spots,
       {String? successMessage}) async {
-    if (spots.isEmpty) return;
-
-    final rows = <List<dynamic>>[];
-    rows.add(['ID', 'Difficulty', 'Rating', 'Tags', 'Buy-in', 'ICM', 'Date']);
-    final today = DateTime.now();
-    final dateStr =
-        '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
-    for (final s in spots) {
-      rows.add([
-        s.tournamentId ?? '',
-        s.difficulty,
-        s.rating,
-        s.tags.join(';'),
-        s.buyIn ?? '',
-        s.tags.contains('ICM') ? '1' : '0',
-        dateStr,
-      ]);
-    }
-
-    final csvStr = const ListToCsvConverter().convert(rows, eol: '\r\n');
-    final bytes = Uint8List.fromList(utf8.encode(csvStr));
-    final name = 'training_spots_${DateTime.now().millisecondsSinceEpoch}';
-    try {
-      await FileSaver.instance.saveAs(
-        name: name,
-        bytes: bytes,
-        ext: 'csv',
-        mimeType: MimeType.csv,
-      );
-      if (mounted) {
-        final msg = successMessage ??
-            'Экспортировано ${spots.length} спотов в CSV';
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(msg)),
-        );
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
-      }
-    }
-  }
-
-  Future<void> _importFromFile(String path) async {
-    final file = File(path);
-    try {
-      final content = await file.readAsString();
-      final data = jsonDecode(content);
-      if (data is! List) {
-        if (mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
-        }
-        return;
-      }
-      final spots = <TrainingSpot>[];
-      for (final e in data) {
-        if (e is Map) {
-          try {
-            spots.add(TrainingSpot.fromJson(Map<String, dynamic>.from(e)));
-          } catch (_) {}
-        }
-      }
-      if (spots.isEmpty) {
-        if (mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
-        }
-        return;
-      }
-      setState(() => widget.spots.addAll(spots));
-      widget.onChanged?.call();
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Импортировано спотов: ${spots.length}')));
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
-      }
-    }
+    await _fileService.exportSpotsCsv(context, spots,
+        successMessage: successMessage);
   }
 
   Future<void> _importPack() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['json'],
-    );
-    if (result == null || result.files.isEmpty) return;
-    final path = result.files.single.path;
-    if (path == null) return;
-    await _importFromFile(path);
+    final spots = await _fileService.pickAndImportSpots(context);
+    if (spots.isEmpty) return;
+    setState(() => widget.spots.addAll(spots));
+    widget.onChanged?.call();
   }
 
   Future<void> _handleDrop(DropDoneDetails details) async {
     for (final item in details.files) {
-      final path = item.path;
-      if (path.toLowerCase().endsWith('.json')) {
-        await _importFromFile(path);
-      }
+      final spots = await _fileService.importSpotsJson(context, item.path);
+      if (spots.isEmpty) continue;
+      setState(() => widget.spots.addAll(spots));
+      widget.onChanged?.call();
     }
   }
 
@@ -4561,7 +4423,7 @@ class _TagFilterSection extends StatelessWidget {
           dropdownColor: AppColors.cardBackground,
           style: const TextStyle(color: Colors.white),
           items: [
-            for (final entry in TrainingSpotListState._tagPresets.entries)
+            for (final entry in kTagPresets.entries)
               DropdownMenuItem(
                 value: entry.key,
                 child: Text(entry.key),
@@ -5193,7 +5055,7 @@ class _QuickPresetRow extends StatelessWidget {
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
-          for (final entry in TrainingSpotListState._quickFilterPresets.entries)
+          for (final entry in kQuickFilterPresets.entries)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4.0),
               child: ChoiceChip(

--- a/lib/widgets/training_spot_filter_panel.dart
+++ b/lib/widgets/training_spot_filter_panel.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class TrainingSpotFilterPanel extends StatelessWidget {
+  final Set<String> tags;
+  final Set<String> positions;
+  final String positionValue;
+  final String tagValue;
+  final ValueChanged<String?> onPositionChanged;
+  final ValueChanged<String?> onTagChanged;
+
+  const TrainingSpotFilterPanel({
+    super.key,
+    required this.tags,
+    required this.positions,
+    required this.positionValue,
+    required this.tagValue,
+    required this.onPositionChanged,
+    required this.onTagChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          DropdownButton<String>(
+            value: positionValue,
+            underline: const SizedBox.shrink(),
+            onChanged: onPositionChanged,
+            items: ['All', ...positions]
+                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                .toList(),
+          ),
+          const SizedBox(width: 12),
+          DropdownButton<String>(
+            value: tagValue,
+            underline: const SizedBox.shrink(),
+            onChanged: onTagChanged,
+            items: ['All', ...tags]
+                .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/training_spot_list_body.dart
+++ b/lib/widgets/training_spot_list_body.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_spot.dart';
+
+class TrainingSpotListBody extends StatelessWidget {
+  final List<TrainingSpot> spots;
+  final Set<TrainingSpot> selected;
+  final void Function(TrainingSpot) onToggle;
+  final Future<void> Function(TrainingSpot) onDelete;
+  final VoidCallback onAddTag;
+  final VoidCallback onRemoveTag;
+  final VoidCallback onExportCsv;
+
+  const TrainingSpotListBody({
+    super.key,
+    required this.spots,
+    required this.selected,
+    required this.onToggle,
+    required this.onDelete,
+    required this.onAddTag,
+    required this.onRemoveTag,
+    required this.onExportCsv,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        ListView.builder(
+          itemCount: spots.length,
+          itemBuilder: (context, index) {
+            final s = spots[index];
+            final isSelected = selected.contains(s);
+            final pos = s.positions.isNotEmpty ? s.positions[s.heroIndex] : '';
+            final stack = s.stacks.isNotEmpty ? s.stacks[s.heroIndex] : 0;
+            return Dismissible(
+              key: ValueKey(s.createdAt),
+              direction: DismissDirection.endToStart,
+              background: Container(
+                color: Colors.red,
+                alignment: Alignment.centerRight,
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: const Icon(Icons.delete, color: Colors.white),
+              ),
+              confirmDismiss: (_) async {
+                await onDelete(s);
+                return false;
+              },
+              child: ListTile(
+                leading: Checkbox(
+                  value: isSelected,
+                  onChanged: (_) => onToggle(s),
+                ),
+                title: Text('$pos ${stack}bb'),
+                subtitle: s.tags.isNotEmpty ? Text(s.tags.join(', ')) : null,
+                onTap: () => onToggle(s),
+              ),
+            );
+          },
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 300),
+            height: selected.isNotEmpty ? 56 : 0,
+            child: selected.isNotEmpty
+                ? Container(
+                    color: Colors.black54,
+                    padding: const EdgeInsets.all(8),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        ElevatedButton(
+                            onPressed: onAddTag,
+                            child: const Text('🏷 Add Tag')),
+                        ElevatedButton(
+                            onPressed: onRemoveTag,
+                            child: const Text('❌ Remove Tag')),
+                        ElevatedButton(
+                            onPressed: onExportCsv,
+                            child: const Text('📄 Export CSV')),
+                      ],
+                    ),
+                  )
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/training_spot_search_bar.dart
+++ b/lib/widgets/training_spot_search_bar.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class TrainingSpotSearchBar extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  const TrainingSpotSearchBar({super.key, required this.controller, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: TextField(
+        controller: controller,
+        decoration: const InputDecoration(hintText: 'Search'),
+        onChanged: onChanged,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- centralize tag presets and quick filters in new `training_spot_filters.dart`
- move spot import/export and sharing to a dedicated `TrainingSpotFileService`
- split training spot library screen into search bar, filter panel, and list body widgets

## Testing
- `flutter format lib/widgets/common/training_spot_filters.dart lib/widgets/common/training_spot_list.dart lib/widgets/training_spot_search_bar.dart lib/widgets/training_spot_filter_panel.dart lib/widgets/training_spot_list_body.dart lib/screens/training_spot_library_screen.dart lib/services/training_spot_file_service.dart` *(command failed: flutter: command not found)*
- `flutter test` *(command failed: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688edd0c2760832aa4f8bd2ca7e90ff5