### PR TITLE
feat: expand template set generation

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -33,7 +33,8 @@ class YamlReader {
         ? await rootBundle.loadString(path)
         : await File(path).readAsString();
     final map = read(source);
-    if (map['template'] is Map && map['variants'] is List) {
+    if ((map['template'] is Map && map['variants'] is List) ||
+        map['templateSet'] is List) {
       final set = TrainingPackTemplateSet.fromJson(map);
       return const TrainingPackTemplateSetGenerator().generate(set);
     }

--- a/lib/models/v2/training_pack_template_set.dart
+++ b/lib/models/v2/training_pack_template_set.dart
@@ -1,32 +1,86 @@
 import 'package:yaml/yaml.dart';
 
 import '../../utils/yaml_utils.dart';
+import '../constraint_set.dart';
 import 'training_pack_template_v2.dart';
 
 /// Defines a template with variant parameters that can be expanded into
 /// multiple [TrainingPackTemplateV2] instances.
 class TrainingPackTemplateSet {
   TrainingPackTemplateV2 template;
+
+  /// Mustache-style variants for legacy expansion.
   List<Map<String, dynamic>> variants;
+
+  /// Named constraint-based entries producing multiple packs from the same
+  /// template.
+  List<TemplateSetEntry> entries;
 
   TrainingPackTemplateSet({
     required this.template,
     List<Map<String, dynamic>>? variants,
-  }) : variants = variants ?? [];
+    List<TemplateSetEntry>? entries,
+  }) : variants = variants ?? [],
+       entries = entries ?? [];
 
-  factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) =>
-      TrainingPackTemplateSet(
-        template: TrainingPackTemplateV2.fromJson(
-          Map<String, dynamic>.from(json['template'] ?? {}),
-        ),
-        variants: [
-          for (final v in (json['variants'] as List? ?? []))
-            Map<String, dynamic>.from(v as Map),
-        ],
-      );
+  factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
+    // Determine base template map. If a nested `template` map is provided use
+    // it, otherwise treat the whole object minus helper keys as the template.
+    final map = Map<String, dynamic>.from(json);
+    Map<String, dynamic> tplMap;
+    if (map['template'] is Map) {
+      tplMap = Map<String, dynamic>.from(map['template']);
+    } else {
+      tplMap = Map<String, dynamic>.from(map);
+      tplMap.remove('variants');
+      tplMap.remove('templateSet');
+    }
+
+    return TrainingPackTemplateSet(
+      template: TrainingPackTemplateV2.fromJson(tplMap),
+      variants: [
+        for (final v in (json['variants'] as List? ?? []))
+          Map<String, dynamic>.from(v as Map),
+      ],
+      entries: [
+        for (final e in (json['templateSet'] as List? ?? []))
+          TemplateSetEntry.fromJson(Map<String, dynamic>.from(e as Map)),
+      ],
+    );
+  }
 
   factory TrainingPackTemplateSet.fromYaml(String yaml) {
     final map = yamlToDart(loadYaml(yaml)) as Map<String, dynamic>;
     return TrainingPackTemplateSet.fromJson(map);
+  }
+}
+
+/// Configuration for a single output pack within a [TrainingPackTemplateSet].
+class TemplateSetEntry {
+  final String name;
+  final ConstraintSet constraints;
+
+  TemplateSetEntry({required this.name, required this.constraints});
+
+  factory TemplateSetEntry.fromJson(Map<String, dynamic> json) {
+    final c = Map<String, dynamic>.from(json['constraints'] ?? {});
+    return TemplateSetEntry(
+      name: json['name']?.toString() ?? '',
+      constraints: ConstraintSet(
+        boardTags: [
+          for (final t in (c['boardTags'] as List? ?? [])) t.toString(),
+        ],
+        positions: [
+          for (final p in (c['positions'] as List? ?? [])) p.toString(),
+        ],
+        handGroup: [
+          for (final g in (c['handGroup'] as List? ?? [])) g.toString(),
+        ],
+        villainActions: [
+          for (final a in (c['villainActions'] as List? ?? [])) a.toString(),
+        ],
+        targetStreet: c['targetStreet']?.toString(),
+      ),
+    );
   }
 }

--- a/lib/services/training_pack_template_set_generator.dart
+++ b/lib/services/training_pack_template_set_generator.dart
@@ -2,14 +2,23 @@ import 'dart:convert';
 
 import '../models/v2/training_pack_template_set.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/spot_seed_format.dart';
+import '../models/card_model.dart';
+import 'constraint_resolver_engine_v2.dart';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackTemplateV2]
-/// instances by applying mustache-style interpolation for each variant.
+/// instances. Supports both legacy mustache-style interpolation and
+/// constraint-based template set entries.
 class TrainingPackTemplateSetGenerator {
   const TrainingPackTemplateSetGenerator();
 
-  /// Generates all packs defined by [set].
+  /// Generates all packs defined by [set]. Supports both legacy mustache
+  /// variants and the new constraint-based [TemplateSetEntry] expansions.
   List<TrainingPackTemplateV2> generate(TrainingPackTemplateSet set) {
+    if (set.entries.isNotEmpty) {
+      return _generateFromEntries(set);
+    }
     final baseJson = jsonEncode(set.template.toJson());
     final result = <TrainingPackTemplateV2>[];
     for (final variant in set.variants) {
@@ -22,6 +31,59 @@ class TrainingPackTemplateSetGenerator {
     }
     return result;
   }
+
+  List<TrainingPackTemplateV2> _generateFromEntries(
+    TrainingPackTemplateSet set,
+  ) {
+    final engine = ConstraintResolverEngine();
+    final baseMap =
+        jsonDecode(jsonEncode(set.template.toJson())) as Map<String, dynamic>;
+    final result = <TrainingPackTemplateV2>[];
+    for (var i = 0; i < set.entries.length; i++) {
+      final entry = set.entries[i];
+      final map = Map<String, dynamic>.from(baseMap);
+      map['name'] = entry.name;
+      if (map['id'] is String) {
+        map['id'] = '${map['id']}_${_slug(entry.name)}';
+      }
+      final tpl = TrainingPackTemplateV2.fromJson(map);
+      final spots = <TrainingPackSpot>[];
+      for (final s in set.template.spots) {
+        final candidate = _toSeed(s);
+        if (engine.isValid(candidate, entry.constraints)) {
+          spots.add(
+            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s.toJson())),
+          );
+        }
+      }
+      tpl.spots = spots;
+      tpl.spotCount = spots.length;
+      result.add(tpl);
+    }
+    return result;
+  }
+
+  SpotSeedFormat _toSeed(TrainingPackSpot spot) {
+    final board = [
+      for (final c in spot.board)
+        CardModel(rank: c[0], suit: c.length > 1 ? c[1] : ''),
+    ];
+    final heroPos = spot.hand.position.name;
+    final actions = <String>[];
+    if (spot.villainAction != null && spot.villainAction!.isNotEmpty) {
+      actions.add(spot.villainAction!.split(' ').first);
+    }
+    return SpotSeedFormat(
+      player: 'hero',
+      handGroup: const [],
+      position: heroPos,
+      board: board,
+      villainActions: actions,
+    );
+  }
+
+  String _slug(String name) =>
+      name.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
 
   /// Parses [yaml] and generates all packs from it.
   List<TrainingPackTemplateV2> generateFromYaml(String yaml) {

--- a/lib/utils/training_pack_yaml_codec_v2.dart
+++ b/lib/utils/training_pack_yaml_codec_v2.dart
@@ -17,7 +17,8 @@ class TrainingPackYamlCodecV2 {
   /// `template` and `variants` fields. Returns all resulting templates.
   List<TrainingPackTemplateV2> decodeMany(String yaml) {
     final map = const YamlReader().read(yaml);
-    if (map['template'] is Map && map['variants'] is List) {
+    if ((map['template'] is Map && map['variants'] is List) ||
+        map['templateSet'] is List) {
       final set = TrainingPackTemplateSet.fromJson(map);
       return const TrainingPackTemplateSetGenerator().generate(set);
     }

--- a/test/training_pack_template_set_test.dart
+++ b/test/training_pack_template_set_test.dart
@@ -29,4 +29,52 @@ variants:
     expect(packs[1].meta['dynamicParams']['villainAction'], '3bet 7.5');
     expect(packs[1].meta['dynamicParams']['targetStreet'], 'turn');
   });
+
+  test('templateSet expands into multiple packs with constraints', () {
+    const yaml = '''
+id: base_pack
+name: Base Pack
+trainingType: mtt
+positions: [btn]
+spots:
+  - id: s1
+    hand:
+      heroCards: Ah Kh
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      board: []
+    board: []
+    villainAction: check
+  - id: s2
+    hand:
+      heroCards: Qh Qd
+      position: btn
+      heroIndex: 0
+      playerCount: 2
+      board: [2h, 2c, 9d]
+    board: [2h, 2c, 9d]
+    villainAction: bet
+spotCount: 2
+templateSet:
+  - name: Paired Boards
+    constraints:
+      boardTags: ['paired']
+      targetStreet: flop
+  - name: Preflop Only
+    constraints:
+      targetStreet: preflop
+''';
+
+    final packs = const TrainingPackTemplateSetGenerator().generateFromYaml(
+      yaml,
+    );
+    expect(packs.length, 2);
+    expect(packs[0].name, 'Paired Boards');
+    expect(packs[0].spots.length, 1);
+    expect(packs[0].spots.first.id, 's2');
+    expect(packs[1].name, 'Preflop Only');
+    expect(packs[1].spots.length, 1);
+    expect(packs[1].spots.first.id, 's1');
+  });
 }


### PR DESCRIPTION
## Summary
- support `templateSet` entries mapping one YAML template to multiple constraint-based packs
- extend generator to filter spots by `ConstraintSet`
- load `templateSet` blocks in YAML reader and codec; added tests

## Testing
- `flutter test test/training_pack_template_set_test.dart` *(fails: missing plugin implementations and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbf07c28832aba5d81980fc1c718