### PR TITLE
feat: add RouteLink equality and hashCode

### DIFF
--- a/lib/utils/route_link.dart
+++ b/lib/utils/route_link.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RouteLink {
   final String pathId;
   final String? stageId;
@@ -30,4 +33,12 @@ class RouteLink {
     }
     return null;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RouteLink && other.pathId == pathId && other.stageId == stageId;
+
+  @override
+  int get hashCode => Object.hash(pathId, stageId);
 }


### PR DESCRIPTION
## Summary
- add @immutable annotation to RouteLink
- implement == operator and hashCode based on pathId and stageId

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d6bf088832aab067e3fca8b60bf