### PR TITLE
refactor: add classes for tag matrix coverage

### DIFF
--- a/lib/screens/tag_matrix_coverage_screen.dart
+++ b/lib/screens/tag_matrix_coverage_screen.dart
@@ -18,7 +18,7 @@ class _TagMatrixCoverageScreenState extends State<TagMatrixCoverageScreen> {
   bool _loading = true;
   TrainingType? _type;
   bool _starter = false;
-  TagMatrixCoverageResult? _result;
+  TagMatrixResult? _result;
   final _service = const TagMatrixCoverageService();
 
   @override

--- a/lib/widgets/tag_matrix_coverage_table.dart
+++ b/lib/widgets/tag_matrix_coverage_table.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 
-import '../services/matrix_tag_config_service.dart';
 import '../services/tag_matrix_coverage_service.dart';
 import '../theme/app_colors.dart';
 
 class TagMatrixCoverageTable extends StatelessWidget {
-  final List<MatrixAxis> axes;
-  final Map<String, Map<String, TagMatrixCellData>> data;
+  final TagMatrixAxes axes;
+  final Map<String, Map<String, TagMatrixCell>> data;
   final int max;
 
   const TagMatrixCoverageTable({


### PR DESCRIPTION
## Summary
- introduce TagMatrixAxes, TagMatrixCell, and TagMatrixResult
- refactor tag matrix coverage service to use typed classes
- update coverage table and screen to rely on new structures

## Testing
- `dart format lib/services/tag_matrix_coverage_service.dart lib/widgets/tag_matrix_coverage_table.dart lib/screens/tag_matrix_coverage_screen.dart` *(fails: command not found: dart)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f3de78832a8d47baa4faa2794f