### PR TITLE
refactor: use suit map for card parsing

### DIFF
--- a/lib/helpers/hand_history_parsing.dart
+++ b/lib/helpers/hand_history_parsing.dart
@@ -1,20 +1,20 @@
 import '../models/card_model.dart';
 
+/// Map of single-letter suit identifiers to their symbol representations.
+const Map<String, String> suits = {
+  'h': '♥',
+  'd': '♦',
+  'c': '♣',
+  's': '♠',
+};
+
 /// Parses a token like `Ah` or `TD` into a [CardModel].
 /// Returns `null` if the token is not valid.
 CardModel? parseCard(String token) {
   if (token.length < 2) return null;
   final rank = token.substring(0, token.length - 1).toUpperCase();
   final suitChar = token[token.length - 1].toLowerCase();
-  switch (suitChar) {
-    case 'h':
-      return CardModel(rank: rank, suit: '♥');
-    case 'd':
-      return CardModel(rank: rank, suit: '♦');
-    case 'c':
-      return CardModel(rank: rank, suit: '♣');
-    case 's':
-      return CardModel(rank: rank, suit: '♠');
-  }
-  return null;
+  final suit = suits[suitChar];
+  if (suit == null) return null;
+  return CardModel(rank: rank, suit: suit);
 }


### PR DESCRIPTION
## Summary
- use suit map instead of switch in parseCard

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f578e03dc832aa682bac34bef4525