### PR TITLE
refactor push fold rank ordering

### DIFF
--- a/lib/helpers/push_fold_helper.dart
+++ b/lib/helpers/push_fold_helper.dart
@@ -8,18 +8,15 @@ Map<String, int> _buildPushFoldThresholds() {
     map['$r$r'] = 15;
   }
 
-  void addBoth(String a, String b) {
-    final ha = val(a) >= val(b) ? a : b;
-    final lb = val(a) >= val(b) ? b : a;
-    map['$ha$lb' 'o'] = 15;
-    map['$ha$lb' 's'] = 15;
+  void add(String a, String b, {bool suited = false, bool offsuit = false}) {
+    final pair = [a, b]..sort((x, y) => val(y).compareTo(val(x)));
+    if (offsuit) map['${pair[0]}${pair[1]}o'] = 15;
+    if (suited) map['${pair[0]}${pair[1]}s'] = 15;
   }
 
-  void addSuited(String a, String b) {
-    final ha = val(a) >= val(b) ? a : b;
-    final lb = val(a) >= val(b) ? b : a;
-    map['$ha$lb' 's'] = 15;
-  }
+  void addBoth(String a, String b) => add(a, b, suited: true, offsuit: true);
+
+  void addSuited(String a, String b) => add(a, b, suited: true);
 
   for (final r in ranks) {
     addPair(r);


### PR DESCRIPTION
## Summary
- extract generic `add` helper that orders rank pairs before inserting thresholds
- refactor `addBoth` and `addSuited` to delegate to the new helper

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f1df18832a8e960aea8ae5cd08