### PR TITLE
feat: add unlock hint overlay

### DIFF
--- a/lib/screens/learning_path_horizontal_view_screen.dart
+++ b/lib/screens/learning_path_horizontal_view_screen.dart
@@ -5,7 +5,9 @@ import '../models/v2/training_pack_template_v2.dart';
 import '../services/learning_graph_engine.dart';
 import '../services/learning_path_loader.dart';
 import '../services/mini_lesson_library_service.dart';
+import '../services/skill_tree_node_detail_unlock_hint_service.dart';
 import '../widgets/path_node_tile.dart';
+import '../widgets/path_node_unlock_hint_overlay.dart';
 import 'mini_lesson_screen.dart';
 import 'training_pack_preview_screen.dart';
 
@@ -106,17 +108,32 @@ class _LearningPathHorizontalViewScreenState
                         nodeIndex > currentIndex &&
                         currentIndex >= 0;
                     final pack = _packs[node.trainingPackTemplateId];
+                    final key = GlobalKey();
                     return Padding(
                       padding: const EdgeInsets.only(right: 12),
                       child: SizedBox(
                         width: 200,
                         child: PathNodeTile(
+                          key: key,
                           node: node,
                           pack: pack,
                           isCurrent: isCurrent,
                           isCompleted: isCompleted,
                           isBlocked: isBlocked,
                           onTap: () async {
+                            if (isBlocked) {
+                              final hint = await const
+                                  SkillTreeNodeDetailUnlockHintService()
+                                      .getHint(node.id);
+                              if (hint != null) {
+                                PathNodeUnlockHintOverlay.show(
+                                  context: context,
+                                  targetKey: key,
+                                  message: hint,
+                                );
+                              }
+                              return;
+                            }
                             await LearningPathEngine.instance
                                 .markStageCompleted(node.id);
                             _refresh();

--- a/lib/screens/learning_path_linear_view_screen.dart
+++ b/lib/screens/learning_path_linear_view_screen.dart
@@ -5,7 +5,9 @@ import '../models/v2/training_pack_template_v2.dart';
 import '../services/learning_graph_engine.dart';
 import '../services/learning_path_loader.dart';
 import '../services/mini_lesson_library_service.dart';
+import '../services/skill_tree_node_detail_unlock_hint_service.dart';
 import '../widgets/path_node_tile.dart';
+import '../widgets/path_node_unlock_hint_overlay.dart';
 import 'mini_lesson_screen.dart';
 import 'training_pack_preview_screen.dart';
 
@@ -106,13 +108,28 @@ class _LearningPathLinearViewScreenState
                       nodeIndex > currentIndex &&
                       currentIndex >= 0;
                   final pack = _packs[node.trainingPackTemplateId];
+                  final key = GlobalKey();
                   return PathNodeTile(
+                    key: key,
                     node: node,
                     pack: pack,
                     isCurrent: isCurrent,
                     isCompleted: isCompleted,
                     isBlocked: isBlocked,
                     onTap: () async {
+                      if (isBlocked) {
+                        final hint = await const
+                            SkillTreeNodeDetailUnlockHintService()
+                                .getHint(node.id);
+                        if (hint != null) {
+                          PathNodeUnlockHintOverlay.show(
+                            context: context,
+                            targetKey: key,
+                            message: hint,
+                          );
+                        }
+                        return;
+                      }
                       await LearningPathEngine.instance
                           .markStageCompleted(node.id);
                       _refresh();

--- a/lib/widgets/path_node_unlock_hint_overlay.dart
+++ b/lib/widgets/path_node_unlock_hint_overlay.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Displays a temporary tooltip above a path node explaining
+/// why it is locked.
+class PathNodeUnlockHintOverlay {
+  static void show({
+    required BuildContext context,
+    required GlobalKey targetKey,
+    required String message,
+  }) {
+    final overlay = Overlay.of(context, rootOverlay: true);
+    final renderBox =
+        targetKey.currentContext?.findRenderObject() as RenderBox?;
+    if (overlay == null || renderBox == null) return;
+
+    final target = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (_) => GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () => entry.remove(),
+        child: Stack(
+          children: [
+            Positioned(
+              left: target.dx + size.width / 2,
+              top: target.dy,
+              child: FractionalTranslation(
+                translation: const Offset(-0.5, -1.0),
+                child: Material(
+                  color: Colors.transparent,
+                  child: Container(
+                    constraints: const BoxConstraints(maxWidth: 200),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withOpacity(0.8),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      message,
+                      style: const TextStyle(color: Colors.white, fontSize: 13),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    overlay.insert(entry);
+    Timer(const Duration(seconds: 4), () {
+      if (entry.mounted) entry.remove();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- show tooltip above locked path nodes with unlock hint
- compute unlock hints using new SkillTreeNodeDetailUnlockHintService.getHint
- wire horizontal and linear learning path views to display hints on locked taps

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d008da8832aa89c7230b35ff4f6