### PR TITLE
refactor: centralize shared preferences access

### DIFF
--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:io';
 
@@ -73,7 +74,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
   }
 
   Future<void> _loadPreferences() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final startStr = prefs.getString('sessions_date_start');
     final endStr = prefs.getString('sessions_date_end');
     DateTimeRange? range;
@@ -118,7 +119,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
   }
 
   Future<void> _savePreferences() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString('sessions_filter', _filter);
     await prefs.setString('sessions_sortMode', _sortMode);
     await prefs.setBool('sessions_show_summary', _showSummary);

--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -46,7 +47,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() => _tagFilter = prefs.getString(_tagKey) ?? 'All');
   }
 
@@ -71,7 +72,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _saveTagFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_tagFilter == 'All') {
       await prefs.remove(_tagKey);
     } else {

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:io';
 import 'dart:convert';
 import 'dart:typed_data';
@@ -65,7 +66,7 @@ class _CloudTrainingSessionDetailsScreenState
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _prefs = prefs;
       _onlyErrors = prefs.getBool(_mistakesKey) ?? false;
@@ -73,7 +74,7 @@ class _CloudTrainingSessionDetailsScreenState
   }
 
   Future<void> _setMistakesOnly(bool v) async {
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     await prefs.setBool(_mistakesKey, v);
     setState(() => _onlyErrors = v);
   }

--- a/lib/screens/create_custom_pack_screen.dart
+++ b/lib/screens/create_custom_pack_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:io';
 
@@ -40,7 +41,7 @@ class _CreateCustomPackScreenState extends State<CreateCustomPackScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final cat = prefs.getString(_lastCategoryKey);
     if (cat != null && cat.isNotEmpty) {
       _categoryController.text = cat;
@@ -203,7 +204,7 @@ class _CreateCustomPackScreenState extends State<CreateCustomPackScreen> {
       history: const [],
     );
     await context.read<TrainingPackStorageService>().addCustomPack(pack);
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     final cat = _categoryController.text.trim();
     if (cat.isNotEmpty) await prefs.setString(_lastCategoryKey, cat);
     if (!mounted) return;

--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -71,7 +72,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _prefs = prefs;
       _color = colorFromHex(prefs.getString(_colorKey) ?? widget.template.defaultColor);
@@ -205,7 +206,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
       return;
     }
     final service = context.read<TrainingPackStorageService>();
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     await prefs.setString(_colorKey, colorToHex(_color));
     await prefs.setBool(_tagsKey, _addTags);
     await prefs.setString(_lastPositionKey, _positionFilter);
@@ -279,7 +280,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
                         onSelected: (s) async {
                           if (!s) return;
                           final prefs = _prefs ??
-                              await SharedPreferences.getInstance();
+                              await PreferencesService.getInstance();
                           await prefs.setString(_lastPositionKey, p);
                           setState(() => _positionFilter = p);
                         },

--- a/lib/screens/daily_spot_screen.dart
+++ b/lib/screens/daily_spot_screen.dart
@@ -1,6 +1,6 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
@@ -20,7 +20,6 @@ class _DailySpotScreenState extends State<DailySpotScreen> {
   bool _show = false;
 
   Future<void> _finish() async {
-    final prefs = await SharedPreferences.getInstance();
     final packs = context.read<TrainingPackStorageService>().packs;
     String? id;
     for (int i = 0; i < packs.length; i++) {
@@ -31,11 +30,15 @@ class _DailySpotScreenState extends State<DailySpotScreen> {
       }
     }
     final now = DateTime.now();
-    await prefs.setString('daily_spot_date', now.toIso8601String());
-    final history = prefs.getStringList('daily_spot_history') ?? [];
+    await PreferencesService.setString(
+        'daily_spot_date', now.toIso8601String());
+    final history =
+        (await PreferencesService.getStringList('daily_spot_history')) ?? [];
     history.add(now.toIso8601String());
-    await prefs.setStringList('daily_spot_history', history);
-    if (id != null) await prefs.setString('daily_spot_id', id);
+    await PreferencesService.setStringList('daily_spot_history', history);
+    if (id != null) {
+      await PreferencesService.setString('daily_spot_id', id);
+    }
     if (mounted) {
       Navigator.pushReplacement(
         context,
@@ -81,9 +84,7 @@ class DailySpotDoneScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Спот дня')),
-      actions: [SyncStatusIcon.of(context)],
-      actions: [SyncStatusIcon.of(context)],
+      appBar: AppBar(title: const Text('Спот дня'), actions: [SyncStatusIcon.of(context)]),
       backgroundColor: const Color(0xFF121212),
       body: const Center(
         child: Text(

--- a/lib/screens/learning_path_launcher_screen.dart
+++ b/lib/screens/learning_path_launcher_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -27,7 +28,7 @@ class _LearningPathLauncherScreenState
   }
 
   Future<void> _loadMode() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final stored = prefs.getString(_prefsKey);
     setState(() {
       if (stored == 'linear') {
@@ -40,7 +41,7 @@ class _LearningPathLauncherScreenState
   }
 
   Future<void> _setMode(LearningPathViewMode mode) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_prefsKey, mode == LearningPathViewMode.linear ? 'linear' : 'horizontal');
     setState(() {
       _mode = mode;

--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/training_pack_template_service.dart';
@@ -43,7 +44,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
   }
 
   Future<void> _init() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final stored = prefs.getString(_prefsKey);
     if (stored != null) {
       for (final entry in _paths.entries) {
@@ -187,7 +188,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
               value: _selected,
               onChanged: (v) async {
                 if (v == null) return;
-                final prefs = await SharedPreferences.getInstance();
+                final prefs = await PreferencesService.getInstance();
                 final file = _paths[v]!.split('/').last;
                 await prefs.setString(_prefsKey, file);
                 setState(() => _selected = v);

--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
@@ -104,7 +105,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     setState(() => _loading = true);
     final aggregated = _progressTracker.aggregateLogsByPack(_logs.logs);
     final mastery = await _mastery.computeMastery();
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final theoryMap = <String, bool>{};
     final boosterMap = <String, String?>{};
     for (final stage in widget.template.stages) {
@@ -252,7 +253,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     }
     await const TrainingSessionLauncher().launch(template);
     if (mounted) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       final completed = prefs.getBool('completed_tpl_${template.id}') ?? false;
       if (completed) {
         await prefs.setBool('completed_booster_$id', true);
@@ -292,7 +293,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     }
     await const TrainingSessionLauncher().launch(template);
     if (mounted) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       final completed = prefs.getBool('completed_tpl_${template.id}') ?? false;
       if (completed) {
         await prefs.setString('justCompletedTheoryStageId', stage.id);

--- a/lib/screens/lesson_path_screen.dart
+++ b/lib/screens/lesson_path_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -42,7 +43,7 @@ class _LessonPathScreenState extends State<LessonPathScreen> {
   }
 
   Future<List<dynamic>> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final id = prefs.getString('lesson_selected_track');
     if (id == null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/screens/lesson_step_recap_screen.dart
+++ b/lib/screens/lesson_step_recap_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
 import 'package:provider/provider.dart';
@@ -59,7 +60,7 @@ class _LessonStepRecapScreenState extends State<LessonStepRecapScreen> {
       completedSteps: completed,
       profile: profile,
     );
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final selectedId = prefs.getString('lesson_selected_track');
     final track = tracks.firstWhereOrNull((t) => t.id == selectedId);
     bool doneTrack = false;

--- a/lib/screens/lesson_step_screen.dart
+++ b/lib/screens/lesson_step_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
@@ -34,7 +35,7 @@ class _LessonStepScreenState extends State<LessonStepScreen> {
   }
 
   Future<void> _maybeShowOnboarding() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final seen = prefs.getBool('lesson_onboarding_seen') ?? false;
     if (seen) return;
     final trackId = prefs.getString('lesson_selected_track');
@@ -50,7 +51,7 @@ class _LessonStepScreenState extends State<LessonStepScreen> {
     if (!isFirst) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showLessonOnboardingOverlay(context, onDismiss: () async {
-        final p = await SharedPreferences.getInstance();
+        final p = await PreferencesService.getInstance();
         await p.setBool('lesson_onboarding_seen', true);
       });
     });

--- a/lib/screens/lesson_track_library_screen.dart
+++ b/lib/screens/lesson_track_library_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -41,7 +42,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
     final tracks = await const TrackVisibilityFilterEngine()
         .filterUnlockedTracks(allTracks, profile);
 
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final selected = prefs.getString('lesson_selected_track');
     final progress =
         await LessonPathProgressService.instance.computeTrackProgress();
@@ -104,7 +105,7 @@ class _LessonTrackLibraryScreenState extends State<LessonTrackLibraryScreen> {
           false;
     }
     if (!ok) return;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString('lesson_selected_track', track.id);
     if (!mounted) return;
     setState(() => _future = _load());

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -78,7 +79,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final sortVal = prefs.getInt(_sortPrefKey);
     if (sortVal != null && sortVal >= 0 && sortVal < _SortOption.values.length) {
       _sort = _SortOption.values[sortVal];
@@ -114,7 +115,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   Future<void> _setSort(_SortOption value) async {
     if (_sort == value) return;
     setState(() => _sort = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_sortPrefKey, value.index);
   }
 

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -1,5 +1,5 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'player_input_screen.dart';
 import 'saved_hands_screen.dart';
@@ -180,8 +180,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
   }
 
   Future<void> _loadDismissed() async {
-    final prefs = await SharedPreferences.getInstance();
-    final str = prefs.getString(_dismissedKey);
+    final str = await PreferencesService.getString(_dismissedKey);
     if (!mounted) return;
     if (str != null) {
       final dt = DateTime.tryParse(str);
@@ -191,7 +190,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           _dismissedDate = dt;
         });
       } else {
-        await prefs.remove(_dismissedKey);
+        await PreferencesService.remove(_dismissedKey);
       }
     }
   }
@@ -217,13 +216,12 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       _suggestedDismissed = true;
       _dismissedDate = now;
     });
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_dismissedKey, now.toIso8601String());
+    await PreferencesService.setString(
+        _dismissedKey, now.toIso8601String());
   }
 
   Future<void> _clearDismissed() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_dismissedKey);
+    await PreferencesService.remove(_dismissedKey);
     if (!mounted) return;
     setState(() {
       _suggestedDismissed = false;

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -114,14 +115,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
   }
 
   Future<void> _loadIndex() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     var idx = prefs.getInt(_indexKey) ?? 0;
     if (_simpleNavigation && idx > 3) idx = 0;
     setState(() => _currentIndex = idx);
   }
 
   Future<void> _saveIndex(int value) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_indexKey, value);
   }
 

--- a/lib/screens/mixed_drill_history_screen.dart
+++ b/lib/screens/mixed_drill_history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -27,7 +28,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final raw = prefs.getString(_prefsKey);
     if (raw != null) {
       try {
@@ -40,7 +41,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
   }
 
   Future<void> _save() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(
       _prefsKey,
       jsonEncode({'street': _street, 'tag': _tag}),

--- a/lib/screens/my_training_history_screen.dart
+++ b/lib/screens/my_training_history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -35,7 +36,7 @@ class _MyTrainingHistoryScreenState extends State<MyTrainingHistoryScreen> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final packs = context.read<TrainingPackStorageService>().packs;
     final List<_HistoryEntry> loaded = [];
     for (final pack in packs) {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -33,7 +34,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   }
 
   Future<void> _finish() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool('tutorial_completed', true);
     await UserPreferences.instance.setTutorialCompleted(true);
     if (mounted) Navigator.pop(context);

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:ui' show FontFeature;
 import 'package:flutter/material.dart';
@@ -190,7 +191,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = TrainingPackAssetLoader.instance.getAll();
     list.sort((a, b) {
       final d1 = b.lastTrainedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
@@ -252,7 +253,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
   }
 
   Future<void> _restoreState() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final data = prefs.getString(_PrefsKey);
     if (data != null) {
       try {
@@ -321,7 +322,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
       groupByPosition: _currentGroupKey == 'position',
       groupByStack: _currentGroupKey == 'stack',
     );
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final json = jsonEncode({
       'query': _query,
       'status': _statusFilters.toList(),
@@ -762,7 +763,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
                       .read<TrainingSessionService>()
                       .startFromPastMistakes(t);
                   if (session == null) {
-                    final prefs = await SharedPreferences.getInstance();
+                    final prefs = await PreferencesService.getInstance();
                     await prefs.setBool('mistakes_tpl_${t.id}', false);
                     if (mounted) {
                       setState(() => _mistakePacks.remove(t.id));

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -183,7 +184,7 @@ class _ProgressScreenState extends State<ProgressScreen>
   }
 
   Future<void> _loadDailySpot() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final dateStr = prefs.getString('daily_spot_date');
     if (dateStr == null) return;
     final date = DateTime.tryParse(dateStr);

--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/training_pack_template_service.dart';
@@ -42,7 +43,7 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    PreferencesService.getInstance().then((p) {
       _showCompleted = p.getBool('show_completed_packs') ?? false;
       if (mounted) _load();
     });
@@ -71,7 +72,7 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
     final similar = last != null
         ? await TrainingPackService.createSimilarMistakeDrill(last)
         : null;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = [
       ...builtIn.where(
         (t) =>
@@ -133,7 +134,7 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   }
 
   Future<void> _toggle(bool value) async {
-    final p = await SharedPreferences.getInstance();
+    final p = await PreferencesService.getInstance();
     await p.setBool('show_completed_packs', value);
     setState(() => _showCompleted = value);
     _load();

--- a/lib/screens/retry_training_screen.dart
+++ b/lib/screens/retry_training_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
@@ -38,7 +39,7 @@ class _RetryTrainingScreenState extends State<RetryTrainingScreen> {
       tags: const [],
       notes: null,
     );
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final history = prefs.getStringList('training_history') ?? [];
     history.add(jsonEncode(result.toJson()));
     await prefs.setStringList('training_history', history);

--- a/lib/screens/session_history_screen.dart
+++ b/lib/screens/session_history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -39,7 +40,7 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final stats = context.read<TrainingStatsService>();
     final startStr = prefs.getString(_startKey);
     final endStr = prefs.getString(_endKey);
@@ -56,7 +57,7 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
   }
 
   Future<void> _savePrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_startDate != null) {
       await prefs.setString(_startKey, _startDate!.toIso8601String());
     } else {

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -47,7 +48,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
   }
 
   Future<void> _loadSelectedStreets() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = prefs.getStringList(_streetPrefsKey);
     if (list != null && list.isNotEmpty) {
       final values = <int>[];
@@ -64,13 +65,13 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
   }
 
   Future<void> _saveSelectedStreets() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList(
         _streetPrefsKey, _selectedStreets.map((e) => e.toString()).toList());
   }
 
   Future<void> _loadActiveTag() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final tag = prefs.getString(_activeTagPrefsKey);
     if (tag != null && tag.isNotEmpty) {
       setState(() => _activeTag = tag);
@@ -78,7 +79,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
   }
 
   Future<void> _saveActiveTag() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_activeTag == null) {
       await prefs.remove(_activeTagPrefsKey);
     } else {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 
 import '../user_preferences.dart';
@@ -120,7 +121,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       initialTime: _challengeTime,
     );
     if (picked != null) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setInt('daily_challenge_reminder_hour', picked.hour);
       await prefs.setInt('daily_challenge_reminder_minute', picked.minute);
       await DailyChallengeNotificationService.scheduleDailyReminder(

--- a/lib/screens/skill_tree_path_screen.dart
+++ b/lib/screens/skill_tree_path_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 
 import '../models/skill_tree.dart';
@@ -77,7 +78,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
     final hasNewTheory = newTheoryNodeIds.isNotEmpty;
     final hasNewPractice = newPracticeNodeIds.isNotEmpty;
 
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final blocks = _listBuilder.stageMarker.build(nodes);
     final folded = <int>{};
     _stageKeys.clear();
@@ -220,7 +221,7 @@ class _SkillTreePathScreenState extends State<SkillTreePathScreen> {
   String _foldKey(int stage) => 'stage_fold_${widget.trackId}_$stage';
 
   Future<void> _toggleStageFold(int stage) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       if (_foldedStages.contains(stage)) {
         _foldedStages.remove(stage);

--- a/lib/screens/snapshot_diff_screen.dart
+++ b/lib/screens/snapshot_diff_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -42,7 +43,7 @@ class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
     super.initState();
     _pack = widget.pack;
     _compute();
-    SharedPreferences.getInstance().then((p) =>
+    PreferencesService.getInstance().then((p) =>
         p.setString('pack_editor_last_snapshot_diff', widget.snapshot.id));
   }
 

--- a/lib/screens/snapshot_manager_screen.dart
+++ b/lib/screens/snapshot_manager_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -56,7 +57,7 @@ class _SnapshotManagerScreenState extends State<SnapshotManagerScreen> {
             ),
             confirmDismiss: (dir) async {
               if (dir == DismissDirection.startToEnd) {
-                final prefs = await SharedPreferences.getInstance();
+                final prefs = await PreferencesService.getInstance();
                 final last =
                     prefs.getString('pack_editor_last_snapshot_restored');
                 if (last == s.id) {

--- a/lib/screens/stage_completed_screen.dart
+++ b/lib/screens/stage_completed_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import '../widgets/confetti_overlay.dart';
 import '../widgets/weakness_booster_overlay.dart';
@@ -39,7 +40,7 @@ class _StageCompletedScreenState extends State<StageCompletedScreen> {
   }
 
   Future<void> _maybeShowBooster() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (!(prefs.getBool('showWeaknessOverlay') ?? true)) return;
     final mastery = context.read<TagMasteryService>();
     final weak = await mastery.findWeakTags(threshold: 0.6);

--- a/lib/screens/start_training_from_pack_screen.dart
+++ b/lib/screens/start_training_from_pack_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
@@ -27,7 +28,7 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
 
   Future<void> _load() async {
     final list = await TrainingPackStorage.load();
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final last = prefs.getString(_lastKey);
     if (!mounted) return;
     setState(() {
@@ -39,7 +40,7 @@ class _StartTrainingFromPackScreenState extends State<StartTrainingFromPackScree
 
 
   Future<void> _start(TrainingPackTemplate tpl) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_lastKey, tpl.name);
     setState(() => _last = tpl.name);
     final hands = [for (final s in tpl.spots) handFromPackSpot(s, anteBb: tpl.anteBb)];

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -77,7 +78,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
   }
 
   Future<void> _loadFilters() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final tags = prefs.getStringList(_tagsKey);
     if (tags != null) _activeTags.addAll(tags);
     final levels = prefs.getStringList(_levelsKey);
@@ -123,7 +124,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
   }
 
   Future<void> _saveTags() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_activeTags.isEmpty) {
       await prefs.remove(_tagsKey);
     } else {
@@ -132,12 +133,12 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
   }
 
   Future<void> _saveLevels() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList(_levelsKey, _levels.map((e) => e.name).toList());
   }
 
   Future<void> _saveRange() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_range == null) {
       await prefs.remove(_startKey);
       await prefs.remove(_endKey);
@@ -148,7 +149,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
   }
 
   Future<void> _saveCompareRange() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (_compareRange == null) {
       await prefs.remove(_cmpStartKey);
       await prefs.remove(_cmpEndKey);
@@ -160,7 +161,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
   }
 
   Future<void> _saveComparePrevious() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prevKey, _comparePrevious);
   }
 
@@ -189,7 +190,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
 
   Future<void> _setChartMode(_ChartMode mode) async {
     setState(() => _chartMode = mode);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_chartModeKey, mode.name);
   }
 

--- a/lib/screens/track_progress_dashboard_screen.dart
+++ b/lib/screens/track_progress_dashboard_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -99,7 +100,7 @@ class _TrackProgressDashboardScreenState
 
   Future<void> _continueTrack(LessonTrack track, Map<String, bool> completed,
       List<LessonStep> steps) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString('lesson_selected_track', track.id);
     final id = track.stepIds.firstWhere((e) => completed[e] != true,
         orElse: () => track.stepIds.last);

--- a/lib/screens/track_selector_screen.dart
+++ b/lib/screens/track_selector_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -42,7 +43,7 @@ class _TrackSelectorScreenState extends State<TrackSelectorScreen> {
   }
 
   Future<void> _select(BuildContext context, LessonTrack track) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString('lesson_selected_track', track.id);
     if (context.mounted) {
       Navigator.pushReplacement(

--- a/lib/screens/training_history/training_history_controller.dart
+++ b/lib/screens/training_history/training_history_controller.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,7 +10,7 @@ class TrainingHistoryController {
   static final instance = TrainingHistoryController._();
 
   Future<List<TrainingResult>> loadHistory() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final stored = prefs.getStringList('training_history') ?? [];
     final results = <TrainingResult>[];
     for (final item in stored) {
@@ -26,7 +27,7 @@ class TrainingHistoryController {
   }
 
   Future<void> clearHistory() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove('training_history');
   }
 }

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:io';
 
@@ -123,7 +124,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final sortIndex = prefs.getInt(_sortKey) ?? 0;
     final ratingIndex = prefs.getInt(_ratingKey) ?? 0;
     final accuracyRangeIndex = prefs.getInt(_accuracyRangeKey) ?? 0;
@@ -193,7 +194,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _saveHistory() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = [for (final r in _history) jsonEncode(r.toJson())];
     await prefs.setStringList('training_history', list);
   }
@@ -941,7 +942,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
 
 
   Future<void> _resetFilters() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_sortKey, _SortOption.newest.index);
     await prefs.setInt(_ratingKey, _RatingFilter.all.index);
     await prefs.setInt(_accuracyRangeKey, _AccuracyRange.all.index);
@@ -969,31 +970,31 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _clearTagFilters() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove(_tagKey);
     setState(() => _selectedTags.clear());
   }
 
   Future<void> _clearColorFilters() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove(_tagColorKey);
     setState(() => _selectedTagColors.clear());
   }
 
   Future<void> _clearLengthFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_lengthKey, _SessionLengthFilter.any.index);
     setState(() => _lengthFilter = _SessionLengthFilter.any);
   }
 
   Future<void> _clearAccuracyFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_accuracyRangeKey, _AccuracyRange.all.index);
     setState(() => _accuracyRange = _AccuracyRange.all);
   }
 
   Future<void> _clearDateFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove(_dateFromKey);
     await prefs.remove(_dateToKey);
     setState(() {
@@ -1311,7 +1312,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 selected: _selectedTags.contains(tag),
                 selectedColor: colorFromHex(tagService.colorOf(tag)),
                 onSelected: (selected) async {
-                  final prefs = await SharedPreferences.getInstance();
+                  final prefs = await PreferencesService.getInstance();
                   setState(() {
                     if (selected) {
                       _selectedTags.add(tag);
@@ -1360,7 +1361,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 selected: _lengthFilter == entry.key,
                 onSelected: (selected) async {
                   if (!selected) return;
-                  final prefs = await SharedPreferences.getInstance();
+                  final prefs = await PreferencesService.getInstance();
                   await prefs.setInt(_lengthKey, entry.key.index);
                   setState(() => _lengthFilter = entry.key);
                 },
@@ -1403,7 +1404,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 selected: _accuracyRange == entry.key,
                 onSelected: (selected) async {
                   if (!selected) return;
-                  final prefs = await SharedPreferences.getInstance();
+                  final prefs = await PreferencesService.getInstance();
                   await prefs.setInt(_accuracyRangeKey, entry.key.index);
                   setState(() => _accuracyRange = entry.key);
                 },
@@ -1452,7 +1453,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                 selected: _selectedTagColors.contains(color),
                 selectedColor: colorFromHex(color),
                 onSelected: (selected) async {
-                  final prefs = await SharedPreferences.getInstance();
+                  final prefs = await PreferencesService.getInstance();
                   setState(() {
                     if (selected) {
                       _selectedTagColors.add(color);
@@ -1591,7 +1592,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       },
     );
     if (result != null) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setStringList(_tagKey, result.toList());
       setState(() => _selectedTags = result);
     }
@@ -1665,7 +1666,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       },
     );
     if (result != null) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setStringList(_tagColorKey, result.toList());
       setState(() => _selectedTagColors = result);
     }
@@ -2069,61 +2070,61 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
 
   Future<void> _setChartsVisible(bool value) async {
     setState(() => _showCharts = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_showChartsKey, _showCharts);
   }
 
   Future<void> _setAvgChartVisible(bool value) async {
     setState(() => _showAvgChart = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_showAvgChartKey, _showAvgChart);
   }
 
   Future<void> _setDistributionVisible(bool value) async {
     setState(() => _showDistribution = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_showDistributionKey, _showDistribution);
   }
 
   Future<void> _setTrendChartVisible(bool value) async {
     setState(() => _showTrendChart = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_showTrendChartKey, _showTrendChart);
   }
 
   Future<void> _setIncludeChartInPdf(bool value) async {
     setState(() => _includeChartInPdf = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_pdfIncludeChartKey, _includeChartInPdf);
   }
 
   Future<void> _setExportTags3Only(bool value) async {
     setState(() => _exportTags3Only = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_exportTags3OnlyKey, _exportTags3Only);
   }
 
   Future<void> _setExportNotesOnly(bool value) async {
     setState(() => _exportNotesOnly = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_exportNotesOnlyKey, _exportNotesOnly);
   }
 
   Future<void> _setHideEmptyTags(bool value) async {
     setState(() => _hideEmptyTags = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_hideEmptyTagsKey, _hideEmptyTags);
   }
 
   Future<void> _setSortByTag(bool value) async {
     setState(() => _sortByTag = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_sortByTagKey, _sortByTag);
   }
 
   Future<void> _setChartMode(_ChartMode mode) async {
     setState(() => _chartMode = mode);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_chartModeKey, mode.index);
   }
 
@@ -2137,7 +2138,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
           : null,
     );
     if (range != null) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setInt(_dateFromKey, DateUtils.dateOnly(range.start).millisecondsSinceEpoch);
       await prefs.setInt(_dateToKey, DateUtils.dateOnly(range.end).millisecondsSinceEpoch);
       setState(() {
@@ -2155,7 +2156,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   }
 
   Future<void> _applyQuickDateFilter(int days) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final now = DateUtils.dateOnly(DateTime.now());
     final from = DateUtils.dateOnly(now.subtract(Duration(days: days - 1)));
     await prefs.setInt(_dateFromKey, from.millisecondsSinceEpoch);
@@ -2469,7 +2470,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         onChanged: (value) async {
                           if (value == null) return;
                           final prefs =
-                              await SharedPreferences.getInstance();
+                              await PreferencesService.getInstance();
                           await prefs.setInt(_ratingKey, value.index);
                           setState(() => _ratingFilter = value);
                         },
@@ -2505,7 +2506,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         onChanged: (value) async {
                           if (value == null) return;
                           final prefs =
-                              await SharedPreferences.getInstance();
+                              await PreferencesService.getInstance();
                           await prefs.setInt(_sortKey, value.index);
                           setState(() => _sort = value);
                         },
@@ -2541,7 +2542,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         ],
                         onChanged: (value) async {
                           if (value == null) return;
-                          final prefs = await SharedPreferences.getInstance();
+                          final prefs = await PreferencesService.getInstance();
                           await prefs.setInt(_tagCountKey, value.index);
                           setState(() => _tagCountFilter = value);
                         },
@@ -2580,7 +2581,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         ],
                         onChanged: (value) async {
                           if (value == null) return;
-                          final prefs = await SharedPreferences.getInstance();
+                          final prefs = await PreferencesService.getInstance();
                           await prefs.setInt(_weekdayKey, value.index);
                           setState(() => _weekdayFilter = value);
                         },
@@ -2615,7 +2616,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         ],
                         onChanged: (value) async {
                           if (value == null) return;
-                          final prefs = await SharedPreferences.getInstance();
+                          final prefs = await PreferencesService.getInstance();
                           await prefs.setInt(_lengthKey, value.index);
                           setState(() => _lengthFilter = value);
                         },
@@ -2649,7 +2650,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                         onChanged: (value) async {
                           if (value == null) return;
                           final prefs =
-                              await SharedPreferences.getInstance();
+                              await PreferencesService.getInstance();
                           await prefs.setInt(_accuracyRangeKey, value.index);
                           setState(() => _accuracyRange = value);
                         },

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -353,7 +354,7 @@ class _PackCard extends StatelessWidget {
 
   Future<void> _onDone(BuildContext context) async {
     onDone();
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final done = prefs.getBool('completed_tpl_${template.id}') ?? false;
     if (!done || !context.mounted) return;
     final templates = context.read<TemplateStorageService>().templates;

--- a/lib/screens/training_onboarding_screen.dart
+++ b/lib/screens/training_onboarding_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../theme/app_colors.dart';
@@ -21,7 +22,7 @@ class _TrainingOnboardingScreenState extends State<TrainingOnboardingScreen> {
   }
 
   Future<void> _finish() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool('seen_training_onboarding', true);
     if (!mounted) return;
     Navigator.pushReplacement(

--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:async';
@@ -250,7 +251,7 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
+    PreferencesService.getInstance().then((p) {
       if (mounted) {
         setState(() {
           _prefs = p;
@@ -539,7 +540,7 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
   }
 
   Future<void> _setColorTag() async {
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     final color = await showColorPickerDialog(
       context,
       initialColor: _lastColor,
@@ -720,7 +721,7 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
                 onChanged: (v) async {
                   final value = v ?? 0;
                   setState(() => _diffFilter = value);
-                  final prefs = _prefs ?? await SharedPreferences.getInstance();
+                  final prefs = _prefs ?? await PreferencesService.getInstance();
                   if (value == 0) {
                     await prefs.remove('pack_diff_filter');
                   } else {
@@ -749,7 +750,7 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
                 style: const TextStyle(color: Colors.white),
                 onChanged: (v) async {
                   final value = v ?? 'All';
-                  final prefs = _prefs ?? await SharedPreferences.getInstance();
+                  final prefs = _prefs ?? await PreferencesService.getInstance();
                   if (value == 'Custom') {
                     final color = await showColorPickerDialog(
                       context,

--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -58,7 +59,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final sortIndex = prefs.getInt(_sortKey) ?? 0;
     setState(() {
       _prefs = prefs;
@@ -69,7 +70,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
   }
 
   Future<void> _savePrefs() async {
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     await prefs.setBool(_mistakesKey, _onlyMistakes);
     await prefs.setInt(_sortKey, _sort.index);
     await prefs.setString(_searchKey, _searchController.text);
@@ -563,7 +564,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
                 : (v) async {
                     setState(() => _onlyMistakes = v);
                     final prefs =
-                        _prefs ?? await SharedPreferences.getInstance();
+                        _prefs ?? await PreferencesService.getInstance();
                     await prefs.setBool(_mistakesKey, v);
                   },
             activeColor: Colors.orange,
@@ -582,7 +583,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
                         onPressed: () async {
                           _searchController.clear();
                           final prefs =
-                              _prefs ?? await SharedPreferences.getInstance();
+                              _prefs ?? await PreferencesService.getInstance();
                           await prefs.setString(_searchKey, '');
                           setState(() {});
                         },
@@ -591,7 +592,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
               onChanged: (_) async {
                 setState(() {});
                 final prefs =
-                    _prefs ?? await SharedPreferences.getInstance();
+                    _prefs ?? await PreferencesService.getInstance();
                 await prefs.setString(_searchKey, _searchController.text);
               },
             ),
@@ -619,7 +620,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
                     if (value == null) return;
                     setState(() => _sort = value);
                     final prefs =
-                        _prefs ?? await SharedPreferences.getInstance();
+                        _prefs ?? await PreferencesService.getInstance();
                     await prefs.setInt(_sortKey, value.index);
                   },
                 ),

--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:convert';
 import 'dart:io';
 
@@ -57,7 +58,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadSort() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final name = prefs.getString(_prefsSortKey);
     if (name != null) {
       try {
@@ -68,7 +69,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadCollapsed() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = prefs.getStringList(_prefsCollapsedKey) ?? [];
     if (list.isNotEmpty && mounted) {
       setState(() {
@@ -80,37 +81,37 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadShowFavorites() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final value = prefs.getBool(_prefsFavKey) ?? false;
     if (mounted) setState(() => _showFavoritesOnly = value);
   }
 
   Future<void> _loadGroupByStreet() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final value = prefs.getBool(_prefsGroupKey) ?? false;
     if (mounted) setState(() => _groupByStreet = value);
   }
 
   Future<void> _setSort(_SortOption value) async {
     setState(() => _sort = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_prefsSortKey, value.name);
   }
 
   Future<void> _setShowFavoritesOnly(bool value) async {
     setState(() => _showFavoritesOnly = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsFavKey, value);
   }
 
   Future<void> _setGroupByStreet(bool value) async {
     setState(() => _groupByStreet = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsGroupKey, value);
   }
 
   Future<void> _saveCollapsed() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList(
       _prefsCollapsedKey,
       [

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -129,7 +130,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
   }
 
   Future<void> _loadPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _prefs = prefs;
       _hideCompleted = prefs.getBool(_hideKey) ?? false;
@@ -145,13 +146,13 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
 
   Future<void> _toggleHideCompleted(bool value) async {
     setState(() => _hideCompleted = value);
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     await prefs.setBool(_hideKey, value);
   }
 
   Future<void> _setTypeFilter(GameType? value) async {
     setState(() => _typeFilter = value);
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     if (value == null) {
       await prefs.remove(_typeKey);
     } else {
@@ -161,7 +162,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
 
   Future<void> _setDiffFilter(int value) async {
     setState(() => _diffFilter = value);
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     if (value == 0) {
       await prefs.remove(_diffKey);
     } else {
@@ -170,7 +171,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
   }
 
   Future<void> _setColorFilter(String value) async {
-    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await PreferencesService.getInstance();
     if (value == 'Custom') {
       final color = await showColorPickerDialog(
         context,
@@ -603,7 +604,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
           value: _groupByColor,
           onChanged: (v) async {
             setState(() => _groupByColor = v);
-            final prefs = _prefs ?? await SharedPreferences.getInstance();
+            final prefs = _prefs ?? await PreferencesService.getInstance();
             await prefs.setBool(_groupKey, v);
           },
           activeColor: Colors.orange,

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -237,7 +238,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     await _checkGoalProgress();
     final tpl = service.template;
     if (tpl != null) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       if (next == null) {
         await prefs.remove('progress_tpl_${tpl.id}');
         await prefs.setBool('completed_tpl_${tpl.id}', true);
@@ -355,7 +356,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
           ),
         );
       }
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       final acc = total == 0 ? 0.0 : correct * 100 / total;
       await prefs.setBool('completed_tpl_${tpl.id}', true);
       await LearningPathProgressService.instance.markCompleted(tpl.id);

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:async';
 import 'dart:io';
 
@@ -173,7 +174,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
     if (accuracy >= 90) return;
     final rec = service.recommendation;
     if (rec == null) return;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final key = 'weak_tip_${rec.position.name}';
     final lastStr = prefs.getString(key);
     if (lastStr != null) {

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
@@ -109,7 +110,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   }
 
   Future<void> _prepare() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _autoAdvance = prefs.getBool('auto_adv_${widget.template.id}') ?? false;
     });
@@ -123,7 +124,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final seqKey = 'tpl_seq_${widget.template.id}';
     final progKey = 'tpl_prog_${widget.template.id}';
     final resKey = 'tpl_res_${widget.template.id}';
@@ -209,7 +210,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
   }
 
   Future<void> _save({bool ts = true}) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList('tpl_seq_${widget.template.id}', [for (final s in _spots) s.id]);
     await prefs.setInt('tpl_prog_${widget.template.id}', _index);
     await prefs.setString('tpl_res_${widget.template.id}', jsonEncode(_results));
@@ -510,7 +511,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
     );
     final ctx = navigatorKey.currentContext;
     if (ctx != null && isFinalStep) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       if (!prefs.containsKey('post_starter_path_choice')) {
         final choice = await showDialog<String>(
           context: ctx,
@@ -580,7 +581,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
           .markActiveToday(context);
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setString('last_training_day',
           DateTime.now().toIso8601String().split('T').first);
       await NotificationService.scheduleDailyReminder(context);
@@ -859,7 +860,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                     : Colors.white70),
             onPressed: () async {
               setState(() => _autoAdvance = !_autoAdvance);
-              final prefs = await SharedPreferences.getInstance();
+              final prefs = await PreferencesService.getInstance();
               prefs.setBool('auto_adv_${widget.template.id}', _autoAdvance);
             },
           ),
@@ -873,7 +874,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen> {
                     _index = 0;
                     _results.clear();
                   });
-                  final prefs = await SharedPreferences.getInstance();
+                  final prefs = await PreferencesService.getInstance();
                   prefs
                     ..remove('tpl_seq_${widget.template.id}')
                     ..remove('tpl_res_${widget.template.id}')

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
@@ -117,7 +118,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
   }
 
   Future<void> _prepare() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _autoAdvance =
           widget.template.targetStreet == null &&
@@ -133,7 +134,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
   }
 
   Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final seqKey = 'tpl_seq_${widget.template.id}';
     final progKey = 'tpl_prog_${widget.template.id}';
     final resKey = 'tpl_res_${widget.template.id}';
@@ -223,7 +224,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
   }
 
   Future<void> _save({bool ts = true}) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList('tpl_seq_${widget.template.id}', [for (final s in _spots) s.id]);
     await prefs.setInt('tpl_prog_${widget.template.id}', _index);
     await prefs.setString('tpl_res_${widget.template.id}', jsonEncode(_results));
@@ -595,7 +596,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2> {
           .markActiveToday(context);
       await NotificationService.cancel(101);
       await NotificationService.cancel(102);
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       await prefs.setString('last_training_day',
           DateTime.now().toIso8601String().split('T').first);
       await NotificationService.scheduleDailyReminder(context);

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
@@ -240,7 +241,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       });
     }
     final achieved = _correct == _total;
-    SharedPreferences.getInstance()
+    PreferencesService.getInstance()
         .then((p) => p.setBool('tpl_goal_${widget.original.id}', achieved));
     final storage = context.read<TrainingPackTemplateStorageService>();
     if (widget.original.focusHandTypes.isNotEmpty) {
@@ -301,7 +302,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       correct: _correct,
       total: _total,
     ));
-    SharedPreferences.getInstance().then((p) =>
+    PreferencesService.getInstance().then((p) =>
         p.setString('last_trained_tpl_${widget.original.id}', DateTime.now().toIso8601String()));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final ctx = _firstKey.currentContext;
@@ -490,7 +491,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
               onPressed: _mistakes == 0
                   ? null
                   : () async {
-                      final prefs = await SharedPreferences.getInstance();
+                      final prefs = await PreferencesService.getInstance();
                       await prefs.remove('tpl_seq_${widget.original.id}');
                       await prefs.remove('tpl_prog_${widget.original.id}');
                       await prefs.remove('tpl_res_${widget.original.id}');
@@ -556,7 +557,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
     final tpl = await weak.buildPack();
     final rec = weak.recommendation;
     if (tpl == null || rec == null) return;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final key = 'weak_tip_${rec.position.name}';
     final lastStr = prefs.getString(key);
     if (lastStr != null) {

--- a/lib/screens/v2/training_pack_result_screen_v2.dart
+++ b/lib/screens/v2/training_pack_result_screen_v2.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 import 'dart:math';
 import 'dart:io';
 import 'dart:convert';
@@ -82,7 +83,7 @@ class _TrainingPackResultScreenV2State extends State<TrainingPackResultScreenV2>
     final tpl = await weak.buildPack();
     final rec = weak.recommendation;
     if (tpl == null || rec == null) return;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final key = 'weak_tip_${rec.position.name}';
     final lastStr = prefs.getString(key);
     if (lastStr != null) {
@@ -162,7 +163,7 @@ class _TrainingPackResultScreenV2State extends State<TrainingPackResultScreenV2>
   }
 
   Future<void> _repeat(BuildContext context) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove('tpl_seq_${widget.original.id}');
     await prefs.remove('tpl_prog_${widget.original.id}');
     await prefs.remove('tpl_res_${widget.original.id}');

--- a/lib/screens/v2/training_pack_template_list_core.dart
+++ b/lib/screens/v2/training_pack_template_list_core.dart
@@ -1,3 +1,4 @@
+import 'package:poker_analyzer/services/preferences_service.dart';
 part of 'training_pack_template_list_screen.dart';
 
 class TrainingPackTemplateListScreen extends StatefulWidget {
@@ -75,7 +76,7 @@ class _TrainingPackTemplateListScreenState
   final List<String> _recentIds = [];
 
   Future<void> _loadSort() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final value = prefs.getString(_prefsSortKey);
     if (mounted && value != null) {
       setState(() {
@@ -90,7 +91,7 @@ class _TrainingPackTemplateListScreenState
       _sort = value;
       _sortTemplates();
     });
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setString(_prefsSortKey, value);
   }
 
@@ -172,7 +173,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadProgress() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final map = <String, int>{};
     final streetMap = <String, int>{};
     final handMap = <String, Map<String, int>>{};
@@ -260,7 +261,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _maybeShowContinueReminder() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final ts = prefs.getInt('tpl_continue_last');
     if (ts != null && DateTime.now().difference(DateTime.fromMillisecondsSinceEpoch(ts)).inHours < 24) {
       return;
@@ -290,7 +291,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadGoals() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     for (final t in _templates) {
       t.goalAchieved = prefs.getBool('tpl_goal_${t.id}') ?? false;
     }
@@ -298,28 +299,28 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadHideCompleted() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() => _hideCompleted = prefs.getBool(_prefsHideKey) ?? false);
     }
   }
 
   Future<void> _loadGroupByStreet() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() => _groupByStreet = prefs.getBool(_prefsGroupKey) ?? false);
     }
   }
 
   Future<void> _loadGroupByType() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() => _groupByType = prefs.getBool(_prefsTypeKey) ?? false);
     }
   }
 
   Future<void> _loadMixedPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() {
         _mixedHandGoalOnly = prefs.getBool(_prefsMixedHandKey) ?? false;
@@ -337,30 +338,30 @@ class _TrainingPackTemplateListScreenState
 
   Future<void> _setHideCompleted(bool value) async {
     setState(() => _hideCompleted = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsHideKey, value);
   }
 
   Future<void> _setGroupByStreet(bool value) async {
     setState(() => _groupByStreet = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsGroupKey, value);
   }
 
   Future<void> _setGroupByType(bool value) async {
     setState(() => _groupByType = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsTypeKey, value);
   }
 
   Future<void> _setMixedHandGoalOnly(bool value) async {
     setState(() => _mixedHandGoalOnly = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsMixedHandKey, value);
   }
 
   Future<void> _saveMixedPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt(_prefsMixedCountKey, _mixedCount);
     await prefs.setString(_prefsMixedStreetKey, _mixedStreet);
     await prefs.setBool(_prefsMixedAutoKey, _mixedAutoOnly);
@@ -380,20 +381,20 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadFavorites() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = prefs.getStringList(_prefsFavoritesKey) ?? [];
     if (mounted) setState(() => _favorites.addAll(list));
   }
 
   Future<void> _loadShowFavoritesOnly() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() => _showFavoritesOnly = prefs.getBool(_prefsShowFavOnlyKey) ?? false);
     }
   }
 
   Future<void> _loadShowInProgressOnly() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) {
       setState(() => _showInProgressOnly = prefs.getBool(_prefsInProgressKey) ?? false);
     }
@@ -401,18 +402,18 @@ class _TrainingPackTemplateListScreenState
 
   Future<void> _setShowFavoritesOnly(bool value) async {
     setState(() => _showFavoritesOnly = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsShowFavOnlyKey, value);
   }
 
   Future<void> _setShowInProgressOnly(bool value) async {
     setState(() => _showInProgressOnly = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setBool(_prefsInProgressKey, value);
   }
 
   Future<void> _saveFavorites() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setStringList(_prefsFavoritesKey, _favorites.toList());
   }
 
@@ -426,13 +427,13 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadStackFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) setState(() => _stackFilter = prefs.getString(_prefsStackKey));
   }
 
   Future<void> _setStackFilter(String? value) async {
     setState(() => _stackFilter = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (value == null) {
       await prefs.remove(_prefsStackKey);
     } else {
@@ -441,7 +442,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadPosFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final name = prefs.getString(_prefsPosKey);
     if (mounted) {
       setState(() => _posFilter = name == null
@@ -454,13 +455,13 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadDifficultyFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) setState(() => _difficultyFilter = prefs.getString(_prefsDifficultyKey));
   }
 
   Future<void> _setPosFilter(HeroPosition? value) async {
     setState(() => _posFilter = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (value == null) {
       await prefs.remove(_prefsPosKey);
     } else {
@@ -470,7 +471,7 @@ class _TrainingPackTemplateListScreenState
 
   Future<void> _setDifficultyFilter(String? value) async {
     setState(() => _difficultyFilter = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (value == null) {
       await prefs.remove(_prefsDifficultyKey);
     } else {
@@ -479,13 +480,13 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadStreetFilter() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (mounted) setState(() => _streetFilter = prefs.getString(_prefsStreetKey));
   }
 
   Future<void> _setStreetFilter(String? value) async {
     setState(() => _streetFilter = value);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     if (value == null) {
       await prefs.remove(_prefsStreetKey);
     } else {
@@ -494,7 +495,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _loadRecent() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     final list = prefs.getStringList(_prefsRecentKey) ?? [];
     if (mounted) {
       setState(() => _recentIds
@@ -504,7 +505,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _addRecent(String id) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() {
       _recentIds.remove(id);
       _recentIds.insert(0, id);
@@ -516,7 +517,7 @@ class _TrainingPackTemplateListScreenState
   }
 
   Future<void> _clearRecent() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     setState(() => _recentIds.clear());
     await prefs.remove(_prefsRecentKey);
   }
@@ -611,7 +612,7 @@ class _TrainingPackTemplateListScreenState
       _icmOnly = false;
       _completedOnly = false;
     });
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.remove(_prefsDifficultyKey);
     await prefs.remove(_prefsPosKey);
     await prefs.remove(_prefsStackKey);
@@ -678,7 +679,7 @@ class _TrainingPackTemplateListScreenState
     );
     if (!mounted) return;
     if (done >= tpl.streetGoal) {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await PreferencesService.getInstance();
       final key = 'tpl_sgoal_${tpl.id}_${tpl.streetGoal}';
       if (!(prefs.getBool(key) ?? false)) {
         await prefs.setBool(key, true);
@@ -2428,7 +2429,7 @@ class _TrainingPackTemplateListScreenState
 
   Future<void> _runMixedDrill() async {
     final now = DateTime.now();
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await PreferencesService.getInstance();
     await prefs.setInt('tpl_mixed_last_run', now.millisecondsSinceEpoch);
     setState(() => _mixedLastRun = now);
     final count = _mixedCount;

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -2,21 +2,89 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../utils/shared_prefs_keys.dart';
 
-/// Provides a cached [SharedPreferences] instance and exports preference keys.
+/// Provides a cached [SharedPreferences] instance along with convenient
+/// asynchronous getters and setters for common preference types. The service
+/// also re-exports preference keys so consumers only need to import this file.
 class PreferencesService {
   PreferencesService._();
 
   static SharedPreferences? _prefs;
 
-  /// Returns the cached [SharedPreferences] instance, initializing it if necessary.
+  /// Returns the cached [SharedPreferences] instance, initializing it if
+  /// necessary.
   static Future<SharedPreferences> getInstance() async {
     return _prefs ??= await SharedPreferences.getInstance();
   }
 
   /// Accessor for the cached [SharedPreferences] instance.
-  ///
   /// Ensure [getInstance] is called at least once before using this getter.
   static SharedPreferences get instance => _prefs!;
+
+  /// Retrieves a `bool` value for the given [key].
+  static Future<bool?> getBool(String key) async {
+    final prefs = await getInstance();
+    return prefs.getBool(key);
+  }
+
+  /// Persists a `bool` [value] for the given [key].
+  static Future<void> setBool(String key, bool value) async {
+    final prefs = await getInstance();
+    await prefs.setBool(key, value);
+  }
+
+  /// Retrieves an `int` value for the given [key].
+  static Future<int?> getInt(String key) async {
+    final prefs = await getInstance();
+    return prefs.getInt(key);
+  }
+
+  /// Persists an `int` [value] for the given [key].
+  static Future<void> setInt(String key, int value) async {
+    final prefs = await getInstance();
+    await prefs.setInt(key, value);
+  }
+
+  /// Retrieves a `double` value for the given [key].
+  static Future<double?> getDouble(String key) async {
+    final prefs = await getInstance();
+    return prefs.getDouble(key);
+  }
+
+  /// Persists a `double` [value] for the given [key].
+  static Future<void> setDouble(String key, double value) async {
+    final prefs = await getInstance();
+    await prefs.setDouble(key, value);
+  }
+
+  /// Retrieves a `String` value for the given [key].
+  static Future<String?> getString(String key) async {
+    final prefs = await getInstance();
+    return prefs.getString(key);
+  }
+
+  /// Persists a `String` [value] for the given [key].
+  static Future<void> setString(String key, String value) async {
+    final prefs = await getInstance();
+    await prefs.setString(key, value);
+  }
+
+  /// Retrieves a list of strings for the given [key].
+  static Future<List<String>?> getStringList(String key) async {
+    final prefs = await getInstance();
+    return prefs.getStringList(key);
+  }
+
+  /// Persists a list of strings [value] for the given [key].
+  static Future<void> setStringList(String key, List<String> value) async {
+    final prefs = await getInstance();
+    await prefs.setStringList(key, value);
+  }
+
+  /// Removes the value associated with the given [key].
+  static Future<void> remove(String key) async {
+    final prefs = await getInstance();
+    await prefs.remove(key);
+  }
 }
 
 // Re-export keys so consumers only need to import this service.


### PR DESCRIPTION
## Summary
- add `PreferencesService` with async getters and setters for common preference types
- replace `SharedPreferences.getInstance` across UI screens with `PreferencesService`
- use new service helpers in `DailySpotScreen` and `MainMenuScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d7791b0832a8874daa871c3b270