### PR TITLE
Cache SharedPreferences in evaluation executor

### DIFF
--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -60,6 +60,7 @@ class EvaluationExecutorService implements EvaluationExecutor {
 
   late final EvaluationQueue _queue;
   final EvaluationCache _cache;
+  SharedPreferences? _prefs;
 
   static const _evaluatedKey = 'eval_total_evaluated';
   static const _correctKey = 'eval_total_correct';
@@ -103,13 +104,13 @@ class EvaluationExecutorService implements EvaluationExecutor {
   }
 
   Future<void> _loadStats() async {
-    final prefs = await SharedPreferences.getInstance();
-    _totalEvaluated = prefs.getInt(_evaluatedKey) ?? 0;
-    _totalCorrect = prefs.getInt(_correctKey) ?? 0;
+    _prefs = await SharedPreferences.getInstance();
+    _totalEvaluated = _prefs?.getInt(_evaluatedKey) ?? 0;
+    _totalCorrect = _prefs?.getInt(_correctKey) ?? 0;
   }
 
   Future<void> _saveStats() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
     await prefs.setInt(_evaluatedKey, _totalEvaluated);
     await prefs.setInt(_correctKey, _totalCorrect);
   }


### PR DESCRIPTION
## Summary
- cache SharedPreferences instance in EvaluationExecutorService
- reuse cached instance when loading and saving evaluation stats

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d54ba24832aba80923d99082121