### PR TITLE
feat: add unlock tracker widget

### DIFF
--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -19,6 +19,7 @@ import '../services/training_pack_performance_tracker_service.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../screens/mini_lesson_screen.dart';
 import 'pack_progress_summary_widget.dart';
+import 'unlock_tracker_widget.dart';
 
 class PackCard extends StatefulWidget {
   final TrainingPackTemplateV2 template;
@@ -509,7 +510,7 @@ class _PackCardState extends State<PackCard>
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          PackProgressSummaryWidget(
+                          UnlockTrackerWidget(
                             accuracy: _accuracy,
                             handsCompleted: _handsCompleted,
                             requiredAccuracy: _requiredAccuracy,

--- a/lib/widgets/unlock_tracker_widget.dart
+++ b/lib/widgets/unlock_tracker_widget.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+/// Displays progress towards unlocking a training pack.
+class UnlockTrackerWidget extends StatelessWidget {
+  final double? accuracy; // 0..1
+  final int handsCompleted;
+  final double? requiredAccuracy; // percent
+  final int? minHands;
+
+  const UnlockTrackerWidget({
+    super.key,
+    this.accuracy,
+    required this.handsCompleted,
+    this.requiredAccuracy,
+    this.minHands,
+  });
+
+  Color _progressColor(double ratio) {
+    if (ratio >= 1) return Colors.green;
+    if (ratio >= 0.5) return Colors.yellow;
+    return Colors.red;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasAccReq = requiredAccuracy != null && requiredAccuracy! > 0;
+    final hasHandsReq = minHands != null && minHands! > 0;
+    if (!hasAccReq && !hasHandsReq) return const SizedBox.shrink();
+
+    final accPct = (accuracy ?? 0) * 100;
+    final accRatio = hasAccReq && requiredAccuracy! > 0
+        ? accPct / requiredAccuracy!
+        : 1;
+    final handsRatio = hasHandsReq && minHands! > 0
+        ? handsCompleted / minHands!.toDouble()
+        : 1;
+    final progress = [accRatio, handsRatio].reduce((a, b) => a < b ? a : b);
+    final color = _progressColor(progress);
+
+    final widgets = <Widget>[
+      LinearProgressIndicator(
+        value: progress.clamp(0, 1),
+        backgroundColor: Colors.white24,
+        valueColor: AlwaysStoppedAnimation<Color>(color),
+      ),
+    ];
+
+    if (hasAccReq) {
+      widgets.add(Padding(
+        padding: const EdgeInsets.only(top: 2),
+        child: Text(
+          'Точность: ${accPct.toStringAsFixed(0)}% / ≥${requiredAccuracy!.toStringAsFixed(0)}%',
+          style: TextStyle(color: color, fontSize: 12),
+        ),
+      ));
+    }
+
+    if (hasHandsReq) {
+      widgets.add(Padding(
+        padding: const EdgeInsets.only(top: 2),
+        child: Text(
+          'Руки: $handsCompleted / ≥${minHands!.toString()}',
+          style: TextStyle(color: color, fontSize: 12),
+        ),
+      ));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: widgets,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add UnlockTrackerWidget to visualize progress toward pack unlock requirements
- show UnlockTrackerWidget in locked pack cards

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f3c7eb2a8832a9426ad83ec6daa35