### PR TITLE
refactor: split hand editor responsibilities

### DIFF
--- a/lib/screens/v2/hand_editor_controller.dart
+++ b/lib/screens/v2/hand_editor_controller.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../../models/v2/hero_position.dart';
+import '../../models/v2/training_pack_spot.dart';
+
+/// Maintains the mutable state for [HandEditorScreen].
+class HandEditorController extends ChangeNotifier {
+  final TrainingPackSpot spot;
+  final TextEditingController cardsCtr;
+  final List<TextEditingController> stackCtr;
+  HeroPosition position;
+  int street = 0;
+
+  HandEditorController(this.spot)
+      : cardsCtr = TextEditingController(text: spot.hand.heroCards),
+        position = spot.hand.position,
+        stackCtr = [
+          for (var i = 0; i < spot.hand.playerCount; i++)
+            TextEditingController(
+                text: spot.hand.stacks['$i']?.toString() ?? ''),
+        ];
+
+  void update() {
+    updateStacks();
+    spot.hand.heroCards = cardsCtr.text;
+    spot.hand.position = position;
+    notifyListeners();
+  }
+
+  void updateStacks() {
+    final m = <String, double>{};
+    for (var i = 0; i < stackCtr.length; i++) {
+      final v = double.tryParse(stackCtr[i].text) ?? 0;
+      m['$i'] = v;
+    }
+    spot.hand.stacks = m;
+  }
+
+  bool validateStacks() {
+    final stacks = spot.hand.stacks;
+    final hero = stacks['${spot.hand.heroIndex}'];
+    if (hero == null || hero <= 0) return false;
+    int count = 0;
+    for (final v in stacks.values) {
+      if (v > 0) count++;
+    }
+    return count >= 2;
+  }
+
+  void setPlayerCount(int v) {
+    for (var i = stackCtr.length; i < v; i++) {
+      stackCtr.add(TextEditingController(
+          text: spot.hand.stacks['$i']?.toString() ?? ''));
+    }
+    while (stackCtr.length > v) {
+      stackCtr.removeLast().dispose();
+    }
+    spot.hand.playerCount = v;
+    if (spot.hand.heroIndex >= v) {
+      spot.hand.heroIndex = 0;
+    }
+    updateStacks();
+    notifyListeners();
+  }
+
+  void setHeroIndex(int v) {
+    spot.hand.heroIndex = v;
+    notifyListeners();
+  }
+
+  void setStreet(int v) {
+    street = v;
+    notifyListeners();
+  }
+
+  String? validate() {
+    final count = spot.hand.playerCount;
+    if (count < 2 || count > 9) {
+      return 'Ошибка: количество игроков 2-9';
+    }
+    if (spot.hand.heroIndex >= count) {
+      return 'Ошибка: hero index выходит за пределы';
+    }
+    if (!validateStacks()) {
+      return 'Ошибка: стеков недостаточно для розыгрыша';
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    cardsCtr.dispose();
+    for (final c in stackCtr) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+}

--- a/lib/screens/v2/hand_editor_form.dart
+++ b/lib/screens/v2/hand_editor_form.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import '../../models/v2/hero_position.dart';
+import '../../widgets/action_list_widget.dart';
+import 'hand_editor_controller.dart';
+
+/// Visual representation of the hand editor inputs.
+class HandEditorForm extends StatelessWidget {
+  final HandEditorController controller;
+  const HandEditorForm({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final spot = controller.spot;
+    const names = ['Preflop', 'Flop', 'Turn', 'River'];
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          TextField(
+            controller: controller.cardsCtr,
+            decoration: const InputDecoration(labelText: 'Hero cards'),
+            onChanged: (_) => controller.update(),
+          ),
+          const SizedBox(height: 16),
+          DropdownButton<HeroPosition>(
+            value: controller.position,
+            items: [
+              for (final p in HeroPosition.values)
+                DropdownMenuItem(value: p, child: Text(p.label))
+            ],
+            onChanged: (v) {
+              if (v == null) return;
+              controller.position = v;
+              controller.update();
+            },
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              const Text('Player count'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: spot.hand.playerCount,
+                items: [
+                  for (int i = 2; i <= 9; i++)
+                    DropdownMenuItem(value: i, child: Text('$i'))
+                ],
+                onChanged: (v) {
+                  if (v == null) return;
+                  controller.setPlayerCount(v);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const Text('Stacks (BB)'),
+          const SizedBox(height: 8),
+          ListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: spot.hand.playerCount,
+            itemBuilder: (_, i) {
+              final ctrl = controller.stackCtr[i];
+              return Row(
+                children: [
+                  SizedBox(width: 32, child: Text('P$i')),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: TextField(
+                      controller: ctrl,
+                      keyboardType:
+                          const TextInputType.numberWithOptions(decimal: true),
+                      decoration: const InputDecoration(
+                        labelText: 'BB',
+                        contentPadding:
+                            EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                      ),
+                      onChanged: (_) => controller.updateStacks(),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              const Text('Hero index'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: spot.hand.heroIndex,
+                items: [
+                  for (int i = 0; i < spot.hand.playerCount; i++)
+                    DropdownMenuItem(value: i, child: Text('$i'))
+                ],
+                onChanged: (v) {
+                  controller.setHeroIndex(v ?? 0);
+                },
+              ),
+              const SizedBox(width: 8),
+              const Tooltip(
+                message: '0 — SB, 1 — BB, 2 — UTG, 3 — MP, 4 — CO, 5 — BTN',
+                child: Icon(Icons.info_outline, size: 16, color: Colors.white54),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          DropdownButton<int>(
+            value: controller.street,
+            items: [
+              for (int i = 0; i < 4; i++)
+                DropdownMenuItem(value: i, child: Text(names[i]))
+            ],
+            onChanged: (v) => controller.setStreet(v ?? 0),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: ActionListWidget(
+              playerCount: spot.hand.playerCount,
+              heroIndex: spot.hand.heroIndex,
+              initial: spot.hand.actions[controller.street],
+              onChanged: (list) {
+                spot.hand.actions[controller.street] = list;
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/v2/hand_editor_screen.dart
+++ b/lib/screens/v2/hand_editor_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+
 import '../../models/v2/training_pack_spot.dart';
-import '../../models/v2/hero_position.dart';
-import '../../helpers/training_pack_storage.dart';
-import '../../widgets/action_list_widget.dart';
+import 'hand_editor_controller.dart';
+import 'hand_editor_form.dart';
+import 'hand_editor_service.dart';
 
 class HandEditorScreen extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -13,237 +14,47 @@ class HandEditorScreen extends StatefulWidget {
 }
 
 class _HandEditorScreenState extends State<HandEditorScreen> {
-  late TextEditingController _cardsCtr;
-  List<TextEditingController> _stackCtr = [];
-  late HeroPosition _position;
-  int _street = 0;
+  late final HandEditorController _controller;
+  final _service = HandEditorService();
 
   @override
   void initState() {
     super.initState();
-    _cardsCtr = TextEditingController(text: widget.spot.hand.heroCards);
-    _position = widget.spot.hand.position;
-    _stackCtr = [
-      for (var i = 0; i < widget.spot.hand.playerCount; i++)
-        TextEditingController(
-          text: widget.spot.hand.stacks['$i']?.toString() ?? '',
-        )
-    ];
+    _controller = HandEditorController(widget.spot);
   }
 
   @override
   void dispose() {
-    _cardsCtr.dispose();
-    for (final c in _stackCtr) {
-      c.dispose();
-    }
+    _controller.dispose();
     super.dispose();
   }
 
-  void _update() {
-    _updateStacks();
-    widget.spot.hand.heroCards = _cardsCtr.text;
-    widget.spot.hand.position = _position;
-  }
-
-  void _updateStacks() {
-    final m = <String, double>{};
-    for (var i = 0; i < _stackCtr.length; i++) {
-      final v = double.tryParse(_stackCtr[i].text) ?? 0;
-      m['$i'] = v;
-    }
-    widget.spot.hand.stacks = m;
-  }
-
-  bool _validateStacks() {
-    final stacks = widget.spot.hand.stacks;
-    final hero = stacks['${widget.spot.hand.heroIndex}'];
-    if (hero == null || hero <= 0) return false;
-    int count = 0;
-    for (final v in stacks.values) {
-      if (v > 0) count++;
-    }
-    return count >= 2;
-  }
-
-  Future<void> _save(BuildContext context) async {
-    _update();
-    final count = widget.spot.hand.playerCount;
-    if (count < 2 || count > 9) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Ошибка: количество игроков 2-9')),
-      );
-      return;
-    }
-    if (widget.spot.hand.heroIndex >= count) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Ошибка: hero index выходит за пределы')),
-      );
-      return;
-    }
-    if (!_validateStacks()) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Ошибка: стеков недостаточно для розыгрыша')),
-      );
+  Future<void> _save() async {
+    _controller.update();
+    final err = _controller.validate();
+    if (err != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(err)));
       return;
     }
     widget.spot.editedAt = DateTime.now();
-    final templates = await TrainingPackStorage.load();
-    for (final t in templates) {
-      for (var i = 0; i < t.spots.length; i++) {
-        if (t.spots[i].id == widget.spot.id) {
-          t.spots[i] = widget.spot;
-          break;
-        }
-      }
-    }
-    await TrainingPackStorage.save(templates);
+    await _service.saveSpot(widget.spot);
     if (mounted) Navigator.pop(context);
   }
 
   @override
   Widget build(BuildContext context) {
-    void onChanged(String _) => _update();
-    const names = ['Preflop', 'Flop', 'Turn', 'River'];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Edit Hand'),
         leading: IconButton(
             icon: const Icon(Icons.arrow_back),
             onPressed: () => Navigator.pop(context)),
-        actions: [
-          IconButton(
-              icon: const Icon(Icons.save), onPressed: () => _save(context))
-        ],
+        actions: [IconButton(icon: const Icon(Icons.save), onPressed: _save)],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            TextField(
-              controller: _cardsCtr,
-              decoration: const InputDecoration(labelText: 'Hero cards'),
-              onChanged: onChanged,
-            ),
-            const SizedBox(height: 16),
-            DropdownButton<HeroPosition>(
-              value: _position,
-              items: [
-                for (final p in HeroPosition.values)
-                  DropdownMenuItem(value: p, child: Text(p.label))
-              ],
-              onChanged: (v) {
-                if (v == null) return;
-                setState(() {
-                  _position = v;
-                  _update();
-                });
-              },
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                const Text('Player count'),
-                const SizedBox(width: 16),
-                DropdownButton<int>(
-                  value: widget.spot.hand.playerCount,
-                  items: [
-                    for (int i = 2; i <= 9; i++)
-                      DropdownMenuItem(value: i, child: Text('$i'))
-                  ],
-                  onChanged: (v) {
-                    if (v == null) return;
-                    setState(() {
-                      for (var i = _stackCtr.length; i < v; i++) {
-                        _stackCtr
-                            .add(TextEditingController(text: widget.spot.hand.stacks['$i']?.toString() ?? ''));
-                      }
-                      while (_stackCtr.length > v) {
-                        _stackCtr.removeLast().dispose();
-                      }
-                      widget.spot.hand.playerCount = v;
-                      if (widget.spot.hand.heroIndex >= v) {
-                        widget.spot.hand.heroIndex = 0;
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Hero index выходит за пределы — сброшен в 0')),
-                        );
-                      }
-                      _updateStacks();
-                    });
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            const Text('Stacks (BB)'),
-            const SizedBox(height: 8),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: widget.spot.hand.playerCount,
-              itemBuilder: (_, i) {
-                final ctrl = _stackCtr[i];
-                return Row(
-                  children: [
-                    SizedBox(width: 32, child: Text('P$i')),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: TextField(
-                        controller: ctrl,
-                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                        decoration: const InputDecoration(
-                          labelText: 'BB',
-                          contentPadding: EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-                        ),
-                        onChanged: (_) => _updateStacks(),
-                      ),
-                    ),
-                  ],
-                );
-              },
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                const Text('Hero index'),
-                const SizedBox(width: 16),
-                DropdownButton<int>(
-                  value: widget.spot.hand.heroIndex,
-                  items: [
-                    for (int i = 0; i < widget.spot.hand.playerCount; i++)
-                      DropdownMenuItem(value: i, child: Text('$i'))
-                  ],
-                  onChanged: (v) =>
-                      setState(() => widget.spot.hand.heroIndex = v ?? 0),
-                ),
-                const SizedBox(width: 8),
-                const Tooltip(
-                  message: '0 — SB, 1 — BB, 2 — UTG, 3 — MP, 4 — CO, 5 — BTN',
-                  child:
-                      Icon(Icons.info_outline, size: 16, color: Colors.white54),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            DropdownButton<int>(
-              value: _street,
-              items: [
-                for (int i = 0; i < 4; i++)
-                  DropdownMenuItem(value: i, child: Text(names[i]))
-              ],
-              onChanged: (v) => setState(() => _street = v ?? 0),
-            ),
-            const SizedBox(height: 8),
-            Expanded(
-              child: ActionListWidget(
-                playerCount: widget.spot.hand.playerCount,
-                heroIndex: widget.spot.hand.heroIndex,
-                initial: widget.spot.hand.actions[_street],
-                onChanged: (list) => widget.spot.hand.actions[_street] = list,
-              ),
-            ),
-          ],
-        ),
+      body: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, __) => HandEditorForm(controller: _controller),
       ),
     );
   }

--- a/lib/screens/v2/hand_editor_service.dart
+++ b/lib/screens/v2/hand_editor_service.dart
@@ -1,0 +1,19 @@
+import '../../models/v2/training_pack_spot.dart';
+import '../../helpers/training_pack_storage.dart';
+
+/// Handles persistence for the hand editor.
+class HandEditorService {
+  /// Saves the updated [spot] into existing templates.
+  Future<void> saveSpot(TrainingPackSpot spot) async {
+    final templates = await TrainingPackStorage.load();
+    for (final t in templates) {
+      for (var i = 0; i < t.spots.length; i++) {
+        if (t.spots[i].id == spot.id) {
+          t.spots[i] = spot;
+          break;
+        }
+      }
+    }
+    await TrainingPackStorage.save(templates);
+  }
+}


### PR DESCRIPTION
## Summary
- move hand editor state into `HandEditorController`
- extract form rendering to `HandEditorForm`
- isolate persistence in `HandEditorService` and simplify `HandEditorScreen`

## Testing
- `flutter format lib/screens/v2/hand_editor_service.dart lib/screens/v2/hand_editor_controller.dart lib/screens/v2/hand_editor_form.dart lib/screens/v2/hand_editor_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f489d3dc0832a9dfb8c9d838f4c04