### PR TITLE
feat: add board filtering params builder

### DIFF
--- a/lib/helpers/board_filtering_params_builder.dart
+++ b/lib/helpers/board_filtering_params_builder.dart
@@ -1,0 +1,67 @@
+/// Helper to construct board filtering params from texture tags.
+///
+/// The [build] method takes a list of high level texture labels such as
+/// `['aceHigh', 'paired', 'rainbow']` and converts them to a map that can be
+/// passed into [FullBoardGeneratorService] via `boardFilterParams`.
+library board_filtering_params_builder;
+
+class BoardFilteringParamsBuilder {
+  /// Builds a map of filter parameters based on [textureTags].
+  ///
+  /// Supported tags include:
+  /// - `rainbow`, `twoTone`, `monotone`
+  /// - `paired`
+  /// - `aceHigh`
+  /// - `lowBoard`
+  /// - `connected` (straight draw heavy)
+  /// - `broadway`
+  static Map<String, dynamic> build(List<String> textureTags) {
+    final filter = <String, dynamic>{};
+    final boardTextures = <String>{};
+    String? suitPattern;
+
+    for (final t in textureTags) {
+      final tag = t.toLowerCase();
+      switch (tag) {
+        case 'rainbow':
+          suitPattern = 'rainbow';
+          break;
+        case 'twotone':
+        case 'two-tone':
+        case 'two_tone':
+          suitPattern = 'twoTone';
+          break;
+        case 'monotone':
+          suitPattern = 'monotone';
+          break;
+        case 'paired':
+          boardTextures.add('paired');
+          break;
+        case 'acehigh':
+          boardTextures.add('aceHigh');
+          break;
+        case 'lowboard':
+        case 'low':
+          boardTextures.add('low');
+          break;
+        case 'connected':
+          boardTextures.add('straightDrawHeavy');
+          break;
+        case 'broadway':
+          boardTextures.add('broadway');
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (boardTextures.isNotEmpty) {
+      filter['boardTexture'] = boardTextures.toList();
+    }
+    if (suitPattern != null) {
+      filter['suitPattern'] = suitPattern;
+    }
+
+    return filter;
+  }
+}

--- a/test/board_filtering_params_builder_test.dart
+++ b/test/board_filtering_params_builder_test.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/helpers/board_filtering_params_builder.dart';
+import 'package:poker_analyzer/services/full_board_generator_service.dart';
+
+void main() {
+  test('build generates filter and generator respects it', () {
+    final params = BoardFilteringParamsBuilder.build([
+      'aceHigh',
+      'paired',
+      'rainbow',
+    ]);
+    expect(params['boardTexture'], containsAll(['aceHigh', 'paired']));
+    expect(params['suitPattern'], 'rainbow');
+
+    final svc = FullBoardGeneratorService(random: Random(42));
+    final board = svc.generateBoard(
+      FullBoardRequest(stages: 3, boardFilterParams: params),
+    );
+
+    expect(board.flop.length, 3);
+    expect(board.flop.any((c) => c.rank == 'A'), isTrue);
+    final ranks = board.flop.map((c) => c.rank).toList();
+    expect(ranks.toSet().length, lessThan(ranks.length));
+    expect(board.flop.map((c) => c.suit).toSet().length, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoardFilteringParamsBuilder to convert texture tags to filter map
- cover builder with test verifying board generation uses tags

## Testing
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*


------
https://chatgpt.com/codex/tasks/task_e_688fa3c56ca4832aa109ee4518409ad4