### PR TITLE
feat: add template set expander

### DIFF
--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -1,0 +1,14 @@
+import 'constraint_set.dart';
+import 'spot_seed_format.dart';
+
+/// Defines a base spot template and a list of variant constraints that
+/// can be expanded into multiple [SpotSeedFormat] instances.
+class TrainingPackTemplateSet {
+  final SpotSeedFormat baseTemplate;
+  final List<ConstraintSet> variants;
+
+  const TrainingPackTemplateSet({
+    required this.baseTemplate,
+    required this.variants,
+  });
+}

--- a/lib/services/training_pack_template_set_expander.dart
+++ b/lib/services/training_pack_template_set_expander.dart
@@ -1,0 +1,79 @@
+
+import '../models/training_pack_template_set.dart';
+import '../models/spot_seed_format.dart';
+import 'constraint_resolver_engine_v2.dart';
+import 'full_board_generator_service.dart';
+
+/// Expands a [TrainingPackTemplateSet] into a list of concrete
+/// [SpotSeedFormat] instances by applying each [ConstraintSet] variant.
+class TrainingPackTemplateSetExpander {
+  TrainingPackTemplateSetExpander({
+    ConstraintResolverEngine? resolver,
+    FullBoardGeneratorService? boardGenerator,
+  })  : _resolver = resolver ?? ConstraintResolverEngine(),
+        _boardGenerator = boardGenerator ?? FullBoardGeneratorService();
+
+  final ConstraintResolverEngine _resolver;
+  final FullBoardGeneratorService _boardGenerator;
+
+  /// Generates all spot seeds defined by [set]. Each variant is used to
+  /// produce one [SpotSeedFormat] that satisfies the given constraints.
+  List<SpotSeedFormat> expand(TrainingPackTemplateSet set) {
+    final results = <SpotSeedFormat>[];
+    for (final variant in set.variants) {
+      final base = set.baseTemplate;
+      // Apply overrides from variant where provided.
+      final template = SpotSeedFormat(
+        player: base.player,
+        handGroup:
+            variant.handGroup.isNotEmpty ? variant.handGroup : base.handGroup,
+        position:
+            variant.positions.isNotEmpty ? variant.positions.first : base.position,
+        villainActions: variant.villainActions.isNotEmpty
+            ? variant.villainActions
+            : base.villainActions,
+      );
+
+      final street = variant.targetStreet ?? base.currentStreet;
+      final stages = _streetToStages(street);
+
+      final boardFilter = variant.boardTags.isNotEmpty
+          ? {'boardTexture': variant.boardTags}
+          : null;
+
+      final board = _boardGenerator
+          .generateBoard(
+            FullBoardRequest(
+              stages: stages,
+              excludedCards: const [],
+              boardFilterParams: boardFilter,
+            ),
+          )
+          .cards;
+
+      final candidate = SpotSeedFormat(
+        player: template.player,
+        handGroup: template.handGroup,
+        position: template.position,
+        board: board,
+        villainActions: template.villainActions,
+      );
+
+      if (_resolver.isValid(candidate, variant)) {
+        results.add(candidate);
+      }
+    }
+    return results;
+  }
+
+  int _streetToStages(String street) {
+    switch (street.toLowerCase()) {
+      case 'turn':
+        return 4;
+      case 'river':
+        return 5;
+      default:
+        return 3;
+    }
+  }
+}

--- a/test/services/training_pack_template_set_expander_test.dart
+++ b/test/services/training_pack_template_set_expander_test.dart
@@ -1,0 +1,45 @@
+import 'dart:math';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/spot_seed_format.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/services/training_pack_template_set_expander.dart';
+import 'package:poker_analyzer/services/constraint_resolver_engine_v2.dart';
+import 'package:poker_analyzer/services/full_board_generator_service.dart';
+
+void main() {
+  test('expand generates spots matching variant constraints', () {
+    final base = SpotSeedFormat(
+      player: 'hero',
+      handGroup: const ['broadways'],
+      position: 'btn',
+      villainActions: const ['check'],
+    );
+
+    final set = TrainingPackTemplateSet(
+      baseTemplate: base,
+      variants: const [
+        ConstraintSet(boardTags: ['paired'], positions: ['btn']),
+        ConstraintSet(
+          boardTags: ['monotone'],
+          positions: ['co'],
+          villainActions: ['bet'],
+        ),
+      ],
+    );
+
+    final expander = TrainingPackTemplateSetExpander(
+      boardGenerator: FullBoardGeneratorService(random: Random(42)),
+    );
+
+    final spots = expander.expand(set);
+    expect(spots, hasLength(2));
+
+    final engine = ConstraintResolverEngine();
+    expect(engine.isValid(spots[0], set.variants[0]), isTrue);
+    expect(engine.isValid(spots[1], set.variants[1]), isTrue);
+    expect(spots[1].position.toLowerCase(), equals('co'));
+    expect(spots[1].villainActions, contains('bet'));
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackTemplateSet` model for multi-variant spot templates
- implement expander service to generate variant spot seeds with board filters
- cover expander with unit test

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc4d234bc832a951d06793b9c541b