### PR TITLE
feat: add training completion screen

### DIFF
--- a/lib/screens/training_session_completion_screen.dart
+++ b/lib/screens/training_session_completion_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/v2/training_pack_template.dart';
+import '../services/training_session_service.dart';
+import 'training_pack_template_list_screen.dart';
+import 'training_session_screen.dart';
+
+class TrainingSessionCompletionScreen extends StatelessWidget {
+  final TrainingPackTemplate template;
+  final int hands;
+  const TrainingSessionCompletionScreen({
+    super.key,
+    required this.template,
+    required this.hands,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Training Complete')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'You completed $hands hands!',
+              style: theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () async {
+                await context
+                    .read<TrainingSessionService>()
+                    .startSession(template, persist: false, startIndex: 0);
+                if (!context.mounted) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TrainingSessionScreen(),
+                  ),
+                );
+              },
+              child: const Text('Try Again'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TrainingPackTemplateListScreen(),
+                  ),
+                );
+              },
+              child: const Text('Choose Another Pack'),
+            ),
+            const SizedBox(height: 12),
+            TextButton(
+              onPressed: () {
+                Navigator.popUntil(context, (route) => route.isFirst);
+              },
+              child: const Text('Exit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/training_progress_logger.dart
+++ b/lib/services/training_progress_logger.dart
@@ -10,5 +10,13 @@ class TrainingProgressLogger {
   static Future<void> startSession(String packId) async {
     unawaited(UserActionLogger.instance.log('training_session_start:$packId'));
   }
+
+  /// Records completion of a training session for the given [packId].
+  static Future<void> completeSession(String packId, int hands) async {
+    unawaited(
+      UserActionLogger.instance
+          .log('training_session_complete:$packId:$hands'),
+    );
+  }
 }
 


### PR DESCRIPTION
## Summary
- add TrainingSessionCompletionScreen with options to retry, choose another pack, or exit
- log training completion via TrainingProgressLogger
- show completion screen when a session finishes

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eed946c7c832a98542c31a2405e7d