### PR TITLE
Add generic CopyWith mixin for models

### DIFF
--- a/lib/models/copy_with_mixin.dart
+++ b/lib/models/copy_with_mixin.dart
@@ -1,0 +1,19 @@
+mixin CopyWithMixin<T> {
+  /// Factory that reconstructs [T] from JSON.
+  T Function(Map<String, dynamic> json) get fromJson;
+
+  /// Serializes the object into JSON.
+  Map<String, dynamic> toJson();
+
+  /// Returns a copy of this object with the provided [changes] applied.
+  ///
+  /// Example:
+  /// ```dart
+  /// final updated = original.copyWith({'name': 'New'});
+  /// ```
+  T copyWith(Map<String, dynamic> changes) {
+    final data = Map<String, dynamic>.from(toJson());
+    data.addAll(changes);
+    return fromJson(data);
+  }
+}

--- a/lib/models/player_model.dart
+++ b/lib/models/player_model.dart
@@ -1,5 +1,6 @@
 import 'action_model.dart';
 import 'card_model.dart';
+import 'copy_with_mixin.dart';
 
 /// Different types of players at the table.
 enum PlayerType {
@@ -22,7 +23,7 @@ enum PlayerType {
   unknown,
 }
 
-class PlayerModel {
+class PlayerModel with CopyWithMixin<PlayerModel> {
   final String name;
   final List<String> cards;
   /// Cards that this player has revealed. Two slots that may be null.
@@ -47,28 +48,6 @@ class PlayerModel {
           'Turn': [],
           'River': [],
         };
-
-  PlayerModel copyWith({
-    String? name,
-    PlayerType? type,
-    List<CardModel?>? revealedCards,
-    int? stack,
-    int? bet,
-  }) {
-    return PlayerModel(
-      name: name ?? this.name,
-      type: type ?? this.type,
-      stack: stack ?? this.stack,
-      bet: bet ?? this.bet,
-      revealedCards: revealedCards ??
-          List<CardModel?>.from(this.revealedCards),
-    )
-      ..cards.addAll(cards)
-      ..actions.addAll({
-        for (final entry in actions.entries)
-          entry.key: List<PlayerActionModel>.from(entry.value)
-      });
-  }
 
   Map<String, dynamic> toJson() => {
         'name': name,
@@ -121,4 +100,8 @@ class PlayerModel {
     });
     return model;
   }
+
+  @override
+  PlayerModel Function(Map<String, dynamic> json) get fromJson =>
+      PlayerModel.fromJson;
 }

--- a/lib/models/training_pack_template.dart
+++ b/lib/models/training_pack_template.dart
@@ -1,10 +1,11 @@
 import 'saved_hand.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'copy_with_mixin.dart';
 
 part 'training_pack_template.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class TrainingPackTemplate {
+class TrainingPackTemplate with CopyWithMixin<TrainingPackTemplate> {
   final String id;
   final String name;
   final String gameType;
@@ -48,6 +49,10 @@ class TrainingPackTemplate {
   factory TrainingPackTemplate.fromJson(Map<String, dynamic> json) =>
       _$TrainingPackTemplateFromJson(json);
   Map<String, dynamic> toJson() => _$TrainingPackTemplateToJson(this);
+
+  @override
+  TrainingPackTemplate Function(Map<String, dynamic> json) get fromJson =>
+      TrainingPackTemplate.fromJson;
 
   factory TrainingPackTemplate.fromMap(Map<String, dynamic> map) {
     return TrainingPackTemplate(

--- a/lib/models/training_pack_template_model.dart
+++ b/lib/models/training_pack_template_model.dart
@@ -1,9 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'copy_with_mixin.dart';
 
 part 'training_pack_template_model.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class TrainingPackTemplateModel {
+class TrainingPackTemplateModel
+    with CopyWithMixin<TrainingPackTemplateModel> {
   final String id;
   final String name;
   final String description;
@@ -33,37 +35,13 @@ class TrainingPackTemplateModel {
   })  : filters = filters ?? const {},
         createdAt = createdAt ?? DateTime.now();
 
-  TrainingPackTemplateModel copyWith({
-    String? id,
-    String? name,
-    String? description,
-    String? category,
-    int? difficulty,
-    Map<String, dynamic>? filters,
-    bool? isTournament,
-    bool? isFavorite,
-    DateTime? createdAt,
-    DateTime? lastGeneratedAt,
-    double? rating,
-  }) {
-    return TrainingPackTemplateModel(
-      id: id ?? this.id,
-      name: name ?? this.name,
-      description: description ?? this.description,
-      category: category ?? this.category,
-      difficulty: difficulty ?? this.difficulty,
-      filters: filters ?? Map<String, dynamic>.from(this.filters),
-      isTournament: isTournament ?? this.isTournament,
-      isFavorite: isFavorite ?? this.isFavorite,
-      createdAt: createdAt ?? this.createdAt,
-      lastGeneratedAt: lastGeneratedAt ?? this.lastGeneratedAt,
-      rating: rating ?? this.rating,
-    );
-  }
-
   factory TrainingPackTemplateModel.fromJson(Map<String, dynamic> json) =>
       _$TrainingPackTemplateModelFromJson(json);
 
   Map<String, dynamic> toJson() => _$TrainingPackTemplateModelToJson(this);
+
+  @override
+  TrainingPackTemplateModel Function(Map<String, dynamic> json) get fromJson =>
+      TrainingPackTemplateModel.fromJson;
 }
 

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -1,8 +1,8 @@
-import 'package:collection/collection.dart';
 import 'hand_data.dart';
 import '../evaluation_result.dart';
+import '../copy_with_mixin.dart';
 
-class TrainingPackSpot {
+class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
   final String id;
   String type;
   String title;
@@ -70,59 +70,6 @@ class TrainingPackSpot {
         editedAt = editedAt ?? DateTime.now(),
         createdAt = createdAt ?? DateTime.now();
 
-  TrainingPackSpot copyWith({
-    String? id,
-    String? type,
-    String? title,
-    String? note,
-    HandData? hand,
-    List<String>? tags,
-    List<String>? categories,
-    DateTime? editedAt,
-    DateTime? createdAt,
-    bool? pinned,
-    bool? dirty,
-    int? priority,
-    bool? isNew,
-    bool? isGenerated,
-    EvaluationResult? evalResult,
-    String? correctAction,
-    String? explanation,
-    String? image,
-    bool? streetMode,
-    List<String>? board,
-    int? street,
-    String? villainAction,
-    List<String>? heroOptions,
-    Map<String, dynamic>? meta,
-  }) =>
-      TrainingPackSpot(
-        id: id ?? this.id,
-        type: type ?? this.type,
-        title: title ?? this.title,
-        note: note ?? this.note,
-        hand: hand ?? this.hand,
-        tags: tags ?? List<String>.from(this.tags),
-        categories: categories ?? List<String>.from(this.categories),
-        editedAt: editedAt ?? this.editedAt,
-        createdAt: createdAt ?? this.createdAt,
-        pinned: pinned ?? this.pinned,
-        dirty: dirty ?? this.dirty,
-        priority: priority ?? this.priority,
-        isNew: isNew ?? this.isNew,
-        isGenerated: isGenerated ?? this.isGenerated,
-        evalResult: evalResult ?? this.evalResult,
-        correctAction: correctAction ?? this.correctAction,
-        explanation: explanation ?? this.explanation,
-        image: image ?? this.image,
-        streetMode: streetMode ?? this.streetMode,
-        board: board ?? List<String>.from(this.board),
-        street: street ?? this.street,
-        villainAction: villainAction ?? this.villainAction,
-        heroOptions: heroOptions ?? List<String>.from(this.heroOptions),
-        meta: meta ?? Map<String, dynamic>.from(this.meta),
-      );
-
   factory TrainingPackSpot.fromJson(Map<String, dynamic> j) => TrainingPackSpot(
         id: j['id'] as String? ?? '',
         type: j['type'] as String? ?? 'quiz',
@@ -185,6 +132,10 @@ class TrainingPackSpot {
         if (heroOptions.isNotEmpty) 'heroOptions': heroOptions,
         if (meta.isNotEmpty) 'meta': meta,
       };
+
+  @override
+  TrainingPackSpot Function(Map<String, dynamic> json) get fromJson =>
+      TrainingPackSpot.fromJson;
 
   /// Converts this spot to a YAML-compatible map.
   ///

--- a/lib/models/v2/training_pack_template.dart
+++ b/lib/models/v2/training_pack_template.dart
@@ -7,8 +7,9 @@ import 'training_pack_variant.dart';
 import '../../services/pack_generator_service.dart';
 import '../../helpers/poker_position_helper.dart';
 import '../../utils/template_coverage_utils.dart';
+import '../copy_with_mixin.dart';
 
-class TrainingPackTemplate {
+class TrainingPackTemplate with CopyWithMixin<TrainingPackTemplate> {
   final String id;
   String slug;
   String name;
@@ -92,85 +93,6 @@ class TrainingPackTemplate {
         meta = meta ?? {},
         createdAt = createdAt ?? DateTime.now() {
     TemplateCoverageUtils.recountAll(this).applyTo(this.meta);
-  }
-
-  TrainingPackTemplate copyWith({
-    String? id,
-    String? slug,
-    String? name,
-    String? description,
-    String? goal,
-    String? category,
-    GameType? gameType,
-    List<TrainingPackSpot>? spots,
-    List<String>? tags,
-    List<String>? focusTags,
-    List<FocusGoal>? focusHandTypes,
-    String? difficulty,
-    int? heroBbStack,
-    List<int>? playerStacksBb,
-    HeroPosition? heroPos,
-    int? spotCount,
-    int? bbCallPct,
-    int? anteBb,
-    double? minEvForCorrect,
-    List<String>? heroRange,
-    DateTime? createdAt,
-    DateTime? lastGeneratedAt,
-    DateTime? lastTrainedAt,
-    Map<String, dynamic>? meta,
-    bool? goalAchieved,
-    int? goalTarget,
-    int? goalProgress,
-    String? targetStreet,
-    int? streetGoal,
-    bool? isDraft,
-    bool? isBuiltIn,
-    String? png,
-    bool? isFavorite,
-    bool? isPinned,
-    bool? trending,
-    bool? recommended,
-  }) {
-    return TrainingPackTemplate(
-      id: id ?? this.id,
-      slug: slug ?? this.slug,
-      name: name ?? this.name,
-      description: description ?? this.description,
-      goal: goal ?? this.goal,
-      category: category ?? this.category,
-      gameType: gameType ?? this.gameType,
-      spots: spots ?? List<TrainingPackSpot>.from(this.spots),
-      tags: tags ?? List<String>.from(this.tags),
-      focusTags: focusTags ?? List<String>.from(this.focusTags),
-      focusHandTypes:
-          focusHandTypes ?? List<FocusGoal>.from(this.focusHandTypes),
-      difficulty: difficulty ?? this.difficulty,
-      heroBbStack: heroBbStack ?? this.heroBbStack,
-      playerStacksBb: playerStacksBb ?? List<int>.from(this.playerStacksBb),
-      heroPos: heroPos ?? this.heroPos,
-      spotCount: spotCount ?? this.spotCount,
-      bbCallPct: bbCallPct ?? this.bbCallPct,
-      anteBb: anteBb ?? this.anteBb,
-      minEvForCorrect: minEvForCorrect ?? this.minEvForCorrect,
-      heroRange: heroRange ?? this.heroRange,
-      createdAt: createdAt ?? this.createdAt,
-      lastGeneratedAt: lastGeneratedAt ?? this.lastGeneratedAt,
-      lastTrainedAt: lastTrainedAt ?? this.lastTrainedAt,
-      meta: meta ?? Map<String, dynamic>.from(this.meta),
-      goalAchieved: goalAchieved ?? this.goalAchieved,
-      goalTarget: goalTarget ?? this.goalTarget,
-      goalProgress: goalProgress ?? this.goalProgress,
-      targetStreet: targetStreet ?? this.targetStreet,
-      streetGoal: streetGoal ?? this.streetGoal,
-      isDraft: isDraft ?? this.isDraft,
-      isBuiltIn: isBuiltIn ?? this.isBuiltIn,
-      png: png ?? this.png,
-      isFavorite: isFavorite ?? this.isFavorite,
-      isPinned: isPinned ?? this.isPinned,
-      trending: trending ?? this.trending,
-      recommended: recommended ?? this.recommended,
-    );
   }
 
   factory TrainingPackTemplate.fromJson(Map<String, dynamic> json) {
@@ -277,6 +199,10 @@ class TrainingPackTemplate {
         if (trending) 'trending': true,
         if (recommended) 'recommended': true,
       };
+
+  @override
+  TrainingPackTemplate Function(Map<String, dynamic> json) get fromJson =>
+      TrainingPackTemplate.fromJson;
 
   int get evCovered => meta['evCovered'] as int? ?? 0;
   int get icmCovered => meta['icmCovered'] as int? ?? 0;


### PR DESCRIPTION
## Summary
- add CopyWithMixin for map-driven copyWith construction
- integrate mixin into TrainingPack and Player models

## Testing
- `dart run build_runner build` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d7ed954832a81d3620a7d80bada