### PR TITLE
Refactor long screens into reusable widgets

### DIFF
--- a/lib/screens/all_sessions/session_filter_bar.dart
+++ b/lib/screens/all_sessions/session_filter_bar.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+class SessionFilterBar extends StatelessWidget {
+  final String filter;
+  final ValueChanged<String?> onFilterChanged;
+  final Set<String> packNames;
+  final VoidCallback onPickDateRange;
+  final String dateFilterText;
+  final String sortMode;
+  final ValueChanged<String?> onSortChanged;
+  final VoidCallback onReset;
+
+  const SessionFilterBar({
+    super.key,
+    required this.filter,
+    required this.onFilterChanged,
+    required this.packNames,
+    required this.onPickDateRange,
+    required this.dateFilterText,
+    required this.sortMode,
+    required this.onSortChanged,
+    required this.onReset,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: DropdownButton<String>(
+            value: filter,
+            dropdownColor: const Color(0xFF2A2B2E),
+            style: const TextStyle(color: Colors.white),
+            onChanged: onFilterChanged,
+            items: [
+              const DropdownMenuItem(
+                value: 'all',
+                child: Text('Все сессии'),
+              ),
+              const DropdownMenuItem(
+                value: 'success',
+                child: Text('Только успешные (>70%)'),
+              ),
+              const DropdownMenuItem(
+                value: 'fail',
+                child: Text('Только неуспешные (<70%)'),
+              ),
+              if (packNames.length > 1)
+                ...[
+                  for (final name in packNames)
+                    DropdownMenuItem(
+                      value: 'pack:$name',
+                      child: Text('Пакет: $name'),
+                    )
+                ],
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        OutlinedButton(
+          onPressed: onPickDateRange,
+          child: Text(dateFilterText),
+        ),
+        const SizedBox(width: 8),
+        const Text('Сортировка:', style: TextStyle(color: Colors.white)),
+        const SizedBox(width: 8),
+        DropdownButton<String>(
+          value: sortMode,
+          dropdownColor: const Color(0xFF2A2B2E),
+          style: const TextStyle(color: Colors.white),
+          onChanged: onSortChanged,
+          items: const [
+            DropdownMenuItem(
+              value: 'date_desc',
+              child: Text('по дате (новые)'),
+            ),
+            DropdownMenuItem(
+              value: 'date_asc',
+              child: Text('по дате (старые)'),
+            ),
+            DropdownMenuItem(
+              value: 'accuracy_desc',
+              child: Text('по точности (высокая)'),
+            ),
+            DropdownMenuItem(
+              value: 'accuracy_asc',
+              child: Text('по точности (низкая)'),
+            ),
+          ],
+        ),
+        IconButton(
+          onPressed: onReset,
+          icon: const Icon(Icons.clear),
+          tooltip: 'Сбросить',
+        )
+      ],
+    );
+  }
+}
+

--- a/lib/screens/all_sessions/session_list_item.dart
+++ b/lib/screens/all_sessions/session_list_item.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../../helpers/date_utils.dart';
+import '../../helpers/accuracy_utils.dart';
+import '../../models/training_pack.dart';
+
+class SessionListItem extends StatelessWidget {
+  final String packName;
+  final String description;
+  final TrainingSessionResult result;
+  final VoidCallback onTap;
+  final VoidCallback onShowOptions;
+
+  const SessionListItem({
+    super.key,
+    required this.packName,
+    required this.description,
+    required this.result,
+    required this.onTap,
+    required this.onShowOptions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFF2A2B2E),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          onLongPress: onShowOptions,
+                          child: Text(
+                            packName,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      GestureDetector(
+                        onLongPress: onShowOptions,
+                        child: const Icon(
+                          Icons.edit,
+                          color: Colors.white70,
+                          size: 16,
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (description.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ],
+                  const SizedBox(height: 4),
+                  Text(
+                    formatDateTime(result.date),
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ],
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  '${result.correct}/${result.total}',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  result.total > 0
+                      ? '${calculateAccuracy(result.correct, result.total).toStringAsFixed(0)}%'
+                      : '0%',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/training_pack_comparison/pack_comparison_filters.dart
+++ b/lib/screens/training_pack_comparison/pack_comparison_filters.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import '../../models/game_type.dart';
+import '../../models/pack_chart_sort_option.dart';
+import '../../theme/app_colors.dart';
+import '../../helpers/color_utils.dart';
+
+class PackComparisonFilters extends StatelessWidget {
+  final bool forgottenOnly;
+  final ValueChanged<bool> onForgottenChanged;
+  final PackChartSort chartSort;
+  final ValueChanged<PackChartSort?> onSortChanged;
+  final GameType? typeFilter;
+  final ValueChanged<GameType?> onTypeChanged;
+  final int diffFilter;
+  final ValueChanged<int> onDiffChanged;
+  final String colorFilter;
+  final ValueChanged<String?> onColorChanged;
+
+  const PackComparisonFilters({
+    super.key,
+    required this.forgottenOnly,
+    required this.onForgottenChanged,
+    required this.chartSort,
+    required this.onSortChanged,
+    required this.typeFilter,
+    required this.onTypeChanged,
+    required this.diffFilter,
+    required this.onDiffChanged,
+    required this.colorFilter,
+    required this.onColorChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SwitchListTile(
+          title: const Text('Давно не повторял'),
+          value: forgottenOnly,
+          onChanged: onForgottenChanged,
+          activeColor: Colors.orange,
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              const Text('Сортировка',
+                  style: TextStyle(color: Colors.white)),
+              const SizedBox(width: 8),
+              DropdownButton<PackChartSort>(
+                value: chartSort,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                items: [
+                  for (final s in PackChartSort.values)
+                    DropdownMenuItem(value: s, child: Text(s.label))
+                ],
+                onChanged: onSortChanged,
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              const Text('Тип', style: TextStyle(color: Colors.white)),
+              const SizedBox(width: 8),
+              DropdownButton<GameType?>(
+                value: typeFilter,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                items: const [
+                  DropdownMenuItem(value: null, child: Text('Все')),
+                  DropdownMenuItem(value: GameType.cash, child: Text('Cash Game')),
+                  DropdownMenuItem(value: GameType.tournament, child: Text('Tournament')),
+                ],
+                onChanged: onTypeChanged,
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              const Text('Сложность', style: TextStyle(color: Colors.white)),
+              const SizedBox(width: 8),
+              DropdownButton<int>(
+                value: diffFilter,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                onChanged: (v) => onDiffChanged(v ?? 0),
+                items: const [
+                  DropdownMenuItem(value: 0, child: Text('All')),
+                  DropdownMenuItem(value: 1, child: Text('Beginner')),
+                  DropdownMenuItem(value: 2, child: Text('Intermediate')),
+                  DropdownMenuItem(value: 3, child: Text('Advanced')),
+                ],
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              const Text('Color', style: TextStyle(color: Colors.white)),
+              const SizedBox(width: 8),
+              DropdownButton<String>(
+                value: colorFilter,
+                dropdownColor: AppColors.cardBackground,
+                style: const TextStyle(color: Colors.white),
+                onChanged: onColorChanged,
+                items: [
+                  const DropdownMenuItem(value: 'All', child: Text('All')),
+                  const DropdownMenuItem(value: 'Red', child: Text('Red')),
+                  const DropdownMenuItem(value: 'Blue', child: Text('Blue')),
+                  const DropdownMenuItem(value: 'Orange', child: Text('Orange')),
+                  const DropdownMenuItem(value: 'Green', child: Text('Green')),
+                  const DropdownMenuItem(value: 'Purple', child: Text('Purple')),
+                  const DropdownMenuItem(value: 'Grey', child: Text('Grey')),
+                  const DropdownMenuItem(value: 'None', child: Text('None')),
+                  const DropdownMenuItem(value: 'Custom', child: Text('Custom...')),
+                  if (colorFilter.startsWith('#'))
+                    DropdownMenuItem(
+                      value: colorFilter,
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 16,
+                            height: 16,
+                            decoration: BoxDecoration(
+                              color: colorFromHex(colorFilter),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(colorFilter),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/screens/training_pack_comparison/pack_completion_bar_chart.dart
+++ b/lib/screens/training_pack_comparison/pack_completion_bar_chart.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../../helpers/date_utils.dart';
+import '../../models/training_pack_stats.dart';
+import '../../models/pack_chart_sort_option.dart';
+
+class PackCompletionBarChart extends StatefulWidget {
+  final List<TrainingPackStats> stats;
+  final bool hideCompleted;
+  final bool forgottenOnly;
+  final PackChartSort sort;
+
+  const PackCompletionBarChart({
+    super.key,
+    required this.stats,
+    required this.hideCompleted,
+    required this.forgottenOnly,
+    required this.sort,
+  });
+
+  @override
+  State<PackCompletionBarChart> createState() => _PackCompletionBarChartState();
+}
+
+class _PackCompletionBarChartState extends State<PackCompletionBarChart>
+    with SingleTickerProviderStateMixin {
+  int? _index;
+  Offset? _pos;
+  Timer? _timer;
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _anim.dispose();
+    super.dispose();
+  }
+
+  void _show(int index, Offset pos) {
+    if (_index == index) {
+      _hide();
+      return;
+    }
+    _timer?.cancel();
+    setState(() {
+      _index = index;
+      _pos = pos;
+    });
+    _anim.forward(from: 0);
+    _timer = Timer(const Duration(seconds: 2), _hide);
+  }
+
+  void _hide() {
+    _timer?.cancel();
+    if (_index != null) {
+      setState(() => _index = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final filtered = widget.stats.where((s) {
+      final progress = s.total > 0 ? (s.total - s.mistakes) / s.total : 0.0;
+      final completed = progress >= 1.0;
+      final forgotten =
+          s.lastSession == null || now.difference(s.lastSession!).inDays >= 7;
+      if (widget.hideCompleted && completed) return false;
+      if (widget.forgottenOnly && !forgotten) return false;
+      return true;
+    }).toList();
+
+    filtered.sort((a, b) {
+      switch (widget.sort) {
+        case PackChartSort.lastSession:
+          final da = a.lastSession ?? DateTime.fromMillisecondsSinceEpoch(0);
+          final db = b.lastSession ?? DateTime.fromMillisecondsSinceEpoch(0);
+          return db.compareTo(da);
+        case PackChartSort.handsPlayed:
+          return b.total.compareTo(a.total);
+        case PackChartSort.progress:
+        default:
+          final pa = a.total > 0 ? (a.total - a.mistakes) * 100 / a.total : 0.0;
+          final pb = b.total > 0 ? (b.total - b.mistakes) * 100 / b.total : 0.0;
+          return pb.compareTo(pa);
+      }
+    });
+
+    if (filtered.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final groups = <BarChartGroupData>[];
+    for (var i = 0; i < filtered.length; i++) {
+      final stat = filtered[i];
+      final percent =
+          stat.total > 0 ? (stat.total - stat.mistakes) * 100 / stat.total : 0.0;
+      groups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: percent,
+              width: 14,
+              borderRadius: BorderRadius.circular(4),
+              gradient: const LinearGradient(
+                colors: [Colors.lightGreenAccent, Colors.green],
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return AspectRatio(
+      aspectRatio: 1.7,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          BarChart(
+            BarChartData(
+              maxY: 100,
+              minY: 0,
+              barGroups: groups,
+              gridData: const FlGridData(show: false),
+              borderData: FlBorderData(show: false),
+              barTouchData: BarTouchData(
+                handleBuiltInTouches: false,
+                touchCallback: (event, response) {
+                  if (!event.isInterestedForInteractions ||
+                      response?.spot == null) {
+                    return;
+                  }
+                  _show(
+                    response!.spot!.touchedBarGroupIndex,
+                    response.touchLocation,
+                  );
+                },
+              ),
+              titlesData: FlTitlesData(
+                leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                bottomTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    interval: 1,
+                    getTitlesWidget: (value, _) {
+                      final idx = value.toInt();
+                      if (idx < 0 || idx >= filtered.length) {
+                        return const SizedBox.shrink();
+                      }
+                      return Transform.rotate(
+                        angle: -1.5708,
+                        child: Text(
+                          filtered[idx].pack.name,
+                          style: const TextStyle(fontSize: 10),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              ),
+            ),
+          ),
+          if (_index != null && _pos != null && _index! < filtered.length)
+            _BarTooltip(
+              position: (context.findRenderObject() as RenderBox)
+                      .globalToLocal(_pos!) -
+                  const Offset(40, 60),
+              stats: filtered[_index!],
+              animation: _anim,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BarTooltip extends StatefulWidget {
+  final Offset position;
+  final TrainingPackStats stats;
+  final Animation<double> animation;
+
+  const _BarTooltip({
+    required this.position,
+    required this.stats,
+    required this.animation,
+  });
+
+  @override
+  State<_BarTooltip> createState() => _BarTooltipState();
+}
+
+class _BarTooltipState extends State<_BarTooltip> {
+  @override
+  Widget build(BuildContext context) {
+    final s = widget.stats;
+    final completed = s.total - s.mistakes;
+    final percent = s.total > 0 ? completed * 100 / s.total : 0.0;
+    final remain = s.total - completed;
+    final last = s.lastSession != null
+        ? formatDate(s.lastSession!)
+        : 'нет данных';
+    return Positioned(
+      left: widget.position.dx,
+      top: widget.position.dy,
+      child: FadeTransition(
+        opacity: widget.animation,
+        child: ScaleTransition(
+          scale: Tween(begin: 0.8, end: 1.0).animate(widget.animation),
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.black87,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${percent.toStringAsFixed(1)}%',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    '$completed/${s.total} (осталось $remain)',
+                    style: const TextStyle(color: Colors.white, fontSize: 11),
+                  ),
+                  Text(
+                    last,
+                    style: const TextStyle(color: Colors.white70, fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract filtering controls and session list item from all_sessions_screen.dart into dedicated widgets
- move training pack comparison filters and completion chart to separate reusable widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d816e18832a99e2b185a59568b4