### PR TITLE
Add push/fold intro mini theory lesson

### DIFF
--- a/assets/theory_mini_lessons/theory_push_fold_intro.yaml
+++ b/assets/theory_mini_lessons/theory_push_fold_intro.yaml
@@ -1,0 +1,23 @@
+id: lesson_push_fold_intro
+title: 'Push/Fold Basics'
+content: 'Core concepts of the push/fold strategy.'
+tags:
+  - pushFold
+  - beginner
+  - level1
+linkedPackIds:
+  - push_fold_mvp
+parts:
+  - title: 'What is push/fold?'
+    content: |
+      Push/fold is a short-stack strategy where you either move all-in or
+      fold before the flop. It simplifies decisions and maximizes fold equity.
+  - title: 'Why 10bb?'
+    content: |
+      Around ten big blinds, traditional raises commit a large portion of your
+      stack. Shoving avoids tough postflop spots and leverages fold equity.
+  - title: 'How to decide'
+    content: |
+      Compare your hand to recommended ranges, consider position and opponents,
+      then choose to push all-in or fold to preserve your stack.
+type: mini

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -9,7 +9,10 @@ class MiniLessonLibraryService {
   MiniLessonLibraryService._();
   static final MiniLessonLibraryService instance = MiniLessonLibraryService._();
 
-  static const String _dir = 'assets/mini_lessons/';
+  static const List<String> _dirs = [
+    'assets/mini_lessons/',
+    'assets/theory_mini_lessons/',
+  ];
 
   final List<TheoryMiniLessonNode> _lessons = [];
   final Map<String, TheoryMiniLessonNode> _byId = {};
@@ -30,7 +33,7 @@ class MiniLessonLibraryService {
     _byTag.clear();
     final manifest = await AssetManifest.instance;
     final paths = manifest.keys
-        .where((p) => p.startsWith(_dir) && p.endsWith('.yaml'))
+        .where((p) => _dirs.any((d) => p.startsWith(d)) && p.endsWith('.yaml'))
         .toList();
     for (final path in paths) {
       try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,6 +113,7 @@ flutter:
     - assets/theory_blocks/
     - assets/theory_tracks/
     - assets/mini_lessons/
+    - assets/theory_mini_lessons/
     - assets/mini_lesson_library.yaml
     - assets/lessons/
     - assets/lesson_tracks/


### PR DESCRIPTION
## Summary
- add a beginner push/fold mini theory lesson linked to the push_fold_mvp pack
- load mini theory lessons from new assets/theory_mini_lessons directory
- include new theory_mini_lessons path in asset bundle

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee9c9c760832ab757f1f0b4b83d66