### PR TITLE
feat: implement constraint resolver engine

### DIFF
--- a/lib/models/constraint_set.dart
+++ b/lib/models/constraint_set.dart
@@ -1,0 +1,15 @@
+class ConstraintSet {
+  final List<String> boardTags;
+  final List<String> positions;
+  final List<String> handGroup;
+  final List<String> villainActions;
+  final String? targetStreet;
+
+  const ConstraintSet({
+    this.boardTags = const [],
+    this.positions = const [],
+    this.handGroup = const [],
+    this.villainActions = const [],
+    this.targetStreet,
+  });
+}

--- a/lib/services/action_pattern_matcher.dart
+++ b/lib/services/action_pattern_matcher.dart
@@ -1,0 +1,14 @@
+class ActionPatternMatcher {
+  const ActionPatternMatcher();
+
+  bool matches(List<String> actions, List<String> pattern) {
+    if (pattern.isEmpty) return true;
+    if (actions.length != pattern.length) return false;
+    for (var i = 0; i < pattern.length; i++) {
+      if (actions[i].toLowerCase() != pattern[i].toLowerCase()) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/lib/services/constraint_resolver_engine_v2.dart
+++ b/lib/services/constraint_resolver_engine_v2.dart
@@ -1,0 +1,52 @@
+import '../models/constraint_set.dart';
+import '../models/spot_seed_format.dart';
+import 'board_texture_filter_service.dart';
+import 'action_pattern_matcher.dart';
+
+class ConstraintResolverEngine {
+  final BoardTextureFilterService _textureFilter;
+  final ActionPatternMatcher _actionMatcher;
+
+  const ConstraintResolverEngine({
+    BoardTextureFilterService? textureFilter,
+    ActionPatternMatcher? actionMatcher,
+  })  : _textureFilter = textureFilter ?? const BoardTextureFilterService(),
+        _actionMatcher = actionMatcher ?? const ActionPatternMatcher();
+
+  bool isValid(SpotSeedFormat candidate, ConstraintSet constraints) {
+    if (constraints.positions.isNotEmpty &&
+        !constraints.positions
+            .map((e) => e.toLowerCase())
+            .contains(candidate.position.toLowerCase())) {
+      return false;
+    }
+
+    if (constraints.handGroup.isNotEmpty &&
+        !candidate.handGroup.any((h) =>
+            constraints.handGroup.map((e) => e.toLowerCase()).contains(h.toLowerCase()))) {
+      return false;
+    }
+
+    if (constraints.boardTags.isNotEmpty) {
+      final board = candidate.board.map((c) => c.toString()).toList();
+      if (!_textureFilter.filter(board, constraints.boardTags)) {
+        return false;
+      }
+    }
+
+    if (constraints.villainActions.isNotEmpty &&
+        !_actionMatcher.matches(
+            candidate.villainActions, constraints.villainActions)) {
+      return false;
+    }
+
+    if (constraints.targetStreet != null &&
+        constraints.targetStreet!.isNotEmpty &&
+        candidate.currentStreet.toLowerCase() !=
+            constraints.targetStreet!.toLowerCase()) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/test/services/constraint_resolver_engine_v2_test.dart
+++ b/test/services/constraint_resolver_engine_v2_test.dart
@@ -1,0 +1,84 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/spot_seed_format.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/services/constraint_resolver_engine_v2.dart';
+
+void main() {
+  final engine = ConstraintResolverEngine();
+
+  SpotSeedFormat buildCandidate({
+    List<CardModel>? board,
+    List<String>? handGroup,
+    String position = 'btn',
+    List<String>? villainActions,
+  }) {
+    return SpotSeedFormat(
+      player: 'hero',
+      handGroup: handGroup ?? ['broadways'],
+      position: position,
+      board: board,
+      villainActions: villainActions,
+    );
+  }
+
+  test('valid candidate passes all constraints', () {
+    final candidate = buildCandidate(
+      board: [
+        CardModel(rank: '2', suit: 'h'),
+        CardModel(rank: '2', suit: 'c'),
+        CardModel(rank: '9', suit: 'd'),
+      ],
+      villainActions: ['check', 'bet'],
+    );
+    final constraints = ConstraintSet(
+      boardTags: ['paired'],
+      positions: ['btn'],
+      handGroup: ['broadways'],
+      villainActions: ['check', 'bet'],
+      targetStreet: 'flop',
+    );
+    expect(engine.isValid(candidate, constraints), isTrue);
+  });
+
+  test('rejects when position mismatch', () {
+    final candidate = buildCandidate();
+    final constraints = ConstraintSet(positions: ['co']);
+    expect(engine.isValid(candidate, constraints), isFalse);
+  });
+
+  test('rejects when board tags mismatch', () {
+    final candidate = buildCandidate(
+      board: [
+        CardModel(rank: 'A', suit: 's'),
+        CardModel(rank: 'K', suit: 'h'),
+        CardModel(rank: '2', suit: 'd'),
+      ],
+    );
+    final constraints = ConstraintSet(boardTags: ['low']);
+    expect(engine.isValid(candidate, constraints), isFalse);
+  });
+
+  test('rejects when hand group mismatch', () {
+    final candidate = buildCandidate(handGroup: ['smallPairs']);
+    final constraints = ConstraintSet(handGroup: ['broadways']);
+    expect(engine.isValid(candidate, constraints), isFalse);
+  });
+
+  test('rejects when villain actions mismatch', () {
+    final candidate = buildCandidate(villainActions: ['bet', 'check']);
+    final constraints = ConstraintSet(villainActions: ['check', 'bet']);
+    expect(engine.isValid(candidate, constraints), isFalse);
+  });
+
+  test('rejects when street mismatch', () {
+    final candidate = buildCandidate(board: [
+      CardModel(rank: '2', suit: 'h'),
+      CardModel(rank: '2', suit: 'c'),
+      CardModel(rank: '9', suit: 'd'),
+      CardModel(rank: 'K', suit: 's'),
+    ]);
+    final constraints = ConstraintSet(targetStreet: 'flop');
+    expect(engine.isValid(candidate, constraints), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `ConstraintSet` and `ActionPatternMatcher`
- implement extensible `ConstraintResolverEngine` for `SpotSeedFormat`
- cover engine with unit tests

## Testing
- `dart format lib/models/constraint_set.dart lib/services/action_pattern_matcher.dart lib/services/constraint_resolver_engine_v2.dart test/services/constraint_resolver_engine_v2_test.dart` *(fails: command not found)*
- `dart test test/services/constraint_resolver_engine_v2_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fba76edb8832aae7dfefdc1adc5f0