### PR TITLE
feat: track mini lesson completion

### DIFF
--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -8,6 +8,7 @@ import '../services/recap_completion_tracker.dart';
 import '../services/theory_streak_service.dart';
 import '../services/theory_booster_recall_engine.dart';
 import '../services/pinned_learning_service.dart';
+import '../services/mini_lesson_completion_tracker_service.dart';
 
 /// Simple viewer for a [TheoryMiniLessonNode].
 class MiniLessonScreen extends StatefulWidget {
@@ -80,6 +81,8 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
         .setLastPosition('lesson', widget.lesson.id, _controller.offset.round());
     _controller.dispose();
     PinnedLearningService.instance.removeListener(_updatePinned);
+    unawaited(MiniLessonCompletionTrackerService.instance
+        .markCompleted(widget.lesson.id));
     super.dispose();
   }
 

--- a/lib/screens/training_pack_preview_screen.dart
+++ b/lib/screens/training_pack_preview_screen.dart
@@ -4,8 +4,11 @@ import '../models/v2/training_pack_v2.dart';
 import '../services/pack_favorite_service.dart';
 import '../services/pack_rating_service.dart';
 import '../services/training_pack_comments_service.dart';
+import '../services/mini_lesson_library_service.dart';
 import '../widgets/pack_insights_banner.dart';
 import '../widgets/pack_recommendation_section.dart';
+import 'mini_lesson_screen.dart';
+import '../models/theory_mini_lesson_node.dart';
 import 'training_session_screen.dart';
 
 class TrainingPackPreviewScreen extends StatefulWidget {
@@ -22,6 +25,7 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
   int? _userRating;
   double? _average;
   String? _comment;
+  TheoryMiniLessonNode? _lesson;
 
   @override
   void initState() {
@@ -29,6 +33,7 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
     _favorite = PackFavoriteService.instance.isFavorite(widget.template.id);
     _loadRating();
     _loadComment();
+    _loadLesson();
   }
 
   Future<void> _loadRating() async {
@@ -36,9 +41,9 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
     final avg = await PackRatingService.instance.getAverageRating(widget.template.id);
     if (mounted) {
       setState(() {
-      _userRating = r;
-      _average = avg;
-    });
+        _userRating = r;
+        _average = avg;
+      });
     }
   }
 
@@ -58,9 +63,9 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
     final avg = await PackRatingService.instance.getAverageRating(widget.template.id);
     if (mounted) {
       setState(() {
-      _userRating = r;
-      _average = avg;
-    });
+        _userRating = r;
+        _average = avg;
+      });
     }
   }
 
@@ -91,6 +96,16 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
       await TrainingPackCommentsService.instance
           .saveComment(widget.template.id, result);
       if (mounted) setState(() => _comment = result);
+    }
+  }
+
+  Future<void> _loadLesson() async {
+    await MiniLessonLibraryService.instance.loadAll();
+    for (final l in MiniLessonLibraryService.instance.all) {
+      if (l.linkedPackIds.contains(widget.template.id)) {
+        if (mounted) setState(() => _lesson = l);
+        break;
+      }
     }
   }
 
@@ -175,6 +190,21 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
           ],
           PackInsightsBanner(templateId: widget.template.id),
           const SizedBox(height: 24),
+          if (_lesson != null) ...[
+            ElevatedButton(
+              onPressed: () {
+                final lesson = _lesson!;
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MiniLessonScreen(lesson: lesson),
+                  ),
+                );
+              },
+              child: const Text('Повторить теорию'),
+            ),
+            const SizedBox(height: 12),
+          ],
           ElevatedButton(
             onPressed: () {
               final pack = TrainingPackV2.fromTemplate(

--- a/lib/services/mini_lesson_completion_tracker_service.dart
+++ b/lib/services/mini_lesson_completion_tracker_service.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores ids of completed theory mini lessons.
+class MiniLessonCompletionTrackerService {
+  MiniLessonCompletionTrackerService._();
+  static final MiniLessonCompletionTrackerService instance =
+      MiniLessonCompletionTrackerService._();
+
+  static const String _key = 'theory_lessons_completed';
+
+  Future<void> markCompleted(String lessonId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    if (!list.contains(lessonId)) {
+      list.add(lessonId);
+      await prefs.setStringList(_key, list);
+    }
+  }
+
+  Future<bool> isCompleted(String lessonId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    return list.contains(lessonId);
+  }
+}

--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -15,6 +15,7 @@ import 'pack_recall_stats_service.dart';
 import '../core/training/library/training_pack_library_v2.dart';
 import 'mini_lesson_library_service.dart';
 import '../screens/mini_lesson_screen.dart';
+import 'mini_lesson_completion_tracker_service.dart';
 
 /// Helper to start a training session from a pack template.
 class TrainingSessionLauncher {
@@ -39,12 +40,16 @@ class TrainingSessionLauncher {
 
     if (lessonId != null) {
       await MiniLessonLibraryService.instance.loadAll();
-      final lesson = MiniLessonLibraryService.instance.getById(lessonId);
-      if (lesson != null) {
-        await Navigator.push(
-          ctx,
-          MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
-        );
+      final completed =
+          await MiniLessonCompletionTrackerService.instance.isCompleted(lessonId);
+      if (!completed) {
+        final lesson = MiniLessonLibraryService.instance.getById(lessonId);
+        if (lesson != null) {
+          await Navigator.push(
+            ctx,
+            MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- track completed mini lessons in SharedPreferences
- skip auto theory playback if lesson already completed
- add button to review theory from pack details

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ef66abdbc832a94cf6036e80359bd