### PR TITLE
refactor: modularize training providers

### DIFF
--- a/lib/providers/training_providers.dart
+++ b/lib/providers/training_providers.dart
@@ -140,42 +140,13 @@ import '../services/skill_tag_decay_tracker.dart';
 import '../services/smart_recap_scheduler.dart';
 import '../utils/loadable_extension.dart';
 import 'provider_globals.dart';
+import 'training_providers_stats.dart';
+import 'training_providers_packs.dart';
 
 /// Providers supporting training features such as history, stats and packs.
 List<SingleChildWidget> buildTrainingProviders() {
   return [
-    Provider(create: (_) => CloudTrainingHistoryService()..init()),
-    ChangeNotifierProvider(
-      create: (context) =>
-          TrainingSpotStorageService(cloud: context.read<CloudSyncService>()),
-    ),
-    ChangeNotifierProvider(
-      create: (context) =>
-          TrainingStatsService(cloud: context.read<CloudSyncService>())..init(),
-    ),
-    ChangeNotifierProvider(
-      create: (context) =>
-          SavedHandStorageService(cloud: context.read<CloudSyncService>())
-            ..init(),
-    ),
-    ChangeNotifierProvider(
-      create: (context) => SavedHandManagerService(
-        storage: context.read<SavedHandStorageService>(),
-        cloud: context.read<CloudSyncService>(),
-        stats: context.read<TrainingStatsService>(),
-      ),
-    ),
-    ChangeNotifierProvider(
-      create: (context) => SavedHandStatsService(
-        manager: context.read<SavedHandManagerService>(),
-      ),
-    ),
-    Provider(
-      create: (context) => SavedHandExportService(
-        manager: context.read<SavedHandManagerService>(),
-        stats: context.read<SavedHandStatsService>(),
-      ),
-    ),
+    ...buildTrainingStatsProviders(),
     ChangeNotifierProvider(
       create: (context) =>
           PlayerProgressService(hands: context.read<SavedHandManagerService>()),
@@ -225,40 +196,7 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) =>
           SessionPinService(cloud: context.read<CloudSyncService>())..init(),
     ),
-    ChangeNotifierProvider<TrainingPackStorageService>.value(
-      value: packStorage,
-    ),
-    Provider<TrainingPackCloudSyncService>.value(value: packCloud),
-    Provider<MistakePackCloudService>.value(value: mistakeCloud),
-    Provider<GoalSyncService>.value(value: goalSync),
-    ChangeNotifierProvider(create: (_) => TemplateStorageService()..init()),
-    ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..init()),
-    Provider(create: (_) => SmartReviewService.instance..init()),
-    ChangeNotifierProvider(
-      create: (context) => AdaptiveTrainingService(
-        templates: context.read<TemplateStorageService>(),
-        mistakes: context.read<MistakeReviewPackService>(),
-        hands: context.read<SavedHandManagerService>(),
-        history: context.read<HandAnalysisHistoryService>(),
-        xp: context.read<XPTrackerService>(),
-        forecast: context.read<ProgressForecastService>(),
-        style: context.read<PlayerStyleService>(),
-        styleForecast: context.read<PlayerStyleForecastService>(),
-      ),
-    ),
-    ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(
-      value: templateStorage,
-    ),
-    Provider<FavoritePackService>.value(value: FavoritePackService.instance),
-    Provider<PackFavoriteService>.value(value: PackFavoriteService.instance),
-    Provider<PackRatingService>.value(value: PackRatingService.instance),
-    Provider<PinnedPackService>.value(value: PinnedPackService.instance),
-    ChangeNotifierProvider(
-      create: (context) => CategoryUsageService(
-        templates: context.read<TemplateStorageService>(),
-        packs: context.read<TrainingPackStorageService>(),
-      ),
-    ),
+    ...buildTrainingPackProviders(),
     ChangeNotifierProvider(create: (_) => DailyHandService()..init()),
     ChangeNotifierProvider(create: (_) => DailyTargetService()..init()),
     ChangeNotifierProvider(create: (_) => DailyTipService()..init()),

--- a/lib/providers/training_providers_packs.dart
+++ b/lib/providers/training_providers_packs.dart
@@ -1,0 +1,64 @@
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+import '../services/training_pack_storage_service.dart';
+import '../services/training_pack_cloud_sync_service.dart';
+import '../services/mistake_pack_cloud_service.dart';
+import '../services/goal_sync_service.dart';
+import '../services/template_storage_service.dart';
+import '../services/hand_analysis_history_service.dart';
+import '../services/smart_review_service.dart';
+import '../services/adaptive_training_service.dart';
+import '../services/mistake_review_pack_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/xp_tracker_service.dart';
+import '../services/progress_forecast_service.dart';
+import '../services/player_style_service.dart';
+import '../services/player_style_forecast_service.dart';
+import '../services/training_pack_template_storage_service.dart';
+import '../services/favorite_pack_service.dart';
+import '../services/pack_favorite_service.dart';
+import '../services/pack_rating_service.dart';
+import '../services/pinned_pack_service.dart';
+import '../services/category_usage_service.dart';
+import 'provider_globals.dart';
+
+/// Providers supporting training pack features.
+List<SingleChildWidget> buildTrainingPackProviders() {
+  return [
+    ChangeNotifierProvider<TrainingPackStorageService>.value(
+      value: packStorage,
+    ),
+    Provider<TrainingPackCloudSyncService>.value(value: packCloud),
+    Provider<MistakePackCloudService>.value(value: mistakeCloud),
+    Provider<GoalSyncService>.value(value: goalSync),
+    ChangeNotifierProvider(create: (_) => TemplateStorageService()..init()),
+    ChangeNotifierProvider(create: (_) => HandAnalysisHistoryService()..init()),
+    Provider(create: (_) => SmartReviewService.instance..init()),
+    ChangeNotifierProvider(
+      create: (context) => AdaptiveTrainingService(
+        templates: context.read<TemplateStorageService>(),
+        mistakes: context.read<MistakeReviewPackService>(),
+        hands: context.read<SavedHandManagerService>(),
+        history: context.read<HandAnalysisHistoryService>(),
+        xp: context.read<XPTrackerService>(),
+        forecast: context.read<ProgressForecastService>(),
+        style: context.read<PlayerStyleService>(),
+        styleForecast: context.read<PlayerStyleForecastService>(),
+      ),
+    ),
+    ChangeNotifierProvider<TrainingPackTemplateStorageService>.value(
+      value: templateStorage,
+    ),
+    Provider<FavoritePackService>.value(value: FavoritePackService.instance),
+    Provider<PackFavoriteService>.value(value: PackFavoriteService.instance),
+    Provider<PackRatingService>.value(value: PackRatingService.instance),
+    Provider<PinnedPackService>.value(value: PinnedPackService.instance),
+    ChangeNotifierProvider(
+      create: (context) => CategoryUsageService(
+        templates: context.read<TemplateStorageService>(),
+        packs: context.read<TrainingPackStorageService>(),
+      ),
+    ),
+  ];
+}

--- a/lib/providers/training_providers_stats.dart
+++ b/lib/providers/training_providers_stats.dart
@@ -1,0 +1,49 @@
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+import '../services/cloud_sync_service.dart';
+import '../services/cloud_training_history_service.dart';
+import '../services/training_spot_storage_service.dart';
+import '../services/training_stats_service.dart';
+import '../services/saved_hand_storage_service.dart';
+import '../services/saved_hand_manager_service.dart';
+import '../services/saved_hand_stats_service.dart';
+import '../services/saved_hand_export_service.dart';
+
+/// Providers supporting training stats and saved hand features.
+List<SingleChildWidget> buildTrainingStatsProviders() {
+  return [
+    Provider(create: (_) => CloudTrainingHistoryService()..init()),
+    ChangeNotifierProvider(
+      create: (context) =>
+          TrainingSpotStorageService(cloud: context.read<CloudSyncService>()),
+    ),
+    ChangeNotifierProvider(
+      create: (context) =>
+          TrainingStatsService(cloud: context.read<CloudSyncService>())..init(),
+    ),
+    ChangeNotifierProvider(
+      create: (context) =>
+          SavedHandStorageService(cloud: context.read<CloudSyncService>())
+            ..init(),
+    ),
+    ChangeNotifierProvider(
+      create: (context) => SavedHandManagerService(
+        storage: context.read<SavedHandStorageService>(),
+        cloud: context.read<CloudSyncService>(),
+        stats: context.read<TrainingStatsService>(),
+      ),
+    ),
+    ChangeNotifierProvider(
+      create: (context) => SavedHandStatsService(
+        manager: context.read<SavedHandManagerService>(),
+      ),
+    ),
+    Provider(
+      create: (context) => SavedHandExportService(
+        manager: context.read<SavedHandManagerService>(),
+        stats: context.read<SavedHandStatsService>(),
+      ),
+    ),
+  ];
+}


### PR DESCRIPTION
## Summary
- extract stats-focused providers into `training_providers_stats.dart`
- extract pack-related providers into `training_providers_packs.dart`
- compose `buildTrainingProviders` from the new provider lists

## Testing
- `flutter format lib/providers/training_providers.dart lib/providers/training_providers_stats.dart lib/providers/training_providers_packs.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f4d174832a81e3fa5aeb585e5b