### PR TITLE
feat: add board tag preview renderer

### DIFF
--- a/lib/widgets/board_tag_preview_renderer.dart
+++ b/lib/widgets/board_tag_preview_renderer.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../models/card_model.dart';
+import '../services/dynamic_board_tagger_service.dart';
+
+/// Renders a horizontal list of board texture tags.
+class BoardTagPreviewRenderer extends StatelessWidget {
+  const BoardTagPreviewRenderer({super.key, required this.board});
+
+  /// The board cards to analyse.
+  final List<CardModel> board;
+
+  static const _highlighted = {'paired', 'wet', 'aceHigh', 'rainbow'};
+
+  @override
+  Widget build(BuildContext context) {
+    final tags = DynamicBoardTaggerService().tag(board).toList()..sort();
+    if (tags.isEmpty) return const SizedBox.shrink();
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (final t in tags)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Chip(
+                label: Text(t),
+                backgroundColor: _highlighted.contains(t)
+                    ? Theme.of(context).colorScheme.primaryContainer
+                    : null,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/board_tag_preview_renderer_test.dart
+++ b/test/widgets/board_tag_preview_renderer_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/widgets/board_tag_preview_renderer.dart';
+
+void main() {
+  testWidgets('renders board tags', (tester) async {
+    final board = [
+      CardModel(rank: 'A', suit: '♠'),
+      CardModel(rank: 'A', suit: '♥'),
+      CardModel(rank: '9', suit: '♦'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: BoardTagPreviewRenderer(board: board)),
+      ),
+    );
+
+    expect(find.text('paired'), findsOneWidget);
+    expect(find.text('rainbow'), findsOneWidget);
+    expect(find.text('aceHigh'), findsOneWidget);
+    expect(find.text('wet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoardTagPreviewRenderer widget to visualize board texture tags
- cover BoardTagPreviewRenderer with a widget test

## Testing
- `flutter analyze 2>&1 | tail -n 20`
- `flutter test test/widgets/board_tag_preview_renderer_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688fc26fb248832abe3c858e267e9fb1