### PR TITLE
refactor: centralize error log limit

### DIFF
--- a/lib/core/error_logger.dart
+++ b/lib/core/error_logger.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 class ErrorLogger {
   ErrorLogger._();
   static final ErrorLogger instance = ErrorLogger._();
+  static const int _maxErrors = 100;
   factory ErrorLogger() => instance;
 
   final List<String> recentErrors = [];
@@ -13,8 +14,8 @@ class ErrorLogger {
     if (error != null) entry += ': $error';
     if (stack != null) entry += '\n$stack';
     recentErrors.add(entry);
-    if (recentErrors.length > 100) {
-      recentErrors.removeRange(0, recentErrors.length - 100);
+    if (recentErrors.length > _maxErrors) {
+      recentErrors.removeRange(0, recentErrors.length - _maxErrors);
     }
     debugPrint(entry);
   }


### PR DESCRIPTION
## Summary
- centralize max stored errors in `ErrorLogger`

## Testing
- `dart format lib/core/error_logger.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update && apt-get install -y dart` *(fails: unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_688f8d612334832ab16f1cf634ef98ee