### PR TITLE
feat: stage session history screen

### DIFF
--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -516,7 +516,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     final stats = _logs.getStatsWithHistory(stage.packId);
     Widget? subtitle;
     if (stats.handsPlayed > 0) {
-      final chip = StageProgressChip(stats: stats);
+      final chip = StageProgressChip(stageId: stage.packId, stats: stats);
       if (stage.description.isNotEmpty) {
         subtitle = Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/stage_session_history_screen.dart
+++ b/lib/screens/stage_session_history_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../helpers/date_utils.dart';
+import '../services/session_log_service.dart';
+
+class StageSessionHistoryScreen extends StatelessWidget {
+  final String stageId;
+  const StageSessionHistoryScreen({super.key, required this.stageId});
+
+  @override
+  Widget build(BuildContext context) {
+    final logs = context
+        .watch<SessionLogService>()
+        .logs
+        .where((l) => l.templateId == stageId)
+        .toList()
+      ..sort((a, b) => b.completedAt.compareTo(a.completedAt));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Session History')),
+      backgroundColor: const Color(0xFF1B1C1E),
+      body: logs.isEmpty
+          ? const Center(
+              child: Text(
+                'No sessions',
+                style: TextStyle(color: Colors.white54),
+              ),
+            )
+          : ListView.builder(
+              itemCount: logs.length,
+              itemBuilder: (context, index) {
+                final log = logs[index];
+                final total = log.correctCount + log.mistakeCount;
+                final acc = total == 0 ? 0.0 : log.correctCount / total * 100;
+                final cats = log.categories.entries.toList()
+                  ..sort((a, b) => b.value.compareTo(a.value));
+                final tagText =
+                    cats.isEmpty ? null : cats.map((e) => e.key).take(3).join(', ');
+                return Card(
+                  color: const Color(0xFF2A2B2D),
+                  child: ListTile(
+                    title: Text(
+                      formatDate(log.completedAt),
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Acc ${acc.toStringAsFixed(1)}% · $total рук · EV 0%',
+                          style: const TextStyle(color: Colors.white70),
+                        ),
+                        if (tagText != null)
+                          Text(
+                            tagText,
+                            style: const TextStyle(color: Colors.white70),
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/widgets/stage_progress_chip.dart
+++ b/lib/widgets/stage_progress_chip.dart
@@ -2,12 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 
 import '../services/session_log_service.dart';
+import '../screens/stage_session_history_screen.dart';
 
 /// Small chip displaying historical stats for a learning path stage.
 class StageProgressChip extends StatelessWidget {
+  final String stageId;
   final StageStatsWithHistory stats;
 
-  const StageProgressChip({super.key, required this.stats});
+  const StageProgressChip({
+    super.key,
+    required this.stageId,
+    required this.stats,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -47,25 +53,35 @@ class StageProgressChip extends StatelessWidget {
     return Tooltip(
       message:
           'Средняя точность за всё время: ${accuracy.toStringAsFixed(0)}% ($hands рук)',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-        decoration: BoxDecoration(
-          color: Colors.grey,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              text,
-              style: const TextStyle(color: Colors.black, fontSize: 12),
+      child: GestureDetector(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => StageSessionHistoryScreen(stageId: stageId),
             ),
-            if (chart != null) ...[
-              const SizedBox(height: 2),
-              chart,
+          );
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.grey,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                text,
+                style: const TextStyle(color: Colors.black, fontSize: 12),
+              ),
+              if (chart != null) ...[
+                const SizedBox(height: 2),
+                chart,
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add tap on stage progress chip to open history screen
- show recent session stats per stage

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f11ceb4b0832aaf42df5b298b08f3