### PR TITLE
feat: add spot line graph engine

### DIFF
--- a/lib/models/spot_line_graph.dart
+++ b/lib/models/spot_line_graph.dart
@@ -1,0 +1,66 @@
+class SpotLineGraph {
+  final SpotLineNode root;
+
+  SpotLineGraph({required this.root});
+
+  /// Returns all action lines from the root to every leaf node.
+  List<SpotActionLine> getAllLines() {
+    final result = <SpotActionLine>[];
+
+    void visit(SpotLineNode node, List<SpotLineEdge> path) {
+      if (node.edges.isEmpty) {
+        result.add(SpotActionLine(List<SpotLineEdge>.from(path)));
+        return;
+      }
+      for (final edge in node.edges) {
+        path.add(edge);
+        visit(edge.target, path);
+        path.removeLast();
+      }
+    }
+
+    visit(root, []);
+    return result;
+  }
+}
+
+class SpotLineNode {
+  final int street;
+  final double stack;
+  final double pot;
+  final String heroPosition;
+  final List<String> actionHistory;
+  final List<SpotLineEdge> edges;
+
+  SpotLineNode({
+    required this.street,
+    required this.stack,
+    required this.pot,
+    required this.heroPosition,
+    List<String>? actionHistory,
+    List<SpotLineEdge>? edges,
+  })  : actionHistory = actionHistory ?? [],
+        edges = edges ?? [];
+}
+
+class SpotLineEdge {
+  final String actor;
+  final String action;
+  final double? ev;
+  final bool? correct;
+  final SpotLineNode target;
+
+  SpotLineEdge({
+    required this.actor,
+    required this.action,
+    required this.target,
+    this.ev,
+    this.correct,
+  });
+}
+
+class SpotActionLine {
+  final List<SpotLineEdge> actions;
+
+  const SpotActionLine(this.actions);
+}

--- a/lib/services/spot_line_graph_engine.dart
+++ b/lib/services/spot_line_graph_engine.dart
@@ -1,0 +1,67 @@
+import '../models/v2/training_pack_spot.dart';
+import '../models/spot_line_graph.dart';
+import '../models/action_entry.dart';
+
+class SpotLineGraphEngine {
+  const SpotLineGraphEngine();
+
+  SpotLineGraph build(TrainingPackSpot spot) {
+    final heroIndex = spot.hand.heroIndex;
+    final heroPos = spot.hand.position.name;
+    final heroStack =
+        spot.hand.stacks[heroIndex.toString()] ?? spot.hand.stacks['0'] ?? 0;
+
+    final root = SpotLineNode(
+      street: 0,
+      stack: heroStack,
+      pot: 0,
+      heroPosition: heroPos,
+    );
+
+    SpotLineNode current = root;
+    for (var street = 0; street < spot.hand.actions.length; street++) {
+      final acts = spot.hand.actions[street] ?? [];
+      for (final ActionEntry act in acts) {
+        final actor = act.playerIndex == heroIndex ? 'hero' : 'villain';
+        final next = SpotLineNode(
+          street: act.street,
+          stack: current.stack,
+          pot: act.potAfter,
+          heroPosition: heroPos,
+          actionHistory: [...current.actionHistory, act.action],
+        );
+        final edge = SpotLineEdge(
+          actor: actor,
+          action: act.action,
+          target: next,
+          ev: act.ev,
+        );
+        current.edges.add(edge);
+        current = next;
+      }
+    }
+
+    if (spot.heroOptions.isNotEmpty) {
+      for (final opt in spot.heroOptions) {
+        final next = SpotLineNode(
+          street: current.street,
+          stack: current.stack,
+          pot: current.pot,
+          heroPosition: heroPos,
+          actionHistory: [...current.actionHistory, opt],
+        );
+        final edge = SpotLineEdge(
+          actor: 'hero',
+          action: opt,
+          target: next,
+          correct: spot.correctAction != null
+              ? opt.toLowerCase() == spot.correctAction!.toLowerCase()
+              : null,
+        );
+        current.edges.add(edge);
+      }
+    }
+
+    return SpotLineGraph(root: root);
+  }
+}

--- a/test/spot_line_graph_engine_test.dart
+++ b/test/spot_line_graph_engine_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/spot_line_graph_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+
+void main() {
+  test('build converts hand actions into a single line', () {
+    final spot = TrainingPackSpot(
+      id: 's',
+      hand: HandData.fromSimpleInput('AhAs', HeroPosition.sb, 10),
+    );
+    final engine = const SpotLineGraphEngine();
+    final graph = engine.build(spot);
+    final lines = graph.getAllLines();
+    expect(lines.length, 1);
+    expect(lines.first.actions.map((e) => e.action).toList(), ['push', 'fold']);
+  });
+
+  test('build adds hero options at terminal node', () {
+    final spot = TrainingPackSpot(
+      id: 's2',
+      hand: HandData(),
+      heroOptions: const ['call', 'fold'],
+      correctAction: 'call',
+    );
+    final engine = const SpotLineGraphEngine();
+    final graph = engine.build(spot);
+    final lines = graph.getAllLines();
+    expect(lines.length, 2);
+    expect(lines.any((l) =>
+        l.actions.length == 1 && l.actions.first.action == 'call' && l.actions.first.correct == true), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add SpotLineGraph model with node/edge structure and line extraction
- implement SpotLineGraphEngine to build line graphs from TrainingPackSpot
- cover SpotLineGraphEngine with unit tests

## Testing
- `dart format lib/models/spot_line_graph.dart lib/services/spot_line_graph_engine.dart test/spot_line_graph_engine_test.dart` *(fails: command not found)*
- `dart test test/spot_line_graph_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fdbce1b8c832abf50c42c66a8e625