### PR TITLE
feat: add high card board texture tag

### DIFF
--- a/lib/helpers/board_filtering_params_builder.dart
+++ b/lib/helpers/board_filtering_params_builder.dart
@@ -15,6 +15,7 @@ class BoardFilteringParamsBuilder {
   /// - `paired`
   /// - `aceHigh`
   /// - `low`
+  /// - `highCard`
   /// - `connected`/`wet`/`dynamic` (straight draw heavy)
   /// - `broadway`
   static Map<String, dynamic> build(List<String> textureTags) {
@@ -46,6 +47,9 @@ class BoardFilteringParamsBuilder {
           break;
         case 'low':
           boardTextures.add('low');
+          break;
+        case 'highCard':
+          boardTextures.add('highCard');
           break;
         case 'connected':
         case 'wet':

--- a/lib/services/board_filtering_tag_library_service.dart
+++ b/lib/services/board_filtering_tag_library_service.dart
@@ -39,6 +39,12 @@ class BoardFilteringTagLibraryService {
       exampleBoards: ['2h 5c 9d'],
     ),
     const BoardFilteringTag(
+      id: 'highCard',
+      description: 'Contains at least one card Ten or higher',
+      aliases: ['highcard', 'high_card'],
+      exampleBoards: ['Kd 7c 2h', 'Th 5s 2d'],
+    ),
+    const BoardFilteringTag(
       id: 'connected',
       description: 'Straight draw heavy',
       aliases: ['straightdrawheavy', 'coordinated'],
@@ -53,7 +59,7 @@ class BoardFilteringTagLibraryService {
     const BoardFilteringTag(
       id: 'wet',
       description: 'Draw-heavy board with many possibilities',
-      aliases: ['dynamic', 'coordinated'],
+      aliases: ['dynamic', 'coordinated', 'drawy'],
       exampleBoards: ['9c Tc Jc'],
     ),
     const BoardFilteringTag(

--- a/lib/services/board_texture_filter_service.dart
+++ b/lib/services/board_texture_filter_service.dart
@@ -19,6 +19,11 @@ class BoardTextureFilterService {
             return false;
           }
           break;
+        case 'highCard':
+          if (!_isHighCard(board.map((c) => CardModel(rank: c[0], suit: c[1])).toList())) {
+            return false;
+          }
+          break;
         case 'paired':
           if (!_isPaired(board.map((c) => CardModel(rank: c[0], suit: c[1])).toList())) {
             return false;
@@ -68,6 +73,9 @@ class BoardTextureFilterService {
           break;
         case 'aceHigh':
           if (!_isAceHigh(board)) return false;
+          break;
+        case 'highCard':
+          if (!_isHighCard(board)) return false;
           break;
         case 'paired':
           if (!_isPaired(board)) return false;
@@ -123,6 +131,9 @@ class BoardTextureFilterService {
 
   bool _isAceHigh(List<CardModel> board) =>
       board.any((c) => _rankValue(c.rank) == 14);
+
+  bool _isHighCard(List<CardModel> board) =>
+      board.any((c) => _rankValue(c.rank) >= 10);
 
   bool _isPaired(List<CardModel> board) {
     final ranks = board.map((c) => c.rank).toList();

--- a/test/board_filtering_params_builder_test.dart
+++ b/test/board_filtering_params_builder_test.dart
@@ -27,9 +27,14 @@ void main() {
   });
 
   test('aliases are resolved via tag library', () {
-    final params = BoardFilteringParamsBuilder.build(['two-tone', 'acehigh']);
+    final params = BoardFilteringParamsBuilder.build([
+      'two-tone',
+      'acehigh',
+      'drawy',
+    ]);
     expect(params['suitPattern'], 'twoTone');
     expect(params['boardTexture'], contains('aceHigh'));
+    expect(params['boardTexture'], contains('straightDrawHeavy'));
   });
 
   test('throws on unknown tag', () {
@@ -37,5 +42,15 @@ void main() {
       () => BoardFilteringParamsBuilder.build(['unknown']),
       throwsArgumentError,
     );
+  });
+
+  test('highCard tag generates board with high card', () {
+    final params = BoardFilteringParamsBuilder.build(['highCard']);
+    final svc = FullBoardGeneratorService(random: Random(7));
+    final board = svc.generateBoard(
+      FullBoardRequest(stages: 3, boardFilterParams: params),
+    );
+    expect(board.flop.any((c) => ['T', 'J', 'Q', 'K', 'A'].contains(c.rank)),
+        isTrue);
   });
 }

--- a/test/dynamic_spot_generation_test.dart
+++ b/test/dynamic_spot_generation_test.dart
@@ -101,6 +101,28 @@ meta:
     }
   });
 
+  test('dynamicParams boardTextureTags highCard generates high card boards', () {
+    const yamlHigh = '''
+id: gen_pack
+name: Generator Pack
+trainingType: mtt
+positions:
+  - hj
+meta:
+  dynamicParams:
+    position: hj
+    villainAction: "3bet 9.0"
+    handGroup: ["pockets"]
+    count: 3
+    boardTextureTags: ['highCard']
+''';
+    final tpl = TrainingPackTemplateV2.fromYamlAuto(yamlHigh);
+    expect(tpl.spots.length, 3);
+    for (final s in tpl.spots) {
+      expect(s.board.any((c) => 'TJQKA'.contains(c[0])), true);
+    }
+  });
+
   test('boardFilter overrides boardTextureTags when conflicting', () {
     const yamlOverride = '''
 id: gen_pack


### PR DESCRIPTION
## Summary
- support `highCard` board texture tag and alias `drawy`
- allow board generation and filtering for high-card flops
- cover new tags with builder and dynamic spot generation tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fafd97940832ab2cc0b6994846366