### PR TITLE
refactor: unify training pack commit workflow

### DIFF
--- a/lib/controllers/training_pack_controller.dart
+++ b/lib/controllers/training_pack_controller.dart
@@ -68,7 +68,7 @@ class TrainingPackController extends ChangeNotifier {
 
   void _commit() {
     _applyStackFilter();
-    saveSpots();
+    unawaited(saveSpots());
     notifyListeners();
   }
 
@@ -99,8 +99,7 @@ class TrainingPackController extends ChangeNotifier {
 
   void reorder(int oldIndex, int newIndex) {
     _moveSpot(oldIndex, newIndex);
-    saveSpots();
-    notifyListeners();
+    _commit();
   }
 
   /// Moves a spot within the filtered list and keeps the base list in sync.


### PR DESCRIPTION
## Summary
- centralize stack filter application, spot persistence, and notification in `_commit`
- reuse `_commit` in `reorder` to avoid manual save + notify

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze lib/controllers/training_pack_controller.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f8d4a5bd8832a8adc98bc4f38ca2a