### PR TITLE
refactor: use JsonSerializable for learning plan cache

### DIFF
--- a/lib/services/learning_plan_cache.dart
+++ b/lib/services/learning_plan_cache.dart
@@ -2,11 +2,8 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../models/learning_goal.dart';
-import '../models/training_track.dart';
-import '../models/v2/training_pack_spot.dart';
-import '../models/v2/training_pack_template_v2.dart';
 import 'adaptive_learning_flow_engine.dart';
+import 'learning_plan_cache_models.dart';
 
 /// Persists the last generated [AdaptiveLearningPlan] to allow instant resume
 /// after app restart.
@@ -18,7 +15,7 @@ class LearningPlanCache {
   /// Saves [plan] to local storage.
   Future<void> save(AdaptiveLearningPlan plan) async {
     final prefs = await SharedPreferences.getInstance();
-    final data = _planToJson(plan);
+    final data = CachedLearningPlan.fromPlan(plan).toJson();
     await prefs.setString(_key, jsonEncode(data));
   }
 
@@ -31,88 +28,11 @@ class LearningPlanCache {
     try {
       final data = jsonDecode(raw);
       if (data is Map<String, dynamic>) {
-        return _planFromJson(Map<String, dynamic>.from(data));
+        return CachedLearningPlan.fromJson(
+          Map<String, dynamic>.from(data),
+        ).toPlan();
       }
     } catch (_) {}
     return null;
   }
-
-  Map<String, dynamic> _planToJson(AdaptiveLearningPlan plan) => {
-        'goals': [for (final g in plan.goals) _goalToJson(g)],
-        'tracks': [for (final t in plan.recommendedTracks) _trackToJson(t)],
-        if (plan.mistakeReplayPack != null)
-          'mistakePack': plan.mistakeReplayPack!.toJson(),
-      };
-
-  Map<String, dynamic> _goalToJson(LearningGoal g) => {
-        'id': g.id,
-        'title': g.title,
-        'description': g.description,
-        'tag': g.tag,
-        'priority': g.priorityScore,
-      };
-
-  Map<String, dynamic> _trackToJson(TrainingTrack t) => {
-        'id': t.id,
-        'title': t.title,
-        'goalId': t.goalId,
-        'tags': t.tags,
-        'spots': [for (final s in t.spots) s.toJson()],
-      };
-
-  AdaptiveLearningPlan? _planFromJson(Map<String, dynamic> j) {
-    final goalsRaw = j['goals'];
-    final tracksRaw = j['tracks'];
-    if (goalsRaw is! List || tracksRaw is! List) return null;
-
-    final goals = <LearningGoal>[];
-    for (final g in goalsRaw) {
-      if (g is! Map) return null;
-      goals.add(LearningGoal(
-        id: g['id'] as String? ?? '',
-        title: g['title'] as String? ?? '',
-        description: g['description'] as String? ?? '',
-        tag: g['tag'] as String? ?? '',
-        priorityScore: (g['priority'] as num?)?.toDouble() ?? 0.0,
-      ));
-    }
-
-    final tracks = <TrainingTrack>[];
-    for (final t in tracksRaw) {
-      if (t is! Map) return null;
-      final spotsRaw = t['spots'];
-      if (spotsRaw is! List) return null;
-      final spots = <TrainingPackSpot>[];
-      for (final s in spotsRaw) {
-        if (s is! Map) return null;
-        spots.add(
-            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s)));
-      }
-      tracks.add(TrainingTrack(
-        id: t['id'] as String? ?? '',
-        title: t['title'] as String? ?? '',
-        goalId: t['goalId'] as String? ?? '',
-        spots: spots,
-        tags: [for (final tag in (t['tags'] as List? ?? [])) tag.toString()],
-      ));
-    }
-
-    TrainingPackTemplateV2? replayPack;
-    final mp = j['mistakePack'];
-    if (mp is Map) {
-      try {
-        replayPack =
-            TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(mp));
-      } catch (_) {
-        return null;
-      }
-    }
-
-    return AdaptiveLearningPlan(
-      recommendedTracks: tracks,
-      goals: goals,
-      mistakeReplayPack: replayPack,
-    );
-  }
 }
-

--- a/lib/services/learning_plan_cache_models.dart
+++ b/lib/services/learning_plan_cache_models.dart
@@ -1,0 +1,120 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../models/learning_goal.dart';
+import '../models/training_track.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'adaptive_learning_flow_engine.dart';
+
+part 'learning_plan_cache_models.g.dart';
+
+/// Cached representation of [AdaptiveLearningPlan].
+@JsonSerializable(explicitToJson: true)
+class CachedLearningPlan {
+  final List<CachedLearningGoal> goals;
+  final List<CachedTrainingTrack> tracks;
+  final TrainingPackTemplateV2? mistakePack;
+
+  const CachedLearningPlan({
+    required this.goals,
+    required this.tracks,
+    this.mistakePack,
+  });
+
+  factory CachedLearningPlan.fromPlan(AdaptiveLearningPlan plan) =>
+      CachedLearningPlan(
+        goals: [for (final g in plan.goals) CachedLearningGoal.fromGoal(g)],
+        tracks: [
+          for (final t in plan.recommendedTracks)
+            CachedTrainingTrack.fromTrack(t),
+        ],
+        mistakePack: plan.mistakeReplayPack,
+      );
+
+  AdaptiveLearningPlan toPlan() => AdaptiveLearningPlan(
+    recommendedTracks: [for (final t in tracks) t.toTrack()],
+    goals: [for (final g in goals) g.toGoal()],
+    mistakeReplayPack: mistakePack,
+  );
+
+  factory CachedLearningPlan.fromJson(Map<String, dynamic> json) =>
+      _$CachedLearningPlanFromJson(json);
+  Map<String, dynamic> toJson() => _$CachedLearningPlanToJson(this);
+}
+
+/// Cached representation of [LearningGoal].
+@JsonSerializable()
+class CachedLearningGoal {
+  final String id;
+  final String title;
+  final String description;
+  final String tag;
+  final double priority;
+
+  const CachedLearningGoal({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.tag,
+    required this.priority,
+  });
+
+  factory CachedLearningGoal.fromGoal(LearningGoal goal) => CachedLearningGoal(
+    id: goal.id,
+    title: goal.title,
+    description: goal.description,
+    tag: goal.tag,
+    priority: goal.priorityScore,
+  );
+
+  LearningGoal toGoal() => LearningGoal(
+    id: id,
+    title: title,
+    description: description,
+    tag: tag,
+    priorityScore: priority,
+  );
+
+  factory CachedLearningGoal.fromJson(Map<String, dynamic> json) =>
+      _$CachedLearningGoalFromJson(json);
+  Map<String, dynamic> toJson() => _$CachedLearningGoalToJson(this);
+}
+
+/// Cached representation of [TrainingTrack].
+@JsonSerializable(explicitToJson: true)
+class CachedTrainingTrack {
+  final String id;
+  final String title;
+  final String goalId;
+  final List<TrainingPackSpot> spots;
+  final List<String> tags;
+
+  const CachedTrainingTrack({
+    required this.id,
+    required this.title,
+    required this.goalId,
+    required this.spots,
+    required this.tags,
+  });
+
+  factory CachedTrainingTrack.fromTrack(TrainingTrack track) =>
+      CachedTrainingTrack(
+        id: track.id,
+        title: track.title,
+        goalId: track.goalId,
+        spots: track.spots,
+        tags: track.tags,
+      );
+
+  TrainingTrack toTrack() => TrainingTrack(
+    id: id,
+    title: title,
+    goalId: goalId,
+    spots: spots,
+    tags: tags,
+  );
+
+  factory CachedTrainingTrack.fromJson(Map<String, dynamic> json) =>
+      _$CachedTrainingTrackFromJson(json);
+  Map<String, dynamic> toJson() => _$CachedTrainingTrackToJson(this);
+}

--- a/lib/services/learning_plan_cache_models.g.dart
+++ b/lib/services/learning_plan_cache_models.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'learning_plan_cache_models.dart';
+
+CachedLearningPlan _$CachedLearningPlanFromJson(Map<String, dynamic> json) =>
+    CachedLearningPlan(
+      goals: (json['goals'] as List<dynamic>)
+          .map((e) => CachedLearningGoal.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      tracks: (json['tracks'] as List<dynamic>)
+          .map((e) => CachedTrainingTrack.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      mistakePack: json['mistakePack'] == null
+          ? null
+          : TrainingPackTemplateV2.fromJson(
+              json['mistakePack'] as Map<String, dynamic>,
+            ),
+    );
+
+Map<String, dynamic> _$CachedLearningPlanToJson(CachedLearningPlan instance) =>
+    <String, dynamic>{
+      'goals': instance.goals.map((e) => e.toJson()).toList(),
+      'tracks': instance.tracks.map((e) => e.toJson()).toList(),
+      'mistakePack': instance.mistakePack?.toJson(),
+    };
+
+CachedLearningGoal _$CachedLearningGoalFromJson(Map<String, dynamic> json) =>
+    CachedLearningGoal(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      tag: json['tag'] as String,
+      priority: (json['priority'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$CachedLearningGoalToJson(CachedLearningGoal instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'tag': instance.tag,
+      'priority': instance.priority,
+    };
+
+CachedTrainingTrack _$CachedTrainingTrackFromJson(Map<String, dynamic> json) =>
+    CachedTrainingTrack(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      goalId: json['goalId'] as String,
+      spots: (json['spots'] as List<dynamic>)
+          .map((e) => TrainingPackSpot.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      tags: (json['tags'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$CachedTrainingTrackToJson(
+  CachedTrainingTrack instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'title': instance.title,
+  'goalId': instance.goalId,
+  'spots': instance.spots.map((e) => e.toJson()).toList(),
+  'tags': instance.tags,
+};


### PR DESCRIPTION
## Summary
- add JsonSerializable models for cached learning plan components
- use generated serialization in LearningPlanCache

## Testing
- `dart run build_runner build --delete-conflicting-outputs` *(fails: Flutter SDK is not available)*
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f4aed4832ab7ed4d4883d4d620