### PR TITLE
feat: support dynamic packs in learning path

### DIFF
--- a/lib/models/learning_path_node_v2.dart
+++ b/lib/models/learning_path_node_v2.dart
@@ -8,6 +8,8 @@ class LearningPathNodeV2 implements LearningPathNode {
   final LearningPathNodeType type;
   final String? miniLessonId;
   final String? trainingPackTemplateId;
+  final String? dynamicPackId;
+  final Map<String, dynamic>? dynamicMeta;
 
   @override
   final bool recoveredFromMistake;
@@ -18,11 +20,15 @@ class LearningPathNodeV2 implements LearningPathNode {
     this.recoveredFromMistake = false,
   })  : type = LearningPathNodeType.theory,
         miniLessonId = miniLessonId,
-        trainingPackTemplateId = null;
+        trainingPackTemplateId = null,
+        dynamicPackId = null,
+        dynamicMeta = null;
 
   const LearningPathNodeV2.training({
     required this.id,
-    required String trainingPackTemplateId,
+    String? trainingPackTemplateId,
+    this.dynamicPackId,
+    this.dynamicMeta,
     this.recoveredFromMistake = false,
   })  : type = LearningPathNodeType.training,
         miniLessonId = null,

--- a/lib/models/v2/training_pack_v2.dart
+++ b/lib/models/v2/training_pack_v2.dart
@@ -83,7 +83,9 @@ class TrainingPackV2 {
 
   factory TrainingPackV2.fromTemplate(TrainingPackTemplateV2 t, String id) {
     final spotList =
-        t.dynamicSpots.isNotEmpty ? t.generateDynamicSpotSamples() : t.spots;
+        (t.dynamicSpots.isNotEmpty || t.meta['dynamicParams'] is Map)
+            ? t.generateDynamicSpotSamples()
+            : t.spots;
     return TrainingPackV2(
       id: id,
       sourceTemplateId: t.id,

--- a/lib/screens/learning_path_horizontal_view_screen.dart
+++ b/lib/screens/learning_path_horizontal_view_screen.dart
@@ -5,6 +5,7 @@ import '../models/v2/training_pack_template_v2.dart';
 import '../services/learning_graph_engine.dart';
 import '../services/learning_path_loader.dart';
 import '../services/mini_lesson_library_service.dart';
+import '../services/training_pack_launcher_service.dart';
 import '../services/skill_tree_node_detail_unlock_hint_service.dart';
 import '../widgets/path_node_tile.dart';
 import '../widgets/path_node_unlock_hint_overlay.dart';
@@ -66,16 +67,22 @@ class _LearningPathHorizontalViewScreenState
         _refresh();
       }
     } else {
-      final pack = _packs[node.trainingPackTemplateId];
-      if (pack != null) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TrainingPackPreviewScreen(template: pack),
-          ),
-        );
+      if (node.dynamicPackId != null) {
+        await const TrainingPackLauncherService().launch(node);
         await LearningPathEngine.instance.markStageCompleted(node.id);
         _refresh();
+      } else {
+        final pack = _packs[node.trainingPackTemplateId];
+        if (pack != null) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => TrainingPackPreviewScreen(template: pack),
+            ),
+          );
+          await LearningPathEngine.instance.markStageCompleted(node.id);
+          _refresh();
+        }
       }
     }
   }
@@ -107,7 +114,8 @@ class _LearningPathHorizontalViewScreenState
                         !isCurrent &&
                         nodeIndex > currentIndex &&
                         currentIndex >= 0;
-                    final pack = _packs[node.trainingPackTemplateId];
+                    final pack =
+                        _packs[node.trainingPackTemplateId ?? node.dynamicPackId];
                     final key = GlobalKey();
                     return Padding(
                       padding: const EdgeInsets.only(right: 12),

--- a/lib/screens/learning_path_linear_view_screen.dart
+++ b/lib/screens/learning_path_linear_view_screen.dart
@@ -5,6 +5,7 @@ import '../models/v2/training_pack_template_v2.dart';
 import '../services/learning_graph_engine.dart';
 import '../services/learning_path_loader.dart';
 import '../services/mini_lesson_library_service.dart';
+import '../services/training_pack_launcher_service.dart';
 import '../services/skill_tree_node_detail_unlock_hint_service.dart';
 import '../widgets/path_node_tile.dart';
 import '../widgets/path_node_unlock_hint_overlay.dart';
@@ -66,16 +67,22 @@ class _LearningPathLinearViewScreenState
         _refresh();
       }
     } else {
-      final pack = _packs[node.trainingPackTemplateId];
-      if (pack != null) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TrainingPackPreviewScreen(template: pack),
-          ),
-        );
+      if (node.dynamicPackId != null) {
+        await const TrainingPackLauncherService().launch(node);
         await LearningPathEngine.instance.markStageCompleted(node.id);
         _refresh();
+      } else {
+        final pack = _packs[node.trainingPackTemplateId];
+        if (pack != null) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => TrainingPackPreviewScreen(template: pack),
+            ),
+          );
+          await LearningPathEngine.instance.markStageCompleted(node.id);
+          _refresh();
+        }
       }
     }
   }
@@ -107,7 +114,8 @@ class _LearningPathLinearViewScreenState
                       !isCurrent &&
                       nodeIndex > currentIndex &&
                       currentIndex >= 0;
-                  final pack = _packs[node.trainingPackTemplateId];
+                  final pack =
+                      _packs[node.trainingPackTemplateId ?? node.dynamicPackId];
                   final key = GlobalKey();
                   return PathNodeTile(
                     key: key,

--- a/lib/services/learning_path_loader.dart
+++ b/lib/services/learning_path_loader.dart
@@ -27,9 +27,13 @@ Future<LearningPathLoadResult> loadLearningPathData() async {
       LearningPathEngine.instance.getCurrentNode() as LearningPathNodeV2?;
   final packIds = <String>{};
   for (final n in nodes) {
-    if (n.type == LearningPathNodeType.training &&
-        n.trainingPackTemplateId != null) {
-      packIds.add(n.trainingPackTemplateId!);
+    if (n.type == LearningPathNodeType.training) {
+      if (n.trainingPackTemplateId != null) {
+        packIds.add(n.trainingPackTemplateId!);
+      }
+      if (n.dynamicPackId != null) {
+        packIds.add(n.dynamicPackId!);
+      }
     }
   }
   final packs = <String, TrainingPackTemplateV2>{};

--- a/lib/services/training_pack_launcher_service.dart
+++ b/lib/services/training_pack_launcher_service.dart
@@ -1,0 +1,43 @@
+import '../models/learning_path_node_v2.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_session_launcher.dart';
+
+/// Launches a training pack referenced by a learning path node.
+class TrainingPackLauncherService {
+  final TrainingSessionLauncher launcher;
+
+  const TrainingPackLauncherService({
+    this.launcher = const TrainingSessionLauncher(),
+  });
+
+  /// Launches training for [node]. Supports dynamic packs by applying
+  /// [LearningPathNodeV2.dynamicMeta] if present.
+  Future<void> launch(LearningPathNodeV2 node) async {
+    if (node.type != LearningPathNodeType.training) return;
+    final String? packId =
+        node.trainingPackTemplateId ?? node.dynamicPackId;
+    if (packId == null) return;
+
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final template = TrainingPackLibraryV2.instance.getById(packId);
+    if (template == null) return;
+
+    // Apply dynamic metadata if provided by the node.
+    if (node.dynamicMeta is Map<String, dynamic>) {
+      final meta = Map<String, dynamic>.from(node.dynamicMeta!);
+      if (meta['dynamicParams'] is Map) {
+        template.meta['dynamicParams'] =
+            Map<String, dynamic>.from(meta['dynamicParams'] as Map);
+      }
+    }
+
+    // Ensure dynamic spots are freshly generated for dynamic packs.
+    if (template.dynamicSpots.isNotEmpty ||
+        template.meta['dynamicParams'] is Map) {
+      template.regenerateDynamicSpots();
+    }
+
+    await launcher.launch(template);
+  }
+}

--- a/lib/widgets/path_node_tile.dart
+++ b/lib/widgets/path_node_tile.dart
@@ -33,7 +33,10 @@ class PathNodeTile extends StatelessWidget {
       title = lesson?.resolvedTitle ?? node.miniLessonId ?? '';
       icon = const Text('📘', style: TextStyle(fontSize: 24));
     } else {
-      title = pack?.name ?? node.trainingPackTemplateId ?? '';
+      title = pack?.name ??
+          node.trainingPackTemplateId ??
+          node.dynamicPackId ??
+          '';
       icon = const Text('🃏', style: TextStyle(fontSize: 24));
     }
 


### PR DESCRIPTION
## Summary
- support dynamic training packs in learning path nodes
- add service to launch dynamic packs with regenerated spots
- refresh loader and views to resolve dynamic packs

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f7e5307f8832aa9d367ac81e4a135