### PR TITLE
feat: tag boards dynamically in constraint resolver

### DIFF
--- a/lib/services/constraint_resolver_engine_v2.dart
+++ b/lib/services/constraint_resolver_engine_v2.dart
@@ -1,16 +1,16 @@
 import '../models/constraint_set.dart';
 import '../models/spot_seed_format.dart';
-import 'board_texture_filter_service.dart';
 import 'action_pattern_matcher.dart';
+import 'dynamic_board_tagger_service.dart';
 
 class ConstraintResolverEngine {
-  final BoardTextureFilterService _textureFilter;
+  final DynamicBoardTaggerService _tagger;
   final ActionPatternMatcher _actionMatcher;
 
   const ConstraintResolverEngine({
-    BoardTextureFilterService? textureFilter,
+    DynamicBoardTaggerService? tagger,
     ActionPatternMatcher? actionMatcher,
-  })  : _textureFilter = textureFilter ?? const BoardTextureFilterService(),
+  })  : _tagger = tagger ?? const DynamicBoardTaggerService(),
         _actionMatcher = actionMatcher ?? const ActionPatternMatcher();
 
   bool isValid(SpotSeedFormat candidate, ConstraintSet constraints) {
@@ -28,8 +28,9 @@ class ConstraintResolverEngine {
     }
 
     if (constraints.boardTags.isNotEmpty) {
-      final board = candidate.board.map((c) => c.toString()).toList();
-      if (!_textureFilter.filter(board, constraints.boardTags)) {
+      final actualTags = _tagger.tag(candidate.board);
+      if (!constraints.boardTags
+          .every((tag) => actualTags.contains(tag))) {
         return false;
       }
     }

--- a/lib/services/dynamic_board_tagger_service.dart
+++ b/lib/services/dynamic_board_tagger_service.dart
@@ -3,6 +3,10 @@ import '../models/card_model.dart';
 class DynamicBoardTaggerService {
   const DynamicBoardTaggerService();
 
+  /// Tags the given [board] based on common board texture heuristics.
+  ///
+  /// This method is the primary entry point and is aliased by [tag] for
+  /// convenience.
   Set<String> tagBoard(List<CardModel> board) {
     final tags = <String>{};
     if (board.isEmpty) return tags;
@@ -36,6 +40,9 @@ class DynamicBoardTaggerService {
 
     return tags;
   }
+
+  /// Shorthand for [tagBoard] to provide a more concise API.
+  Set<String> tag(List<CardModel> board) => tagBoard(board);
 
   bool _isLow(List<CardModel> board) =>
       board.every((c) => _rankValue(c.rank) <= 8);


### PR DESCRIPTION
## Summary
- replace BoardTextureFilterService with DynamicBoardTaggerService in ConstraintResolverEngine
- add shorthand `tag` method to DynamicBoardTaggerService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc1082134832ab353c6454ba07174