### PR TITLE
Add training session completion screen

### DIFF
--- a/lib/screens/training_session_completion_screen.dart
+++ b/lib/screens/training_session_completion_screen.dart
@@ -18,17 +18,20 @@ class TrainingSessionCompletionScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final total = template.spots.length;
     return Scaffold(
-      appBar: AppBar(title: const Text('Training Complete')),
+      appBar: AppBar(title: const Text('Тренировка завершена')),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(
-              'You completed $hands hands!',
+              'Вы завершили тренировку!',
               style: theme.textTheme.headlineSmall,
               textAlign: TextAlign.center,
             ),
+            const SizedBox(height: 8),
+            Text('$hands / $total пройдено'),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () async {
@@ -43,7 +46,7 @@ class TrainingSessionCompletionScreen extends StatelessWidget {
                   ),
                 );
               },
-              child: const Text('Try Again'),
+              child: const Text('Повторить'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(
@@ -55,14 +58,14 @@ class TrainingSessionCompletionScreen extends StatelessWidget {
                   ),
                 );
               },
-              child: const Text('Choose Another Pack'),
+              child: const Text('Выбрать другой пак'),
             ),
             const SizedBox(height: 12),
             TextButton(
               onPressed: () {
                 Navigator.popUntil(context, (route) => route.isFirst);
               },
-              child: const Text('Exit'),
+              child: const Text('Домой'),
             ),
           ],
         ),

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -29,7 +29,6 @@ import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/v2/hero_position.dart';
 import 'booster_recap_screen.dart';
-import '../services/training_gap_notification_service.dart';
 import '../services/tag_mastery_service.dart';
 import '../services/user_goal_engine.dart';
 import '../services/goal_toast_service.dart';
@@ -255,6 +254,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
           ),
         );
         unawaited(context.read<DailyLearningGoalService>().markCompleted());
+        return;
       } else {
         await prefs.setInt(
           'progress_tpl_${tpl.id}',
@@ -269,42 +269,8 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         _continue = true;
         Navigator.pop(context);
         widget.onSessionEnd!();
-      } else {
-        final suggestion = await const TrainingGapNotificationService()
-            .suggestNextPack(excludeId: tpl?.id);
-        if (suggestion != null) {
-          final start = await showDialog<bool>(
-            context: context,
-            builder: (_) => AlertDialog(
-              title: const Text('🎯 Рекомендовано продолжение:'),
-              content: Text('[${suggestion.name}] – слабая зона'),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context, false),
-                  child: const Text('Закрыть'),
-                ),
-                TextButton(
-                  onPressed: () => Navigator.pop(context, true),
-                  child: const Text('Начать следующую тренировку'),
-                ),
-              ],
-            ),
-          );
-          if (start == true) {
-            await context.read<TrainingSessionService>().startSession(
-              suggestion,
-            );
-            if (!context.mounted) return;
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
-            );
-            return;
-          }
-        }
-        _summaryShown = true;
-        _showSummary(service);
       }
+      return;
     } else {
       setState(() {
         _selected = null;
@@ -662,9 +628,6 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
               service.template != null &&
               service.session!.index >= service.template!.spots.length) {
             _summaryShown = true;
-            WidgetsBinding.instance.addPostFrameCallback(
-              (_) => _showSummary(service),
-            );
           }
           final spot = service.currentSpot;
           if (spot == null) {

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -8,6 +8,7 @@ import '../helpers/hand_utils.dart';
 import '../helpers/hand_type_utils.dart';
 import '../helpers/training_pack_storage.dart';
 import '../screens/training_session_summary_screen.dart';
+import '../screens/training_session_completion_screen.dart';
 import 'mistake_review_pack_service.dart';
 import 'smart_review_service.dart';
 import 'learning_path_progress_service.dart';
@@ -38,6 +39,7 @@ import 'gift_drop_service.dart';
 import 'session_streak_tracker_service.dart';
 import 'smart_recap_banner_controller.dart';
 import 'training_progress_tracker_service.dart';
+import 'training_progress_logger.dart';
 
 class TrainingSessionService extends ChangeNotifier {
   Box<dynamic>? _box;
@@ -644,8 +646,19 @@ class TrainingSessionService extends ChangeNotifier {
       if (ctx != null) {
         unawaited(
             ctx.read<SmartRecapBannerController>().triggerBannerIfNeeded());
+        if (_template != null) {
+          final totalHands = _spots.length;
+          unawaited(
+              TrainingProgressLogger.completeSession(_template!.id, totalHands));
+          unawaited(complete(
+            ctx,
+            resultBuilder: (_) => TrainingSessionCompletionScreen(
+              template: _template!,
+              hands: totalHands,
+            ),
+          ));
+        }
       }
-      unawaited(_clearIndex());
     }
     if (_box != null) _box!.put(_session!.id, _session!.toJson());
     _saveActive();


### PR DESCRIPTION
## Summary
- Show progress and next-step options on new training completion screen
- Trigger completion flow from `TrainingSessionService.nextSpot`
- Simplify session flow to rely on service-level completion logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efa46dc10832a88176b034985c6e0