### PR TITLE
Add UTG postflop vs HJ 3-bet stage

### DIFF
--- a/assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
+++ b/assets/theory_lessons/level3/postflop_utg_call_vs_hj_3bet_cash.yaml
@@ -2,7 +2,6 @@ id: postflop_utg_call_vs_hj_3bet_cash
 title: 'UTG Postflop Play After HJ 3-bet Call'
 tags: ['threebetDefense', 'cash', 'postflop', 'level3', 'utg', 'vsHj']
 content: |-
-  After calling a 3-bet from the Hijack, UTG enters the flop out of position and at a range disadvantage.
-  Our tight calling range interacts with boards that favor the aggressor, demanding careful play.
-  Without initiative, prioritize strong value hands and disciplined bluff catching to navigate equity
-  realization.
+  Calling a 3-bet from the Hijack leaves UTG out of position with a capped, tight range.
+  The aggressor's stronger range connects with many flops, so judge board texture carefully.
+  Lacking initiative, lean on value bets and selective bluff catching to realize equity.

--- a/lib/templates/stage_template_postflop_utg_call_vs_hj_3bet_cash.dart
+++ b/lib/templates/stage_template_postflop_utg_call_vs_hj_3bet_cash.dart
@@ -4,7 +4,8 @@ import '../models/learning_path_stage_model.dart';
 const LearningPathStageModel postflopUtgCallVsHj3betCashStageTemplate = LearningPathStageModel(
   id: 'postflop_utg_call_vs_hj_3bet_cash',
   title: 'UTG Postflop vs HJ 3-bet (Cash)',
-  description: 'Navigate flop play after defending an HJ 3-bet from UTG in 6-max cash games',
+  description:
+      'Play OOP after calling an HJ 3-bet; handle range disadvantage, board interaction, and lost initiative',
   packId: 'postflop_utg_call_vs_hj_3bet_cash',
   requiredAccuracy: 80,
   minHands: 10,


### PR DESCRIPTION
## Summary
- flesh out UTG postflop vs HJ 3-bet stage template
- add supporting theory for out-of-position postflop play after defending a 3-bet

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f750ad988832abe743c04a34a01a6