### PR TITLE
link theory lessons to training packs

### DIFF
--- a/assets/theory_mini_lessons/theory_push_fold_intro.yaml
+++ b/assets/theory_mini_lessons/theory_push_fold_intro.yaml
@@ -6,7 +6,8 @@ tags:
   - beginner
   - level1
 linkedPackIds:
-  - push_fold_mvp
+  - pushfold_btn_15bb
+  - pushfold_sb_15bb
 parts:
   - title: 'What is push/fold?'
     content: |

--- a/assets/training_packs/pushfold_btn_15bb.json
+++ b/assets/training_packs/pushfold_btn_15bb.json
@@ -4,6 +4,7 @@
   "category": "Push-Fold",
   "gameType": "Tournament",
   "isBuiltIn": true,
+  "meta": {"requiresTheoryCompleted": true},
   "hands": [
     {
       "name": "BTN shove 15bb",

--- a/assets/training_packs/pushfold_sb_15bb.json
+++ b/assets/training_packs/pushfold_sb_15bb.json
@@ -4,6 +4,7 @@
   "category": "Push-Fold",
   "gameType": "Tournament",
   "isBuiltIn": true,
+  "meta": {"requiresTheoryCompleted": true},
   "hands": [
     {
       "name": "SB shove 15bb",

--- a/lib/services/learning_path_engine.dart
+++ b/lib/services/learning_path_engine.dart
@@ -8,6 +8,7 @@ import 'tag_mastery_service.dart';
 import 'weakness_cluster_engine_v2.dart';
 import 'training_pack_generator_v2.dart';
 import 'theory_stage_progress_tracker.dart';
+import 'mini_lesson_library_service.dart';
 
 /// Engine driving adaptive learning path stages.
 class LearningPathEngine {
@@ -41,7 +42,16 @@ class LearningPathEngine {
         allPacks.firstWhereOrNull((p) => p.id == stage.packId);
 
     if (stage.type == StageType.theory) {
-      return defaultPack;
+      final ids = MiniLessonLibraryService.instance.linkedPacksFor(stage.id);
+      final linked = [
+        for (final id in ids)
+          allPacks.firstWhereOrNull((p) => p.id == id)
+      ].whereType<TrainingPackTemplateV2>().toList();
+      if (linked.isEmpty) return defaultPack;
+      if (linked.length == 1) return linked.first;
+      final first = linked.first;
+      first.meta['stageGroup'] = [for (final p in linked) p.id];
+      return first;
     }
 
     if (stage.type != StageType.theory && stage.theoryPackId != null) {

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -19,9 +19,13 @@ class MiniLessonLibraryService {
   final Map<String, TheoryMiniLessonNode> _byId = {};
   final Map<String, List<TheoryMiniLessonNode>> _byTag = {};
 
-  List<TheoryMiniLessonNode> get all => List.unmodifiable(_lessons);
+    List<TheoryMiniLessonNode> get all => List.unmodifiable(_lessons);
 
-  TheoryMiniLessonNode? getById(String id) => _byId[id];
+    TheoryMiniLessonNode? getById(String id) => _byId[id];
+
+    /// Returns training pack ids linked to [lessonId].
+    List<String> linkedPacksFor(String lessonId) =>
+        _byId[lessonId]?.linkedPackIds ?? const [];
 
   Future<void> loadAll() async {
     if (_lessons.isNotEmpty) return;


### PR DESCRIPTION
## Summary
- connect push/fold intro lesson to button and small blind 15bb training packs
- expose linked training packs via MiniLessonLibraryService and surface them through LearningPathEngine
- require theory completion before accessing linked practice packs

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f54e50f44832ab7838da4a78aca7e