### PR TITLE
feat: add UTG defense vs HJ 3bet stage

### DIFF
--- a/assets/learning_paths/cash_path.yaml
+++ b/assets/learning_paths/cash_path.yaml
@@ -7,6 +7,7 @@ packs:
   - assets/packs/v2/preflop/threebet_btn_vs_co_cash.yaml
   - assets/packs/v2/preflop/threebet_co_vs_hj_cash.yaml
   - assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
+  # UTG defense versus Hijack 3-bet
   - assets/packs/v2/preflop/defend_utg_vs_hj_3bet_cash.yaml
   - assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml
   - assets/packs/v2/preflop/open_fold_mid_cash.yaml

--- a/assets/paths/cash_online.yaml
+++ b/assets/paths/cash_online.yaml
@@ -23,6 +23,7 @@ nodes:
   - type: stage
     stageId: threebet_hj_vs_utg_cash
     next: [defend_utg_vs_hj_3bet_cash]
+  # UTG choice: defend or fold versus Hijack 3-bet
   - type: stage
     stageId: defend_utg_vs_hj_3bet_cash
     next: [postflop_utg_call_vs_hj_3bet_cash]

--- a/lib/templates/stage_template_defend_utg_vs_hj_3bet_cash.dart
+++ b/lib/templates/stage_template_defend_utg_vs_hj_3bet_cash.dart
@@ -9,4 +9,5 @@ const LearningPathStageModel defendUtgVsHj3betCashStageTemplate = LearningPathSt
   requiredAccuracy: 80,
   minHands: 10,
   tags: ['threebetDefense', 'cash', 'preflop', 'level2', 'utg', 'vsHj'],
+  unlocks: ['postflop_utg_call_vs_hj_3bet_cash'],
 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,6 +115,7 @@ flutter:
     - assets/theory_lessons/level2/threebet_co_vs_hj_cash.yaml
     - assets/packs/v2/preflop/threebet_hj_vs_utg_cash.yaml
     - assets/theory_lessons/level2/threebet_hj_vs_utg_cash.yaml
+    # UTG defense versus Hijack 3-bet
     - assets/packs/v2/preflop/defend_utg_vs_hj_3bet_cash.yaml
     - assets/theory_lessons/level2/defend_utg_vs_hj_3bet_cash.yaml
     - assets/packs/v2/postflop/postflop_utg_call_vs_hj_3bet_cash.yaml


### PR DESCRIPTION
## Summary
- add UTG defense vs HJ 3-bet stage template unlocking postflop follow-up
- document defense stage in cash path, online path, and pubspec assets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f75100968832a8a0b9edf29953247