### PR TITLE
Make training spot reorder asynchronous

### DIFF
--- a/lib/controllers/training_pack_controller.dart
+++ b/lib/controllers/training_pack_controller.dart
@@ -97,9 +97,9 @@ class TrainingPackController extends ChangeNotifier {
     _commit();
   }
 
-  void reorder(int oldIndex, int newIndex) {
+  Future<void> reorder(int oldIndex, int newIndex) async {
     _moveSpot(oldIndex, newIndex);
-    saveSpots();
+    await saveSpots();
     notifyListeners();
   }
 

--- a/lib/screens/training_pack_spot_panel.dart
+++ b/lib/screens/training_pack_spot_panel.dart
@@ -22,7 +22,8 @@ class TrainingPackSpotPanel extends StatelessWidget {
         spots: controller.spots,
         onRemove: controller.removeSpot,
         onChanged: controller.saveSpots,
-        onReorder: controller.reorder,
+        onReorder: (oldIndex, newIndex) =>
+            controller.reorder(oldIndex, newIndex),
       ),
     );
   }

--- a/lib/widgets/pack_spot_list.dart
+++ b/lib/widgets/pack_spot_list.dart
@@ -24,7 +24,8 @@ class PackSpotList extends StatelessWidget {
         onEdit: onEdit,
         onRemove: controller.removeSpot,
         onChanged: controller.saveSpots,
-        onReorder: controller.reorder,
+        onReorder: (oldIndex, newIndex) =>
+            controller.reorder(oldIndex, newIndex),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- make `TrainingPackController.reorder` async and await saving
- update widgets to use new reorder callback

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d67a2d4832a980d42352b7aac30