### PR TITLE
Refactor AppBootstrap init into discrete steps

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'services/training_pack_asset_loader.dart';
 import 'services/favorite_pack_service.dart';
 import 'services/pack_favorite_service.dart';
@@ -14,6 +16,7 @@ import 'services/service_registry.dart';
 import 'services/pack_library_loader_service.dart';
 import 'services/xp_goal_panel_booster_injector.dart';
 import 'helpers/training_pack_storage.dart';
+import 'core/error_logger.dart';
 import 'core/plugin_runtime.dart';
 import 'core/training/library/training_pack_library_v2.dart';
 
@@ -32,27 +35,9 @@ class AppBootstrap {
   }) async {
     await runtime.initialize();
     final ServiceRegistry registry = runtime.registry.createChild();
-    await Future.wait([
-      // Asset and library loading
-      TrainingPackAssetLoader.instance.loadAll(),
-      PackLibraryLoaderService.instance.loadLibrary(),
-      TrainingPackLibraryV2.instance.loadFromFolder(),
-      // Service initialization
-      PackFavoriteService.instance.load(),
-      PackRatingService.instance.load(),
-      TrainingPackCommentsService.instance.load(),
-      FavoritePackService.instance.init(),
-      PinnedPackService.instance.init(),
-      UserProfilePreferenceService.instance.load(),
-    ]);
-    if (cloud != null) {
-      await cloud.init();
-      await cloud.syncUp();
-      await cloud.syncDown();
-      await cloud.loadHands();
-      cloud.watchChanges();
-      _sync = ConnectivitySyncController(cloud: cloud);
-    }
+    await _loadAssets();
+    await _initServices();
+    await _setupCloudSync(cloud);
     await SessionNoteService(cloud: cloud).load();
     final packs = await TrainingPackStorage.load();
     if (packs.isEmpty) {
@@ -68,5 +53,55 @@ class AppBootstrap {
     _sync?.dispose();
     _sync = null;
     _registry = null;
+  }
+
+  static Future<void> _loadAssets() async {
+    try {
+      await _run('TrainingPackAssetLoader.loadAll', () => TrainingPackAssetLoader.instance.loadAll());
+      await _run('PackLibraryLoaderService.loadLibrary', () => PackLibraryLoaderService.instance.loadLibrary());
+      await _run('TrainingPackLibraryV2.loadFromFolder', () => TrainingPackLibraryV2.instance.loadFromFolder());
+    } catch (e, s) {
+      ErrorLogger.instance.logError('Failed to load assets', e, s);
+      rethrow;
+    }
+  }
+
+  static Future<void> _initServices() async {
+    try {
+      await _run('PackFavoriteService.load', () => PackFavoriteService.instance.load());
+      await _run('PackRatingService.load', () => PackRatingService.instance.load());
+      await _run('TrainingPackCommentsService.load', () => TrainingPackCommentsService.instance.load());
+      await _run('FavoritePackService.init', () => FavoritePackService.instance.init());
+      await _run('PinnedPackService.init', () => PinnedPackService.instance.init());
+      await _run('UserProfilePreferenceService.load', () => UserProfilePreferenceService.instance.load());
+    } catch (e, s) {
+      ErrorLogger.instance.logError('Failed to initialize services', e, s);
+      rethrow;
+    }
+  }
+
+  static Future<void> _setupCloudSync(CloudSyncService? cloud) async {
+    if (cloud == null) return;
+    try {
+      await _run('CloudSyncService.init', cloud.init);
+      await _run('CloudSyncService.syncUp', cloud.syncUp);
+      await _run('CloudSyncService.syncDown', cloud.syncDown);
+      await _run('CloudSyncService.loadHands', cloud.loadHands);
+      cloud.watchChanges();
+      _sync = ConnectivitySyncController(cloud: cloud);
+    } catch (e, s) {
+      ErrorLogger.instance.logError('Failed to setup cloud sync', e, s);
+    }
+  }
+
+  static Future<void> _run(String name, Future<void> Function() task) async {
+    try {
+      debugPrint('Starting $name');
+      await task();
+      debugPrint('Completed $name');
+    } catch (e, s) {
+      ErrorLogger.instance.logError('$name failed', e, s);
+      rethrow;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Split `AppBootstrap.init` into `_loadAssets`, `_initServices`, and `_setupCloudSync`
- Added per-task logging and error handling wrappers
- Sequentialized initialization steps for assets, services, and cloud sync

## Testing
- `flutter format lib/app_bootstrap.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f92f36264832ab5316e724b439978