### PR TITLE
feat: add line graph engine for multi-street spot generation

### DIFF
--- a/lib/models/spot_seed_format.dart
+++ b/lib/models/spot_seed_format.dart
@@ -1,0 +1,45 @@
+import 'card_model.dart';
+
+class SpotSeedFormat {
+  final String player;
+  final List<String> handGroup;
+  final String position;
+  final List<CardModel> board;
+  final List<String> villainActions;
+
+  SpotSeedFormat({
+    required this.player,
+    required this.handGroup,
+    required this.position,
+    List<CardModel>? board,
+    List<String>? villainActions,
+  })  : board = board ?? [],
+        villainActions = villainActions ?? [];
+
+  SpotSeedFormat copyWith({
+    List<CardModel>? board,
+    List<String>? villainActions,
+  }) => SpotSeedFormat(
+        player: player,
+        handGroup: handGroup,
+        position: position,
+        board: board ?? this.board,
+        villainActions: villainActions ?? this.villainActions,
+      );
+
+  /// Returns the street name based on current board length.
+  String get currentStreet {
+    switch (board.length) {
+      case 0:
+        return 'preflop';
+      case 3:
+        return 'flop';
+      case 4:
+        return 'turn';
+      case 5:
+        return 'river';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/lib/services/line_graph_engine.dart
+++ b/lib/services/line_graph_engine.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+
+import '../models/spot_seed_format.dart';
+import '../models/card_model.dart';
+import 'full_board_generator_service.dart';
+
+class LineGraphConfig {
+  final bool keepHeroHand;
+  final bool keepBoard;
+  final int variationDepth;
+
+  const LineGraphConfig({
+    this.keepHeroHand = true,
+    this.keepBoard = true,
+    this.variationDepth = 0,
+  });
+}
+
+class LineGraphRequest {
+  final SpotSeedFormat root;
+  final int stages;
+  final LineGraphConfig config;
+
+  const LineGraphRequest({
+    required this.root,
+    required this.stages,
+    this.config = const LineGraphConfig(),
+  });
+}
+
+class LineGraphEngine {
+  LineGraphEngine({FullBoardGeneratorService? boardGenerator, Random? random})
+      : _boardGenerator =
+            boardGenerator ?? FullBoardGeneratorService(random: random ?? Random());
+
+  final FullBoardGeneratorService _boardGenerator;
+
+  List<SpotSeedFormat> generate(LineGraphRequest request) {
+    final spots = <SpotSeedFormat>[];
+    var current = request.root;
+    spots.add(current);
+    for (var i = 1; i < request.stages; i++) {
+      current = _nextSpot(current, request);
+      spots.add(current);
+    }
+    return spots;
+  }
+
+  SpotSeedFormat _nextSpot(SpotSeedFormat current, LineGraphRequest req) {
+    final nextStage = current.board.length + 1;
+    List<CardModel> board = current.board;
+    if (req.config.keepBoard) {
+      final generated = _boardGenerator.generateBoard(
+        FullBoardRequest(
+          stages: nextStage,
+          excludedCards: current.board,
+        ),
+      );
+      board = List<CardModel>.from(current.board)..add(generated.cards.last);
+    }
+
+    // maintain villain actions prefix
+    final villain = req.root.villainActions.take(nextStage - 2).toList();
+    return current.copyWith(board: board, villainActions: villain);
+  }
+}

--- a/test/line_graph_engine_test.dart
+++ b/test/line_graph_engine_test.dart
@@ -1,0 +1,46 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/spot_seed_format.dart';
+import 'package:poker_analyzer/services/line_graph_engine.dart';
+import 'package:poker_analyzer/services/full_board_generator_service.dart';
+
+void main() {
+  test('generates sequential spots preserving hero and board', () {
+    final root = SpotSeedFormat(
+      player: 'hero',
+      handGroup: ['AKs'],
+      position: 'btn',
+      board: [
+        CardModel(rank: 'A', suit: '♠'),
+        CardModel(rank: 'K', suit: '♥'),
+        CardModel(rank: 'Q', suit: '♦'),
+      ],
+      villainActions: ['check', 'bet', 'call'],
+    );
+
+    final engine = LineGraphEngine(
+      boardGenerator: FullBoardGeneratorService(random: Random(1)),
+    );
+
+    final spots = engine.generate(
+      LineGraphRequest(root: root, stages: 3, config: const LineGraphConfig()),
+    );
+
+    expect(spots.length, 3);
+    for (final s in spots) {
+      expect(s.player, root.player);
+      expect(s.handGroup, root.handGroup);
+      expect(s.position, root.position);
+    }
+    expect(spots[0].board.length, 3);
+    expect(spots[1].board.length, 4);
+    expect(spots[2].board.length, 5);
+    expect(spots[1].board.sublist(0, 3), root.board);
+    expect(spots[2].board.sublist(0, 4), spots[1].board);
+    expect(spots[0].villainActions, ['check']);
+    expect(spots[1].villainActions, ['check', 'bet']);
+    expect(spots[2].villainActions, ['check', 'bet', 'call']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SpotSeedFormat` model to hold hero, hand group, position, board and villain action data
- implement `LineGraphEngine` to produce sequential spots while preserving line attributes
- cover engine with unit test for board and action consistency

## Testing
- `dart test test/line_graph_engine_test.dart` *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb8872e54832a9933ed15fab0e3ed