### PR TITLE
feat: show near-unlock badge for packs

### DIFF
--- a/test/widgets/pack_card_almost_unlocked_badge_test.dart
+++ b/test/widgets/pack_card_almost_unlocked_badge_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/training_type.dart';
+import 'package:poker_analyzer/widgets/pack_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows almost unlocked badge when halfway to requirements',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'tpl_stat_pack': '{"accuracy":0.6,"last":0}',
+      'tpl_prog_pack': 5,
+    });
+
+    final tpl = TrainingPackTemplateV2(
+      id: 'pack',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      requiredAccuracy: 80,
+      minHands: 10,
+      spotCount: 20,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: PackCard(template: tpl, onTap: () {}),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Почти разблокировано'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- highlight when a pack is halfway to unlocking with a yellow "Почти разблокировано" badge
- cover near-unlock case with widget test

## Testing
- `/usr/local/flutter/bin/flutter test` *(fails: The current Dart SDK version is 3.3.0. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_688f29db7b34832a98132bfe8030052f