### PR TITLE
feat: support declarative hand group tags

### DIFF
--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -14,6 +14,7 @@ import 'training_pack_template.dart' show TrainingPackTemplate;
 import '../../services/training_spot_generator_service.dart';
 import '../../services/constraint_resolver_engine.dart';
 import '../../helpers/board_filtering_params_builder.dart';
+import '../../services/hand_group_tag_library_service.dart';
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -79,14 +80,14 @@ class TrainingPackTemplateV2 {
     this.minHands,
     bool? isGeneratedPack,
     bool? isSampledPack,
-  })  : tags = tags ?? [],
-        spots = spots ?? [],
-        dynamicSpots = dynamicSpots ?? [],
-        positions = positions ?? [],
-        created = created ?? DateTime.now(),
-        meta = meta ?? {},
-        isGeneratedPack = isGeneratedPack ?? false,
-        isSampledPack = isSampledPack ?? false {
+  }) : tags = tags ?? [],
+       spots = spots ?? [],
+       dynamicSpots = dynamicSpots ?? [],
+       positions = positions ?? [],
+       created = created ?? DateTime.now(),
+       meta = meta ?? {},
+       isGeneratedPack = isGeneratedPack ?? false,
+       isSampledPack = isSampledPack ?? false {
     if (theme != null) meta['theme'] = theme;
     if (requiredAccuracy != null) meta['requiredAccuracy'] = requiredAccuracy;
     if (minHands != null) meta['minHands'] = minHands;
@@ -98,6 +99,16 @@ class TrainingPackTemplateV2 {
       final m = ConstraintResolverEngine.normalizeParams(
         Map<String, dynamic>.from(meta['dynamicParams']),
       );
+      final tagList = (m['handGroupTags'] as List?)
+          ?.map((e) => e.toString())
+          .toList();
+      if (tagList != null && tagList.isNotEmpty) {
+        final expanded = HandGroupTagLibraryService.expandTags(tagList);
+        final existing = (m['handGroup'] as List? ?? [])
+            .map((e) => e.toString())
+            .toList();
+        m['handGroup'] = [...existing, ...expanded];
+      }
       Map<String, dynamic>? boardFilter;
       final tags = (m['boardTextureTags'] as List? ?? m['textureTags'] as List?)
           ?.cast<String>();
@@ -150,8 +161,9 @@ class TrainingPackTemplateV2 {
   }
 
   factory TrainingPackTemplateV2.fromJson(Map<String, dynamic> j) {
-    final metaMap =
-        j['meta'] != null ? Map<String, dynamic>.from(j['meta']) : {};
+    final metaMap = j['meta'] != null
+        ? Map<String, dynamic>.from(j['meta'])
+        : {};
 
     final dynParams = metaMap['dynamicParams'];
     var dynamicList = <DynamicSpotTemplate>[];
@@ -161,6 +173,16 @@ class TrainingPackTemplateV2 {
       final norm = ConstraintResolverEngine.normalizeParams(
         Map<String, dynamic>.from(dynParams),
       );
+      final tagList = (norm['handGroupTags'] as List?)
+          ?.map((e) => e.toString())
+          .toList();
+      if (tagList != null && tagList.isNotEmpty) {
+        final expanded = HandGroupTagLibraryService.expandTags(tagList);
+        final existing = (norm['handGroup'] as List? ?? [])
+            .map((e) => e.toString())
+            .toList();
+        norm['handGroup'] = [...existing, ...expanded];
+      }
       Map<String, dynamic>? boardFilter;
       final tags =
           (norm['boardTextureTags'] as List? ?? norm['textureTags'] as List?)
@@ -221,7 +243,8 @@ class TrainingPackTemplateV2 {
       name: j['name'] as String? ?? '',
       description: j['description'] as String? ?? '',
       goal: j['goal'] as String? ?? '',
-      audience: j['audience'] as String? ??
+      audience:
+          j['audience'] as String? ??
           (j['meta'] is Map ? (j['meta']['audience'] as String?) : null),
       theme: j['meta'] is Map ? (j['meta']['theme'] as String?) : null,
       tags: [for (final t in (j['tags'] as List? ?? [])) t.toString()],
@@ -240,7 +263,8 @@ class TrainingPackTemplateV2 {
         for (final p in (j['positions'] as List? ?? [])) p.toString(),
       ],
       meta: metaMap,
-      recommended: j['recommended'] as bool? ??
+      recommended:
+          j['recommended'] as bool? ??
           (j['meta'] is Map ? j['meta']['recommended'] == true : false),
       requiresTheoryCompleted: j['meta'] is Map
           ? j['meta']['requiresTheoryCompleted'] == true
@@ -252,8 +276,9 @@ class TrainingPackTemplateV2 {
       requiredAccuracy: j['meta'] is Map
           ? (j['meta']['requiredAccuracy'] as num?)?.toDouble()
           : null,
-      minHands:
-          j['meta'] is Map ? (j['meta']['minHands'] as num?)?.toInt() : null,
+      minHands: j['meta'] is Map
+          ? (j['meta']['minHands'] as num?)?.toInt()
+          : null,
       dynamicSpots: dynamicList,
     );
     tpl.category ??= tpl.tags.isNotEmpty ? tpl.tags.first : null;
@@ -369,30 +394,27 @@ class TrainingPackTemplateV2 {
   factory TrainingPackTemplateV2.fromTemplate(
     TrainingPackTemplate template, {
     required TrainingType type,
-  }) =>
-      TrainingPackTemplateV2(
-        id: template.id,
-        name: template.name,
-        description: template.description,
-        goal: template.goal,
-        audience: template.meta['audience'] as String?,
-        theme: template.meta['theme'] as String?,
-        tags: List<String>.from(template.tags),
-        category: template.tags.isNotEmpty ? template.tags.first : null,
-        trainingType: type,
-        spots: List<SpotTemplate>.from(template.spots),
-        spotCount: template.spotCount,
-        created: template.createdAt,
-        gameType: template.gameType,
-        bb: template.heroBbStack,
-        positions: [template.heroPos.name],
-        meta: Map<String, dynamic>.from(template.meta),
-        recommended: template.recommended,
-        requiresTheoryCompleted:
-            template.meta['requiresTheoryCompleted'] == true,
-        targetStreet: template.targetStreet,
-        requiredAccuracy:
-            (template.meta['requiredAccuracy'] as num?)?.toDouble(),
-        minHands: (template.meta['minHands'] as num?)?.toInt(),
-      );
+  }) => TrainingPackTemplateV2(
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    goal: template.goal,
+    audience: template.meta['audience'] as String?,
+    theme: template.meta['theme'] as String?,
+    tags: List<String>.from(template.tags),
+    category: template.tags.isNotEmpty ? template.tags.first : null,
+    trainingType: type,
+    spots: List<SpotTemplate>.from(template.spots),
+    spotCount: template.spotCount,
+    created: template.createdAt,
+    gameType: template.gameType,
+    bb: template.heroBbStack,
+    positions: [template.heroPos.name],
+    meta: Map<String, dynamic>.from(template.meta),
+    recommended: template.recommended,
+    requiresTheoryCompleted: template.meta['requiresTheoryCompleted'] == true,
+    targetStreet: template.targetStreet,
+    requiredAccuracy: (template.meta['requiredAccuracy'] as num?)?.toDouble(),
+    minHands: (template.meta['minHands'] as num?)?.toInt(),
+  );
 }

--- a/lib/services/hand_group_tag_library_service.dart
+++ b/lib/services/hand_group_tag_library_service.dart
@@ -1,0 +1,33 @@
+import 'hand_range_library.dart';
+
+/// Provides expansion of abstract hand group tags into concrete hand group
+/// identifiers understood by [HandRangeLibrary].
+class HandGroupTagLibraryService {
+  /// Mapping of normalized tag id to a list of hand group identifiers.
+  static final Map<String, List<String>> _tagMap = {
+    'pockets': const ['pockets'],
+    'broadway': const ['broadways'],
+    'broadways': const ['broadways'],
+    'suitedconnectors': const ['suitedConnectors'],
+    'lowax': const ['lowAx'],
+    'kxsuited': const ['KxSuited'],
+  };
+
+  /// Expands [tags] into a list of concrete hand group identifiers.
+  ///
+  /// Unknown tags are ignored. Returned identifiers are unique.
+  static List<String> expandTags(List<String> tags) {
+    final result = <String>{};
+    for (final t in tags) {
+      final key = t.toLowerCase();
+      final groups = _tagMap[key];
+      if (groups != null) {
+        result.addAll(groups);
+      }
+    }
+    return result.toList();
+  }
+
+  /// Exposes all supported tag identifiers.
+  static List<String> supportedTagIds() => _tagMap.keys.toList();
+}

--- a/lib/services/hand_range_library.dart
+++ b/lib/services/hand_range_library.dart
@@ -12,6 +12,7 @@ class HandRangeLibrary {
         return PackGeneratorService.topNHands(70).toList();
       case 'icm':
         return PackGeneratorService.topNHands(10).toList();
+      case 'broadway':
       case 'broadways':
         const ranks = ['A', 'K', 'Q', 'J', 'T'];
         final hands = <String>[];
@@ -78,6 +79,25 @@ class HandRangeLibrary {
           'A9o',
           'ATo',
         ];
+      case 'suitedconnectors':
+        return ['54s', '65s', '76s', '87s', '98s', 'T9s', 'JTs'];
+      case 'lowax':
+        return ['A2s', 'A3s', 'A4s', 'A5s', 'A2o', 'A3o', 'A4o', 'A5o'];
+      case 'kxsuited':
+        const kxKickers = [
+          'Q',
+          'J',
+          'T',
+          '9',
+          '8',
+          '7',
+          '6',
+          '5',
+          '4',
+          '3',
+          '2',
+        ];
+        return [for (final k in kxKickers) 'K${k}s'];
     }
     throw ArgumentError('Range group not found: $name');
   }

--- a/lib/services/training_pack_preview_service.dart
+++ b/lib/services/training_pack_preview_service.dart
@@ -4,12 +4,13 @@ import 'training_spot_generator_service.dart';
 import 'constraint_resolver_engine.dart';
 import 'dart:math';
 import '../helpers/board_filtering_params_builder.dart';
+import 'hand_group_tag_library_service.dart';
 
 class TrainingPackPreviewService {
   final TrainingSpotGeneratorService _generator;
 
   TrainingPackPreviewService({TrainingSpotGeneratorService? generator})
-      : _generator = generator ?? TrainingSpotGeneratorService();
+    : _generator = generator ?? TrainingSpotGeneratorService();
 
   List<TrainingPackPreviewSpot> getPreviewSpots(
     TrainingPackTemplateV2 tpl, {
@@ -20,6 +21,16 @@ class TrainingPackPreviewService {
     final m = ConstraintResolverEngine.normalizeParams(
       Map<String, dynamic>.from(dyn),
     );
+    final tagList = (m['handGroupTags'] as List?)
+        ?.map((e) => e.toString())
+        .toList();
+    if (tagList != null && tagList.isNotEmpty) {
+      final expanded = HandGroupTagLibraryService.expandTags(tagList);
+      final existing = (m['handGroup'] as List? ?? [])
+          .map((e) => e.toString())
+          .toList();
+      m['handGroup'] = [...existing, ...expanded];
+    }
     Map<String, dynamic>? boardFilter;
     final tags = (m['boardTextureTags'] as List? ?? m['textureTags'] as List?)
         ?.cast<String>();

--- a/test/models/training_pack_template_v2_hand_group_tags_test.dart
+++ b/test/models/training_pack_template_v2_hand_group_tags_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  test('dynamicParams handGroupTags expand into handGroup', () {
+    final tpl = TrainingPackTemplateV2(
+      id: 'id',
+      name: 'name',
+      trainingType: TrainingType.pushFold,
+      meta: {
+        'dynamicParams': {
+          'handGroupTags': ['pockets'],
+          'count': 1,
+        },
+      },
+    );
+    final spots = tpl.generateDynamicSpotSamples();
+    expect(spots.length, 1);
+  });
+}

--- a/test/services/hand_group_tag_library_service_test.dart
+++ b/test/services/hand_group_tag_library_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/hand_group_tag_library_service.dart';
+
+void main() {
+  test('expandTags maps tags to groups', () {
+    final groups = HandGroupTagLibraryService.expandTags([
+      'broadway',
+      'pockets',
+    ]);
+    expect(groups, contains('broadways'));
+    expect(groups, contains('pockets'));
+  });
+
+  test('unsupported tags return empty list', () {
+    final groups = HandGroupTagLibraryService.expandTags(['unknown']);
+    expect(groups, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add HandGroupTagLibraryService to expand tags like `pockets` and `broadway`
- extend HandRangeLibrary with suited connectors, low Ax, and Kx suited groups
- merge `handGroupTags` into `handGroup` for dynamic templates and previews

## Testing
- `dart format lib/services/hand_group_tag_library_service.dart lib/services/hand_range_library.dart lib/models/v2/training_pack_template_v2.dart lib/services/training_pack_preview_service.dart test/services/hand_group_tag_library_service_test.dart test/models/training_pack_template_v2_hand_group_tags_test.dart`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_688fac257b24832ab6b13a1cf63e147f