### PR TITLE
feat: add board texture filtering

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -12,6 +12,7 @@ import 'unlock_rules.dart';
 import 'hero_position.dart';
 import 'training_pack_template.dart' show TrainingPackTemplate;
 import '../../services/training_spot_generator_service.dart';
+import '../../services/board_texture_filter_service.dart';
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -103,7 +104,21 @@ class TrainingPackTemplateV2 {
         ],
         count: (m['count'] as num?)?.toInt() ?? 0,
       );
-      final gen = TrainingSpotGeneratorService().generate(params);
+      var gen = TrainingSpotGeneratorService().generate(params);
+      final filters = <String>[
+        if (m['boardFilter'] is String) m['boardFilter'].toString(),
+        if (m['boardFilter'] is List)
+          for (final f in (m['boardFilter'] as List)) f.toString(),
+      ];
+      if (filters.isNotEmpty) {
+        final svc = BoardTextureFilterService();
+        gen = [
+          for (final s in gen)
+            if (svc.filter(
+                [for (final c in s.boardCards) '${c.rank}${c.suit}'], filters))
+              s,
+        ];
+      }
       return [
         for (final s in gen)
           TrainingPackSpot.fromTrainingSpot(

--- a/lib/services/board_texture_filter_service.dart
+++ b/lib/services/board_texture_filter_service.dart
@@ -1,0 +1,69 @@
+class BoardTextureFilterService {
+  const BoardTextureFilterService();
+
+  bool filter(List<String> board, List<String> filters) {
+    if (filters.isEmpty) return true;
+    if (board.isEmpty) return false;
+    for (final f in filters) {
+      switch (f) {
+        case 'low':
+        case 'lowBoards':
+          if (!_isLow(board)) return false;
+          break;
+        case 'aceHigh':
+          if (!_isAceHigh(board)) return false;
+          break;
+        case 'paired':
+          if (!_isPaired(board)) return false;
+          break;
+        default:
+          break;
+      }
+    }
+    return true;
+  }
+
+  bool _isLow(List<String> board) =>
+      board.every((c) => _rankValue(c[0]) <= 8);
+
+  bool _isAceHigh(List<String> board) =>
+      board.any((c) => _rankValue(c[0]) == 14);
+
+  bool _isPaired(List<String> board) {
+    final ranks = board.map((c) => c[0]).toList();
+    return ranks.toSet().length < ranks.length;
+  }
+
+  int _rankValue(String r) {
+    switch (r.toUpperCase()) {
+      case 'A':
+        return 14;
+      case 'K':
+        return 13;
+      case 'Q':
+        return 12;
+      case 'J':
+        return 11;
+      case 'T':
+        return 10;
+      case '9':
+        return 9;
+      case '8':
+        return 8;
+      case '7':
+        return 7;
+      case '6':
+        return 6;
+      case '5':
+        return 5;
+      case '4':
+        return 4;
+      case '3':
+        return 3;
+      case '2':
+        return 2;
+      default:
+        return 0;
+    }
+  }
+}

--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -55,4 +55,24 @@ meta:
     expect(tpl.spots.length, 3);
     expect(tpl.spotCount, 3);
   });
+
+  test('dynamicParams boardFilter filters unmatched boards', () {
+    const yaml3 = '''
+id: gen_pack
+name: Generator Pack
+trainingType: mtt
+positions:
+  - hj
+meta:
+  dynamicParams:
+    position: hj
+    villainAction: "3bet 9.0"
+    handGroup: ["pockets"]
+    count: 3
+    boardFilter: ["aceHigh"]
+''';
+    final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml3);
+    expect(tpl.spots.length, 0);
+    expect(tpl.spotCount, 0);
+  });
 }

--- a/test/services/board_texture_filter_service_test.dart
+++ b/test/services/board_texture_filter_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/board_texture_filter_service.dart';
+
+void main() {
+  const svc = BoardTextureFilterService();
+
+  test('low paired board matches low and paired filters', () {
+    final board = ['2h', '5c', '5d'];
+    expect(svc.filter(board, ['low', 'paired']), true);
+    expect(svc.filter(board, ['aceHigh']), false);
+  });
+
+  test('ace high board matches aceHigh filter only', () {
+    final board = ['As', 'Kd', '3c'];
+    expect(svc.filter(board, ['aceHigh']), true);
+    expect(svc.filter(board, ['low']), false);
+  });
+}


### PR DESCRIPTION
## Summary
- support board texture filtering in TrainingPackTemplateV2 dynamic spot generation
- introduce BoardTextureFilterService with low, paired and ace-high checks
- cover board filter logic with new tests

## Testing
- `flutter test test/dynamic_spot_generation_test.dart test/services/board_texture_filter_service_test.dart` *(fails: command not found)*
- `dart test test/dynamic_spot_generation_test.dart test/services/board_texture_filter_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f83ffabd4832ab951f061603526d5