### PR TITLE
refactor: extract color hex helper

### DIFF
--- a/lib/helpers/color_utils.dart
+++ b/lib/helpers/color_utils.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 
+String _toHex(int value) =>
+    value.toRadixString(16).padLeft(2, '0').toUpperCase();
+
 String colorToHex(Color c) =>
-    '#${c.red.toRadixString(16).padLeft(2, '0')}${c.green.toRadixString(16).padLeft(2, '0')}${c.blue.toRadixString(16).padLeft(2, '0')}'.toUpperCase();
+    '#${_toHex(c.red)}${_toHex(c.green)}${_toHex(c.blue)}';
 
 Color colorFromHex(String hex) {
   final h = hex.replaceFirst('#', '');


### PR DESCRIPTION
## Summary
- factor out `_toHex` helper for component-to-hex conversion
- simplify `colorToHex` using the new helper

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f578bc1b0832abcfec222d6fe106d