### PR TITLE
feat: add BTN cash push-fold training pack

### DIFF
--- a/assets/packs/v2/library_index.json
+++ b/assets/packs/v2/library_index.json
@@ -197,6 +197,27 @@
     }
   },
   {
+    "id": "push_fold_btn_cash",
+    "name": "BTN Push/Fold Cash 10bb",
+    "description": "Short stack BTN shove or fold decisions",
+    "type": "cash",
+    "gameType": "cash",
+    "bb": 10,
+    "spotCount": 8,
+    "positions": [
+      "btn"
+    ],
+    "tags": [
+      "pushFold",
+      "btn",
+      "cash",
+      "beginner"
+    ],
+    "meta": {
+      "icon": "cash"
+    }
+  },
+  {
     "id": "open_fold_mid_cash",
     "name": "Open/Fold Mid Cash",
     "description": "Open or fold from LJ, HJ and CO in cash games",

--- a/test/push_fold_btn_cash_library_test.dart
+++ b/test/push_fold_btn_cash_library_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('BTN cash push/fold pack loads and filters correctly', () async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final pack = TrainingPackLibraryV2.instance.getById('push_fold_btn_cash');
+    expect(pack, isNotNull);
+    expect(pack!.name, 'BTN Push/Fold Cash 10bb');
+    expect(pack.meta['schemaVersion'], '2.0.0');
+    expect(TrainingPackLibraryV2.instance.packs.first.id,
+        TrainingPackLibraryV2.mvpPackId);
+    final filtered = TrainingPackLibraryV2.instance
+        .filterBy(tags: ['pushFold', 'btn', 'cash', 'beginner']);
+    expect(filtered.map((p) => p.id), contains('push_fold_btn_cash'));
+  });
+}


### PR DESCRIPTION
## Summary
- add BTN cash push/fold pack to training library index
- test that BTN cash push/fold pack loads and filters correctly

## Testing
- `flutter test test/push_fold_btn_cash_library_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688ef26221e8832aa17d8080f0bca71e