### PR TITLE
feat: auto theory link injection

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -6,6 +6,7 @@ import '../training_spot.dart';
 import 'hero_position.dart';
 import '../card_model.dart';
 import 'package:uuid/uuid.dart';
+import '../../services/inline_theory_linker.dart';
 
 class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
   final String id;
@@ -38,6 +39,12 @@ class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
   String? villainAction;
   List<String> heroOptions;
   Map<String, dynamic> meta;
+
+  /// Ephemeral link to a related theory lesson.
+  ///
+  /// This field is populated at runtime by [AutoSpotTheoryInjectorService]
+  /// and is never serialized.
+  InlineTheoryLink? theoryLink;
 
   TrainingPackSpot({
     required this.id,

--- a/lib/services/auto_spot_theory_injector_service.dart
+++ b/lib/services/auto_spot_theory_injector_service.dart
@@ -1,0 +1,26 @@
+import '../models/v2/training_pack_spot.dart';
+import 'inline_theory_linker.dart';
+
+/// Automatically attaches an [InlineTheoryLink] to [TrainingPackSpot]s
+/// based on their existing theory tags.
+class AutoSpotTheoryInjectorService {
+  AutoSpotTheoryInjectorService({InlineTheoryLinker? linker})
+      : _linker = linker ?? InlineTheoryLinker();
+
+  final InlineTheoryLinker _linker;
+
+  /// Attaches a matching [InlineTheoryLink] to [spot] if available.
+  ///
+  /// The method mutates [spot] in place and returns it for convenience.
+  TrainingPackSpot inject(TrainingPackSpot spot) {
+    spot.theoryLink = _linker.getLink(spot.tags);
+    return spot;
+  }
+
+  /// Convenience method to inject links for multiple [spots].
+  void injectAll(Iterable<TrainingPackSpot> spots) {
+    for (final s in spots) {
+      inject(s);
+    }
+  }
+}

--- a/test/services/auto_spot_theory_injector_service_test.dart
+++ b/test/services/auto_spot_theory_injector_service_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/hand_data.dart';
+import 'package:poker_analyzer/services/auto_spot_theory_injector_service.dart';
+import 'package:poker_analyzer/services/inline_theory_linker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_navigator.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, TheoryMiniLessonNode> byTag;
+  _FakeLibrary(this.byTag);
+
+  @override
+  List<TheoryMiniLessonNode> get all => byTag.values.toList();
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      all.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [
+        for (final t in tags)
+          if (byTag[t] != null) byTag[t]!,
+      ];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [
+        for (final t in tags)
+          if (byTag[t] != null) byTag[t]!,
+      ];
+}
+
+class _FakeNavigator extends TheoryMiniLessonNavigator {
+  String? openedTag;
+
+  @override
+  Future<void> openLessonByTag(String tag, [context]) async {
+    openedTag = tag;
+  }
+}
+
+void main() {
+  group('AutoSpotTheoryInjectorService', () {
+    test('injects matching theory link', () {
+      final library = _FakeLibrary({
+        'cbet': const TheoryMiniLessonNode(
+            id: '1', title: 'CBet', content: '', tags: ['cbet']),
+      });
+      final nav = _FakeNavigator();
+      final linker = InlineTheoryLinker(library: library, navigator: nav);
+      final service = AutoSpotTheoryInjectorService(linker: linker);
+      final spot = TrainingPackSpot(id: 's1', hand: HandData(), tags: ['cbet']);
+
+      service.inject(spot);
+
+      expect(spot.theoryLink?.title, 'CBet');
+      spot.theoryLink?.onTap();
+      expect(nav.openedTag, 'cbet');
+    });
+
+    test('leaves theoryLink null when no match', () {
+      final library = _FakeLibrary({});
+      final service = AutoSpotTheoryInjectorService(
+          linker: InlineTheoryLinker(
+              library: library, navigator: _FakeNavigator()));
+      final spot = TrainingPackSpot(id: 's1', hand: HandData(), tags: ['cbet']);
+
+      service.inject(spot);
+
+      expect(spot.theoryLink, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add inline theory link field to `TrainingPackSpot`
- introduce `AutoSpotTheoryInjectorService` for automated theory linking
- add unit tests for theory injector

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688fe08eb95c832aa898aba67fdb71c8