### PR TITLE
feat: add centralized app logger

### DIFF
--- a/lib/services/auto_theory_review_engine.dart
+++ b/lib/services/auto_theory_review_engine.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 
 import '../models/learning_path_node.dart';
 import 'learning_graph_engine.dart';
@@ -16,6 +15,7 @@ import 'theory_pack_library_service.dart';
 import 'smart_booster_summary_engine.dart';
 import 'session_log_service.dart';
 import 'training_session_service.dart';
+import '../utils/app_logger.dart';
 
 /// Background service that injects weak theory lessons before the next node.
 class AutoTheoryReviewEngine {
@@ -108,8 +108,8 @@ class AutoTheoryReviewEngine {
               .logInjection(id, 'mini', 'auto');
         }
       }
-    } catch (e) {
-      debugPrint('AutoTheoryReviewEngine error: $e');
+    } catch (e, stack) {
+      AppLogger.error('AutoTheoryReviewEngine error', e, stack);
     } finally {
       _lastRun = DateTime.now();
     }

--- a/lib/services/backup_snapshot_service.dart
+++ b/lib/services/backup_snapshot_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -11,6 +10,7 @@ import '../models/action_evaluation_request.dart';
 import 'backup_file_manager.dart';
 import 'evaluation_queue_serializer.dart';
 import 'evaluation_queue_service.dart';
+import '../utils/app_logger.dart';
 
 /// Handles snapshot creation, loading and import/export utilities for the
 /// evaluation queue.
@@ -53,12 +53,12 @@ class BackupSnapshotService {
       if (snapshotRetentionEnabled) {
         await cleanupOldEvaluationSnapshots();
       }
-      if (showNotification && kDebugMode) {
-        debugPrint('Snapshot saved: ${file.path}');
+      if (showNotification) {
+        AppLogger.log('Snapshot saved: ${file.path}');
       }
-    } catch (e) {
-      if (showNotification && kDebugMode) {
-        debugPrint('Failed to export snapshot: $e');
+    } catch (e, stack) {
+      if (showNotification) {
+        AppLogger.error('Failed to export snapshot', e, stack);
       }
     }
   }
@@ -86,10 +86,8 @@ class BackupSnapshotService {
       entries.sort((a, b) => b.value.compareTo(a.value));
       final file = entries.first.key;
       return await fileManager.readJsonFile(file);
-    } catch (e) {
-      if (kDebugMode) {
-        debugPrint('Failed to load snapshot: $e');
-      }
+    } catch (e, stack) {
+      AppLogger.error('Failed to load snapshot', e, stack);
       return null;
     }
   }

--- a/lib/services/evaluation_queue_import_export_service.dart
+++ b/lib/services/evaluation_queue_import_export_service.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
@@ -10,6 +9,7 @@ import '../models/action_evaluation_request.dart';
 import 'evaluation_queue_service.dart';
 import 'backup_manager_service.dart';
 import 'debug_snapshot_service.dart';
+import '../utils/app_logger.dart';
 
 class EvaluationQueueImportExportService {
   EvaluationQueueImportExportService({
@@ -102,13 +102,11 @@ class EvaluationQueueImportExportService {
           ..clear()
           ..addAll(queues['completed']!);
         await _persist();
-      } else if (kDebugMode) {
-        debugPrint('Invalid clipboard data format');
+      } else {
+        AppLogger.warn('Invalid clipboard data format');
       }
-    } catch (e) {
-      if (kDebugMode) {
-        debugPrint('Failed to import from clipboard: $e');
-      }
+    } catch (e, stack) {
+      AppLogger.error('Failed to import from clipboard', e, stack);
     }
   }
 

--- a/lib/services/yaml_pack_archive_auto_cleaner_service.dart
+++ b/lib/services/yaml_pack_archive_auto_cleaner_service.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import '../app_config.dart';
 import 'dev_console_log_service.dart';
+import '../utils/app_logger.dart';
 
 class YamlPackArchiveAutoCleanerService {
   const YamlPackArchiveAutoCleanerService();
@@ -29,11 +30,11 @@ class YamlPackArchiveAutoCleanerService {
       }
       if (deleted > 0) {
         final msg = 'Archive auto-clean removed $deleted files';
-        debugPrint(msg);
+        AppLogger.log(msg);
         DevConsoleLogService.instance.log(msg);
       }
-    } catch (e) {
-      debugPrint('Archive auto-clean failed: $e');
+    } catch (e, stack) {
+      AppLogger.error('Archive auto-clean failed', e, stack);
     }
   }
 }

--- a/lib/utils/app_logger.dart
+++ b/lib/utils/app_logger.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+
+/// A simple logging utility that centralizes log output.
+///
+/// In debug mode, logs are printed to the console. In release mode, this
+/// prepares for integration with services like Crashlytics.
+class AppLogger {
+  AppLogger._();
+
+  static void log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    } else {
+      // TODO: Add release logging implementation, e.g., send to Crashlytics.
+    }
+  }
+
+  static void warn(String message) {
+    if (kDebugMode) {
+      debugPrint('⚠️ $message');
+    } else {
+      // TODO: Add release logging implementation, e.g., send to Crashlytics.
+    }
+  }
+
+  static void error(String message, [Object? error, StackTrace? stack]) {
+    if (kDebugMode) {
+      debugPrint('❌ $message');
+      if (error != null) {
+        debugPrint('Error: $error');
+      }
+      if (stack != null) {
+        debugPrint(stack.toString());
+      }
+    } else {
+      // TODO: Add release logging implementation, e.g., send to Crashlytics.
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce `AppLogger` to centralize logging and prep for Crashlytics
- use `AppLogger` in several services instead of `debugPrint`

## Testing
- `flutter format lib/utils/app_logger.dart lib/services/evaluation_queue_import_export_service.dart lib/services/backup_snapshot_service.dart lib/services/auto_theory_review_engine.dart lib/services/yaml_pack_archive_auto_cleaner_service.dart` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_688f98f5c330832abb57f03d5a9142ca