### PR TITLE
feat: add learning path graph snapshot service

### DIFF
--- a/lib/screens/dev_menu/debug_tools_section.dart
+++ b/lib/screens/dev_menu/debug_tools_section.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../services/learning_path_node_graph_snapshot_service.dart';
+import '../../services/learning_graph_engine.dart';
+
+class DebugToolsSection extends StatefulWidget {
+  const DebugToolsSection({super.key});
+
+  @override
+  State<DebugToolsSection> createState() => _DebugToolsSectionState();
+}
+
+class _DebugToolsSectionState extends State<DebugToolsSection> {
+  bool _dumping = false;
+
+  Future<void> _dumpGraph() async {
+    if (_dumping || !kDebugMode) return;
+    final engine = LearningPathEngine.instance.engine;
+    if (engine == null) return;
+    setState(() => _dumping = true);
+    final text =
+        LearningPathNodeGraphSnapshotService(engine: engine).debugSnapshot();
+    if (!mounted) return;
+    setState(() => _dumping = false);
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF121212),
+        title: const Text('Learning Path Graph'),
+        content: SingleChildScrollView(
+          child: SelectableText(text),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: text));
+              Navigator.pop(context);
+            },
+            child: const Text('Copy'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (kDebugMode)
+          ListTile(
+            title: const Text('🧠 Dump Learning Path Graph'),
+            onTap: _dumping ? null : _dumpGraph,
+          ),
+      ],
+    );
+  }
+}
+

--- a/lib/screens/dev_menu_screen.dart
+++ b/lib/screens/dev_menu_screen.dart
@@ -4,6 +4,7 @@ import 'dev_menu/booster_section.dart';
 import 'dev_menu/coverage_section.dart';
 import 'dev_menu/dev_menu_section.dart';
 import 'dev_menu/pack_generation_section.dart';
+import 'dev_menu/debug_tools_section.dart';
 
 class DevMenuScreen extends StatelessWidget {
   const DevMenuScreen({super.key});
@@ -22,6 +23,10 @@ class DevMenuScreen extends StatelessWidget {
       DevMenuSection(
         title: 'Booster Tools',
         builder: (_) => const BoosterSection(),
+      ),
+      DevMenuSection(
+        title: 'Debug Tools',
+        builder: (_) => const DebugToolsSection(),
       ),
     ];
 

--- a/lib/services/learning_path_node_graph_snapshot_service.dart
+++ b/lib/services/learning_path_node_graph_snapshot_service.dart
@@ -1,0 +1,56 @@
+import 'package:collection/collection.dart';
+
+import '../models/learning_branch_node.dart';
+import '../models/learning_path_node.dart';
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'learning_path_node_history.dart';
+import 'path_map_engine.dart';
+
+/// Dumps a formatted snapshot of the current PathMapEngine graph.
+class LearningPathNodeGraphSnapshotService {
+  const LearningPathNodeGraphSnapshotService({required this.engine});
+
+  final PathMapEngine engine;
+
+  /// Returns a formatted multiline snapshot of all nodes.
+  String debugSnapshot() {
+    final autoInjected =
+        LearningPathNodeHistory.instance.getAutoInjectedIds().toSet();
+    final buffer = StringBuffer();
+    for (final node in engine.allNodes.sortedBy((n) => n.id)) {
+      final marker = autoInjected.contains(node.id) ? '*' : '';
+      final type = _typeOf(node);
+      final next = _nextIds(node).join(', ');
+      final depends = _dependsOn(node).join(', ');
+      buffer.writeln(
+          '${node.id}$marker [$type] nextIds: [$next] dependsOn: [$depends]');
+    }
+    return buffer.toString();
+  }
+
+  String _typeOf(LearningPathNode node) {
+    if (node is LearningBranchNode) return 'Branch';
+    if (node is TrainingStageNode) return 'Training';
+    if (node is TheoryStageNode) return 'Theory';
+    if (node is TheoryLessonNode) return 'Theory';
+    if (node is TheoryMiniLessonNode) return 'Theory';
+    return node.runtimeType.toString();
+  }
+
+  List<String> _nextIds(LearningPathNode node) {
+    if (node is LearningBranchNode) {
+      return node.branches.values.toList();
+    }
+    if (node is StageNode) return node.nextIds;
+    if (node is TheoryLessonNode) return node.nextIds;
+    if (node is TheoryMiniLessonNode) return node.nextIds;
+    return const [];
+  }
+
+  List<String> _dependsOn(LearningPathNode node) {
+    if (node is StageNode) return node.dependsOn;
+    return const [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `LearningPathNodeGraphSnapshotService` to inspect learning path graph
- expose snapshot via new Debug Tools in dev menu

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5d0d9f4c832a90ab1361840f0d5a