### PR TITLE
feat: add board filtering tag library

### DIFF
--- a/lib/helpers/board_filtering_params_builder.dart
+++ b/lib/helpers/board_filtering_params_builder.dart
@@ -5,6 +5,8 @@
 /// passed into [FullBoardGeneratorService] via `boardFilterParams`.
 library board_filtering_params_builder;
 
+import '../services/board_filtering_tag_library_service.dart';
+
 class BoardFilteringParamsBuilder {
   /// Builds a map of filter parameters based on [textureTags].
   ///
@@ -12,8 +14,8 @@ class BoardFilteringParamsBuilder {
   /// - `rainbow`, `twoTone`, `monotone`
   /// - `paired`
   /// - `aceHigh`
-  /// - `lowBoard`
-  /// - `connected` (straight draw heavy)
+  /// - `low`
+  /// - `connected`/`wet`/`dynamic` (straight draw heavy)
   /// - `broadway`
   static Map<String, dynamic> build(List<String> textureTags) {
     final filter = <String, dynamic>{};
@@ -21,14 +23,12 @@ class BoardFilteringParamsBuilder {
     String? suitPattern;
 
     for (final t in textureTags) {
-      final tag = t.toLowerCase();
-      switch (tag) {
+      final resolved = BoardFilteringTagLibraryService.resolve(t)?.id ?? t;
+      switch (resolved) {
         case 'rainbow':
           suitPattern = 'rainbow';
           break;
-        case 'twotone':
-        case 'two-tone':
-        case 'two_tone':
+        case 'twoTone':
           suitPattern = 'twoTone';
           break;
         case 'monotone':
@@ -37,14 +37,15 @@ class BoardFilteringParamsBuilder {
         case 'paired':
           boardTextures.add('paired');
           break;
-        case 'acehigh':
+        case 'aceHigh':
           boardTextures.add('aceHigh');
           break;
-        case 'lowboard':
         case 'low':
           boardTextures.add('low');
           break;
         case 'connected':
+        case 'wet':
+        case 'dynamic':
           boardTextures.add('straightDrawHeavy');
           break;
         case 'broadway':

--- a/lib/models/board_filtering_tag.dart
+++ b/lib/models/board_filtering_tag.dart
@@ -1,0 +1,13 @@
+class BoardFilteringTag {
+  final String id;
+  final String description;
+  final List<String> aliases;
+  final List<String> exampleBoards;
+
+  const BoardFilteringTag({
+    required this.id,
+    required this.description,
+    this.aliases = const [],
+    this.exampleBoards = const [],
+  });
+}

--- a/lib/services/board_filtering_tag_library_service.dart
+++ b/lib/services/board_filtering_tag_library_service.dart
@@ -1,0 +1,85 @@
+import '../models/board_filtering_tag.dart';
+
+class BoardFilteringTagLibraryService {
+  static final List<BoardFilteringTag> _tags = [
+    const BoardFilteringTag(
+      id: 'aceHigh',
+      description: 'Boards with A-high',
+      aliases: ['acehigh', 'ace_high'],
+      exampleBoards: ['As Kd 3c', 'Ah 7s 2d'],
+    ),
+    const BoardFilteringTag(
+      id: 'rainbow',
+      description: 'Three different suits',
+      aliases: ['rbw'],
+      exampleBoards: ['As Kd 3c'],
+    ),
+    const BoardFilteringTag(
+      id: 'twoTone',
+      description: 'Two suits present',
+      aliases: ['twotone', 'two-tone', 'two_tone'],
+      exampleBoards: ['As Kd 3d'],
+    ),
+    const BoardFilteringTag(
+      id: 'monotone',
+      description: 'All cards of the same suit',
+      aliases: ['mono'],
+      exampleBoards: ['Ah 7h 2h'],
+    ),
+    const BoardFilteringTag(
+      id: 'paired',
+      description: 'Flop contains a pair',
+      aliases: ['pair'],
+      exampleBoards: ['Ah As 7c'],
+    ),
+    const BoardFilteringTag(
+      id: 'low',
+      description: 'Max rank ≤ 9',
+      aliases: ['lowboard', 'low_board'],
+      exampleBoards: ['2h 5c 9d'],
+    ),
+    const BoardFilteringTag(
+      id: 'connected',
+      description: 'Straight draw heavy',
+      aliases: ['straightdrawheavy', 'coordinated'],
+      exampleBoards: ['7c 8d 9h'],
+    ),
+    const BoardFilteringTag(
+      id: 'broadway',
+      description: 'All cards Ten or higher',
+      exampleBoards: ['Qs Jh Td'],
+      aliases: [],
+    ),
+    const BoardFilteringTag(
+      id: 'wet',
+      description: 'Draw-heavy board with many possibilities',
+      aliases: ['dynamic', 'coordinated'],
+      exampleBoards: ['9c Tc Jc'],
+    ),
+    const BoardFilteringTag(
+      id: 'dry',
+      description: 'Static board lacking draws',
+      aliases: [],
+      exampleBoards: ['As 7d 2c'],
+    ),
+    const BoardFilteringTag(
+      id: 'dynamic',
+      description: 'Boards that can change drastically on later streets',
+      aliases: [],
+      exampleBoards: ['7c 8d Ts'],
+    ),
+  ];
+
+  static List<BoardFilteringTag> get allTags => List.unmodifiable(_tags);
+
+  static BoardFilteringTag? resolve(String tagIdOrAlias) {
+    final key = tagIdOrAlias.toLowerCase();
+    for (final t in _tags) {
+      if (t.id.toLowerCase() == key) return t;
+      if (t.aliases.any((a) => a.toLowerCase() == key)) return t;
+    }
+    return null;
+  }
+
+  static List<String> get supportedTagIds => [for (final t in _tags) t.id];
+}

--- a/test/board_filtering_params_builder_test.dart
+++ b/test/board_filtering_params_builder_test.dart
@@ -25,4 +25,10 @@ void main() {
     expect(ranks.toSet().length, lessThan(ranks.length));
     expect(board.flop.map((c) => c.suit).toSet().length, 3);
   });
+
+  test('aliases are resolved via tag library', () {
+    final params = BoardFilteringParamsBuilder.build(['two-tone', 'acehigh']);
+    expect(params['suitPattern'], 'twoTone');
+    expect(params['boardTexture'], contains('aceHigh'));
+  });
 }

--- a/test/services/board_filtering_tag_library_service_test.dart
+++ b/test/services/board_filtering_tag_library_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/board_filtering_tag_library_service.dart';
+
+void main() {
+  test('resolve matches aliases and ids', () {
+    final tag = BoardFilteringTagLibraryService.resolve('two-tone');
+    expect(tag?.id, 'twoTone');
+    expect(
+      BoardFilteringTagLibraryService.resolve('aceHigh')?.description,
+      contains('A-high'),
+    );
+  });
+
+  test('supportedTagIds exposes all ids', () {
+    final ids = BoardFilteringTagLibraryService.supportedTagIds();
+    expect(ids, contains('aceHigh'));
+    expect(ids, contains('rainbow'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoardFilteringTag` model and centralized `BoardFilteringTagLibraryService`
- resolve texture tag aliases in `BoardFilteringParamsBuilder`
- test tag library and alias resolution

## Testing
- `./flutter/bin/flutter test` *(fails: missing TrainingPackTemplateV2 and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fa7f8bd94832aa4326d9f94cb4498