### PR TITLE
refactor: centralize poker actions model

### DIFF
--- a/lib/models/poker_actions.dart
+++ b/lib/models/poker_actions.dart
@@ -1,0 +1,19 @@
+class PokerAction {
+  final String label;
+  final String value;
+  final String icon;
+
+  const PokerAction({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+}
+
+const List<PokerAction> pokerActions = [
+  PokerAction(label: 'Fold', value: 'fold', icon: '❌'),
+  PokerAction(label: 'Call', value: 'call', icon: '📞'),
+  PokerAction(label: 'Check', value: 'check', icon: '✅'),
+  PokerAction(label: 'Bet', value: 'bet', icon: '💰'),
+  PokerAction(label: 'Raise', value: 'raise', icon: '📈'),
+];

--- a/lib/widgets/action_bottom_sheet.dart
+++ b/lib/widgets/action_bottom_sheet.dart
@@ -1,13 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../models/poker_actions.dart';
+
 Future<String?> showActionBottomSheet(BuildContext context) {
-  const actions = [
-    {'label': 'Fold', 'value': 'fold', 'icon': '❌'},
-    {'label': 'Call', 'value': 'call', 'icon': '📞'},
-    {'label': 'Check', 'value': 'check', 'icon': '✅'},
-    {'label': 'Bet', 'value': 'bet', 'icon': '💰'},
-    {'label': 'Raise', 'value': 'raise', 'icon': '📈'},
-  ];
   return showModalBottomSheet<String>(
     context: context,
     backgroundColor: Colors.grey[900],
@@ -20,7 +15,7 @@ Future<String?> showActionBottomSheet(BuildContext context) {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          for (int i = 0; i < actions.length; i++) ...[
+          for (final entry in pokerActions.asMap().entries) ...[
             ElevatedButton.icon(
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.black87,
@@ -30,11 +25,12 @@ Future<String?> showActionBottomSheet(BuildContext context) {
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              onPressed: () => Navigator.pop(ctx, actions[i]['value'] as String),
-              icon: Text(actions[i]['icon'] as String, style: const TextStyle(fontSize: 24)),
-              label: Text(actions[i]['label'] as String, style: const TextStyle(fontSize: 20)),
+              onPressed: () => Navigator.pop(ctx, entry.value.value),
+              icon: Text(entry.value.icon, style: const TextStyle(fontSize: 24)),
+              label:
+                  Text(entry.value.label, style: const TextStyle(fontSize: 20)),
             ),
-            if (i != actions.length - 1) const SizedBox(height: 12),
+            if (entry.key != pokerActions.length - 1) const SizedBox(height: 12),
           ],
         ],
       ),

--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
+import '../models/poker_actions.dart';
 
 /// Dialog allowing to quickly choose an action for a player.
 class ActionDialog extends StatefulWidget {
@@ -20,10 +21,8 @@ class ActionDialog extends StatefulWidget {
   State<ActionDialog> createState() => _ActionDialogState();
 }
 
-enum _Action { fold, check, call, bet, raise }
-
 class _ActionDialogState extends State<ActionDialog> {
-  _Action? _selected;
+  String? _selected;
   double _slider = 0;
 
   @override
@@ -32,17 +31,17 @@ class _ActionDialogState extends State<ActionDialog> {
     _slider = 0;
   }
 
-  void _selectSimple(_Action act) {
+  void _selectSimple(String act) {
     Navigator.pop(
       context,
-      ActionEntry(widget.street, widget.playerIndex, act.name, amount: null),
+      ActionEntry(widget.street, widget.playerIndex, act, amount: null),
     );
   }
 
   void _selectBetAmount(double amount) {
     Navigator.pop(
       context,
-      ActionEntry(widget.street, widget.playerIndex, _selected!.name,
+      ActionEntry(widget.street, widget.playerIndex, _selected!,
           amount: amount.clamp(1, widget.stackSize.toDouble())),
     );
   }
@@ -55,25 +54,28 @@ class _ActionDialogState extends State<ActionDialog> {
     }
   }
 
-  Widget _actionButton(String label, _Action act) {
-    return ElevatedButton(
+  Widget _actionButton(PokerAction action) {
+    return ElevatedButton.icon(
       style: ElevatedButton.styleFrom(
         backgroundColor:
-            _selected == act ? Colors.blueGrey : Colors.black87,
+            _selected == action.value ? Colors.blueGrey : Colors.black87,
         foregroundColor: Colors.white,
         padding: const EdgeInsets.symmetric(vertical: 16),
       ),
       onPressed: () {
-        if (act == _Action.fold || act == _Action.check || act == _Action.call) {
-          _selectSimple(act);
+        if (action.value == 'fold' ||
+            action.value == 'check' ||
+            action.value == 'call') {
+          _selectSimple(action.value);
         } else {
           setState(() {
-            _selected = act;
+            _selected = action.value;
             _slider = 0;
           });
         }
       },
-      child: Text(label, style: const TextStyle(fontSize: 20)),
+      icon: Text(action.icon, style: const TextStyle(fontSize: 20)),
+      label: Text(action.label, style: const TextStyle(fontSize: 20)),
     );
   }
 
@@ -120,17 +122,11 @@ class _ActionDialogState extends State<ActionDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _actionButton('Fold', _Action.fold),
-          const SizedBox(height: 8),
-          _actionButton('Check', _Action.check),
-          const SizedBox(height: 8),
-          _actionButton('Call', _Action.call),
-          const SizedBox(height: 8),
-          _actionButton('Bet', _Action.bet),
-          const SizedBox(height: 8),
-          _actionButton('Raise', _Action.raise),
-          if (_selected == _Action.bet || _selected == _Action.raise)
-            _buildBetSizer(),
+          for (int i = 0; i < pokerActions.length; i++) ...[
+            _actionButton(pokerActions[i]),
+            if (i != pokerActions.length - 1) const SizedBox(height: 8),
+          ],
+          if (_selected == 'bet' || _selected == 'raise') _buildBetSizer(),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add `poker_actions.dart` with shared action label/icon/value triples
- generate buttons in `ActionBottomSheet` and `ActionDialog` from the shared list

## Testing
- `dart format lib/models/poker_actions.dart lib/widgets/action_bottom_sheet.dart lib/widgets/action_dialog.dart` *(command not found)*
- `apt-get install -y dart` *(unable to locate package)*
- `flutter test` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f4d47b21c832abe0d6f1c1ec8d671