### PR TITLE
fix: remove duplicate templates asset entry

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -119,7 +119,6 @@ flutter:
     - assets/theory_lessons/level2/defend_utg_vs_hj_3bet_cash.yaml
     - assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
     - assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
-  - assets/templates/
     - assets/built_in_packs.yaml
     - assets/theory_packs/
     - assets/theory_blocks/


### PR DESCRIPTION
## Summary
- remove dangling `assets/templates/` entry from `pubspec.yaml` to restore valid YAML structure

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688f71e9d548832abd1e899b946ffa6b