### PR TITLE
feat: add json_serializable for training models

### DIFF
--- a/lib/models/decay_tag_reinforcement_event.dart
+++ b/lib/models/decay_tag_reinforcement_event.dart
@@ -1,6 +1,12 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'decay_tag_reinforcement_event.g.dart';
+
+@JsonSerializable()
 class DecayTagReinforcementEvent {
   final String tag;
   final double delta;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime timestamp;
 
   DecayTagReinforcementEvent({
@@ -9,18 +15,12 @@ class DecayTagReinforcementEvent {
     required this.timestamp,
   });
 
-  Map<String, dynamic> toJson() => {
-        'tag': tag,
-        'delta': delta,
-        'timestamp': timestamp.toIso8601String(),
-      };
-
   factory DecayTagReinforcementEvent.fromJson(Map<String, dynamic> json) =>
-      DecayTagReinforcementEvent(
-        tag: json['tag'] as String? ?? '',
-        delta: (json['delta'] as num?)?.toDouble() ?? 0.0,
-        timestamp:
-            DateTime.tryParse(json['timestamp'] as String? ?? '') ??
-                DateTime.now(),
-      );
+      _$DecayTagReinforcementEventFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DecayTagReinforcementEventToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/decay_tag_reinforcement_event.g.dart
+++ b/lib/models/decay_tag_reinforcement_event.g.dart
@@ -1,0 +1,18 @@
+part of 'decay_tag_reinforcement_event.dart';
+
+DecayTagReinforcementEvent _$DecayTagReinforcementEventFromJson(
+        Map<String, dynamic> json) =>
+    DecayTagReinforcementEvent(
+      tag: json['tag'] as String,
+      delta: (json['delta'] as num).toDouble(),
+      timestamp: DecayTagReinforcementEvent._dateFromJson(
+          json['timestamp'] as String?),
+    );
+
+Map<String, dynamic> _$DecayTagReinforcementEventToJson(
+        DecayTagReinforcementEvent instance) =>
+    <String, dynamic>{
+      'tag': instance.tag,
+      'delta': instance.delta,
+      'timestamp': DecayTagReinforcementEvent._dateToJson(instance.timestamp),
+    };

--- a/lib/models/drill_result.dart
+++ b/lib/models/drill_result.dart
@@ -1,11 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
 
+part 'drill_result.g.dart';
+
+@JsonSerializable()
 class DrillResult {
   final String templateId;
   final String templateName;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime date;
   final int total;
   final int correct;
   final double evLoss;
+  @JsonKey(defaultValue: [])
   final List<String> wrongSpotIds;
   DrillResult({
     required this.templateId,
@@ -17,23 +23,12 @@ class DrillResult {
     List<String>? wrongSpotIds,
   }) : wrongSpotIds = wrongSpotIds ?? [];
 
-  Map<String, dynamic> toJson() => {
-        'templateId': templateId,
-        'templateName': templateName,
-        'date': date.toIso8601String(),
-        'total': total,
-        'correct': correct,
-        'evLoss': evLoss,
-        if (wrongSpotIds.isNotEmpty) 'wrongSpotIds': wrongSpotIds,
-      };
+  factory DrillResult.fromJson(Map<String, dynamic> json) =>
+      _$DrillResultFromJson(json);
 
-  factory DrillResult.fromJson(Map<String, dynamic> j) => DrillResult(
-        templateId: j['templateId'] as String? ?? '',
-        templateName: j['templateName'] as String? ?? '',
-        date: DateTime.tryParse(j['date'] as String? ?? '') ?? DateTime.now(),
-        total: j['total'] as int? ?? 0,
-        correct: j['correct'] as int? ?? 0,
-        evLoss: (j['evLoss'] as num?)?.toDouble() ?? 0.0,
-        wrongSpotIds: [for (final id in (j['wrongSpotIds'] as List? ?? [])) id as String],
-      );
+  Map<String, dynamic> toJson() => _$DrillResultToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/drill_result.g.dart
+++ b/lib/models/drill_result.g.dart
@@ -1,0 +1,25 @@
+part of 'drill_result.dart';
+
+DrillResult _$DrillResultFromJson(Map<String, dynamic> json) => DrillResult(
+      templateId: json['templateId'] as String,
+      templateName: json['templateName'] as String,
+      date: DrillResult._dateFromJson(json['date'] as String?),
+      total: (json['total'] as num).toInt(),
+      correct: (json['correct'] as num).toInt(),
+      evLoss: (json['evLoss'] as num).toDouble(),
+      wrongSpotIds: (json['wrongSpotIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+    );
+
+Map<String, dynamic> _$DrillResultToJson(DrillResult instance) =>
+    <String, dynamic>{
+      'templateId': instance.templateId,
+      'templateName': instance.templateName,
+      'date': DrillResult._dateToJson(instance.date),
+      'total': instance.total,
+      'correct': instance.correct,
+      'evLoss': instance.evLoss,
+      'wrongSpotIds': instance.wrongSpotIds,
+    };

--- a/lib/models/hand_analysis_record.dart
+++ b/lib/models/hand_analysis_record.dart
@@ -1,5 +1,10 @@
+import 'package:json_annotation/json_annotation.dart';
+
 import 'card_model.dart';
 
+part 'hand_analysis_record.g.dart';
+
+@JsonSerializable()
 class HandAnalysisRecord {
   final String card1;
   final String card2;
@@ -10,6 +15,7 @@ class HandAnalysisRecord {
   final double icm;
   final String action;
   final String hint;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime date;
 
   HandAnalysisRecord({
@@ -30,29 +36,12 @@ class HandAnalysisRecord {
         CardModel(rank: card2[0], suit: card2.substring(1)),
       ];
 
-  Map<String, dynamic> toJson() => {
-        'card1': card1,
-        'card2': card2,
-        'stack': stack,
-        'playerCount': playerCount,
-        'heroIndex': heroIndex,
-        'ev': ev,
-        'icm': icm,
-        'action': action,
-        'hint': hint,
-        'date': date.toIso8601String(),
-      };
+  factory HandAnalysisRecord.fromJson(Map<String, dynamic> json) =>
+      _$HandAnalysisRecordFromJson(json);
 
-  factory HandAnalysisRecord.fromJson(Map<String, dynamic> j) => HandAnalysisRecord(
-        card1: j['card1'] as String? ?? '',
-        card2: j['card2'] as String? ?? '',
-        stack: j['stack'] as int? ?? 0,
-        playerCount: j['playerCount'] as int? ?? 0,
-        heroIndex: j['heroIndex'] as int? ?? 0,
-        ev: (j['ev'] as num?)?.toDouble() ?? 0,
-        icm: (j['icm'] as num?)?.toDouble() ?? 0,
-        action: j['action'] as String? ?? '',
-        hint: j['hint'] as String? ?? '',
-        date: DateTime.tryParse(j['date'] as String? ?? '') ?? DateTime.now(),
-      );
+  Map<String, dynamic> toJson() => _$HandAnalysisRecordToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/hand_analysis_record.g.dart
+++ b/lib/models/hand_analysis_record.g.dart
@@ -1,0 +1,29 @@
+part of 'hand_analysis_record.dart';
+
+HandAnalysisRecord _$HandAnalysisRecordFromJson(Map<String, dynamic> json) =>
+    HandAnalysisRecord(
+      card1: json['card1'] as String,
+      card2: json['card2'] as String,
+      stack: (json['stack'] as num).toInt(),
+      playerCount: (json['playerCount'] as num).toInt(),
+      heroIndex: (json['heroIndex'] as num).toInt(),
+      ev: (json['ev'] as num).toDouble(),
+      icm: (json['icm'] as num).toDouble(),
+      action: json['action'] as String,
+      hint: json['hint'] as String,
+      date: HandAnalysisRecord._dateFromJson(json['date'] as String?),
+    );
+
+Map<String, dynamic> _$HandAnalysisRecordToJson(HandAnalysisRecord instance) =>
+    <String, dynamic>{
+      'card1': instance.card1,
+      'card2': instance.card2,
+      'stack': instance.stack,
+      'playerCount': instance.playerCount,
+      'heroIndex': instance.heroIndex,
+      'ev': instance.ev,
+      'icm': instance.icm,
+      'action': instance.action,
+      'hint': instance.hint,
+      'date': HandAnalysisRecord._dateToJson(instance.date),
+    };

--- a/lib/models/reinforcement_log.dart
+++ b/lib/models/reinforcement_log.dart
@@ -1,7 +1,13 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'reinforcement_log.g.dart';
+
+@JsonSerializable()
 class ReinforcementLog {
   final String id;
   final String type;
   final String source;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime timestamp;
 
   ReinforcementLog({
@@ -11,18 +17,12 @@ class ReinforcementLog {
     required this.timestamp,
   });
 
-  Map<String, dynamic> toJson() => {
-    'id': id,
-    'type': type,
-    'source': source,
-    'timestamp': timestamp.toIso8601String(),
-  };
+  factory ReinforcementLog.fromJson(Map<String, dynamic> json) =>
+      _$ReinforcementLogFromJson(json);
 
-  factory ReinforcementLog.fromJson(Map<String, dynamic> j) => ReinforcementLog(
-    id: j['id'] as String? ?? '',
-    type: j['type'] as String? ?? '',
-    source: j['source'] as String? ?? '',
-    timestamp:
-        DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
-  );
+  Map<String, dynamic> toJson() => _$ReinforcementLogToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/reinforcement_log.g.dart
+++ b/lib/models/reinforcement_log.g.dart
@@ -1,0 +1,17 @@
+part of 'reinforcement_log.dart';
+
+ReinforcementLog _$ReinforcementLogFromJson(Map<String, dynamic> json) =>
+    ReinforcementLog(
+      id: json['id'] as String,
+      type: json['type'] as String,
+      source: json['source'] as String,
+      timestamp: ReinforcementLog._dateFromJson(json['timestamp'] as String?),
+    );
+
+Map<String, dynamic> _$ReinforcementLogToJson(ReinforcementLog instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'source': instance.source,
+      'timestamp': ReinforcementLog._dateToJson(instance.timestamp),
+    };

--- a/lib/models/reward_analytics_entry.dart
+++ b/lib/models/reward_analytics_entry.dart
@@ -1,6 +1,12 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'reward_analytics_entry.g.dart';
+
+@JsonSerializable()
 class RewardAnalyticsEntry {
   final String tag;
   final String rewardType;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime timestamp;
 
   const RewardAnalyticsEntry({
@@ -9,18 +15,12 @@ class RewardAnalyticsEntry {
     required this.timestamp,
   });
 
-  Map<String, dynamic> toJson() => {
-        'tag': tag,
-        'rewardType': rewardType,
-        'timestamp': timestamp.toIso8601String(),
-      };
+  factory RewardAnalyticsEntry.fromJson(Map<String, dynamic> json) =>
+      _$RewardAnalyticsEntryFromJson(json);
 
-  factory RewardAnalyticsEntry.fromJson(Map<String, dynamic> json) {
-    return RewardAnalyticsEntry(
-      tag: json['tag'] as String? ?? '',
-      rewardType: json['rewardType'] as String? ?? '',
-      timestamp:
-          DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
-    );
-  }
+  Map<String, dynamic> toJson() => _$RewardAnalyticsEntryToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/reward_analytics_entry.g.dart
+++ b/lib/models/reward_analytics_entry.g.dart
@@ -1,0 +1,18 @@
+part of 'reward_analytics_entry.dart';
+
+RewardAnalyticsEntry _$RewardAnalyticsEntryFromJson(
+        Map<String, dynamic> json) =>
+    RewardAnalyticsEntry(
+      tag: json['tag'] as String,
+      rewardType: json['rewardType'] as String,
+      timestamp:
+          RewardAnalyticsEntry._dateFromJson(json['timestamp'] as String?),
+    );
+
+Map<String, dynamic> _$RewardAnalyticsEntryToJson(
+        RewardAnalyticsEntry instance) =>
+    <String, dynamic>{
+      'tag': instance.tag,
+      'rewardType': instance.rewardType,
+      'timestamp': RewardAnalyticsEntry._dateToJson(instance.timestamp),
+    };

--- a/lib/models/training_attempt.dart
+++ b/lib/models/training_attempt.dart
@@ -1,6 +1,12 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'training_attempt.g.dart';
+
+@JsonSerializable()
 class TrainingAttempt {
   final String packId;
   final String spotId;
+  @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
   final DateTime timestamp;
   final double accuracy;
   final double ev;
@@ -15,22 +21,12 @@ class TrainingAttempt {
     required this.icm,
   });
 
-  factory TrainingAttempt.fromJson(Map<String, dynamic> j) => TrainingAttempt(
-        packId: j['packId'] as String? ?? '',
-        spotId: j['spotId'] as String? ?? '',
-        timestamp:
-            DateTime.tryParse(j['timestamp'] as String? ?? '') ?? DateTime.now(),
-        accuracy: (j['accuracy'] as num?)?.toDouble() ?? 0,
-        ev: (j['ev'] as num?)?.toDouble() ?? 0,
-        icm: (j['icm'] as num?)?.toDouble() ?? 0,
-      );
+  factory TrainingAttempt.fromJson(Map<String, dynamic> json) =>
+      _$TrainingAttemptFromJson(json);
 
-  Map<String, dynamic> toJson() => {
-        'packId': packId,
-        'spotId': spotId,
-        'timestamp': timestamp.toIso8601String(),
-        'accuracy': accuracy,
-        'ev': ev,
-        'icm': icm,
-      };
+  Map<String, dynamic> toJson() => _$TrainingAttemptToJson(this);
+
+  static DateTime _dateFromJson(String? date) =>
+      DateTime.tryParse(date ?? '') ?? DateTime.now();
+  static String _dateToJson(DateTime date) => date.toIso8601String();
 }

--- a/lib/models/training_attempt.g.dart
+++ b/lib/models/training_attempt.g.dart
@@ -1,0 +1,21 @@
+part of 'training_attempt.dart';
+
+TrainingAttempt _$TrainingAttemptFromJson(Map<String, dynamic> json) =>
+    TrainingAttempt(
+      packId: json['packId'] as String,
+      spotId: json['spotId'] as String,
+      timestamp: TrainingAttempt._dateFromJson(json['timestamp'] as String?),
+      accuracy: (json['accuracy'] as num).toDouble(),
+      ev: (json['ev'] as num).toDouble(),
+      icm: (json['icm'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$TrainingAttemptToJson(TrainingAttempt instance) =>
+    <String, dynamic>{
+      'packId': instance.packId,
+      'spotId': instance.spotId,
+      'timestamp': TrainingAttempt._dateToJson(instance.timestamp),
+      'accuracy': instance.accuracy,
+      'ev': instance.ev,
+      'icm': instance.icm,
+    };


### PR DESCRIPTION
## Summary
- annotate core training analytics models with `json_serializable`
- remove manual JSON encoding/decoding in favor of generated helpers

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.5.3; project requires >=3.6.0 <4.0.0)*
- `flutter test` *(fails: The current Dart SDK version is 3.5.3; project requires >=3.6.0 <4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d7ec3ec832a961b3991c1093c90