### PR TITLE
feat: add training spot filter

### DIFF
--- a/lib/models/training_spot_filter.dart
+++ b/lib/models/training_spot_filter.dart
@@ -1,0 +1,52 @@
+import 'training_spot.dart';
+
+class TrainingSpotFilter {
+  final List<String> tags;
+  final List<String> positions;
+  final int? minDifficulty;
+  final int? maxDifficulty;
+
+  const TrainingSpotFilter({
+    this.tags = const [],
+    this.positions = const [],
+    this.minDifficulty,
+    this.maxDifficulty,
+  });
+
+  factory TrainingSpotFilter.fromMap(Map<String, dynamic> map) {
+    return TrainingSpotFilter(
+      tags: map['tags'] is List ? List<String>.from(map['tags']) : const [],
+      positions:
+          map['positions'] is List ? List<String>.from(map['positions']) : const [],
+      minDifficulty: map['minDifficulty'] is int
+          ? map['minDifficulty'] as int
+          : (map['minDifficulty'] as num?)?.toInt(),
+      maxDifficulty: map['maxDifficulty'] is int
+          ? map['maxDifficulty'] as int
+          : (map['maxDifficulty'] as num?)?.toInt(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        if (tags.isNotEmpty) 'tags': tags,
+        if (positions.isNotEmpty) 'positions': positions,
+        if (minDifficulty != null) 'minDifficulty': minDifficulty,
+        if (maxDifficulty != null) 'maxDifficulty': maxDifficulty,
+      };
+
+  bool get isEmpty =>
+      tags.isEmpty && positions.isEmpty && minDifficulty == null && maxDifficulty == null;
+
+  bool matches(TrainingSpot spot) {
+    if (tags.isNotEmpty && !tags.every((t) => spot.tags.contains(t))) {
+      return false;
+    }
+    if (positions.isNotEmpty) {
+      final heroPos = spot.positions.isNotEmpty ? spot.positions[spot.heroIndex] : '';
+      if (!positions.contains(heroPos)) return false;
+    }
+    if (minDifficulty != null && spot.difficulty < minDifficulty!) return false;
+    if (maxDifficulty != null && spot.difficulty > maxDifficulty!) return false;
+    return true;
+  }
+}

--- a/lib/screens/training_pack_template_list_screen.dart
+++ b/lib/screens/training_pack_template_list_screen.dart
@@ -13,6 +13,7 @@ import '../helpers/map_utils.dart';
 import '../models/training_pack_template_model.dart';
 import '../services/training_pack_template_storage_service.dart';
 import '../services/training_spot_storage_service.dart';
+import '../models/training_spot_filter.dart';
 import 'training_pack_template_editor_screen.dart';
 import 'package:uuid/uuid.dart';
 import 'package:timeago/timeago.dart' as timeago;
@@ -150,7 +151,8 @@ class _TrainingPackTemplateListScreenState
   void _ensureCount(String id, Map<String, dynamic> filters) {
     if (_counts.containsKey(id)) return;
     _counts[id] = null;
-    _spotStorage.evaluateFilterCount(filters).then((value) {
+    final filter = TrainingSpotFilter.fromMap(filters);
+    _spotStorage.evaluateFilterCount(filter).then((value) {
       if (mounted) setState(() => _counts[id] = value);
     });
   }


### PR DESCRIPTION
## Summary
- add `TrainingSpotFilter` model for tag, position and difficulty filtering
- use `TrainingSpotFilter` in `TrainingSpotStorageService` filtering methods
- adapt template list screen to build and pass the new filter type

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f92dfe534832aaac470c736c4d8a1