### PR TITLE
feat: add dynamic flop generation

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -12,7 +12,6 @@ import 'unlock_rules.dart';
 import 'hero_position.dart';
 import 'training_pack_template.dart' show TrainingPackTemplate;
 import '../../services/training_spot_generator_service.dart';
-import '../../services/board_texture_filter_service.dart';
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -96,6 +95,8 @@ class TrainingPackTemplateV2 {
   List<TrainingPackSpot> generateDynamicSpotSamples() {
     if (meta['dynamicParams'] is Map) {
       final m = Map<String, dynamic>.from(meta['dynamicParams']);
+      final boardFilter =
+          m['boardFilter'] is Map ? Map<String, dynamic>.from(m['boardFilter']) : null;
       final params = SpotGenerationParams(
         position: m['position']?.toString() ?? 'btn',
         villainAction: m['villainAction']?.toString() ?? '',
@@ -103,22 +104,9 @@ class TrainingPackTemplateV2 {
           for (final g in (m['handGroup'] as List? ?? [])) g.toString()
         ],
         count: (m['count'] as num?)?.toInt() ?? 0,
+        boardFilter: boardFilter,
       );
-      var gen = TrainingSpotGeneratorService().generate(params);
-      final filters = <String>[
-        if (m['boardFilter'] is String) m['boardFilter'].toString(),
-        if (m['boardFilter'] is List)
-          for (final f in (m['boardFilter'] as List)) f.toString(),
-      ];
-      if (filters.isNotEmpty) {
-        final svc = BoardTextureFilterService();
-        gen = [
-          for (final s in gen)
-            if (svc.filter(
-                [for (final c in s.boardCards) '${c.rank}${c.suit}'], filters))
-              s,
-        ];
-      }
+      final gen = TrainingSpotGeneratorService().generate(params);
       return [
         for (final s in gen)
           TrainingPackSpot.fromTrainingSpot(
@@ -148,6 +136,9 @@ class TrainingPackTemplateV2 {
     var spots = <TrainingPackSpot>[];
 
     if (dynParams is Map) {
+      final boardFilter = dynParams['boardFilter'] is Map
+          ? Map<String, dynamic>.from(dynParams['boardFilter'])
+          : null;
       final params = SpotGenerationParams(
         position: dynParams['position']?.toString() ?? 'btn',
         villainAction: dynParams['villainAction']?.toString() ?? '',
@@ -155,6 +146,7 @@ class TrainingPackTemplateV2 {
           for (final g in (dynParams['handGroup'] as List? ?? [])) g.toString()
         ],
         count: (dynParams['count'] as num?)?.toInt() ?? 0,
+        boardFilter: boardFilter,
       );
       final generator = TrainingSpotGeneratorService();
       final genSpots = generator.generate(params);

--- a/lib/services/board_texture_filter_service.dart
+++ b/lib/services/board_texture_filter_service.dart
@@ -1,3 +1,5 @@
+import '../models/card_model.dart';
+
 class BoardTextureFilterService {
   const BoardTextureFilterService();
 
@@ -8,13 +10,19 @@ class BoardTextureFilterService {
       switch (f) {
         case 'low':
         case 'lowBoards':
-          if (!_isLow(board)) return false;
+          if (!_isLow(board.map((c) => CardModel(rank: c[0], suit: c[1])).toList())) {
+            return false;
+          }
           break;
         case 'aceHigh':
-          if (!_isAceHigh(board)) return false;
+          if (!_isAceHigh(board.map((c) => CardModel(rank: c[0], suit: c[1])).toList())) {
+            return false;
+          }
           break;
         case 'paired':
-          if (!_isPaired(board)) return false;
+          if (!_isPaired(board.map((c) => CardModel(rank: c[0], suit: c[1])).toList())) {
+            return false;
+          }
           break;
         default:
           break;
@@ -23,16 +31,121 @@ class BoardTextureFilterService {
     return true;
   }
 
-  bool _isLow(List<String> board) =>
-      board.every((c) => _rankValue(c[0]) <= 8);
+  bool isMatch(List<CardModel> board, Map<String, dynamic>? filter) {
+    if (filter == null || filter.isEmpty) return true;
+    if (board.isEmpty) return false;
 
-  bool _isAceHigh(List<String> board) =>
-      board.any((c) => _rankValue(c[0]) == 14);
+    final ranks = board.map((c) => c.rank.toUpperCase()).toList();
+    final suits = board.map((c) => c.suit).toList();
 
-  bool _isPaired(List<String> board) {
-    final ranks = board.map((c) => c[0]).toList();
+    final excluded = <String>{
+      for (final r in (filter['excludedRanks'] as List? ?? []))
+        r.toString().toUpperCase(),
+    };
+    if (ranks.any(excluded.contains)) return false;
+
+    final requiredRanks = <String>[...
+      (filter['requiredRanks'] as List? ?? [])
+          .map((e) => e.toString().toUpperCase())
+    ];
+    for (final r in requiredRanks) {
+      if (!ranks.contains(r)) return false;
+    }
+
+    final requiredSuits = <String>[...
+      (filter['requiredSuits'] as List? ?? [])
+          .map((e) => e.toString())
+    ];
+    for (final s in requiredSuits) {
+      if (!suits.contains(s)) return false;
+    }
+
+    final textures = _asList(filter['boardTexture']);
+    for (final t in textures) {
+      switch (t) {
+        case 'low':
+          if (!_isLow(board)) return false;
+          break;
+        case 'aceHigh':
+          if (!_isAceHigh(board)) return false;
+          break;
+        case 'paired':
+          if (!_isPaired(board)) return false;
+          break;
+        case 'straightDrawHeavy':
+          if (!_isStraightDrawHeavy(board)) return false;
+          break;
+        case 'broadway':
+          if (!_isBroadway(board)) return false;
+          break;
+        case 'rainbow':
+          if (!_isRainbow(board)) return false;
+          break;
+        case 'twoTone':
+          if (!_isTwoTone(board)) return false;
+          break;
+        case 'monotone':
+          if (!_isMonotone(board)) return false;
+          break;
+        default:
+          break;
+      }
+    }
+
+    final pattern = filter['suitPattern']?.toString();
+    if (pattern != null) {
+      switch (pattern) {
+        case 'rainbow':
+          if (!_isRainbow(board)) return false;
+          break;
+        case 'twoTone':
+          if (!_isTwoTone(board)) return false;
+          break;
+        case 'monotone':
+          if (!_isMonotone(board)) return false;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return true;
+  }
+
+  List<String> _asList(dynamic v) {
+    if (v == null) return const [];
+    if (v is List) return [for (final e in v) e.toString()];
+    return [v.toString()];
+  }
+
+  bool _isLow(List<CardModel> board) =>
+      board.every((c) => _rankValue(c.rank) <= 8);
+
+  bool _isAceHigh(List<CardModel> board) =>
+      board.any((c) => _rankValue(c.rank) == 14);
+
+  bool _isPaired(List<CardModel> board) {
+    final ranks = board.map((c) => c.rank).toList();
     return ranks.toSet().length < ranks.length;
   }
+
+  bool _isRainbow(List<CardModel> board) =>
+      board.map((c) => c.suit).toSet().length == 3;
+
+  bool _isTwoTone(List<CardModel> board) =>
+      board.map((c) => c.suit).toSet().length == 2;
+
+  bool _isMonotone(List<CardModel> board) =>
+      board.map((c) => c.suit).toSet().length == 1;
+
+  bool _isStraightDrawHeavy(List<CardModel> board) {
+    final values = board.map((c) => _rankValue(c.rank)).toList()
+      ..sort();
+    return values.last - values.first <= 4;
+  }
+
+  bool _isBroadway(List<CardModel> board) =>
+      board.every((c) => _rankValue(c.rank) >= 10);
 
   int _rankValue(String r) {
     switch (r.toUpperCase()) {

--- a/lib/services/training_pack_preview_service.dart
+++ b/lib/services/training_pack_preview_service.dart
@@ -23,6 +23,9 @@ class TrainingPackPreviewService {
         for (final g in (m['handGroup'] as List? ?? [])) g.toString()
       ],
       count: min(count, (m['count'] as num?)?.toInt() ?? count),
+      boardFilter: m['boardFilter'] is Map
+          ? Map<String, dynamic>.from(m['boardFilter'])
+          : null,
     );
     final spots = _generator.generate(params);
     return [

--- a/lib/services/training_spot_generator_service.dart
+++ b/lib/services/training_spot_generator_service.dart
@@ -5,18 +5,21 @@ import '../models/card_model.dart';
 import '../models/action_entry.dart';
 import '../models/player_model.dart';
 import 'hand_range_library.dart';
+import 'board_texture_filter_service.dart';
 
 class SpotGenerationParams {
   final String position;
   final String villainAction;
   final List<String> handGroup;
   final int count;
+  final Map<String, dynamic>? boardFilter;
 
   SpotGenerationParams({
     required this.position,
     required this.villainAction,
     required this.handGroup,
     required this.count,
+    this.boardFilter,
   });
 }
 
@@ -49,6 +52,8 @@ class TrainingSpotGeneratorService {
     final playerCards = List.generate(6, (_) => <CardModel>[]);
     playerCards[idx] = _cardsForHand(hand);
 
+    final board = generateRandomFlop(boardFilter: params.boardFilter);
+
     final villain = (idx + 1) % 6;
     final parts = params.villainAction.split(' ');
     final action = parts.isNotEmpty ? parts.first : params.villainAction;
@@ -57,7 +62,7 @@ class TrainingSpotGeneratorService {
     final actions = [ActionEntry(0, villain, action, amount: amount)];
     return TrainingSpot(
       playerCards: playerCards,
-      boardCards: const [],
+      boardCards: board,
       actions: actions,
       heroIndex: idx,
       numberOfPlayers: 6,
@@ -94,6 +99,49 @@ class TrainingSpotGeneratorService {
       s2 = suits[_random.nextInt(4)];
     }
     return [CardModel(rank: r1, suit: s1), CardModel(rank: r2, suit: s2)];
+  }
+
+  List<CardModel> generateRandomFlop({Map<String, dynamic>? boardFilter}) {
+    if (boardFilter == null) return const [];
+
+    const ranks = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
+    const suits = ['♠', '♥', '♦', '♣'];
+
+    final excluded = <String>{
+      for (final r in (boardFilter['excludedRanks'] as List? ?? []))
+        r.toString().toUpperCase()
+    };
+
+    final requiredRanks = <String>[...
+      (boardFilter['requiredRanks'] as List? ?? [])
+          .map((e) => e.toString().toUpperCase())
+    ];
+    final requiredSuits = <String>[...
+      (boardFilter['requiredSuits'] as List? ?? [])
+          .map((e) => e.toString())
+    ];
+
+    final deck = <CardModel>[
+      for (final r in ranks)
+        if (!excluded.contains(r))
+          for (final s in suits) CardModel(rank: r, suit: s)
+    ];
+
+    final svc = const BoardTextureFilterService();
+    for (var i = 0; i < 10000; i++) {
+      deck.shuffle(_random);
+      final board = deck.take(3).toList();
+      if (requiredRanks.any((r) => !board.any((c) => c.rank == r))) {
+        continue;
+      }
+      if (requiredSuits.any((s) => !board.any((c) => c.suit == s))) {
+        continue;
+      }
+      if (svc.isMatch(board, boardFilter)) {
+        return board;
+      }
+    }
+    throw StateError('Unable to generate flop with given filter');
   }
 }
 

--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -56,7 +56,7 @@ meta:
     expect(tpl.spotCount, 3);
   });
 
-  test('dynamicParams boardFilter filters unmatched boards', () {
+  test('dynamicParams boardFilter generates ace high boards', () {
     const yaml3 = '''
 id: gen_pack
 name: Generator Pack
@@ -69,10 +69,13 @@ meta:
     villainAction: "3bet 9.0"
     handGroup: ["pockets"]
     count: 3
-    boardFilter: ["aceHigh"]
+    boardFilter:
+      boardTexture: aceHigh
 ''';
     final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml3);
-    expect(tpl.spots.length, 0);
-    expect(tpl.spotCount, 0);
+    expect(tpl.spots.length, 3);
+    for (final s in tpl.spots) {
+      expect(s.board.any((c) => c.startsWith('A')), true);
+    }
   });
 }

--- a/test/services/board_texture_filter_service_test.dart
+++ b/test/services/board_texture_filter_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/services/board_texture_filter_service.dart';
+import 'package:poker_analyzer/models/card_model.dart';
 
 void main() {
   const svc = BoardTextureFilterService();
@@ -14,5 +15,21 @@ void main() {
     final board = ['As', 'Kd', '3c'];
     expect(svc.filter(board, ['aceHigh']), true);
     expect(svc.filter(board, ['low']), false);
+  });
+
+  test('isMatch supports suit patterns and exclusions', () {
+    final board = [
+      CardModel(rank: 'A', suit: '♠'),
+      CardModel(rank: '7', suit: '♠'),
+      CardModel(rank: '3', suit: '♠'),
+    ];
+    expect(
+      svc.isMatch(board, {'suitPattern': 'monotone', 'excludedRanks': ['K']}),
+      true,
+    );
+    expect(
+      svc.isMatch(board, {'requiredRanks': ['K']}),
+      false,
+    );
   });
 }

--- a/test/services/training_spot_generator_service_test.dart
+++ b/test/services/training_spot_generator_service_test.dart
@@ -1,0 +1,26 @@
+import 'dart:math';
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_spot_generator_service.dart';
+
+void main() {
+  test('generateRandomFlop respects suitPattern and excludedRanks', () {
+    final svc = TrainingSpotGeneratorService(random: Random(42));
+    final board = svc.generateRandomFlop(boardFilter: {
+      'suitPattern': 'rainbow',
+      'excludedRanks': ['A']
+    });
+    expect(board.length, 3);
+    expect(board.any((c) => c.rank == 'A'), false);
+    expect(board.map((c) => c.suit).toSet().length, 3);
+  });
+
+  test('generateRandomFlop supports requiredRanks', () {
+    final svc = TrainingSpotGeneratorService(random: Random(1));
+    final board = svc.generateRandomFlop(boardFilter: {
+      'requiredRanks': ['A', 'K']
+    });
+    final ranks = board.map((c) => c.rank).toSet();
+    expect(ranks.contains('A'), true);
+    expect(ranks.contains('K'), true);
+  });
+}


### PR DESCRIPTION
## Summary
- add board-filtered flop generation to TrainingSpotGeneratorService
- extend BoardTextureFilterService with rich texture and suit pattern checks
- wire boardFilter through template and preview services for dynamic boards

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f8589c400832a87bd1076bc66a985