### PR TITLE
Refactor training history screen

### DIFF
--- a/lib/screens/training_history/filter_panel.dart
+++ b/lib/screens/training_history/filter_panel.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+
+class FilterPanel extends StatelessWidget {
+  final int filterDays;
+  final ValueChanged<int> onFilterChanged;
+
+  const FilterPanel({
+    super.key,
+    required this.filterDays,
+    required this.onFilterChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          const Text('Show:', style: TextStyle(color: Colors.white)),
+          const SizedBox(width: 8),
+          DropdownButton<int>(
+            value: filterDays,
+            dropdownColor: AppColors.cardBackground,
+            style: const TextStyle(color: Colors.white),
+            items: const [
+              DropdownMenuItem(value: 7, child: Text('7 days')),
+              DropdownMenuItem(value: 30, child: Text('30 days')),
+              DropdownMenuItem(value: 90, child: Text('90 days')),
+            ],
+            onChanged: (value) {
+              if (value != null) {
+                onFilterChanged(value);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/training_history/history_list.dart
+++ b/lib/screens/training_history/history_list.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../../models/training_result.dart';
+import '../../widgets/common/history_list_item.dart';
+
+class HistoryList extends StatelessWidget {
+  final List<TrainingResult> sessions;
+  final Future<void> Function(TrainingResult result) onDelete;
+  final void Function(TrainingResult result) onLongPress;
+  final void Function(TrainingResult result) onTap;
+  final void Function(TrainingResult result) onTagTap;
+
+  const HistoryList({
+    super.key,
+    required this.sessions,
+    required this.onDelete,
+    required this.onLongPress,
+    required this.onTap,
+    required this.onTagTap,
+  });
+
+  Future<bool?> _confirmDelete(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete Session?'),
+          content:
+              const Text('Are you sure you want to delete this session?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemBuilder: (context, index) {
+        final result = sessions[index];
+        return Dismissible(
+          key: ValueKey(result.date.toIso8601String()),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            color: Colors.red,
+            child: const Icon(Icons.delete, color: Colors.white),
+          ),
+          confirmDismiss: (_) => _confirmDelete(context),
+          onDismissed: (_) => onDelete(result),
+          child: HistoryListItem(
+            result: result,
+            onLongPress: () => onLongPress(result),
+            onTap: () => onTap(result),
+            onTagTap: () => onTagTap(result),
+            onDelete: () async {
+              final confirm = await _confirmDelete(context);
+              if (confirm ?? false) {
+                await onDelete(result);
+              }
+            },
+          ),
+        );
+      },
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemCount: sessions.length,
+    );
+  }
+}

--- a/lib/screens/training_history/stats_summary.dart
+++ b/lib/screens/training_history/stats_summary.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../models/training_result.dart';
+import '../../theme/app_colors.dart';
+import 'streak_summary.dart';
+
+class StatsSummary extends StatelessWidget {
+  final List<TrainingResult> sessions;
+  final bool showStreak;
+  final int currentStreak;
+  final int bestStreak;
+
+  const StatsSummary({
+    super.key,
+    required this.sessions,
+    required this.showStreak,
+    required this.currentStreak,
+    required this.bestStreak,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final totalSessions = sessions.length;
+    final totalCorrect = sessions.fold<int>(0, (sum, r) => sum + r.correct);
+    final avg = sessions.isEmpty
+        ? 0.0
+        : sessions.map((r) => r.accuracy).reduce((a, b) => a + b) /
+            sessions.length;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: AppColors.cardBackground,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                Text('Сессии: $totalSessions',
+                    style: const TextStyle(color: Colors.white)),
+                Text('Верно: $totalCorrect',
+                    style: const TextStyle(color: Colors.white)),
+                Text('Средняя: ${avg.toStringAsFixed(1)}%',
+                    style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+        ),
+        StreakSummary(
+          show: showStreak,
+          current: currentStreak,
+          best: bestStreak,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/training_history_service.dart
+++ b/lib/services/training_history_service.dart
@@ -2,11 +2,11 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../models/training_result.dart';
+import '../models/training_result.dart';
 
-class TrainingHistoryController {
-  TrainingHistoryController._();
-  static final instance = TrainingHistoryController._();
+class TrainingHistoryService {
+  TrainingHistoryService._();
+  static final instance = TrainingHistoryService._();
 
   Future<List<TrainingResult>> loadHistory() async {
     final prefs = await SharedPreferences.getInstance();
@@ -25,9 +25,14 @@ class TrainingHistoryController {
     return results;
   }
 
+  Future<void> saveHistory(List<TrainingResult> history) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = [for (final r in history) jsonEncode(r.toJson())];
+    await prefs.setStringList('training_history', list);
+  }
+
   Future<void> clearHistory() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('training_history');
   }
 }
-


### PR DESCRIPTION
## Summary
- extract filter, stats, and history widgets for modular training history UI
- centralize training history persistence in a dedicated service
- simplify TrainingHistoryScreen by composing new widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f57809ffc832a9652838b6b382e4c