### PR TITLE
feat: add dynamic training pack generation

### DIFF
--- a/lib/models/v2/dynamic_spot_template.dart
+++ b/lib/models/v2/dynamic_spot_template.dart
@@ -1,0 +1,79 @@
+import 'dart:math';
+
+import 'hand_data.dart';
+import 'hero_position.dart';
+import 'training_pack_spot.dart';
+
+class DynamicSpotTemplate {
+  final List<String> handPool;
+  final String villainAction;
+  final List<String> heroOptions;
+  final HeroPosition position;
+  final int playerCount;
+  final int stack;
+  final int sampleSize;
+
+  const DynamicSpotTemplate({
+    required this.handPool,
+    required this.villainAction,
+    required this.heroOptions,
+    required this.position,
+    required this.playerCount,
+    required this.stack,
+    required this.sampleSize,
+  });
+
+  factory DynamicSpotTemplate.fromJson(Map<String, dynamic> j) {
+    return DynamicSpotTemplate(
+      handPool: [for (final h in (j['handPool'] as List? ?? [])) h.toString()],
+      villainAction: j['villainAction']?.toString() ?? '',
+      heroOptions: [for (final o in (j['heroOptions'] as List? ?? [])) o.toString()],
+      position: parseHeroPosition(j['position']?.toString() ?? ''),
+      playerCount: (j['playerCount'] as num?)?.toInt() ?? 2,
+      stack: (j['stack'] as num?)?.toInt() ?? 0,
+      sampleSize: (j['sampleSize'] as num?)?.toInt() ?? 1,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'handPool': handPool,
+        'villainAction': villainAction,
+        if (heroOptions.isNotEmpty) 'heroOptions': heroOptions,
+        'position': position.name,
+        'playerCount': playerCount,
+        'stack': stack,
+        'sampleSize': sampleSize,
+      };
+
+  List<TrainingPackSpot> generateSpots() {
+    final rng = Random();
+    final pool = List<String>.from(handPool);
+    pool.shuffle(rng);
+    final count = sampleSize.clamp(1, pool.length);
+    final spots = <TrainingPackSpot>[];
+    for (final hand in pool.take(count)) {
+      final handId = hand.replaceAll(' ', '');
+      final id =
+          '${position.name.toUpperCase()}_${handId}_vs_${villainAction.replaceAll(' ', '')}';
+      final title = '${position.name.toUpperCase()} $hand vs $villainAction';
+      final stacks = {
+        for (var i = 0; i < playerCount; i++) '$i': stack.toDouble()
+      };
+      final hd = HandData(
+        heroCards: hand,
+        position: position,
+        heroIndex: 0,
+        playerCount: playerCount,
+        stacks: stacks,
+      );
+      spots.add(TrainingPackSpot(
+        id: id,
+        title: title,
+        villainAction: villainAction,
+        heroOptions: List<String>.from(heroOptions),
+        hand: hd,
+      ));
+    }
+    return spots;
+  }
+}

--- a/lib/models/v2/training_pack_v2.dart
+++ b/lib/models/v2/training_pack_v2.dart
@@ -81,20 +81,23 @@ class TrainingPackV2 {
     if (meta.isNotEmpty) 'meta': meta,
   };
 
-  factory TrainingPackV2.fromTemplate(TrainingPackTemplateV2 t, String id) =>
-      TrainingPackV2(
-        id: id,
-        sourceTemplateId: t.id,
-        name: t.name,
-        description: t.description,
-        tags: List<String>.from(t.tags),
-        type: t.trainingType,
-        spots: [for (final s in t.spots) TrainingPackSpot.fromJson(s.toJson())],
-        spotCount: t.spotCount,
-        generatedAt: DateTime.now(),
-        gameType: t.gameType,
-        bb: t.bb,
-        positions: List<String>.from(t.positions),
-        meta: Map<String, dynamic>.from(t.meta),
-      );
+  factory TrainingPackV2.fromTemplate(TrainingPackTemplateV2 t, String id) {
+    final spotList =
+        t.dynamicSpots.isNotEmpty ? t.generateDynamicSpotSamples() : t.spots;
+    return TrainingPackV2(
+      id: id,
+      sourceTemplateId: t.id,
+      name: t.name,
+      description: t.description,
+      tags: List<String>.from(t.tags),
+      type: t.trainingType,
+      spots: [for (final s in spotList) TrainingPackSpot.fromJson(s.toJson())],
+      spotCount: spotList.length,
+      generatedAt: DateTime.now(),
+      gameType: t.gameType,
+      bb: t.bb,
+      positions: List<String>.from(t.positions),
+      meta: Map<String, dynamic>.from(t.meta),
+    );
+  }
 }

--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -1,0 +1,39 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_v2.dart';
+
+void main() {
+  const yaml = '''
+id: dyn_pack
+name: Dynamic Pack
+trainingType: mtt
+bb: 100
+positions:
+  - utg
+meta:
+  schemaVersion: 2.0.0
+dynamicSpots:
+  - handPool:
+      - Ad Qh
+      - Ac Qd
+      - Ah Qc
+    villainAction: 3bet 9.0
+    heroOptions: [call, fold]
+    position: utg
+    playerCount: 6
+    stack: 100
+    sampleSize: 2
+''';
+
+  test('dynamic pack generates random spots from hand pool', () {
+    final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+    expect(tpl.dynamicSpots.length, 1);
+    final pack = TrainingPackV2.fromTemplate(tpl, 'p1');
+    expect(pack.spots.length, 2);
+    final pool = tpl.dynamicSpots.first.handPool;
+    for (final s in pack.spots) {
+      expect(pool.contains(s.hand.heroCards), true);
+      expect(s.heroOptions, ['call', 'fold']);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- extend training pack templates with `dynamicSpots` definitions
- generate random spot samples from hand pools at runtime
- cover dynamic spot generation with tests

## Testing
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f711973bc832ab5fda207bf35ad31