### PR TITLE
feat: show total stages in goal status

### DIFF
--- a/lib/models/goal_progress.dart
+++ b/lib/models/goal_progress.dart
@@ -1,11 +1,13 @@
 class GoalProgress {
   final String tag;
   final int stagesCompleted;
+  final int totalStages;
   final double averageAccuracy;
 
   const GoalProgress({
     required this.tag,
     required this.stagesCompleted,
+    this.totalStages = 3,
     required this.averageAccuracy,
   });
 }

--- a/lib/services/goal_completion_engine.dart
+++ b/lib/services/goal_completion_engine.dart
@@ -1,4 +1,5 @@
 import '../models/goal_progress.dart';
+
 class GoalCompletionEngine {
   GoalCompletionEngine._();
   static final instance = GoalCompletionEngine._();
@@ -11,7 +12,8 @@ class GoalCompletionEngine {
     final cached = _cache[key];
     if (cached != null) return cached;
     final completed =
-        progress.stagesCompleted >= 3 && progress.averageAccuracy >= 80;
+        progress.stagesCompleted >= progress.totalStages &&
+        progress.averageAccuracy >= 80;
     _cache[key] = completed;
     return completed;
   }

--- a/lib/utils/goal_status_utils.dart
+++ b/lib/utils/goal_status_utils.dart
@@ -7,5 +7,5 @@ String getGoalStatus(GoalProgress progress) {
     return '✔ Завершено';
   }
   final accuracy = progress.averageAccuracy.toStringAsFixed(0);
-  return 'Пройдено: ${progress.stagesCompleted}/3 · Точность: $accuracy%';
+  return 'Пройдено: ${progress.stagesCompleted}/${progress.totalStages} · Точность: $accuracy%';
 }


### PR DESCRIPTION
## Summary
- display goal progress against total stages
- track total stage count in GoalProgress model
- complete goals when completed stages reach total

## Testing
- `dart test` *(fails: Flutter SDK is not available)*
- `dart analyze` *(fails: only 'Analyzing Poker_Analyzer...' printed, likely due to missing Flutter packages)*

------
https://chatgpt.com/codex/tasks/task_e_688f92e38ca0832aaf1ab4c447f95e4d