### PR TITLE
refactor: centralize action color mapping

### DIFF
--- a/lib/helpers/action_color_helper.dart
+++ b/lib/helpers/action_color_helper.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+Color actionColor(String action) {
+  switch (action) {
+    case 'fold':
+      return Colors.red;
+    case 'call':
+      return Colors.blue;
+    case 'raise':
+    case 'bet':
+      return Colors.green;
+    case 'check':
+      return Colors.grey;
+    case 'custom':
+      return Colors.purple;
+    default:
+      return Colors.white;
+  }
+}

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../helpers/action_color_helper.dart';
 import 'street_actions_list.dart';
 
 /// Collapsible block showing actions for a specific street.
@@ -42,23 +43,8 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
 
   String get _streetName => ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][widget.street];
 
-  String _capitalize(String s) => s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
-
-  Color _colorForAction(String action) {
-    switch (action) {
-      case 'fold':
-        return Colors.red;
-      case 'call':
-        return Colors.blue;
-      case 'raise':
-      case 'bet':
-        return Colors.green;
-      case 'custom':
-        return Colors.purple;
-      default:
-        return Colors.white;
-    }
-  }
+  String _capitalize(String s) =>
+      s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
 
   String _buildSummary(List<ActionEntry> actions) {
     if (actions.isEmpty) return 'Нет действий';
@@ -81,7 +67,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
 
     final summary = _buildSummary(streetActions);
     final summaryColor = streetActions.isNotEmpty
-        ? _colorForAction(streetActions.last.action)
+        ? actionColor(streetActions.last.action)
         : Colors.white54;
     bool hasNegative = false;
     if (widget.evaluateActionQuality != null) {

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'edit_action_dialog.dart';
 import 'package:intl/intl.dart';
+import '../helpers/action_color_helper.dart';
 
 import 'street_pot_widget.dart';
 import 'chip_stack_widget.dart';
@@ -47,26 +48,7 @@ class StreetActionsList extends StatelessWidget {
 
   Widget _buildTile(
       BuildContext context, ActionEntry a, int globalIndex, int index) {
-    Color color;
-    switch (a.action) {
-      case 'fold':
-        color = Colors.red;
-        break;
-      case 'call':
-        color = Colors.blue;
-        break;
-      case 'raise':
-        color = Colors.green;
-        break;
-      case 'check':
-        color = Colors.grey;
-        break;
-      case 'custom':
-        color = Colors.purple;
-        break;
-      default:
-        color = Colors.white;
-    }
+    final color = actionColor(a.action);
     final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
     final actLabel = a.action == 'custom' ? (a.customLabel ?? 'custom') : a.action;
     final baseTitle = '$pos — $actLabel';


### PR DESCRIPTION
## Summary
- add helper to map poker actions to colors
- use `actionColor` in street section summary
- use `actionColor` in street actions list

## Testing
- `dart format lib/helpers/action_color_helper.dart lib/widgets/collapsible_street_section.dart lib/widgets/street_actions_list.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f48ab63cc832a9c690ba08903cb5e