### PR TITLE
Log error when pack library load fails

### DIFF
--- a/lib/services/pack_library_loader_service.dart
+++ b/lib/services/pack_library_loader_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
 
 import '../models/v2/training_pack_template_v2.dart';
+import '../core/error_logger.dart';
 
 class PackLibraryLoaderService {
   PackLibraryLoaderService._();
@@ -25,7 +26,9 @@ class PackLibraryLoaderService {
         ];
         return _cache!;
       }
-    } catch (_) {}
+    } catch (e, st) {
+      ErrorLogger.instance.logError('Pack library load failed', e, st);
+    }
     _cache = [];
     return const [];
   }


### PR DESCRIPTION
## Summary
- log pack library load failures through ErrorLogger

## Testing
- `dart format lib/services/pack_library_loader_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d62bfd8832a81616f44bbc93b1a