### PR TITLE
refactor: reuse deep equality in map utils

### DIFF
--- a/lib/helpers/map_utils.dart
+++ b/lib/helpers/map_utils.dart
@@ -1,5 +1,7 @@
 import 'package:collection/collection.dart';
 
 extension MapEqualsExtension<K, V> on Map<K, V> {
-  bool equals(Map<K, V> other) => const DeepCollectionEquality().equals(this, other);
+  static const _equality = DeepCollectionEquality();
+
+  bool equals(Map<K, V> other) => _equality.equals(this, other);
 }


### PR DESCRIPTION
## Summary
- reuse a static DeepCollectionEquality in MapEqualsExtension

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d650db4832abc491da2f7639272