### PR TITLE
feat: centralize shared preferences access

### DIFF
--- a/lib/screens/ready_to_train_screen.dart
+++ b/lib/screens/ready_to_train_screen.dart
@@ -10,7 +10,7 @@ import '../models/v2/training_pack_template.dart';
 import 'training_session_screen.dart';
 import 'pack_history_screen.dart';
 import 'package:collection/collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 import '../widgets/training_pack_card.dart';
 import 'empty_training_screen.dart';
 
@@ -21,7 +21,8 @@ class ReadyToTrainScreen extends StatefulWidget {
   State<ReadyToTrainScreen> createState() => _ReadyToTrainScreenState();
 }
 
-class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
+class _ReadyToTrainScreenState extends State<ReadyToTrainScreen>
+    with PreferenceState<ReadyToTrainScreen> {
   final List<TrainingPackTemplate> _templates = [];
   bool _loading = true;
   final Map<String, int> _progress = {};
@@ -42,10 +43,13 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   @override
   void initState() {
     super.initState();
-    SharedPreferences.getInstance().then((p) {
-      _showCompleted = p.getBool('show_completed_packs') ?? false;
-      if (mounted) _load();
-    });
+    // _load will be triggered in onPrefsLoaded once preferences are ready.
+  }
+
+  @override
+  void onPrefsLoaded() {
+    _showCompleted = prefs.getBool('show_completed_packs') ?? false;
+    _load();
   }
 
   Future<void> _load() async {
@@ -71,7 +75,7 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
     final similar = last != null
         ? await TrainingPackService.createSimilarMistakeDrill(last)
         : null;
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = this.prefs;
     final list = [
       ...builtIn.where(
         (t) =>
@@ -133,8 +137,7 @@ class _ReadyToTrainScreenState extends State<ReadyToTrainScreen> {
   }
 
   Future<void> _toggle(bool value) async {
-    final p = await SharedPreferences.getInstance();
-    await p.setBool('show_completed_packs', value);
+    await prefs.setBool('show_completed_packs', value);
     setState(() => _showCompleted = value);
     _load();
   }

--- a/lib/screens/snapshot_diff_screen.dart
+++ b/lib/screens/snapshot_diff_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 
 import '../models/pack_snapshot.dart';
 import '../models/training_pack.dart';
@@ -27,7 +27,7 @@ class _Mod {
 }
 
 class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, PreferenceState<SnapshotDiffScreen> {
   late TrainingPack _pack;
   late List<SavedHand> _added;
   late List<SavedHand> _removed;
@@ -42,8 +42,11 @@ class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
     super.initState();
     _pack = widget.pack;
     _compute();
-    SharedPreferences.getInstance().then((p) =>
-        p.setString('pack_editor_last_snapshot_diff', widget.snapshot.id));
+  }
+
+  @override
+  void onPrefsLoaded() {
+    prefs.setString('pack_editor_last_snapshot_diff', widget.snapshot.id);
   }
 
   void _compute() {

--- a/lib/utils/preference_state.dart
+++ b/lib/utils/preference_state.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+mixin PreferenceState<T extends StatefulWidget> on State<T> {
+  static SharedPreferences? _cachedPrefs;
+  late final SharedPreferences prefs;
+  bool _prefsReady = false;
+  bool get prefsReady => _prefsReady;
+
+  @override
+  void initState() {
+    super.initState();
+    _initPrefs();
+  }
+
+  Future<void> _initPrefs() async {
+    prefs = _cachedPrefs ??= await SharedPreferences.getInstance();
+    _prefsReady = true;
+    if (mounted) onPrefsLoaded();
+  }
+
+  void onPrefsLoaded() {}
+}
+

--- a/lib/widgets/category_drill_card.dart
+++ b/lib/widgets/category_drill_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
@@ -14,24 +14,22 @@ class CategoryDrillCard extends StatefulWidget {
   State<CategoryDrillCard> createState() => _CategoryDrillCardState();
 }
 
-class _CategoryDrillCardState extends State<CategoryDrillCard> {
+class _CategoryDrillCardState extends State<CategoryDrillCard>
+    with PreferenceState<CategoryDrillCard> {
   static const _key = 'top_mistake_drill_done';
   static const _tsKey = 'category_drill_last_time';
   bool _done = false;
 
   @override
-  void initState() {
-    super.initState();
-    SharedPreferences.getInstance().then((p) {
-      final done = p.getBool(_key) ?? false;
-      final ts = p.getInt(_tsKey);
-      final hide = ts != null &&
-          DateTime.now()
-                  .difference(DateTime.fromMillisecondsSinceEpoch(ts))
-                  .inDays <
-              7;
-      if (mounted) setState(() => _done = done && !hide);
-    });
+  void onPrefsLoaded() {
+    final done = prefs.getBool(_key) ?? false;
+    final ts = prefs.getInt(_tsKey);
+    final hide = ts != null &&
+        DateTime.now()
+                .difference(DateTime.fromMillisecondsSinceEpoch(ts))
+                .inDays <
+            7;
+    setState(() => _done = done && !hide);
   }
 
   @override
@@ -84,10 +82,9 @@ class _CategoryDrillCardState extends State<CategoryDrillCard> {
                   context, entry.key);
               if (tpl == null) return;
               await context.read<TrainingSessionService>().startSession(tpl);
-              final p = await SharedPreferences.getInstance();
-              await p.setInt(
+              await prefs.setInt(
                   _tsKey, DateTime.now().millisecondsSinceEpoch);
-              if (mounted) setState(() => _done = false);
+              setState(() => _done = false);
               if (context.mounted) {
                 await Navigator.push(
                   context,

--- a/lib/widgets/last_mistake_drill_card.dart
+++ b/lib/widgets/last_mistake_drill_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
@@ -15,22 +15,19 @@ class LastMistakeDrillCard extends StatefulWidget {
   State<LastMistakeDrillCard> createState() => _LastMistakeDrillCardState();
 }
 
-class _LastMistakeDrillCardState extends State<LastMistakeDrillCard> {
+class _LastMistakeDrillCardState extends State<LastMistakeDrillCard>
+    with PreferenceState<LastMistakeDrillCard> {
   static const _key = 'last_mistake_drill_ts';
   int? _ts;
 
   @override
-  void initState() {
-    super.initState();
-    SharedPreferences.getInstance().then((p) {
-      if (mounted) setState(() => _ts = p.getInt(_key));
-    });
+  void onPrefsLoaded() {
+    setState(() => _ts = prefs.getInt(_key));
   }
 
   Future<void> _mark(int ts) async {
-    final p = await SharedPreferences.getInstance();
-    await p.setInt(_key, ts);
-    if (mounted) setState(() => _ts = ts);
+    await prefs.setInt(_key, ts);
+    setState(() => _ts = ts);
   }
 
   @override

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 import '../services/training_stats_service.dart';
 import '../services/daily_target_service.dart';
 import '../services/streak_counter_service.dart';
@@ -17,7 +17,7 @@ class TodayProgressBanner extends StatefulWidget {
 }
 
 class _TodayProgressBannerState extends State<TodayProgressBanner>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, PreferenceState<TodayProgressBanner> {
   late final AnimationController _controller;
   late final Animation<double> _pulse;
   DateTime? _day;
@@ -58,18 +58,21 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
         ),
       );
     });
-    SharedPreferences.getInstance().then((prefs) {
-      final str = prefs.getString(_prefKey);
-      if (str != null) {
-        _lastCelebration = DateTime.tryParse(str);
-      }
-    });
+  }
+
+  @override
+  void onPrefsLoaded() {
+    final str = prefs.getString(_prefKey);
+    if (str != null) {
+      _lastCelebration = DateTime.tryParse(str);
+    }
   }
 
   bool _isSameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
   void _checkCelebrate(int hands, int target) {
+    if (!prefsReady) return;
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
     if (_day == null || !_isSameDay(_day!, today)) {
@@ -80,9 +83,7 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
       if (_lastCelebration == null || !_isSameDay(_lastCelebration!, today)) {
         _celebrated = true;
         _lastCelebration = today;
-        SharedPreferences.getInstance().then(
-          (p) => p.setString(_prefKey, today.toIso8601String()),
-        );
+        prefs.setString(_prefKey, today.toIso8601String());
         _controller.forward(from: 0);
         HapticFeedback.mediumImpact();
         showConfettiOverlay(context);

--- a/lib/widgets/top_mistake_drill_card.dart
+++ b/lib/widgets/top_mistake_drill_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/preference_state.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
@@ -13,22 +13,19 @@ class TopMistakeDrillCard extends StatefulWidget {
   State<TopMistakeDrillCard> createState() => _TopMistakeDrillCardState();
 }
 
-class _TopMistakeDrillCardState extends State<TopMistakeDrillCard> {
+class _TopMistakeDrillCardState extends State<TopMistakeDrillCard>
+    with PreferenceState<TopMistakeDrillCard> {
   static const _key = 'top_mistake_drill_done';
   bool _done = false;
 
   @override
-  void initState() {
-    super.initState();
-    SharedPreferences.getInstance().then((p) {
-      if (mounted) setState(() => _done = p.getBool(_key) ?? false);
-    });
+  void onPrefsLoaded() {
+    setState(() => _done = prefs.getBool(_key) ?? false);
   }
 
   Future<void> _mark() async {
-    final p = await SharedPreferences.getInstance();
-    await p.setBool(_key, true);
-    if (mounted) setState(() => _done = true);
+    await prefs.setBool(_key, true);
+    setState(() => _done = true);
   }
 
   @override


### PR DESCRIPTION
## Summary
- add `PreferenceState` mixin for cached SharedPreferences access
- refactor widgets and screens to use `PreferenceState`
- remove redundant `then` chains and `mounted` checks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f57843578832ab9830305d182fbd8