### PR TITLE
Add Level II open/fold 3bb cash stage and theory module

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -1,4 +1,5 @@
 packs:
   - assets/packs/v2/preflop/push_fold_cash.yaml
+  - assets/packs/v2/preflop/openfold_3bb_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/preflop/openfold_3bb_cash.yaml
+++ b/assets/packs/v2/preflop/openfold_3bb_cash.yaml
@@ -1,0 +1,52 @@
+
+id: openfold_3bb_cash
+name: Open/Fold vs 3bb (Cash)
+
+trainingType: cash
+
+recommended: false
+
+icon: cash
+
+bb: 100
+
+gameType: cash
+
+positions:
+  - utg
+  - hj
+  - co
+  - btn
+  - sb
+
+tags:
+  - cash
+  - openfold
+  - preflop
+  - level2
+
+spots:
+  - id: of_3bb_cash_1
+    title: KJo CO facing folds
+    villainAction: none
+    heroOptions:
+      - open
+      - fold
+    hand:
+      heroCards: Ks Jd
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+
+spotCount: 1
+
+meta:
+  schemaVersion: 2.0.0
+

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -1,3 +1,6 @@
 nodes:
   - type: stage
-    id: start
+    stageId: push_fold_cash
+    next: [openfold_3bb_cash]
+  - type: stage
+    stageId: openfold_3bb_cash

--- a/assets/theory_lessons/level2/openfold_3bb_cash.yaml
+++ b/assets/theory_lessons/level2/openfold_3bb_cash.yaml
@@ -1,0 +1,12 @@
+id: openfold_3bb_cash
+title: 'Open/Fold vs 3bb Raise (Cash)'
+tags: ['openfold', 'cash', 'preflop', 'level2']
+content: |-
+  After mastering push/fold play, the next frontier is deciding which hands to open when everyone folds to you in a 6-max cash game.
+  Facing a standard 3bb raise, understanding open/fold decisions keeps you aggressive while avoiding marginal opens.
+
+  6-max dynamics to remember:
+  - Standard open size is 3bb.
+  - Positions: UTG, HJ, CO, BTN, SB, BB.
+  - Fewer opponents allow wider ranges from late position.
+nextIds: ['openfold_btn_vs_utg_cash']

--- a/lib/templates/stage_template_openfold_3bb_cash.dart
+++ b/lib/templates/stage_template_openfold_3bb_cash.dart
@@ -1,0 +1,13 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for open/fold decisions versus a 3bb raise in 6-max cash games.
+const LearningPathStageModel openFold3bbCashStageTemplate = LearningPathStageModel(
+  id: 'openfold_3bb_cash',
+  title: 'Open/Fold vs 3bb Raise (Cash)',
+  description: 'Decide whether to open or fold facing a standard 3bb raise in 6-max cash games',
+  packId: 'openfold_3bb_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['openfold', 'cash', 'preflop', 'level2'],
+  unlocks: ['openfold_btn_vs_utg_cash'],
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,6 +115,7 @@ flutter:
     - assets/mini_lessons/
     - assets/theory_mini_lessons/
     - assets/theory_lessons/level1/
+    - assets/theory_lessons/level2/
     - assets/mini_lesson_library.yaml
     - assets/lessons/
     - assets/lesson_tracks/


### PR DESCRIPTION
## Summary
- introduce Level II theory module `openfold_3bb_cash` covering 6-max cash open/fold vs 3bb
- add stage template and pack asset for the new skill block
- extend cash learning path to chain `push_fold_cash` into `openfold_3bb_cash`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f5e43d77c832a95cf4e52ab16542e