### PR TITLE
feat: show unlock progress after session

### DIFF
--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -16,6 +16,8 @@ import '../core/training/library/training_pack_library_v2.dart';
 import 'mini_lesson_library_service.dart';
 import '../screens/mini_lesson_screen.dart';
 import 'theory_lesson_completion_logger.dart';
+import 'training_pack_stats_service.dart';
+import '../widgets/unlock_progress_dialog.dart';
 
 /// Helper to start a training session from a pack template.
 class TrainingSessionLauncher {
@@ -68,6 +70,9 @@ class TrainingSessionLauncher {
       return;
     }
 
+    final statBefore = await TrainingPackStatsService.getStats(template.id);
+    final handsBefore = await TrainingPackStatsService.getHandsCompleted(template.id);
+
     final pack = TrainingPackV2.fromTemplate(template, template.id);
     await Navigator.push(
       ctx,
@@ -77,6 +82,20 @@ class TrainingSessionLauncher {
       ),
     );
     unawaited(AchievementsEngine.instance.checkAll());
+
+    final statAfter = await TrainingPackStatsService.getStats(template.id);
+    final handsAfter = await TrainingPackStatsService.getHandsCompleted(template.id);
+    if (template.requiredAccuracy != null || template.minHands != null) {
+      await showUnlockProgressDialog(
+        ctx,
+        accuracyBefore: (statBefore?.accuracy ?? 0) * 100,
+        accuracyAfter: (statAfter?.accuracy ?? 0) * 100,
+        handsBefore: handsBefore,
+        handsAfter: handsAfter,
+        requiredAccuracy: template.requiredAccuracy,
+        minHands: template.minHands,
+      );
+    }
   }
 
   /// Finds and launches a booster drill relevant to [lesson].

--- a/lib/widgets/unlock_progress_dialog.dart
+++ b/lib/widgets/unlock_progress_dialog.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'confetti_overlay.dart';
+
+Future<void> showUnlockProgressDialog(
+  BuildContext context, {
+  required double accuracyBefore,
+  required double accuracyAfter,
+  required int handsBefore,
+  required int handsAfter,
+  double? requiredAccuracy,
+  int? minHands,
+}) async {
+  final accReq = requiredAccuracy;
+  final handsReq = minHands;
+
+  final neededAcc =
+      accReq != null ? (accReq - accuracyAfter).clamp(0, double.infinity) : 0;
+  final neededHands =
+      handsReq != null ? (handsReq - handsAfter).clamp(0, double.infinity) : 0;
+
+  final achieved = (neededAcc <= 0) && (neededHands <= 0);
+
+  final remainingParts = <String>[];
+  if (neededAcc > 0) {
+    remainingParts.add('+${neededAcc.toStringAsFixed(0)}% точности');
+  }
+  if (neededHands > 0) {
+    final h = neededHands.toInt();
+    remainingParts.add('$h ру${h == 1 ? 'ка' : h < 5 ? 'ки' : 'к'}');
+  }
+  final remainingText = achieved
+      ? 'Цель достигнута!'
+      : 'Осталось: ${remainingParts.join(' и ')}';
+
+  if (achieved) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+  }
+
+  await showDialog(
+    context: context,
+    builder: (_) => AlertDialog(
+      title: const Text('📈 Прогресс разблокировки'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Точность: ${accuracyBefore.toStringAsFixed(0)}% → ${accuracyAfter.toStringAsFixed(0)}%'
+            '${accReq != null ? ' / ≥${accReq.toStringAsFixed(0)}%' : ''}',
+          ),
+          Text(
+            'Руки: $handsBefore → $handsAfter'
+            '${handsReq != null ? ' / ≥$handsReq' : ''}',
+          ),
+          const SizedBox(height: 12),
+          Text(remainingText),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- track stats before and after training sessions and show progress toward unlock thresholds
- introduce unlock progress dialog with optional confetti when goals met

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f217f5f34832aa75144407c06772c