### PR TITLE
feat: add UTG postflop node after HJ 3bet

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -8,5 +8,6 @@ packs:
   - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
   - assets/packs/v2/preflop/defend_utg_vs_hj_3bet_cash.yaml
+  - assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml
   - assets/packs/v2/preflop/threebet_push_late_cash.yaml

--- a/assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
+++ b/assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
@@ -1,0 +1,51 @@
+id: postflop_utg_call_vs_hj_3bet_cash
+name: UTG Postflop vs HJ 3-bet (Cash)
+trainingType: postflop
+bb: 100
+gameType: cash
+positions: [utg, hj]
+tags: [cash, postflop, threebetDefense, level3, utg, hj]
+spots:
+  - id: pf_utg_call_hj_3bet_cash_1
+    title: AQ on K72r
+    board: [Kc,7d,2s]
+    street: 1
+    villainAction: bet 6.0
+    heroOptions: [call, fold]
+    hand:
+      heroCards: 'As Qd'
+      position: utg
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 100, '1': 100}
+      board: [Kc,7d,2s]
+  - id: pf_utg_call_hj_3bet_cash_2
+    title: 99 on T84s
+    board: [Ts,8s,4d]
+    street: 1
+    villainAction: bet 6.0
+    heroOptions: [call, fold]
+    hand:
+      heroCards: '9c 9d'
+      position: utg
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 100, '1': 100}
+      board: [Ts,8s,4d]
+  - id: pf_utg_call_hj_3bet_cash_3
+    title: KQs on Q63
+    board: [Qd,6c,3s]
+    street: 1
+    villainAction: bet 6.0
+    heroOptions: [call, raise]
+    hand:
+      heroCards: 'Ks Qs'
+      position: utg
+      heroIndex: 0
+      playerCount: 2
+      stacks: {'0': 100, '1': 100}
+      board: [Qd,6c,3s]
+spotCount: 3
+
+meta:
+  schemaVersion: 2.0.0

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -25,3 +25,6 @@ nodes:
     next: [defend_utg_vs_hj_3bet_cash]
   - type: stage
     stageId: defend_utg_vs_hj_3bet_cash
+    next: [postflop_utg_call_vs_hj_3bet_cash]
+  - type: stage
+    stageId: postflop_utg_call_vs_hj_3bet_cash

--- a/assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
+++ b/assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
@@ -1,0 +1,8 @@
+id: postflop_utg_call_vs_hj_3bet_cash
+title: 'UTG Postflop Play After HJ 3-bet Call'
+tags: ['threebetDefense', 'cash', 'postflop', 'level3', 'utg', 'vsHj']
+content: |-
+  After calling a 3-bet from the Hijack, UTG enters the flop out of position and at a range disadvantage.
+  Our tight calling range interacts with boards that favor the aggressor, demanding careful play.
+  Without initiative, prioritize strong value hands and disciplined bluff catching to navigate equity
+  realization.

--- a/lib/templates/stage_template_postflop_utg_call_vs_hj_3bet_cash.dart
+++ b/lib/templates/stage_template_postflop_utg_call_vs_hj_3bet_cash.dart
@@ -1,0 +1,12 @@
+import '../models/learning_path_stage_model.dart';
+
+/// Stage template for UTG postflop decisions after calling an HJ 3-bet in 6-max cash games.
+const LearningPathStageModel postflopUtgCallVsHj3betCashStageTemplate = LearningPathStageModel(
+  id: 'postflop_utg_call_vs_hj_3bet_cash',
+  title: 'UTG Postflop vs HJ 3-bet (Cash)',
+  description: 'Navigate flop play after defending an HJ 3-bet from UTG in 6-max cash games',
+  packId: 'postflop_utg_call_vs_hj_3bet_cash',
+  requiredAccuracy: 80,
+  minHands: 10,
+  tags: ['threebetDefense', 'cash', 'postflop', 'level3', 'utg', 'vsHj'],
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -117,6 +117,8 @@ flutter:
     - assets/theory_lessons/level2/threebet_hj_vs_utg_cash.yaml
     - assets/packs/v2/preflop/defend_utg_vs_hj_3bet_cash.yaml
     - assets/theory_lessons/level2/defend_utg_vs_hj_3bet_cash.yaml
+    - assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
+    - assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
   - assets/templates/
     - assets/built_in_packs.yaml
     - assets/theory_packs/
@@ -126,6 +128,7 @@ flutter:
     - assets/theory_mini_lessons/
     - assets/theory_lessons/level1/
     - assets/theory_lessons/level2/
+    - assets/theory_lessons/level3/
     - assets/mini_lesson_library.yaml
     - assets/lessons/
     - assets/lesson_tracks/


### PR DESCRIPTION
## Summary
- add UTG postflop vs HJ 3-bet stage template and theory pack
- introduce practice hands for common flop scenarios
- link new postflop node into cash learning path and asset manifest

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f9956a0832abe3b75feffa62a48