### PR TITLE
feat: add dark alert dialog

### DIFF
--- a/lib/services/stage_completion_celebration_service.dart
+++ b/lib/services/stage_completion_celebration_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
@@ -22,9 +23,9 @@ class StageCompletionCelebrationService {
     SkillTreeLibraryService? library,
     SkillTreeNodeProgressTracker? progress,
     SkillTreeStageCompletionEvaluator? evaluator,
-  }) : library = library ?? SkillTreeLibraryService.instance,
-       progress = progress ?? SkillTreeNodeProgressTracker.instance,
-       evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
+  })  : library = library ?? SkillTreeLibraryService.instance,
+        progress = progress ?? SkillTreeNodeProgressTracker.instance,
+        evaluator = evaluator ?? const SkillTreeStageCompletionEvaluator();
 
   static StageCompletionCelebrationService instance =
       StageCompletionCelebrationService();
@@ -57,7 +58,7 @@ class StageCompletionCelebrationService {
 
     await showDialog<void>(
       context: ctx,
-      builder: (context) => AlertDialog(
+      builder: (context) => DarkAlertDialog(
         title: const Text('Этап завершён'),
         content: Text('Этап $stageIndex успешно завершён!'),
         actions: [

--- a/lib/services/track_completion_celebration_service.dart
+++ b/lib/services/track_completion_celebration_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
@@ -35,7 +36,7 @@ class TrackCompletionCelebrationService {
 
     await showDialog<void>(
       context: ctx,
-      builder: (context) => AlertDialog(
+      builder: (context) => DarkAlertDialog(
         title: const Text('🎉 Трек завершён!'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
@@ -45,7 +46,8 @@ class TrackCompletionCelebrationService {
               duration: const Duration(milliseconds: 700),
               builder: (context, value, child) =>
                   Transform.scale(scale: value, child: child),
-              child: const Icon(Icons.celebration, size: 48, color: Colors.orange),
+              child:
+                  const Icon(Icons.celebration, size: 48, color: Colors.orange),
             ),
             const SizedBox(height: 12),
             const Text('Вы прошли весь трек!'),

--- a/lib/services/track_reward_unlocker_service.dart
+++ b/lib/services/track_reward_unlocker_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 
 import '../main.dart';
 import '../screens/player_stats_screen.dart';
@@ -37,7 +38,7 @@ class TrackRewardUnlockerService {
 
     await showDialog<void>(
       context: ctx,
-      builder: (context) => AlertDialog(
+      builder: (context) => DarkAlertDialog(
         title: const Text('Награда за прохождение!'),
         content: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/dark_alert_dialog.dart
+++ b/lib/widgets/dark_alert_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class DarkAlertDialog extends StatelessWidget {
+  final Widget? title;
+  final Widget? content;
+  final List<Widget>? actions;
+  final EdgeInsetsGeometry? contentPadding;
+  final EdgeInsetsGeometry? insetPadding;
+  final ShapeBorder? shape;
+  final Color? backgroundColor;
+
+  const DarkAlertDialog({
+    super.key,
+    this.title,
+    this.content,
+    this.actions,
+    this.contentPadding,
+    this.insetPadding,
+    this.shape,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: backgroundColor ?? Colors.grey[900],
+      titleTextStyle: const TextStyle(color: Colors.white),
+      contentTextStyle: const TextStyle(color: Colors.white70),
+      shape: shape ??
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      contentPadding:
+          contentPadding ?? const EdgeInsets.fromLTRB(24, 20, 24, 24),
+      insetPadding: insetPadding,
+      title: title,
+      content: content,
+      actions: actions,
+    );
+  }
+}

--- a/lib/widgets/reward_dialog.dart
+++ b/lib/widgets/reward_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dark_alert_dialog.dart';
 import 'confetti_overlay.dart';
 
 class RewardDialog extends StatelessWidget {
@@ -10,9 +11,7 @@ class RewardDialog extends StatelessWidget {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showConfettiOverlay(context);
     });
-    return AlertDialog(
-      backgroundColor: Colors.grey[900],
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    return DarkAlertDialog(
       title: const Text('Reward'),
       content: Text('+$reward'),
       actions: [

--- a/lib/widgets/track_celebration_dialog.dart
+++ b/lib/widgets/track_celebration_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dark_alert_dialog.dart';
 
 import 'confetti_overlay.dart';
 
@@ -13,8 +14,7 @@ class TrackCelebrationDialog extends StatelessWidget {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showConfettiOverlay(context);
     });
-    return AlertDialog(
-      backgroundColor: Colors.grey[900],
+    return DarkAlertDialog(
       title: const Text('🎉 Трек завершён!',
           style: TextStyle(color: Colors.white)),
       content: Text(

--- a/test/services/stage_completion_celebration_service_test.dart
+++ b/test/services/stage_completion_celebration_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -67,7 +68,7 @@ void main() {
     await svc.checkAndCelebrate('T');
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(DarkAlertDialog), findsOneWidget);
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('stage_celebrated_T_0'), isTrue);
   });
@@ -95,6 +96,6 @@ void main() {
     await svc.checkAndCelebrate('T');
     await tester.pump();
 
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(DarkAlertDialog), findsNothing);
   });
 }

--- a/test/services/track_completion_celebration_service_test.dart
+++ b/test/services/track_completion_celebration_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -55,7 +56,7 @@ void main() {
     await svc.maybeCelebrate('T');
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(DarkAlertDialog), findsOneWidget);
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('track_completion_shown_T'), isTrue);
   });
@@ -74,21 +75,27 @@ void main() {
     await svc.maybeCelebrate('T');
     await tester.pump();
 
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(DarkAlertDialog), findsNothing);
   });
 
   testWidgets('offers next track navigation', (tester) async {
-    final node1 = SkillTreeNodeModel(id: 'a', title: 'A', category: 'T1', level: 0);
-    final node2 = SkillTreeNodeModel(id: 'b', title: 'B', category: 'T2', level: 0);
+    final node1 =
+        SkillTreeNodeModel(id: 'a', title: 'A', category: 'T1', level: 0);
+    final node2 =
+        SkillTreeNodeModel(id: 'b', title: 'B', category: 'T2', level: 0);
     const builder = SkillTreeBuilderService();
     final tree1 = builder.build([node1]).tree;
     final tree2 = builder.build([node2]).tree;
     final lib = _FakeLibraryService({
       'T1': SkillTreeBuildResult(tree: tree1),
       'T2': SkillTreeBuildResult(tree: tree2),
-    }, [node1, node2]);
+    }, [
+      node1,
+      node2
+    ]);
 
-    TrackRecommendationEngine.instance = TrackRecommendationEngine(library: lib);
+    TrackRecommendationEngine.instance =
+        TrackRecommendationEngine(library: lib);
     String opened = '';
     SkillTreeNavigator.instance = _RecordingSkillTreeNavigator((id) {
       opened = id;

--- a/test/services/track_reward_unlocker_service_test.dart
+++ b/test/services/track_reward_unlocker_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/widgets/dark_alert_dialog.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -32,7 +33,7 @@ void main() {
     }
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(DarkAlertDialog), findsOneWidget);
   });
 
   testWidgets('skips reward if track incomplete', (tester) async {
@@ -45,6 +46,6 @@ void main() {
     await svc.unlockReward('T');
     await tester.pump();
 
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(DarkAlertDialog), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- add reusable DarkAlertDialog with dark theme styling
- apply DarkAlertDialog to celebration and reward services/widgets
- adjust dialog tests to expect DarkAlertDialog

## Testing
- `flutter test` *(fails: The current Dart SDK version is 3.4.1...)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d4cc8dc832a852dbd5cba39c8f0