### PR TITLE
refactor: add generics to map equals extension

### DIFF
--- a/lib/helpers/map_utils.dart
+++ b/lib/helpers/map_utils.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
 
-extension MapEqualsExtension on Map<String, dynamic> {
-  bool equals(Map<String, dynamic> other) => const DeepCollectionEquality().equals(this, other);
+extension MapEqualsExtension<K, V> on Map<K, V> {
+  bool equals(Map<K, V> other) => const DeepCollectionEquality().equals(this, other);
 }


### PR DESCRIPTION
## Summary
- generalize MapEqualsExtension to work with any Map key/value types

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f578c8e14832abeda9156ce4ab54d