### PR TITLE
refactor: extract positions map

### DIFF
--- a/lib/helpers/poker_position_helper.dart
+++ b/lib/helpers/poker_position_helper.dart
@@ -1,3 +1,15 @@
+const Map<int, List<String>> positionsByCount = {
+  2: ['SB', 'BB'],
+  3: ['BTN', 'SB', 'BB'],
+  4: ['CO', 'BTN', 'SB', 'BB'],
+  5: ['MP', 'CO', 'BTN', 'SB', 'BB'],
+  6: ['UTG', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+  7: ['UTG', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+  8: ['UTG', 'UTG+1', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+  9: ['UTG', 'UTG+1', 'UTG+2', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+  10: ['UTG', 'UTG+1', 'UTG+2', 'UTG+3', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
+};
+
 /// Returns the list of position names for a given number of players.
 ///
 /// The list is ordered from UTG to BB and supports tables with 2 to 10 players.
@@ -6,18 +18,6 @@ List<String> getPositionList(int playerCount) {
   if (playerCount < 2 || playerCount > 10) {
     throw ArgumentError('Supported range: 2 to 10 players');
   }
-
-  const Map<int, List<String>> positionsByCount = {
-    2: ['SB', 'BB'],
-    3: ['BTN', 'SB', 'BB'],
-    4: ['CO', 'BTN', 'SB', 'BB'],
-    5: ['MP', 'CO', 'BTN', 'SB', 'BB'],
-    6: ['UTG', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
-    7: ['UTG', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
-    8: ['UTG', 'UTG+1', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
-    9: ['UTG', 'UTG+1', 'UTG+2', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
-    10: ['UTG', 'UTG+1', 'UTG+2', 'UTG+3', 'MP', 'HJ', 'CO', 'BTN', 'SB', 'BB'],
-  };
 
   return positionsByCount[playerCount]!;
 }


### PR DESCRIPTION
## Summary
- move positions-by-count map to a top-level constant
- reference shared map inside `getPositionList`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f92de0440832a869f0a7e50b9faa2