### PR TITLE
Add Level I push/fold learning path builder

### DIFF
--- a/lib/models/learning_path_node_v2.dart
+++ b/lib/models/learning_path_node_v2.dart
@@ -1,0 +1,30 @@
+import 'learning_path_node.dart';
+
+enum LearningPathNodeType { theory, training }
+
+class LearningPathNodeV2 implements LearningPathNode {
+  @override
+  final String id;
+  final LearningPathNodeType type;
+  final String? miniLessonId;
+  final String? trainingPackTemplateId;
+
+  @override
+  final bool recoveredFromMistake;
+
+  const LearningPathNodeV2.theory({
+    required this.id,
+    required String miniLessonId,
+    this.recoveredFromMistake = false,
+  })  : type = LearningPathNodeType.theory,
+        miniLessonId = miniLessonId,
+        trainingPackTemplateId = null;
+
+  const LearningPathNodeV2.training({
+    required this.id,
+    required String trainingPackTemplateId,
+    this.recoveredFromMistake = false,
+  })  : type = LearningPathNodeType.training,
+        miniLessonId = null,
+        trainingPackTemplateId = trainingPackTemplateId;
+}

--- a/lib/services/learning_path_level_one_builder_service.dart
+++ b/lib/services/learning_path_level_one_builder_service.dart
@@ -1,0 +1,50 @@
+import '../models/learning_path_node_v2.dart';
+
+class LearningPathLevelOneBuilderService {
+  const LearningPathLevelOneBuilderService();
+
+  List<LearningPathNodeV2> build() {
+    return const [
+      LearningPathNodeV2.theory(
+        id: 'lesson_push_fold_intro',
+        miniLessonId: 'lesson_push_fold_intro',
+      ),
+      LearningPathNodeV2.training(
+        id: 'pack_intro_push_fold_mtt',
+        trainingPackTemplateId: 'pack_intro_push_fold_mtt',
+      ),
+      LearningPathNodeV2.theory(
+        id: 'lesson_ranges_vs_bb',
+        miniLessonId: 'lesson_ranges_vs_bb',
+      ),
+      LearningPathNodeV2.training(
+        id: 'pack_ranges_vs_bb',
+        trainingPackTemplateId: 'pack_ranges_vs_bb',
+      ),
+      LearningPathNodeV2.theory(
+        id: 'lesson_ranges_vs_sb',
+        miniLessonId: 'lesson_ranges_vs_sb',
+      ),
+      LearningPathNodeV2.training(
+        id: 'pack_ranges_vs_sb',
+        trainingPackTemplateId: 'pack_ranges_vs_sb',
+      ),
+      LearningPathNodeV2.theory(
+        id: 'lesson_ranges_vs_button',
+        miniLessonId: 'lesson_ranges_vs_button',
+      ),
+      LearningPathNodeV2.training(
+        id: 'pack_ranges_vs_button',
+        trainingPackTemplateId: 'pack_ranges_vs_button',
+      ),
+      LearningPathNodeV2.theory(
+        id: 'lesson_traps_and_exploit',
+        miniLessonId: 'lesson_traps_and_exploit',
+      ),
+      LearningPathNodeV2.training(
+        id: 'pack_final_challenge',
+        trainingPackTemplateId: 'pack_final_challenge',
+      ),
+    ];
+  }
+}


### PR DESCRIPTION
## Summary
- add `LearningPathNodeV2` model for theory and training items
- build Level I Push/Fold path with new builder service
- use builder in `LearningPathEngine` when no graph is provided

## Testing
- `dart format lib/models/learning_path_node_v2.dart lib/services/learning_path_level_one_builder_service.dart lib/services/learning_graph_engine.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f3cfb2a38832aa1bf8729a1ece224