### PR TITLE
feat: show session EV percent when available

### DIFF
--- a/lib/models/session_log.dart
+++ b/lib/models/session_log.dart
@@ -6,6 +6,7 @@ class SessionLog {
   final DateTime completedAt;
   final int correctCount;
   final int mistakeCount;
+  final double? evPercent;
   final Map<String, int> categories;
   final List<String> tags;
 
@@ -16,6 +17,7 @@ class SessionLog {
     required this.completedAt,
     required this.correctCount,
     required this.mistakeCount,
+    this.evPercent,
     Map<String, int>? categories,
     List<String>? tags,
   })  : categories = categories ?? const {},
@@ -29,11 +31,12 @@ class SessionLog {
         completedAt:
             DateTime.tryParse(j['completedAt'] as String? ?? '') ?? DateTime.now(),
         correctCount: j['correct'] as int? ?? 0,
-      mistakeCount: j['mistakes'] as int? ?? 0,
-      categories: {
-        for (final e in (j['categories'] as Map? ?? {}).entries)
-          e.key as String: (e.value as num).toInt()
-        },
+        mistakeCount: j['mistakes'] as int? ?? 0,
+        evPercent: (j['evPercent'] as num?)?.toDouble(),
+        categories: {
+          for (final e in (j['categories'] as Map? ?? {}).entries)
+            e.key as String: (e.value as num).toInt()
+          },
         tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
       );
 
@@ -44,6 +47,7 @@ class SessionLog {
       'completedAt': completedAt.toIso8601String(),
       'correct': correctCount,
       'mistakes': mistakeCount,
+        if (evPercent != null) 'evPercent': evPercent,
         if (categories.isNotEmpty) 'categories': categories,
         if (tags.isNotEmpty) 'tags': tags,
       };

--- a/lib/screens/stage_session_history_screen.dart
+++ b/lib/screens/stage_session_history_screen.dart
@@ -46,6 +46,8 @@ class _StageSessionHistoryScreenState extends State<StageSessionHistoryScreen> {
               final log = visibleLogs[index];
               final total = log.correctCount + log.mistakeCount;
               final acc = total == 0 ? 0.0 : log.correctCount / total * 100;
+              final ev = log.evPercent;
+              final evText = ev != null ? ev.toStringAsFixed(1) : '—';
               final cats = log.categories.entries.toList()
                 ..sort((a, b) => b.value.compareTo(a.value));
               final tagText =
@@ -61,7 +63,7 @@ class _StageSessionHistoryScreenState extends State<StageSessionHistoryScreen> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Acc ${acc.toStringAsFixed(1)}% · $total рук · EV 0%',
+                        'Acc ${acc.toStringAsFixed(1)}% · $total рук · EV ${evText}%',
                         style: const TextStyle(color: Colors.white70),
                       ),
                       if (tagText != null)


### PR DESCRIPTION
## Summary
- add optional `evPercent` to `SessionLog` with JSON serialization
- render EV% in `StageSessionHistoryScreen` when log provides it

## Testing
- `dart format lib/models/session_log.dart lib/screens/stage_session_history_screen.dart` *(command not found)*
- `apt-get install -y dart` *(package not found)*
- `flutter test` *(command not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f141c8968832a978468476077b773