### PR TITLE
Handle missing timestamps in reinforcement log

### DIFF
--- a/lib/models/reinforcement_log.dart
+++ b/lib/models/reinforcement_log.dart
@@ -8,7 +8,7 @@ class ReinforcementLog {
   final String type;
   final String source;
   @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)
-  final DateTime timestamp;
+  final DateTime? timestamp;
 
   ReinforcementLog({
     required this.id,
@@ -22,7 +22,6 @@ class ReinforcementLog {
 
   Map<String, dynamic> toJson() => _$ReinforcementLogToJson(this);
 
-  static DateTime _dateFromJson(String? date) =>
-      DateTime.tryParse(date ?? '') ?? DateTime.now();
-  static String _dateToJson(DateTime date) => date.toIso8601String();
+  static DateTime? _dateFromJson(String? date) => DateTime.tryParse(date ?? '');
+  static String? _dateToJson(DateTime? date) => date?.toIso8601String();
 }

--- a/lib/services/theory_reinforcement_log_service.dart
+++ b/lib/services/theory_reinforcement_log_service.dart
@@ -55,7 +55,7 @@ class TheoryReinforcementLogService {
     final cutoff = DateTime.now().subtract(within);
     return [
       for (final l in list)
-        if (l.timestamp.isAfter(cutoff)) l,
+        if (l.timestamp != null && l.timestamp!.isAfter(cutoff)) l,
     ];
   }
 }

--- a/lib/widgets/booster_injection_tracker_widget.dart
+++ b/lib/widgets/booster_injection_tracker_widget.dart
@@ -102,7 +102,9 @@ class _BoosterInjectionTrackerWidgetState
                   ),
                 ),
                 Text(
-                  timeago.format(_logs[i].timestamp, allowFromNow: true),
+                  _logs[i].timestamp != null
+                      ? timeago.format(_logs[i].timestamp!, allowFromNow: true)
+                      : 'unknown',
                   style: const TextStyle(color: Colors.white70, fontSize: 12),
                 ),
               ],


### PR DESCRIPTION
## Summary
- Allow reinforcement logs to store null timestamps and emit them when parsing fails
- Skip logs without timestamps in recent log queries
- Show fallback label when booster log timestamp is missing

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f45920832a8fc84f61f9456437