### PR TITLE
refactor: centralize padding constants

### DIFF
--- a/lib/ui/padding_constants.dart
+++ b/lib/ui/padding_constants.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/widgets.dart';
+
+const kCardPadding = EdgeInsets.all(8);
+const kScreenPadding = EdgeInsets.all(16);
+

--- a/lib/widgets/booster_suggestion_block.dart
+++ b/lib/widgets/booster_suggestion_block.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
 
@@ -96,7 +97,7 @@ class _BoosterSuggestionBlockState extends State<BoosterSuggestionBlock> {
   Widget build(BuildContext context) {
     if (_loading) {
       return const Padding(
-        padding: EdgeInsets.all(16),
+        padding: kScreenPadding,
         child: Center(child: CircularProgressIndicator()),
       );
     }
@@ -141,7 +142,7 @@ class _BoosterSuggestionBlockState extends State<BoosterSuggestionBlock> {
         : null;
     return Container(
       width: 180,
-      padding: const EdgeInsets.all(8),
+      padding: kCardPadding,
       decoration: BoxDecoration(
         color: Colors.grey[800],
         borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 /// Small HUD overlay showing current street, pot and effective stack.
 class HudOverlay extends StatelessWidget {
@@ -21,8 +22,8 @@ class HudOverlay extends StatelessWidget {
       duration: const Duration(milliseconds: 300),
       child: Container(
         key: ValueKey('$streetName-$potText-$stackText-${sprText ?? ''}'),
-        margin: const EdgeInsets.all(8),
-        padding: const EdgeInsets.all(8),
+        margin: kCardPadding,
+        padding: kCardPadding,
         decoration: BoxDecoration(
           color: Colors.black54,
           borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/learning_path_progress_widget.dart
+++ b/lib/widgets/learning_path_progress_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import '../models/learning_path_template_v2.dart';
 import '../models/learning_path_progress_stats.dart';
@@ -41,7 +42,7 @@ class _LearningPathProgressWidgetState extends State<LearningPathProgressWidget>
     final pct = (section.completionPercent.clamp(0.0, 1.0) * 100).round();
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 4),
-      padding: const EdgeInsets.all(8),
+      padding: kCardPadding,
       decoration: BoxDecoration(
         color: Colors.grey[800],
         borderRadius: BorderRadius.circular(6),

--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:confetti/confetti.dart';
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -506,7 +507,7 @@ class _PackCardState extends State<PackCard>
                     Container(
                       width: double.infinity,
                       color: Colors.black87,
-                      padding: const EdgeInsets.all(8),
+                      padding: kCardPadding,
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [

--- a/lib/widgets/replay_spot_widget.dart
+++ b/lib/widgets/replay_spot_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import '../models/training_spot.dart';
 import '../models/action_entry.dart';
@@ -124,7 +125,7 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
     return Container(
       width: double.infinity,
       margin: const EdgeInsets.only(bottom: 12),
-      padding: const EdgeInsets.all(8),
+      padding: kCardPadding,
       decoration: BoxDecoration(
         color: highlight ? Colors.redAccent.withOpacity(0.2) : Colors.white10,
         borderRadius: BorderRadius.circular(8),
@@ -185,7 +186,7 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
     final subset = TrainingSpot.fromJson(json);
 
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: kScreenPadding,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/widgets/skill_card.dart
+++ b/lib/widgets/skill_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import 'tag_progress_sparkline.dart';
 
@@ -25,7 +26,7 @@ class SkillCard extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        padding: const EdgeInsets.all(8),
+        padding: kCardPadding,
         decoration: BoxDecoration(
           color: Colors.grey[850],
           borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/skill_tree_stage_badge_legend_widget.dart
+++ b/lib/widgets/skill_tree_stage_badge_legend_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import 'skill_tree_stage_badge_icon.dart';
 
@@ -9,7 +10,7 @@ class SkillTreeStageBadgeLegendWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Padding(
-      padding: EdgeInsets.all(8),
+      padding: kCardPadding,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/widgets/tag_skill_tile.dart
+++ b/lib/widgets/tag_skill_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import '../screens/tag_insight_screen.dart';
 
@@ -25,7 +26,7 @@ class TagSkillTile extends StatelessWidget {
                     builder: (_) => TagInsightScreen(tag: tag)),
               ),
       child: Container(
-        padding: const EdgeInsets.all(8),
+        padding: kCardPadding,
         decoration: BoxDecoration(
           color: color,
           borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/track_unlock_preview_card.dart
+++ b/lib/widgets/track_unlock_preview_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import '../models/v3/lesson_track.dart';
 import '../services/learning_path_unlock_engine.dart';
@@ -166,7 +167,7 @@ class _TrackUnlockPreviewCardState extends State<TrackUnlockPreviewCard> {
                     final pct = info.total == 0 ? 0.0 : info.met / info.total;
                     return Container(
                       width: 200,
-                      padding: const EdgeInsets.all(8),
+                      padding: kCardPadding,
                       decoration: BoxDecoration(
                         color: Colors.grey[800],
                         borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/training_streak_indicator.dart
+++ b/lib/widgets/training_streak_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/padding_constants.dart';
 
 import '../services/training_streak_tracker_service.dart';
 
@@ -58,7 +59,7 @@ class _TrainingStreakIndicatorState extends State<TrainingStreakIndicator>
     final accent = Theme.of(context).colorScheme.secondary;
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
-      padding: const EdgeInsets.all(8),
+      padding: kCardPadding,
       decoration: BoxDecoration(
         color: Colors.grey[850],
         borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
## Summary
- add `kCardPadding` and `kScreenPadding` constants
- refactor widgets to reuse padding constants instead of inline `EdgeInsets`

## Testing
- `dart format lib/ui/padding_constants.dart lib/widgets/skill_card.dart lib/widgets/track_unlock_preview_card.dart lib/widgets/tag_skill_tile.dart lib/widgets/pack_card.dart lib/widgets/learning_path_progress_widget.dart lib/widgets/training_streak_indicator.dart lib/widgets/replay_spot_widget.dart lib/widgets/booster_suggestion_block.dart lib/widgets/skill_tree_stage_badge_legend_widget.dart lib/widgets/hud_overlay.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f48b7ee98832ab2db5f693d3133e1