### PR TITLE
Add time helpers and refactor widgets

### DIFF
--- a/lib/helpers/date_utils.dart
+++ b/lib/helpers/date_utils.dart
@@ -24,3 +24,16 @@ String formatDuration(Duration d) {
   parts.add('${minutes}м');
   return parts.join(' ');
 }
+
+String shortTime(DateTime date) {
+  return DateFormat('HH:mm', _currentLocale()).format(date);
+}
+
+String timeDiff(DateTime prev, DateTime next) {
+  final diffMs = next.difference(prev).inMilliseconds;
+  final diffSec = diffMs / 1000;
+  final value = diffSec % 1 == 0
+      ? diffSec.toInt().toString()
+      : diffSec.toStringAsFixed(1);
+  return '+$value';
+}

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'edit_action_dialog.dart';
-import 'package:intl/intl.dart';
+import '../helpers/date_utils.dart';
 
 import 'street_pot_widget.dart';
 import 'chip_stack_widget.dart';
@@ -273,23 +273,21 @@ class StreetActionsList extends StatelessWidget {
       final prev = actions[index - 1];
       final diff = a.timestamp.difference(prev.timestamp).inSeconds;
       if (diff > 0 && diff < 60) {
-        return '+${diff}s';
+        return '${timeDiff(prev.timestamp, a.timestamp)}s';
       }
     }
-    return '⏱ ${DateFormat('HH:mm', Intl.getCurrentLocale()).format(a.timestamp)}';
+    return '⏱ ${shortTime(a.timestamp)}';
   }
 
   String _buildTooltipMessage(
       ActionEntry a, int index, String? qualityLabel) {
-    final buffer = StringBuffer(
-        'Время: ${DateFormat('HH:mm:ss', Intl.getCurrentLocale()).format(a.timestamp)}');
+    final seconds = a.timestamp.second.toString().padLeft(2, '0');
+    final buffer =
+        StringBuffer('Время: ${shortTime(a.timestamp)}:$seconds');
     if (index > 0) {
       final prev = actions[index - 1];
-      final diffMs =
-          a.timestamp.difference(prev.timestamp).inMilliseconds;
-      final diffSec = diffMs / 1000;
       buffer.writeln(
-          '\nС момента прошлого действия: +${diffSec.toStringAsFixed(1)} сек');
+          '\nС момента прошлого действия: ${timeDiff(prev.timestamp, a.timestamp)} сек');
     }
     if (qualityLabel != null) {
       buffer.writeln('\nОценка: $qualityLabel');

--- a/lib/widgets/training_action_log_dialog.dart
+++ b/lib/widgets/training_action_log_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import '../helpers/date_utils.dart';
 import 'package:provider/provider.dart';
 
 import '../models/v2/training_action.dart';
@@ -25,7 +25,8 @@ class TrainingActionLogDialog extends StatelessWidget {
                 itemBuilder: (context, index) {
                   final a = actions[index];
                   final color = a.isCorrect ? AppColors.cardBackground : AppColors.errorBg;
-                  final time = DateFormat('HH:mm:ss', Intl.getCurrentLocale()).format(a.timestamp);
+                  final seconds = a.timestamp.second.toString().padLeft(2, '0');
+                  final time = '${shortTime(a.timestamp)}:$seconds';
                   TrainingPackSpot? spot;
                   try {
                     spot = context.read<TrainingSessionService>().spots.firstWhere((s) => s.id == a.spotId);


### PR DESCRIPTION
## Summary
- add reusable `shortTime` and `timeDiff` helpers for consistent time formatting
- refactor `StreetActionsList` and `TrainingActionLogDialog` to use new helpers

## Testing
- `dart format lib/helpers/date_utils.dart lib/widgets/street_actions_list.dart lib/widgets/training_action_log_dialog.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f48b87990832abc8ddbad6dace8de