### PR TITLE
Refactor backup management helpers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,8 @@ This document summarizes the current set of services used by the Poker Analyzer 
 - **ActionSyncService** – central event bus for actions; synchronizes playback index, folded players and stack manager.
 - **ActionTagService** – manages per-player action tags and serializes them with hands.
 - **BackupManagerService** – creates, loads and cleans up evaluation queue backups.
-- **BackupService** – low level helper used by `BackupManagerService` to persist backup files.
+- **BackupFileManager** – low level helper used by `BackupManagerService` for file operations.
+- **EvaluationQueueSerializer** – encodes/decodes `ActionEvaluationRequest` queue states.
 - **BoardEditingService** – validates board edits and warns about inconsistent card choices.
 - **BoardManagerService** – controls board street transitions, visible cards and locks during playback.
 - **BoardRevealService** – animates board card reveal sequences while respecting transition locks.

--- a/lib/services/evaluation_queue_serializer.dart
+++ b/lib/services/evaluation_queue_serializer.dart
@@ -1,0 +1,61 @@
+import '../models/action_evaluation_request.dart';
+import 'package:uuid/uuid.dart';
+
+/// Handles encoding and decoding of evaluation queue requests.
+class EvaluationQueueSerializer {
+  const EvaluationQueueSerializer();
+
+  /// Encodes lists of requests into a JSON-friendly map.
+  Map<String, dynamic> encodeQueues({
+    required List<ActionEvaluationRequest> pending,
+    required List<ActionEvaluationRequest> failed,
+    required List<ActionEvaluationRequest> completed,
+  }) {
+    return {
+      'pending': [for (final e in pending) e.toJson()],
+      'failed': [for (final e in failed) e.toJson()],
+      'completed': [for (final e in completed) e.toJson()],
+    };
+  }
+
+  /// Decodes a JSON representation into request queues.
+  Map<String, List<ActionEvaluationRequest>> decodeQueues(dynamic json) {
+    if (json is List) {
+      return {
+        'pending': decodeList(json),
+        'failed': <ActionEvaluationRequest>[],
+        'completed': <ActionEvaluationRequest>[],
+      };
+    } else if (json is Map) {
+      return {
+        'pending': decodeList(json['pending']),
+        'failed': decodeList(json['failed']),
+        'completed': decodeList(json['completed']),
+      };
+    }
+    throw const FormatException();
+  }
+
+  ActionEvaluationRequest _decodeRequest(Map<String, dynamic> json) {
+    final map = Map<String, dynamic>.from(json);
+    if (map['id'] == null || map['id'] is! String || (map['id'] as String).isEmpty) {
+      map['id'] = const Uuid().v4();
+    }
+    return ActionEvaluationRequest.fromJson(map);
+  }
+
+  List<ActionEvaluationRequest> decodeList(dynamic list) {
+    final items = <ActionEvaluationRequest>[];
+    if (list is List) {
+      for (final item in list) {
+        if (item is Map) {
+          try {
+            items.add(_decodeRequest(Map<String, dynamic>.from(item)));
+          } catch (_) {}
+        }
+      }
+    }
+    return items;
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce `EvaluationQueueSerializer` to handle `ActionEvaluationRequest` encode/decode
- extract file operations into new `BackupFileManager`
- update `BackupManagerService` to orchestrate helpers and adjust docs

## Testing
- `dart format lib/services/backup_file_manager.dart lib/services/backup_manager_service.dart lib/services/evaluation_queue_serializer.dart ARCHITECTURE.md` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y dart-sdk` *(fails: Unable to locate package dart-sdk)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688edd11fa88832a875812aea414b1e5