### PR TITLE
feat: add context media query extension

### DIFF
--- a/lib/utils/context_extensions.dart
+++ b/lib/utils/context_extensions.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 
 extension ContextExtensions on BuildContext {
+  MediaQueryData get mediaQuery => MediaQuery.of(this);
+
   Future<void> ifMounted(FutureOr<void> Function() fn) async {
     if (mounted) {
       await fn();

--- a/lib/utils/responsive.dart
+++ b/lib/utils/responsive.dart
@@ -1,31 +1,27 @@
 import 'package:flutter/widgets.dart';
 
+import 'context_extensions.dart';
+
 bool isCompactWidth(BuildContext context) {
-  final mq = MediaQuery.of(context);
-  return mq.size.width < 360;
+  return context.mediaQuery.size.width < 360;
 }
 
 double responsiveSize(BuildContext context, double value) {
-  final mq = MediaQuery.of(context);
-  return mq.size.width < 360 ? value / 2 : value;
+  return isCompactWidth(context) ? value / 2 : value;
 }
 
 EdgeInsets responsiveAll(BuildContext context, double value) {
-  final mq = MediaQuery.of(context);
-  return EdgeInsets.all(mq.size.width < 360 ? value / 2 : value);
+  return EdgeInsets.all(isCompactWidth(context) ? value / 2 : value);
 }
 
 Orientation currentOrientation(BuildContext context) {
-  final mq = MediaQuery.of(context);
-  return mq.orientation;
+  return context.mediaQuery.orientation;
 }
 
 bool isPortrait(BuildContext context) {
-  final mq = MediaQuery.of(context);
-  return mq.orientation == Orientation.portrait;
+  return context.mediaQuery.orientation == Orientation.portrait;
 }
 
 bool isLandscape(BuildContext context) {
-  final mq = MediaQuery.of(context);
-  return mq.orientation == Orientation.landscape;
+  return context.mediaQuery.orientation == Orientation.landscape;
 }


### PR DESCRIPTION
## Summary
- add `mediaQuery` getter extension for easier access to `MediaQuery` data
- refactor responsive utilities to use new extension and centralize width checks

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*


------
https://chatgpt.com/codex/tasks/task_e_688f92defc1c832a903ac6438c6744f4