### PR TITLE
feat: generate turn and river boards

### DIFF
--- a/test/services/training_spot_generator_service_test.dart
+++ b/test/services/training_spot_generator_service_test.dart
@@ -3,24 +3,49 @@ import 'package:test/test.dart';
 import 'package:poker_analyzer/services/training_spot_generator_service.dart';
 
 void main() {
-  test('generateRandomFlop respects suitPattern and excludedRanks', () {
+  test('generateRandomBoard respects suitPattern and excludedRanks', () {
     final svc = TrainingSpotGeneratorService(random: Random(42));
-    final board = svc.generateRandomFlop(boardFilter: {
-      'suitPattern': 'rainbow',
-      'excludedRanks': ['A']
-    });
+    final board = svc.generateRandomBoard(
+      street: 'flop',
+      boardFilter: {
+        'suitPattern': 'rainbow',
+        'excludedRanks': ['A']
+      },
+    );
     expect(board.length, 3);
     expect(board.any((c) => c.rank == 'A'), false);
     expect(board.map((c) => c.suit).toSet().length, 3);
   });
 
-  test('generateRandomFlop supports requiredRanks', () {
+  test('generateRandomBoard supports requiredRanks on river', () {
     final svc = TrainingSpotGeneratorService(random: Random(1));
-    final board = svc.generateRandomFlop(boardFilter: {
-      'requiredRanks': ['A', 'K']
-    });
+    final board = svc.generateRandomBoard(
+      street: 'river',
+      boardFilter: {
+        'requiredRanks': ['A', 'K']
+      },
+    );
     final ranks = board.map((c) => c.rank).toSet();
+    expect(board.length, 5);
     expect(ranks.contains('A'), true);
     expect(ranks.contains('K'), true);
+  });
+
+  test('generate builds board up to targetStreet without card overlap', () {
+    final svc = TrainingSpotGeneratorService(random: Random(3));
+    final spot = svc
+        .generate(SpotGenerationParams(
+          position: 'btn',
+          villainAction: 'check',
+          handGroup: ['AKs'],
+          count: 1,
+          targetStreet: 'turn',
+        ))
+        .first;
+    expect(spot.boardCards.length, 4);
+    final hero = spot.playerCards[spot.heroIndex];
+    final clash = spot.boardCards.any((b) =>
+        hero.any((h) => h.rank == b.rank && h.suit == b.suit));
+    expect(clash, false);
   });
 }


### PR DESCRIPTION
## Summary
- extend spot generator to handle turn and river boards
- allow board filters via targetStreet and avoid using hero cards
- cover new board generation paths in unit tests

## Testing
- `flutter test test/services/training_spot_generator_service_test.dart` *(fails: command not found)*
- `dart test test/services/training_spot_generator_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f8783fba8832aafd7b104cea266b7