### PR TITLE
feat: add constraint resolver engine

### DIFF
--- a/lib/services/action_pattern_matcher.dart
+++ b/lib/services/action_pattern_matcher.dart
@@ -5,7 +5,9 @@ class ActionPatternMatcher {
     if (pattern.isEmpty) return true;
     if (actions.length != pattern.length) return false;
     for (var i = 0; i < pattern.length; i++) {
-      if (actions[i].toLowerCase() != pattern[i].toLowerCase()) {
+      final actual = actions[i].split(' ').first.toLowerCase();
+      final expected = pattern[i].split(' ').first.toLowerCase();
+      if (actual != expected) {
         return false;
       }
     }

--- a/lib/services/constraint_resolver_engine_v2.dart
+++ b/lib/services/constraint_resolver_engine_v2.dart
@@ -22,22 +22,29 @@ class ConstraintResolverEngine {
     }
 
     if (constraints.handGroup.isNotEmpty &&
-        !candidate.handGroup.any((h) =>
-            constraints.handGroup.map((e) => e.toLowerCase()).contains(h.toLowerCase()))) {
+        !candidate.handGroup.any(
+          (h) => constraints.handGroup
+              .map((e) => e.toLowerCase())
+              .contains(h.toLowerCase()),
+        )) {
       return false;
     }
 
     if (constraints.boardTags.isNotEmpty) {
-      final actualTags = _tagger.tag(candidate.board);
-      if (!constraints.boardTags
-          .every((tag) => actualTags.contains(tag))) {
+      final actualTags =
+          _tagger.tag(candidate.board).map((t) => t.toLowerCase()).toSet();
+      final required =
+          constraints.boardTags.map((t) => t.toLowerCase()).toList();
+      if (!required.every(actualTags.contains)) {
         return false;
       }
     }
 
     if (constraints.villainActions.isNotEmpty &&
         !_actionMatcher.matches(
-            candidate.villainActions, constraints.villainActions)) {
+          candidate.villainActions,
+          constraints.villainActions,
+        )) {
       return false;
     }
 

--- a/test/services/constraint_resolver_engine_v2_test.dart
+++ b/test/services/constraint_resolver_engine_v2_test.dart
@@ -71,13 +71,33 @@ void main() {
     expect(engine.isValid(candidate, constraints), isFalse);
   });
 
+  test('matches villain actions using first word only', () {
+    final candidate = buildCandidate(villainActions: ['bet 50', 'check 100']);
+    final constraints = ConstraintSet(villainActions: ['bet', 'check']);
+    expect(engine.isValid(candidate, constraints), isTrue);
+  });
+
+  test('board tag comparison is case-insensitive', () {
+    final candidate = buildCandidate(
+      board: [
+        CardModel(rank: '2', suit: 'h'),
+        CardModel(rank: '2', suit: 'c'),
+        CardModel(rank: '9', suit: 'd'),
+      ],
+    );
+    final constraints = ConstraintSet(boardTags: ['PAIRED']);
+    expect(engine.isValid(candidate, constraints), isTrue);
+  });
+
   test('rejects when street mismatch', () {
-    final candidate = buildCandidate(board: [
-      CardModel(rank: '2', suit: 'h'),
-      CardModel(rank: '2', suit: 'c'),
-      CardModel(rank: '9', suit: 'd'),
-      CardModel(rank: 'K', suit: 's'),
-    ]);
+    final candidate = buildCandidate(
+      board: [
+        CardModel(rank: '2', suit: 'h'),
+        CardModel(rank: '2', suit: 'c'),
+        CardModel(rank: '9', suit: 'd'),
+        CardModel(rank: 'K', suit: 's'),
+      ],
+    );
     final constraints = ConstraintSet(targetStreet: 'flop');
     expect(engine.isValid(candidate, constraints), isFalse);
   });


### PR DESCRIPTION
## Summary
- improve action matcher to compare only the first word of actions
- make constraint resolver board tag checks case-insensitive and test extra scenarios

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*
- `dart test test/services/constraint_resolver_engine_v2_test.dart` *(fails: The argument type 'TrainingPackTemplate' can't be assigned to the parameter type 'TrainingPackTemplateV2')*

------
https://chatgpt.com/codex/tasks/task_e_688fcffc4e7c832a93fb7e0de6d32465