### PR TITLE
Add HJ vs UTG cash three-bet stage

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -6,5 +6,6 @@ packs:
   - assets/packs/v2/preflop/openfold_hj_vs_utg_cash.yaml
   - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
   - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
+  - assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
+++ b/assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
@@ -1,0 +1,84 @@
+id: threebet_hj_vs_utg_cash
+name: HJ vs UTG 3-bet Decision (Cash)
+
+trainingType: cash
+
+recommended: false
+
+icon: cash
+
+bb: 100
+
+gameType: cash
+
+positions:
+  - hj
+
+tags:
+  - cash
+  - threebet
+  - preflop
+  - level2
+  - hj
+  - utg
+
+spots:
+  - id: tb_hj_utg_cash_1
+    title: HJ AJs vs UTG 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: As Js
+      position: hj
+      heroIndex: 1
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_hj_utg_cash_2
+    title: HJ TT vs UTG 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: Th Td
+      position: hj
+      heroIndex: 1
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+  - id: tb_hj_utg_cash_3
+    title: HJ A5s vs UTG 3bb
+    villainAction: open 3.0
+    heroOptions:
+      - 3bet
+      - fold
+    hand:
+      heroCards: As 5s
+      position: hj
+      heroIndex: 1
+      playerCount: 6
+      stacks:
+        '0': 100
+        '1': 100
+        '2': 100
+        '3': 100
+        '4': 100
+        '5': 100
+
+spotCount: 3
+
+meta:
+  schemaVersion: 2.0.0

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -19,3 +19,6 @@ nodes:
     next: [threebet_co_vs_hj_cash]
   - type: stage
     stageId: threebet_co_vs_hj_cash
+    next: [threebet_hj_vs_utg_cash]
+  - type: stage
+    stageId: threebet_hj_vs_utg_cash

--- a/assets/theory_lessons/level2/threebet_hj_vs_utg_cash.yaml
+++ b/assets/theory_lessons/level2/threebet_hj_vs_utg_cash.yaml
@@ -1,0 +1,7 @@
+id: threebet_hj_vs_utg_cash
+title: 'HJ vs UTG — 3-bet Range Construction'
+tags: ['threebet', 'cash', 'preflop', 'level2']
+content: |-
+  Facing an UTG open, the Hijack continues with disciplined aggression.
+  Prioritize suited Ax blockers and strong pairs for a mostly linear range.
+  Mix in select suited wheel Ax to avoid over-polarization while keeping the range tight.

--- a/lib/templates/stage_template_threebet_co_vs_hj_cash.dart
+++ b/lib/templates/stage_template_threebet_co_vs_hj_cash.dart
@@ -9,4 +9,5 @@ const LearningPathStageModel threeBetCoVsHjCashStageTemplate = LearningPathStage
   requiredAccuracy: 80,
   minHands: 10,
   tags: ['threebet', 'cash', 'preflop', 'level2', 'co', 'vsHj'],
+  unlocks: ['threebet_hj_vs_utg_cash'],
 );

--- a/lib/templates/stage_template_threebet_hj_vs_utg_cash.dart
+++ b/lib/templates/stage_template_threebet_hj_vs_utg_cash.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for HJ 3-bet or fold decisions facing an UTG 3bb open in 6-max cash games.
+const LearningPathStageModel threeBetHjVsUtgCashStageTemplate = LearningPathStageModel(
+  id: 'threebet_hj_vs_utg_cash',
+  title: 'HJ vs UTG 3-bet (Cash)',
+  description: 'Decide whether to 3-bet or fold from the Hijack facing an UTG 3bb open in 6-max cash games',
+  packId: 'threebet_hj_vs_utg_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['threebet', 'cash', 'preflop', 'level2', 'hj', 'vsUtg'],
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,6 +113,8 @@ flutter:
     - assets/theory_lessons/level2/threebet_btn_vs_co_cash.yaml
     - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
     - assets/theory_lessons/level2/threebet_co_vs_hj_cash.yaml
+    - assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
+    - assets/theory_lessons/level2/threebet_hj_vs_utg_cash.yaml
     - assets/templates/
     - assets/built_in_packs.yaml
     - assets/theory_packs/


### PR DESCRIPTION
## Summary
- Add Hijack vs UTG cash 3-bet stage template and link from existing CO vs HJ stage
- Provide HJ vs UTG 3-bet theory lesson and training pack with AJs, TT and A5s examples
- Register new stage in cash path, online path, and asset bundle

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c78b98c832aaa8afa81f7ac5cff