### PR TITLE
Add dart async import to training pack controller

### DIFF
--- a/lib/controllers/training_pack_controller.dart
+++ b/lib/controllers/training_pack_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../models/saved_hand.dart';


### PR DESCRIPTION
## Summary
- add dart async import for unawaited in training pack controller

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f92db9a10832abd6126d484a96849