### PR TITLE
Add BTN vs CO 3-bet cash stage

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -4,5 +4,6 @@ packs:
   - assets/packs/v2/preflop/openfold_btn_vs_utg_cash.yaml
   - assets/packs/v2/preflop/openfold_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/openfold_hj_vs_utg_cash.yaml
+  - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
+++ b/assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
@@ -1,0 +1,84 @@
+id: threebet_btn_vs_co_cash
+name: BTN vs CO 3-bet Decision (Cash)
+
+trainingType: cash
+
+recommended: false
+
+icon: cash
+
+bb: 100
+
+gameType: cash
+
+positions:
+  - btn
+
+tags:
+  - cash
+  - threebet
+  - preflop
+  - level2
+  - btn
+  - co
+
+spots:
+  - id: tb_btn_co_cash_1
+    title: BTN QTs vs CO 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: Qh Th
+      position: btn
+      heroIndex: 3
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_btn_co_cash_2
+    title: BTN A5s vs CO 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: As 5s
+      position: btn
+      heroIndex: 3
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_btn_co_cash_3
+    title: BTN 55 vs CO 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: 5h 5d
+      position: btn
+      heroIndex: 3
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+
+spotCount: 3
+
+meta:
+  schemaVersion: 2.0.0

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -13,3 +13,6 @@ nodes:
     next: [openfold_hj_vs_utg_cash]
   - type: stage
     stageId: openfold_hj_vs_utg_cash
+    next: [threebet_btn_vs_co_cash]
+  - type: stage
+    stageId: threebet_btn_vs_co_cash

--- a/assets/theory_lessons/level2/threebet_btn_vs_co_cash.yaml
+++ b/assets/theory_lessons/level2/threebet_btn_vs_co_cash.yaml
@@ -1,0 +1,8 @@
+id: threebet_btn_vs_co_cash
+title: 'BTN vs CO — 3-bet Spots'
+tags: ['threebet', 'cash', 'preflop', 'level2']
+content: |-
+  Polarize your Button 3-bet range versus CO opens. Favor Ax and Kx blockers to
+  maximize fold equity while mixing suited connectors and small pairs that can
+  realize equity postflop. The Button's positional advantage amplifies fold
+  leverage, letting you pressure the Cutoff's wider opens.

--- a/lib/templates/stage_template_openfold_hj_vs_utg_cash.dart
+++ b/lib/templates/stage_template_openfold_hj_vs_utg_cash.dart
@@ -9,4 +9,5 @@ const LearningPathStageModel openFoldHjVsUtgCashStageTemplate = LearningPathStag
   requiredAccuracy: 80,
   minHands: 10,
   tags: ['openfold', 'cash', 'preflop', 'level2', 'hj', 'vsUtg'],
+  unlocks: ['threebet_btn_vs_co_cash'],
 );

--- a/lib/templates/stage_template_threebet_btn_vs_co_cash.dart
+++ b/lib/templates/stage_template_threebet_btn_vs_co_cash.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for BTN 3-bet or fold decisions facing a CO 3bb open in 6-max cash games.
+const LearningPathStageModel threeBetBtnVsCoCashStageTemplate = LearningPathStageModel(
+  id: 'threebet_btn_vs_co_cash',
+  title: 'BTN vs CO 3-bet (Cash)',
+  description: 'Decide whether to 3-bet or fold from the Button facing a Cutoff 3bb open in 6-max cash games',
+  packId: 'threebet_btn_vs_co_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['threebet', 'cash', 'preflop', 'level2', 'btn', 'vsCo'],
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,6 +109,8 @@ flutter:
     - assets/packs/v2/library_index.json
     - assets/packs/v2/preflop/openfold_hj_vs_utg_cash.yaml
     - assets/theory_lessons/level2/openfold_hj_vs_utg_cash.yaml
+    - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
+    - assets/theory_lessons/level2/threebet_btn_vs_co_cash.yaml
     - assets/templates/
     - assets/built_in_packs.yaml
     - assets/theory_packs/


### PR DESCRIPTION
## Summary
- add theory and training pack for BTN vs CO 3-bet decisions in cash games
- wire new stage into cash learning path and online path
- register assets and stage templates for new node

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f678bdd60832a86c25e3e6f36c40b