### PR TITLE
Add BTN cash push/fold auto-theory mini lesson

### DIFF
--- a/assets/theory_mini_lessons/lesson_push_fold_btn_cash.yaml
+++ b/assets/theory_mini_lessons/lesson_push_fold_btn_cash.yaml
@@ -1,0 +1,24 @@
+id: lesson_push_fold_btn_cash
+title: 'BTN Cash Push/Fold'
+content: 'Why and how to shove from the Button in cash games.'
+tags:
+  - pushFold
+  - btn
+  - cash
+  - beginner
+linkedPackIds:
+  - push_fold_btn_cash
+parts:
+  - title: 'Button position'
+    content: |
+      In cash games the Button acts last after the flop. This positional edge lets you
+      shove wider, knowing the blinds must act first postflop.
+  - title: 'Leveraging fold equity'
+    content: |
+      Your shove threatens the blinds with losing their entire stack. Many hands
+      fold, allowing you to win the pot immediately and avoid tricky flops.
+  - title: 'Understanding cash blinds'
+    content: |
+      Unlike tournaments, cash blind sizes never increase. Preserving chips matters,
+      so choose shoves that keep a workable stack while exploiting the blinds.
+type: mini

--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -30,11 +30,16 @@ class TrainingSessionLauncher {
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
 
+    String? lessonId;
     if (template.id == TrainingPackLibraryV2.mvpPackId) {
+      lessonId = 'lesson_push_fold_intro';
+    } else if (template.id == 'push_fold_btn_cash') {
+      lessonId = 'lesson_push_fold_btn_cash';
+    }
+
+    if (lessonId != null) {
       await MiniLessonLibraryService.instance.loadAll();
-      final lesson = MiniLessonLibraryService.instance.getById(
-        'lesson_push_fold_intro',
-      );
+      final lesson = MiniLessonLibraryService.instance.getById(lessonId);
       if (lesson != null) {
         await Navigator.push(
           ctx,

--- a/test/services/training_session_launcher_btn_cash_lesson_test.dart
+++ b/test/services/training_session_launcher_btn_cash_lesson_test.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/main.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/screens/training_session_screen.dart';
+import 'package:poker_analyzer/services/training_session_launcher.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('shows btn cash lesson before training', (tester) async {
+    final tpl = TrainingPackTemplateV2(
+      id: 'push_fold_btn_cash',
+      name: 'BTN Cash',
+      trainingType: TrainingType.pushFold,
+      gameType: GameType.cash,
+      spots: [TrainingPackSpot(id: 's1')],
+      spotCount: 1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(navigatorKey: navigatorKey, home: const SizedBox.shrink()),
+    );
+
+    unawaited(const TrainingSessionLauncher().launch(tpl));
+    await tester.pumpAndSettle();
+
+    expect(find.text('BTN Cash Push/Fold'), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TrainingSessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add BTN cash push/fold theory mini lesson and tag it to push_fold_btn_cash pack
- show the mini lesson before launching the BTN cash push/fold training pack
- test mini lesson injection for BTN cash pack

## Testing
- `flutter test test/services/training_session_launcher_intro_lesson_test.dart test/services/training_session_launcher_btn_cash_lesson_test.dart` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688ef3f80b60832abf088fadb2c8542d