### PR TITLE
Validate stack range inputs

### DIFF
--- a/lib/utils/stack_range_filter.dart
+++ b/lib/utils/stack_range_filter.dart
@@ -7,14 +7,17 @@ class StackRangeFilter {
 
   static (int?, int?) _parseRange(String raw) {
     if (raw.endsWith('+')) {
-      return (int.tryParse(raw.substring(0, raw.length - 1)) ?? 0, null);
+      final min = int.tryParse(raw.substring(0, raw.length - 1));
+      if (min == null || min < 0) return (null, null);
+      return (min, null);
     }
     final parts = raw.split('-');
     if (parts.length == 2) {
-      return (
-        int.tryParse(parts[0]) ?? 0,
-        int.tryParse(parts[1]) ?? 0,
-      );
+      final min = int.tryParse(parts[0]);
+      final max = int.tryParse(parts[1]);
+      if (min == null || max == null) return (null, null);
+      if (min < 0 || max < 0 || min > max) return (null, null);
+      return (min, max);
     }
     return (null, null);
   }

--- a/test/stack_range_filter_test.dart
+++ b/test/stack_range_filter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/utils/stack_range_filter.dart';
+
+void main() {
+  group('StackRangeFilter', () {
+    test('handles plus notation', () {
+      final filter = StackRangeFilter('10+');
+      expect(filter.matches(9), isFalse);
+      expect(filter.matches(10), isTrue);
+      expect(filter.matches(20), isTrue);
+    });
+
+    test('handles range notation', () {
+      final filter = StackRangeFilter('5-10');
+      expect(filter.matches(4), isFalse);
+      expect(filter.matches(5), isTrue);
+      expect(filter.matches(10), isTrue);
+      expect(filter.matches(11), isFalse);
+    });
+
+    test('invalid ranges are ignored', () {
+      expect(StackRangeFilter('-5+').matches(0), isTrue);
+      expect(StackRangeFilter('10-5').matches(7), isTrue);
+      expect(StackRangeFilter('5--10').matches(7), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- tighten stack range parsing to reject negative values and min > max
- add unit tests for stack range filter

## Testing
- `flutter analyze` *(fails: The current Dart SDK version is 3.4.3; requires >=3.6.0 <4.0.0)*
- `flutter test test/stack_range_filter_test.dart` *(fails: The current Dart SDK version is 3.4.3; requires >=3.6.0 <4.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_688f92f12938832a923ed2a3097c88ea