### PR TITLE
feat: classify mistake theory tags

### DIFF
--- a/test/mistake_tag_classifier_test.dart
+++ b/test/mistake_tag_classifier_test.dart
@@ -28,4 +28,10 @@ void main() {
     expect(cls!.tag, MistakeTag.overfoldBtn);
     expect(cls.severity, greaterThan(0.8));
   });
+
+  test('provides theory tags for overfold', () {
+    final tags = const MistakeTagClassifier().classifyTheory(_attempt());
+    expect(tags, contains('pushRange'));
+    expect(tags, contains('overfold'));
+  });
 }


### PR DESCRIPTION
## Summary
- expand MistakeTagClassifier with rule-based theory tag detection
- show personalized theory links after wrong answers
- test MistakeTagClassifier theory tags

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688fd822bb90832abf313c30f331ca0c