### PR TITLE
refactor: use VoidCallback in update

### DIFF
--- a/lib/controllers/poker_analyzer_controller.dart
+++ b/lib/controllers/poker_analyzer_controller.dart
@@ -29,7 +29,7 @@ class PokerAnalyzerController extends ChangeNotifier {
   /// Flag controlling display of debug information in the overlay.
   bool _debugMode = false;
 
-  void _update(void Function() action) {
+  void _update(VoidCallback action) {
     action();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- refactor PokerAnalyzerController's internal update helper to accept VoidCallback for better Flutter integration

## Testing
- `dart format lib/controllers/poker_analyzer_controller.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688f92dd1234832aa33db72ea312e606