### PR TITLE
chore: replace todos with placeholders

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        // Placeholder Application ID used for development; replace with a unique ID for production.
         applicationId = "com.example.poker_ai_analyzer"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
@@ -32,8 +32,8 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
+            // Signing with the debug keys for now so `flutter run --release` works.
+            // Provide a release signing configuration before publishing the app.
             signingConfig = signingConfigs.getByName("debug")
         }
     }

--- a/lib/screens/lesson_track_library_screen.dart
+++ b/lib/screens/lesson_track_library_screen.dart
@@ -36,7 +36,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
     final yaml = await YamlLessonTrackLoader.instance.loadTracksFromAssets();
     final allTracks = [...builtIn, ...yaml];
 
-    // TODO: load real profile data when available
+    // Uses a temporary profile until real profile data becomes available.
     final profile = PlayerProfile();
     final tracks = await const TrackVisibilityFilterEngine()
         .filterUnlockedTracks(allTracks, profile);

--- a/lib/screens/training_pack_overlay.dart
+++ b/lib/screens/training_pack_overlay.dart
@@ -9,7 +9,9 @@ class TrainingPackOverlay extends StatelessWidget {
   const TrainingPackOverlay({super.key, required this.pack});
 
   Future<void> _export(BuildContext context) async {
-    // TODO: implement export logic
+    // Export functionality is not yet implemented; show a placeholder message.
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Export is unavailable')));
   }
 
   Future<void> _share(BuildContext context) async {
@@ -17,7 +19,9 @@ class TrainingPackOverlay extends StatelessWidget {
   }
 
   Future<void> _print(BuildContext context) async {
-    // TODO: implement print logic
+    // Printing is currently unsupported; notify the user.
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Print is unavailable')));
   }
 
   @override

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -39,7 +39,7 @@ class _TrainingPackTemplateEditorScreenState
   }
 
   void _save() {
-    // TODO: implement persistence
+    // Persistence layer is not yet implemented; show confirmation only.
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Template saved')));
   }

--- a/lib/services/booster_pack_auto_fix_engine.dart
+++ b/lib/services/booster_pack_auto_fix_engine.dart
@@ -27,7 +27,7 @@ class BoosterPackAutoFixEngine extends TheoryPackAutoFixEngine {
       sections.add(
         const TheorySectionModel(
           title: 'Placeholder',
-          text: 'TODO: Add content',
+          text: 'Content will be added later',
           type: 'tip',
         ),
       );

--- a/lib/services/mastery_level_engine.dart
+++ b/lib/services/mastery_level_engine.dart
@@ -26,7 +26,7 @@ class MasteryLevelEngine {
 
     final stepCount = completedSteps.length;
 
-    // TODO: incorporate EV/ICM metrics from trainings
+    // Future enhancement: incorporate EV/ICM metrics from trainings.
 
     if (stepCount >= 100 && completedTracks >= 3) {
       return MasteryLevel.expert;

--- a/lib/services/path_suggestion_service.dart
+++ b/lib/services/path_suggestion_service.dart
@@ -8,7 +8,7 @@ class PathSuggestionService {
 
   /// Returns next recommended [LearningPathTemplateV2] or `null` if none.
   Future<LearningPathTemplateV2?> nextPath() async {
-    // TODO: implement actual suggestion logic
+    // Currently returns the second template as a simple placeholder suggestion.
     final templates = await LearningPathRegistryService.instance.loadAll();
     if (templates.length < 2) return null;
     return templates[1];

--- a/lib/services/theory_pack_auto_fix_engine.dart
+++ b/lib/services/theory_pack_auto_fix_engine.dart
@@ -21,7 +21,7 @@ class TheoryPackAutoFixEngine {
       sections.add(
         TheorySectionModel(
           title: 'Placeholder',
-          text: 'TODO: Add content',
+          text: 'Content will be added later',
           type: 'info',
         ),
       );


### PR DESCRIPTION
## Summary
- remove remaining TODO markers by replacing them with placeholder implementations or explanatory comments

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d4fb794832a909ac3bf5011ce99