### PR TITLE
feat: auto expand learning path via nextIds

### DIFF
--- a/lib/services/learning_path_auto_expander.dart
+++ b/lib/services/learning_path_auto_expander.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+import '../models/learning_branch_node.dart';
+import '../models/learning_path_node.dart';
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../models/stage_type.dart';
+import 'mini_lesson_library_service.dart';
+import 'learning_path_stage_library.dart';
+import 'path_map_engine.dart';
+
+/// Automatically injects nodes referenced by `nextIds` when theory mini lessons
+/// are completed.
+class LearningPathAutoExpander {
+  final MiniLessonLibraryService library;
+  final LearningPathStageLibrary stageLibrary;
+
+  const LearningPathAutoExpander({
+    MiniLessonLibraryService? library,
+    LearningPathStageLibrary? stageLibrary,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        stageLibrary = stageLibrary ?? LearningPathStageLibrary.instance;
+
+  /// Ensures that all nodes referenced by [from.nextIds] exist in [engine].
+  /// Missing nodes are loaded from libraries and appended to the path.
+  Future<void> expand(PathMapEngine engine, TheoryMiniLessonNode from) async {
+    await library.loadAll();
+    final existing = {for (final n in engine.allNodes) n.id};
+    final toAdd = <LearningPathNode>[];
+    final injected = <String>{};
+
+    void addNode(String id) {
+      if (existing.contains(id) || !injected.add(id)) return;
+      final mini = library.getById(id);
+      if (mini != null) {
+        toAdd.add(TheoryMiniLessonNode(
+          id: mini.id,
+          refId: mini.refId,
+          title: mini.title,
+          content: mini.content,
+          tags: List<String>.from(mini.tags),
+          nextIds: List<String>.from(mini.nextIds),
+        ));
+        for (final next in mini.nextIds) {
+          addNode(next);
+        }
+        return;
+      }
+      final stage = stageLibrary.getById(id);
+      if (stage != null) {
+        final nextIds = List<String>.from(stage.unlocks);
+        final node = stage.type == StageType.theory
+            ? TheoryStageNode(
+                id: stage.id,
+                nextIds: nextIds,
+                dependsOn: List<String>.from(stage.unlockAfter),
+              )
+            : TrainingStageNode(
+                id: stage.id,
+                nextIds: nextIds,
+                dependsOn: List<String>.from(stage.unlockAfter),
+              );
+        toAdd.add(node);
+        for (final next in nextIds) {
+          addNode(next);
+        }
+      }
+    }
+
+    for (final id in from.nextIds) {
+      addNode(id);
+    }
+    if (toAdd.isEmpty) return;
+
+    final updated = <LearningPathNode>[];
+    for (final n in engine.allNodes) {
+      updated.add(_clone(n));
+    }
+    updated.addAll(toAdd);
+
+    final state = engine.getState();
+    await engine.loadNodes(updated);
+    await engine.restoreState(state);
+    debugPrint('LearningPathAutoExpander: injected ${injected.join(', ')}');
+  }
+
+  LearningPathNode _clone(LearningPathNode node) {
+    if (node is LearningBranchNode) {
+      return LearningBranchNode(
+        id: node.id,
+        prompt: node.prompt,
+        branches: Map<String, String>.from(node.branches),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TrainingStageNode) {
+      return TrainingStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryStageNode) {
+      return TheoryStageNode(
+        id: node.id,
+        nextIds: List<String>.from(node.nextIds),
+        dependsOn: List<String>.from(node.dependsOn),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryLessonNode) {
+      return TheoryLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    } else if (node is TheoryMiniLessonNode) {
+      return TheoryMiniLessonNode(
+        id: node.id,
+        refId: node.refId,
+        title: node.title,
+        content: node.content,
+        tags: List<String>.from(node.tags),
+        nextIds: List<String>.from(node.nextIds),
+        recoveredFromMistake: node.recoveredFromMistake,
+      );
+    }
+    return node;
+  }
+}

--- a/test/learning_path_auto_expander_test.dart
+++ b/test/learning_path_auto_expander_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/learning_path_node.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/learning_graph_engine.dart';
+import 'package:poker_analyzer/services/learning_path_graph_orchestrator.dart';
+import 'package:poker_analyzer/services/training_path_progress_service_v2.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/learning_path_auto_expander.dart';
+
+class _FakeOrchestrator extends LearningPathGraphOrchestrator {
+  final List<LearningPathNode> nodes;
+  _FakeOrchestrator(this.nodes);
+  @override
+  Future<List<LearningPathNode>> loadGraph() async => nodes;
+}
+
+class _FakeProgress extends TrainingPathProgressServiceV2 {
+  final Set<String> completed;
+  _FakeProgress(this.completed)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+  @override
+  Future<void> loadProgress(String pathId) async {}
+  @override
+  bool isStageUnlocked(String stageId) => true;
+  @override
+  bool getStageCompletion(String stageId) => completed.contains(stageId);
+  @override
+  double getStageAccuracy(String stageId) => 0.0;
+  @override
+  int getStageHands(String stageId) => 0;
+  @override
+  Future<void> markStageCompleted(String stageId, double accuracy) async {
+    completed.add(stageId);
+  }
+  @override
+  List<String> unlockedStageIds() => [];
+}
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      items.firstWhere((e) => e.id == id, orElse: () => null);
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+  @override
+  List<String> linkedPacksFor(String lessonId) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('auto expands mini lesson chain on completion', () async {
+    final a = TheoryMiniLessonNode(id: 'a', title: 'A', content: '', nextIds: const ['b']);
+    final orch = _FakeOrchestrator([a]);
+    final progress = _FakeProgress({});
+    final library = _FakeLibrary([
+      a,
+      TheoryMiniLessonNode(id: 'b', title: 'B', content: '', nextIds: const ['c']),
+      TheoryMiniLessonNode(id: 'c', title: 'C', content: '', nextIds: const []),
+    ]);
+    final expander = LearningPathAutoExpander(library: library);
+    final engine = LearningPathEngine(
+      orchestrator: orch,
+      progress: progress,
+      autoExpander: expander,
+    );
+
+    await engine.initialize();
+    expect(engine.getCurrentNode()!.id, 'a');
+    await engine.markStageCompleted('a');
+    expect(engine.getCurrentNode()!.id, 'b');
+    final nodes = engine.engine!.allNodes;
+    expect(nodes.any((n) => n.id == 'c'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- integrate `LearningPathAutoExpander` into `LearningPathEngine` to inject nodes linked by `nextIds`
- implement recursive `LearningPathAutoExpander` that loads missing mini lessons or stages and logs inserted nodes
- cover auto-expansion chain behavior with dedicated unit test

## Testing
- `flutter test test/learning_path_auto_expander_test.dart` *(fails: command not found)*
- `dart test test/learning_path_auto_expander_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5681df28832ab5a5cf7fcf652547