### PR TITLE
feat: show intro lesson before push fold mvp

### DIFF
--- a/test/services/training_session_launcher_intro_lesson_test.dart
+++ b/test/services/training_session_launcher_intro_lesson_test.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/screens/training_session_screen.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('shows intro lesson before training', (tester) async {
+    final tpl = TrainingPackTemplateV2(
+      id: TrainingPackLibraryV2.mvpPackId,
+      name: 'MVP',
+      trainingType: TrainingType.pushFold,
+      gameType: GameType.tournament,
+      spots: [TrainingPackSpot(id: 's1')],
+      spotCount: 1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox.shrink()),
+    );
+
+    unawaited(const TrainingSessionLauncher().launch(tpl));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Push/Fold Basics'), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- inject push/fold intro mini lesson when launching MVP training pack
- test to ensure intro lesson shows before training

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*


------
https://chatgpt.com/codex/tasks/task_e_688eeb3a33b4832a9185efd3d0a3355e