### PR TITLE
feat: add dynamic training spot generator

### DIFF
--- a/lib/services/hand_range_library.dart
+++ b/lib/services/hand_range_library.dart
@@ -12,6 +12,49 @@ class HandRangeLibrary {
         return PackGeneratorService.topNHands(70).toList();
       case 'icm':
         return PackGeneratorService.topNHands(10).toList();
+      case 'broadways':
+        const ranks = ['A', 'K', 'Q', 'J', 'T'];
+        final hands = <String>[];
+        for (var i = 0; i < ranks.length; i++) {
+          hands.add('${ranks[i]}${ranks[i]}');
+          for (var j = i + 1; j < ranks.length; j++) {
+            hands.add('${ranks[i]}${ranks[j]}s');
+            hands.add('${ranks[i]}${ranks[j]}o');
+          }
+        }
+        return hands;
+      case 'pockets':
+        return [
+          'AA',
+          'KK',
+          'QQ',
+          'JJ',
+          'TT',
+          '99',
+          '88',
+          '77',
+          '66',
+          '55',
+          '44',
+          '33',
+          '22',
+        ];
+      case 'suitedAx':
+        const kickers = [
+          'K',
+          'Q',
+          'J',
+          'T',
+          '9',
+          '8',
+          '7',
+          '6',
+          '5',
+          '4',
+          '3',
+          '2',
+        ];
+        return [for (final k in kickers) 'A${k}s'];
       case 'nash-10bb':
         return [
           '22',

--- a/lib/services/training_spot_generator_service.dart
+++ b/lib/services/training_spot_generator_service.dart
@@ -1,0 +1,99 @@
+import 'dart:math';
+
+import '../models/training_spot.dart';
+import '../models/card_model.dart';
+import '../models/action_entry.dart';
+import '../models/player_model.dart';
+import 'hand_range_library.dart';
+
+class SpotGenerationParams {
+  final String position;
+  final String villainAction;
+  final List<String> handGroup;
+  final int count;
+
+  SpotGenerationParams({
+    required this.position,
+    required this.villainAction,
+    required this.handGroup,
+    required this.count,
+  });
+}
+
+class TrainingSpotGeneratorService {
+  TrainingSpotGeneratorService({Random? random}) : _random = random ?? Random();
+
+  final Random _random;
+  static const List<String> _positions6max = ['utg', 'hj', 'co', 'btn', 'sb', 'bb'];
+
+  List<TrainingSpot> generate(SpotGenerationParams params) {
+    final pool = <String>{};
+    for (final g in params.handGroup) {
+      pool.addAll(HandRangeLibrary.getGroup(g));
+    }
+    final hands = pool.toList()..shuffle(_random);
+
+    final used = <String>{};
+    final spots = <TrainingSpot>[];
+    for (final h in hands) {
+      if (spots.length >= params.count) break;
+      if (!used.add(h)) continue;
+      spots.add(_buildSpot(h, params));
+    }
+    return spots;
+  }
+
+  TrainingSpot _buildSpot(String hand, SpotGenerationParams params) {
+    var idx = _positions6max.indexOf(params.position.toLowerCase());
+    if (idx < 0) idx = 0;
+    final playerCards = List.generate(6, (_) => <CardModel>[]);
+    playerCards[idx] = _cardsForHand(hand);
+
+    final villain = (idx + 1) % 6;
+    final parts = params.villainAction.split(' ');
+    final action = parts.isNotEmpty ? parts.first : params.villainAction;
+    final amount = parts.length > 1 ? double.tryParse(parts[1]) : null;
+
+    final actions = [ActionEntry(0, villain, action, amount: amount)];
+    return TrainingSpot(
+      playerCards: playerCards,
+      boardCards: const [],
+      actions: actions,
+      heroIndex: idx,
+      numberOfPlayers: 6,
+      playerTypes: List.filled(6, PlayerType.unknown),
+      positions: List.of(_positions6max),
+      stacks: List.filled(6, 100),
+      actionType: SpotActionType.pushFold,
+      heroPosition: _positions6max[idx],
+      villainPosition: _positions6max[villain],
+    );
+  }
+
+  List<CardModel> _cardsForHand(String hand) {
+    const suits = ['♠', '♥', '♦', '♣'];
+    if (hand.length == 2) {
+      final r = hand[0];
+      final s1 = suits[_random.nextInt(4)];
+      var s2 = suits[_random.nextInt(4)];
+      while (s2 == s1) {
+        s2 = suits[_random.nextInt(4)];
+      }
+      return [CardModel(rank: r, suit: s1), CardModel(rank: r, suit: s2)];
+    }
+    final r1 = hand[0];
+    final r2 = hand[1];
+    final suited = hand[2] == 's';
+    if (suited) {
+      final s = suits[_random.nextInt(4)];
+      return [CardModel(rank: r1, suit: s), CardModel(rank: r2, suit: s)];
+    }
+    final s1 = suits[_random.nextInt(4)];
+    var s2 = suits[_random.nextInt(4)];
+    while (s2 == s1) {
+      s2 = suits[_random.nextInt(4)];
+    }
+    return [CardModel(rank: r1, suit: s1), CardModel(rank: r2, suit: s2)];
+  }
+}
+


### PR DESCRIPTION
## Summary
- expand HandRangeLibrary with broadways, pockets and suitedAx ranges
- add TrainingSpotGeneratorService to generate random spots from hand groups

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f756decc8832aab6f9185e2a7e39f