### PR TITLE
feat: add view mode toggle for learning path

### DIFF
--- a/lib/screens/learning_path_launcher_screen.dart
+++ b/lib/screens/learning_path_launcher_screen.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'learning_path_horizontal_view_screen.dart';
+import 'learning_path_linear_view_screen.dart';
+
+enum LearningPathViewMode { horizontal, linear }
+
+class LearningPathLauncherScreen extends StatefulWidget {
+  const LearningPathLauncherScreen({super.key});
+
+  @override
+  State<LearningPathLauncherScreen> createState() =>
+      _LearningPathLauncherScreenState();
+}
+
+class _LearningPathLauncherScreenState
+    extends State<LearningPathLauncherScreen> {
+  static const _prefsKey = 'learning_path_view_mode';
+  LearningPathViewMode _mode = LearningPathViewMode.horizontal;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMode();
+  }
+
+  Future<void> _loadMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_prefsKey);
+    setState(() {
+      if (stored == 'linear') {
+        _mode = LearningPathViewMode.linear;
+      } else {
+        _mode = LearningPathViewMode.horizontal;
+      }
+      _loading = false;
+    });
+  }
+
+  Future<void> _setMode(LearningPathViewMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, mode == LearningPathViewMode.linear ? 'linear' : 'horizontal');
+    setState(() {
+      _mode = mode;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Learning Path'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: PopupMenuButton<LearningPathViewMode>(
+              onSelected: _setMode,
+              itemBuilder: (context) => [
+                PopupMenuItem(
+                  value: LearningPathViewMode.horizontal,
+                  child: Row(
+                    children: const [
+                      Icon(Icons.arrow_forward),
+                      SizedBox(width: 8),
+                      Text('Горизонтальный'),
+                    ],
+                  ),
+                ),
+                PopupMenuItem(
+                  value: LearningPathViewMode.linear,
+                  child: Row(
+                    children: const [
+                      Icon(Icons.arrow_upward),
+                      SizedBox(width: 8),
+                      Text('Вертикальный'),
+                    ],
+                  ),
+                ),
+              ],
+              child: Row(
+                children: const [
+                  Icon(Icons.swap_vert),
+                  SizedBox(width: 4),
+                  Text('Режим просмотра'),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: _mode == LearningPathViewMode.horizontal
+          ? const LearningPathHorizontalViewScreen(showAppBar: false)
+          : const LearningPathLinearViewScreen(showAppBar: false),
+    );
+  }
+}

--- a/lib/screens/learning_path_linear_view_screen.dart
+++ b/lib/screens/learning_path_linear_view_screen.dart
@@ -10,7 +10,8 @@ import 'mini_lesson_screen.dart';
 import 'training_pack_preview_screen.dart';
 
 class LearningPathLinearViewScreen extends StatefulWidget {
-  const LearningPathLinearViewScreen({super.key});
+  final bool showAppBar;
+  const LearningPathLinearViewScreen({super.key, this.showAppBar = true});
 
   @override
   State<LearningPathLinearViewScreen> createState() =>
@@ -79,60 +80,64 @@ class _LearningPathLinearViewScreenState
 
   @override
   Widget build(BuildContext context) {
+    final body = FutureBuilder<void>(
+      future: _initFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.all(16),
+                itemCount: _nodes.length,
+                itemBuilder: (context, index) {
+                  final node = _nodes[index];
+                  final currentId = _current?.id;
+                  final isCompleted =
+                      LearningPathEngine.instance.isCompleted(node.id);
+                  final isCurrent = node.id == currentId;
+                  final currentIndex =
+                      _nodes.indexWhere((n) => n.id == currentId);
+                  final nodeIndex = _nodes.indexOf(node);
+                  final isBlocked = !isCompleted &&
+                      !isCurrent &&
+                      nodeIndex > currentIndex &&
+                      currentIndex >= 0;
+                  final pack = _packs[node.trainingPackTemplateId];
+                  return PathNodeTile(
+                    node: node,
+                    pack: pack,
+                    isCurrent: isCurrent,
+                    isCompleted: isCompleted,
+                    isBlocked: isBlocked,
+                    onTap: () async {
+                      await LearningPathEngine.instance
+                          .markStageCompleted(node.id);
+                      _refresh();
+                    },
+                  );
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: ElevatedButton(
+                onPressed: _openCurrent,
+                child: const Text('Продолжить'),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    if (!widget.showAppBar) {
+      return body;
+    }
     return Scaffold(
       appBar: AppBar(title: const Text('Level I: Push/Fold Essentials')),
-      body: FutureBuilder<void>(
-        future: _initFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          return Column(
-            children: [
-              Expanded(
-                child: ListView.builder(
-                  padding: const EdgeInsets.all(16),
-                  itemCount: _nodes.length,
-                  itemBuilder: (context, index) {
-                    final node = _nodes[index];
-                    final currentId = _current?.id;
-                    final isCompleted =
-                        LearningPathEngine.instance.isCompleted(node.id);
-                    final isCurrent = node.id == currentId;
-                    final currentIndex =
-                        _nodes.indexWhere((n) => n.id == currentId);
-                    final nodeIndex = _nodes.indexOf(node);
-                    final isBlocked = !isCompleted &&
-                        !isCurrent &&
-                        nodeIndex > currentIndex &&
-                        currentIndex >= 0;
-                    final pack = _packs[node.trainingPackTemplateId];
-                    return PathNodeTile(
-                      node: node,
-                      pack: pack,
-                      isCurrent: isCurrent,
-                      isCompleted: isCompleted,
-                      isBlocked: isBlocked,
-                      onTap: () async {
-                        await LearningPathEngine.instance
-                            .markStageCompleted(node.id);
-                        _refresh();
-                      },
-                    );
-                  },
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: ElevatedButton(
-                  onPressed: _openCurrent,
-                  child: const Text('Продолжить'),
-                ),
-              ),
-            ],
-          );
-        },
-      ),
+      body: body,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add LearningPathLauncherScreen with view mode toggle and stored preference
- allow horizontal and linear learning path views to hide their own app bars for embedding

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f44971b88832aa13bdf6db2a5af18