### PR TITLE
refactor: centralize poker street names

### DIFF
--- a/lib/helpers/poker_street_helper.dart
+++ b/lib/helpers/poker_street_helper.dart
@@ -4,12 +4,23 @@
 /// numeric indices to those names.
 library poker_street_helper;
 
+import 'package:intl/intl.dart';
+
 /// Street name list ordered from preflop to river.
 const kStreetNames = ['Preflop', 'Flop', 'Turn', 'River'];
 
-/// Returns the street name for [index].
+/// Returns the localized street name for [index].
 ///
 /// Values outside the valid range are clamped.
 String streetName(int index) {
-  return kStreetNames[index.clamp(0, kStreetNames.length - 1)];
+  switch (index.clamp(0, kStreetNames.length - 1)) {
+    case 0:
+      return Intl.message('Preflop', name: 'street_preflop');
+    case 1:
+      return Intl.message('Flop', name: 'street_flop');
+    case 2:
+      return Intl.message('Turn', name: 'street_turn');
+    default:
+      return Intl.message('River', name: 'street_river');
+  }
 }

--- a/lib/widgets/action_history_expansion_tile.dart
+++ b/lib/widgets/action_history_expansion_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/action_entry.dart';
+import '../helpers/poker_street_helper.dart';
 import 'street_actions_list.dart';
 import 'package:sticky_headers/sticky_headers.dart';
 
@@ -45,7 +46,7 @@ class _ActionHistoryExpansionTileState
   @override
   void initState() {
     super.initState();
-    _streetExpanded = List<bool>.filled(4, true);
+    _streetExpanded = List<bool>.filled(kStreetNames.length, true);
   }
 
   void _toggleAll() {
@@ -59,7 +60,6 @@ class _ActionHistoryExpansionTileState
 
   @override
   Widget build(BuildContext context) {
-    const streetNames = ['Preflop', 'Flop', 'Turn', 'River'];
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       decoration: BoxDecoration(
@@ -100,7 +100,7 @@ class _ActionHistoryExpansionTileState
         backgroundColor: Colors.black54,
         childrenPadding: const EdgeInsets.only(bottom: 8),
         children: [
-          for (int i = 0; i < 4; i++)
+          for (int i = 0; i < kStreetNames.length; i++)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4),
               child: StickyHeader(
@@ -113,7 +113,7 @@ class _ActionHistoryExpansionTileState
                     child: Row(
                       children: [
                         Text(
-                          streetNames[i],
+                          streetName(i),
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,

--- a/lib/widgets/action_history_overlay.dart
+++ b/lib/widgets/action_history_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/action_entry.dart';
 import '../helpers/action_formatting_helper.dart';
+import '../helpers/poker_street_helper.dart';
 import '../services/action_history_service.dart';
 import 'edit_action_dialog.dart';
 
@@ -34,7 +35,6 @@ class ActionHistoryOverlay extends StatelessWidget {
     final Map<int, List<ActionEntry>> grouped = actionHistory.hudView();
     final screenWidth = MediaQuery.of(context).size.width;
     final double scale = screenWidth < 350 ? 0.8 : 1.0;
-    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
 
     Widget buildChip(ActionEntry a, int index) {
       final pos = playerPositions[a.playerIndex] ?? 'P${a.playerIndex + 1}';
@@ -153,7 +153,7 @@ class ActionHistoryOverlay extends StatelessWidget {
         height: 70 * scale,
         child: ListView.builder(
           scrollDirection: Axis.horizontal,
-          itemCount: 4,
+          itemCount: kStreetNames.length,
           itemBuilder: (context, index) {
             final list = grouped[index] ?? [];
             if (list.isEmpty) {
@@ -174,7 +174,7 @@ class ActionHistoryOverlay extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      streetNames[index],
+                      streetName(index),
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 12 * scale,

--- a/lib/widgets/action_history_widget.dart
+++ b/lib/widgets/action_history_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../helpers/poker_street_helper.dart';
 
 class ActionHistoryWidget extends StatelessWidget {
   final List<ActionEntry> actions;
@@ -19,12 +20,11 @@ class ActionHistoryWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        for (int street = 0; street < 4; street++)
-          _buildStreetTile(context, street, streetNames[street]),
+        for (int street = 0; street < kStreetNames.length; street++)
+          _buildStreetTile(context, street, streetName(street)),
       ],
     );
   }

--- a/lib/widgets/collapsible_action_history.dart
+++ b/lib/widgets/collapsible_action_history.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import '../helpers/action_utils.dart';
+import '../helpers/poker_street_helper.dart';
 import '../services/action_history_service.dart';
 import '../utils/responsive.dart';
 
@@ -45,7 +46,7 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
   @override
   void initState() {
     super.initState();
-    _controller = TabController(length: 4, vsync: this);
+    _controller = TabController(length: kStreetNames.length, vsync: this);
   }
 
   @override
@@ -130,11 +131,9 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
                   labelColor: Colors.white,
                   unselectedLabelColor: Colors.white70,
                   indicatorColor: Colors.white,
-                  tabs: const [
-                    Tab(text: 'Preflop'),
-                    Tab(text: 'Flop'),
-                    Tab(text: 'Turn'),
-                    Tab(text: 'River'),
+                  tabs: [
+                    for (int i = 0; i < kStreetNames.length; i++)
+                      Tab(text: streetName(i)),
                   ],
                 ),
                 const Divider(height: 1, color: Colors.white24),
@@ -142,10 +141,8 @@ class _CollapsibleActionHistoryState extends State<CollapsibleActionHistory>
                   child: TabBarView(
                     controller: _controller,
                     children: [
-                      _buildList(0),
-                      _buildList(1),
-                      _buildList(2),
-                      _buildList(3),
+                      for (int i = 0; i < kStreetNames.length; i++)
+                        _buildList(i),
                     ],
                   ),
                 ),

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../helpers/poker_street_helper.dart';
 import 'street_actions_list.dart';
 
 /// Collapsible block showing actions for a specific street.
@@ -40,7 +41,7 @@ class CollapsibleStreetSection extends StatefulWidget {
 class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
   bool _open = false;
 
-  String get _streetName => ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'][widget.street];
+  String get _streetName => streetName(widget.street);
 
   String _capitalize(String s) => s.isNotEmpty ? s[0].toUpperCase() + s.substring(1) : s;
 

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../helpers/poker_street_helper.dart';
 import 'street_actions_list.dart';
 
 class CollapsibleStreetSummary extends StatefulWidget {
@@ -78,9 +79,8 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
 
   @override
   Widget build(BuildContext context) {
-    const streetNames = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
     return Column(
-      children: List.generate(4, (i) {
+      children: List.generate(kStreetNames.length, (i) {
         final expanded = _expandedStreet == i;
         final streetActions =
             widget.actions.where((a) => a.street == i).toList(growable: false);
@@ -106,7 +106,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          streetNames[i],
+                          streetName(i),
                           style: const TextStyle(color: Colors.white),
                         ),
                         const SizedBox(height: 4),

--- a/lib/widgets/common/mistake_by_street_chart.dart
+++ b/lib/widgets/common/mistake_by_street_chart.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import '../../theme/app_colors.dart';
+import '../../helpers/poker_street_helper.dart';
 import '../../utils/responsive.dart';
 
 class MistakeByStreetChart extends StatelessWidget {
@@ -17,7 +18,7 @@ class MistakeByStreetChart extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    const labels = ['Preflop', 'Flop', 'Turn', 'River'];
+    final labels = kStreetNames;
     final values = [for (final l in labels) counts[l] ?? 0];
     final maxCount = values.reduce(max);
 
@@ -95,7 +96,7 @@ class MistakeByStreetChart extends StatelessWidget {
                     if (index < 0 || index >= labels.length) {
                       return const SizedBox.shrink();
                     }
-                    final text = '${labels[index]} (${values[index]})';
+                    final text = '${streetName(index)} (${values[index]})';
                     return Transform.rotate(
                       angle: -pi / 2,
                       child: Text(

--- a/lib/widgets/mistake_summary_card.dart
+++ b/lib/widgets/mistake_summary_card.dart
@@ -10,15 +10,19 @@ class MistakeSummaryCard extends StatelessWidget {
   const MistakeSummaryCard({super.key});
 
   IconData _streetIcon(String street) {
-    switch (street) {
-      case 'Preflop':
+    final index = List.generate(kStreetNames.length, (i) => i)
+        .firstWhere((i) => streetName(i) == street, orElse: () => -1);
+    switch (index) {
+      case 0:
         return Icons.filter_1;
-      case 'Flop':
+      case 1:
         return Icons.filter_2;
-      case 'Turn':
+      case 2:
         return Icons.filter_3;
-      default:
+      case 3:
         return Icons.filter_4;
+      default:
+        return Icons.filter_1;
     }
   }
 

--- a/lib/widgets/player_zone/player_zone_core.dart
+++ b/lib/widgets/player_zone/player_zone_core.dart
@@ -38,6 +38,7 @@ import 'winner_flying_chip.dart';
 import 'action_tag_label.dart';
 import 'player_effective_stack_label.dart';
 import 'player_position_label.dart';
+import '../../helpers/poker_street_helper.dart';
 import 'player_zone_animations.dart';
 import 'player_zone_overlay.dart';
 import 'player_zone_animator.dart';
@@ -2659,18 +2660,8 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
   }
 
   String _streetName(String street) {
-    switch (street) {
-      case 'Preflop':
-        return 'Префлоп';
-      case 'Flop':
-        return 'Флоп';
-      case 'Turn':
-        return 'Тёрн';
-      case 'River':
-        return 'Ривер';
-      default:
-        return street;
-    }
+    final index = kStreetNames.indexOf(street);
+    return index == -1 ? street : streetName(index);
   }
 
   String _capitalize(String s) =>

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -6,6 +6,7 @@ import '../core/training/engine/training_type_engine.dart';
 import '../widgets/spot_quiz_widget.dart';
 import '../widgets/action_history_widget.dart';
 import '../models/action_entry.dart';
+import '../helpers/poker_street_helper.dart';
 import '../services/training_session_service.dart';
 import '../services/tag_service.dart';
 import 'share_dialog.dart';
@@ -67,13 +68,12 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
       if (board.isNotEmpty) 'Board: $board',
       'Position: $pos'
     ];
-    const names = ['Preflop', 'Flop', 'Turn', 'River'];
-    for (int s = 0; s < 4; s++) {
+    for (int s = 0; s < kStreetNames.length; s++) {
       final acts = _actions()
           .where((a) => a.street == s && a.action != 'board' && !a.generated)
           .toList();
       if (acts.isEmpty) continue;
-      lines.add('${names[s]}:');
+      lines.add('${streetName(s)}:');
       for (final a in acts) {
         final posName = map[a.playerIndex] ?? 'P${a.playerIndex + 1}';
         final label =

--- a/lib/widgets/street_actions_widget.dart
+++ b/lib/widgets/street_actions_widget.dart
@@ -6,6 +6,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../helpers/poker_street_helper.dart';
+
 class StreetActionsWidget extends StatelessWidget {
   final int currentStreet;
   final Function(int) onStreetChanged;
@@ -22,8 +24,6 @@ class StreetActionsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const List<String> streets = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
-
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Row(
@@ -34,7 +34,7 @@ class StreetActionsWidget extends StatelessWidget {
             color: Colors.white,
             onPressed: canGoPrev ? onPrevStreet : null,
           ),
-          ...List.generate(streets.length, (index) {
+          ...List.generate(kStreetNames.length, (index) {
             final isSelected = index == currentStreet;
             return ElevatedButton(
               onPressed: () => onStreetChanged(index),
@@ -47,7 +47,7 @@ class StreetActionsWidget extends StatelessWidget {
                 ),
               ),
               child: Text(
-                streets[index],
+                streetName(index),
                 style: const TextStyle(fontSize: 16),
               ),
             );

--- a/lib/widgets/street_indicator.dart
+++ b/lib/widgets/street_indicator.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 
+import '../helpers/poker_street_helper.dart';
+
 /// Badge displaying the name of the current street.
 class StreetIndicator extends StatelessWidget {
   final int street;
   const StreetIndicator({Key? key, required this.street}) : super(key: key);
 
-  static const _names = ['Preflop', 'Flop', 'Turn', 'River'];
-
   @override
   Widget build(BuildContext context) {
-    final name = _names[street.clamp(0, _names.length - 1)];
+    final name = streetName(street);
     return Align(
       alignment: Alignment.topCenter,
       child: AnimatedSwitcher(

--- a/lib/widgets/street_pot_widget.dart
+++ b/lib/widgets/street_pot_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
+import '../helpers/poker_street_helper.dart';
 import 'chip_stack_widget.dart';
 
 /// Displays pot size for a specific street in the history panel.
@@ -15,13 +16,7 @@ class StreetPotWidget extends StatelessWidget {
     this.sprValue,
   });
 
-  String get _streetName {
-    const names = ['Префлоп', 'Флоп', 'Тёрн', 'Ривер'];
-    if (streetIndex >= 0 && streetIndex < names.length) {
-      return names[streetIndex];
-    }
-    return '';
-  }
+  String get _streetName => streetName(streetIndex);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/street_tabs.dart
+++ b/lib/widgets/street_tabs.dart
@@ -1,6 +1,8 @@
 // lib/widgets/street_tabs.dart
 import 'package:flutter/material.dart';
 
+import '../helpers/poker_street_helper.dart';
+
 class StreetTabs extends StatelessWidget {
   final int currentStreet;
   final Function(int) onStreetChanged;
@@ -17,12 +19,10 @@ class StreetTabs extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          _buildTab('Preflop', 0),
-          _buildTab('Flop', 1),
-          _buildTab('Turn', 2),
-          _buildTab('River', 3),
-        ],
+        children: List.generate(
+          kStreetNames.length,
+          (index) => _buildTab(streetName(index), index),
+        ),
       ),
     );
   }

--- a/lib/widgets/training_pack_play_screen_v2_toolbar.dart
+++ b/lib/widgets/training_pack_play_screen_v2_toolbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../services/app_settings_service.dart';
 import '../services/mistake_hint_service.dart';
 import '../user_preferences.dart';
+import '../helpers/poker_street_helper.dart';
 
 class TrainingPackPlayScreenV2Toolbar extends StatelessWidget {
   final String title;
@@ -63,7 +64,7 @@ class TrainingPackPlayScreenV2Toolbar extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(top: 2),
                         child: Text(
-                          ['Preflop', 'Flop', 'Turn', 'River'][streetIndex!],
+                          streetName(streetIndex!),
                           style: textStyle.copyWith(fontSize: mini ? 10 : 12),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- use `streetName` helper for localized poker street strings
- remove hard-coded street arrays across widgets
- expose shared poker street constants in `poker_street_helper`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f48aa7694832a9ea8f360f8122a44