### PR TITLE
Avoid redundant updates in poker analyzer controller

### DIFF
--- a/lib/controllers/poker_analyzer_controller.dart
+++ b/lib/controllers/poker_analyzer_controller.dart
@@ -39,6 +39,8 @@ class PokerAnalyzerController extends ChangeNotifier {
 
   Map<int, String> get playerPositions => Map.unmodifiable(_playerPositions);
   void setPlayerPosition(int index, String position) {
+    final current = _playerPositions[index];
+    if (current == position) return;
     _update(() {
       _playerPositions[index] = position;
     });
@@ -46,6 +48,8 @@ class PokerAnalyzerController extends ChangeNotifier {
 
   Map<int, PlayerType> get playerTypes => Map.unmodifiable(_playerTypes);
   void setPlayerType(int index, PlayerType type) {
+    final current = _playerTypes[index];
+    if (current == type) return;
     _update(() {
       _playerTypes[index] = type;
     });


### PR DESCRIPTION
## Summary
- check for changes in `setPlayerPosition` and `setPlayerType` before calling `_update`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d474ad4832aacf4014f69c5b966