### PR TITLE
feat: add full board generator service

### DIFF
--- a/lib/models/board.dart
+++ b/lib/models/board.dart
@@ -1,0 +1,16 @@
+import 'card_model.dart';
+
+class Board {
+  final List<CardModel> flop;
+  final CardModel? turn;
+  final CardModel? river;
+
+  Board({required this.flop, this.turn, this.river});
+
+  List<CardModel> get cards => [
+        ...flop,
+        if (turn != null) turn!,
+        if (river != null) river!,
+      ];
+}
+

--- a/lib/services/card_deck_service.dart
+++ b/lib/services/card_deck_service.dart
@@ -1,0 +1,22 @@
+import '../models/card_model.dart';
+
+class CardDeckService {
+  const CardDeckService();
+
+  List<CardModel> buildDeck({
+    List<CardModel> excludedCards = const [],
+    Set<String> excludedRanks = const {},
+  }) {
+    const ranks = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
+    const suits = ['♠', '♥', '♦', '♣'];
+    final deck = <CardModel>[
+      for (final r in ranks)
+        if (!excludedRanks.contains(r))
+          for (final s in suits) CardModel(rank: r, suit: s),
+    ];
+    deck.removeWhere((c) =>
+        excludedCards.any((e) => e.rank == c.rank && e.suit == c.suit));
+    return deck;
+  }
+}
+

--- a/lib/services/full_board_generator_service.dart
+++ b/lib/services/full_board_generator_service.dart
@@ -1,0 +1,84 @@
+import 'dart:math';
+
+import '../models/board.dart';
+import '../models/card_model.dart';
+import 'board_texture_filter_service.dart';
+import 'card_deck_service.dart';
+
+class FullBoardGeneratorService {
+  FullBoardGeneratorService({
+    Random? random,
+    CardDeckService? deckService,
+    BoardTextureFilterService? textureFilter,
+  })  : _random = random ?? Random(),
+        _deckService = deckService ?? const CardDeckService(),
+        _textureFilter = textureFilter ?? const BoardTextureFilterService();
+
+  final Random _random;
+  final CardDeckService _deckService;
+  final BoardTextureFilterService _textureFilter;
+
+  Board generateFullBoard({
+    List<CardModel> excludedCards = const [],
+    Map<String, dynamic>? boardFilterParams,
+    int maxAttempts = 10000,
+  }) =>
+      generatePartialBoard(
+        stages: 5,
+        excludedCards: excludedCards,
+        boardFilterParams: boardFilterParams,
+        maxAttempts: maxAttempts,
+      );
+
+  Board generatePartialBoard({
+    required int stages,
+    List<CardModel> excludedCards = const [],
+    Map<String, dynamic>? boardFilterParams,
+    int maxAttempts = 10000,
+  }) {
+    if (stages < 3 || stages > 5) {
+      throw ArgumentError('stages must be between 3 and 5');
+    }
+    final deck = _buildDeck(excludedCards, boardFilterParams);
+    final requiredRanks = <String>[...
+      (boardFilterParams?['requiredRanks'] as List? ?? [])
+          .map((e) => e.toString().toUpperCase()),
+    ];
+    final requiredSuits = <String>[...
+      (boardFilterParams?['requiredSuits'] as List? ?? [])
+          .map((e) => e.toString()),
+    ];
+    for (var i = 0; i < maxAttempts; i++) {
+      deck.shuffle(_random);
+      final cards = deck.take(5).toList();
+      final partial = cards.sublist(0, stages);
+      if (requiredRanks.any((r) => !partial.any((c) => c.rank.toUpperCase() == r))) {
+        continue;
+      }
+      if (requiredSuits.any((s) => !partial.any((c) => c.suit == s))) {
+        continue;
+      }
+      if (_textureFilter.isMatch(partial, boardFilterParams)) {
+        return Board(
+          flop: cards.sublist(0, 3),
+          turn: stages >= 4 ? cards[3] : null,
+          river: stages == 5 ? cards[4] : null,
+        );
+      }
+    }
+    throw StateError('Unable to generate board with given filter');
+  }
+
+  List<CardModel> _buildDeck(
+      List<CardModel> excludedCards, Map<String, dynamic>? boardFilterParams) {
+    final excludedRanks = <String>{
+      for (final r in (boardFilterParams?['excludedRanks'] as List? ?? []))
+        r.toString().toUpperCase(),
+    };
+    return _deckService.buildDeck(
+      excludedCards: excludedCards,
+      excludedRanks: excludedRanks,
+    );
+  }
+}
+

--- a/test/full_board_generator_service_test.dart
+++ b/test/full_board_generator_service_test.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/services/full_board_generator_service.dart';
+
+void main() {
+  test('generates full board without excluded cards', () {
+    final svc = FullBoardGeneratorService(random: Random(1));
+    final excluded = [CardModel(rank: 'A', suit: '♠')];
+    final board = svc.generateFullBoard(excludedCards: excluded);
+    expect(board.cards.length, 5);
+    expect(board.cards.any((c) => c.rank == 'A' && c.suit == '♠'), isFalse);
+  });
+
+  test('generatePartialBoard respects stages and filter', () {
+    final svc = FullBoardGeneratorService(random: Random(2));
+    final board = svc.generatePartialBoard(
+      stages: 3,
+      boardFilterParams: {'requiredRanks': ['A']},
+    );
+    expect(board.flop.length, 3);
+    expect(board.turn, isNull);
+    expect(board.river, isNull);
+    expect(board.flop.any((c) => c.rank == 'A'), isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add Board model to represent flop, turn, and river
- add CardDeckService for constructing decks without collisions
- implement FullBoardGeneratorService to build full or partial boards using texture filters
- cover board generation with unit tests

## Testing
- `flutter test test/full_board_generator_service_test.dart` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688f9980584c832aa87f07372014464a