### PR TITLE
feat: centralize snackbar messages

### DIFF
--- a/lib/core/training/export/training_pack_clipboard_sharer.dart
+++ b/lib/core/training/export/training_pack_clipboard_sharer.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import '../../../models/v2/training_pack_template_v2.dart';
 import 'training_pack_exporter_v2.dart';
+import '../../../utils/snackbar_util.dart';
 
 class TrainingPackClipboardSharer {
   const TrainingPackClipboardSharer._();
@@ -14,9 +15,7 @@ class TrainingPackClipboardSharer {
     final yaml = const TrainingPackExporterV2().exportYaml(pack);
     await Clipboard.setData(ClipboardData(text: yaml));
     if (context != null && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('YAML copied to clipboard')),
-      );
+      SnackbarUtil.showMessage(context, 'YAML copied to clipboard');
     }
   }
 }

--- a/lib/plugins/plugin_loader_io.dart
+++ b/lib/plugins/plugin_loader_io.dart
@@ -31,6 +31,7 @@ import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
 import 'partypoker_converter_plugin.dart';
 import '../../plugins/LocalEvPlugin.dart';
+import '../utils/snackbar_util.dart';
 
 /// Prototype loader for built-in plug-ins.
 ///
@@ -366,10 +367,7 @@ class PluginLoader {
         await manager.logStatus(name, 'duplicate');
       }
       if (context != null && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text('Duplicate plugins: ${duplicates.join(', ')}')),
-        );
+        SnackbarUtil.showMessage(context, 'Duplicate plugins: ${duplicates.join(', ')}');
       }
     }
 

--- a/lib/plugins/plugin_loader_web.dart
+++ b/lib/plugins/plugin_loader_web.dart
@@ -28,6 +28,7 @@ import 'gg_poker_converter_plugin.dart';
 import 'ipoker_converter_plugin.dart';
 import 'partypoker_converter_plugin.dart';
 import '../../plugins/LocalEvPlugin.dart';
+import '../utils/snackbar_util.dart';
 
 class PluginLoader {
   static const String _suffix = 'Plugin.dart';
@@ -346,9 +347,7 @@ class PluginLoader {
         await manager.logStatus(name, 'duplicate');
       }
       if (context != null && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Duplicate plugins: ${duplicates.join(', ')}')),
-        );
+        SnackbarUtil.showMessage(context, 'Duplicate plugins: ${duplicates.join(', ')}');
       }
     }
 

--- a/lib/screens/all_sessions_screen.dart
+++ b/lib/screens/all_sessions_screen.dart
@@ -20,6 +20,7 @@ import '../models/game_type.dart';
 import 'session_detail_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
+import '../utils/snackbar_util.dart';
 
 class AllSessionsScreen extends StatefulWidget {
   const AllSessionsScreen({super.key});
@@ -320,17 +321,12 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
 
     if (mounted) {
       final name = savePath.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $name'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () {
               OpenFilex.open(file.path);
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -364,17 +360,12 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
 
     if (mounted) {
       final name = savePath.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $name'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () {
               OpenFilex.open(file.path);
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -603,17 +594,12 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
 
     if (mounted) {
       final name = savePath.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $name'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () {
               OpenFilex.open(file.path);
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -650,9 +636,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     _packs.clear();
     _applyFilter();
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Все сессии удалены')),
-    );
+    SnackbarUtil.showMessage(context, 'Все сессии удалены');
   }
 
   Widget _buildAccuracyChart() {
@@ -929,9 +913,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     _applyFilter();
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Пакет переименован')),
-      );
+      SnackbarUtil.showMessage(context, 'Пакет переименован');
     }
   }
 
@@ -981,9 +963,7 @@ class _AllSessionsScreenState extends State<AllSessionsScreen> {
     _applyFilter();
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Пакет удалён')),
-      );
+      SnackbarUtil.showMessage(context, 'Пакет удалён');
     }
   }
 

--- a/lib/screens/analyzer_result_screen.dart
+++ b/lib/screens/analyzer_result_screen.dart
@@ -15,6 +15,7 @@ import '../models/v2/hand_data.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/action_entry.dart';
 import 'package:uuid/uuid.dart';
+import '../utils/snackbar_util.dart';
 
 class AnalyzerResultScreen extends StatefulWidget {
   final SavedHand hand;
@@ -97,10 +98,7 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final loss = _hand.evLoss ?? 0;
       if (loss.abs() >= 1.0) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('EV Loss ≥ 1.0'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'EV Loss ≥ 1.0', action: SnackBarAction(
               label: 'Тренировать похожее',
               onPressed: () async {
                 final tpl = await TrainingPackService.createSimilarMistakeDrill(
@@ -117,9 +115,7 @@ class _AnalyzerResultScreenState extends State<AnalyzerResultScreen> {
                   );
                 }
               },
-            ),
-          ),
-        );
+            ));
       }
       await _offerDrill();
       await _offerSimilarDrill();

--- a/lib/screens/booster_variation_editor_screen.dart
+++ b/lib/screens/booster_variation_editor_screen.dart
@@ -10,6 +10,7 @@ import '../services/booster_cluster_engine.dart';
 import 'v2/training_pack_spot_editor_screen.dart';
 import '../theme/app_colors.dart';
 import '../core/training/engine/training_type_engine.dart';
+import '../utils/snackbar_util.dart';
 
 class BoosterVariationEditorScreen extends StatefulWidget {
   const BoosterVariationEditorScreen({super.key});
@@ -69,8 +70,7 @@ class _BoosterVariationEditorScreenState
     pack.spotCount = pack.spots.length;
     await file.writeAsString(pack.toYamlString());
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Сохранено')));
+    SnackbarUtil.showMessage(context, 'Сохранено');
   }
 
   Future<void> _editSpot(TrainingPackSpot spot) async {

--- a/lib/screens/cloud_training_history_screen.dart
+++ b/lib/screens/cloud_training_history_screen.dart
@@ -17,6 +17,7 @@ import 'training_pack_screen.dart';
 import '../widgets/history/accuracy_trend_chart.dart';
 import 'cloud_training_session_details_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   const TrainingHistoryScreen({super.key});
@@ -121,15 +122,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
         mimeType: MimeType.other,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-              content: Text('История сохранена в training_history.md')),
-        );
+        SnackbarUtil.showMessage(context, 'История сохранена в training_history.md');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта');
       }
     }
   }
@@ -148,8 +145,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final hands = [for (final n in names) if (map[n] != null) map[n]!];
     if (hands.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Раздачи не найдены')));
+        SnackbarUtil.showMessage(context, 'Раздачи не найдены');
       }
       return;
     }

--- a/lib/screens/cloud_training_history_service_screen.dart
+++ b/lib/screens/cloud_training_history_service_screen.dart
@@ -10,6 +10,7 @@ import '../models/cloud_history_entry.dart';
 import '../services/cloud_training_history_service.dart';
 import '../services/cloud_training_session_import_service.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 enum _SortOption { newest, oldest, accuracyDesc, accuracyAsc }
 
@@ -73,9 +74,7 @@ class _CloudTrainingHistoryScreenState extends State<CloudTrainingHistoryScreen>
     await file.writeAsString(buffer.toString());
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('История сохранена в cloud_history.md')),
-      );
+      SnackbarUtil.showMessage(context, 'История сохранена в cloud_history.md');
     }
   }
 
@@ -92,16 +91,13 @@ class _CloudTrainingHistoryScreenState extends State<CloudTrainingHistoryScreen>
     final session = await service.importFromJson(file);
     if (session == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Invalid file')));
+        SnackbarUtil.showMessage(context, 'Invalid file');
       }
       return;
     }
     await _load();
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Imported ${formatDateTime(session.date)}')),
-      );
+      SnackbarUtil.showMessage(context, 'Imported ${formatDateTime(session.date)}');
     }
   }
 

--- a/lib/screens/cloud_training_session_details_screen.dart
+++ b/lib/screens/cloud_training_session_details_screen.dart
@@ -21,6 +21,7 @@ import '../models/training_pack.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'training_pack_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class CloudTrainingSessionDetailsScreen extends StatefulWidget {
   final CloudTrainingSession session;
@@ -196,9 +197,7 @@ class _CloudTrainingSessionDetailsScreenState
     await file.writeAsString(buffer.toString());
     await Share.shareXFiles([XFile(file.path)], text: 'cloud_session.md');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: cloud_session.md')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: cloud_session.md');
     }
   }
 
@@ -257,9 +256,7 @@ class _CloudTrainingSessionDetailsScreenState
     await file.writeAsBytes(bytes);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: cloud_session.pdf')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: cloud_session.pdf');
     }
   }
 
@@ -285,14 +282,11 @@ class _CloudTrainingSessionDetailsScreenState
         mimeType: MimeType.other,
       );
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Файл сохранён: $name.json')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл сохранён: $name.json');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Ошибка экспорта JSON')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта JSON');
       }
     }
   }
@@ -309,9 +303,7 @@ class _CloudTrainingSessionDetailsScreenState
     }
     if (hands.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Раздачи не найдены')),
-        );
+        SnackbarUtil.showMessage(context, 'Раздачи не найдены');
       }
       return;
     }
@@ -345,9 +337,7 @@ class _CloudTrainingSessionDetailsScreenState
     }
     if (hands.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Раздачи не найдены')),
-        );
+        SnackbarUtil.showMessage(context, 'Раздачи не найдены');
       }
       return;
     }

--- a/lib/screens/community_plugin_screen.dart
+++ b/lib/screens/community_plugin_screen.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import '../plugins/plugin_loader.dart';
 import '../plugins/plugin_manager.dart';
+import '../utils/snackbar_util.dart';
 
 class CommunityPlugin {
   final String name;
@@ -95,13 +96,7 @@ class _CommunityPluginScreenState extends State<CommunityPluginScreen> {
         checksum: p.checksum,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              downloaded ? 'Plugin installed' : 'Plugin up to date',
-            ),
-          ),
-        );
+        SnackbarUtil.showMessage(context, downloaded ? 'Plugin installed' : 'Plugin up to date',);
         await _load();
       }
     } catch (e) {

--- a/lib/screens/community_template_screen.dart
+++ b/lib/screens/community_template_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/training_pack_template_model.dart';
 import '../services/training_pack_cloud_sync_service.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../utils/snackbar_util.dart';
 
 class CommunityTemplateScreen extends StatefulWidget {
   const CommunityTemplateScreen({super.key});
@@ -41,9 +42,7 @@ class _CommunityTemplateScreenState extends State<CommunityTemplateScreen> {
       await storage.add(tpl);
     }
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(exists ? 'Обновлено' : 'Загружено')),
-    );
+    SnackbarUtil.showMessage(context, exists ? 'Обновлено' : 'Загружено');
   }
 
   Widget _rating(double value) {

--- a/lib/screens/create_custom_pack_screen.dart
+++ b/lib/screens/create_custom_pack_screen.dart
@@ -14,6 +14,7 @@ import '../services/training_pack_storage_service.dart';
 import '../widgets/color_picker_dialog.dart';
 import 'my_training_packs_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class CreateCustomPackScreen extends StatefulWidget {
   const CreateCustomPackScreen({super.key});
@@ -212,8 +213,7 @@ class _CreateCustomPackScreenState extends State<CreateCustomPackScreen> {
       MaterialPageRoute(builder: (_) => const MyTrainingPacksScreen()),
       (r) => false,
     );
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Пак сохранён')));
+    SnackbarUtil.showMessage(context, 'Пак сохранён');
   }
 
   @override

--- a/lib/screens/create_pack_from_history_screen.dart
+++ b/lib/screens/create_pack_from_history_screen.dart
@@ -13,6 +13,7 @@ import '../helpers/training_pack_storage.dart';
 import '../services/template_storage_service.dart';
 import '../widgets/sync_status_widget.dart';
 import '../models/v2/training_pack_template.dart';
+import '../utils/snackbar_util.dart';
 
 class CreatePackFromHistoryScreen extends StatefulWidget {
   const CreatePackFromHistoryScreen({super.key});
@@ -70,8 +71,7 @@ class _CreatePackFromHistoryScreenState extends State<CreatePackFromHistoryScree
     context.read<TemplateStorageService>().addTemplate(tpl);
     if (!mounted) return;
     Navigator.pop(context);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Пак "${tpl.name}" создан')));
+    SnackbarUtil.showMessage(context, 'Пак "${tpl.name}" создан');
   }
 
   Future<void> _export() async {

--- a/lib/screens/create_pack_from_template_screen.dart
+++ b/lib/screens/create_pack_from_template_screen.dart
@@ -9,6 +9,7 @@ import '../services/training_pack_storage_service.dart';
 import 'training_pack_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
+import '../utils/snackbar_util.dart';
 
 class CreatePackFromTemplateScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -197,11 +198,7 @@ class _CreatePackFromTemplateScreenState extends State<CreatePackFromTemplateScr
 
   Future<void> _create() async {
     if (_selected.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Выберите хотя бы одну раздачу перед созданием пака'),
-        ),
-      );
+      SnackbarUtil.showMessage(context, 'Выберите хотя бы одну раздачу перед созданием пака');
       return;
     }
     final service = context.read<TrainingPackStorageService>();

--- a/lib/screens/decay_heatmap_screen.dart
+++ b/lib/screens/decay_heatmap_screen.dart
@@ -4,6 +4,7 @@ import '../models/tag_decay_entry.dart';
 import '../services/booster_path_history_service.dart';
 import '../services/decay_tag_retention_tracker_service.dart';
 import '../utils/responsive.dart';
+import '../utils/snackbar_util.dart';
 
 class DecayHeatmapScreen extends StatefulWidget {
   static const route = '/decay_heatmap';
@@ -75,9 +76,7 @@ class _DecayHeatmapScreenState extends State<DecayHeatmapScreen> {
     final textColor = _textColor(color);
     return GestureDetector(
       onTap: () {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Selected ${e.tag}')),
-        );
+        SnackbarUtil.showMessage(context, 'Selected ${e.tag}');
       },
       child: Container(
         decoration: BoxDecoration(

--- a/lib/screens/decay_stats_dashboard_screen.dart
+++ b/lib/screens/decay_stats_dashboard_screen.dart
@@ -5,6 +5,7 @@ import '../models/decay_retention_summary.dart';
 import '../services/decay_retention_summary_service.dart';
 import '../services/tag_decay_forecast_service.dart';
 import '../services/inbox_booster_delivery_controller.dart';
+import '../utils/snackbar_util.dart';
 
 class DecayStatsDashboardScreen extends StatefulWidget {
   static const route = '/decay_stats_dashboard';
@@ -46,8 +47,7 @@ class _DecayStatsDashboardScreenState extends State<DecayStatsDashboardScreen> {
   Future<void> _reviewNow() async {
     await InboxBoosterDeliveryController().maybeTriggerBoosterInbox();
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Review triggered')));
+    SnackbarUtil.showMessage(context, 'Review triggered');
   }
 
   Widget _summarySection() {

--- a/lib/screens/dev_menu/booster_section.dart
+++ b/lib/screens/dev_menu/booster_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../../services/booster_refiner_engine.dart';
 import '../../services/booster_similarity_pruner.dart';
 import '../../services/booster_tag_coverage_stats.dart';
+import '../../utils/snackbar_util.dart';
 
 class BoosterSection extends StatefulWidget {
   const BoosterSection({super.key});
@@ -45,8 +46,7 @@ class _BoosterSectionState extends State<BoosterSection> {
     final count = await const BoosterRefinerEngine().refineAll();
     if (!mounted) return;
     setState(() => _refineLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Обновлено: $count')));
+    SnackbarUtil.showMessage(context, 'Обновлено: $count');
   }
 
   Future<void> _pruneDuplicates() async {
@@ -55,8 +55,7 @@ class _BoosterSectionState extends State<BoosterSection> {
     final count = await const BoosterSimilarityPruner().pruneAndSaveAll();
     if (!mounted) return;
     setState(() => _pruneLoading = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Обновлено: $count')));
+    SnackbarUtil.showMessage(context, 'Обновлено: $count');
   }
 
   @override

--- a/lib/screens/dev_menu/coverage_section.dart
+++ b/lib/screens/dev_menu/coverage_section.dart
@@ -5,6 +5,7 @@ import '../../services/training_coverage_service.dart';
 import '../pack_coverage_stats_screen.dart';
 import '../theory_coverage_dashboard.dart';
 import '../yaml_coverage_stats_screen.dart';
+import '../../utils/snackbar_util.dart';
 
 class CoverageSection extends StatefulWidget {
   const CoverageSection({super.key});
@@ -22,8 +23,7 @@ class _CoverageSectionState extends State<CoverageSection> {
     final ok = await compute(_coverageTask, '');
     if (!mounted) return;
     setState(() => _exporting = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
+    SnackbarUtil.showMessage(context, ok ? 'Готово' : 'Ошибка');
   }
 
   @override

--- a/lib/screens/dev_menu/pack_generation_section.dart
+++ b/lib/screens/dev_menu/pack_generation_section.dart
@@ -11,6 +11,7 @@ import '../../core/training/generation/pack_yaml_config_parser.dart';
 import '../../core/training/engine/training_type_engine.dart';
 import '../../services/tag_service.dart';
 import '../../ui/tools/training_pack_yaml_previewer.dart';
+import '../../utils/snackbar_util.dart';
 
 class PackGenerationSection extends StatefulWidget {
   const PackGenerationSection({super.key});
@@ -232,9 +233,7 @@ class _PackGenerationSectionState extends State<PackGenerationSection> {
     );
     if (!mounted) return;
     setState(() => _batchLoading = false);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Создано: $success')),
-    );
+    SnackbarUtil.showMessage(context, 'Создано: $success');
   }
 
   @override

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -13,6 +13,7 @@ import '../models/v2/training_pack_spot.dart';
 import '../helpers/pack_spot_utils.dart';
 import 'package:collection/collection.dart';
 import 'training_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class DrillHistoryScreen extends StatefulWidget {
   const DrillHistoryScreen({super.key});
@@ -162,8 +163,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
       ids.addAll(r.wrongSpotIds.where((e) => e.isNotEmpty));
     }
     if (ids.isEmpty) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Ошибок не найдено')));
+      SnackbarUtil.showMessage(context, 'Ошибок не найдено');
       return;
     }
     final packs = context.read<TrainingPackStorageService>().packs;
@@ -174,8 +174,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
       }
     }
     if (hands.isEmpty) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Ошибок не найдено')));
+      SnackbarUtil.showMessage(context, 'Ошибок не найдено');
       return;
     }
     await Navigator.push(
@@ -193,16 +192,14 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
   Future<void> _repeatLast() async {
     final history = context.read<DrillHistoryService>().results;
     if (history.isEmpty) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('История пуста')));
+      SnackbarUtil.showMessage(context, 'История пуста');
       return;
     }
     final last = history.first;
     final packs = context.read<TrainingPackStorageService>().packs;
     final pack = packs.firstWhereOrNull((p) => p.id == last.templateId);
     if (pack == null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Шаблон не найден')));
+      SnackbarUtil.showMessage(context, 'Шаблон не найден');
       return;
     }
     await Navigator.push(

--- a/lib/screens/goal_center_screen.dart
+++ b/lib/screens/goal_center_screen.dart
@@ -12,6 +12,7 @@ import '../services/smart_goal_tracking_service.dart';
 import '../services/goal_completion_engine.dart';
 import '../services/goal_completion_event_service.dart';
 import '../widgets/training_goal_card.dart';
+import '../utils/snackbar_util.dart';
 
 class GoalCenterScreen extends StatefulWidget {
   static const route = '/goals';
@@ -70,9 +71,7 @@ class _GoalCenterScreenState extends State<GoalCenterScreen> {
     final pack = await PackLibraryService.instance.findByTag(goal.tag!);
     if (pack == null) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Тренировка не найдена')),
-      );
+      SnackbarUtil.showMessage(context, 'Тренировка не найдена');
       return;
     }
     await const TrainingSessionLauncher().launch(pack);

--- a/lib/screens/graph_path_authoring_wizard_screen.dart
+++ b/lib/screens/graph_path_authoring_wizard_screen.dart
@@ -13,6 +13,7 @@ import '../models/learning_path_node.dart';
 import '../services/learning_path_validator.dart';
 import '../theme/app_colors.dart';
 import '../ui/tools/path_map_visualizer.dart';
+import '../utils/snackbar_util.dart';
 
 class GraphPathAuthoringWizardScreen extends StatefulWidget {
   final String? initialTemplateId;
@@ -331,8 +332,7 @@ class _GraphPathAuthoringWizardScreenState extends State<GraphPathAuthoringWizar
     final file = File(path);
     await file.writeAsString(_yaml);
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Saved')));
+    SnackbarUtil.showMessage(context, 'Saved');
   }
 
   Future<void> _exportTemplate() async {
@@ -466,8 +466,7 @@ class _GraphPathAuthoringWizardScreenState extends State<GraphPathAuthoringWizar
             ElevatedButton(
               onPressed: () {
                 Clipboard.setData(ClipboardData(text: _yaml));
-                ScaffoldMessenger.of(context)
-                    .showSnackBar(const SnackBar(content: Text('Copied')));
+                SnackbarUtil.showMessage(context, 'Copied');
               },
               child: const Text('Copy'),
             ),

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -12,6 +12,7 @@ import '../models/card_model.dart';
 import '../models/action_entry.dart';
 import '../helpers/poker_position_helper.dart';
 import '../services/hand_evaluator.dart';
+import '../utils/snackbar_util.dart';
 
 class UndoIntent extends Intent { const UndoIntent(); }
 class RedoIntent extends Intent { const RedoIntent(); }
@@ -252,9 +253,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     if (_canUndo) {
       _redo.add(_makeSnapshot());
       _applySnapshot(_undo.removeLast());
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Undo')),
-      );
+      SnackbarUtil.showMessage(context, 'Undo');
     }
   }
 
@@ -262,9 +261,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     if (_canRedo) {
       _undo.add(_makeSnapshot());
       _applySnapshot(_redo.removeLast());
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Redo')),
-      );
+      SnackbarUtil.showMessage(context, 'Redo');
     }
   }
 
@@ -398,9 +395,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
   Future<void> _exportJson() async {
     final jsonStr = jsonEncode(_toJson());
     await Clipboard.setData(ClipboardData(text: jsonStr));
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Hand copied to clipboard')),
-    );
+    SnackbarUtil.showMessage(context, 'Hand copied to clipboard');
   }
 
   Future<void> _importJson() async {
@@ -408,13 +403,9 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     if (data?.text == null || data!.text!.trim().isEmpty) return;
     try {
       _applyFromJson(Map<String, dynamic>.from(jsonDecode(data.text!)));
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Hand loaded')),
-      );
+      SnackbarUtil.showMessage(context, 'Hand loaded');
     } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Invalid JSON')),
-      );
+      SnackbarUtil.showMessage(context, 'Invalid JSON');
     }
   }
 
@@ -465,12 +456,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
   void _nextStreet() {
     final current = _tabController.index;
     if (current < 4) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-              'Stakes committed — moving to ${['Flop', 'Turn', 'River', 'Showdown'][current + 1]}'),
-        ),
-      );
+      SnackbarUtil.showMessage(context, 'Stakes committed — moving to ${['Flop', 'Turn', 'River', 'Showdown'][current + 1]}');
       setState(() {
         for (int i = 0; i < _playerCount; i++) {
           _pot += _bets[i];
@@ -770,9 +756,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
                     onChanged: (v) {
                       final val = double.tryParse(v);
                       if (val == null || val < 0) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Enter valid stack')),
-                        );
+                        SnackbarUtil.showMessage(context, 'Enter valid stack');
                         return;
                       }
                       setState(() {

--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -22,6 +22,7 @@ import '../services/booster_recap_hook.dart';
 import '../helpers/mistake_advice.dart';
 import '../widgets/sync_status_widget.dart';
 import 'saved_hand_editor_screen.dart';
+import '../utils/snackbar_util.dart';
 
 /// Displays a saved hand with simple playback controls.
 /// Shows GTO recommendation and range group when available.
@@ -142,9 +143,7 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
     await file.writeAsString(buffer.toString());
     await Share.shareXFiles([XFile(file.path)], text: 'hand_export.md');
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: hand_export.md')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: hand_export.md');
     }
   }
 
@@ -201,9 +200,7 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
     await file.writeAsBytes(bytes);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: hand_export.pdf')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: hand_export.pdf');
     }
   }
 
@@ -303,8 +300,7 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
     selected.spots.add(spot);
     await TrainingPackStorage.save(templates);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Spot added')));
+      SnackbarUtil.showMessage(context, 'Spot added');
     }
   }
 

--- a/lib/screens/learning_path_screen.dart
+++ b/lib/screens/learning_path_screen.dart
@@ -8,6 +8,7 @@ import '../services/training_pack_stats_service.dart';
 import '../models/learning_path_stage_model.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'learning_progress_stats_screen.dart';
+import '../utils/snackbar_util.dart';
 
 enum StageStatus { completed, open, locked }
 
@@ -302,9 +303,7 @@ class _DynamicStageTile extends StatelessWidget {
                         context,
                       );
                       if (tpl == null) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Template not found')),
-                        );
+                        SnackbarUtil.showMessage(context, 'Template not found');
                         return;
                       }
                       await Navigator.push(

--- a/lib/screens/learning_path_stage_detailed_screen.dart
+++ b/lib/screens/learning_path_stage_detailed_screen.dart
@@ -19,6 +19,7 @@ import '../models/mistake_tag_cluster.dart';
 import '../models/sub_stage_model.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../widgets/skill_card.dart';
+import '../utils/snackbar_util.dart';
 
 class LearningPathStageDetailedScreen extends StatefulWidget {
   final LearningPathTemplateV2 path;
@@ -177,9 +178,7 @@ class _LearningPathStageDetailedScreenState
         await PackLibraryService.instance.getById(widget.stage.packId);
     if (template == null) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Training pack not found')),
-      );
+      SnackbarUtil.showMessage(context, 'Training pack not found');
       return;
     }
     await const TrainingSessionLauncher().launch(template);
@@ -190,9 +189,7 @@ class _LearningPathStageDetailedScreenState
     final template = await PackLibraryService.instance.getById(sub.packId);
     if (template == null) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Training pack not found')),
-      );
+      SnackbarUtil.showMessage(context, 'Training pack not found');
       return;
     }
     final copy = TrainingPackTemplateV2.fromJson(template.toJson())

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -71,6 +71,7 @@ import '../widgets/goal_suggestion_row.dart';
 import '../services/smart_goal_aggregator_service.dart';
 import '../models/goal_recommendation.dart';
 import '../widgets/skill_tree_main_menu_entry.dart';
+import '../utils/snackbar_util.dart';
 
 class _MenuItem {
   final IconData icon;
@@ -975,13 +976,9 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                                 listen: false);
                         final path = await exporter.exportAllHandsMarkdown();
                         if (!context.mounted) return;
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(path != null
+                        SnackbarUtil.showMessage(context, path != null
                                 ? 'Файл сохранён: all_saved_hands.md'
-                                : 'Нет сохранённых раздач'),
-                          ),
-                        );
+                                : 'Нет сохранённых раздач');
                       },
                       child: const Text('Экспорт всех раздач'),
                     ),
@@ -993,13 +990,9 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                                 listen: false);
                         final path = await exporter.exportAllHandsPdf();
                         if (!context.mounted) return;
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(path != null
+                        SnackbarUtil.showMessage(context, path != null
                                 ? 'Файл сохранён: all_saved_hands.pdf'
-                                : 'Нет сохранённых раздач'),
-                          ),
-                        );
+                                : 'Нет сохранённых раздач');
                       },
                       child: const Text('Экспорт PDF раздач'),
                     ),

--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -77,6 +77,7 @@ import '../services/session_streak_overlay_prompt_service.dart';
 import '../services/overlay_decay_booster_orchestrator.dart';
 import '../services/decay_badge_banner_controller.dart';
 import 'dart:async';
+import '../utils/snackbar_util.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -372,14 +373,8 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
           onLongPress: () {
             SmartInboxDebugService.instance.toggle();
             Navigator.of(context).pop();
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                  'Smart Inbox debug '
-                  '${SmartInboxDebugService.instance.enabled ? 'enabled' : 'disabled'}',
-                ),
-              ),
-            );
+            SnackbarUtil.showMessage(context, 'Smart Inbox debug '
+                  '${SmartInboxDebugService.instance.enabled ? 'enabled' : 'disabled'}',);
           },
           child: Text('Version ${info.version}'),
         ),

--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -9,6 +9,7 @@ import '../services/theory_streak_service.dart';
 import '../services/theory_booster_recall_engine.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/theory_lesson_completion_logger.dart';
+import '../utils/snackbar_util.dart';
 
 /// Simple viewer for a [TheoryMiniLessonNode].
 class MiniLessonScreen extends StatefulWidget {
@@ -61,9 +62,7 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
     final pinned =
         PinnedLearningService.instance.isPinned('lesson', widget.lesson.id);
     setState(() => _pinned = pinned);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(pinned ? 'Pinned' : 'Unpinned')),
-    );
+    SnackbarUtil.showMessage(context, pinned ? 'Pinned' : 'Unpinned');
   }
 
   @override

--- a/lib/screens/mistake_detail_screen.dart
+++ b/lib/screens/mistake_detail_screen.dart
@@ -7,6 +7,7 @@ import '../models/action_entry.dart';
 import '../services/saved_hand_manager_service.dart';
 import 'ev_recovery_history_screen.dart';
 import 'package:provider/provider.dart';
+import '../utils/snackbar_util.dart';
 
 class MistakeDetailScreen extends StatelessWidget {
   final SavedHand hand;
@@ -51,12 +52,7 @@ class MistakeDetailScreen extends StatelessWidget {
                 final updated = hand.markAsCorrected();
                 await manager.update(index, updated);
                 if (!context.mounted) return;
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      '+${updated.evLossRecovered!.toStringAsFixed(1)} EV восстановлено',
-                    ),
-                    action: SnackBarAction(
+                SnackbarUtil.showMessage(context, '+${updated.evLossRecovered!.toStringAsFixed(1)} EV восстановлено',, action: SnackBarAction(
                       label: 'История',
                       onPressed: () {
                         Navigator.push(
@@ -65,9 +61,7 @@ class MistakeDetailScreen extends StatelessWidget {
                               builder: (_) => const EVRecoveryHistoryScreen()),
                         );
                       },
-                    ),
-                  ),
-                );
+                    ));
               },
               icon: const Icon(Icons.check),
               label: const Text('Исправлено'),

--- a/lib/screens/mistake_repeat_screen.dart
+++ b/lib/screens/mistake_repeat_screen.dart
@@ -17,6 +17,7 @@ import '../services/mistake_streak_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
 import 'training_session_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class MistakeRepeatScreen extends StatefulWidget {
   const MistakeRepeatScreen({super.key});
@@ -108,15 +109,10 @@ class _MistakeRepeatScreenState extends State<MistakeRepeatScreen> {
     await file.writeAsBytes(bytes);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $fileName'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () => OpenFilex.open(file.path),
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -149,15 +145,10 @@ class _MistakeRepeatScreenState extends State<MistakeRepeatScreen> {
     await file.writeAsString(buffer.toString());
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $fileName'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () => OpenFilex.open(file.path),
-          ),
-        ),
-      );
+          ));
     }
   }
 

--- a/lib/screens/online_plugin_catalog_screen.dart
+++ b/lib/screens/online_plugin_catalog_screen.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import '../plugins/plugin_loader.dart';
 import '../plugins/plugin_manager.dart';
 import '../services/service_registry.dart';
+import '../utils/snackbar_util.dart';
 
 class OnlinePlugin {
   final String name;
@@ -67,7 +68,7 @@ class _OnlinePluginCatalogScreenState extends State<OnlinePluginCatalogScreen> {
     final manager = PluginManager();
     await PluginLoader().loadAll(registry, manager, context: context);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugins reloaded')));
+      SnackbarUtil.showMessage(context, 'Plugins reloaded');
     }
     await _load();
   }
@@ -76,17 +77,12 @@ class _OnlinePluginCatalogScreenState extends State<OnlinePluginCatalogScreen> {
     try {
       final downloaded = await PluginLoader().downloadFromUrl(p.url, checksum: p.checksum);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(downloaded ? 'Plugin installed' : 'Plugin up to date'),
-            action: SnackBarAction(label: 'Reload', onPressed: _reload),
-          ),
-        );
+        SnackbarUtil.showMessage(context, downloaded ? 'Plugin installed' : 'Plugin up to date', action: SnackBarAction(label: 'Reload', onPressed: _reload));
         await _load();
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Install failed: $e')));
+        SnackbarUtil.showMessage(context, 'Install failed: $e');
       }
     }
   }

--- a/lib/screens/pack_matrix_config_editor_screen.dart
+++ b/lib/screens/pack_matrix_config_editor_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../services/pack_matrix_config.dart';
 import '../theme/app_colors.dart';
+import '../utils/snackbar_util.dart';
 
 class PackMatrixConfigEditorScreen extends StatefulWidget {
   const PackMatrixConfigEditorScreen({super.key});
@@ -37,8 +38,7 @@ class _PackMatrixConfigEditorScreenState
   Future<void> _save() async {
     await const PackMatrixConfig().saveMatrix(_matrix);
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Сохранено')));
+    SnackbarUtil.showMessage(context, 'Сохранено');
   }
 
   void _reorderAudience(int oldIndex, int newIndex) {

--- a/lib/screens/pack_merge_duplicates_screen.dart
+++ b/lib/screens/pack_merge_duplicates_screen.dart
@@ -9,6 +9,7 @@ import '../services/yaml_pack_conflict_detector.dart';
 import '../services/yaml_pack_merge_engine.dart';
 import '../theme/app_colors.dart';
 import '../ui/tools/training_pack_yaml_previewer.dart';
+import '../utils/snackbar_util.dart';
 
 class PackMergeDuplicatesScreen extends StatefulWidget {
   const PackMergeDuplicatesScreen({super.key});
@@ -61,9 +62,7 @@ class _PackMergeDuplicatesScreenState extends State<PackMergeDuplicatesScreen> {
     if (ok != true) return;
     await compute(_saveTask, merged.toJson());
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Шаблон сохранён')),
-    );
+    SnackbarUtil.showMessage(context, 'Шаблон сохранён');
   }
 
   @override

--- a/lib/screens/pack_overview_screen.dart
+++ b/lib/screens/pack_overview_screen.dart
@@ -25,6 +25,7 @@ import '../models/v2/hand_data.dart';
 import '../models/v2/hero_position.dart';
 import '../services/pack_export_service.dart';
 import 'package:uuid/uuid.dart';
+import '../utils/snackbar_util.dart';
 
 class PackOverviewScreen extends StatefulWidget {
   const PackOverviewScreen({super.key});
@@ -149,17 +150,14 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
     final link = PackExportService.exportShareLink(tpl);
     await Clipboard.setData(ClipboardData(text: link));
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Link copied')));
+      SnackbarUtil.showMessage(context, 'Link copied');
     }
   }
 
   Future<void> _exportPack(TrainingPack pack) async {
     final file = await context.read<TrainingPackStorageService>().exportPack(pack);
     if (!mounted || file == null) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Файл сохранён: ${file.path}')),
-    );
+    SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path}');
   }
 
   Future<void> _renamePack(TrainingPack pack) async {
@@ -341,16 +339,15 @@ class _PackOverviewScreenState extends State<PackOverviewScreen> {
     if (confirm == true) {
       final result = await context.read<TrainingPackStorageService>().removePack(pack);
       if (result != null && mounted) {
-        final snack = SnackBar(
-          content: const Text('Пак удалён'),
+        SnackbarUtil.showMessage(
+          context,
+          'Пак удалён',
           action: SnackBarAction(
             label: 'Undo',
             onPressed: () =>
                 context.read<TrainingPackStorageService>().restorePack(result.\$1, result.\$2),
           ),
-          duration: const Duration(seconds: 5),
         );
-        ScaffoldMessenger.of(context).showSnackBar(snack);
       }
     }
   }

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -27,6 +27,7 @@ import 'training_session_screen.dart';
 import 'pack_preview_screen.dart';
 import '../widgets/combined_progress_bar.dart';
 import '../widgets/street_coverage_bar.dart';
+import '../utils/snackbar_util.dart';
 
 enum _StackRange { l8, b9_12, b13_20 }
 
@@ -377,8 +378,7 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
       ),
     );
     final l = AppLocalizations.of(context)!;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(l.packCreated(tpl.name))));
+    SnackbarUtil.showMessage(context, l.packCreated(tpl.name));
   }
 
   Future<void> _resetPack(TrainingPackTemplate pack) async {

--- a/lib/screens/plugin_manager_screen.dart
+++ b/lib/screens/plugin_manager_screen.dart
@@ -9,6 +9,7 @@ import 'package:poker_analyzer/plugins/plugin_loader.dart';
 import 'package:poker_analyzer/plugins/plugin_manager.dart';
 import '../services/service_registry.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class PluginManagerScreen extends StatefulWidget {
   const PluginManagerScreen({super.key});
@@ -84,7 +85,7 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
     final loader = PluginLoader();
     await loader.loadAll(registry, manager, context: context);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugins reloaded')));
+      SnackbarUtil.showMessage(context, 'Plugins reloaded');
     }
     await _load();
   }
@@ -96,7 +97,7 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
     if (await config.exists()) await config.delete();
     if (await cache.exists()) await cache.delete();
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugin config reset')));
+      SnackbarUtil.showMessage(context, 'Plugin config reset');
     }
     await _load();
   }
@@ -149,11 +150,11 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
       manager.load(plugin);
       manager.initializeAll(registry);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugin loaded')));
+        SnackbarUtil.showMessage(context, 'Plugin loaded');
       }
     } else {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Plugin failed')));
+        SnackbarUtil.showMessage(context, 'Plugin failed');
       }
     }
     await _load();
@@ -162,8 +163,7 @@ class _PluginManagerScreenState extends State<PluginManagerScreen> {
   Future<void> _delete(String file) async {
     await PluginLoader().delete(file);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Plugin deleted')));
+      SnackbarUtil.showMessage(context, 'Plugin deleted');
     }
     await _load();
   }

--- a/lib/screens/poker_table_demo_screen.dart
+++ b/lib/screens/poker_table_demo_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../widgets/poker_table_view.dart';
 import '../models/table_state.dart';
 import '../services/table_edit_history.dart';
+import '../utils/snackbar_util.dart';
 
 class PokerTableDemoScreen extends StatefulWidget {
   const PokerTableDemoScreen({super.key});
@@ -118,9 +119,7 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
     final jsonStr = jsonEncode(_state.toJson());
     await Clipboard.setData(ClipboardData(text: jsonStr));
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Table copied')),
-      );
+      SnackbarUtil.showMessage(context, 'Table copied');
     }
   }
 
@@ -133,18 +132,11 @@ class _PokerTableDemoScreenState extends State<PokerTableDemoScreen> {
       final state = TableState.fromJson(Map<String, dynamic>.from(json as Map));
       _applyState(state);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Table pasted')),
-        );
+        SnackbarUtil.showMessage(context, 'Table pasted');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            backgroundColor: Colors.red,
-            content: Text('Invalid JSON'),
-          ),
-        );
+        SnackbarUtil.showMessage(context, 'Invalid JSON');
       }
     }
   }

--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -21,6 +21,7 @@ import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
 import '../utils/responsive.dart';
 import 'mistake_review_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class ProgressDashboardScreen extends StatefulWidget {
   const ProgressDashboardScreen({super.key});
@@ -72,8 +73,7 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
     final file = File('${dir.path}/$fileName');
     await file.writeAsString(csvStr, encoding: utf8);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Файл сохранён: $fileName')));
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName');
     }
   }
 

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -38,6 +38,7 @@ import 'weekly_progress_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
 import '../widgets/xp_progress_card.dart';
+import '../utils/snackbar_util.dart';
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -808,7 +809,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Saved: $path')));
+    SnackbarUtil.showMessage(context, 'Saved: $path');
   }
 
   @override

--- a/lib/screens/reward_gallery_screen.dart
+++ b/lib/screens/reward_gallery_screen.dart
@@ -3,6 +3,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../services/reward_card_renderer_service.dart';
 import '../services/reward_gallery_group_by_track_service.dart';
+import '../utils/snackbar_util.dart';
 
 class RewardGalleryScreen extends StatefulWidget {
   static const route = '/rewards';
@@ -62,11 +63,7 @@ class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
                         final img = await renderer.exportImage(g.trackId);
                         nav.pop();
                         if (img.isEmpty) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                                content:
-                                    Text('Не удалось сгенерировать карточку')),
-                          );
+                          SnackbarUtil.showMessage(context, 'Не удалось сгенерировать карточку');
                           return;
                         }
                         await Share.shareXFiles(
@@ -76,10 +73,7 @@ class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
                         );
                       } catch (_) {
                         nav.pop();
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                              content: Text('Не удалось сгенерировать карточку')),
-                        );
+                        SnackbarUtil.showMessage(context, 'Не удалось сгенерировать карточку');
                       }
                     },
                   ),

--- a/lib/screens/saved_hand_editor_screen.dart
+++ b/lib/screens/saved_hand_editor_screen.dart
@@ -11,6 +11,7 @@ import '../services/evaluation_executor_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/card_picker_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class SavedHandEditorScreen extends StatefulWidget {
   final SavedHand hand;
@@ -144,12 +145,7 @@ class _SavedHandEditorScreenState extends State<SavedHandEditorScreen> {
       await context.read<SavedHandManagerService>().save(hand);
       final ev = spot.heroEv;
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content:
-                Text('Saved ${ev != null ? ev.toStringAsFixed(2) : '--'} BB'),
-          ),
-        );
+        SnackbarUtil.showMessage(context, 'Saved ${ev != null ? ev.toStringAsFixed(2) : '--'} BB');
       }
       if (mounted) Navigator.pop(context, hand);
     } else {

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/saved_hand_viewer_dialog.dart';
 import '../helpers/poker_street_helper.dart';
 import '../widgets/sync_status_widget.dart';
 import '../services/user_preferences_service.dart';
+import '../utils/snackbar_util.dart';
 
 class SavedHandsScreen extends StatefulWidget {
   final String? initialTag;
@@ -262,8 +263,7 @@ class _SavedHandsScreenState extends State<SavedHandsScreen> {
     await Share.shareXFiles([XFile(path)], text: 'saved_hands_archive.zip');
     if (context.mounted) {
       final name = path.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
     }
   }
 }

--- a/lib/screens/session_analysis_import_screen.dart
+++ b/lib/screens/session_analysis_import_screen.dart
@@ -31,6 +31,7 @@ import '../plugins/converter_registry.dart';
 import '../services/service_registry.dart';
 import 'v2/training_pack_play_screen.dart';
 import 'session_replay_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class SessionAnalysisImportScreen extends StatefulWidget {
   const SessionAnalysisImportScreen({super.key});
@@ -80,8 +81,7 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     if (plugin == null) {
       if (mounted) {
         setState(() => _loading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Unsupported format')));
+        SnackbarUtil.showMessage(context, 'Unsupported format');
       }
       return;
     }
@@ -251,8 +251,7 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     }
     await PackExportService.exportSessionCsv(list, evs, icms);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('CSV exported')));
+      SnackbarUtil.showMessage(context, 'CSV exported');
     }
   }
 
@@ -269,8 +268,7 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     }
     await PackExportService.exportSessionPdf(list, evs, icms);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('PDF exported')));
+      SnackbarUtil.showMessage(context, 'PDF exported');
     }
   }
 
@@ -278,8 +276,7 @@ class _SessionAnalysisImportScreenState extends State<SessionAnalysisImportScree
     if (_hands.isEmpty) return;
     await context.read<SavedHandManagerService>().addHands(_hands);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Hands saved')));
+      SnackbarUtil.showMessage(context, 'Hands saved');
     }
   }
 

--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -24,6 +24,7 @@ import 'package:uuid/uuid.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:share_plus/share_plus.dart';
 import 'training_session_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class SessionAnalysisScreen extends StatefulWidget {
   final List<SavedHand> hands;
@@ -251,12 +252,10 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
         ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
       if (!mounted) return;
       await PackExportService.exportSessionCsv(list, _evs, _icms);
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('CSV exported')));
+      SnackbarUtil.showMessage(context, 'CSV exported');
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Export failed: $e')));
+        SnackbarUtil.showMessage(context, 'Export failed: $e');
       }
     }
   }
@@ -267,12 +266,10 @@ class _SessionAnalysisScreenState extends State<SessionAnalysisScreen> {
         ..sort((a, b) => a.savedAt.compareTo(b.savedAt));
       if (!mounted) return;
       await PackExportService.exportSessionPdf(list, _evs, _icms);
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('PDF exported')));
+      SnackbarUtil.showMessage(context, 'PDF exported');
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Export failed: $e')));
+        SnackbarUtil.showMessage(context, 'Export failed: $e');
       }
     }
   }

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -16,6 +16,7 @@ import '../theme/app_colors.dart';
 import '../theme/constants.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class SessionHandsScreen extends StatefulWidget {
   final int sessionId;
@@ -175,9 +176,7 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
     if (path == null) return;
     await Share.shareXFiles([XFile(path)], text: 'session_${widget.sessionId}.md');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: session_${widget.sessionId}.md')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: session_${widget.sessionId}.md');
     }
   }
 
@@ -189,9 +188,7 @@ class _SessionHandsScreenState extends State<SessionHandsScreen> {
     if (path == null) return;
     await Share.shareXFiles([XFile(path)], text: 'session_${widget.sessionId}.pdf');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: session_${widget.sessionId}.pdf')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: session_${widget.sessionId}.pdf');
     }
   }
 

--- a/lib/screens/session_history_screen.dart
+++ b/lib/screens/session_history_screen.dart
@@ -11,6 +11,7 @@ import '../services/training_stats_service.dart';
 import 'session_analysis_screen.dart';
 import 'package:provider/provider.dart';
 import 'dart:io';
+import '../utils/snackbar_util.dart';
 
 class SessionHistoryScreen extends StatefulWidget {
   const SessionHistoryScreen({super.key});
@@ -132,8 +133,7 @@ class _SessionHistoryScreenState extends State<SessionHistoryScreen> {
     final path = await notes.exportAsPdf(stats);
     if (path == null || !mounted) return;
     final name = path.split(Platform.pathSeparator).last;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+    SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
   }
 
   @override

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -24,6 +24,7 @@ import 'saved_hands_screen.dart';
 import 'mistake_overview_screen.dart';
 import 'accuracy_mistake_overview_screen.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class SessionStatsScreen extends StatefulWidget {
   const SessionStatsScreen({super.key});
@@ -636,9 +637,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     await file.writeAsString(buffer.toString());
     await Share.shareXFiles([XFile(file.path)], text: 'session_stats.md');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: session_stats.md')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: session_stats.md');
     }
   }
 
@@ -732,9 +731,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     await file.writeAsBytes(bytes);
     await Share.shareXFiles([XFile(file.path)], text: 'session_stats.pdf');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Файл сохранён: session_stats.pdf')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: session_stats.pdf');
     }
   }
 
@@ -746,8 +743,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     await Share.shareXFiles([XFile(path)], text: 'training_summary.csv');
     if (context.mounted) {
       final name = path.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
     }
   }
 
@@ -759,9 +755,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     final file = await service.exportEvIcmCsv(hands);
     await Share.shareXFiles([XFile(file.path)], text: file.path.split('/').last);
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
@@ -773,9 +767,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
     final file = await service.exportEvIcmPdf(hands);
     await Share.shareXFiles([XFile(file.path)], text: file.path.split('/').last);
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/sync_status_widget.dart';
 import 'notification_settings_screen.dart';
 import 'goal_overview_screen.dart';
 import 'weakness_overview_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class SettingsPlaceholderScreen extends StatelessWidget {
   const SettingsPlaceholderScreen({super.key});
@@ -51,13 +52,10 @@ class SettingsPlaceholderScreen extends StatelessWidget {
         mimeType: MimeType.csv,
       );
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: $name.csv')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $name.csv');
     } catch (_) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+      SnackbarUtil.showMessage(context, 'Ошибка экспорта CSV');
     }
   }
 
@@ -68,8 +66,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
     await Share.shareXFiles([XFile(path)], text: 'saved_hands_archive.zip');
     if (!context.mounted) return;
     final name = path.split(Platform.pathSeparator).last;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+    SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
   }
 
   Future<void> _exportSummary(BuildContext context) async {
@@ -78,8 +75,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
     final path = await manager.exportAllSessionsPdf(notes);
     if (path == null || !context.mounted) return;
     final name = path.split(Platform.pathSeparator).last;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+    SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
   }
 
   Future<void> _exportSummaryCsv(BuildContext context) async {
@@ -90,8 +86,7 @@ class SettingsPlaceholderScreen extends StatelessWidget {
     await Share.shareXFiles([XFile(path)], text: 'training_summary.csv');
     if (!context.mounted) return;
     final name = path.split(Platform.pathSeparator).last;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Файл сохранён: $name')));
+    SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
   }
 
   @override

--- a/lib/screens/shop_screen.dart
+++ b/lib/screens/shop_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/coins_service.dart';
 import '../shop/shop_items.dart';
 import '../shop/shop_item.dart';
+import '../utils/snackbar_util.dart';
 
 class ShopScreen extends StatelessWidget {
   const ShopScreen({super.key});
@@ -11,18 +12,14 @@ class ShopScreen extends StatelessWidget {
   Future<void> _buy(BuildContext context, ShopItem item) async {
     final coins = context.read<CoinsService>();
     if (coins.coins < item.price) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Недостаточно монет')),
-      );
+      SnackbarUtil.showMessage(context, 'Недостаточно монет');
       return;
     }
     final ok = await coins.spendCoins(item.price);
     if (!ok) return;
     await item.onPurchase(context);
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Куплено: ${item.name}')),
-      );
+      SnackbarUtil.showMessage(context, 'Куплено: ${item.name}');
     }
   }
 

--- a/lib/screens/smart_path_preview_screen.dart
+++ b/lib/screens/smart_path_preview_screen.dart
@@ -5,6 +5,7 @@ import '../models/learning_path_stage_model.dart';
 import '../models/stage_type.dart';
 import '../services/theory_pack_library_service.dart';
 import '../ui/tools/theory_pack_quick_view.dart';
+import '../utils/snackbar_util.dart';
 
 /// Lightweight preview showing key details of a learning path.
 class SmartPathPreviewScreen extends StatelessWidget {
@@ -93,9 +94,7 @@ class SmartPathPreviewScreen extends StatelessWidget {
         if (pack != null) {
           await TheoryPackQuickView.launch(context, pack);
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Pack not found: ${stage.packId}')),
-          );
+          SnackbarUtil.showMessage(context, 'Pack not found: ${stage.packId}');
         }
       },
     );

--- a/lib/screens/snapshot_diff_screen.dart
+++ b/lib/screens/snapshot_diff_screen.dart
@@ -7,6 +7,7 @@ import '../models/training_pack.dart';
 import '../models/saved_hand.dart';
 import '../services/training_pack_storage_service.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
+import '../utils/snackbar_util.dart';
 
 class SnapshotDiffScreen extends StatefulWidget {
   final TrainingPack pack;
@@ -104,11 +105,7 @@ class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
       _changed = true;
       _compute();
     });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content:
-            Text('Restored ${add.length + rem.length + mod.length} changes'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Restored ${add.length + rem.length + mod.length} changes', action: SnackBarAction(
           label: 'Undo',
           onPressed: () {
             service.applyDiff(
@@ -123,9 +120,7 @@ class _SnapshotDiffScreenState extends State<SnapshotDiffScreen>
               _compute();
             });
           },
-        ),
-      ),
-    );
+        ));
   }
 
   @override

--- a/lib/screens/snapshot_manager_screen.dart
+++ b/lib/screens/snapshot_manager_screen.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/training_pack.dart';
 import '../services/training_pack_storage_service.dart';
 import 'snapshot_diff_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class SnapshotManagerScreen extends StatefulWidget {
   final TrainingPack pack;
@@ -60,9 +61,7 @@ class _SnapshotManagerScreenState extends State<SnapshotManagerScreen> {
                 final last =
                     prefs.getString('pack_editor_last_snapshot_restored');
                 if (last == s.id) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Already restored')),
-                  );
+                  SnackbarUtil.showMessage(context, 'Already restored');
                   return false;
                 }
                 final ok = await showDialog<bool>(
@@ -89,10 +88,7 @@ class _SnapshotManagerScreenState extends State<SnapshotManagerScreen> {
                     .read<TrainingPackStorageService>()
                     .deleteSnapshot(widget.pack, s);
                 if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: const Text('Snapshot deleted'),
-                      action: SnackBarAction(
+                  SnackbarUtil.showMessage(context, 'Snapshot deleted', action: SnackBarAction(
                         label: 'Undo',
                         onPressed: () {
                           context
@@ -103,9 +99,7 @@ class _SnapshotManagerScreenState extends State<SnapshotManagerScreen> {
                                   removed.tags,
                                   removed.comment);
                         },
-                      ),
-                    ),
-                  );
+                      ));
                 }
                 return false;
               }

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -32,6 +32,7 @@ enum _ChartMode { daily, weekly }
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 /// Displays a list of tags sorted by mistake count.
 ///
@@ -327,8 +328,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
           h
     ];
     if (hands.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Нет ошибок в этот день')));
+      SnackbarUtil.showMessage(context, 'Нет ошибок в этот день');
       return;
     }
     Navigator.push(

--- a/lib/screens/tools/spot_duplication_wizard.dart
+++ b/lib/screens/tools/spot_duplication_wizard.dart
@@ -12,6 +12,7 @@ import '../../models/v2/hand_data.dart';
 import '../../models/v2/training_pack_spot.dart';
 import '../../models/v2/training_pack_template_v2.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/snackbar_util.dart';
 
 class SpotDuplicationWizard extends StatefulWidget {
   const SpotDuplicationWizard({super.key});
@@ -46,9 +47,7 @@ class _SpotDuplicationWizardState extends State<SpotDuplicationWizard> {
           ..addEntries(pack.spots.map((e) => MapEntry(e.id, false)));
       });
     } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Ошибка чтения файла')),
-      );
+      SnackbarUtil.showMessage(context, 'Ошибка чтения файла');
     }
   }
 
@@ -147,8 +146,7 @@ class _SpotDuplicationWizardState extends State<SpotDuplicationWizard> {
     if (path == null) return;
     await const YamlWriter().write(dup.toJson(), path);
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Файл сохранён')));
+    SnackbarUtil.showMessage(context, 'Файл сохранён');
   }
 
   @override

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -34,6 +34,7 @@ import '../widgets/sync_status_widget.dart';
 import 'training_history/average_accuracy_summary.dart';
 import 'training_history/filter_summary.dart';
 import 'training_history/streak_summary.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   final TutorialFlow? tutorial;
@@ -242,16 +243,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
         mimeType: MimeType.other,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content:
-                  Text('Экспортировано ${sessions.length} сессий в MD')),
-        );
+        SnackbarUtil.showMessage(context, 'Экспортировано ${sessions.length} сессий в MD');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта MD')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта MD');
       }
     }
   }
@@ -304,16 +300,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
         mimeType: MimeType.other,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content:
-                  Text('Экспортировано ${sessions.length} сессий в HTML')),
-        );
+        SnackbarUtil.showMessage(context, 'Экспортировано ${sessions.length} сессий в HTML');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта HTML')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта HTML');
       }
     }
   }
@@ -361,15 +352,11 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
         mimeType: MimeType.other,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Экспортировано ${sessions.length} сессий в JSON')),
-        );
+        SnackbarUtil.showMessage(context, 'Экспортировано ${sessions.length} сессий в JSON');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(
-                const SnackBar(content: Text('Ошибка экспорта JSON')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта JSON');
       }
     }
   }
@@ -397,10 +384,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     );
     _lastCsvPath = file.path;
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-            content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
@@ -421,9 +405,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     }
     await Clipboard.setData(ClipboardData(text: lines.join('\\n')));
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Скопировано ${sessions.length} сессий')),
-      );
+      SnackbarUtil.showMessage(context, 'Скопировано ${sessions.length} сессий');
     }
   }
 
@@ -436,10 +418,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final file = await _exportService.exportVisibleCsv(sessions);
     _lastCsvPath = file.path;
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-            content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
@@ -458,10 +437,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     );
     _lastPdfPath = file.path;
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-            content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
@@ -471,9 +447,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final file = await service.exportCsv(weekly: weekly);
     _lastCsvPath = file.path;
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
@@ -483,18 +457,14 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final file = await service.exportPdf(weekly: weekly);
     _lastPdfPath = file.path;
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
     }
   }
 
   Future<void> _shareLatestExport() async {
     if (_lastCsvPath == null && _lastPdfPath == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Нет экспортированных файлов')),
-        );
+        SnackbarUtil.showMessage(context, 'Нет экспортированных файлов');
       }
       return;
     }
@@ -529,9 +499,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final file = File(selectedPath);
     if (!await file.exists()) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Файл не найден')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл не найден');
       }
       return;
     }
@@ -542,9 +510,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   Future<void> _openLatestExport() async {
     if (_lastCsvPath == null && _lastPdfPath == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Нет экспортированных файлов')),
-        );
+        SnackbarUtil.showMessage(context, 'Нет экспортированных файлов');
       }
       return;
     }
@@ -579,9 +545,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
     final file = File(selectedPath);
     if (!await file.exists()) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Файл не найден')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл не найден');
       }
       return;
     }
@@ -592,9 +556,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   Future<void> _deleteLatestExports() async {
     if (_lastCsvPath == null && _lastPdfPath == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Нет экспортированных файлов')),
-        );
+        SnackbarUtil.showMessage(context, 'Нет экспортированных файлов');
       }
       return;
     }
@@ -628,12 +590,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       _lastPdfPath = null;
     });
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content:
-              Text(deleted ? 'Файлы удалены' : 'Файлы не найдены'),
-        ),
-      );
+      SnackbarUtil.showMessage(context, deleted ? 'Файлы удалены' : 'Файлы не найдены');
     }
   }
 
@@ -650,9 +607,7 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       final content = await file.readAsString();
       final data = jsonDecode(content);
       if (data is! List) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Invalid file format')),
-        );
+        SnackbarUtil.showMessage(context, 'Invalid file format');
         return;
       }
       final List<TrainingSession> sessions = [];
@@ -665,22 +620,16 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
         }
       }
       if (sessions.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Invalid file format')),
-        );
+        SnackbarUtil.showMessage(context, 'Invalid file format');
         return;
       }
       setState(() {
         _history.addAll([for (final s in sessions) s.toTrainingResult()]);
       });
       await _saveHistory();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Imported ${sessions.length} sessions')),
-      );
+      SnackbarUtil.showMessage(context, 'Imported ${sessions.length} sessions');
     } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Invalid file format')),
-      );
+      SnackbarUtil.showMessage(context, 'Invalid file format');
     }
   }
 

--- a/lib/screens/training_pack_comparison_screen.dart
+++ b/lib/screens/training_pack_comparison_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/color_picker_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 import 'training_pack_comparison/pack_comparison_filters.dart';
 import 'training_pack_comparison/pack_completion_bar_chart.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingPackComparisonScreen extends StatefulWidget {
   const TrainingPackComparisonScreen({super.key});
@@ -327,16 +328,15 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
   }
 
   void _showUndoDelete(TrainingPack pack, int index) {
-    final snack = SnackBar(
-      content: const Text('Пакет удалён'),
+    SnackbarUtil.showMessage(
+      context,
+      'Пакет удалён',
       action: SnackBarAction(
         label: 'Отмена',
         onPressed: () =>
             context.read<TrainingPackStorageService>().restorePack(pack, index),
       ),
-      duration: const Duration(seconds: 5),
     );
-    ScaffoldMessenger.of(context).showSnackBar(snack);
   }
 
   Future<void> _showRowMenu(TrainingPackStats s) async {
@@ -470,14 +470,11 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
     try {
       await Share.shareXFiles([XFile(file.path)], text: name);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('CSV экспортирован')),
-        );
+        SnackbarUtil.showMessage(context, 'CSV экспортирован');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта CSV');
       }
     }
   }
@@ -518,13 +515,11 @@ class _TrainingPackComparisonScreenState extends State<TrainingPackComparisonScr
     try {
       await Share.shareXFiles([XFile(file.path)], text: name);
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Markdown экспортирован')));
+        SnackbarUtil.showMessage(context, 'Markdown экспортирован');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта Markdown')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта Markdown');
       }
     }
   }

--- a/lib/screens/training_pack_overlay.dart
+++ b/lib/screens/training_pack_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../models/training_pack.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingPackOverlay extends StatelessWidget {
   final TrainingPack pack;
@@ -18,8 +19,7 @@ class TrainingPackOverlay extends StatelessWidget {
 
   Future<void> _export(BuildContext context) async {
     // Export functionality is not yet implemented; show a placeholder message.
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Export is unavailable')));
+    SnackbarUtil.showMessage(context, 'Export is unavailable');
   }
 
   Future<void> _share(BuildContext context) async {
@@ -28,8 +28,7 @@ class TrainingPackOverlay extends StatelessWidget {
 
   Future<void> _print(BuildContext context) async {
     // Printing is currently unsupported; notify the user.
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Print is unavailable')));
+    SnackbarUtil.showMessage(context, 'Print is unavailable');
   }
 
   @override

--- a/lib/screens/training_pack_preset_list_screen.dart
+++ b/lib/screens/training_pack_preset_list_screen.dart
@@ -10,6 +10,7 @@ import '../services/pack_generator_service.dart';
 import '../repositories/training_pack_preset_repository.dart';
 import '../models/training_pack_template_model.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingPackPresetListScreen extends StatefulWidget {
   const TrainingPackPresetListScreen({super.key});
@@ -56,9 +57,7 @@ class _TrainingPackPresetListScreenState extends State<TrainingPackPresetListScr
       await service.add(model);
     }
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(exists ? 'Пак обновлён' : 'Пак создан')),
-    );
+    SnackbarUtil.showMessage(context, exists ? 'Пак обновлён' : 'Пак создан');
   }
 
   Future<void> _generateAll() async {
@@ -126,9 +125,7 @@ class _TrainingPackPresetListScreenState extends State<TrainingPackPresetListScr
       },
     );
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Generated $done of $total packs')),
-    );
+    SnackbarUtil.showMessage(context, 'Generated $done of $total packs');
   }
 
   Future<void> _import() async {
@@ -159,9 +156,7 @@ class _TrainingPackPresetListScreenState extends State<TrainingPackPresetListScr
     }
     if (!mounted) return;
     if (ok) setState(() => _presets.addAll(list));
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(ok ? 'Импортировано ${list.length}' : '⚠️ Ошибка импорта')),
-    );
+    SnackbarUtil.showMessage(context, ok ? 'Импортировано ${list.length}' : '⚠️ Ошибка импорта');
   }
 
   @override

--- a/lib/screens/training_pack_review_screen.dart
+++ b/lib/screens/training_pack_review_screen.dart
@@ -23,6 +23,7 @@ import '../services/training_pack_template_storage_service.dart';
 import 'training_pack_template_editor_screen.dart';
 import 'package:uuid/uuid.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 /// Displays all spots from [pack] with option to show only mistaken ones.
 class TrainingPackReviewScreen extends StatefulWidget {
@@ -258,9 +259,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
     final markdown = _generateMarkdown();
     await Clipboard.setData(ClipboardData(text: markdown));
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Markdown copied to clipboard')),
-      );
+      SnackbarUtil.showMessage(context, 'Markdown copied to clipboard');
     }
   }
 
@@ -294,15 +293,10 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
     final file = File('${dir.path}/$fileName');
     await file.writeAsString(markdown);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $fileName'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () => OpenFilex.open(file.path),
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -354,17 +348,12 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
     await file.writeAsBytes(bytes);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Файл сохранён: $fileName'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName', action: SnackBarAction(
             label: 'Открыть',
             onPressed: () {
               OpenFilex.open(file.path);
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -403,8 +392,7 @@ class _TrainingPackReviewScreenState extends State<TrainingPackReviewScreen> {
     );
     if (model != null && mounted) {
       await context.read<TrainingPackTemplateStorageService>().add(model);
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Шаблон сохранён')));
+      SnackbarUtil.showMessage(context, 'Шаблон сохранён');
     }
   }
 

--- a/lib/screens/training_pack_template_editor_screen.dart
+++ b/lib/screens/training_pack_template_editor_screen.dart
@@ -13,6 +13,7 @@ import '../models/training_pack_template_model.dart';
 import '../models/training_pack_template.dart';
 import '../widgets/sync_status_widget.dart';
 import '../services/training_pack_template_storage_service.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingPackTemplateEditorScreen extends StatefulWidget {
   final TrainingPackTemplateModel? initial;
@@ -84,21 +85,18 @@ class _TrainingPackTemplateEditorScreenState
           throw const FormatException();
         }
       } catch (_) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Некорректный JSON фильтров')));
+        SnackbarUtil.showMessage(context, 'Некорректный JSON фильтров');
         return;
       }
     }
     final streets = filters['streets'];
     if (streets is! List || streets.isEmpty || streets.any((e) => e is! String)) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Некорректный список улиц')));
+      SnackbarUtil.showMessage(context, 'Некорректный список улиц');
       return;
     }
     for (final s in streets) {
       if (!_validStreets.contains(s)) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Улица "$s" не поддерживается')));
+        SnackbarUtil.showMessage(context, 'Улица "$s" не поддерживается');
         return;
       }
     }
@@ -169,29 +167,25 @@ class _TrainingPackTemplateEditorScreenState
       final error = service.validateTemplateJson(Map<String, dynamic>.from(map));
       if (error != null) {
         if (mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text(error)));
+          SnackbarUtil.showMessage(context, error);
         }
         return;
       }
       final template = TrainingPackTemplate.fromMap(map);
       if (service.templates.any((t) => t.id == template.id)) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Такой шаблон уже есть')));
+          SnackbarUtil.showMessage(context, 'Такой шаблон уже есть');
         }
         return;
       }
       service.addTemplate(template);
       await service.saveAll();
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Шаблон импортирован')));
+        SnackbarUtil.showMessage(context, 'Шаблон импортирован');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка импорта файла')));
+        SnackbarUtil.showMessage(context, 'Ошибка импорта файла');
       }
     }
   }

--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -20,6 +20,7 @@ import '../services/theme_service.dart';
 import '../services/training_pack_service.dart';
 import '../services/training_session_service.dart';
 import 'training_session_screen.dart';
+import '../utils/snackbar_util.dart';
 
 enum _SortOption { name, category, difficulty, createdAt }
 
@@ -199,15 +200,11 @@ class _TrainingPackTemplateListScreenState
         jsonEncode([for (final t in service.templates) t.toJson()]),
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Файл экспортирован в Загрузки')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл экспортирован в Загрузки');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('⚠️ Ошибка экспорта')),
-        );
+        SnackbarUtil.showMessage(context, '⚠️ Ошибка экспорта');
       }
     }
   }
@@ -242,11 +239,7 @@ class _TrainingPackTemplateListScreenState
       ok = false;
     }
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(ok ? 'Шаблоны импортированы' : '⚠️ Ошибка импорта'),
-      ),
-    );
+    SnackbarUtil.showMessage(context, ok ? 'Шаблоны импортированы' : '⚠️ Ошибка импорта');
   }
 
   void _toggleSelection(String id) {
@@ -271,14 +264,11 @@ class _TrainingPackTemplateListScreenState
       final file = File('${dir.path}/selected_templates.json');
       await file.writeAsString(jsonEncode(list));
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Файл экспортирован')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл экспортирован');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('⚠️ Ошибка экспорта')));
+        SnackbarUtil.showMessage(context, '⚠️ Ошибка экспорта');
       }
     }
   }
@@ -319,13 +309,11 @@ class _TrainingPackTemplateListScreenState
       final file = File('${dir.path}/pack_template_${t.id}.json');
       await file.writeAsString(jsonEncode(t.toJson()));
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Файл сохранён')));
+        SnackbarUtil.showMessage(context, 'Файл сохранён');
       }
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('⚠️ Ошибка экспорта')));
+        SnackbarUtil.showMessage(context, '⚠️ Ошибка экспорта');
       }
     }
   }
@@ -339,9 +327,7 @@ class _TrainingPackTemplateListScreenState
       if (await file.exists()) await file.delete();
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('⚠️ Не удалось поделиться')),
-        );
+        SnackbarUtil.showMessage(context, '⚠️ Не удалось поделиться');
       }
     }
   }
@@ -411,9 +397,7 @@ class _TrainingPackTemplateListScreenState
     if (confirm != true) return;
     await context.read<TrainingPackTemplateStorageService>().clear();
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Все шаблоны удалены')),
-    );
+    SnackbarUtil.showMessage(context, 'Все шаблоны удалены');
   }
 
   void _toggleAll(List<String> categories) {
@@ -853,8 +837,7 @@ class _TrainingPackTemplateListScreenState
                                     : (t.evCovered * 100 / total).round();
                                 final text =
                                     'EV calculated for $pct% of spots';
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(SnackBar(content: Text(text)));
+                                SnackbarUtil.showMessage(context, text);
                               },
                             ),
                             IconButton(
@@ -899,10 +882,7 @@ class _TrainingPackTemplateListScreenState
                                         ..clear()
                                         ..addAll(t.filters);
                                       _spotStorage.notifyListeners();
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(const SnackBar(
-                                              content:
-                                                  Text('Шаблон применён')));
+                                      SnackbarUtil.showMessage(context, 'Шаблон применён');
                                       break;
                                     case 'export':
                                       if (!t.isDraft) await _exportTemplate(t);

--- a/lib/screens/training_packs_screen.dart
+++ b/lib/screens/training_packs_screen.dart
@@ -29,6 +29,7 @@ import 'training_session_screen.dart';
 import '../models/saved_hand.dart';
 import 'top_packs_screen.dart';
 import 'popular_now_screen.dart';
+import '../utils/snackbar_util.dart';
 
 enum _PackSort { recommended, newest, hardest }
 
@@ -65,9 +66,7 @@ class _TrainingPacksScreenState extends State<TrainingPacksScreen> {
     final service = context.read<TrainingPackStorageService>();
     final msg = await service.importPackFromFile();
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(msg ?? 'Пак импортирован')),
-    );
+    SnackbarUtil.showMessage(context, msg ?? 'Пак импортирован');
   }
 
   void _openHistory() {

--- a/lib/screens/training_progress_analytics_screen.dart
+++ b/lib/screens/training_progress_analytics_screen.dart
@@ -8,6 +8,7 @@ import '../services/progress_forecast_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
 import '../utils/responsive.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingProgressAnalyticsScreen extends StatelessWidget {
   static const route = '/training/analytics';
@@ -16,9 +17,7 @@ class TrainingProgressAnalyticsScreen extends StatelessWidget {
   Future<void> _exportCsv(BuildContext context) async {
     final file = await context.read<ProgressForecastService>().exportForecastCsv();
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Файл сохранён: ${file.path.split('/').last}')),
-    );
+    SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path.split('/').last}');
   }
 
   Widget _chart(List<MapEntry<DateTime, int>> data, Color color) {

--- a/lib/screens/training_screen.dart
+++ b/lib/screens/training_screen.dart
@@ -15,6 +15,7 @@ import '../widgets/sync_status_widget.dart';
 import '../helpers/training_pack_storage.dart';
 import '../helpers/pack_spot_utils.dart';
 import 'package:collection/collection.dart';
+import '../utils/snackbar_util.dart';
 
 /// Simple screen that shows a single [TrainingSpot].
 class TrainingScreen extends StatefulWidget {
@@ -97,12 +98,7 @@ class _TrainingScreenState extends State<TrainingScreen> {
       }
     });
     ScaffoldMessenger.of(context).clearSnackBars();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-            isCorrect ? '✅ Correct!' : '❌ Correct was $expected'),
-      ),
-    );
+    SnackbarUtil.showMessage(context, isCorrect ? '✅ Correct!' : '❌ Correct was $expected');
     Future.delayed(const Duration(seconds: 1), () {
       if (!mounted) return;
       _next();

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -54,6 +54,7 @@ import '../services/booster_auto_retry_suggester.dart';
 import '../services/mistake_booster_progress_tracker.dart';
 import '../services/training_progress_logger.dart';
 import 'training_session_completion_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -301,9 +302,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
       final isBooster = tpl.meta['type']?.toString().toLowerCase() == 'booster';
       if (isBooster && _boosterRecapShown) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Booster recap already shown')),
-          );
+          SnackbarUtil.showMessage(context, 'Booster recap already shown');
         }
         return;
       }
@@ -366,13 +365,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
         for (final id in newly) {
           final pack = lib.firstWhereOrNull((p) => p.id == id);
           if (pack != null) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                  '\uD83D\uDD13 Новый пак разблокирован: ${pack.name}',
-                ),
-              ),
-            );
+            SnackbarUtil.showMessage(context, '\uD83D\uDD13 Новый пак разблокирован: ${pack.name}',);
           }
         }
       }

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -46,6 +46,7 @@ import '../widgets/confetti_overlay.dart';
 import '../services/overlay_booster_manager.dart';
 import '../widgets/decay_recall_stats_card.dart';
 import '../services/decay_session_tag_impact_recorder.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -184,11 +185,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
     }
     await prefs.setString(key, DateTime.now().toIso8601String());
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-              'Want to improve your ${rec.position.label}? Try ${_weakPack!.name}.'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Want to improve your ${rec.position.label}? Try ${_weakPack!.name}.', action: SnackBarAction(
             label: 'Train',
             onPressed: () async {
               await context.read<TrainingSessionService>().startSession(_weakPack!, persist: false);
@@ -198,10 +195,7 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
                 MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
               );
             },
-          ),
-          duration: const Duration(seconds: 6),
-        ),
-      );
+          ));
     });
   }
 

--- a/lib/screens/training_spot_builder_screen.dart
+++ b/lib/screens/training_spot_builder_screen.dart
@@ -11,6 +11,7 @@ import '../services/template_storage_service.dart';
 import '../widgets/board_cards_widget.dart';
 import '../widgets/template_selection_dialog.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingSpotBuilderScreen extends StatefulWidget {
   const TrainingSpotBuilderScreen({super.key});
@@ -140,8 +141,7 @@ class _TrainingSpotBuilderScreenState extends State<TrainingSpotBuilderScreen> {
   Future<void> _save() async {
     final name = _nameController.text.trim();
     if (name.isEmpty) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Введите название')));
+      SnackbarUtil.showMessage(context, 'Введите название');
       return;
     }
     final stacks = [
@@ -170,9 +170,7 @@ class _TrainingSpotBuilderScreenState extends State<TrainingSpotBuilderScreen> {
     );
     await _storage.addSpot(spot);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Spot saved')),
-    );
+    SnackbarUtil.showMessage(context, 'Spot saved');
     Navigator.pop(context, true);
   }
 

--- a/lib/screens/training_spot_library_screen.dart
+++ b/lib/screens/training_spot_library_screen.dart
@@ -13,6 +13,7 @@ import 'training_pack_template_editor_screen.dart';
 import 'training_spot_builder_screen.dart';
 import 'package:uuid/uuid.dart';
 import '../widgets/sync_status_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingSpotLibraryScreen extends StatefulWidget {
   const TrainingSpotLibraryScreen({super.key});
@@ -224,8 +225,7 @@ class _TrainingSpotLibraryScreenState extends State<TrainingSpotLibraryScreen> {
                 final service = context.read<TrainingSpotStorageService>();
                 service.activeFilters.clear();
                 service.notifyListeners();
-                ScaffoldMessenger.of(context)
-                    .showSnackBar(const SnackBar(content: Text('Фильтр сброшен')));
+                SnackbarUtil.showMessage(context, 'Фильтр сброшен');
               },
             ),
         ],

--- a/lib/screens/v2/hand_editor_screen.dart
+++ b/lib/screens/v2/hand_editor_screen.dart
@@ -4,6 +4,7 @@ import '../../models/v2/training_pack_spot.dart';
 import 'hand_editor_controller.dart';
 import 'hand_editor_form.dart';
 import 'hand_editor_service.dart';
+import '../../utils/snackbar_util.dart';
 
 class HandEditorScreen extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -33,8 +34,7 @@ class _HandEditorScreenState extends State<HandEditorScreen> {
     _controller.update();
     final err = _controller.validate();
     if (err != null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(err)));
+      SnackbarUtil.showMessage(context, err);
       return;
     }
     widget.spot.editedAt = DateTime.now();

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -52,6 +52,7 @@ import '../../models/v2/training_pack_template_v2.dart';
 import '../../services/training_session_launcher.dart';
 import '../../services/pinned_learning_service.dart';
 import 'training_pack_play_core.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackPlayScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -489,9 +490,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen>
         .read<MistakeReviewPackService>()
         .addSpot(widget.original, _spots[_index]);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Сохранено в Повторы ошибок')),
-      );
+      SnackbarUtil.showMessage(context, 'Сохранено в Повторы ошибок');
     }
   }
 
@@ -508,9 +507,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen>
       for (final id in newly) {
         final pack = lib.firstWhereOrNull((p) => p.id == id);
         if (pack != null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('\uD83D\uDD13 Новый пак разблокирован: ${pack.name}')),
-          );
+          SnackbarUtil.showMessage(context, '\uD83D\uDD13 Новый пак разблокирован: ${pack.name}');
         }
       }
     }
@@ -732,9 +729,7 @@ class _TrainingPackPlayScreenState extends State<TrainingPackPlayScreen>
             .read<MistakeReviewPackService>()
             .addSpot(widget.original, spot);
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Сохранено в Повторы ошибок')),
-          );
+          SnackbarUtil.showMessage(context, 'Сохранено в Повторы ошибок');
         }
       }
       if (_autoAdvance && !incorrect) {

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -39,6 +39,7 @@ import '../../services/user_preferences_service.dart';
 import 'package:provider/provider.dart';
 import '../../services/pinned_learning_service.dart';
 import 'training_pack_play_core.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackPlayScreenV2 extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -579,9 +580,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2>
         .read<MistakeReviewPackService>()
         .addSpot(widget.original, _spots[_index]);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Сохранено в Повторы ошибок')),
-      );
+      SnackbarUtil.showMessage(context, 'Сохранено в Повторы ошибок');
     }
   }
 
@@ -746,9 +745,7 @@ class _TrainingPackPlayScreenV2State extends State<TrainingPackPlayScreenV2>
             .read<MistakeReviewPackService>()
             .addSpot(widget.original, spot);
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Сохранено в Повторы ошибок')),
-          );
+          SnackbarUtil.showMessage(context, 'Сохранено в Повторы ошибок');
         }
       }
       if (_autoAdvance && !incorrect) {

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -25,6 +25,7 @@ import '../training_session_screen.dart';
 import '../../services/booster_recap_hook.dart';
 import '../../services/training_session_service.dart';
 import '../../services/pack_library_completion_service.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackResultScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -566,10 +567,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
       }
     }
     await prefs.setString(key, DateTime.now().toIso8601String());
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Want to improve your ${rec.position.label}? Try ${tpl.name}.'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Want to improve your ${rec.position.label}? Try ${tpl.name}.', action: SnackBarAction(
           label: 'Train',
           onPressed: () async {
             await context.read<TrainingSessionService>().startSession(tpl, persist: false);
@@ -579,10 +577,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
               MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
             );
           },
-        ),
-        duration: const Duration(seconds: 6),
-      ),
-    );
+        ));
   }
 
 }

--- a/lib/screens/v2/training_pack_result_screen_v2.dart
+++ b/lib/screens/v2/training_pack_result_screen_v2.dart
@@ -23,6 +23,7 @@ import '../training_session_screen.dart';
 import '../../services/auto_mistake_tagger_engine.dart';
 import '../../models/training_spot_attempt.dart';
 import '../../models/mistake_tag.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackResultScreenV2 extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -92,11 +93,7 @@ class _TrainingPackResultScreenV2State extends State<TrainingPackResultScreenV2>
       }
     }
     await prefs.setString(key, DateTime.now().toIso8601String());
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-            'Want to improve your ${rec.position.label}? Try ${tpl.name}.'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Want to improve your ${rec.position.label}? Try ${tpl.name}.', action: SnackBarAction(
           label: 'Train',
           onPressed: () async {
             await context.read<TrainingSessionService>().startSession(tpl, persist: false);
@@ -106,10 +103,7 @@ class _TrainingPackResultScreenV2State extends State<TrainingPackResultScreenV2>
               MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
             );
           },
-        ),
-        duration: const Duration(seconds: 6),
-      ),
-    );
+        ));
   }
 
   String? _expected(TrainingPackSpot s) {

--- a/lib/screens/v2/training_pack_spot_editor_screen.dart
+++ b/lib/screens/v2/training_pack_spot_editor_screen.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import '../../services/evaluation_executor_service.dart';
 import '../../services/template_storage_service.dart';
 import '../../core/training/engine/training_type_engine.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackSpotEditorScreen extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -256,7 +257,7 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
     widget.spot.title = normalized;
     _titleCtr.text = normalized;
     if (widget.spot.title.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Title is required')));
+      SnackbarUtil.showMessage(context, 'Title is required');
       return;
     }
     widget.spot.editedAt = DateTime.now();
@@ -279,12 +280,9 @@ class _TrainingPackSpotEditorScreenState extends State<TrainingPackSpotEditorScr
       final res = await context.read<EvaluationExecutorService>().evaluate(widget.spot);
       setState(() => widget.spot.evalResult = res);
       final ev = (res.expectedEquity * 100).toStringAsFixed(1);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('EV $ev% ${res.expectedAction}')),
-      );
+      SnackbarUtil.showMessage(context, 'EV $ev% ${res.expectedAction}');
     } catch (e) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Evaluation failed')));
+      SnackbarUtil.showMessage(context, 'Evaluation failed');
     } finally {
       if (mounted) setState(() => _loading = false);
     }

--- a/lib/screens/v2/training_pack_template_editor_screen.dart
+++ b/lib/screens/v2/training_pack_template_editor_screen.dart
@@ -8,6 +8,7 @@ import '../../models/v2/hand_data.dart';
 import 'spot_list_section.dart';
 import 'statistics_pane.dart';
 import 'actions_toolbar.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackTemplateEditorScreen extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -40,8 +41,7 @@ class _TrainingPackTemplateEditorScreenState
 
   void _save() {
     // Persistence layer is not yet implemented; show confirmation only.
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Template saved')));
+    SnackbarUtil.showMessage(context, 'Template saved');
   }
 
   @override

--- a/lib/screens/v2/training_pack_template_io.dart
+++ b/lib/screens/v2/training_pack_template_io.dart
@@ -1,3 +1,4 @@
+import '../../utils/snackbar_util.dart';
 part of 'training_pack_template_list_screen.dart';
 
 mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
@@ -7,9 +8,7 @@ mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
         if (!t.isDraft) t.toJson()
     ]);
     await Clipboard.setData(ClipboardData(text: json));
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Templates copied to clipboard')),
-    );
+    SnackbarUtil.showMessage(context, 'Templates copied to clipboard');
   }
 
   Future<void> _import() async {
@@ -20,8 +19,7 @@ mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
       raw = jsonDecode(clip.text!);
     } catch (_) {}
     if (raw is! List) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Invalid JSON')));
+      SnackbarUtil.showMessage(context, 'Invalid JSON');
       return;
     }
     final imported = [
@@ -49,9 +47,7 @@ mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
         _sortTemplates();
       });
       TrainingPackStorage.save(_templates);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${imported.length} template(s) imported')),
-      );
+      SnackbarUtil.showMessage(context, '${imported.length} template(s) imported');
     }
   }
 
@@ -87,15 +83,10 @@ mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
         _sortTemplates();
       });
       TrainingPackStorage.save(_templates);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Imported ${tpl.spots.length} spots${skipped > 0 ? ', $skipped skipped' : ''}'),
-        ),
-      );
+      SnackbarUtil.showMessage(context, 'Imported ${tpl.spots.length} spots${skipped > 0 ? ', $skipped skipped' : ''}');
       _edit(tpl);
     } catch (_) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Invalid CSV')));
+      SnackbarUtil.showMessage(context, 'Invalid CSV');
     }
   }
 
@@ -125,15 +116,10 @@ mixin TrainingPackTemplateIo on State<TrainingPackTemplateListScreen> {
         _sortTemplates();
       });
       TrainingPackStorage.save(_templates);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Imported ${tpl.spots.length} spots${skipped > 0 ? ', $skipped skipped' : ''}'),
-        ),
-      );
+      SnackbarUtil.showMessage(context, 'Imported ${tpl.spots.length} spots${skipped > 0 ? ', $skipped skipped' : ''}');
       _edit(tpl);
     } catch (_) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Invalid CSV')));
+      SnackbarUtil.showMessage(context, 'Invalid CSV');
     }
   }
 }

--- a/lib/screens/v2/training_pack_template_list_core.dart
+++ b/lib/screens/v2/training_pack_template_list_core.dart
@@ -1,3 +1,4 @@
+import '../../utils/snackbar_util.dart';
 part of 'training_pack_template_list_screen.dart';
 
 class TrainingPackTemplatePrefs {
@@ -253,15 +254,10 @@ class _TrainingPackTemplateListScreenState
     if (street == null || best >= 0.7) return;
     final tpl = _suggestTemplate(street);
     if (tpl == null) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Low ${_streetName(street)} progress'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Low ${_streetName(street)} progress', action: SnackBarAction(
           label: 'Try Now',
           onPressed: () => _chooseVariant(tpl),
-        ),
-      ),
-    );
+        ));
   }
 
   Future<void> _maybeShowContinueReminder() async {
@@ -278,16 +274,10 @@ class _TrainingPackTemplateListScreenState
       final ratio = val / t.streetGoal;
       if (ratio >= 0.5 && ratio < 1.0 && !t.goalAchieved) {
         ScaffoldMessenger.of(context).removeCurrentSnackBar();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            duration: const Duration(days: 1),
-            content: Text('${_streetName(street)} почти закрыт в ${t.name} — доиграем?'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, '${_streetName(street)} почти закрыт в ${t.name} — доиграем?', action: SnackBarAction(
               label: 'Продолжить',
               onPressed: () => _chooseVariant(t),
-            ),
-          ),
-        );
+            ));
         await prefs.setInt(TrainingPackTemplatePrefs.continueLast,
             DateTime.now().millisecondsSinceEpoch);
         break;
@@ -1559,14 +1549,12 @@ class _TrainingPackTemplateListScreenState
     const service = TrainingPackTemplateUiService();
     final missing = await service.generateMissingSpotsWithProgress(context, t);
     if (missing.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('All spots already present 🎉')));
+      SnackbarUtil.showMessage(context, 'All spots already present 🎉');
       return;
     }
     setState(() => t.spots.addAll(missing));
     TrainingPackStorage.save(_templates);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Added ${missing.length} spots')));
+    SnackbarUtil.showMessage(context, 'Added ${missing.length} spots');
   }
 
   Future<void> _delete(TrainingPackTemplate t) async {
@@ -1597,10 +1585,7 @@ class _TrainingPackTemplateListScreenState
       });
       TrainingPackStorage.save(_templates);
       _saveFavorites();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: const Text('Deleted'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Deleted', action: SnackBarAction(
             label: 'UNDO',
             onPressed: () {
               if (_lastRemoved != null) {
@@ -1608,9 +1593,7 @@ class _TrainingPackTemplateListScreenState
                 TrainingPackStorage.save(_templates);
               }
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 
@@ -1879,8 +1862,7 @@ class _TrainingPackTemplateListScreenState
     }
     if (hands.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('No favorites found')));
+        SnackbarUtil.showMessage(context, 'No favorites found');
       }
       return;
     }
@@ -1921,8 +1903,7 @@ class _TrainingPackTemplateListScreenState
       ..sort((a, b) => (a.evLoss ?? 0).compareTo(b.evLoss ?? 0));
     if (hands.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('No history')));
+        SnackbarUtil.showMessage(context, 'No history');
       }
       return;
     }
@@ -1934,8 +1915,7 @@ class _TrainingPackTemplateListScreenState
     }
     if (spots.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Недостаточно данных')));
+        SnackbarUtil.showMessage(context, 'Недостаточно данных');
       }
       return;
     }
@@ -1981,9 +1961,7 @@ class _TrainingPackTemplateListScreenState
     if (ok == true) {
       final range = PackGeneratorService.parseRangeString(ctrl.text).toList();
       if (range.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No valid hands found.')),
-        );
+        SnackbarUtil.showMessage(context, 'No valid hands found.');
       } else {
         final template = await PackGeneratorService.generatePushFoldPack(
           id: const Uuid().v4(),
@@ -2287,8 +2265,7 @@ class _TrainingPackTemplateListScreenState
         if (t.evCovered < t.totalWeight || t.icmCovered < t.totalWeight) t
     ];
     if (list.isEmpty) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Nothing to update')));
+      SnackbarUtil.showMessage(context, 'Nothing to update');
       return;
     }
     double progress = 0;
@@ -2874,8 +2851,7 @@ class _TrainingPackTemplateListScreenState
                             if (tpl != null) {
                               _edit(tpl);
                             } else {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(content: Text('Pack not found')));
+                              SnackbarUtil.showMessage(context, 'Pack not found');
                             }
                           },
                         )();
@@ -3183,9 +3159,7 @@ class _TrainingPackTemplateListScreenState
                   ),
                 );
               } else {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('No mistakes to review')),
-                );
+                SnackbarUtil.showMessage(context, 'No mistakes to review');
               }
             },
           ),

--- a/lib/screens/yaml_library_preview_screen.dart
+++ b/lib/screens/yaml_library_preview_screen.dart
@@ -18,6 +18,7 @@ import 'package:open_filex/open_filex.dart';
 import '../widgets/markdown_preview_dialog.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlLibraryPreviewScreen extends StatefulWidget {
   const YamlLibraryPreviewScreen({super.key});
@@ -97,11 +98,10 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       final msg = report.errors.isEmpty && report.warnings.isEmpty
           ? 'OK'
           : 'Ошибки: ${report.errors.length} \u2022 Предупреждения: ${report.warnings.length}';
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      SnackbarUtil.showMessage(context, msg);
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка')));
+        SnackbarUtil.showMessage(context, 'Ошибка');
       }
     }
   }
@@ -117,8 +117,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       service.addChangeLog(fixed, 'fix', 'editor', 'auto');
       await const YamlWriter().write(fixed.toJson(), file.path);
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Готово')));
+        SnackbarUtil.showMessage(context, 'Готово');
         if (_selected >= 0 && _files[_selected].path == file.path) {
           _markdown = const YamlPackMarkdownPreviewService()
               .generateMarkdownPreview(fixed);
@@ -128,8 +127,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка')));
+        SnackbarUtil.showMessage(context, 'Ошибка');
       }
     }
   }
@@ -146,8 +144,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       final outMap = const YamlReader().read(formatted);
       await const YamlWriter().write(outMap, file.path);
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Готово')));
+        SnackbarUtil.showMessage(context, 'Готово');
         if (_selected >= 0 && _files[_selected].path == file.path) {
           _markdown = const YamlPackMarkdownPreviewService()
               .generateMarkdownPreview(tpl);
@@ -157,8 +154,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка')));
+        SnackbarUtil.showMessage(context, 'Ошибка');
       }
     }
   }
@@ -183,8 +179,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
       final md = await const YamlPackChangelogService().loadChangeLog(tpl.id);
       if (!mounted) return;
       if (md == null) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('История изменений отсутствует')));
+        SnackbarUtil.showMessage(context, 'История изменений отсутствует');
       } else {
         await showMarkdownPreviewDialog(context, md);
       }
@@ -217,15 +212,10 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
     if (format == null) return;
     final fileOut = await const YamlPackExporterService().exportToTextFile(file, format);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Файл сохранён: ${fileOut.path}'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Файл сохранён: ${fileOut.path}', action: SnackBarAction(
           label: '📂 Открыть',
           onPressed: () => OpenFilex.open(fileOut.path),
-        ),
-      ),
-    );
+        ));
   }
 
   @override
@@ -345,10 +335,7 @@ class _YamlLibraryPreviewScreenState extends State<YamlLibraryPreviewScreen> {
                                 onPressed: () {
                                   Clipboard.setData(
                                       ClipboardData(text: _markdown!));
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                        content: Text('Скопировано')),
-                                  );
+                                  SnackbarUtil.showMessage(context, 'Скопировано');
                                 },
                                 child: const Text('📋 Скопировать'),
                               ),

--- a/lib/screens/yaml_pack_archive_cleanup_screen.dart
+++ b/lib/screens/yaml_pack_archive_cleanup_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import '../theme/app_colors.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackArchiveCleanupScreen extends StatefulWidget {
   const YamlPackArchiveCleanupScreen({super.key});
@@ -96,9 +97,7 @@ class _YamlPackArchiveCleanupScreenState extends State<YamlPackArchiveCleanupScr
     }
     if (!mounted) return;
     await _load();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Удалено файлов: $deleted')),
-    );
+    SnackbarUtil.showMessage(context, 'Удалено файлов: $deleted');
   }
 
   Future<void> _deletePack(String id) async {
@@ -125,9 +124,7 @@ class _YamlPackArchiveCleanupScreenState extends State<YamlPackArchiveCleanupScr
     }
     if (!mounted) return;
     await _load();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Удалено файлов: $deleted')),
-    );
+    SnackbarUtil.showMessage(context, 'Удалено файлов: $deleted');
   }
 
   Future<void> _clearAll() async {
@@ -156,9 +153,7 @@ class _YamlPackArchiveCleanupScreenState extends State<YamlPackArchiveCleanupScr
     }
     if (!mounted) return;
     await _load();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Удалено файлов: $deleted')),
-    );
+    SnackbarUtil.showMessage(context, 'Удалено файлов: $deleted');
   }
 
   @override

--- a/lib/screens/yaml_pack_archive_duplicates_screen.dart
+++ b/lib/screens/yaml_pack_archive_duplicates_screen.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import '../theme/app_colors.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackArchiveDuplicatesScreen extends StatefulWidget {
   const YamlPackArchiveDuplicatesScreen({super.key});
@@ -50,7 +51,7 @@ class _YamlPackArchiveDuplicatesScreenState extends State<YamlPackArchiveDuplica
     }
     await _load();
     if (mounted && deleted > 0) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Удалено файлов: $deleted')));
+      SnackbarUtil.showMessage(context, 'Удалено файлов: $deleted');
     }
   }
 
@@ -79,7 +80,7 @@ class _YamlPackArchiveDuplicatesScreenState extends State<YamlPackArchiveDuplica
     }
     await _load();
     if (mounted && deleted > 0) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Удалено файлов: $deleted')));
+      SnackbarUtil.showMessage(context, 'Удалено файлов: $deleted');
     }
   }
 

--- a/lib/screens/yaml_pack_archive_screen.dart
+++ b/lib/screens/yaml_pack_archive_screen.dart
@@ -12,6 +12,7 @@ import '../services/yaml_pack_diff_service.dart';
 import '../widgets/markdown_preview_dialog.dart';
 import '../services/yaml_pack_changelog_service.dart';
 import '../widgets/selectable_list_item.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackArchiveScreen extends StatefulWidget {
   const YamlPackArchiveScreen({super.key});
@@ -64,9 +65,7 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
 
   void _toggleSelection(String id, File f) {
     if (_selectedPack != null && _selectedPack != id) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Выберите версии одного пака')),
-      );
+      SnackbarUtil.showMessage(context, 'Выберите версии одного пака');
       return;
     }
     setState(() {
@@ -89,9 +88,7 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
 
   Future<void> _compareSelected() async {
     if (_selected.length != 2) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нужно выбрать две версии')),
-      );
+      SnackbarUtil.showMessage(context, 'Нужно выбрать две версии');
       return;
     }
     final files = _selected.toList();
@@ -200,9 +197,7 @@ class _YamlPackArchiveScreenState extends State<YamlPackArchiveScreen> {
           'восстановление из архива ${DateTime.now().toIso8601String()}',
         );
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Пак успешно восстановлен из архива')),
-          );
+          SnackbarUtil.showMessage(context, 'Пак успешно восстановлен из архива');
         }
       }
     } else if (action == 'copy') {

--- a/lib/screens/yaml_pack_diff_screen.dart
+++ b/lib/screens/yaml_pack_diff_screen.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
 import '../core/training/export/training_pack_exporter_v2.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackDiffScreen extends StatelessWidget {
   final TrainingPackTemplateV2 packA;
@@ -32,7 +33,7 @@ class YamlPackDiffScreen extends StatelessWidget {
             icon: const Icon(Icons.copy),
             onPressed: () {
               Clipboard.setData(ClipboardData(text: yamlA));
-              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Copied A')));
+              SnackbarUtil.showMessage(context, 'Copied A');
             },
           ),
           IconButton(
@@ -40,7 +41,7 @@ class YamlPackDiffScreen extends StatelessWidget {
             icon: const Icon(Icons.copy),
             onPressed: () {
               Clipboard.setData(ClipboardData(text: yamlB));
-              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Copied B')));
+              SnackbarUtil.showMessage(context, 'Copied B');
             },
           ),
         ],

--- a/lib/screens/yaml_pack_editor_screen.dart
+++ b/lib/screens/yaml_pack_editor_screen.dart
@@ -14,6 +14,7 @@ import 'package:open_filex/open_filex.dart';
 import '../widgets/markdown_preview_dialog.dart';
 import 'v2/training_pack_spot_editor_screen.dart';
 import '../core/training/engine/training_type_engine.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackEditorScreen extends StatefulWidget {
   const YamlPackEditorScreen({super.key});
@@ -106,8 +107,7 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
         .appendChangeLog(pack, 'ручное обновление');
     await file.writeAsString(pack.toYaml());
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Сохранено')));
+    SnackbarUtil.showMessage(context, 'Сохранено');
   }
 
   Future<void> _editSpot(TrainingPackSpot spot) async {
@@ -181,15 +181,10 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
     if (format == null) return;
     final file = await const YamlPackExporterService().exportToTextFile(pack, format);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Файл сохранён: ${file.path}'),
-        action: SnackBarAction(
+    SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path}', action: SnackBarAction(
           label: '📂 Открыть',
           onPressed: () => OpenFilex.open(file.path),
-        ),
-      ),
-    );
+        ));
   }
 
   Future<void> _showHistory() async {
@@ -198,9 +193,7 @@ class _YamlPackEditorScreenState extends State<YamlPackEditorScreen> {
     final md = await const YamlPackChangelogService().loadChangeLog(pack.id);
     if (!mounted) return;
     if (md == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('История изменений отсутствует')),
-      );
+      SnackbarUtil.showMessage(context, 'История изменений отсутствует');
     } else {
       await showMarkdownPreviewDialog(context, md);
     }

--- a/lib/screens/yaml_pack_validator_screen.dart
+++ b/lib/screens/yaml_pack_validator_screen.dart
@@ -11,6 +11,7 @@ import '../core/training/generation/yaml_reader.dart';
 import '../core/training/generation/yaml_writer.dart';
 import '../services/training_pack_template_validator.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlPackValidatorScreen extends StatefulWidget {
   const YamlPackValidatorScreen({super.key});
@@ -69,8 +70,7 @@ class _YamlPackValidatorScreenState extends State<YamlPackValidatorScreen> {
     await const YamlPackHistoryService().saveSnapshot(pack, 'fix');
     await const YamlWriter().write(json, path);
     if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Готово')));
+      SnackbarUtil.showMessage(context, 'Готово');
       _load();
     }
   }

--- a/lib/screens/yaml_viewer_screen.dart
+++ b/lib/screens/yaml_viewer_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../theme/app_colors.dart';
+import '../utils/snackbar_util.dart';
 
 class YamlViewerScreen extends StatelessWidget {
   final String yamlText;
@@ -17,7 +18,7 @@ class YamlViewerScreen extends StatelessWidget {
             icon: const Icon(Icons.copy),
             onPressed: () {
               Clipboard.setData(ClipboardData(text: yamlText));
-              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Copied')));
+              SnackbarUtil.showMessage(context, 'Copied');
             },
           ),
         ],

--- a/lib/services/backup_manager_service.dart
+++ b/lib/services/backup_manager_service.dart
@@ -12,6 +12,7 @@ import 'backup_file_manager.dart';
 import 'evaluation_queue_serializer.dart';
 import 'debug_panel_preferences.dart';
 import 'evaluation_queue_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Manages creation, loading and cleanup of evaluation queue backups
 /// and related import/export utilities.
@@ -73,21 +74,14 @@ class BackupManagerService {
       await fileManager
           .writeJsonFile(file, [for (final e in _pending) e.toJson()]);
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Файл сохранён: $fileName'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName', action: SnackBarAction(
               label: 'Открыть',
               onPressed: () => OpenFilex.open(file.path),
-            ),
-          ),
-        );
+            ));
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось экспортировать очередь')),
-        );
+        SnackbarUtil.showMessage(context, 'Не удалось экспортировать очередь');
       }
     }
   }
@@ -109,15 +103,11 @@ class BackupManagerService {
       await fileManager.writeJsonFile(file, _currentState());
       if (context.mounted) {
         final name = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Queue exported: $name')),
-        );
+        SnackbarUtil.showMessage(context, 'Queue exported: $name');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to export queue')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to export queue');
       }
     }
   }
@@ -127,9 +117,7 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(exportsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No export files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No export files found');
         }
         return;
       }
@@ -155,17 +143,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text(
-                  'Imported ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Imported ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to import queue state')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to import queue state');
       }
     }
   }
@@ -195,17 +177,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text(
-                  'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to restore full queue state')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to restore full queue state');
       }
     }
   }
@@ -219,15 +195,11 @@ class BackupManagerService {
       await fileManager.writeJsonFile(file, _currentState());
       Future(() => cleanupOldEvaluationBackups());
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Backup created: $fileName')),
-        );
+        SnackbarUtil.showMessage(context, 'Backup created: $fileName');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось создать бэкап')),
-        );
+        SnackbarUtil.showMessage(context, 'Не удалось создать бэкап');
       }
     }
   }
@@ -241,15 +213,11 @@ class BackupManagerService {
       Future(() => cleanupOldEvaluationBackups());
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Quick backup saved: $fileName')),
-        );
+        SnackbarUtil.showMessage(context, 'Quick backup saved: $fileName');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to create quick backup')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to create quick backup');
       }
     }
   }
@@ -259,9 +227,7 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(backupsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No quick backup files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No quick backup files found');
         }
         return;
       }
@@ -308,15 +274,11 @@ class BackupManagerService {
           ? 'Imported $total evaluations from ${result.files.length} files'
           : 'Imported $total evaluations, $skipped files skipped';
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(msg)),
-        );
+        SnackbarUtil.showMessage(context, msg);
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to import quick backups')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to import quick backups');
       }
     }
   }
@@ -420,16 +382,14 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(subfolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text(emptyMsg)));
+          SnackbarUtil.showMessage(context, emptyMsg);
         }
         return;
       }
       final files = await dir.list(recursive: true).whereType<File>().toList();
       if (files.isEmpty) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text(emptyMsg)));
+          SnackbarUtil.showMessage(context, emptyMsg);
         }
         return;
       }
@@ -452,13 +412,11 @@ class BackupManagerService {
       await zipFile.writeAsBytes(bytes, flush: true);
       if (context.mounted) {
         final name = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Archive saved: $name')));
+        SnackbarUtil.showMessage(context, 'Archive saved: $name');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(failMsg)));
+        SnackbarUtil.showMessage(context, failMsg);
       }
     }
   }
@@ -480,9 +438,7 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(autoBackupsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No auto-backup files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No auto-backup files found');
         }
         return;
       }
@@ -508,17 +464,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text(
-                  'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to restore auto-backup')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to restore auto-backup');
       }
     }
   }
@@ -546,15 +496,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Imported ${items.length} evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Imported ${items.length} evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to import queue')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to import queue');
       }
     }
   }
@@ -564,9 +510,7 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(backupsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No backup files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No backup files found');
         }
         return;
       }
@@ -577,9 +521,7 @@ class BackupManagerService {
           .toList();
       if (files.isEmpty) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No backup files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No backup files found');
         }
         return;
       }
@@ -612,17 +554,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text(
-                  'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Restored ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to restore queue')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to restore queue');
       }
     }
   }
@@ -675,9 +611,7 @@ class BackupManagerService {
         ? 'Imported $total evaluations from ${result.files.length} files'
         : 'Imported $total evaluations, $skipped files skipped';
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(msg)),
-      );
+      SnackbarUtil.showMessage(context, msg);
     }
   }
 
@@ -689,9 +623,7 @@ class BackupManagerService {
     final dir = await fileManager.getBackupDirectory(backupsFolder);
     if (!await dir.exists()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No backup files found')),
-        );
+        SnackbarUtil.showMessage(context, 'No backup files found');
       }
       return;
     }
@@ -702,9 +634,7 @@ class BackupManagerService {
     final dir = await fileManager.getBackupDirectory(autoBackupsFolder);
     if (!await dir.exists()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No auto-backup files found')),
-        );
+        SnackbarUtil.showMessage(context, 'No auto-backup files found');
       }
       return;
     }
@@ -716,9 +646,7 @@ class BackupManagerService {
       final dir = await fileManager.getBackupDirectory(snapshotsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No snapshot files found')),
-          );
+          SnackbarUtil.showMessage(context, 'No snapshot files found');
         }
         return;
       }
@@ -744,17 +672,11 @@ class BackupManagerService {
       await queueService.persist();
       debugPanelCallback?.call();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text(
-                  'Imported ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations')),
-        );
+        SnackbarUtil.showMessage(context, 'Imported ${_pending.length} pending, ${_failed.length} failed, ${_completed.length} completed evaluations');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to import snapshot')),
-        );
+        SnackbarUtil.showMessage(context, 'Failed to import snapshot');
       }
     }
   }
@@ -763,9 +685,7 @@ class BackupManagerService {
     final dir = await fileManager.getBackupDirectory(snapshotsFolder);
     if (!await dir.exists()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No snapshot files found')),
-        );
+        SnackbarUtil.showMessage(context, 'No snapshot files found');
       }
       return;
     }

--- a/lib/services/booster_pack_launcher.dart
+++ b/lib/services/booster_pack_launcher.dart
@@ -8,6 +8,7 @@ import 'pack_library_service.dart';
 import 'skill_map_booster_recommender.dart';
 import 'tag_mastery_service.dart';
 import 'training_session_launcher.dart';
+import '../utils/snackbar_util.dart';
 
 class BoosterPackLauncher {
   final TagMasteryService mastery;
@@ -36,9 +37,7 @@ class BoosterPackLauncher {
     if (pack != null) {
       await launcher.launch(pack);
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Нет подходящих бустеров')),
-      );
+      SnackbarUtil.showMessage(context, 'Нет подходящих бустеров');
     }
   }
 }

--- a/lib/services/cluster_node_navigator.dart
+++ b/lib/services/cluster_node_navigator.dart
@@ -4,6 +4,7 @@ import '../models/player_profile.dart';
 import '../models/theory_mini_lesson_node.dart';
 import '../services/mini_lesson_library_service.dart';
 import '../screens/theory_lesson_preview_screen.dart';
+import '../utils/snackbar_util.dart';
 
 /// Handles navigation from cluster map nodes to lesson previews.
 class ClusterNodeNavigator {
@@ -17,9 +18,7 @@ class ClusterNodeNavigator {
   ) async {
     final unlocked = await _isUnlocked(node.id, profile);
     if (!unlocked) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Урок пока недоступен')),
-      );
+      SnackbarUtil.showMessage(context, 'Урок пока недоступен');
       return;
     }
 

--- a/lib/services/daily_review_booster_launcher.dart
+++ b/lib/services/daily_review_booster_launcher.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'decay_smart_scheduler_service.dart';
 import 'booster_pack_factory.dart';
 import '../screens/training_session_screen.dart';
+import '../utils/snackbar_util.dart';
 
 /// Starts a review session for decayed tags.
 class DailyReviewBoosterLauncher {
@@ -13,17 +14,13 @@ class DailyReviewBoosterLauncher {
     final plan = await DecaySmartSchedulerService().generateTodayPlan();
     final tags = plan.tags;
     if (tags.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Сегодня ничего не забыто!')),
-      );
+      SnackbarUtil.showMessage(context, 'Сегодня ничего не забыто!');
       return;
     }
 
     final pack = await BoosterPackFactory.buildFromTags(tags);
     if (pack == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Сегодня ничего не забыто!')),
-      );
+      SnackbarUtil.showMessage(context, 'Сегодня ничего не забыто!');
       return;
     }
 

--- a/lib/services/debug_snapshot_service.dart
+++ b/lib/services/debug_snapshot_service.dart
@@ -8,6 +8,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:synchronized/synchronized.dart';
+import '../utils/snackbar_util.dart';
 
 /// Handles saving and loading of evaluation queue snapshots for debugging.
 class DebugSnapshotService {
@@ -183,16 +184,14 @@ class DebugSnapshotService {
       final dir = await _getDir(snapshotsFolder);
       if (!await dir.exists()) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('No snapshot files found')));
+          SnackbarUtil.showMessage(context, 'No snapshot files found');
         }
         return;
       }
       final files = await dir.list(recursive: true).whereType<File>().toList();
       if (files.isEmpty) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('No snapshot files found')));
+          SnackbarUtil.showMessage(context, 'No snapshot files found');
         }
         return;
       }
@@ -215,13 +214,11 @@ class DebugSnapshotService {
       await zipFile.writeAsBytes(bytes, flush: true);
       if (context.mounted) {
         final name = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Archive saved: $name')));
+        SnackbarUtil.showMessage(context, 'Archive saved: $name');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to export snapshots')));
+        SnackbarUtil.showMessage(context, 'Failed to export snapshots');
       }
     }
   }

--- a/lib/services/decay_milestone_celebration_service.dart
+++ b/lib/services/decay_milestone_celebration_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/confetti_overlay.dart';
 import 'coins_service.dart';
 import 'decay_streak_tracker_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Shows a small celebration when the decay streak hits key milestones.
 class DecayMilestoneCelebrationService {
@@ -62,13 +63,7 @@ class DecayMilestoneCelebrationService {
 
     await prefs.setInt(_prefsKey, milestone);
     showConfettiOverlay(context, particlePath: _starPath);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          '🧠 Your focus is paying off — $milestone days without decay!',
-        ),
-      ),
-    );
+    SnackbarUtil.showMessage(context, '🧠 Your focus is paying off — $milestone days without decay!',);
     unawaited(coins.addCoins(_coinBonus));
   }
 }

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -40,6 +40,7 @@ import '../services/training_session_service.dart';
 import '../screens/training_session_screen.dart';
 import 'evaluation_queue.dart';
 import 'evaluation_cache.dart';
+import '../utils/snackbar_util.dart';
 
 /// Interface for evaluation execution logic.
 abstract class EvaluationExecutor {
@@ -600,10 +601,7 @@ class EvaluationExecutorService implements EvaluationExecutor {
     if (spot.evalResult != null &&
         !spot.evalResult!.correct &&
         category != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: const Text('Train this category?'),
-          action: SnackBarAction(
+      SnackbarUtil.showMessage(context, 'Train this category?', action: SnackBarAction(
             label: 'Train',
             onPressed: () async {
               final tpl = await TrainingPackService.createDrillFromCategory(
@@ -618,9 +616,7 @@ class EvaluationExecutorService implements EvaluationExecutor {
                 );
               }
             },
-          ),
-        ),
-      );
+          ));
     }
   }
 

--- a/lib/services/evaluation_queue_import_export_service.dart
+++ b/lib/services/evaluation_queue_import_export_service.dart
@@ -10,6 +10,7 @@ import '../models/action_evaluation_request.dart';
 import 'evaluation_queue_service.dart';
 import 'backup_manager_service.dart';
 import 'debug_snapshot_service.dart';
+import '../utils/snackbar_util.dart';
 
 class EvaluationQueueImportExportService {
   EvaluationQueueImportExportService({
@@ -124,18 +125,14 @@ class EvaluationQueueImportExportService {
   Future<void> exportQueueToClipboard(BuildContext context) async {
     await _exportToClipboard();
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Queue copied to clipboard')),
-      );
+      SnackbarUtil.showMessage(context, 'Queue copied to clipboard');
     }
   }
 
   Future<void> importQueueFromClipboard(BuildContext context) async {
     await _importFromClipboard();
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Queue imported from clipboard')),
-      );
+      SnackbarUtil.showMessage(context, 'Queue imported from clipboard');
     }
     debugPanelCallback?.call();
   }
@@ -236,8 +233,7 @@ class EvaluationQueueImportExportService {
     if (dir == null) return;
     if (!await dir.exists()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No snapshot files found')));
+        SnackbarUtil.showMessage(context, 'No snapshot files found');
       }
       return;
     }
@@ -264,9 +260,7 @@ class EvaluationQueueImportExportService {
       ..addAll(queues['completed']!);
     await _persist();
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(
-              'Imported ${queueService.pending.length} pending, ${queueService.failed.length} failed, ${queueService.completed.length} completed evaluations')));
+      SnackbarUtil.showMessage(context, 'Imported ${queueService.pending.length} pending, ${queueService.failed.length} failed, ${queueService.completed.length} completed evaluations');
     }
     debugPanelCallback?.call();
   }
@@ -276,8 +270,7 @@ class EvaluationQueueImportExportService {
     if (dir == null) return;
     if (!await dir.exists()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No snapshot files found')));
+        SnackbarUtil.showMessage(context, 'No snapshot files found');
       }
       return;
     }
@@ -320,7 +313,7 @@ class EvaluationQueueImportExportService {
         ? 'Imported $total evaluations from ${result.files.length} files'
         : 'Imported $total evaluations, $skipped files skipped';
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      SnackbarUtil.showMessage(context, msg);
     }
     debugPanelCallback?.call();
   }

--- a/lib/services/gift_drop_service.dart
+++ b/lib/services/gift_drop_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'coins_service.dart';
+import '../utils/snackbar_util.dart';
 
 class GiftDropService {
   GiftDropService({this.interval = const Duration(hours: 24)});
@@ -29,9 +30,7 @@ class GiftDropService {
     await CoinsService.instance.addCoins(amount);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('🎁 Подарок: +$amount монет!')),
-      );
+      SnackbarUtil.showMessage(context, '🎁 Подарок: +$amount монет!');
     }
   }
 }

--- a/lib/services/goals_service.dart
+++ b/lib/services/goals_service.dart
@@ -15,6 +15,7 @@ import 'streak_service.dart';
 import 'user_action_logger.dart';
 import 'goal_persistence.dart';
 import 'achievement_manager.dart';
+import '../utils/snackbar_util.dart';
 
 class Goal {
   final String title;
@@ -280,10 +281,7 @@ class GoalsService extends ChangeNotifier {
       _hintShown = true;
       await _persistence.saveHintShown(true);
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Вы завершили 5 раздач подряд!'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'Вы завершили 5 раздач подряд!', action: SnackBarAction(
               label: 'Посмотреть прогресс',
               onPressed: () {
                 Navigator.push(
@@ -291,9 +289,7 @@ class GoalsService extends ChangeNotifier {
                   MaterialPageRoute(builder: (_) => const ProgressScreen()),
                 );
               },
-            ),
-          ),
-        );
+            ));
       }
     }
   }

--- a/lib/services/hand_history_file_service.dart
+++ b/lib/services/hand_history_file_service.dart
@@ -17,6 +17,7 @@ import 'hand_analysis_history_service.dart';
 import 'xp_tracker_service.dart';
 
 import 'saved_hand_manager_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Handles importing external hand history files using available converters.
 class HandHistoryFileService {
@@ -57,17 +58,13 @@ class HandHistoryFileService {
     }
     if (imported.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось импортировать файлы')),
-        );
+        SnackbarUtil.showMessage(context, 'Не удалось импортировать файлы');
       }
       return 0;
     }
     await _handManager.addHands(imported);
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Импортировано ${imported.length} раздач')),
-      );
+      SnackbarUtil.showMessage(context, 'Импортировано ${imported.length} раздач');
     }
     if (context.mounted) {
       final analyzer = Provider.of<HandAnalyzerService>(context, listen: false);

--- a/lib/services/learning_path_launcher_service.dart
+++ b/lib/services/learning_path_launcher_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'learning_path_summary_cache_v2.dart';
 import 'pack_library_service.dart';
 import 'training_session_launcher.dart';
+import '../utils/snackbar_util.dart';
 
 /// Launches the next available stage for a learning path.
 class LearningPathLauncherService {
@@ -22,25 +23,19 @@ class LearningPathLauncherService {
     await cache.refresh();
     final summary = cache.summaryById(pathId);
     if (summary == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Learning path not found')),
-      );
+      SnackbarUtil.showMessage(context, 'Learning path not found');
       return;
     }
 
     final stage = summary.nextStageToTrain;
     if (stage == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('All stages completed')),
-      );
+      SnackbarUtil.showMessage(context, 'All stages completed');
       return;
     }
 
     final template = await library.getById(stage.packId);
     if (template == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Training pack not found')),
-      );
+      SnackbarUtil.showMessage(context, 'Training pack not found');
       return;
     }
 

--- a/lib/services/learning_path_preview_launcher.dart
+++ b/lib/services/learning_path_preview_launcher.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../screens/learning_path_screen_v2.dart';
 import 'learning_path_library.dart';
+import '../utils/snackbar_util.dart';
 
 /// Opens a staged learning path by [id] for preview.
 class LearningPathPreviewLauncher {
@@ -10,9 +11,7 @@ class LearningPathPreviewLauncher {
   Future<void> launch(BuildContext context, String id) async {
     final template = LearningPathLibrary.staging.getById(id);
     if (template == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Path not found: $id')),
-      );
+      SnackbarUtil.showMessage(context, 'Path not found: $id');
       return;
     }
     await Navigator.push(

--- a/lib/services/learning_path_stage_launcher.dart
+++ b/lib/services/learning_path_stage_launcher.dart
@@ -11,6 +11,7 @@ import '../screens/theory_pack_reader_screen.dart';
 import 'user_action_logger.dart';
 import 'overlay_decay_booster_orchestrator.dart';
 import 'dart:async';
+import '../utils/snackbar_util.dart';
 
 /// Helper to open a learning path stage.
 class LearningPathStageLauncher {
@@ -41,17 +42,13 @@ class LearningPathStageLauncher {
       case StageType.theory:
         final id = stage.theoryPackId;
         if (id == null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Theory pack not found')),
-          );
+          SnackbarUtil.showMessage(context, 'Theory pack not found');
           return;
         }
         await _theoryLibrary.loadAll();
         final pack = _theoryLibrary.getById(id);
         if (pack == null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Theory pack not found')),
-          );
+          SnackbarUtil.showMessage(context, 'Theory pack not found');
           return;
         }
         await Navigator.push(
@@ -65,9 +62,7 @@ class LearningPathStageLauncher {
       case StageType.practice:
         final tpl = await _library.getById(stage.packId);
         if (tpl == null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Training pack not found')),
-          );
+          SnackbarUtil.showMessage(context, 'Training pack not found');
           return;
         }
         await _launcher.launch(tpl);
@@ -83,9 +78,7 @@ class LearningPathStageLauncher {
           (p) => stage.tags.any((t) => p.tags.contains(t)),
         );
         if (booster == null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Booster not found')),
-          );
+          SnackbarUtil.showMessage(context, 'Booster not found');
           return;
         }
         await Navigator.push(

--- a/lib/services/player_profile_import_export_service.dart
+++ b/lib/services/player_profile_import_export_service.dart
@@ -9,6 +9,7 @@ import 'package:open_filex/open_filex.dart';
 
 import 'player_profile_service.dart';
 import '../models/player_model.dart';
+import '../utils/snackbar_util.dart';
 
 class PlayerProfileImportExportService {
   PlayerProfileImportExportService(this.profile);
@@ -97,8 +98,7 @@ class PlayerProfileImportExportService {
   Future<void> exportToClipboard(BuildContext context) async {
     await Clipboard.setData(ClipboardData(text: serialize()));
     if (context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Profile copied to clipboard')));
+      SnackbarUtil.showMessage(context, 'Profile copied to clipboard');
     }
   }
 
@@ -107,19 +107,16 @@ class PlayerProfileImportExportService {
       final data = await Clipboard.getData('text/plain');
       if (data == null || data.text == null || !deserialize(data.text!)) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Invalid clipboard data')));
+          SnackbarUtil.showMessage(context, 'Invalid clipboard data');
         }
         return;
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Profile loaded from clipboard')));
+        SnackbarUtil.showMessage(context, 'Profile loaded from clipboard');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to read clipboard')));
+        SnackbarUtil.showMessage(context, 'Failed to read clipboard');
       }
     }
   }
@@ -139,20 +136,14 @@ class PlayerProfileImportExportService {
       await file.writeAsString(serialize());
       if (context.mounted) {
         final displayName = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('File saved: $displayName'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'File saved: $displayName', action: SnackBarAction(
               label: 'Open',
               onPressed: () => OpenFilex.open(file.path),
-            ),
-          ),
-        );
+            ));
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to save file')));
+        SnackbarUtil.showMessage(context, 'Failed to save file');
       }
     }
   }
@@ -170,19 +161,16 @@ class PlayerProfileImportExportService {
       final content = await file.readAsString();
       if (!deserialize(content)) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Invalid file format')));
+          SnackbarUtil.showMessage(context, 'Invalid file format');
         }
         return;
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('File loaded: ${file.path.split(Platform.pathSeparator).last}')));
+        SnackbarUtil.showMessage(context, 'File loaded: ${file.path.split(Platform.pathSeparator).last}');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to read file')));
+        SnackbarUtil.showMessage(context, 'Failed to read file');
       }
     }
   }
@@ -207,13 +195,11 @@ class PlayerProfileImportExportService {
       await file.writeAsBytes(bytes, flush: true);
       if (context.mounted) {
         final displayName = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Archive saved: $displayName')));
+        SnackbarUtil.showMessage(context, 'Archive saved: $displayName');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to save archive')));
+        SnackbarUtil.showMessage(context, 'Failed to save archive');
       }
     }
   }

--- a/lib/services/saved_hand_import_export_service.dart
+++ b/lib/services/saved_hand_import_export_service.dart
@@ -30,6 +30,7 @@ import 'playback_manager_service.dart';
 import 'folded_players_service.dart';
 import 'all_in_players_service.dart';
 import 'action_tag_service.dart';
+import '../utils/snackbar_util.dart';
 
 class SavedHandImportExportService {
   SavedHandImportExportService(this.manager, {ServiceRegistry? registry})
@@ -171,9 +172,7 @@ class SavedHandImportExportService {
     if (hand == null) return;
     await Clipboard.setData(ClipboardData(text: serializeHand(hand)));
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Раздача скопирована.')),
-      );
+      SnackbarUtil.showMessage(context, 'Раздача скопирована.');
     }
   }
 
@@ -183,9 +182,7 @@ class SavedHandImportExportService {
     final jsonStr = jsonEncode([for (final h in hands) h.toJson()]);
     await Clipboard.setData(ClipboardData(text: jsonStr));
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${hands.length} hands exported to clipboard')),
-      );
+      SnackbarUtil.showMessage(context, '${hands.length} hands exported to clipboard');
     }
   }
 
@@ -193,9 +190,7 @@ class SavedHandImportExportService {
     final data = await Clipboard.getData('text/plain');
     if (data == null || data.text == null) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Неверный формат данных.')),
-        );
+        SnackbarUtil.showMessage(context, 'Неверный формат данных.');
       }
       return null;
     }
@@ -208,9 +203,7 @@ class SavedHandImportExportService {
     }
     hand ??= _tryInternal(data.text!);
     if (hand == null && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Неверный формат данных.')),
-      );
+      SnackbarUtil.showMessage(context, 'Неверный формат данных.');
     }
     return hand;
   }
@@ -219,9 +212,7 @@ class SavedHandImportExportService {
     final data = await Clipboard.getData('text/plain');
     if (data == null || data.text == null) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Invalid data format')),
-        );
+        SnackbarUtil.showMessage(context, 'Invalid data format');
       }
       return 0;
     }
@@ -242,8 +233,7 @@ class SavedHandImportExportService {
       }
       if (count > 0) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text('Imported $count hands')));
+          SnackbarUtil.showMessage(context, 'Imported $count hands');
         }
         return count;
       }
@@ -262,18 +252,14 @@ class SavedHandImportExportService {
       }
 
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          count > 0
-              ? SnackBar(content: Text('Imported $count hands'))
-              : const SnackBar(content: Text('Invalid data format')),
-        );
+        final message =
+            count > 0 ? 'Imported $count hands' : 'Invalid data format';
+        SnackbarUtil.showMessage(context, message);
       }
       return count;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Invalid data format')),
-        );
+        SnackbarUtil.showMessage(context, 'Invalid data format');
       }
       return 0;
     }
@@ -289,8 +275,7 @@ class SavedHandImportExportService {
     final file = await _defaultFile(fileName);
     await file.writeAsString(jsonEncode(hand.toJson()));
     if (context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Файл сохранён: $fileName')));
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName');
       OpenFilex.open(file.path);
     }
   }
@@ -305,8 +290,7 @@ class SavedHandImportExportService {
           '${hand.name},${hand.heroPosition},${hand.date.toIso8601String()},${hand.isFavorite},"${hand.tags.join('|')}","${hand.comment ?? ''}","${hand.tournamentId ?? ''}",${hand.buyIn ?? ''},${hand.totalPrizePool ?? ''},${hand.numberOfEntrants ?? ''},"${hand.gameType ?? ''}"');
     await file.writeAsString(buffer.toString());
     if (context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Файл сохранён: $fileName')));
+      SnackbarUtil.showMessage(context, 'Файл сохранён: $fileName');
       OpenFilex.open(file.path);
     }
   }
@@ -315,8 +299,7 @@ class SavedHandImportExportService {
     final hands = manager.hands;
     if (hands.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('No saved hands to export')));
+        SnackbarUtil.showMessage(context, 'No saved hands to export');
       }
       return;
     }
@@ -339,8 +322,7 @@ class SavedHandImportExportService {
     await file.writeAsBytes(bytes, flush: true);
     if (context.mounted) {
       final name = savePath.split(Platform.pathSeparator).last;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Archive saved: $name')));
+      SnackbarUtil.showMessage(context, 'Archive saved: $name');
     }
   }
 }

--- a/lib/services/saved_hand_manager_service.dart
+++ b/lib/services/saved_hand_manager_service.dart
@@ -14,6 +14,7 @@ import 'saved_hand_storage_service.dart';
 import 'cloud_sync_service.dart';
 
 import 'training_stats_service.dart';
+import '../utils/snackbar_util.dart';
 
 class SavedHandManagerService extends ChangeNotifier {
   static SavedHandManagerService? _instance;
@@ -422,9 +423,7 @@ class SavedHandManagerService extends ChangeNotifier {
                                     );
                                     await _storage.update(savedIndex, updated);
                                     setStateSheet(() {});
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(content: Text('Раздача обновлена')),
-                                    );
+                                    SnackbarUtil.showMessage(context, 'Раздача обновлена');
                                   }
 
                                   nameController.dispose();

--- a/lib/services/skill_tree_unlock_notification_service.dart
+++ b/lib/services/skill_tree_unlock_notification_service.dart
@@ -5,6 +5,7 @@ import '../models/skill_tree.dart';
 import 'skill_tree_unlock_evaluator.dart';
 import 'skill_tree_stage_gate_evaluator.dart';
 import 'skill_tree_node_progress_tracker.dart';
+import '../utils/snackbar_util.dart';
 
 /// Shows a toast when new skill tree nodes or stages become unlocked.
 class SkillTreeUnlockNotificationService {
@@ -45,17 +46,13 @@ class SkillTreeUnlockNotificationService {
 
     for (final level in newStages) {
       if (!context.mounted) break;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Открыт новый этап: $level')),
-      );
+      SnackbarUtil.showMessage(context, 'Открыт новый этап: $level');
     }
 
     for (final id in newNodes) {
       if (!context.mounted) break;
       final title = tree.nodes[id]?.title ?? id;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Открыт новый узел: $title')),
-      );
+      SnackbarUtil.showMessage(context, 'Открыт новый узел: $title');
     }
 
     await prefs.setStringList(_nodeKey(trackId), unlockedNodes.toList());

--- a/lib/services/tag_service.dart
+++ b/lib/services/tag_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/snackbar_util.dart';
 
 class TagService extends ChangeNotifier {
   static const _prefsKey = 'global_tags';
@@ -122,15 +123,11 @@ class TagService extends ChangeNotifier {
       await file.writeAsString(jsonStr);
       if (context.mounted) {
         final name = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Файл сохранён: $name')),
-        );
+        SnackbarUtil.showMessage(context, 'Файл сохранён: $name');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось сохранить файл')),
-        );
+        SnackbarUtil.showMessage(context, 'Не удалось сохранить файл');
       }
     }
   }
@@ -184,15 +181,11 @@ class TagService extends ChangeNotifier {
       notifyListeners();
       if (context.mounted) {
         final name = path.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Импортировано из $name')),
-        );
+        SnackbarUtil.showMessage(context, 'Импортировано из $name');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Ошибка импорта файла')),
-        );
+        SnackbarUtil.showMessage(context, 'Ошибка импорта файла');
       }
     }
   }

--- a/lib/services/template_storage_service.dart
+++ b/lib/services/template_storage_service.dart
@@ -14,6 +14,7 @@ import 'thumbnail_cache_service.dart';
 import '../models/training_pack_template.dart';
 import '../core/training/generation/yaml_reader.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/snackbar_util.dart';
 
 class TemplateStorageService extends ChangeNotifier {
   static final _manifestFuture = AssetManifest.instance;
@@ -147,16 +148,14 @@ class TemplateStorageService extends ChangeNotifier {
       final data = jsonDecode(content);
       if (data is! Map<String, dynamic>) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Неверный формат шаблона: неверный JSON')));
+          SnackbarUtil.showMessage(context, 'Неверный формат шаблона: неверный JSON');
         }
         return null;
       }
       final error = validateTemplateJson(Map<String, dynamic>.from(data));
       if (error != null) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text('Неверный формат шаблона: $error')));
+          SnackbarUtil.showMessage(context, 'Неверный формат шаблона: $error');
         }
         return null;
       }
@@ -187,27 +186,20 @@ class TemplateStorageService extends ChangeNotifier {
             ThumbnailCacheService.instance.invalidate(template.id);
             notifyListeners();
             if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Шаблон обновлён'),
-                  action: SnackBarAction(
+              SnackbarUtil.showMessage(context, 'Шаблон обновлён', action: SnackBarAction(
                     label: 'Отмена',
                     onPressed: () {
                       _templates[index] = existing;
                       notifyListeners();
                     },
-                  ),
-                ),
-              );
+                  ));
             }
             return template;
           }
           return null;
         } else if (template.revision == existing.revision) {
           if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Такой шаблон уже есть')),
-            );
+            SnackbarUtil.showMessage(context, 'Такой шаблон уже есть');
           }
           return null;
         } else {
@@ -236,18 +228,13 @@ class TemplateStorageService extends ChangeNotifier {
             ThumbnailCacheService.instance.invalidate(template.id);
             notifyListeners();
             if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Шаблон обновлён'),
-                  action: SnackBarAction(
+              SnackbarUtil.showMessage(context, 'Шаблон обновлён', action: SnackBarAction(
                     label: 'Отмена',
                     onPressed: () {
                       _templates[index] = existing;
                       notifyListeners();
                     },
-                  ),
-                ),
-              );
+                  ));
             }
             return template;
           } else if (action == 'keep') {
@@ -274,16 +261,12 @@ class TemplateStorageService extends ChangeNotifier {
       _resort();
       notifyListeners();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Шаблон импортирован')),
-        );
+        SnackbarUtil.showMessage(context, 'Шаблон импортирован');
       }
       return template;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Ошибка импорта файла')),
-        );
+        SnackbarUtil.showMessage(context, 'Ошибка импорта файла');
       }
       return null;
     }
@@ -328,21 +311,14 @@ class TemplateStorageService extends ChangeNotifier {
       final file = File('${dir.path}/$safeName.json');
       await file.writeAsString(jsonEncode(template.toJson()));
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Экспорт завершён'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'Экспорт завершён', action: SnackBarAction(
               label: 'Открыть',
               onPressed: () => OpenFilex.open(file.path),
-            ),
-          ),
-        );
+            ));
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось экспортировать файл')),
-        );
+        SnackbarUtil.showMessage(context, 'Не удалось экспортировать файл');
       }
     }
   }

--- a/lib/services/theory_block_launcher.dart
+++ b/lib/services/theory_block_launcher.dart
@@ -8,6 +8,7 @@ import '../services/pinned_learning_service.dart';
 import '../services/user_progress_service.dart';
 import '../services/training_session_launcher.dart';
 import '../services/theory_track_resume_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Launches the next appropriate item within a [TheoryBlockModel].
 class TheoryBlockLauncher {
@@ -51,8 +52,7 @@ class TheoryBlockLauncher {
       }
     }
     if (context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Block Completed')));
+      SnackbarUtil.showMessage(context, 'Block Completed');
     }
   }
 }

--- a/lib/services/theory_stage_completion_watcher.dart
+++ b/lib/services/theory_stage_completion_watcher.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'theory_stage_progress_tracker.dart';
+import '../utils/snackbar_util.dart';
 
 /// Watches scroll position and time spent on a theory stage
 /// to automatically mark it as completed.
@@ -63,9 +64,7 @@ class TheoryStageCompletionWatcher {
     tracker.markCompleted(id);
     _onCompleted?.call();
     if (context != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('✓ Completed')),
-      );
+      SnackbarUtil.showMessage(context, '✓ Completed');
     }
   }
 

--- a/lib/services/training_import_export_service.dart
+++ b/lib/services/training_import_export_service.dart
@@ -18,6 +18,7 @@ import 'current_hand_context_service.dart';
 import 'player_manager_service.dart';
 import 'playback_manager_service.dart';
 import 'stack_manager_service.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingImportExportService {
   const TrainingImportExportService();
@@ -386,28 +387,24 @@ class TrainingImportExportService {
       final data = await Clipboard.getData('text/plain');
       if (data == null || data.text == null) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Неверный формат данных')));
+          SnackbarUtil.showMessage(context, 'Неверный формат данных');
         }
         return null;
       }
       final spot = deserializeSpot(data.text!);
       if (spot == null) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Неверный формат данных')));
+          SnackbarUtil.showMessage(context, 'Неверный формат данных');
         }
         return null;
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Спот загружен из буфера')));
+        SnackbarUtil.showMessage(context, 'Спот загружен из буфера');
       }
       return spot;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка загрузки')));
+        SnackbarUtil.showMessage(context, 'Ошибка загрузки');
       }
       return null;
     }
@@ -418,8 +415,7 @@ class TrainingImportExportService {
     final jsonStr = serializeSpot(spot);
     await Clipboard.setData(ClipboardData(text: jsonStr));
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Спот скопирован в буфер')));
+      SnackbarUtil.showMessage(context, 'Спот скопирован в буфер');
     }
   }
 
@@ -437,20 +433,17 @@ class TrainingImportExportService {
       final spot = deserializeSpot(content);
       if (spot == null) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Неверный формат файла')));
+          SnackbarUtil.showMessage(context, 'Неверный формат файла');
         }
         return null;
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Файл загружен: ${file.path.split(Platform.pathSeparator).last}')));
+        SnackbarUtil.showMessage(context, 'Файл загружен: ${file.path.split(Platform.pathSeparator).last}');
       }
       return spot;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+        SnackbarUtil.showMessage(context, 'Ошибка чтения файла');
       }
       return null;
     }
@@ -472,20 +465,14 @@ class TrainingImportExportService {
       await file.writeAsString(serializeSpot(spot));
       if (context.mounted) {
         final displayName = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Файл сохранён: $displayName'),
-            action: SnackBarAction(
+        SnackbarUtil.showMessage(context, 'Файл сохранён: $displayName', action: SnackBarAction(
               label: 'Открыть',
               onPressed: () => OpenFilex.open(file.path),
-            ),
-          ),
-        );
+            ));
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка сохранения файла')));
+        SnackbarUtil.showMessage(context, 'Ошибка сохранения файла');
       }
     }
   }
@@ -494,8 +481,7 @@ class TrainingImportExportService {
       BuildContext context, List<TrainingSpot> spots) async {
     if (spots.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Нет спотов для экспорта')));
+        SnackbarUtil.showMessage(context, 'Нет спотов для экспорта');
       }
       return;
     }
@@ -519,13 +505,11 @@ class TrainingImportExportService {
       await file.writeAsBytes(bytes, flush: true);
       if (context.mounted) {
         final displayName = savePath.split(Platform.pathSeparator).last;
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Архив сохранён: $displayName')));
+        SnackbarUtil.showMessage(context, 'Архив сохранён: $displayName');
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка сохранения архива')));
+        SnackbarUtil.showMessage(context, 'Ошибка сохранения архива');
       }
     }
   }

--- a/lib/services/training_spot_file_service.dart
+++ b/lib/services/training_spot_file_service.dart
@@ -11,6 +11,7 @@ import 'package:file_saver/file_saver.dart';
 
 import '../models/training_spot.dart';
 import 'training_import_export_service.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingSpotFileService {
   final TrainingImportExportService _importExport;
@@ -31,22 +32,17 @@ class TrainingSpotFileService {
       final spots = _importExport.importAllSpotsCsv(content);
       if (spots.isEmpty) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Ошибка импорта CSV')),
-          );
+          SnackbarUtil.showMessage(context, 'Ошибка импорта CSV');
         }
         return [];
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Импортировано спотов: ${spots.length}')),
-        );
+        SnackbarUtil.showMessage(context, 'Импортировано спотов: ${spots.length}');
       }
       return spots;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+        SnackbarUtil.showMessage(context, 'Ошибка чтения файла');
       }
       return [];
     }
@@ -63,9 +59,7 @@ class TrainingSpotFileService {
     await file.writeAsString(markdown);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Файл сохранён: ${file.path}')),
-      );
+      SnackbarUtil.showMessage(context, 'Файл сохранён: ${file.path}');
     }
     return file.path;
   }
@@ -103,13 +97,11 @@ class TrainingSpotFileService {
       if (context.mounted) {
         final msg = successMessage ??
             'Экспортировано ${spots.length} спотов в CSV';
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(msg)));
+        SnackbarUtil.showMessage(context, msg);
       }
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка экспорта CSV')));
+        SnackbarUtil.showMessage(context, 'Ошибка экспорта CSV');
       }
     }
   }
@@ -122,8 +114,7 @@ class TrainingSpotFileService {
       final data = jsonDecode(content);
       if (data is! List) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+          SnackbarUtil.showMessage(context, 'Неверный формат файла');
         }
         return [];
       }
@@ -137,21 +128,17 @@ class TrainingSpotFileService {
       }
       if (spots.isEmpty) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Неверный формат файла')));
+          SnackbarUtil.showMessage(context, 'Неверный формат файла');
         }
         return [];
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(
-                SnackBar(content: Text('Импортировано спотов: ${spots.length}')));
+        SnackbarUtil.showMessage(context, 'Импортировано спотов: ${spots.length}');
       }
       return spots;
     } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Ошибка чтения файла')));
+        SnackbarUtil.showMessage(context, 'Ошибка чтения файла');
       }
       return [];
     }
@@ -190,9 +177,7 @@ class TrainingSpotFileService {
     await file.writeAsString(jsonStr);
     await Share.shareXFiles([XFile(file.path)], text: '$safe.json');
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Пакет "$name" создан, спотов: ${spots.length}')),
-      );
+      SnackbarUtil.showMessage(context, 'Пакет "$name" создан, спотов: ${spots.length}');
     }
   }
 

--- a/lib/ui/tools/training_pack_yaml_previewer.dart
+++ b/lib/ui/tools/training_pack_yaml_previewer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../core/training/export/training_pack_exporter_v2.dart';
 import '../../models/v2/training_pack_template_v2.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/snackbar_util.dart';
 
 class TrainingPackYamlPreviewer extends StatelessWidget {
   final TrainingPackTemplateV2 pack;
@@ -20,9 +21,7 @@ class TrainingPackYamlPreviewer extends StatelessWidget {
             icon: const Icon(Icons.copy),
             onPressed: () {
               Clipboard.setData(ClipboardData(text: yaml));
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Copied')),
-              );
+              SnackbarUtil.showMessage(context, 'Copied');
             },
           ),
           IconButton(

--- a/lib/utils/snackbar_util.dart
+++ b/lib/utils/snackbar_util.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SnackbarUtil {
+  const SnackbarUtil._();
+
+  static void showMessage(BuildContext ctx, String text, {SnackBarAction? action}) {
+    ScaffoldMessenger.of(ctx).showSnackBar(
+      SnackBar(content: Text(text), action: action),
+    );
+  }
+}

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/action_entry.dart';
 import 'dart:math' as math;
+import '../utils/snackbar_util.dart';
 
 class ActionListWidget extends StatefulWidget {
   final int playerCount;
@@ -374,9 +375,7 @@ class _ActionListWidgetState extends State<ActionListWidget> {
       _recalcErrors();
     });
     _notify();
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('All actions cleared')),
-    );
+    SnackbarUtil.showMessage(context, 'All actions cleared');
   }
 
   @override

--- a/lib/widgets/booster_recommendation_banner.dart
+++ b/lib/widgets/booster_recommendation_banner.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/theory_booster_recommender.dart';
 import '../services/booster_library_service.dart';
 import '../services/training_session_launcher.dart';
+import '../utils/snackbar_util.dart';
 
 /// Persistent banner recommending a booster pack after theory lessons.
 class BoosterRecommendationBanner extends StatefulWidget {
@@ -43,9 +44,7 @@ class _BoosterRecommendationBannerState
         .getById(widget.recommendation.boosterId);
     if (tpl == null) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Booster pack not found')),
-      );
+      SnackbarUtil.showMessage(context, 'Booster pack not found');
       return;
     }
     await const TrainingSessionLauncher().launch(tpl);

--- a/lib/widgets/continue_training_button.dart
+++ b/lib/widgets/continue_training_button.dart
@@ -5,6 +5,7 @@ import '../services/suggested_next_step_engine.dart';
 import '../services/training_session_service.dart';
 import '../models/v2/training_pack_template.dart';
 import '../screens/v2/training_pack_play_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class ContinueTrainingButton extends StatefulWidget {
   const ContinueTrainingButton({super.key});
@@ -42,9 +43,7 @@ class _ContinueTrainingButtonState extends State<ContinueTrainingButton> {
     final tpl = await engine.suggestNext();
     if (!mounted) return;
     if (tpl == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('All training completed — well done!')),
-      );
+      SnackbarUtil.showMessage(context, 'All training completed — well done!');
       setState(() => _starting = false);
       return;
     }

--- a/lib/widgets/decay_boosted_banner.dart
+++ b/lib/widgets/decay_boosted_banner.dart
@@ -3,6 +3,7 @@ import '../services/decay_boosted_practice_queue.dart';
 import '../services/booster_queue_service.dart';
 import '../services/decay_booster_training_launcher.dart';
 import '../models/v2/training_spot_v2.dart';
+import '../utils/snackbar_util.dart';
 
 /// Banner prompting the user to refresh decayed skills.
 class DecayBoostedBanner extends StatefulWidget {
@@ -39,9 +40,7 @@ class _DecayBoostedBannerState extends State<DecayBoostedBanner> {
     await const DecayBoosterTrainingLauncher().launch();
     if (!mounted) return;
     setState(() => _visible = false);
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Навык восстановлен')),
-    );
+    SnackbarUtil.showMessage(context, 'Навык восстановлен');
   }
 
   void _dismiss() {

--- a/lib/widgets/goal_suggestion_row.dart
+++ b/lib/widgets/goal_suggestion_row.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/goal_recommendation.dart';
 import '../models/user_goal.dart';
 import '../services/user_goal_engine.dart';
+import '../utils/snackbar_util.dart';
 
 /// Horizontal list of goal recommendation cards.
 class GoalSuggestionRow extends StatelessWidget {
@@ -26,8 +27,7 @@ class GoalSuggestionRow extends StatelessWidget {
     );
     await engine.addGoal(goal);
     if (context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Цель добавлена!')));
+      SnackbarUtil.showMessage(context, 'Цель добавлена!');
     }
   }
 

--- a/lib/widgets/markdown_preview_dialog.dart
+++ b/lib/widgets/markdown_preview_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/v2/training_pack_template.dart';
 import '../services/pack_export_service.dart';
+import '../utils/snackbar_util.dart';
 
 class MarkdownPreviewDialog extends StatelessWidget {
   final String? markdown;
@@ -23,9 +24,7 @@ class MarkdownPreviewDialog extends StatelessWidget {
         TextButton(
           onPressed: () {
             Clipboard.setData(ClipboardData(text: md));
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Copied')),
-            );
+            SnackbarUtil.showMessage(context, 'Copied');
           },
           child: const Text('Copy'),
         ),

--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -21,6 +21,7 @@ import '../services/mini_lesson_library_service.dart';
 import '../screens/mini_lesson_screen.dart';
 import 'pack_progress_summary_widget.dart';
 import 'unlock_tracker_widget.dart';
+import '../utils/snackbar_util.dart';
 
 class PackCard extends StatefulWidget {
   final TrainingPackTemplateV2 template;
@@ -353,9 +354,7 @@ class _PackCardState extends State<PackCard>
     return GestureDetector(
       onTap: () async {
         if (_locked) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(_lockMsg ?? 'Пак заблокирован')),
-          );
+          SnackbarUtil.showMessage(context, _lockMsg ?? 'Пак заблокирован');
           return;
         }
         if (widget.template.id == TrainingPackLibraryV2.mvpPackId) {

--- a/lib/widgets/share_dialog.dart
+++ b/lib/widgets/share_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
+import '../utils/snackbar_util.dart';
 
 class ShareDialog extends StatelessWidget {
   final String text;
@@ -21,9 +22,7 @@ class ShareDialog extends StatelessWidget {
           onPressed: () {
             Clipboard.setData(ClipboardData(text: text));
             Navigator.pop(context);
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Copied to clipboard')),
-            );
+            SnackbarUtil.showMessage(context, 'Copied to clipboard');
           },
           child: const Text('Copy'),
         ),

--- a/lib/widgets/skill_decay_dashboard_tile.dart
+++ b/lib/widgets/skill_decay_dashboard_tile.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../services/decay_spot_booster_engine.dart';
 import '../services/theory_tag_decay_tracker.dart';
 import '../services/theory_booster_queue_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Dashboard tile showing most decayed theory tags with quick actions.
 class SkillDecayDashboardTile extends StatefulWidget {
@@ -37,17 +38,13 @@ class _SkillDecayDashboardTileState extends State<SkillDecayDashboardTile> {
     final engine = DecaySpotBoosterEngine();
     await engine.enqueueForTag(tag);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Споты добавлены в очередь')),
-    );
+    SnackbarUtil.showMessage(context, 'Споты добавлены в очередь');
   }
 
   Future<void> _reviewTheory(String tag) async {
     await TheoryBoosterQueueService.instance.enqueue(tag);
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Теория добавлена в очередь')),
-    );
+    SnackbarUtil.showMessage(context, 'Теория добавлена в очередь');
   }
 
   @override

--- a/lib/widgets/smart_decay_goal_banner.dart
+++ b/lib/widgets/smart_decay_goal_banner.dart
@@ -5,6 +5,7 @@ import '../models/goal_recommendation.dart';
 import '../models/user_goal.dart';
 import '../services/smart_decay_goal_generator.dart';
 import '../services/user_goal_engine.dart';
+import '../utils/snackbar_util.dart';
 
 class SmartDecayGoalBanner extends StatefulWidget {
   const SmartDecayGoalBanner({super.key});
@@ -49,9 +50,7 @@ class _SmartDecayGoalBannerState extends State<SmartDecayGoalBanner> {
     );
     await context.read<UserGoalEngine>().addGoal(goal);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Цель добавлена!')),
-      );
+      SnackbarUtil.showMessage(context, 'Цель добавлена!');
     }
   }
 

--- a/lib/widgets/smart_mistake_goal_banner.dart
+++ b/lib/widgets/smart_mistake_goal_banner.dart
@@ -5,6 +5,7 @@ import '../models/goal_recommendation.dart';
 import '../models/user_goal.dart';
 import '../services/smart_mistake_goal_generator.dart';
 import '../services/user_goal_engine.dart';
+import '../utils/snackbar_util.dart';
 
 class SmartMistakeGoalBanner extends StatefulWidget {
   const SmartMistakeGoalBanner({super.key});
@@ -49,9 +50,7 @@ class _SmartMistakeGoalBannerState extends State<SmartMistakeGoalBanner> {
     );
     await context.read<UserGoalEngine>().addGoal(goal);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Цель добавлена!')),
-      );
+      SnackbarUtil.showMessage(context, 'Цель добавлена!');
     }
   }
 

--- a/lib/widgets/smart_recap_suggestion_banner.dart
+++ b/lib/widgets/smart_recap_suggestion_banner.dart
@@ -6,6 +6,7 @@ import '../services/booster_pack_factory.dart';
 import '../screens/training_session_screen.dart';
 import '../services/user_goal_engine.dart';
 import '../models/user_goal.dart';
+import '../utils/snackbar_util.dart';
 
 /// Banner suggesting a quick recap for a recently completed goal.
 class SmartRecapSuggestionBanner extends StatefulWidget {
@@ -69,9 +70,7 @@ class _SmartRecapSuggestionBannerState
     final pack = await BoosterPackFactory.buildFromTags([tag]);
     if (pack == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Нет тренировок по тегу')),
-        );
+        SnackbarUtil.showMessage(context, 'Нет тренировок по тегу');
       }
       return;
     }

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -10,6 +10,7 @@ import '../services/training_session_service.dart';
 import '../services/tag_service.dart';
 import 'share_dialog.dart';
 import '../screens/v2/training_pack_spot_editor_screen.dart';
+import '../utils/snackbar_util.dart';
 
 class SpotViewerDialog extends StatefulWidget {
   final TrainingPackSpot spot;
@@ -176,9 +177,7 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
 
   void _copyId() {
     Clipboard.setData(ClipboardData(text: spot.id));
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Spot ID copied to clipboard')),
-    );
+    SnackbarUtil.showMessage(context, 'Spot ID copied to clipboard');
   }
 
   Widget _evCard() {

--- a/lib/widgets/stage_share_button.dart
+++ b/lib/widgets/stage_share_button.dart
@@ -4,6 +4,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../models/learning_path_template_v2.dart';
 import '../models/learning_path_stage_model.dart';
+import '../utils/snackbar_util.dart';
 
 /// Button for copying or sharing a direct link to a learning path stage preview.
 class StageShareButton extends StatelessWidget {
@@ -22,15 +23,9 @@ class StageShareButton extends StatelessWidget {
   Future<void> _share(BuildContext context) async {
     await Clipboard.setData(ClipboardData(text: _link));
     await Share.share(_link);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          Localizations.localeOf(context).languageCode == 'ru'
+    SnackbarUtil.showMessage(context, Localizations.localeOf(context).languageCode == 'ru'
               ? 'Ссылка скопирована'
-              : 'Link copied',
-        ),
-      ),
-    );
+              : 'Link copied',);
   }
 
   @override

--- a/lib/widgets/streak_banner.dart
+++ b/lib/widgets/streak_banner.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/goals_service.dart';
 import '../screens/error_free_streak_screen.dart';
+import '../utils/snackbar_util.dart';
 
 /// Displays the current "Без ошибок подряд" streak as a small banner.
 /// Fades in and out when the value changes.
@@ -62,13 +63,7 @@ class _StreakBannerState extends State<StreakBanner>
       _motivationalShown = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content:
-                  Text('🔥 5 раздач без ошибок! Отличная серия!'),
-              duration: Duration(seconds: 3),
-            ),
-          );
+          SnackbarUtil.showMessage(context, '🔥 5 раздач без ошибок! Отличная серия!');
         }
       });
     }

--- a/lib/widgets/street_actions_list.dart
+++ b/lib/widgets/street_actions_list.dart
@@ -8,6 +8,7 @@ import 'street_pot_widget.dart';
 import 'chip_stack_widget.dart';
 import 'package:provider/provider.dart';
 import '../services/user_preferences_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Список действий на конкретной улице
 class StreetActionsList extends StatelessWidget {
@@ -338,19 +339,14 @@ class StreetActionsList extends StatelessWidget {
                     final index = actions.indexOf(entry);
                     onDelete(index);
                     ScaffoldMessenger.of(context).clearSnackBars();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: const Text('Действие удалено'),
-                        action: SnackBarAction(
+                    SnackbarUtil.showMessage(context, 'Действие удалено', action: SnackBarAction(
                           label: 'Отмена',
                           onPressed: () {
                             if (onInsert != null) {
                               onInsert!(index, entry);
                             }
                           },
-                        ),
-                      ),
-                    );
+                        ));
                   },
                   child: Column(
                     children: [

--- a/lib/widgets/theory_block_card_widget.dart
+++ b/lib/widgets/theory_block_card_widget.dart
@@ -6,6 +6,7 @@ import '../services/user_progress_service.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/theory_block_launcher.dart';
 import 'theory_block_context_sheet.dart';
+import '../utils/snackbar_util.dart';
 
 /// Card widget displaying a [TheoryBlockModel] with completion progress.
 class TheoryBlockCardWidget extends StatefulWidget {
@@ -96,9 +97,7 @@ class _TheoryBlockCardWidgetState extends State<TheoryBlockCardWidget> {
         PinnedLearningService.instance.isPinned('block', widget.block.id);
     if (mounted) {
       setState(() => _pinned = pinned);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(pinned ? 'Pinned' : 'Unpinned')),
-      );
+      SnackbarUtil.showMessage(context, pinned ? 'Pinned' : 'Unpinned');
     }
   }
 

--- a/lib/widgets/theory_block_context_sheet.dart
+++ b/lib/widgets/theory_block_context_sheet.dart
@@ -9,6 +9,7 @@ import '../services/mini_lesson_library_service.dart';
 import '../services/pack_library_service.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/user_progress_service.dart';
+import '../utils/snackbar_util.dart';
 
 /// Displays the same options sheet used by [TheoryBlockCardWidget] when long
 /// pressed. Allows pin/unpin and quick navigation to lessons or packs.
@@ -50,9 +51,7 @@ Future<void> showTheoryBlockContextSheet(
                 await PinnedLearningService.instance.toggleBlock(block);
                 pinned =
                     PinnedLearningService.instance.isPinned('block', block.id);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text(pinned ? 'Pinned' : 'Unpinned')),
-                );
+                SnackbarUtil.showMessage(context, pinned ? 'Pinned' : 'Unpinned');
               },
             ),
             if (lessons.isNotEmpty)

--- a/lib/widgets/theory_lesson_feedback_bar.dart
+++ b/lib/widgets/theory_lesson_feedback_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/theory_lesson_feedback.dart';
 import '../services/theory_feedback_storage.dart';
+import '../utils/snackbar_util.dart';
 
 class TheoryLessonFeedbackBar extends StatefulWidget {
   final String lessonId;
@@ -32,9 +33,7 @@ class _TheoryLessonFeedbackBarState extends State<TheoryLessonFeedbackBar> {
     await TheoryFeedbackStorage.instance.record(widget.lessonId, choice);
     if (mounted) {
       setState(() => _choice = choice);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Спасибо за отзыв!')),
-      );
+      SnackbarUtil.showMessage(context, 'Спасибо за отзыв!');
     }
   }
 

--- a/lib/widgets/today_progress_banner.dart
+++ b/lib/widgets/today_progress_banner.dart
@@ -8,6 +8,7 @@ import '../services/daily_target_service.dart';
 import '../services/streak_counter_service.dart';
 import 'package:intl/intl.dart';
 import 'confetti_overlay.dart';
+import '../utils/snackbar_util.dart';
 
 class TodayProgressBanner extends StatefulWidget {
   const TodayProgressBanner({super.key});
@@ -50,13 +51,7 @@ class _TodayProgressBannerState extends State<TodayProgressBanner>
     _recordSub =
         context.read<StreakCounterService>().recordStream.listen((_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('🏆 New record!'),
-          duration: Duration(seconds: 2),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      SnackbarUtil.showMessage(context, '🏆 New record!');
     });
     SharedPreferences.getInstance().then((prefs) {
       final str = prefs.getString(_prefKey);

--- a/lib/widgets/training_pack_play_screen_v2_toolbar.dart
+++ b/lib/widgets/training_pack_play_screen_v2_toolbar.dart
@@ -3,6 +3,7 @@ import '../services/app_settings_service.dart';
 import '../services/mistake_hint_service.dart';
 import '../services/user_preferences_service.dart';
 import 'package:provider/provider.dart';
+import '../utils/snackbar_util.dart';
 
 class TrainingPackPlayScreenV2Toolbar extends StatelessWidget {
   final String title;
@@ -79,8 +80,7 @@ class TrainingPackPlayScreenV2Toolbar extends StatelessWidget {
                   tooltip: 'Hint',
                   onPressed: () {
                     final hint = MistakeHintService.instance.getHint();
-                    ScaffoldMessenger.of(context)
-                        .showSnackBar(SnackBar(content: Text(hint)));
+                    SnackbarUtil.showMessage(context, hint);
                   },
                 ),
               IconButton(

--- a/lib/widgets/v2/training_pack_spot_preview_card.dart
+++ b/lib/widgets/v2/training_pack_spot_preview_card.dart
@@ -8,6 +8,7 @@ import '../../models/action_entry.dart';
 import '../../screens/v2/hand_editor_screen.dart';
 import '../../services/evaluation_executor_service.dart';
 import '../../theme/app_colors.dart';
+import '../../utils/snackbar_util.dart';
 
 /// ***Only the new Stateful implementation below is kept.
 ///   The former Stateless version has been removed to avoid a duplicate-class error.***
@@ -521,12 +522,7 @@ class _TrainingPackSpotPreviewCardState
               right: 4,
               child: GestureDetector(
                 onTap: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: const Text(
-                        'EV or ICM is missing or outdated',
-                      ),
-                      action: SnackBarAction(
+                  SnackbarUtil.showMessage(context, 'EV or ICM is missing or outdated',, action: SnackBarAction(
                         label: 'Fix',
                         onPressed: () async {
                           await context
@@ -534,9 +530,7 @@ class _TrainingPackSpotPreviewCardState
                               .evaluateSingle(context, widget.spot);
                           if (mounted) setState(() {});
                         },
-                      ),
-                    ),
-                  );
+                      ));
                 },
                 child:
                     const Icon(Icons.error_outline, color: Colors.redAccent),


### PR DESCRIPTION
## Summary
- add `SnackbarUtil.showMessage` helper
- refactor direct `ScaffoldMessenger.of(context).showSnackBar` calls to use `SnackbarUtil.showMessage`

## Testing
- `dart format lib/utils/snackbar_util.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f577b4000832aaf99402f8f0befb3