### PR TITLE
feat: include mvp push fold pack in default library

### DIFF
--- a/test/mvp_pack_library_test.dart
+++ b/test/mvp_pack_library_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('MVP push/fold pack is loaded and first', () async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final pack = TrainingPackLibraryV2.instance.getById('push_fold_mvp');
+    expect(pack, isNotNull);
+    expect(pack!.name, 'Push/Fold Beginner Pack');
+    expect(pack.audience, 'Beginner');
+    expect(pack.trainingType.name, 'pushFold');
+    final first = TrainingPackLibraryV2.instance.packs.first;
+    expect(first.id, 'push_fold_mvp');
+  });
+}


### PR DESCRIPTION
## Summary
- load training packs from `assets/training_packs/` alongside existing library
- ensure only v2 schema packs are added and sort library to show MVP pack first
- test that the MVP push/fold pack loads with expected metadata

## Testing
- `flutter test` *(fails: The current Dart SDK version is 3.3.1. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_688ee501f3fc832ab9b3e4de055559fe