### PR TITLE
feat: generate dynamic training spots

### DIFF
--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -36,4 +36,23 @@ dynamicSpots:
       expect(s.heroOptions, ['call', 'fold']);
     }
   });
+
+  test('dynamicParams generate spots via generator service', () {
+    const yaml2 = '''
+id: gen_pack
+name: Generator Pack
+trainingType: mtt
+positions:
+  - hj
+meta:
+  dynamicParams:
+    position: hj
+    villainAction: "3bet 9.0"
+    handGroup: ["pockets"]
+    count: 3
+''';
+    final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml2);
+    expect(tpl.spots.length, 3);
+    expect(tpl.spotCount, 3);
+  });
 }


### PR DESCRIPTION
## Summary
- add conversion from TrainingSpot to TrainingPackSpot
- allow TrainingPackTemplateV2 to generate spots using TrainingSpotGeneratorService when `meta.dynamicParams` is set
- cover dynamicParams generation with unit test

## Testing
- `flutter test test/dynamic_spot_generation_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f772dd53c832a9ba0efbe06086447