### PR TITLE
refactor: extract investment helpers

### DIFF
--- a/lib/helpers/stack_manager.dart
+++ b/lib/helpers/stack_manager.dart
@@ -22,18 +22,26 @@ class StackManager {
 
   /// Replays [actions] from the beginning and updates current stacks.
   void applyActions(List<ActionEntry> actions) {
+    _resetInvestments();
+    for (final ActionEntry a in actions) {
+      _applyInvestment(a);
+    }
+  }
+
+  void _resetInvestments() {
     for (final StackWithInvestments sw in _currentStacks.values) {
       sw.clear();
     }
-    for (final ActionEntry a in actions) {
-      if (investmentActions.contains(a.action)) {
-        final double? amount = a.amount;
-        if (amount != null) {
-          _currentStacks[a.playerIndex]?.addInvestment(
-            a.street,
-            amount.round(),
-          );
-        }
+  }
+
+  void _applyInvestment(ActionEntry a) {
+    if (investmentActions.contains(a.action)) {
+      final double? amount = a.amount;
+      if (amount != null) {
+        _currentStacks[a.playerIndex]?.addInvestment(
+          a.street,
+          amount.round(),
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- factor investment reset into `_resetInvestments`
- encapsulate per-action investment handling in `_applyInvestment`

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: unable to locate package)*
- `sudo apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f578a76a0832ab7d3423c4bb5d0dd