### PR TITLE
Refactor evaluation execution architecture

### DIFF
--- a/lib/services/evaluation_cache.dart
+++ b/lib/services/evaluation_cache.dart
@@ -1,0 +1,16 @@
+import '../models/eval_result.dart';
+
+/// Simple in-memory cache for [EvalResult]s keyed by request hash.
+class EvaluationCache {
+  final Map<String, EvalResult> _cache = {};
+
+  /// Retrieves a cached result for [key] if present.
+  EvalResult? get(String key) => _cache[key];
+
+  /// Stores [value] in cache for [key].
+  void set(String key, EvalResult value) => _cache[key] = value;
+
+  /// Clears all cached results.
+  void clear() => _cache.clear();
+}
+

--- a/lib/services/evaluation_queue.dart
+++ b/lib/services/evaluation_queue.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'dart:collection';
+
+import '../models/eval_request.dart';
+import '../models/eval_result.dart';
+
+/// Serial queue for processing [EvalRequest]s one at a time.
+class EvaluationQueue {
+  EvaluationQueue(this._processor);
+
+  final Future<EvalResult> Function(EvalRequest) _processor;
+  final Queue<_QueueItem> _queue = Queue();
+  bool _processing = false;
+
+  /// Enqueues [request] for processing and returns its eventual [EvalResult].
+  Future<EvalResult> enqueue(EvalRequest request) {
+    final completer = Completer<EvalResult>();
+    _queue.add(_QueueItem(request, completer));
+    _process();
+    return completer.future;
+  }
+
+  void _process() {
+    if (_processing || _queue.isEmpty) return;
+    _processing = true;
+    final item = _queue.removeFirst();
+    _processor(item.request).then(item.completer.complete).catchError((e, s) {
+      item.completer.completeError(e, s);
+    }).whenComplete(() {
+      _processing = false;
+      _process();
+    });
+  }
+}
+
+class _QueueItem {
+  final EvalRequest request;
+  final Completer<EvalResult> completer;
+  _QueueItem(this.request, this.completer);
+}
+


### PR DESCRIPTION
## Summary
- Extract caching into a new `EvaluationCache` utility
- Introduce `EvaluationQueue` to serialize evaluation requests
- Refactor `EvaluationExecutorService` to orchestrate queue and cache while tracking stats

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688edd155e40832aafd5604b8e095b63