### PR TITLE
feat: add training pack preview service and card

### DIFF
--- a/lib/models/v2/training_pack_preview_spot.dart
+++ b/lib/models/v2/training_pack_preview_spot.dart
@@ -1,0 +1,11 @@
+class TrainingPackPreviewSpot {
+  final String hand;
+  final String position;
+  final String action;
+
+  TrainingPackPreviewSpot({
+    required this.hand,
+    required this.position,
+    required this.action,
+  });
+}

--- a/lib/services/training_pack_preview_service.dart
+++ b/lib/services/training_pack_preview_service.dart
@@ -1,0 +1,39 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_preview_spot.dart';
+import 'training_spot_generator_service.dart';
+import 'dart:math';
+
+class TrainingPackPreviewService {
+  final TrainingSpotGeneratorService _generator;
+
+  TrainingPackPreviewService({TrainingSpotGeneratorService? generator})
+      : _generator = generator ?? TrainingSpotGeneratorService();
+
+  List<TrainingPackPreviewSpot> getPreviewSpots(
+    TrainingPackTemplateV2 tpl, {
+    int count = 5,
+  }) {
+    final dyn = tpl.meta['dynamicParams'];
+    if (dyn is! Map) return [];
+    final m = Map<String, dynamic>.from(dyn);
+    final params = SpotGenerationParams(
+      position: m['position']?.toString() ?? 'btn',
+      villainAction: m['villainAction']?.toString() ?? '',
+      handGroup: [
+        for (final g in (m['handGroup'] as List? ?? [])) g.toString()
+      ],
+      count: min(count, (m['count'] as num?)?.toInt() ?? count),
+    );
+    final spots = _generator.generate(params);
+    return [
+      for (final s in spots)
+        TrainingPackPreviewSpot(
+          hand: s.playerCards[s.heroIndex]
+              .map((c) => c.toString())
+              .join(' '),
+          position: s.heroPosition ?? params.position,
+          action: params.villainAction,
+        )
+    ];
+  }
+}

--- a/lib/widgets/training_pack_preview_card.dart
+++ b/lib/widgets/training_pack_preview_card.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_preview_spot.dart';
+import '../theme/app_colors.dart';
+
+class TrainingPackPreviewCard extends StatelessWidget {
+  final TrainingPackPreviewSpot spot;
+  const TrainingPackPreviewCard({super.key, required this.spot});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white24),
+      ),
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(spot.position.toUpperCase(),
+              style: const TextStyle(fontWeight: FontWeight.bold)),
+          Text(spot.hand, style: const TextStyle(fontFamily: 'monospace')),
+          Text(spot.action, style: const TextStyle(color: Colors.white70)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackPreviewService` for sampling dynamic spots
- create lightweight `TrainingPackPreviewSpot` model
- introduce `TrainingPackPreviewCard` widget for compact preview display

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f79315f00832abfe98a89edf932af