### PR TITLE
refactor: centralize theme colors

### DIFF
--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -18,4 +18,14 @@ class AppColors {
   static const textSecondaryDark = Colors.white70;
   static const textPrimaryLight = Colors.black;
   static const textSecondaryLight = Colors.black54;
+  static const surface = Color(0xFF1E1E1E);
+  static const progressBackground = Colors.white24;
+  static const success = Colors.greenAccent;
+  static const info = Colors.blue;
+  static const warning = Colors.yellow;
+  static const error = Colors.red;
+  static const overlay = Color(0xCC000000);
+  static const shadow = Colors.black45;
+  static const neutral = Colors.grey;
+  static const transparent = Colors.transparent;
 }

--- a/lib/widgets/player_info_overlay.dart
+++ b/lib/widgets/player_info_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/theme/app_colors.dart';
 
 /// Small tooltip overlay showing a player's stack, position and strategy advice.
 class PlayerInfoOverlay extends StatefulWidget {
@@ -29,19 +30,19 @@ class _PlayerInfoOverlayState extends State<PlayerInfoOverlay>
   late final Animation<double> _opacity;
 
   Color _actionColor(String action) {
-    if (action.isEmpty) return Colors.white;
+    if (action.isEmpty) return AppColors.textPrimaryDark;
     final type = action.split(' ').first.toUpperCase();
     switch (type) {
       case 'PUSH':
-        return Colors.green;
+        return AppColors.success;
       case 'FOLD':
-        return Colors.red;
+        return AppColors.error;
       case 'CALL':
-        return Colors.blue;
+        return AppColors.info;
       case 'RAISE':
-        return Colors.yellow;
+        return AppColors.warning;
       default:
-        return Colors.white;
+        return AppColors.textPrimaryDark;
     }
   }
 
@@ -90,13 +91,13 @@ class _PlayerInfoOverlayState extends State<PlayerInfoOverlay>
       child: FadeTransition(
         opacity: _opacity,
         child: Material(
-          color: Colors.transparent,
+          color: AppColors.transparent,
           child: Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
-              color: Colors.black.withOpacity(0.8),
+              color: AppColors.overlay,
               borderRadius: BorderRadius.circular(8),
-              boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
+              boxShadow: const [BoxShadow(color: AppColors.shadow, blurRadius: 4)],
             ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -105,7 +106,7 @@ class _PlayerInfoOverlayState extends State<PlayerInfoOverlay>
                 Text(
                   'Stack: ${widget.stack}',
                   style: const TextStyle(
-                    color: Colors.white,
+                    color: AppColors.textPrimaryDark,
                     fontSize: 12,
                     fontWeight: FontWeight.bold,
                   ),
@@ -113,7 +114,7 @@ class _PlayerInfoOverlayState extends State<PlayerInfoOverlay>
                 Text(
                   'Pos: ${widget.positionName}',
                   style: const TextStyle(
-                    color: Colors.white,
+                    color: AppColors.textPrimaryDark,
                     fontSize: 12,
                     fontWeight: FontWeight.bold,
                   ),
@@ -122,7 +123,7 @@ class _PlayerInfoOverlayState extends State<PlayerInfoOverlay>
                   Text(
                     'EQ: ${widget.equity!.round()}%',
                     style: const TextStyle(
-                      color: Colors.grey,
+                      color: AppColors.neutral,
                       fontSize: 10,
                     ),
                   ),

--- a/lib/widgets/xp_level_bar.dart
+++ b/lib/widgets/xp_level_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/theme/app_colors.dart';
 
 class XPLevelBar extends StatelessWidget {
   final int currentXp;
@@ -16,12 +17,12 @@ class XPLevelBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.secondary;
     final pct = levelXp > 0 ? (currentXp / levelXp).clamp(0.0, 1.0) : 0.0;
-    final barColor = currentXp >= levelXp ? Colors.greenAccent : accent;
+    final barColor = currentXp >= levelXp ? AppColors.success : accent;
     return Container(
       margin: const EdgeInsets.all(16),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: const Color(0xFF1E1E1E),
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -31,10 +32,12 @@ class XPLevelBar extends StatelessWidget {
             children: [
               Text('Level $level',
                   style: const TextStyle(
-                      color: Colors.white, fontWeight: FontWeight.bold)),
+                      color: AppColors.textPrimaryDark,
+                      fontWeight: FontWeight.bold)),
               const Spacer(),
               Text('$currentXp / $levelXp XP',
-                  style: const TextStyle(color: Colors.white70)),
+                  style:
+                      const TextStyle(color: AppColors.textSecondaryDark)),
             ],
           ),
           const SizedBox(height: 4),
@@ -46,7 +49,7 @@ class XPLevelBar extends StatelessWidget {
                 borderRadius: BorderRadius.circular(4),
                 child: LinearProgressIndicator(
                   value: value,
-                  backgroundColor: Colors.white24,
+                  backgroundColor: AppColors.progressBackground,
                   valueColor: AlwaysStoppedAnimation(barColor),
                   minHeight: 6,
                 ),

--- a/main.dart
+++ b/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:poker_analyzer/core/plugin_runtime.dart';
+import 'package:poker_analyzer/theme/app_colors.dart';
 
 import 'package:poker_analyzer/screens/poker_analyzer_screen.dart';
 import 'package:poker_analyzer/services/action_sync_service.dart';
@@ -155,12 +156,13 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
               title: 'Poker AI Analyzer Demo',
               debugShowCheckedModeBanner: false,
               theme: ThemeData.dark().copyWith(
-                colorScheme: ColorScheme.fromSeed(seedColor: Colors.greenAccent),
-                scaffoldBackgroundColor: Colors.black,
+                colorScheme: ColorScheme.fromSeed(seedColor: AppColors.accent),
+                scaffoldBackgroundColor: AppColors.background,
+                cardColor: AppColors.cardBackground,
                 textTheme: ThemeData.dark().textTheme.apply(
                       fontFamily: 'Roboto',
-                      bodyColor: Colors.white,
-                      displayColor: Colors.white,
+                      bodyColor: AppColors.textPrimaryDark,
+                      displayColor: AppColors.textPrimaryDark,
                     ),
               ),
               builder: (context, child) {
@@ -177,13 +179,13 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
-                              color: Colors.white.withOpacity(0.2),
+                              color: AppColors.textPrimaryDark.withOpacity(0.2),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Text(
                               'Demo Mode Active',
                               style: TextStyle(
-                                color: Colors.white.withOpacity(0.8),
+                                color: AppColors.textPrimaryDark.withOpacity(0.8),
                                 fontSize: 12,
                               ),
                             ),


### PR DESCRIPTION
## Summary
- add reusable theme color constants
- refactor demo app theme and widgets to use centralized colors

## Testing
- `dart format lib/theme/app_colors.dart lib/widgets/xp_level_bar.dart lib/widgets/player_info_overlay.dart main.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d4c83b8832a8a7138b23e35f741