### PR TITLE
refactor: extract session stats widgets

### DIFF
--- a/lib/widgets/session_stats/accuracy_progress_bar.dart
+++ b/lib/widgets/session_stats/accuracy_progress_bar.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Progress bar for the number of sessions with accuracy greater than 80%.
+class AccuracyProgressBar extends StatelessWidget {
+  final int good;
+  final int total;
+  final double scale;
+
+  const AccuracyProgressBar({
+    super.key,
+    required this.good,
+    required this.total,
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = total > 0 ? good / total : 0.0;
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Padding(
+      padding: EdgeInsets.only(bottom: 12 * scale),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          LayoutBuilder(builder: (context, constraints) {
+            if (constraints.maxWidth < 360) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Сессии с точностью > 80%',
+                      style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+                  SizedBox(height: 4 * scale),
+                  Text('$good из $total',
+                      style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+                ],
+              );
+            }
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Сессии с точностью > 80%',
+                    style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+                Text('$good из $total',
+                    style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+              ],
+            );
+          }),
+          SizedBox(height: 4 * scale),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: progress,
+              backgroundColor: Colors.white24,
+              valueColor: AlwaysStoppedAnimation<Color>(accent),
+              minHeight: 6 * scale,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/session_stats/goal_progress_bar.dart
+++ b/lib/widgets/session_stats/goal_progress_bar.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Progress bar for the monthly goal of ten sessions with accuracy over 90%.
+class GoalProgressBar extends StatelessWidget {
+  final int good;
+  final double scale;
+
+  const GoalProgressBar({
+    super.key,
+    required this.good,
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (good / 10.0).clamp(0.0, 1.0);
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Padding(
+      padding: EdgeInsets.only(bottom: 12 * scale),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          LayoutBuilder(builder: (context, constraints) {
+            if (constraints.maxWidth < 360) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Цель месяца: 10 сессий с точностью > 90%',
+                      style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+                  SizedBox(height: 4 * scale),
+                  Text('$good из 10',
+                      style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+                ],
+              );
+            }
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Flexible(
+                  child: Text('Цель месяца: 10 сессий с точностью > 90%',
+                      style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+                ),
+                Text('$good из 10',
+                    style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+              ],
+            );
+          }),
+          SizedBox(height: 4 * scale),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: progress,
+              backgroundColor: Colors.white24,
+              valueColor: AlwaysStoppedAnimation<Color>(accent),
+              minHeight: 6 * scale,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/session_stats/position_accuracy_row.dart
+++ b/lib/widgets/session_stats/position_accuracy_row.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Displays accuracy information for a specific player position.
+class PositionAccuracyRow extends StatelessWidget {
+  final String position;
+  final int correct;
+  final int total;
+  final double scale;
+  final VoidCallback? onTap;
+
+  const PositionAccuracyRow({
+    super.key,
+    required this.position,
+    required this.correct,
+    required this.total,
+    required this.scale,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = total > 0 ? (correct / total * 100).round() : 0;
+    final row = Padding(
+      padding: EdgeInsets.only(bottom: 12 * scale),
+      child: Text(
+        '$position — $accuracy% точность ($correct из $total верно)',
+        style: TextStyle(color: Colors.white, fontSize: 14 * scale),
+      ),
+    );
+    return onTap != null ? InkWell(onTap: onTap, child: row) : row;
+  }
+}

--- a/lib/widgets/session_stats/section_header.dart
+++ b/lib/widgets/session_stats/section_header.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+/// Standard section header used throughout the session stats screen.
+class SessionSectionHeader extends StatelessWidget {
+  final String text;
+
+  const SessionSectionHeader(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(text, style: const TextStyle(color: Colors.white70));
+  }
+}

--- a/lib/widgets/session_stats/stat_row.dart
+++ b/lib/widgets/session_stats/stat_row.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// Displays a single statistic as a responsive row with a label and value.
+///
+/// On narrow layouts (<360px) the label and value are stacked vertically to
+/// preserve space. A tap callback can be supplied for interactive rows.
+class SessionStatRow extends StatelessWidget {
+  final String label;
+  final String value;
+  final double scale;
+  final VoidCallback? onTap;
+
+  const SessionStatRow({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.scale,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final child = LayoutBuilder(builder: (context, constraints) {
+      if (constraints.maxWidth < 360) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+            SizedBox(height: 4 * scale),
+            Text(value, style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+          ],
+        );
+      }
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(label,
+                style: TextStyle(color: Colors.white70, fontSize: 14 * scale)),
+          ),
+          Text(value, style: TextStyle(color: Colors.white, fontSize: 14 * scale)),
+        ],
+      );
+    });
+
+    final row = Padding(
+      padding: EdgeInsets.only(bottom: 12 * scale),
+      child: child,
+    );
+    return onTap != null ? InkWell(onTap: onTap, child: row) : row;
+  }
+}

--- a/lib/widgets/session_stats/street_filter_chips.dart
+++ b/lib/widgets/session_stats/street_filter_chips.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../helpers/poker_street_helper.dart';
+
+/// Chips allowing the user to filter session stats by poker street.
+class StreetFilterChips extends StatelessWidget {
+  final Set<int> selected;
+  final double scale;
+  final void Function(int index, bool selected) onChanged;
+
+  const StreetFilterChips({
+    super.key,
+    required this.selected,
+    required this.scale,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: 12 * scale),
+      child: Wrap(
+        spacing: 8 * scale,
+        children: [
+          for (int i = 0; i < kStreetNames.length; i++)
+            FilterChip(
+              label: Text(kStreetNames[i]),
+              selected: selected.contains(i),
+              onSelected: (v) => onChanged(i, v),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/session_stats/tag_row.dart
+++ b/lib/widgets/session_stats/tag_row.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+/// Displays a tag with its usage count. Tapping toggles selection to filter
+/// session stats by a specific tag.
+class SessionTagRow extends StatelessWidget {
+  final String tag;
+  final int count;
+  final double scale;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const SessionTagRow({
+    super.key,
+    required this.tag,
+    required this.count,
+    required this.scale,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.secondary;
+    final style = TextStyle(
+      color: selected ? accent : Colors.white,
+      fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+    );
+
+    final content = LayoutBuilder(builder: (context, constraints) {
+      if (constraints.maxWidth < 360) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(tag, style: style.copyWith(fontSize: 14 * scale)),
+            SizedBox(height: 4 * scale),
+            Text(count.toString(), style: style.copyWith(fontSize: 14 * scale)),
+          ],
+        );
+      }
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(child: Text(tag, style: style.copyWith(fontSize: 14 * scale))),
+          Text(count.toString(), style: style.copyWith(fontSize: 14 * scale)),
+        ],
+      );
+    });
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.only(bottom: 12 * scale),
+        child: content,
+      ),
+    );
+  }
+}

--- a/lib/widgets/session_stats/weekly_winrate_chart.dart
+++ b/lib/widgets/session_stats/weekly_winrate_chart.dart
@@ -1,0 +1,102 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+import '../../utils/responsive.dart';
+
+/// Represents the average winrate for a week starting at [weekStart].
+class WeekWinrate {
+  final DateTime weekStart;
+  final double winrate;
+
+  const WeekWinrate(this.weekStart, this.winrate);
+}
+
+/// Line chart visualising weekly winrate trends.
+class WeeklyWinrateChart extends StatelessWidget {
+  final List<WeekWinrate> data;
+  final double scale;
+
+  const WeeklyWinrateChart({
+    super.key,
+    required this.data,
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final spots = <FlSpot>[];
+    for (var i = 0; i < data.length; i++) {
+      spots.add(FlSpot(i.toDouble(), data[i].winrate));
+    }
+    final step = (data.length / 6).ceil();
+
+    return Container(
+      height: responsiveSize(context, 200),
+      padding: EdgeInsets.all(12 * scale),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LineChart(
+        LineChartData(
+          minY: 0,
+          maxY: 100,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 20,
+            getDrawingHorizontalLine: (value) =>
+                const FlLine(color: Colors.white24, strokeWidth: 1),
+          ),
+          titlesData: FlTitlesData(
+            rightTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            topTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 20,
+                reservedSize: 30,
+                getTitlesWidget: (value, meta) => Text(
+                  value.toInt().toString(),
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                ),
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  final index = value.toInt();
+                  if (index < 0 || index >= data.length) {
+                    return const SizedBox.shrink();
+                  }
+                  if (index % step != 0 && index != data.length - 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final d = data[index].weekStart;
+                  return Text(
+                    '${d.month}/${d.day}',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: true,
+              color: Colors.greenAccent,
+              barWidth: 2,
+              dotData: const FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract common session stat rows, tag rows, position rows, progress bars, street filters and weekly win rate chart into dedicated widgets
- update session stats screen to use new widgets and add section headers

## Testing
- `dart format lib/screens/session_stats_screen.dart lib/widgets/session_stats/*.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5782accc832ab5b1bf76ede35581