### PR TITLE
feat: add pack template set variations

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -34,7 +34,8 @@ class YamlReader {
         : await File(path).readAsString();
     final map = read(source);
     if ((map['template'] is Map && map['variants'] is List) ||
-        map['templateSet'] is List) {
+        map['templateSet'] is List ||
+        (map['base'] is Map && map['variations'] is List)) {
       final set = TrainingPackTemplateSet.fromJson(map);
       return const TrainingPackTemplateSetGenerator().generate(set);
     }

--- a/lib/services/training_pack_template_set_generator.dart
+++ b/lib/services/training_pack_template_set_generator.dart
@@ -47,6 +47,10 @@ class TrainingPackTemplateSetGenerator {
         map['id'] = '${map['id']}_${_slug(entry.name)}';
       }
       final tpl = TrainingPackTemplateV2.fromJson(map);
+      if (entry.tags.isNotEmpty) {
+        final tagSet = {...tpl.tags, ...entry.tags};
+        tpl.tags = tagSet.toList()..sort();
+      }
       final spots = <TrainingPackSpot>[];
       for (final s in set.template.spots) {
         final candidate = _toSeed(s);

--- a/test/training_pack_template_set_test.dart
+++ b/test/training_pack_template_set_test.dart
@@ -77,4 +77,31 @@ templateSet:
     expect(packs[1].spots.length, 1);
     expect(packs[1].spots.first.id, 's1');
   });
+
+  test('base/variations format expands with ids and tags', () {
+    const yaml = '''
+templateId: defend
+base:
+  name: Base Pack
+  trainingType: pushFold
+  tags: [base]
+  spots: []
+  spotCount: 0
+variations:
+  - tags: [flat]
+    villainActions: ['3bet', 'call']
+  - tags: ['4bet shove']
+    villainActions: ['3bet', '4bet']
+''';
+
+    final packs = const TrainingPackTemplateSetGenerator().generateFromYaml(yaml);
+    expect(packs.length, 2);
+    expect(packs[0].id, contains('defend'));
+    expect(packs[0].name, 'Base Pack - flat');
+    expect(packs[0].tags.contains('base'), isTrue);
+    expect(packs[0].tags.contains('flat'), isTrue);
+    expect(packs[1].id, contains('defend'));
+    expect(packs[1].name, 'Base Pack - 4bet shove');
+    expect(packs[1].tags.contains('4bet shove'), isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- support base+variation pack template sets and merge variant tags
- update YAML reader and library generation engine to expand packset definitions
- add tests for new packset format

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fcda39a10832a89d2ffeebcd90e1b