### PR TITLE
feat: linear learning path view

### DIFF
--- a/lib/screens/learning_path_linear_view_screen.dart
+++ b/lib/screens/learning_path_linear_view_screen.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+import '../models/learning_path_node_v2.dart';
+import '../services/learning_graph_engine.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/pack_library_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'mini_lesson_screen.dart';
+import 'training_pack_preview_screen.dart';
+
+class LearningPathLinearViewScreen extends StatefulWidget {
+  const LearningPathLinearViewScreen({super.key});
+
+  @override
+  State<LearningPathLinearViewScreen> createState() =>
+      _LearningPathLinearViewScreenState();
+}
+
+class _LearningPathLinearViewScreenState
+    extends State<LearningPathLinearViewScreen> {
+  late Future<void> _initFuture;
+  List<LearningPathNodeV2> _nodes = [];
+  LearningPathNodeV2? _current;
+  final Map<String, TrainingPackTemplateV2> _packs = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _initFuture = _load();
+  }
+
+  Future<void> _load() async {
+    await LearningPathEngine.instance.initialize();
+    await MiniLessonLibraryService.instance.loadAll();
+    final nodes = LearningPathEngine.instance
+        .getAllNodes()
+        .whereType<LearningPathNodeV2>()
+        .toList();
+    final current =
+        LearningPathEngine.instance.getCurrentNode() as LearningPathNodeV2?;
+    final packIds = <String>{};
+    for (final n in nodes) {
+      if (n.type == LearningPathNodeType.training &&
+          n.trainingPackTemplateId != null) {
+        packIds.add(n.trainingPackTemplateId!);
+      }
+    }
+    for (final id in packIds) {
+      final tpl = await PackLibraryService.instance.getById(id);
+      if (tpl != null) _packs[id] = tpl;
+    }
+    _nodes = nodes;
+    _current = current;
+  }
+
+  void _refresh() {
+    setState(() {
+      _current =
+          LearningPathEngine.instance.getCurrentNode() as LearningPathNodeV2?;
+    });
+  }
+
+  Future<void> _openCurrent() async {
+    final node = _current;
+    if (node == null) return;
+    if (node.type == LearningPathNodeType.theory) {
+      final lesson =
+          MiniLessonLibraryService.instance.getById(node.miniLessonId ?? '');
+      if (lesson != null) {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => MiniLessonScreen(lesson: lesson),
+          ),
+        );
+        await LearningPathEngine.instance.markStageCompleted(node.id);
+        _refresh();
+      }
+    } else {
+      final pack = _packs[node.trainingPackTemplateId];
+      if (pack != null) {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TrainingPackPreviewScreen(template: pack),
+          ),
+        );
+        await LearningPathEngine.instance.markStageCompleted(node.id);
+        _refresh();
+      }
+    }
+  }
+
+  Widget _buildTile(LearningPathNodeV2 node) {
+    final currentId = _current?.id;
+    final isCompleted = LearningPathEngine.instance.isCompleted(node.id);
+    final isCurrent = node.id == currentId;
+    final currentIndex = _nodes.indexWhere((n) => n.id == currentId);
+    final nodeIndex = _nodes.indexOf(node);
+    final isBlocked =
+        !isCompleted && !isCurrent && nodeIndex > currentIndex && currentIndex >= 0;
+
+    String title;
+    Widget icon;
+    if (node.type == LearningPathNodeType.theory) {
+      final lesson =
+          MiniLessonLibraryService.instance.getById(node.miniLessonId ?? '');
+      title = lesson?.resolvedTitle ?? node.miniLessonId ?? '';
+      icon = const Text('📘', style: TextStyle(fontSize: 24));
+    } else {
+      final pack = _packs[node.trainingPackTemplateId];
+      title = pack?.name ?? node.trainingPackTemplateId ?? '';
+      icon = const Text('🃏', style: TextStyle(fontSize: 24));
+    }
+
+    String? subtitle;
+    if (isCompleted) {
+      subtitle = 'Completed';
+    } else if (isCurrent) {
+      subtitle = 'Current';
+    } else if (isBlocked) {
+      subtitle = 'Locked';
+    }
+
+    final border = isCurrent
+        ? Border.all(color: Theme.of(context).colorScheme.primary, width: 2)
+        : null;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: border ?? BorderSide.none,
+      ),
+      child: ListTile(
+        leading: icon,
+        title: Text(title),
+        subtitle: subtitle != null ? Text(subtitle) : null,
+        onTap: () async {
+          await LearningPathEngine.instance.markStageCompleted(node.id);
+          _refresh();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Level I: Push/Fold Essentials')),
+      body: FutureBuilder<void>(
+        future: _initFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return Column(
+            children: [
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: _nodes.length,
+                  itemBuilder: (context, index) {
+                    final node = _nodes[index];
+                    return _buildTile(node);
+                  },
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: ElevatedButton(
+                  onPressed: _openCurrent,
+                  child: const Text('Продолжить'),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/services/learning_graph_engine.dart
+++ b/lib/services/learning_graph_engine.dart
@@ -87,6 +87,9 @@ class LearningPathEngine {
   bool isCompleted(String nodeId) =>
       LearningPathNodeHistory.instance.isCompleted(nodeId);
 
+  /// Returns all nodes in the active learning path.
+  List<LearningPathNode> getAllNodes() => _engine?.allNodes ?? const [];
+
   /// Returns a snapshot of the current session state.
   LearningPathSessionState? getSessionState() => _engine?.getState();
 


### PR DESCRIPTION
## Summary
- expose `getAllNodes` from `LearningPathEngine`
- implement `LearningPathLinearViewScreen` to visualize Push/Fold path

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f3fd50354832aa21490e6b6c12e95