### PR TITLE
refactor: add SharedPrefsKey enum

### DIFF
--- a/lib/services/booster_interaction_tracker_service.dart
+++ b/lib/services/booster_interaction_tracker_service.dart
@@ -12,7 +12,7 @@ class BoosterInteractionTrackerService {
   Future<void> logOpened(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(
-      SharedPrefsKeys.boosterOpened(tag),
+      SharedPrefsKey.boosterOpened.asString(tag),
       DateTime.now().millisecondsSinceEpoch,
     );
     await UserActionLogger.instance.logEvent({
@@ -24,7 +24,7 @@ class BoosterInteractionTrackerService {
   Future<void> logDismissed(String tag) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(
-      SharedPrefsKeys.boosterDismissed(tag),
+      SharedPrefsKey.boosterDismissed.asString(tag),
       DateTime.now().millisecondsSinceEpoch,
     );
     await UserActionLogger.instance.logEvent({
@@ -35,14 +35,14 @@ class BoosterInteractionTrackerService {
 
   Future<DateTime?> getLastOpened(String tag) async {
     final prefs = await SharedPreferences.getInstance();
-    final ts = prefs.getInt(SharedPrefsKeys.boosterOpened(tag));
+    final ts = prefs.getInt(SharedPrefsKey.boosterOpened.asString(tag));
     if (ts == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(ts);
   }
 
   Future<DateTime?> getLastDismissed(String tag) async {
     final prefs = await SharedPreferences.getInstance();
-    final ts = prefs.getInt(SharedPrefsKeys.boosterDismissed(tag));
+    final ts = prefs.getInt(SharedPrefsKey.boosterDismissed.asString(tag));
     if (ts == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(ts);
   }
@@ -52,16 +52,16 @@ class BoosterInteractionTrackerService {
     final prefs = await SharedPreferences.getInstance();
     final result = <String, Map<String, DateTime?>>{};
     for (final key in prefs.getKeys()) {
-      if (key.startsWith(SharedPrefsKeys.boosterOpenedPrefix)) {
-        final tag = key.substring(SharedPrefsKeys.boosterOpenedPrefix.length);
+      if (key.startsWith(SharedPrefsKey.boosterOpened.asString())) {
+        final tag = key.substring(SharedPrefsKey.boosterOpened.asString().length);
         final ts = prefs.getInt(key);
         final map = result.putIfAbsent(tag, () => {});
         if (ts != null) {
           map['opened'] = DateTime.fromMillisecondsSinceEpoch(ts);
         }
-      } else if (key.startsWith(SharedPrefsKeys.boosterDismissedPrefix)) {
+      } else if (key.startsWith(SharedPrefsKey.boosterDismissed.asString())) {
         final tag =
-            key.substring(SharedPrefsKeys.boosterDismissedPrefix.length);
+            key.substring(SharedPrefsKey.boosterDismissed.asString().length);
         final ts = prefs.getInt(key);
         final map = result.putIfAbsent(tag, () => {});
         if (ts != null) {

--- a/lib/services/smart_booster_exclusion_tracker_service.dart
+++ b/lib/services/smart_booster_exclusion_tracker_service.dart
@@ -13,7 +13,8 @@ class SmartBoosterExclusionTrackerService {
   /// Records that a booster with [tag] was skipped for [reason].
   Future<void> logExclusion(String tag, String reason) async {
     final prefs = await SharedPreferences.getInstance();
-    final entries = prefs.getStringList(SharedPrefsKeys.boosterExclusionLog) ?? [];
+    final entries =
+        prefs.getStringList(SharedPrefsKey.boosterExclusionLog.asString()) ?? [];
     entries.add(jsonEncode({
       'tag': tag,
       'reason': reason,
@@ -22,13 +23,15 @@ class SmartBoosterExclusionTrackerService {
     if (entries.length > _maxEntries) {
       entries.removeRange(0, entries.length - _maxEntries);
     }
-    await prefs.setStringList(SharedPrefsKeys.boosterExclusionLog, entries);
+    await prefs.setStringList(
+        SharedPrefsKey.boosterExclusionLog.asString(), entries);
   }
 
   /// Returns the raw exclusion log entries for diagnostics.
   Future<List<Map<String, dynamic>>> exportLog() async {
     final prefs = await SharedPreferences.getInstance();
-    final entries = prefs.getStringList(SharedPrefsKeys.boosterExclusionLog) ?? [];
+    final entries =
+        prefs.getStringList(SharedPrefsKey.boosterExclusionLog.asString()) ?? [];
     return entries
         .map((e) => jsonDecode(e) as Map<String, dynamic>)
         .toList();
@@ -37,7 +40,7 @@ class SmartBoosterExclusionTrackerService {
   /// Clears the stored exclusion log.
   Future<void> clear() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(SharedPrefsKeys.boosterExclusionLog);
+    await prefs.remove(SharedPrefsKey.boosterExclusionLog.asString());
   }
 }
 

--- a/lib/services/smart_booster_inbox_limiter_service.dart
+++ b/lib/services/smart_booster_inbox_limiter_service.dart
@@ -9,8 +9,10 @@ class SmartBoosterInboxLimiterService {
 
   static const int maxPerDay = 2;
   static const Duration tagCooldown = Duration(hours: 48);
-  static const String _totalDateKey = SharedPrefsKeys.boosterInboxTotalDate;
-  static const String _totalCountKey = SharedPrefsKeys.boosterInboxTotalCount;
+  static final String _totalDateKey =
+      SharedPrefsKey.boosterInboxTotalDate.asString();
+  static final String _totalCountKey =
+      SharedPrefsKey.boosterInboxTotalCount.asString();
 
   String _todayKey(DateTime dt) =>
       '${dt.year.toString().padLeft(4, '0')}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
@@ -33,7 +35,7 @@ class SmartBoosterInboxLimiterService {
     }
 
     final lastMillis =
-        prefs.getInt(SharedPrefsKeys.boosterInboxLast(tag));
+        prefs.getInt(SharedPrefsKey.boosterInboxLast.asString(tag));
     if (lastMillis != null) {
       final last = DateTime.fromMillisecondsSinceEpoch(lastMillis);
       if (now.difference(last) < tagCooldown) {
@@ -50,7 +52,7 @@ class SmartBoosterInboxLimiterService {
     final prefs = await SharedPreferences.getInstance();
     final now = DateTime.now();
     await prefs.setInt(
-      SharedPrefsKeys.boosterInboxLast(tag),
+      SharedPrefsKey.boosterInboxLast.asString(tag),
       now.millisecondsSinceEpoch,
     );
 

--- a/lib/services/smart_inbox_priority_scorer_service.dart
+++ b/lib/services/smart_inbox_priority_scorer_service.dart
@@ -16,7 +16,7 @@ class SmartInboxPriorityScorerService {
     for (final s in input) {
       final base = _scoreForAction(s.action);
       final lastMillis =
-          prefs.getInt(SharedPrefsKeys.boosterInboxLast(s.tag));
+          prefs.getInt(SharedPrefsKey.boosterInboxLast.asString(s.tag));
       final last = lastMillis == null
           ? null
           : DateTime.fromMillisecondsSinceEpoch(lastMillis);

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -1,39 +1,94 @@
 /// Centralized SharedPreferences keys used across the app.
-class SharedPrefsKeys {
-  SharedPrefsKeys._();
+enum SharedPrefsKey {
+  boosterInboxLast,
+  boosterInboxTotalDate,
+  boosterInboxTotalCount,
+  boosterExclusionLog,
+  boosterOpened,
+  boosterDismissed,
+  trainingPresetTags,
+  trainingPresetSearch,
+  trainingPresetExpanded,
+  trainingPresetSort,
+  trainingPresetIcmOnly,
+  trainingPresetRatedOnly,
+  trainingHideCompleted,
+  trainingMistakesOnly,
+  trainingSpotsOrder,
+  trainingSpotListVisible,
+  trainingPresetDifficulties,
+  trainingPresetRatings,
+  trainingPresetRatingSort,
+  trainingSimpleSortField,
+  trainingSimpleSortOrder,
+  trainingCustomTagPresets,
+  trainingQuickPreset,
+  trainingSearchHistory,
+  trainingSpotListSort,
+  trainingQuickSortOption,
+}
 
-  static String boosterInboxLast(String tag) => 'booster_inbox_last_$tag';
-  static const String boosterInboxTotalDate = 'booster_inbox_total_date';
-  static const String boosterInboxTotalCount = 'booster_inbox_total_count';
-  static const String boosterExclusionLog = 'booster_exclusion_log';
-
-  static const String boosterOpenedPrefix = 'booster_opened_';
-  static String boosterOpened(String tag) => '${boosterOpenedPrefix}$tag';
-
-  static const String boosterDismissedPrefix = 'booster_dismissed_';
-  static String boosterDismissed(String tag) => '${boosterDismissedPrefix}$tag';
-
-  // Training spot list keys
-  static const String trainingPresetTags = 'training_preset_tags';
-  static const String trainingPresetSearch = 'training_preset_search';
-  static const String trainingPresetExpanded = 'training_preset_expanded';
-  static const String trainingPresetSort = 'training_preset_sort';
-  static const String trainingPresetIcmOnly = 'training_preset_icm_only';
-  static const String trainingPresetRatedOnly = 'training_preset_rated_only';
-  static const String trainingHideCompleted = 'training_hide_completed';
-  static const String trainingMistakesOnly = 'training_mistakes_only';
-  static const String trainingSpotsOrder = 'training_spots_order';
-  static const String trainingSpotListVisible = 'training_spot_list_visible';
-  static const String trainingPresetDifficulties =
-      'training_preset_difficulties';
-  static const String trainingPresetRatings = 'training_preset_ratings';
-  static const String trainingPresetRatingSort = 'training_preset_rating_sort';
-  static const String trainingSimpleSortField = 'training_simple_sort_field';
-  static const String trainingSimpleSortOrder = 'training_simple_sort_order';
-  static const String trainingCustomTagPresets =
-      'training_custom_tag_presets';
-  static const String trainingQuickPreset = 'training_quick_preset';
-  static const String trainingSearchHistory = 'training_search_history';
-  static const String trainingSpotListSort = 'training_spot_list_sort';
-  static const String trainingQuickSortOption = 'training_quick_sort_option';
+extension SharedPrefsKeyExt on SharedPrefsKey {
+  /// Returns the string value for this key.
+  ///
+  /// [tag] is required for keys that are scoped per tag. When omitted for
+  /// those keys, the base prefix is returned, allowing prefix matching.
+  String asString([String? tag]) {
+    switch (this) {
+      case SharedPrefsKey.boosterInboxLast:
+        return tag != null
+            ? 'booster_inbox_last_\$tag'
+            : 'booster_inbox_last_';
+      case SharedPrefsKey.boosterInboxTotalDate:
+        return 'booster_inbox_total_date';
+      case SharedPrefsKey.boosterInboxTotalCount:
+        return 'booster_inbox_total_count';
+      case SharedPrefsKey.boosterExclusionLog:
+        return 'booster_exclusion_log';
+      case SharedPrefsKey.boosterOpened:
+        return tag != null ? 'booster_opened_\$tag' : 'booster_opened_';
+      case SharedPrefsKey.boosterDismissed:
+        return tag != null ? 'booster_dismissed_\$tag' : 'booster_dismissed_';
+      case SharedPrefsKey.trainingPresetTags:
+        return 'training_preset_tags';
+      case SharedPrefsKey.trainingPresetSearch:
+        return 'training_preset_search';
+      case SharedPrefsKey.trainingPresetExpanded:
+        return 'training_preset_expanded';
+      case SharedPrefsKey.trainingPresetSort:
+        return 'training_preset_sort';
+      case SharedPrefsKey.trainingPresetIcmOnly:
+        return 'training_preset_icm_only';
+      case SharedPrefsKey.trainingPresetRatedOnly:
+        return 'training_preset_rated_only';
+      case SharedPrefsKey.trainingHideCompleted:
+        return 'training_hide_completed';
+      case SharedPrefsKey.trainingMistakesOnly:
+        return 'training_mistakes_only';
+      case SharedPrefsKey.trainingSpotsOrder:
+        return 'training_spots_order';
+      case SharedPrefsKey.trainingSpotListVisible:
+        return 'training_spot_list_visible';
+      case SharedPrefsKey.trainingPresetDifficulties:
+        return 'training_preset_difficulties';
+      case SharedPrefsKey.trainingPresetRatings:
+        return 'training_preset_ratings';
+      case SharedPrefsKey.trainingPresetRatingSort:
+        return 'training_preset_rating_sort';
+      case SharedPrefsKey.trainingSimpleSortField:
+        return 'training_simple_sort_field';
+      case SharedPrefsKey.trainingSimpleSortOrder:
+        return 'training_simple_sort_order';
+      case SharedPrefsKey.trainingCustomTagPresets:
+        return 'training_custom_tag_presets';
+      case SharedPrefsKey.trainingQuickPreset:
+        return 'training_quick_preset';
+      case SharedPrefsKey.trainingSearchHistory:
+        return 'training_search_history';
+      case SharedPrefsKey.trainingSpotListSort:
+        return 'training_spot_list_sort';
+      case SharedPrefsKey.trainingQuickSortOption:
+        return 'training_quick_sort_option';
+    }
+  }
 }

--- a/lib/widgets/common/training_spot_list_core.dart
+++ b/lib/widgets/common/training_spot_list_core.dart
@@ -40,13 +40,15 @@ class TrainingSpotListState extends State<TrainingSpotList> {
 
   Future<void> _loadPrefs() async {
     final prefs = await SharedPreferences.getInstance();
-    _ascending = prefs.getBool(SharedPrefsKeys.trainingSpotListSort) ?? true;
+    _ascending =
+        prefs.getBool(SharedPrefsKey.trainingSpotListSort.asString()) ?? true;
     _sort();
   }
 
   Future<void> _savePrefs() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(SharedPrefsKeys.trainingSpotListSort, _ascending);
+    await prefs
+        .setBool(SharedPrefsKey.trainingSpotListSort.asString(), _ascending);
   }
 
   void _sort() {


### PR DESCRIPTION
## Summary
- centralize SharedPreferences keys in a new SharedPrefsKey enum with asString() helper
- update services and widgets to use the new SharedPrefsKey API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d4f409c832ab3bd9f38b9c4c876