### PR TITLE
refactor: reuse formatDuration for exports

### DIFF
--- a/lib/helpers/export_utils.dart
+++ b/lib/helpers/export_utils.dart
@@ -60,15 +60,6 @@ class ExportUtils {
     return widgets;
   }
 
-  static String durationString(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60);
-    final parts = <String>[];
-    if (h > 0) parts.add('$hч');
-    parts.add('$mм');
-    return parts.join(' ');
-  }
-
   static List<dynamic> csvRow(
     DateTime date,
     Duration duration,
@@ -81,7 +72,7 @@ class ExportUtils {
     final icm = icmAvg != null ? icmAvg.toStringAsFixed(3) : '';
     return [
       formatDateTime(date),
-      durationString(duration),
+      formatDuration(duration),
       count,
       correct,
       ev,

--- a/lib/services/saved_hand_export_service.dart
+++ b/lib/services/saved_hand_export_service.dart
@@ -78,7 +78,7 @@ class SavedHandExportService {
   Future<String?> exportAllSessionsMarkdown(Map<int, String> notes) async {
     if (_hands.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
+    String durToStr(Duration d) => formatDuration(d);
 
     final grouped = _stats.handsBySession().entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
@@ -121,7 +121,7 @@ class SavedHandExportService {
   Future<String?> exportAllSessionsPdf(Map<int, String> notes) async {
     if (_hands.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
+    String durToStr(Duration d) => formatDuration(d);
 
     final regularFont = await pw.PdfGoogleFonts.robotoRegular();
     final boldFont = await pw.PdfGoogleFonts.robotoBold();
@@ -189,7 +189,7 @@ class SavedHandExportService {
       List<int> sessionIds, Map<int, String> notes) async {
     if (sessionIds.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
+    String durToStr(Duration d) => formatDuration(d);
 
     final grouped = _stats.handsBySession();
     final ids = List<int>.from(sessionIds)..sort();
@@ -232,7 +232,7 @@ class SavedHandExportService {
       List<int> sessionIds, Map<int, String> notes) async {
     if (sessionIds.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
+    String durToStr(Duration d) => formatDuration(d);
 
     final regularFont = await pw.PdfGoogleFonts.robotoRegular();
     final boldFont = await pw.PdfGoogleFonts.robotoBold();
@@ -298,7 +298,6 @@ class SavedHandExportService {
   Future<String?> exportAllSessionsCsv(Map<int, String> notes) async {
     if (_hands.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
 
     final grouped = _stats.handsBySession().entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
@@ -333,7 +332,6 @@ class SavedHandExportService {
       List<int> sessionIds, Map<int, String> notes) async {
     if (sessionIds.isEmpty) return null;
 
-    String durToStr(Duration d) => ExportUtils.durationString(d);
 
     final grouped = _stats.handsBySession();
     final ids = List<int>.from(sessionIds)..sort();


### PR DESCRIPTION
## Summary
- remove durationString helper and use shared formatDuration
- replace durationString usage in saved hand exports

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f489589dc832aa2e90608c4546ac9