### PR TITLE
feat: add daily training streak tracker

### DIFF
--- a/lib/services/daily_streak_tracker_service.dart
+++ b/lib/services/daily_streak_tracker_service.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks consecutive days with completed training sessions.
+class DailyStreakTrackerService {
+  DailyStreakTrackerService._();
+
+  static final DailyStreakTrackerService instance =
+      DailyStreakTrackerService._();
+
+  static const _lastDateKey = 'daily_streak_last';
+  static const _countKey = 'daily_streak_count';
+
+  final _controller = StreamController<int>.broadcast();
+  Stream<int> get streakStream => _controller.stream;
+
+  /// Marks today as a completed training day and updates the streak.
+  Future<void> markCompletedToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastStr = prefs.getString(_lastDateKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    int count = prefs.getInt(_countKey) ?? 0;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = today.difference(lastDay).inDays;
+      if (diff == 0) {
+        return;
+      } else if (diff == 1) {
+        count += 1;
+      } else {
+        count = 1;
+      }
+    } else {
+      count = 1;
+    }
+
+    await prefs.setString(_lastDateKey, today.toIso8601String());
+    await prefs.setInt(_countKey, count);
+    _controller.add(count);
+  }
+
+  /// Returns the current streak value. Resets to 0 if a day was missed.
+  Future<int> getCurrentStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastDateKey);
+    final last = lastStr != null ? DateTime.tryParse(lastStr) : null;
+    int count = prefs.getInt(_countKey) ?? 0;
+
+    if (last != null) {
+      final lastDay = DateTime(last.year, last.month, last.day);
+      final diff = DateTime.now().difference(lastDay).inDays;
+      if (diff > 1) {
+        count = 0;
+        await prefs.setInt(_countKey, 0);
+      }
+    } else if (count != 0) {
+      count = 0;
+      await prefs.setInt(_countKey, 0);
+    }
+    return count;
+  }
+
+  /// Returns the date when the last training was recorded, if any.
+  Future<DateTime?> getLastCompletionDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastDateKey);
+    return lastStr != null ? DateTime.tryParse(lastStr) : null;
+  }
+
+  /// Clears the stored streak information. Useful for tests.
+  Future<void> reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastDateKey);
+    await prefs.remove(_countKey);
+    _controller.add(0);
+  }
+}
+

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -22,6 +22,7 @@ import '../models/result_entry.dart';
 import '../models/evaluation_result.dart';
 import 'streak_tracker_service.dart';
 import 'training_streak_tracker_service.dart';
+import 'daily_streak_tracker_service.dart';
 
 import '../models/v2/training_pack_template.dart';
 import '../models/v2/training_pack_spot.dart';
@@ -541,6 +542,7 @@ class TrainingSessionService extends ChangeNotifier {
       unawaited(TagGoalTrackerService.instance.logTraining(tag));
     }
     unawaited(TrainingStreakTrackerService.instance.markTrainingCompletedToday());
+    unawaited(DailyStreakTrackerService.instance.markCompletedToday());
     unawaited(StreakRewardEngine.instance.checkAndTriggerRewards());
     unawaited(context
         .read<GiftDropService>()

--- a/lib/widgets/daily_streak_badge_widget.dart
+++ b/lib/widgets/daily_streak_badge_widget.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../services/daily_streak_tracker_service.dart';
+
+/// Small badge displaying current daily training streak.
+class DailyStreakBadgeWidget extends StatefulWidget {
+  const DailyStreakBadgeWidget({super.key});
+
+  @override
+  State<DailyStreakBadgeWidget> createState() => _DailyStreakBadgeWidgetState();
+}
+
+class _DailyStreakBadgeWidgetState extends State<DailyStreakBadgeWidget> {
+  int _streak = 0;
+  StreamSubscription<int>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _sub = DailyStreakTrackerService.instance.streakStream.listen((value) {
+      if (mounted) {
+        setState(() => _streak = value);
+      }
+    });
+  }
+
+  Future<void> _load() async {
+    final value = await DailyStreakTrackerService.instance.getCurrentStreak();
+    if (mounted) {
+      setState(() => _streak = value);
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_streak <= 0) return const SizedBox.shrink();
+    final label = '$_streak дней 🔥';
+    return Tooltip(
+      message: 'Серийная тренировка: $_streak дней подряд',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.orange.shade100,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.local_fire_department,
+                size: 16, color: Colors.deepOrange),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/test/services/daily_streak_tracker_service_test.dart
+++ b/test/services/daily_streak_tracker_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/daily_streak_tracker_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('increments when training on consecutive days', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    await prefs.setString('daily_streak_last', yesterday.toIso8601String());
+    await prefs.setInt('daily_streak_count', 2);
+
+    await DailyStreakTrackerService.instance.markCompletedToday();
+    final count = prefs.getInt('daily_streak_count');
+    expect(count, 3);
+  });
+
+  test('resets when day is skipped', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final old = DateTime.now().subtract(const Duration(days: 3));
+    await prefs.setString('daily_streak_last', old.toIso8601String());
+    await prefs.setInt('daily_streak_count', 5);
+
+    await DailyStreakTrackerService.instance.markCompletedToday();
+    final count = prefs.getInt('daily_streak_count');
+    expect(count, 1);
+  });
+
+  test('does not change when completed twice same day', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final today = DateTime.now();
+    await prefs.setString('daily_streak_last', today.toIso8601String());
+    await prefs.setInt('daily_streak_count', 4);
+
+    await DailyStreakTrackerService.instance.markCompletedToday();
+    final count = prefs.getInt('daily_streak_count');
+    expect(count, 4);
+  });
+
+  test('getCurrentStreak resets if gap is too big', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final old = DateTime.now().subtract(const Duration(days: 2));
+    await prefs.setString('daily_streak_last', old.toIso8601String());
+    await prefs.setInt('daily_streak_count', 7);
+
+    final current = await DailyStreakTrackerService.instance.getCurrentStreak();
+    expect(current, 0);
+    expect(prefs.getInt('daily_streak_count'), 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- track consecutive training days with `DailyStreakTrackerService`
- show streak via `DailyStreakBadgeWidget`
- update daily streak when sessions complete

## Testing
- `flutter test test/services/daily_streak_tracker_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f0acab668832a9f4a83267bf1fd37