### PR TITLE
feat: add template set generator

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -4,6 +4,7 @@ import 'package:yaml/yaml.dart';
 
 import '../../models/v2/training_pack_template_v2.dart';
 import '../../models/v2/training_pack_template_set.dart';
+import '../../services/training_pack_template_set_generator.dart';
 import '../../../utils/yaml_utils.dart';
 
 class YamlReader {
@@ -24,19 +25,17 @@ class YamlReader {
   }
 
   /// Loads all templates defined in [path]. The file may contain either a
-  /// single template or a `templateSet` definition. When a set is provided, it
-  /// expands into multiple [TrainingPackTemplateV2] instances using the
-  /// `dynamicParamVariants`.
+  /// single template or a template set with `template` and `variants` fields.
+  /// When a set is provided, it expands into multiple [TrainingPackTemplateV2]
+  /// instances using the variant values.
   Future<List<TrainingPackTemplateV2>> loadTemplates(String path) async {
     final source = path.startsWith('assets/')
         ? await rootBundle.loadString(path)
         : await File(path).readAsString();
     final map = read(source);
-    if (map['templateSet'] is Map) {
-      final set = TrainingPackTemplateSet.fromJson(
-        Map<String, dynamic>.from(map['templateSet'] as Map),
-      );
-      return set.generateAllPacks();
+    if (map['template'] is Map && map['variants'] is List) {
+      final set = TrainingPackTemplateSet.fromJson(map);
+      return const TrainingPackTemplateSetGenerator().generate(set);
     }
     final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
     return [tpl];

--- a/lib/models/v2/training_pack_template_set.dart
+++ b/lib/models/v2/training_pack_template_set.dart
@@ -3,59 +3,30 @@ import 'package:yaml/yaml.dart';
 import '../../utils/yaml_utils.dart';
 import 'training_pack_template_v2.dart';
 
+/// Defines a template with variant parameters that can be expanded into
+/// multiple [TrainingPackTemplateV2] instances.
 class TrainingPackTemplateSet {
-  String id;
-  String name;
-  TrainingPackTemplateV2 baseTemplate;
-  List<Map<String, dynamic>> dynamicParamVariants;
+  TrainingPackTemplateV2 template;
+  List<Map<String, dynamic>> variants;
 
   TrainingPackTemplateSet({
-    required this.id,
-    required this.name,
-    required this.baseTemplate,
-    List<Map<String, dynamic>>? dynamicParamVariants,
-  }) : dynamicParamVariants = dynamicParamVariants ?? [];
-
-  List<TrainingPackTemplateV2> generateAllPacks() {
-    final packs = <TrainingPackTemplateV2>[];
-    for (final variant in dynamicParamVariants) {
-      final baseMap = Map<String, dynamic>.from(baseTemplate.toJson());
-      final meta = Map<String, dynamic>.from(baseMap['meta'] ?? {});
-      final dyn = Map<String, dynamic>.from(variant);
-      final id = dyn.remove('id');
-      final name = dyn.remove('name');
-      meta['dynamicParams'] = dyn;
-      baseMap['meta'] = meta;
-      if (id != null) baseMap['id'] = id.toString();
-      if (name != null) baseMap['name'] = name.toString();
-      packs.add(TrainingPackTemplateV2.fromJson(baseMap));
-    }
-    return packs;
-  }
+    required this.template,
+    List<Map<String, dynamic>>? variants,
+  }) : variants = variants ?? [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) =>
       TrainingPackTemplateSet(
-        id: json['id']?.toString() ?? '',
-        name: json['name']?.toString() ?? '',
-        baseTemplate: TrainingPackTemplateV2.fromJson(
-          Map<String, dynamic>.from(json['baseTemplate'] ?? {}),
+        template: TrainingPackTemplateV2.fromJson(
+          Map<String, dynamic>.from(json['template'] ?? {}),
         ),
-        dynamicParamVariants: [
-          for (final v in (json['dynamicParamVariants'] as List? ?? []))
+        variants: [
+          for (final v in (json['variants'] as List? ?? []))
             Map<String, dynamic>.from(v as Map),
         ],
       );
 
   factory TrainingPackTemplateSet.fromYaml(String yaml) {
     final map = yamlToDart(loadYaml(yaml)) as Map<String, dynamic>;
-    final root = map['templateSet'] is Map
-        ? Map<String, dynamic>.from(map['templateSet'])
-        : map;
-    return TrainingPackTemplateSet.fromJson(root);
-  }
-
-  static List<TrainingPackTemplateV2> generateAllFromYaml(String yaml) {
-    final set = TrainingPackTemplateSet.fromYaml(yaml);
-    return set.generateAllPacks();
+    return TrainingPackTemplateSet.fromJson(map);
   }
 }

--- a/lib/services/training_pack_template_set_generator.dart
+++ b/lib/services/training_pack_template_set_generator.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import '../models/v2/training_pack_template_set.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackTemplateV2]
+/// instances by applying mustache-style interpolation for each variant.
+class TrainingPackTemplateSetGenerator {
+  const TrainingPackTemplateSetGenerator();
+
+  /// Generates all packs defined by [set].
+  List<TrainingPackTemplateV2> generate(TrainingPackTemplateSet set) {
+    final baseJson = jsonEncode(set.template.toJson());
+    final result = <TrainingPackTemplateV2>[];
+    for (final variant in set.variants) {
+      var json = baseJson;
+      variant.forEach((key, value) {
+        json = json.replaceAll('{{${key}}}', value.toString());
+      });
+      final map = jsonDecode(json) as Map<String, dynamic>;
+      result.add(TrainingPackTemplateV2.fromJson(map));
+    }
+    return result;
+  }
+
+  /// Parses [yaml] and generates all packs from it.
+  List<TrainingPackTemplateV2> generateFromYaml(String yaml) {
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    return generate(set);
+  }
+}

--- a/lib/utils/training_pack_yaml_codec_v2.dart
+++ b/lib/utils/training_pack_yaml_codec_v2.dart
@@ -1,6 +1,7 @@
 import '../models/v2/training_pack_template_v2.dart';
 import '../models/v2/training_pack_template_set.dart';
 import '../core/training/generation/yaml_reader.dart';
+import '../services/training_pack_template_set_generator.dart';
 
 class TrainingPackYamlCodecV2 {
   const TrainingPackYamlCodecV2();
@@ -12,15 +13,13 @@ class TrainingPackYamlCodecV2 {
     return TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
   }
 
-  /// Decodes [yaml] that may contain a single template or a `templateSet`.
-  /// Returns all resulting templates.
+  /// Decodes [yaml] that may contain a single template or a template set with
+  /// `template` and `variants` fields. Returns all resulting templates.
   List<TrainingPackTemplateV2> decodeMany(String yaml) {
     final map = const YamlReader().read(yaml);
-    if (map['templateSet'] is Map) {
-      final set = TrainingPackTemplateSet.fromJson(
-        Map<String, dynamic>.from(map['templateSet'] as Map),
-      );
-      return set.generateAllPacks();
+    if (map['template'] is Map && map['variants'] is List) {
+      final set = TrainingPackTemplateSet.fromJson(map);
+      return const TrainingPackTemplateSetGenerator().generate(set);
     }
     return [TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map))];
   }

--- a/test/training_pack_template_set_test.dart
+++ b/test/training_pack_template_set_test.dart
@@ -1,35 +1,32 @@
 import 'package:test/test.dart';
-import 'package:poker_analyzer/models/v2/training_pack_template_set.dart';
+import 'package:poker_analyzer/services/training_pack_template_set_generator.dart';
 
 void main() {
-  test('generateAllPacks expands variants', () {
+  test('generate expands variants', () {
     const yaml = '''
-templateSet:
-  id: set1
-  name: Streets
-  baseTemplate:
-    id: base
-    name: Base
-    trainingType: pushFold
-    spots: []
-    spotCount: 0
-  dynamicParamVariants:
-    - id: pack-flop
-      name: BTN vs BB Flop
-      targetStreet: flop
-      count: 0
-    - id: pack-turn
-      name: BTN vs BB Turn
-      targetStreet: turn
-      count: 0
+template:
+  id: gen_pack
+  trainingType: pushFold
+  spots: []
+  spotCount: 0
+  meta:
+    dynamicParams:
+      villainAction: "{{action}}"
+      targetStreet: "{{street}}"
+variants:
+  - action: "3bet 9.0"
+    street: flop
+  - action: "3bet 7.5"
+    street: turn
 ''';
 
-    final packs = TrainingPackTemplateSet.generateAllFromYaml(yaml);
+    final packs = const TrainingPackTemplateSetGenerator().generateFromYaml(
+      yaml,
+    );
     expect(packs.length, 2);
-    expect(packs[0].id, 'pack-flop');
-    expect(packs[0].name, 'BTN vs BB Flop');
+    expect(packs[0].meta['dynamicParams']['villainAction'], '3bet 9.0');
     expect(packs[0].meta['dynamicParams']['targetStreet'], 'flop');
-    expect(packs[1].id, 'pack-turn');
+    expect(packs[1].meta['dynamicParams']['villainAction'], '3bet 7.5');
     expect(packs[1].meta['dynamicParams']['targetStreet'], 'turn');
   });
 }


### PR DESCRIPTION
## Summary
- add TrainingPackTemplateSet model to hold a base template with variant parameter sets
- introduce TrainingPackTemplateSetGenerator to expand variants via mustache-style interpolation
- update YAML parsing utilities to decode new template set structure
- cover generator logic with unit test

## Testing
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_688fb18637ac832ab175d04d7a27cbd9