### PR TITLE
Modularize PokerAnalyzerScreen components

### DIFF
--- a/lib/screens/components/poker_analyzer_screen_components.dart
+++ b/lib/screens/components/poker_analyzer_screen_components.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
 
-import '../models/player_model.dart';
-import '../theme/app_colors.dart';
-import '../theme/constants.dart';
-import '../widgets/hand_completion_indicator.dart';
-import 'poker_analyzer/action_controls_widget.dart';
-import 'poker_analyzer/board_controls_widget.dart';
+import '../../models/player_model.dart';
+import '../../theme/app_colors.dart';
+import '../../theme/constants.dart';
+import '../../widgets/hand_completion_indicator.dart';
+import '../poker_analyzer/action_controls_widget.dart';
+import '../poker_analyzer/board_controls_widget.dart';
+import '../poker_analyzer/action_editor_widget.dart';
+import '../poker_analyzer/evaluation_panel_widget.dart';
 
-class GameplayAreaWidget extends StatelessWidget {
+class AnalyzerTableAreaWidget extends StatelessWidget {
   final bool landscape;
   final double uiScale;
-  const GameplayAreaWidget({
+  const AnalyzerTableAreaWidget({
     super.key,
     required this.landscape,
     required this.uiScale,
@@ -48,9 +50,26 @@ class GameplayAreaWidget extends StatelessWidget {
   }
 }
 
-class SmartInboxContainer extends StatelessWidget {
+class AnalyzerSidebarWidget extends StatelessWidget {
+  const AnalyzerSidebarWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      flex: 2,
+      child: Column(
+        children: const [
+          Expanded(child: ActionEditor()),
+          Expanded(child: EvaluationPanel()),
+        ],
+      ),
+    );
+  }
+}
+
+class SmartInboxRegion extends StatelessWidget {
   final String? message;
-  const SmartInboxContainer({super.key, this.message});
+  const SmartInboxRegion({super.key, this.message});
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +78,7 @@ class SmartInboxContainer extends StatelessWidget {
   }
 }
 
-class AnalyzerHUDPanel extends StatelessWidget {
+class AnalyzerTopHUD extends StatelessWidget {
   final String handName;
   final int playerCount;
   final String streetName;
@@ -72,7 +91,7 @@ class AnalyzerHUDPanel extends StatelessWidget {
   final bool disabled;
   final int handProgressStep;
 
-  const AnalyzerHUDPanel({
+  const AnalyzerTopHUD({
     super.key,
     required this.handName,
     required this.playerCount,

--- a/lib/screens/poker_analyzer_screen.dart
+++ b/lib/screens/poker_analyzer_screen.dart
@@ -123,11 +123,7 @@ import 'package:poker_analyzer/plugins/plugin_manager.dart';
 import 'package:poker_analyzer/plugins/plugin_loader.dart';
 import 'package:poker_analyzer/plugins/plugin.dart';
 import '../services/demo_playback_controller.dart';
-import 'poker_analyzer/board_controls_widget.dart';
-import 'poker_analyzer/action_editor_widget.dart';
-import 'poker_analyzer/evaluation_panel_widget.dart';
-import 'poker_analyzer/action_controls_widget.dart';
-import 'poker_analyzer_screen_components.dart';
+import 'components/poker_analyzer_screen_components.dart';
 part 'poker_analyzer/debug_dialog.dart';
 
 class PokerAnalyzerScreen extends StatefulWidget {
@@ -5498,7 +5494,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
 
 
               final content = <Widget>[
-                AnalyzerHUDPanel(
+                AnalyzerTopHUD(
                   handName: _handContext.currentHandName ?? 'New Hand',
                   playerCount: numberOfPlayers,
                   streetName: ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][currentStreet],
@@ -5512,7 +5508,7 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                   disabled: lockService.isLocked,
                   handProgressStep: _handProgressStep(),
                 ),
-                SmartInboxContainer(message: hint),
+                SmartInboxRegion(message: hint),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4.0),
                   child: Text(
@@ -5520,12 +5516,11 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
                     style: const TextStyle(color: Colors.white, fontSize: 16),
                   ),
                 ),
-                GameplayAreaWidget(
+                AnalyzerTableAreaWidget(
                   landscape: landscape,
                   uiScale: _uiScale,
                 ),
-                const Expanded(child: ActionEditor()),
-                const Expanded(child: EvaluationPanel()),
+                const AnalyzerSidebarWidget(),
               ];
               return AnimatedPadding(
                 duration: const Duration(milliseconds: 200),


### PR DESCRIPTION
## Summary
- extract AnalyzerTableAreaWidget, AnalyzerSidebarWidget, SmartInboxRegion and AnalyzerTopHUD into dedicated components
- simplify PokerAnalyzerScreen by using new modular widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee7b50114832ab5ad7d0ecbb8bb70