### PR TITLE
feat: add theory booster banner

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../services/intro_seen_tracker.dart';
 import '../services/booster_thematic_descriptions.dart';
 import '../widgets/theory_intro_banner.dart';
+import '../widgets/theory_booster_banner.dart';
 import 'learning_path_celebration_screen.dart';
 import '../widgets/next_steps_modal.dart';
 import '../widgets/stage_progress_chip.dart';
@@ -598,8 +599,26 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
                     }
                   });
                 }
+                final pendingStage = stages.firstWhereOrNull(
+                  (s) =>
+                      _stageStates[s.id] == LearningStageUIState.active &&
+                      s.theoryPackId != null &&
+                      !(_theoryDone[s.id] ?? false),
+                );
                 return Column(
                   children: [
+                    if (pendingStage != null)
+                      TheoryBoosterBanner(
+                        onOpen: () async {
+                          final start = await showDialog<bool>(
+                            context: context,
+                            builder: (_) => StagePreviewDialog(stage: pendingStage),
+                          );
+                          if (start == true) {
+                            await _handleStageTap(pendingStage);
+                          }
+                        },
+                      ),
                     hud,
                     Expanded(
                       child: ListView(

--- a/lib/widgets/theory_booster_banner.dart
+++ b/lib/widgets/theory_booster_banner.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// Banner prompting user to complete missed theory block.
+class TheoryBoosterBanner extends StatelessWidget {
+  final VoidCallback onOpen;
+
+  const TheoryBoosterBanner({super.key, required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.yellow.shade700,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Text(
+              'Вы пропустили теоретический блок',
+              style: TextStyle(color: Colors.black),
+            ),
+          ),
+          TextButton(
+            onPressed: onOpen,
+            style: TextButton.styleFrom(foregroundColor: Colors.black),
+            child: const Text('Открыть'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add yellow TheoryBoosterBanner widget for missed theory
- show banner atop LearningPathScreen when an active stage lacks theory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f06a91ed0832a8d16c08abec53109