### PR TITLE
refactor: modularize analyzer state and widgets

### DIFF
--- a/lib/controllers/poker_analyzer_controller.dart
+++ b/lib/controllers/poker_analyzer_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/player_model.dart';
+
+/// Controller responsible for managing the state of the poker analyzer.
+///
+/// Moving the mutable state out of the UI widgets allows the view layer to
+/// remain declarative and focused purely on presentation. The controller can
+/// later be expanded with more complex logic and persistence as the feature
+/// grows.
+class PokerAnalyzerController extends ChangeNotifier {
+  /// Number of players at the table.
+  int numberOfPlayers = 2;
+
+  /// Mapping from player index to their table position (e.g. "BTN").
+  final Map<int, String> playerPositions = {};
+
+  /// Player type metadata keyed by player index.
+  final Map<int, PlayerType> playerTypes = {};
+
+  /// List of current players.
+  final List<PlayerModel> players = [];
+
+  /// Flag controlling display of debug information in the overlay.
+  bool debugMode = false;
+
+  /// Toggles [debugMode] and notifies listeners.
+  void toggleDebug() {
+    debugMode = !debugMode;
+    notifyListeners();
+  }
+}
+

--- a/lib/screens/poker_analyzer_action_panel.dart
+++ b/lib/screens/poker_analyzer_action_panel.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/poker_analyzer_controls.dart';
+
 /// Panel containing action controls and evaluation information.
 class PokerAnalyzerActionPanel extends StatelessWidget {
   const PokerAnalyzerActionPanel({super.key});
@@ -8,12 +10,7 @@ class PokerAnalyzerActionPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.grey.shade900,
-      child: const Center(
-        child: Text(
-          'Action Panel',
-          style: TextStyle(color: Colors.white),
-        ),
-      ),
+      child: const PokerAnalyzerControls(),
     );
   }
 }

--- a/lib/screens/poker_analyzer_board_panel.dart
+++ b/lib/screens/poker_analyzer_board_panel.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/poker_analyzer_board_display.dart';
+
 /// Panel responsible for board editing and visualization.
 class PokerAnalyzerBoardPanel extends StatelessWidget {
   const PokerAnalyzerBoardPanel({super.key});
@@ -8,12 +10,7 @@ class PokerAnalyzerBoardPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.green.shade800,
-      child: const Center(
-        child: Text(
-          'Board Panel',
-          style: TextStyle(color: Colors.white),
-        ),
-      ),
+      child: const PokerAnalyzerBoardDisplay(),
     );
   }
 }

--- a/lib/screens/poker_analyzer_core.dart
+++ b/lib/screens/poker_analyzer_core.dart
@@ -1,43 +1,30 @@
 import 'package:flutter/material.dart';
-import '../models/player_model.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/poker_analyzer_controller.dart';
 import 'poker_analyzer_action_panel.dart';
 import 'poker_analyzer_board_panel.dart';
 import 'poker_analyzer_overlay.dart';
 
 /// Primary poker analyzer screen.
 ///
-/// This widget hosts the core state management and delegates UI pieces
-/// to the action/board panels and overlay modules.
-class PokerAnalyzerScreen extends StatefulWidget {
+/// Provides a [PokerAnalyzerController] to the widget subtree and composes the
+/// high level panels responsible for board interaction, action controls and
+/// overlays.
+class PokerAnalyzerScreen extends StatelessWidget {
   const PokerAnalyzerScreen({super.key});
 
   @override
-  PokerAnalyzerScreenState createState() => PokerAnalyzerScreenState();
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => PokerAnalyzerController(),
+      child: const _PokerAnalyzerView(),
+    );
+  }
 }
 
-/// Core state for [PokerAnalyzerScreen].
-///
-/// Only a tiny subset of the original implementation is preserved here to
-/// keep the example lightweight while demonstrating the new modular
-/// structure.  Services and complex logic from the original screen can be
-/// reintroduced as needed.
-class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
-  /// Number of players at the table.
-  int numberOfPlayers = 2;
-
-  /// Mapping from player index to their table position (e.g. "BTN").
-  final Map<int, String> playerPositions = {};
-
-  /// Player type metadata keyed by player index.
-  final Map<int, PlayerType> playerTypes = {};
-
-  /// List of current players.  In the full application this would be managed
-  /// by dedicated services; here it's only a placeholder to illustrate
-  /// how the state object exposes information to the overlay widgets.
-  final List<PlayerModel> players = [];
-
-  /// Flag controlling display of debug information in the overlay.
-  bool debugMode = false;
+class _PokerAnalyzerView extends StatelessWidget {
+  const _PokerAnalyzerView();
 
   @override
   Widget build(BuildContext context) {
@@ -51,9 +38,10 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
             ],
           ),
           // Overlay elements such as HUD, chip animations and debug UI.
-          PokerAnalyzerOverlay(state: this),
+          const PokerAnalyzerOverlay(),
         ],
       ),
     );
   }
 }
+

--- a/lib/screens/poker_analyzer_overlay.dart
+++ b/lib/screens/poker_analyzer_overlay.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
-import '../models/player_model.dart';
-import 'poker_analyzer_core.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/poker_analyzer_controller.dart';
 
 /// Overlay and animation elements for [PokerAnalyzerScreen].
 ///
@@ -10,8 +11,7 @@ import 'poker_analyzer_core.dart';
 /// refactor it serves as a lightweight facade that can be expanded in later
 /// iterations.
 class PokerAnalyzerOverlay extends StatelessWidget {
-  final PokerAnalyzerScreenState state;
-  const PokerAnalyzerOverlay({super.key, required this.state});
+  const PokerAnalyzerOverlay({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,8 @@ class PokerAnalyzerOverlay extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _HudHeader(
-            playerCount: state.players.length,
+            playerCount:
+                context.watch<PokerAnalyzerController>().players.length,
             handName: 'Hand',
           ),
           const Spacer(),

--- a/lib/widgets/poker_analyzer_board_display.dart
+++ b/lib/widgets/poker_analyzer_board_display.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Renders the current board state for the poker analyzer.
+///
+/// Separated from [PokerAnalyzerBoardPanel] so that the visualisation can grow
+/// independently from layout and styling concerns.
+class PokerAnalyzerBoardDisplay extends StatelessWidget {
+  const PokerAnalyzerBoardDisplay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Board Panel',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/poker_analyzer_controls.dart
+++ b/lib/widgets/poker_analyzer_controls.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Standalone widget hosting the action controls for the analyzer.
+///
+/// The actual control set is intentionally minimal for now; splitting the
+/// layout into its own widget keeps [PokerAnalyzerActionPanel] focused purely
+/// on styling and composition.
+class PokerAnalyzerControls extends StatelessWidget {
+  const PokerAnalyzerControls({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Action Panel',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce `PokerAnalyzerController` to manage analyzer state via Provider
- refactor `PokerAnalyzerScreen` and overlay to use the controller
- extract board and action panels into dedicated widgets for board display and controls

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f48a1e8d0832a90d228f0bfbac484