### PR TITLE
Refactor analyzer screen into services and reusable widgets

### DIFF
--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -8,7 +8,6 @@ import 'services/board_editing_service.dart';
 import 'services/board_manager_service.dart';
 import 'services/board_reveal_service.dart';
 import 'services/board_sync_service.dart';
-import 'services/current_hand_context_service.dart';
 import 'services/folded_players_service.dart';
 import 'services/player_editing_service.dart';
 import 'services/player_manager_service.dart';
@@ -18,10 +17,10 @@ import 'services/pot_history_service.dart';
 import 'services/pot_sync_service.dart';
 import 'services/stack_manager_service.dart';
 import 'services/transition_lock_service.dart';
-import 'services/action_history_service.dart';
 import 'services/ignored_mistake_service.dart';
 import 'services/training_import_export_service.dart';
 import 'services/demo_playback_controller.dart';
+import 'services/poker_analyzer_service.dart';
 import 'screens/weakness_overview_screen.dart';
 import 'screens/master_mode_screen.dart';
 import 'screens/goal_center_screen.dart';
@@ -70,6 +69,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+        ChangeNotifierProvider(create: (_) => PokerAnalyzerService()),
         ChangeNotifierProvider(
           create: (context) =>
               PlayerManagerService(context.read<PlayerProfileService>()),
@@ -105,7 +105,6 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
             actionSync: context.read<ActionSyncService>(),
           ),
         ),
-        Provider(create: (_) => ActionHistoryService()),
         ChangeNotifierProvider(create: (_) => IgnoredMistakeService()..load()),
         Provider(create: (_) => const TrainingImportExportService()),
       ],
@@ -215,33 +214,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                     ],
                   );
                 },
-                home: PokerAnalyzerScreen(
-                  actionSync: context.read<ActionSyncService>(),
-                  foldedPlayersService: context.read<FoldedPlayersService>(),
-                  allInPlayersService: context.read<AllInPlayersService>(),
-                  handContext: CurrentHandContextService(),
-                  playbackManager: context.read<PlaybackManagerService>(),
-                  stackService: context
-                      .read<PlaybackManagerService>()
-                      .stackService,
-                  potSyncService: context
-                      .read<PlaybackManagerService>()
-                      .potSync,
-                  boardManager: context.read<BoardManagerService>(),
-                  boardSync: context.read<BoardSyncService>(),
-                  boardEditing: context.read<BoardEditingService>(),
-                  playerEditing: context.read<PlayerEditingService>(),
-                  playerManager: context.read<PlayerManagerService>(),
-                  playerProfile: context.read<PlayerProfileService>(),
-                  actionTagService: context
-                      .read<PlayerProfileService>()
-                      .actionTagService,
-                  boardReveal: boardReveal,
-                  lockService: lockService,
-                  actionHistory: context.read<ActionHistoryService>(),
-                  demoMode: widget.demoMode,
-                  key: analyzerKey,
-                ),
+                home: PokerAnalyzerScreen(key: analyzerKey),
               ),
             ),
           );

--- a/lib/screens/poker_analyzer_action_panel.dart
+++ b/lib/screens/poker_analyzer_action_panel.dart
@@ -1,19 +1,16 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/panel_placeholder.dart';
+
 /// Panel containing action controls and evaluation information.
 class PokerAnalyzerActionPanel extends StatelessWidget {
   const PokerAnalyzerActionPanel({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return PanelPlaceholder(
       color: Colors.grey.shade900,
-      child: const Center(
-        child: Text(
-          'Action Panel',
-          style: TextStyle(color: Colors.white),
-        ),
-      ),
+      label: 'Action Panel',
     );
   }
 }

--- a/lib/screens/poker_analyzer_board_panel.dart
+++ b/lib/screens/poker_analyzer_board_panel.dart
@@ -1,19 +1,16 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/panel_placeholder.dart';
+
 /// Panel responsible for board editing and visualization.
 class PokerAnalyzerBoardPanel extends StatelessWidget {
   const PokerAnalyzerBoardPanel({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return PanelPlaceholder(
       color: Colors.green.shade800,
-      child: const Center(
-        child: Text(
-          'Board Panel',
-          style: TextStyle(color: Colors.white),
-        ),
-      ),
+      label: 'Board Panel',
     );
   }
 }

--- a/lib/screens/poker_analyzer_core.dart
+++ b/lib/screens/poker_analyzer_core.dart
@@ -1,57 +1,30 @@
 import 'package:flutter/material.dart';
-import '../models/player_model.dart';
+
 import 'poker_analyzer_action_panel.dart';
 import 'poker_analyzer_board_panel.dart';
 import 'poker_analyzer_overlay.dart';
 
 /// Primary poker analyzer screen.
 ///
-/// This widget hosts the core state management and delegates UI pieces
-/// to the action/board panels and overlay modules.
-class PokerAnalyzerScreen extends StatefulWidget {
+/// After refactoring, this widget is responsible solely for composing its
+/// child widgets.  All state and game logic has been moved into dedicated
+/// services, keeping the UI focused on layout.
+class PokerAnalyzerScreen extends StatelessWidget {
   const PokerAnalyzerScreen({super.key});
-
-  @override
-  PokerAnalyzerScreenState createState() => PokerAnalyzerScreenState();
-}
-
-/// Core state for [PokerAnalyzerScreen].
-///
-/// Only a tiny subset of the original implementation is preserved here to
-/// keep the example lightweight while demonstrating the new modular
-/// structure.  Services and complex logic from the original screen can be
-/// reintroduced as needed.
-class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen> {
-  /// Number of players at the table.
-  int numberOfPlayers = 2;
-
-  /// Mapping from player index to their table position (e.g. "BTN").
-  final Map<int, String> playerPositions = {};
-
-  /// Player type metadata keyed by player index.
-  final Map<int, PlayerType> playerTypes = {};
-
-  /// List of current players.  In the full application this would be managed
-  /// by dedicated services; here it's only a placeholder to illustrate
-  /// how the state object exposes information to the overlay widgets.
-  final List<PlayerModel> players = [];
-
-  /// Flag controlling display of debug information in the overlay.
-  bool debugMode = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Stack(
-        children: [
+        children: const [
           Row(
-            children: const [
+            children: [
               Expanded(child: PokerAnalyzerBoardPanel()),
               Expanded(child: PokerAnalyzerActionPanel()),
             ],
           ),
           // Overlay elements such as HUD, chip animations and debug UI.
-          PokerAnalyzerOverlay(state: this),
+          PokerAnalyzerOverlay(),
         ],
       ),
     );

--- a/lib/screens/poker_analyzer_overlay.dart
+++ b/lib/screens/poker_analyzer_overlay.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-import '../models/player_model.dart';
-import 'poker_analyzer_core.dart';
+import '../services/poker_analyzer_service.dart';
 
 /// Overlay and animation elements for [PokerAnalyzerScreen].
 ///
@@ -10,17 +10,17 @@ import 'poker_analyzer_core.dart';
 /// refactor it serves as a lightweight facade that can be expanded in later
 /// iterations.
 class PokerAnalyzerOverlay extends StatelessWidget {
-  final PokerAnalyzerScreenState state;
-  const PokerAnalyzerOverlay({super.key, required this.state});
+  const PokerAnalyzerOverlay({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final service = context.watch<PokerAnalyzerService>();
     return IgnorePointer(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _HudHeader(
-            playerCount: state.players.length,
+            playerCount: service.players.length,
             handName: 'Hand',
           ),
           const Spacer(),

--- a/lib/services/poker_analyzer_service.dart
+++ b/lib/services/poker_analyzer_service.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/player_model.dart';
+
+/// Service holding the core state for the [PokerAnalyzerScreen].
+///
+/// Moving this logic out of the screen allows the UI widgets to remain
+/// focused on composition. The service can later be expanded with additional
+/// game logic and exposed through providers.
+class PokerAnalyzerService extends ChangeNotifier {
+  /// Number of players at the table.
+  int numberOfPlayers = 2;
+
+  /// Mapping from player index to their table position (e.g. "BTN").
+  final Map<int, String> playerPositions = {};
+
+  /// Player type metadata keyed by player index.
+  final Map<int, PlayerType> playerTypes = {};
+
+  /// List of current players.
+  final List<PlayerModel> players = [];
+
+  /// Flag controlling display of debug information in the overlay.
+  bool debugMode = false;
+
+  /// Updates the number of players and notifies listeners.
+  void setNumberOfPlayers(int count) {
+    if (count == numberOfPlayers) return;
+    numberOfPlayers = count;
+    notifyListeners();
+  }
+
+  /// Toggles the debug mode flag.
+  void toggleDebugMode() {
+    debugMode = !debugMode;
+    notifyListeners();
+  }
+}
+

--- a/lib/widgets/panel_placeholder.dart
+++ b/lib/widgets/panel_placeholder.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Simple placeholder panel used by the action and board panels.
+///
+/// It keeps the demo UI light while avoiding repetition of the same
+/// container structure in multiple widgets.
+class PanelPlaceholder extends StatelessWidget {
+  final Color color;
+  final String label;
+  const PanelPlaceholder({super.key, required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: color,
+      child: Center(
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}
+

--- a/main.dart
+++ b/main.dart
@@ -9,7 +9,6 @@ import 'package:poker_analyzer/services/board_editing_service.dart';
 import 'package:poker_analyzer/services/board_manager_service.dart';
 import 'package:poker_analyzer/services/board_reveal_service.dart';
 import 'package:poker_analyzer/services/board_sync_service.dart';
-import 'package:poker_analyzer/services/current_hand_context_service.dart';
 import 'package:poker_analyzer/services/folded_players_service.dart';
 import 'package:poker_analyzer/services/player_editing_service.dart';
 import 'package:poker_analyzer/services/player_manager_service.dart';
@@ -22,6 +21,7 @@ import 'package:poker_analyzer/services/transition_lock_service.dart';
 import 'package:poker_analyzer/services/action_history_service.dart';
 import 'package:poker_analyzer/services/training_import_export_service.dart';
 import 'package:poker_analyzer/services/demo_playback_controller.dart';
+import 'package:poker_analyzer/services/poker_analyzer_service.dart';
 
 final PluginRuntime pluginRuntime = PluginRuntime();
 
@@ -65,6 +65,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PlayerProfileService()),
+        ChangeNotifierProvider(create: (_) => PokerAnalyzerService()),
         ChangeNotifierProvider(
           create: (context) =>
               PlayerManagerService(context.read<PlayerProfileService>()),
@@ -193,28 +194,7 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                   ],
                 );
               },
-              home: PokerAnalyzerScreen(
-                actionSync: context.read<ActionSyncService>(),
-                foldedPlayersService: context.read<FoldedPlayersService>(),
-                allInPlayersService: context.read<AllInPlayersService>(),
-                handContext: CurrentHandContextService(),
-                playbackManager: context.read<PlaybackManagerService>(),
-                stackService:
-                    context.read<PlaybackManagerService>().stackService,
-                potSyncService: context.read<PlaybackManagerService>().potSync,
-                boardManager: context.read<BoardManagerService>(),
-                boardSync: context.read<BoardSyncService>(),
-                boardEditing: context.read<BoardEditingService>(),
-                playerEditing: context.read<PlayerEditingService>(),
-                playerManager: context.read<PlayerManagerService>(),
-                playerProfile: context.read<PlayerProfileService>(),
-                actionTagService:
-                    context.read<PlayerProfileService>().actionTagService,
-                boardReveal: boardReveal,
-                lockService: lockService,
-                actionHistory: context.read<ActionHistoryService>(),
-                demoMode: widget.demoMode,
-              ),
+              home: const PokerAnalyzerScreen(),
               routes: const {},
             ),
           );


### PR DESCRIPTION
## Summary
- Move analyzer view-model state into `PokerAnalyzerService`
- Extract panel placeholder widget and apply to board/action panels
- Simplify analyzer screen to composition-only and wire overlay via provider

## Testing
- `flutter format lib/services/poker_analyzer_service.dart lib/widgets/panel_placeholder.dart lib/screens/poker_analyzer_board_panel.dart lib/screens/poker_analyzer_action_panel.dart lib/screens/poker_analyzer_overlay.dart lib/screens/poker_analyzer_core.dart main.dart lib/main_demo.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f489f2480832aae55d8eacfd0739d