### PR TITLE
refactor: extract reinforcement entry

### DIFF
--- a/lib/services/theory_reinforcement_entry.dart
+++ b/lib/services/theory_reinforcement_entry.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'theory_reinforcement_entry.g.dart';
+
+@JsonSerializable()
+class TheoryReinforcementEntry {
+  final int level;
+  final DateTime next;
+
+  const TheoryReinforcementEntry({required this.level, required this.next});
+
+  factory TheoryReinforcementEntry.fromJson(Map<String, dynamic> json) =>
+      _$TheoryReinforcementEntryFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$TheoryReinforcementEntryToJson(this);
+}
+

--- a/lib/services/theory_reinforcement_entry.g.dart
+++ b/lib/services/theory_reinforcement_entry.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theory_reinforcement_entry.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TheoryReinforcementEntry _$TheoryReinforcementEntryFromJson(
+        Map<String, dynamic> json) =>
+    TheoryReinforcementEntry(
+      level: (json['level'] as num).toInt(),
+      next: DateTime.parse(json['next'] as String),
+    );
+
+Map<String, dynamic> _$TheoryReinforcementEntryToJson(
+        TheoryReinforcementEntry instance) =>
+    <String, dynamic>{
+      'level': instance.level,
+      'next': instance.next.toIso8601String(),
+    };


### PR DESCRIPTION
## Summary
- extract shared TheoryReinforcementEntry model with JsonSerializable
- reuse TheoryReinforcementEntry in reinforcement scheduler and queue service

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(failed: Failed to update packages)*
- `flutter test` *(failed: Error: the Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688f92f4aa30832abb5cb661faee6ca5