### PR TITLE
refactor: simplify stack filter application

### DIFF
--- a/lib/controllers/training_pack_controller.dart
+++ b/lib/controllers/training_pack_controller.dart
@@ -49,21 +49,14 @@ class TrainingPackController extends ChangeNotifier {
     _applyStackFilter();
     notifyListeners();
   }
-
-  List<T> _filterByStack<T>(Iterable<T> items, bool Function(T item) predicate) {
-    return [for (final item in items) if (predicate(item)) item];
-  }
-
   void _applyStackFilter() {
     final filter = StackRangeFilter(_stackFilter);
-    _sessionHands = _filterByStack(
-      allHands,
-      (h) => filter.matches(h.stackSizes[h.heroIndex] ?? 0),
-    );
-    _spots = _filterByStack(
-      _allSpots,
-      (s) => filter.matches(s.stacks[s.heroIndex]),
-    );
+    _sessionHands = allHands
+        .where((h) => filter.matches(h.stackSizes[h.heroIndex] ?? 0))
+        .toList();
+    _spots = _allSpots
+        .where((s) => filter.matches(s.stacks[s.heroIndex]))
+        .toList();
   }
 
   void _commit() {


### PR DESCRIPTION
## Summary
- simplify stack filtering logic by removing helper

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d69481c832ab07a38713e5046a0