### PR TITLE
refactor: use Set for HH markers

### DIFF
--- a/lib/utils/clipboard_hh_detector.dart
+++ b/lib/utils/clipboard_hh_detector.dart
@@ -1,6 +1,9 @@
-const _hhMarkers = [
+const Set<String> _hhMarkers = {
   '*** hole cards ***', 'pokerstars', 'hand #', 'pokertracker',
   'карманные карты', 'раздача #', 'рука #',
-];
-bool containsPokerHistoryMarkers(String text) =>
-    _hhMarkers.any(text.toLowerCase().contains);
+};
+
+bool containsPokerHistoryMarkers(String text) {
+  final lowerText = text.toLowerCase();
+  return _hhMarkers.any(lowerText.contains);
+}


### PR DESCRIPTION
## Summary
- use a `Set<String>` for poker hand history markers
- check for markers with a lowercase comparison

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f92e28af8832a8a326a688b3fa6c3