### PR TITLE
feat: add theory mini lesson navigator service

### DIFF
--- a/lib/services/theory_mini_lesson_navigator.dart
+++ b/lib/services/theory_mini_lesson_navigator.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../screens/mini_lesson_screen.dart';
+import 'mini_lesson_library_service.dart';
+import 'navigation_service.dart';
+
+/// Opens [MiniLessonScreen] for a lesson resolved by [theoryTag].
+class TheoryMiniLessonNavigator {
+  TheoryMiniLessonNavigator({
+    MiniLessonLibraryService? library,
+    NavigationService navigation = const NavigationService(),
+  })  : _library = library ?? MiniLessonLibraryService.instance,
+        _navigation = navigation;
+
+  final MiniLessonLibraryService _library;
+  final NavigationService _navigation;
+
+  static final TheoryMiniLessonNavigator instance =
+      TheoryMiniLessonNavigator();
+
+  /// Resolves a mini lesson by [tag] and pushes [MiniLessonScreen].
+  ///
+  /// Uses [context] if it is valid; otherwise falls back to the global
+  /// [NavigationService] context. Does nothing if the lesson cannot be found or
+  /// no valid context is available.
+  Future<void> openLessonByTag(String tag, [BuildContext? context]) async {
+    await _library.loadAll();
+    final lessons = _library.getByTags({tag});
+    if (lessons.isEmpty) return;
+    final lesson = lessons.first;
+
+    BuildContext? ctx = context;
+    if (ctx == null || !(ctx.mounted)) {
+      ctx = _navigation.context;
+    }
+    if (ctx == null || !(ctx.mounted)) return;
+
+    await Navigator.of(ctx).push(
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+}
+

--- a/test/services/theory_mini_lesson_navigator_test.dart
+++ b/test/services/theory_mini_lesson_navigator_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/main.dart' show navigatorKey;
+import 'package:poker_analyzer/services/theory_mini_lesson_navigator.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/screens/mini_lesson_screen.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, TheoryMiniLessonNode> byTag;
+  _FakeLibrary(this.byTag);
+
+  @override
+  List<TheoryMiniLessonNode> get all => byTag.values.toList();
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      all.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [
+        for (final t in tags)
+          if (byTag[t] != null) byTag[t]!,
+      ];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [
+        for (final t in tags)
+          if (byTag[t] != null) byTag[t]!,
+      ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('opens lesson using provided context', (tester) async {
+    const lesson =
+        TheoryMiniLessonNode(id: 'l1', title: 'Intro', content: '', tags: ['t']);
+    final library = _FakeLibrary({'t': lesson});
+    final nav = TheoryMiniLessonNavigator(library: library);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (ctx) => ElevatedButton(
+          onPressed: () => nav.openLessonByTag('t', ctx),
+          child: const Text('open'),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.byType(MiniLessonScreen), findsOneWidget);
+  });
+
+  testWidgets('opens lesson using global navigator when no context', (tester) async {
+    const lesson =
+        TheoryMiniLessonNode(id: 'l1', title: 'Intro', content: '', tags: ['t']);
+    final library = _FakeLibrary({'t': lesson});
+    final nav = TheoryMiniLessonNavigator(library: library);
+
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navigatorKey,
+      home: const SizedBox.shrink(),
+    ));
+
+    await nav.openLessonByTag('t');
+    await tester.pumpAndSettle();
+    expect(find.byType(MiniLessonScreen), findsOneWidget);
+  });
+
+  testWidgets('no-op when lesson not found', (tester) async {
+    final library = _FakeLibrary({});
+    final nav = TheoryMiniLessonNavigator(library: library);
+
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navigatorKey,
+      home: const SizedBox.shrink(),
+    ));
+
+    await nav.openLessonByTag('missing');
+    await tester.pumpAndSettle();
+    expect(find.byType(MiniLessonScreen), findsNothing);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TheoryMiniLessonNavigator service to open mini lessons by tag and fallback to global navigation
- cover service with widget tests for direct, global, and missing tag cases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc8b74468832a9cbd63b6763f442d