### PR TITLE
feat: support partial board generation

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -133,6 +133,7 @@ class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
     for (var i = 0; i < spot.stacks.length; i++) {
       stacks['$i'] = spot.stacks[i].toDouble();
     }
+    final boardList = [for (final c in spot.boardCards) '${c.rank}${c.suit}'];
     final handData = HandData(
       heroCards: cardStr,
       position: parseHeroPosition(spot.heroPosition ?? ''),
@@ -140,11 +141,12 @@ class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
       playerCount: spot.numberOfPlayers,
       actions: actions,
       stacks: stacks,
-      board: [for (final c in spot.boardCards) '${c.rank}${c.suit}'],
+      board: boardList,
     );
     return TrainingPackSpot(
       id: id ?? const Uuid().v4(),
       hand: handData,
+      board: boardList,
       villainAction: villainAction,
       heroOptions: heroOptions ?? const [],
     );

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -105,6 +105,8 @@ class TrainingPackTemplateV2 {
         ],
         count: (m['count'] as num?)?.toInt() ?? 0,
         boardFilter: boardFilter,
+        targetStreet: m['targetStreet']?.toString() ?? 'flop',
+        boardStages: (m['boardStages'] as num?)?.toInt(),
       );
       final gen = TrainingSpotGeneratorService().generate(params);
       return [
@@ -147,6 +149,8 @@ class TrainingPackTemplateV2 {
         ],
         count: (dynParams['count'] as num?)?.toInt() ?? 0,
         boardFilter: boardFilter,
+        targetStreet: dynParams['targetStreet']?.toString() ?? 'flop',
+        boardStages: (dynParams['boardStages'] as num?)?.toInt(),
       );
       final generator = TrainingSpotGeneratorService();
       final genSpots = generator.generate(params);

--- a/lib/services/training_pack_preview_service.dart
+++ b/lib/services/training_pack_preview_service.dart
@@ -26,6 +26,8 @@ class TrainingPackPreviewService {
       boardFilter: m['boardFilter'] is Map
           ? Map<String, dynamic>.from(m['boardFilter'])
           : null,
+      targetStreet: m['targetStreet']?.toString() ?? 'flop',
+      boardStages: (m['boardStages'] as num?)?.toInt(),
     );
     final spots = _generator.generate(params);
     return [

--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -78,4 +78,26 @@ meta:
       expect(s.board.any((c) => c.startsWith('A')), true);
     }
   });
+
+  test('dynamicParams boardStages generates full boards', () {
+    const yaml4 = '''
+id: gen_pack
+name: Generator Pack
+trainingType: mtt
+positions:
+  - hj
+meta:
+  dynamicParams:
+    position: hj
+    villainAction: "3bet 9.0"
+    handGroup: ["pockets"]
+    count: 2
+    boardStages: 5
+''';
+    final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml4);
+    expect(tpl.spots.length, 2);
+    for (final s in tpl.spots) {
+      expect(s.board.length, 5);
+    }
+  });
 }

--- a/test/services/training_spot_generator_service_test.dart
+++ b/test/services/training_spot_generator_service_test.dart
@@ -48,4 +48,18 @@ void main() {
         hero.any((h) => h.rank == b.rank && h.suit == b.suit));
     expect(clash, false);
   });
+
+  test('boardStages generates river board when set to 5', () {
+    final svc = TrainingSpotGeneratorService(random: Random(4));
+    final spot = svc
+        .generate(SpotGenerationParams(
+          position: 'btn',
+          villainAction: 'check',
+          handGroup: ['AKs'],
+          count: 1,
+          boardStages: 5,
+        ))
+        .first;
+    expect(spot.boardCards.length, 5);
+  });
 }


### PR DESCRIPTION
## Summary
- extend spot generation to delegate board building to `FullBoardGeneratorService` and support configurable board stages
- carry board cards into `TrainingPackSpot` and propagate `boardStages` through pack templates and previews
- cover new board stage handling with tests for generator and dynamic packs

## Testing
- `dart test test/services/training_spot_generator_service_test.dart test/dynamic_spot_generation_test.dart` *(fails: command not found)*
- `flutter test test/services/training_spot_generator_service_test.dart test/dynamic_spot_generation_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f9b0fb664832a807b72296ca89601