### PR TITLE
feat: add stage accuracy trend sparkline

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -513,7 +513,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
             borderRadius: BorderRadius.circular(4),
           )
         : null;
-    final stats = _logs.getStats(stage.packId);
+    final stats = _logs.getStatsWithHistory(stage.packId);
     Widget? subtitle;
     if (stats.handsPlayed > 0) {
       final chip = StageProgressChip(stats: stats);

--- a/lib/widgets/stage_progress_chip.dart
+++ b/lib/widgets/stage_progress_chip.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
 import '../services/session_log_service.dart';
 
 /// Small chip displaying historical stats for a learning path stage.
 class StageProgressChip extends StatelessWidget {
-  final StageStats stats;
+  final StageStatsWithHistory stats;
 
   const StageProgressChip({super.key, required this.stats});
 
@@ -12,18 +14,58 @@ class StageProgressChip extends StatelessWidget {
     final hands = stats.handsPlayed;
     final accuracy = stats.accuracy;
     final text = '$hands рук · ${accuracy.toStringAsFixed(0)}%';
+    Widget? chart;
+    if (stats.history.length >= 3) {
+      final spots = <FlSpot>[];
+      for (var i = 0; i < stats.history.length; i++) {
+        spots.add(FlSpot(i.toDouble(), stats.history[i].accuracy));
+      }
+      chart = SizedBox(
+        height: 32,
+        width: stats.history.length * 8.0,
+        child: LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: 100,
+            gridData: const FlGridData(show: false),
+            titlesData: const FlTitlesData(show: false),
+            borderData: FlBorderData(show: false),
+            lineTouchData: const LineTouchData(enabled: false),
+            lineBarsData: [
+              LineChartBarData(
+                spots: spots,
+                isCurved: true,
+                color: Theme.of(context).colorScheme.primary,
+                barWidth: 2,
+                dotData: const FlDotData(show: false),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     return Tooltip(
       message:
           'Средняя точность за всё время: ${accuracy.toStringAsFixed(0)}% ($hands рук)',
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
         decoration: BoxDecoration(
           color: Colors.grey,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.black, fontSize: 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              text,
+              style: const TextStyle(color: Colors.black, fontSize: 12),
+            ),
+            if (chart != null) ...[
+              const SizedBox(height: 2),
+              chart,
+            ],
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- extend session log stats with recent accuracy history
- visualize session accuracy trend in StageProgressChip using a sparkline
- surface stage history stats in learning path screen

## Testing
- `flutter format lib/services/session_log_service.dart lib/widgets/stage_progress_chip.dart lib/screens/learning_path_screen_v2.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f10b4fc74832a87419d2dcd3209c2