### PR TITLE
Add CO vs HJ open/fold cash stage

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -2,5 +2,6 @@ packs:
   - assets/packs/v2/preflop/push_fold_cash.yaml
   - assets/packs/v2/preflop/openfold_3bb_cash.yaml
   - assets/packs/v2/preflop/openfold_btn_vs_utg_cash.yaml
+  - assets/packs/v2/preflop/openfold_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/preflop/openfold_co_vs_hj_cash.yaml
+++ b/assets/packs/v2/preflop/openfold_co_vs_hj_cash.yaml
@@ -1,0 +1,84 @@
+id: openfold_co_vs_hj_cash
+name: CO vs HJ Open/Fold (Cash)
+
+trainingType: cash
+
+recommended: false
+
+icon: cash
+
+bb: 100
+
+gameType: cash
+
+positions:
+  - co
+
+tags:
+  - cash
+  - openfold
+  - preflop
+  - level2
+  - co
+  - hj
+
+spots:
+  - id: of_co_hj_cash_1
+    title: CO QJo vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - open
+      - fold
+    hand:
+      heroCards: Qc Jd
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: of_co_hj_cash_2
+    title: CO A5s vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - open
+      - fold
+    hand:
+      heroCards: As 5s
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: of_co_hj_cash_3
+    title: CO 66 vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - open
+      - fold
+    hand:
+      heroCards: 6h 6d
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+
+spotCount: 3
+
+meta:
+  schemaVersion: 2.0.0

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -7,3 +7,6 @@ nodes:
     next: [openfold_btn_vs_utg_cash]
   - type: stage
     stageId: openfold_btn_vs_utg_cash
+    next: [openfold_co_vs_hj_cash]
+  - type: stage
+    stageId: openfold_co_vs_hj_cash

--- a/assets/theory_lessons/level2/openfold_btn_vs_utg_cash.yaml
+++ b/assets/theory_lessons/level2/openfold_btn_vs_utg_cash.yaml
@@ -5,3 +5,4 @@ content: |-
   Facing an under-the-gun 3bb raise on the button, your continue range must stay tight.
   The opener's range is strongest, so exploit opportunities are limited and many hands become marginal.
   Use blocker effects when selecting 3-bet bluffs and avoid dominated calls.
+nextIds: ['openfold_co_vs_hj_cash']

--- a/assets/theory_lessons/level2/openfold_co_vs_hj_cash.yaml
+++ b/assets/theory_lessons/level2/openfold_co_vs_hj_cash.yaml
@@ -1,0 +1,7 @@
+id: openfold_co_vs_hj_cash
+title: 'CO vs HJ Open — Marginal Edges'
+tags: ['openfold', 'cash', 'preflop', 'level2']
+content: |-
+  Mid-position confrontations carry marginal edges. The hijack's opening range is tighter,
+  so the cutoff should emphasize blocker weight and separate value hands from speculative bluffs.
+  Attack with suited blockers and small pairs while dropping dominated offsuit combos.

--- a/lib/templates/stage_template_openfold_btn_vs_utg_cash.dart
+++ b/lib/templates/stage_template_openfold_btn_vs_utg_cash.dart
@@ -9,5 +9,6 @@ const LearningPathStageModel openFoldBtnVsUtgCashStageTemplate = LearningPathSta
   requiredAccuracy: 80,
   minHands: 10,
   tags: ['openfold', 'cash', 'preflop', 'level2', 'btn', 'vsUtg'],
+  unlocks: ['openfold_co_vs_hj_cash'],
 );
 

--- a/lib/templates/stage_template_openfold_co_vs_hj_cash.dart
+++ b/lib/templates/stage_template_openfold_co_vs_hj_cash.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for CO open/fold decisions facing a HJ 3bb raise in 6-max cash games.
+const LearningPathStageModel openFoldCoVsHjCashStageTemplate = LearningPathStageModel(
+  id: 'openfold_co_vs_hj_cash',
+  title: 'CO vs HJ Open/Fold (Cash)',
+  description: 'Decide whether to 3-bet or fold the Cutoff facing a Hijack 3bb open in 6-max cash games',
+  packId: 'openfold_co_vs_hj_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['openfold', 'cash', 'preflop', 'level2', 'co', 'vsHj'],
+);


### PR DESCRIPTION
## Summary
- add Level II CO vs HJ open/fold (cash) theory lesson and training pack
- connect BTN vs UTG stage to new CO vs HJ stage in learning path

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f61f4856c832a8c52977db37c8bfc