### PR TITLE
refactor: extract training history preferences

### DIFF
--- a/lib/services/training_history_preferences.dart
+++ b/lib/services/training_history_preferences.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'training_history_prefs.dart';
+
+/// Service to manage persistence of Training History preferences.
+class TrainingHistoryPreferences {
+  TrainingHistoryPreferences(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  static Future<TrainingHistoryPreferences> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return TrainingHistoryPreferences(prefs);
+  }
+
+  SortOption get sort => SortOption.values[_prefs.getInt(sortKey) ?? 0];
+  Future<void> setSort(SortOption value) =>
+      _prefs.setInt(sortKey, value.index);
+
+  RatingFilter get ratingFilter =>
+      RatingFilter.values[_prefs.getInt(ratingKey) ?? 0];
+  Future<void> setRatingFilter(RatingFilter value) =>
+      _prefs.setInt(ratingKey, value.index);
+
+  AccuracyRange get accuracyRange =>
+      AccuracyRange.values[_prefs.getInt(accuracyRangeKey) ?? 0];
+  Future<void> setAccuracyRange(AccuracyRange value) =>
+      _prefs.setInt(accuracyRangeKey, value.index);
+
+  Set<String> get selectedTags =>
+      _prefs.getStringList(tagKey)?.toSet() ?? {};
+  Future<void> setSelectedTags(Set<String> tags) =>
+      _prefs.setStringList(tagKey, tags.toList());
+
+  Set<String> get selectedTagColors =>
+      _prefs.getStringList(tagColorKey)?.toSet() ?? {};
+  Future<void> setSelectedTagColors(Set<String> colors) =>
+      _prefs.setStringList(tagColorKey, colors.toList());
+
+  bool get showCharts => _prefs.getBool(showChartsKey) ?? true;
+  Future<void> setShowCharts(bool value) =>
+      _prefs.setBool(showChartsKey, value);
+
+  bool get showAvgChart => _prefs.getBool(showAvgChartKey) ?? true;
+  Future<void> setShowAvgChart(bool value) =>
+      _prefs.setBool(showAvgChartKey, value);
+
+  bool get showDistribution =>
+      _prefs.getBool(showDistributionKey) ?? true;
+  Future<void> setShowDistribution(bool value) =>
+      _prefs.setBool(showDistributionKey, value);
+
+  bool get showTrendChart =>
+      _prefs.getBool(showTrendChartKey) ?? true;
+  Future<void> setShowTrendChart(bool value) =>
+      _prefs.setBool(showTrendChartKey, value);
+
+  bool get hideEmptyTags => _prefs.getBool(hideEmptyTagsKey) ?? false;
+  Future<void> setHideEmptyTags(bool value) =>
+      _prefs.setBool(hideEmptyTagsKey, value);
+
+  bool get sortByTag => _prefs.getBool(sortByTagKey) ?? false;
+  Future<void> setSortByTag(bool value) =>
+      _prefs.setBool(sortByTagKey, value);
+
+  ChartMode get chartMode =>
+      ChartMode.values[_prefs.getInt(chartModeKey) ?? 0];
+  Future<void> setChartMode(ChartMode mode) =>
+      _prefs.setInt(chartModeKey, mode.index);
+
+  TagCountFilter get tagCountFilter =>
+      TagCountFilter.values[_prefs.getInt(tagCountKey) ?? 0];
+  Future<void> setTagCountFilter(TagCountFilter value) =>
+      _prefs.setInt(tagCountKey, value.index);
+
+  WeekdayFilter get weekdayFilter =>
+      WeekdayFilter.values[_prefs.getInt(weekdayKey) ?? 0];
+  Future<void> setWeekdayFilter(WeekdayFilter value) =>
+      _prefs.setInt(weekdayKey, value.index);
+
+  SessionLengthFilter get lengthFilter =>
+      SessionLengthFilter.values[_prefs.getInt(lengthKey) ?? 0];
+  Future<void> setLengthFilter(SessionLengthFilter value) =>
+      _prefs.setInt(lengthKey, value.index);
+
+  bool get includeChartInPdf =>
+      _prefs.getBool(pdfIncludeChartKey) ?? true;
+  Future<void> setIncludeChartInPdf(bool value) =>
+      _prefs.setBool(pdfIncludeChartKey, value);
+
+  bool get exportTags3Only =>
+      _prefs.getBool(exportTags3OnlyKey) ?? false;
+  Future<void> setExportTags3Only(bool value) =>
+      _prefs.setBool(exportTags3OnlyKey, value);
+
+  bool get exportNotesOnly =>
+      _prefs.getBool(exportNotesOnlyKey) ?? false;
+  Future<void> setExportNotesOnly(bool value) =>
+      _prefs.setBool(exportNotesOnlyKey, value);
+
+  DateTime? get dateFrom {
+    final millis = _prefs.getInt(dateFromKey);
+    return millis != null
+        ? DateTime.fromMillisecondsSinceEpoch(millis)
+        : null;
+  }
+
+  DateTime? get dateTo {
+    final millis = _prefs.getInt(dateToKey);
+    return millis != null
+        ? DateTime.fromMillisecondsSinceEpoch(millis)
+        : null;
+  }
+
+  Future<void> setDateRange(DateTime? from, DateTime? to) async {
+    if (from != null) {
+      await _prefs.setInt(
+          dateFromKey, DateUtils.dateOnly(from).millisecondsSinceEpoch);
+    } else {
+      await _prefs.remove(dateFromKey);
+    }
+    if (to != null) {
+      await _prefs.setInt(
+          dateToKey, DateUtils.dateOnly(to).millisecondsSinceEpoch);
+    } else {
+      await _prefs.remove(dateToKey);
+    }
+  }
+
+  Future<void> resetFilters() async {
+    await _prefs.setInt(sortKey, SortOption.newest.index);
+    await _prefs.setInt(ratingKey, RatingFilter.all.index);
+    await _prefs.setInt(accuracyRangeKey, AccuracyRange.all.index);
+    await _prefs.setInt(tagCountKey, TagCountFilter.any.index);
+    await _prefs.setInt(weekdayKey, WeekdayFilter.all.index);
+    await _prefs.setInt(lengthKey, SessionLengthFilter.any.index);
+    await _prefs.setBool(sortByTagKey, false);
+    await _prefs.remove(tagKey);
+    await _prefs.remove(tagColorKey);
+    await _prefs.remove(dateFromKey);
+    await _prefs.remove(dateToKey);
+  }
+
+  Future<void> clearTagFilters() => _prefs.remove(tagKey);
+
+  Future<void> clearColorFilters() => _prefs.remove(tagColorKey);
+
+  Future<void> clearLengthFilter() =>
+      _prefs.setInt(lengthKey, SessionLengthFilter.any.index);
+
+  Future<void> clearAccuracyFilter() =>
+      _prefs.setInt(accuracyRangeKey, AccuracyRange.all.index);
+
+  Future<void> clearDateFilter() async {
+    await _prefs.remove(dateFromKey);
+    await _prefs.remove(dateToKey);
+  }
+}
+

--- a/lib/services/training_history_prefs.dart
+++ b/lib/services/training_history_prefs.dart
@@ -1,0 +1,37 @@
+/// Enumerations and preference keys for Training History features.
+
+enum SortOption { newest, oldest, position, mistakes, evDiff, icmDiff }
+
+enum RatingFilter { all, pct40, pct60, pct80 }
+
+enum AccuracyRange { all, lt50, pct50to75, pct75plus }
+
+enum ChartMode { daily, weekly, monthly }
+
+enum TagCountFilter { any, one, twoPlus, threePlus }
+
+enum WeekdayFilter { all, mon, tue, wed, thu, fri, sat, sun }
+
+enum SessionLengthFilter { any, oneToFive, sixToTen, elevenPlus }
+
+const sortKey = 'training_history_sort';
+const ratingKey = 'training_history_rating';
+const tagKey = 'training_history_tags';
+const tagColorKey = 'training_history_tag_colors';
+const showChartsKey = 'training_history_show_charts';
+const showAvgChartKey = 'training_history_show_chart';
+const showDistributionKey = 'training_history_show_distribution';
+const showTrendChartKey = 'training_history_show_trend_chart';
+const dateFromKey = 'training_history_date_from';
+const dateToKey = 'training_history_date_to';
+const chartModeKey = 'training_history_chart_mode';
+const hideEmptyTagsKey = 'hide_empty_tags';
+const sortByTagKey = 'training_history_sort_by_tag';
+const accuracyRangeKey = 'training_history_accuracy_range';
+const tagCountKey = 'training_history_tag_count';
+const weekdayKey = 'training_history_weekday';
+const lengthKey = 'training_history_length';
+const pdfIncludeChartKey = 'training_history_pdf_include_chart';
+const exportTags3OnlyKey = 'training_history_export_tags_3plus';
+const exportNotesOnlyKey = 'training_history_export_notes_only';
+


### PR DESCRIPTION
## Summary
- move training history enums and keys into dedicated `training_history_prefs.dart`
- add `TrainingHistoryPreferences` service for persisting history filters
- update `TrainingHistoryScreen` to use the new service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d760a10832a8bbb6cbd8783f8c0