### PR TITLE
Add CO vs HJ cash 3-bet stage

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -5,5 +5,6 @@ packs:
   - assets/packs/v2/preflop/openfold_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/openfold_hj_vs_utg_cash.yaml
   - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
+  - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
+++ b/assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
@@ -1,0 +1,84 @@
+id: threebet_co_vs_hj_cash
+name: CO vs HJ 3-bet Decision (Cash)
+
+trainingType: cash
+
+recommended: false
+
+icon: cash
+
+bb: 100
+
+gameType: cash
+
+positions:
+  - co
+
+tags:
+  - cash
+  - threebet
+  - preflop
+  - level2
+  - co
+  - hj
+
+spots:
+  - id: tb_co_hj_cash_1
+    title: CO KQo vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: Kh Qd
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_co_hj_cash_2
+    title: CO A2s vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: As 2s
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_co_hj_cash_3
+    title: CO 66 vs HJ 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: 6h 6d
+      position: co
+      heroIndex: 2
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+
+spotCount: 3
+
+meta:
+  schemaVersion: 2.0.0

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -16,3 +16,6 @@ nodes:
     next: [threebet_btn_vs_co_cash]
   - type: stage
     stageId: threebet_btn_vs_co_cash
+    next: [threebet_co_vs_hj_cash]
+  - type: stage
+    stageId: threebet_co_vs_hj_cash

--- a/assets/theory_lessons/level2/threebet_co_vs_hj_cash.yaml
+++ b/assets/theory_lessons/level2/threebet_co_vs_hj_cash.yaml
@@ -1,0 +1,8 @@
+id: threebet_co_vs_hj_cash
+title: 'CO vs HJ — 3-bet Lines'
+tags: ['threebet', 'cash', 'preflop', 'level2']
+content: |-
+  CO reacts to Hijack opens with a semi-polar 3-bet range.
+  Mix strong value hands with suited Ax and Kx blockers that deny equity while
+  adding dynamic postflop potential from suited connectors and pairs.
+  Balance aggression with hands that can continue on various board textures.

--- a/lib/templates/stage_template_threebet_btn_vs_co_cash.dart
+++ b/lib/templates/stage_template_threebet_btn_vs_co_cash.dart
@@ -9,4 +9,5 @@ const LearningPathStageModel threeBetBtnVsCoCashStageTemplate = LearningPathStag
   requiredAccuracy: 80,
   minHands: 10,
   tags: ['threebet', 'cash', 'preflop', 'level2', 'btn', 'vsCo'],
+  unlocks: ['threebet_co_vs_hj_cash'],
 );

--- a/lib/templates/stage_template_threebet_co_vs_hj_cash.dart
+++ b/lib/templates/stage_template_threebet_co_vs_hj_cash.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for CO 3-bet or fold decisions facing a HJ 3bb open in 6-max cash games.
+const LearningPathStageModel threeBetCoVsHjCashStageTemplate = LearningPathStageModel(
+  id: 'threebet_co_vs_hj_cash',
+  title: 'CO vs HJ 3-bet (Cash)',
+  description: 'Decide whether to 3-bet or fold from the Cutoff facing a Hijack 3bb open in 6-max cash games',
+  packId: 'threebet_co_vs_hj_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['threebet', 'cash', 'preflop', 'level2', 'co', 'vsHj'],
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,6 +111,8 @@ flutter:
     - assets/theory_lessons/level2/openfold_hj_vs_utg_cash.yaml
     - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
     - assets/theory_lessons/level2/threebet_btn_vs_co_cash.yaml
+    - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
+    - assets/theory_lessons/level2/threebet_co_vs_hj_cash.yaml
     - assets/templates/
     - assets/built_in_packs.yaml
     - assets/theory_packs/


### PR DESCRIPTION
## Summary
- introduce CO vs HJ 3-bet decision stage with theory and training pack
- link new stage after BTN vs CO 3-bet in cash learning path
- register assets and update stage templates

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a6a6fd4832aa5250385fe1a98ff