### PR TITLE
refactor: use developer log instead of print

### DIFF
--- a/lib/services/booster_exclusion_analytics_dashboard_service.dart
+++ b/lib/services/booster_exclusion_analytics_dashboard_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:poker_analyzer/services/smart_booster_exclusion_tracker_service.dart';
 
 class BoosterExclusionAnalytics {
@@ -46,16 +48,16 @@ class BoosterExclusionAnalyticsDashboardService {
     final tags = data.exclusionsByTag.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
-    print('Top exclusion reasons:');
+    developer.log('Top exclusion reasons:');
     for (int i = 0; i < reasons.length && i < 5; i++) {
       final r = reasons[i];
-      print('${r.key}: ${r.value}');
+      developer.log('${r.key}: ${r.value}');
     }
 
-    print('Top exclusion tags:');
+    developer.log('Top exclusion tags:');
     for (int i = 0; i < tags.length && i < 5; i++) {
       final t = tags[i];
-      print('${t.key}: ${t.value}');
+      developer.log('${t.key}: ${t.value}');
     }
   }
 }

--- a/lib/services/inbox_delivery_rule_simulator_service.dart
+++ b/lib/services/inbox_delivery_rule_simulator_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'smart_booster_exclusion_tracker_service.dart';
 import 'smart_booster_inbox_limiter_service.dart';
 import 'smart_inbox_heuristic_tuning_service.dart';
@@ -77,8 +79,7 @@ class InboxDeliveryRuleSimulatorService {
   void printSimulationReport(List<InboxSimulationResult> results) {
     for (final r in results) {
       final status = r.wouldShow ? 'SHOW' : 'EXCLUDED (${r.reasonIfExcluded})';
-      // ignore: avoid_print
-      print('${r.tag}: $status');
+      developer.log('${r.tag}: $status');
     }
   }
 }

--- a/lib/services/smart_inbox_heuristic_tuning_service.dart
+++ b/lib/services/smart_inbox_heuristic_tuning_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'booster_exclusion_analytics_dashboard_service.dart';
 
 /// Dynamically tunes Smart Inbox delivery heuristics based on exclusion analytics.
@@ -34,8 +36,7 @@ class SmartInboxHeuristicTuningService {
 
       if (total > overuseThreshold) {
         cooldownOverrides[tag] = const Duration(hours: 12);
-        // ignore: avoid_print
-        print(
+        developer.log(
             'SmartInboxHeuristicTuningService: increased cooldown for $tag due to $total exclusions');
       }
 
@@ -43,16 +44,14 @@ class SmartInboxHeuristicTuningService {
       if (dedup > reasonThreshold) {
         priorityAdjustments[tag] =
             (priorityAdjustments[tag] ?? 0) - 0.5; // lower priority
-        // ignore: avoid_print
-        print(
+        developer.log(
             'SmartInboxHeuristicTuningService: lowered priority for $tag due to $dedup deduplications');
       }
 
       final rateLimited = reasons['rateLimited'] ?? 0;
       if (rateLimited > reasonThreshold) {
         dailyLimitAdjustments[tag] = (dailyLimitAdjustments[tag] ?? 0) + 1;
-        // ignore: avoid_print
-        print(
+        developer.log(
             'SmartInboxHeuristicTuningService: increased daily limit for $tag due to $rateLimited rate limits');
       }
     }
@@ -61,14 +60,12 @@ class SmartInboxHeuristicTuningService {
     const globalThreshold = 10;
     final dedupTotal = data.exclusionsByReason['deduplicated'] ?? 0;
     if (dedupTotal > globalThreshold) {
-      // ignore: avoid_print
-      print(
+      developer.log(
           'SmartInboxHeuristicTuningService: high global deduplicated count ($dedupTotal), consider relaxing dedupe rules');
     }
     final rateLimitTotal = data.exclusionsByReason['rateLimited'] ?? 0;
     if (rateLimitTotal > globalThreshold) {
-      // ignore: avoid_print
-      print(
+      developer.log(
           'SmartInboxHeuristicTuningService: high global rateLimited count ($rateLimitTotal), consider adjusting rate limits');
     }
   }


### PR DESCRIPTION
## Summary
- import `dart:developer` in analytics and simulation services
- replace `print` calls with `developer.log`
- remove `avoid_print` ignores

## Testing
- `dart format lib/services/booster_exclusion_analytics_dashboard_service.dart lib/services/inbox_delivery_rule_simulator_service.dart lib/services/smart_inbox_heuristic_tuning_service.dart` *(command failed: dart not found)*
- `apt-get install -y dart` *(package not found)*
- `flutter test` *(command failed: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d4b5ff8832aad71f1ba8c623c1f