### PR TITLE
refactor: extract player zone animations and widgets

### DIFF
--- a/lib/widgets/player_zone/bet_chip.dart
+++ b/lib/widgets/player_zone/bet_chip.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// Displays the current bet as a circular chip.
+class BetChip extends StatelessWidget {
+  final int currentBet;
+  final double scale;
+  final TextStyle style;
+
+  const BetChip({
+    Key? key,
+    required this.currentBet,
+    required this.scale,
+    required this.style,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final double radius = 12 * scale;
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(scale: animation, child: child),
+      ),
+      child: currentBet > 0
+          ? Container(
+              key: ValueKey(currentBet),
+              width: radius * 2,
+              height: radius * 2,
+              margin: EdgeInsets.symmetric(horizontal: 4 * scale),
+              decoration: BoxDecoration(
+                color: Colors.yellowAccent,
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.4),
+                    blurRadius: 3 * scale,
+                    offset: const Offset(1, 2),
+                  ),
+                ],
+              ),
+              alignment: Alignment.center,
+              child: Text(
+                '$currentBet',
+                style: style.copyWith(
+                  color: Colors.black,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            )
+          : SizedBox(width: radius * 2, height: radius * 2),
+    );
+  }
+}
+

--- a/lib/widgets/player_zone/effective_stack_info.dart
+++ b/lib/widgets/player_zone/effective_stack_info.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../services/pot_sync_service.dart';
+
+/// Displays the effective stack size with a tooltip explaining its meaning.
+class EffectiveStackInfo extends StatelessWidget {
+  final String street;
+  final TextStyle style;
+
+  const EffectiveStackInfo({
+    Key? key,
+    required this.street,
+    required this.style,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final potSync = context.watch<PotSyncService>();
+    final eff = potSync.effectiveStacks[street];
+    final effText = eff != null ? eff.toDouble().toStringAsFixed(1) : '--';
+    final platform = Theme.of(context).platform;
+    final isMobile =
+        platform == TargetPlatform.android || platform == TargetPlatform.iOS;
+    return Tooltip(
+      triggerMode:
+          isMobile ? TooltipTriggerMode.longPress : TooltipTriggerMode.hover,
+      message:
+          'Эффективный стек — минимальный стек между вами и соперником. Используется при пуш/фолд.',
+      child: Text(
+        'Eff. stack: $effText BB',
+        style: style,
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/player_zone/player_zone_label_animations.dart
+++ b/lib/widgets/player_zone/player_zone_label_animations.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+/// Groups animation controllers related to player labels and textual overlays.
+class PlayerZoneLabelAnimations {
+  PlayerZoneLabelAnimations({required TickerProvider vsync, required bool isHero}) {
+    showdownLabelController = AnimationController(
+      vsync: vsync,
+      duration: const Duration(milliseconds: 300),
+    );
+    showdownLabelOpacity =
+        CurvedAnimation(parent: showdownLabelController, curve: Curves.easeIn);
+
+    finalStackController = AnimationController(
+      vsync: vsync,
+      duration: const Duration(milliseconds: 300),
+    );
+    finalStackOpacity =
+        CurvedAnimation(parent: finalStackController, curve: Curves.easeIn);
+    finalStackOffset = Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero)
+        .animate(
+            CurvedAnimation(parent: finalStackController, curve: Curves.easeOut));
+
+    winnerLabelController = AnimationController(
+      vsync: vsync,
+      duration: const Duration(milliseconds: 1500),
+    );
+    winnerLabelOpacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 20,
+      ),
+    ]).animate(winnerLabelController);
+    winnerLabelScale = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.9, end: 1.05)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.05, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 50,
+      ),
+    ]).animate(winnerLabelController);
+
+    heroLabelController = AnimationController(
+      vsync: vsync,
+      duration: const Duration(milliseconds: 300),
+    );
+    heroLabelOpacity =
+        CurvedAnimation(parent: heroLabelController, curve: Curves.easeIn);
+    heroLabelScale = Tween<double>(begin: 0.8, end: 1.0)
+        .animate(CurvedAnimation(parent: heroLabelController, curve: Curves.easeOut));
+    if (isHero) {
+      heroLabelController.forward();
+    }
+
+    victoryController = AnimationController(
+      vsync: vsync,
+      duration: const Duration(milliseconds: 1200),
+    );
+    victoryOpacity = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 20,
+      ),
+      const TweenSequenceItem(tween: ConstantTween(1.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 20,
+      ),
+    ]).animate(victoryController);
+  }
+
+  late final AnimationController showdownLabelController;
+  late final Animation<double> showdownLabelOpacity;
+  late final AnimationController finalStackController;
+  late final Animation<double> finalStackOpacity;
+  late final Animation<Offset> finalStackOffset;
+  late final AnimationController winnerLabelController;
+  late final Animation<double> winnerLabelOpacity;
+  late final Animation<double> winnerLabelScale;
+  late final AnimationController heroLabelController;
+  late final Animation<double> heroLabelOpacity;
+  late final Animation<double> heroLabelScale;
+  late final AnimationController victoryController;
+  late final Animation<double> victoryOpacity;
+
+  void dispose() {
+    showdownLabelController.dispose();
+    finalStackController.dispose();
+    winnerLabelController.dispose();
+    heroLabelController.dispose();
+    victoryController.dispose();
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize label-related animations into new PlayerZoneLabelAnimations class
- extract bet chip display and effective stack tooltip into dedicated widgets
- wire PlayerZoneWidget to orchestrate through the new animation manager and sub-widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f577e8624832a97847283232100b6