### PR TITLE
Add training pack template sets for multi-variant generation

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:yaml/yaml.dart';
 
 import '../../models/v2/training_pack_template_v2.dart';
+import '../../models/v2/training_pack_template_set.dart';
 import '../../../utils/yaml_utils.dart';
 
 class YamlReader {
@@ -20,5 +21,24 @@ class YamlReader {
         ? await rootBundle.loadString(path)
         : await File(path).readAsString();
     return TrainingPackTemplateV2.fromYamlAuto(source);
+  }
+
+  /// Loads all templates defined in [path]. The file may contain either a
+  /// single template or a `templateSet` definition. When a set is provided, it
+  /// expands into multiple [TrainingPackTemplateV2] instances using the
+  /// `dynamicParamVariants`.
+  Future<List<TrainingPackTemplateV2>> loadTemplates(String path) async {
+    final source = path.startsWith('assets/')
+        ? await rootBundle.loadString(path)
+        : await File(path).readAsString();
+    final map = read(source);
+    if (map['templateSet'] is Map) {
+      final set = TrainingPackTemplateSet.fromJson(
+        Map<String, dynamic>.from(map['templateSet'] as Map),
+      );
+      return set.generateAllPacks();
+    }
+    final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    return [tpl];
   }
 }

--- a/lib/models/v2/training_pack_template_set.dart
+++ b/lib/models/v2/training_pack_template_set.dart
@@ -1,0 +1,61 @@
+import 'package:yaml/yaml.dart';
+
+import '../../utils/yaml_utils.dart';
+import 'training_pack_template_v2.dart';
+
+class TrainingPackTemplateSet {
+  String id;
+  String name;
+  TrainingPackTemplateV2 baseTemplate;
+  List<Map<String, dynamic>> dynamicParamVariants;
+
+  TrainingPackTemplateSet({
+    required this.id,
+    required this.name,
+    required this.baseTemplate,
+    List<Map<String, dynamic>>? dynamicParamVariants,
+  }) : dynamicParamVariants = dynamicParamVariants ?? [];
+
+  List<TrainingPackTemplateV2> generateAllPacks() {
+    final packs = <TrainingPackTemplateV2>[];
+    for (final variant in dynamicParamVariants) {
+      final baseMap = Map<String, dynamic>.from(baseTemplate.toJson());
+      final meta = Map<String, dynamic>.from(baseMap['meta'] ?? {});
+      final dyn = Map<String, dynamic>.from(variant);
+      final id = dyn.remove('id');
+      final name = dyn.remove('name');
+      meta['dynamicParams'] = dyn;
+      baseMap['meta'] = meta;
+      if (id != null) baseMap['id'] = id.toString();
+      if (name != null) baseMap['name'] = name.toString();
+      packs.add(TrainingPackTemplateV2.fromJson(baseMap));
+    }
+    return packs;
+  }
+
+  factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) =>
+      TrainingPackTemplateSet(
+        id: json['id']?.toString() ?? '',
+        name: json['name']?.toString() ?? '',
+        baseTemplate: TrainingPackTemplateV2.fromJson(
+          Map<String, dynamic>.from(json['baseTemplate'] ?? {}),
+        ),
+        dynamicParamVariants: [
+          for (final v in (json['dynamicParamVariants'] as List? ?? []))
+            Map<String, dynamic>.from(v as Map),
+        ],
+      );
+
+  factory TrainingPackTemplateSet.fromYaml(String yaml) {
+    final map = yamlToDart(loadYaml(yaml)) as Map<String, dynamic>;
+    final root = map['templateSet'] is Map
+        ? Map<String, dynamic>.from(map['templateSet'])
+        : map;
+    return TrainingPackTemplateSet.fromJson(root);
+  }
+
+  static List<TrainingPackTemplateV2> generateAllFromYaml(String yaml) {
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    return set.generateAllPacks();
+  }
+}

--- a/lib/utils/training_pack_yaml_codec_v2.dart
+++ b/lib/utils/training_pack_yaml_codec_v2.dart
@@ -1,4 +1,5 @@
 import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_template_set.dart';
 import '../core/training/generation/yaml_reader.dart';
 
 class TrainingPackYamlCodecV2 {
@@ -9,5 +10,18 @@ class TrainingPackYamlCodecV2 {
   TrainingPackTemplateV2 decode(String yaml) {
     final map = const YamlReader().read(yaml);
     return TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+  }
+
+  /// Decodes [yaml] that may contain a single template or a `templateSet`.
+  /// Returns all resulting templates.
+  List<TrainingPackTemplateV2> decodeMany(String yaml) {
+    final map = const YamlReader().read(yaml);
+    if (map['templateSet'] is Map) {
+      final set = TrainingPackTemplateSet.fromJson(
+        Map<String, dynamic>.from(map['templateSet'] as Map),
+      );
+      return set.generateAllPacks();
+    }
+    return [TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map))];
   }
 }

--- a/test/training_pack_template_set_test.dart
+++ b/test/training_pack_template_set_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_set.dart';
+
+void main() {
+  test('generateAllPacks expands variants', () {
+    const yaml = '''
+templateSet:
+  id: set1
+  name: Streets
+  baseTemplate:
+    id: base
+    name: Base
+    trainingType: pushFold
+    spots: []
+    spotCount: 0
+  dynamicParamVariants:
+    - id: pack-flop
+      name: BTN vs BB Flop
+      targetStreet: flop
+      count: 0
+    - id: pack-turn
+      name: BTN vs BB Turn
+      targetStreet: turn
+      count: 0
+''';
+
+    final packs = TrainingPackTemplateSet.generateAllFromYaml(yaml);
+    expect(packs.length, 2);
+    expect(packs[0].id, 'pack-flop');
+    expect(packs[0].name, 'BTN vs BB Flop');
+    expect(packs[0].meta['dynamicParams']['targetStreet'], 'flop');
+    expect(packs[1].id, 'pack-turn');
+    expect(packs[1].meta['dynamicParams']['targetStreet'], 'turn');
+  });
+}


### PR DESCRIPTION
## Summary
- introduce TrainingPackTemplateSet to expand a base template with variant dynamic parameters
- load YAML files containing templateSet and decode many templates
- add unit test validating set expansion

## Testing
- `dart test test/training_pack_template_set_test.dart` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_688f9dddebcc832a83b4b14cc5980d9e