### PR TITLE
feat: gate packs behind performance

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -9,6 +9,7 @@ import 'training_pack_spot.dart';
 import 'spot_template.dart';
 import 'unlock_rules.dart';
 import 'hero_position.dart';
+import 'training_pack_template.dart' show TrainingPackTemplate;
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -31,16 +32,14 @@ class TrainingPackTemplateV2 {
   bool requiresTheoryCompleted;
   String? targetStreet;
   UnlockRules? unlockRules;
+  double? requiredAccuracy;
+  int? minHands;
 
+  // Legacy fields kept for backwards compatibility.
   double? get requiresAccuracy =>
       (meta['requiresAccuracy'] as num?)?.toDouble();
   int? get requiresVolume =>
       (meta['requiresVolume'] as num?)?.toInt();
-
-  // New performance gating fields.
-  double? get requiredAccuracy =>
-      (meta['requiredAccuracy'] as num?)?.toDouble();
-  int? get minHands => (meta['minHands'] as num?)?.toInt();
 
   /// Ephemeral flag – marks automatically generated packs. Never
   /// serialized to or from disk.
@@ -71,6 +70,8 @@ class TrainingPackTemplateV2 {
     this.requiresTheoryCompleted = false,
     this.targetStreet,
     this.unlockRules,
+    this.requiredAccuracy,
+    this.minHands,
     bool? isGeneratedPack,
     bool? isSampledPack,
   }) : tags = tags ?? [],
@@ -81,6 +82,8 @@ class TrainingPackTemplateV2 {
        isGeneratedPack = isGeneratedPack ?? false,
        isSampledPack = isSampledPack ?? false {
     if (theme != null) meta['theme'] = theme;
+    if (requiredAccuracy != null) meta['requiredAccuracy'] = requiredAccuracy;
+    if (minHands != null) meta['minHands'] = minHands;
     category ??= this.tags.isNotEmpty ? this.tags.first : null;
   }
 
@@ -122,6 +125,11 @@ class TrainingPackTemplateV2 {
       unlockRules: j['unlockRules'] is Map
           ? UnlockRules.fromJson(Map<String, dynamic>.from(j['unlockRules']))
           : null,
+      requiredAccuracy: j['meta'] is Map
+          ? (j['meta']['requiredAccuracy'] as num?)?.toDouble()
+          : null,
+      minHands:
+          j['meta'] is Map ? (j['meta']['minHands'] as num?)?.toInt() : null,
     );
     tpl.category ??= tpl.tags.isNotEmpty ? tpl.tags.first : null;
     if (tpl.theme != null) tpl.meta['theme'] = tpl.theme;
@@ -155,6 +163,12 @@ class TrainingPackTemplateV2 {
     if (theme != null) metaMap['theme'] = theme;
     if (requiresTheoryCompleted) {
       metaMap['requiresTheoryCompleted'] = true;
+    }
+    if (requiredAccuracy != null) {
+      metaMap['requiredAccuracy'] = requiredAccuracy;
+    }
+    if (minHands != null) {
+      metaMap['minHands'] = minHands;
     }
     if (metaMap.isNotEmpty) map['meta'] = metaMap;
     return map;
@@ -247,5 +261,8 @@ class TrainingPackTemplateV2 {
     requiresTheoryCompleted:
         template.meta['requiresTheoryCompleted'] == true,
     targetStreet: template.targetStreet,
+    requiredAccuracy:
+        (template.meta['requiredAccuracy'] as num?)?.toDouble(),
+    minHands: (template.meta['minHands'] as num?)?.toInt(),
   );
 }

--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -131,21 +131,21 @@ class _PackCardState extends State<PackCard> with SingleTickerProviderStateMixin
     final ok = await TrainingPackPerformanceTrackerService.instance
         .meetsRequirements(
       widget.template.id,
-      requiredAccuracy: reqAcc,
+      requiredAccuracy: reqAcc != null ? reqAcc / 100 : null,
       minHands: minHands,
     );
     if (!ok && mounted && !kDebugMode) {
       setState(() {
         _locked = true;
-        final parts = <String>[];
-        if (reqAcc != null) {
-          parts.add('точность ≥ ${(reqAcc * 100).toStringAsFixed(0)}%');
+        if (reqAcc != null && minHands != null) {
+          _lockMsg =
+              'Достигните точности ${reqAcc.toStringAsFixed(0)}% и сыграйте $minHands рук, чтобы открыть';
+        } else if (reqAcc != null) {
+          _lockMsg =
+              'Достигните точности ${reqAcc.toStringAsFixed(0)}%, чтобы открыть';
+        } else if (minHands != null) {
+          _lockMsg = 'Сыграйте $minHands рук, чтобы открыть';
         }
-        if (minHands != null) {
-          parts.add('≥ $minHands рук');
-        }
-        _lockMsg =
-            'Пройдите с ${parts.join(' и ')}, чтобы открыть следующую стадию';
       });
     }
   }
@@ -181,10 +181,10 @@ class _PackCardState extends State<PackCard> with SingleTickerProviderStateMixin
     final widgets = <Widget>[];
     if (reqAcc != null) {
       final accPct = (_accuracy ?? 0) * 100;
-      final target = reqAcc * 100;
+      final target = reqAcc;
       final color = _progressColor(accPct, target);
       widgets.add(LinearProgressIndicator(
-        value: (_accuracy ?? 0) / reqAcc,
+        value: target == 0 ? 0 : accPct / target,
         backgroundColor: Colors.white24,
         valueColor: AlwaysStoppedAnimation<Color>(color),
       ));

--- a/test/widgets/pack_card_lock_test.dart
+++ b/test/widgets/pack_card_lock_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/training_type.dart';
+import 'package:poker_analyzer/widgets/pack_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('locks pack when requirements not met', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'tpl_stat_pack': '{"accuracy":0.6,"last":0}',
+      'tpl_prog_pack': 4,
+    });
+
+    final tpl = TrainingPackTemplateV2(
+      id: 'pack',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      requiredAccuracy: 80,
+      minHands: 10,
+      spotCount: 20,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: PackCard(template: tpl, onTap: () {}),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.lock), findsOneWidget);
+    expect(
+      find.text('Достигните точности 80% и сыграйте 10 рук, чтобы открыть'),
+      findsOneWidget,
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
- persist `requiredAccuracy` and `minHands` in training pack meta for performance gating
- lock PackCard until accuracy/hands requirements met and display informative tooltip
- add widget test for lock tooltip behavior

## Testing
- `flutter test test/widgets/pack_card_lock_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f24a4939c832a9e94c756fc77afd4