### PR TITLE
feat: add constraint resolver engine

### DIFF
--- a/lib/models/constraint_set.dart
+++ b/lib/models/constraint_set.dart
@@ -1,3 +1,12 @@
+import '../services/inline_theory_linker.dart';
+
+/// Describes a set of constraints and mutation rules that can be applied to a
+/// base [TrainingPackSpot] to produce variations.
+///
+/// Existing fields such as [boardTags] and [villainActions] are used by other
+/// parts of the system for filtering purposes.  The additional fields introduced
+/// here allow the resolver engine to modify tags and inline metadata when
+/// generating spots from templates.
 class ConstraintSet {
   final List<String> boardTags;
   final List<String> positions;
@@ -5,11 +14,42 @@ class ConstraintSet {
   final List<String> villainActions;
   final String? targetStreet;
 
+  /// Property overrides where each key maps to a list of possible values. The
+  /// resolver engine will expand the cartesian product of these lists.
+  final Map<String, List<dynamic>> overrides;
+
+  /// Tags to inject into the resulting spot.  Behaviour is controlled by
+  /// [tagMergeMode].
+  final List<String> tags;
+
+  /// Determines how [tags] are applied: [MergeMode.add] merges them with the
+  /// base tags, while [MergeMode.override] replaces the base tags entirely.
+  final MergeMode tagMergeMode;
+
+  /// Arbitrary metadata to merge with or override the base spot's [meta].
+  final Map<String, dynamic> metadata;
+
+  /// Controls how [metadata] is applied. [MergeMode.add] merges the maps while
+  /// [MergeMode.override] replaces the base metadata.
+  final MergeMode metaMergeMode;
+
+  /// Optional theory link override.
+  final InlineTheoryLink? theoryLink;
+
   const ConstraintSet({
     this.boardTags = const [],
     this.positions = const [],
     this.handGroup = const [],
     this.villainActions = const [],
     this.targetStreet,
+    this.overrides = const {},
+    this.tags = const [],
+    this.tagMergeMode = MergeMode.add,
+    this.metadata = const {},
+    this.metaMergeMode = MergeMode.add,
+    this.theoryLink,
   });
 }
+
+/// Strategy for merging list/map data when applying a [ConstraintSet].
+enum MergeMode { add, override }

--- a/lib/services/constraint_resolver_engine_v2.dart
+++ b/lib/services/constraint_resolver_engine_v2.dart
@@ -1,7 +1,10 @@
 import '../models/constraint_set.dart';
 import '../models/spot_seed_format.dart';
+import '../models/v2/hero_position.dart';
+import '../models/v2/training_pack_spot.dart';
 import 'action_pattern_matcher.dart';
 import 'dynamic_board_tagger_service.dart';
+import 'package:uuid/uuid.dart';
 
 class ConstraintResolverEngine {
   final DynamicBoardTaggerService _tagger;
@@ -56,5 +59,113 @@ class ConstraintResolverEngine {
     }
 
     return true;
+  }
+
+  /// Applies [sets] to [base] producing all valid [TrainingPackSpot]
+  /// variations. Each [ConstraintSet] may define multiple override options via
+  /// [ConstraintSet.overrides]; the cartesian product of those options is
+  /// generated and applied to the base spot. Tags, theory links and metadata are
+  /// merged or overridden according to the `MergeMode` settings.
+  List<TrainingPackSpot> apply(
+    TrainingPackSpot base,
+    List<ConstraintSet> sets,
+  ) {
+    if (sets.isEmpty) {
+      return [_cloneBase(base)];
+    }
+
+    final results = <TrainingPackSpot>[];
+    for (final set in sets) {
+      final combos = _cartesian(set.overrides);
+      for (final combo in combos) {
+        final spot = _cloneBase(base);
+
+        combo.forEach((key, value) {
+          switch (key) {
+            case 'board':
+              final board = [for (final c in value as List) c.toString()];
+              spot.board = board;
+              spot.hand.board = List<String>.from(board);
+              break;
+            case 'heroStack':
+              final stack = (value as num).toDouble();
+              spot.hand.stacks = {...spot.hand.stacks, '0': stack};
+              break;
+            case 'heroPosition':
+            case 'position':
+              spot.hand.position = parseHeroPosition(value.toString());
+              break;
+            case 'tags':
+              final tags = [for (final t in value as List) t.toString()];
+              spot.tags = _mergeTags(spot.tags, tags, set.tagMergeMode);
+              break;
+            default:
+              spot.meta[key] = value;
+          }
+        });
+
+        // Apply constant tag/meta overrides from the set.
+        spot.tags = _mergeTags(spot.tags, set.tags, set.tagMergeMode);
+        spot.meta = _mergeMeta(spot.meta, set.metadata, set.metaMergeMode);
+        if (set.theoryLink != null) {
+          spot.theoryLink = set.theoryLink;
+        }
+
+        results.add(spot);
+      }
+    }
+
+    return results;
+  }
+
+  TrainingPackSpot _cloneBase(TrainingPackSpot base) {
+    final json = Map<String, dynamic>.from(base.toJson());
+    json['id'] = const Uuid().v4();
+    final copy = TrainingPackSpot.fromJson(json);
+    copy.templateSourceId = base.id;
+    copy.tags = List<String>.from(base.tags);
+    copy.theoryLink = base.theoryLink;
+    copy.meta = Map<String, dynamic>.from(base.meta);
+    return copy;
+  }
+
+  List<Map<String, dynamic>> _cartesian(Map<String, List<dynamic>> input) {
+    var result = <Map<String, dynamic>>[{}];
+    input.forEach((key, values) {
+      final next = <Map<String, dynamic>>[];
+      for (final combo in result) {
+        for (final v in values) {
+          final map = Map<String, dynamic>.from(combo);
+          map[key] = v;
+          next.add(map);
+        }
+      }
+      result = next;
+    });
+    return result;
+  }
+
+  List<String> _mergeTags(
+    List<String> base,
+    List<String> updates,
+    MergeMode mode,
+  ) {
+    final set = <String>{};
+    if (mode == MergeMode.add) {
+      set.addAll(base);
+    }
+    set.addAll(updates);
+    return set.toList();
+  }
+
+  Map<String, dynamic> _mergeMeta(
+    Map<String, dynamic> base,
+    Map<String, dynamic> updates,
+    MergeMode mode,
+  ) {
+    if (mode == MergeMode.override) {
+      return Map<String, dynamic>.from(updates);
+    }
+    return {...base, ...updates};
   }
 }

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -1,80 +1,26 @@
-import 'package:uuid/uuid.dart';
-
 import '../models/training_pack_template_set.dart';
+import '../models/constraint_set.dart';
 import '../models/v2/training_pack_spot.dart';
+import 'constraint_resolver_engine_v2.dart';
 
-/// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s.
+/// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
+/// [ConstraintResolverEngine].
 ///
-/// Each variation defines a map of property names to a list of values. The
-/// expander generates the cartesian product of all values within a variation
-/// and applies them to the base spot, producing a unique spot for every
-/// combination. Tags from the base spot are inherited by all generated spots,
-/// and the base `theoryLink` is preserved. The original spot `id` is stored in
-/// [TrainingPackSpot.templateSourceId].
+/// Each entry in [TrainingPackTemplateSet.variations] is treated as a
+/// [ConstraintSet] describing property overrides and tag/metadata updates. The
+/// resolver generates the cartesian product of all values within a variation and
+/// applies them to the base spot, producing a unique spot for every combination.
 class TrainingPackTemplateExpanderService {
-  const TrainingPackTemplateExpanderService();
+  final ConstraintResolverEngine _engine;
+
+  const TrainingPackTemplateExpanderService({ConstraintResolverEngine? engine})
+      : _engine = engine ?? const ConstraintResolverEngine();
 
   /// Generates all spots described by [set].
   List<TrainingPackSpot> expand(TrainingPackTemplateSet set) {
-    final results = <TrainingPackSpot>[];
-    if (set.variations.isEmpty) {
-      results.add(_cloneBase(set.baseSpot));
-      return results;
-    }
-
-    for (final variation in set.variations) {
-      final combos = _cartesian(variation);
-      for (final combo in combos) {
-        final spot = _cloneBase(set.baseSpot);
-        combo.forEach((key, value) {
-          switch (key) {
-            case 'board':
-              final board = List<String>.from(value as List);
-              spot.board = board;
-              spot.hand.board = List<String>.from(board);
-              break;
-            case 'heroStack':
-              final stack = (value as num).toDouble();
-              spot.hand.stacks = {...spot.hand.stacks, '0': stack};
-              break;
-            case 'tags':
-              final tags = [for (final t in value as List) t.toString()];
-              final merged = {...set.baseSpot.tags, ...tags};
-              spot.tags = merged.toList();
-              break;
-            default:
-              spot.meta[key] = value;
-          }
-        });
-        results.add(spot);
-      }
-    }
-    return results;
-  }
-
-  TrainingPackSpot _cloneBase(TrainingPackSpot base) {
-    final json = Map<String, dynamic>.from(base.toJson());
-    json['id'] = const Uuid().v4();
-    final copy = TrainingPackSpot.fromJson(json);
-    copy.templateSourceId = base.id;
-    copy.tags = List<String>.from(base.tags);
-    copy.theoryLink = base.theoryLink;
-    return copy;
-  }
-
-  List<Map<String, dynamic>> _cartesian(Map<String, List<dynamic>> input) {
-    var result = <Map<String, dynamic>>[{}];
-    input.forEach((key, values) {
-      final next = <Map<String, dynamic>>[];
-      for (final combo in result) {
-        for (final v in values) {
-          final map = Map<String, dynamic>.from(combo);
-          map[key] = v;
-          next.add(map);
-        }
-      }
-      result = next;
-    });
-    return result;
+    final sets = [
+      for (final v in set.variations) ConstraintSet(overrides: v),
+    ];
+    return _engine.apply(set.baseSpot, sets);
   }
 }

--- a/test/services/constraint_resolver_engine_generation_test.dart
+++ b/test/services/constraint_resolver_engine_generation_test.dart
@@ -1,0 +1,61 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/constraint_resolver_engine_v2.dart';
+import 'package:poker_analyzer/services/inline_theory_linker.dart';
+
+void main() {
+  final engine = ConstraintResolverEngine();
+
+  TrainingPackSpot baseSpot() => TrainingPackSpot(
+        id: 'base',
+        hand: HandData.fromSimpleInput('Ah Kh', HeroPosition.btn, 30),
+        tags: ['base'],
+        meta: {'a': 1},
+      )..theoryLink = InlineTheoryLink(title: 't1', onTap: () {});
+
+  test('merges tags and meta by default', () {
+    final base = baseSpot();
+    final sets = [
+      ConstraintSet(
+        overrides: {
+          'heroStack': [10],
+        },
+        tags: ['extra'],
+        metadata: {'b': 2},
+      ),
+    ];
+    final spots = engine.apply(base, sets);
+    expect(spots, hasLength(1));
+    final s = spots.first;
+    expect(s.tags.toSet(), {'base', 'extra'});
+    expect(s.meta['a'], 1);
+    expect(s.meta['b'], 2);
+    expect(s.theoryLink?.title, 't1');
+  });
+
+  test('override tags and meta', () {
+    final base = baseSpot();
+    final sets = [
+      ConstraintSet(
+        overrides: {
+          'heroStack': [10],
+        },
+        tags: ['new'],
+        tagMergeMode: MergeMode.override,
+        metadata: {'c': 3},
+        metaMergeMode: MergeMode.override,
+        theoryLink: InlineTheoryLink(title: 't2', onTap: () {}),
+      ),
+    ];
+    final spots = engine.apply(base, sets);
+    expect(spots, hasLength(1));
+    final s = spots.first;
+    expect(s.tags, ['new']);
+    expect(s.meta.containsKey('a'), isFalse);
+    expect(s.meta['c'], 3);
+    expect(s.theoryLink?.title, 't2');
+  });
+}


### PR DESCRIPTION
## Summary
- centralize variation logic with ConstraintResolverEngine
- allow ConstraintSet to merge or override tags and metadata
- drive template expansion through new resolver

## Testing
- `apt-get install -y dart` (failed: Unable to locate package dart)
- `apt-get install -y flutter` (failed: Unable to locate package flutter)
- `dart test test/services/constraint_resolver_engine_v2_test.dart` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_688fe5b73fd0832ab1e82a55ef3755a6