### PR TITLE
Simplify stack filtering

### DIFF
--- a/lib/controllers/training_pack_controller.dart
+++ b/lib/controllers/training_pack_controller.dart
@@ -50,20 +50,20 @@ class TrainingPackController extends ChangeNotifier {
     notifyListeners();
   }
 
-  List<T> _filterByStack<T>(Iterable<T> items, bool Function(T item) predicate) {
-    return [for (final item in items) if (predicate(item)) item];
-  }
+  Iterable<T> _filterByStack<T>(
+          Iterable<T> items, bool Function(T) predicate) =>
+      items.where(predicate);
 
   void _applyStackFilter() {
     final filter = StackRangeFilter(_stackFilter);
     _sessionHands = _filterByStack(
       allHands,
       (h) => filter.matches(h.stackSizes[h.heroIndex] ?? 0),
-    );
+    ).toList();
     _spots = _filterByStack(
       _allSpots,
       (s) => filter.matches(s.stacks[s.heroIndex]),
-    );
+    ).toList();
   }
 
   void _commit() {


### PR DESCRIPTION
## Summary
- Simplify stack filtering to use `Iterable.where`
- Collect filtered hands and spots into lists

## Testing
- `dart format lib/controllers/training_pack_controller.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d491340832a9493ad2641c90a49