### PR TITLE
Add Level 1 push-fold theory mini lessons

### DIFF
--- a/assets/theory_lessons/level1/basic_range_logic.yaml
+++ b/assets/theory_lessons/level1/basic_range_logic.yaml
@@ -1,0 +1,7 @@
+id: basic_range_logic
+title: 'Basic Range Logic'
+tags: ['pushfold', 'range', 'basics']
+content: |-
+  Push ranges tighten or loosen based on stack depth and opponent tendencies.
+  Recognize when to shove wider or narrower to remain profitable.
+nextIds: ['effective_stack_sizes']

--- a/assets/theory_lessons/level1/effective_stack_sizes.yaml
+++ b/assets/theory_lessons/level1/effective_stack_sizes.yaml
@@ -1,0 +1,7 @@
+id: effective_stack_sizes
+title: 'Effective Stack Sizes and BB'
+tags: ['pushfold', 'stack', 'bb']
+content: |-
+  Effective stack size is the smaller of the two stacks in a hand.
+  Expressing stacks in big blinds standardizes decisions across blind levels.
+nextIds: ['risk_reward_tradeoff']

--- a/assets/theory_lessons/level1/positional_decisions.yaml
+++ b/assets/theory_lessons/level1/positional_decisions.yaml
@@ -1,0 +1,7 @@
+id: positional_decisions
+title: 'Preflop Decisions by Position'
+tags: ['pushfold', 'position']
+content: |-
+  Position dictates how wide you can shove.
+  Early seats require tighter ranges while late positions can apply maximum pressure.
+nextIds: []

--- a/assets/theory_lessons/level1/push_fold_intro.yaml
+++ b/assets/theory_lessons/level1/push_fold_intro.yaml
@@ -1,0 +1,7 @@
+id: push_fold_intro
+title: 'What is Push/Fold?'
+tags: ['pushfold', 'intro']
+content: |-
+  Push/fold is the short-stack strategy where you either go all-in or fold before the flop.
+  It simplifies decisions and maximizes fold equity when your stack is shallow.
+nextIds: ['basic_range_logic']

--- a/assets/theory_lessons/level1/risk_reward_tradeoff.yaml
+++ b/assets/theory_lessons/level1/risk_reward_tradeoff.yaml
@@ -1,0 +1,7 @@
+id: risk_reward_tradeoff
+title: 'Risk-Reward Tradeoff'
+tags: ['pushfold', 'risk', 'reward']
+content: |-
+  Each shove risks your tournament life for the chance to win blinds and antes.
+  Weigh the chips gained against elimination to choose profitable shoves.
+nextIds: ['positional_decisions']

--- a/lib/models/theory_mini_lesson_node.dart
+++ b/lib/models/theory_mini_lesson_node.dart
@@ -68,7 +68,8 @@ class TheoryMiniLessonNode implements LearningPathNode {
         tags.add(t.toString());
       }
     }
-    final nextIds = <String>[for (final v in (yaml['next'] as List? ?? [])) v.toString()];
+    final rawNext = yaml['nextIds'] ?? yaml['next'];
+    final nextIds = <String>[for (final v in (rawNext as List? ?? [])) v.toString()];
     final linked = <String>[for (final v in (yaml['linkedPackIds'] as List? ?? [])) v.toString()];
     return TheoryMiniLessonNode(
       id: yaml['id']?.toString() ?? '',

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -12,6 +12,7 @@ class MiniLessonLibraryService {
   static const List<String> _dirs = [
     'assets/mini_lessons/',
     'assets/theory_mini_lessons/',
+    'assets/theory_lessons/level1/',
   ];
 
   final List<TheoryMiniLessonNode> _lessons = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,6 +114,7 @@ flutter:
     - assets/theory_tracks/
     - assets/mini_lessons/
     - assets/theory_mini_lessons/
+    - assets/theory_lessons/level1/
     - assets/mini_lesson_library.yaml
     - assets/lessons/
     - assets/lesson_tracks/


### PR DESCRIPTION
## Summary
- add Level I push/fold theory mini lessons in YAML and link sequentially
- load new theory lesson directory at startup and support `nextIds` parsing
- register level1 theory lessons in pubspec assets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f504a00c4832aa35b73be5350b907