### PR TITLE
refactor: separate training progress concerns

### DIFF
--- a/lib/services/training_progress_notifier.dart
+++ b/lib/services/training_progress_notifier.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/foundation.dart';
+
+/// Dispatches updates when training progress changes.
+class TrainingProgressNotifier extends ChangeNotifier {
+  void notifyProgressChanged() => notifyListeners();
+}

--- a/lib/services/training_progress_storage_service.dart
+++ b/lib/services/training_progress_storage_service.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Handles persistence for training progress data.
+class TrainingProgressStorageService {
+  const TrainingProgressStorageService();
+
+  String _key(String packId) => 'pack_progress_' + packId;
+
+  Future<Set<String>> loadCompletedSpotIds(String packId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key(packId));
+    return list?.toSet() ?? {};
+  }
+
+  Future<void> saveCompletedSpotIds(String packId, Set<String> ids) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key(packId), ids.toList());
+  }
+}


### PR DESCRIPTION
## Summary
- break out training progress storage to its own service
- route notifications through a dedicated notifier
- refactor training progress tracker to compose storage and notifier helpers

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f48a3355c832aa73d02263a4b7637