### PR TITLE
feat: add spot template set with constraint variations

### DIFF
--- a/lib/models/constraint_set.dart
+++ b/lib/models/constraint_set.dart
@@ -49,6 +49,58 @@ class ConstraintSet {
     this.metaMergeMode = MergeMode.add,
     this.theoryLink,
   });
+
+  factory ConstraintSet.fromJson(Map<String, dynamic> json) {
+    final overrides = <String, List<dynamic>>{};
+    if (json['overrides'] is Map) {
+      (json['overrides'] as Map).forEach((key, value) {
+        overrides[key.toString()] = [
+          for (final v in (value as List? ?? [])) v,
+        ];
+      });
+    }
+    return ConstraintSet(
+      boardTags: [
+        for (final t in (json['boardTags'] as List? ?? [])) t.toString(),
+      ],
+      positions: [
+        for (final p in (json['positions'] as List? ?? [])) p.toString(),
+      ],
+      handGroup: [
+        for (final g in (json['handGroup'] as List? ?? [])) g.toString(),
+      ],
+      villainActions: [
+        for (final a in (json['villainActions'] as List? ?? [])) a.toString(),
+      ],
+      targetStreet: json['targetStreet']?.toString(),
+      overrides: overrides,
+      tags: [
+        for (final t in (json['tags'] as List? ?? [])) t.toString(),
+      ],
+      tagMergeMode: json['tagMergeMode'] == 'override'
+          ? MergeMode.override
+          : MergeMode.add,
+      metadata: json['metadata'] is Map
+          ? Map<String, dynamic>.from(json['metadata'])
+          : const {},
+      metaMergeMode: json['metaMergeMode'] == 'override'
+          ? MergeMode.override
+          : MergeMode.add,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        if (boardTags.isNotEmpty) 'boardTags': boardTags,
+        if (positions.isNotEmpty) 'positions': positions,
+        if (handGroup.isNotEmpty) 'handGroup': handGroup,
+        if (villainActions.isNotEmpty) 'villainActions': villainActions,
+        if (targetStreet != null) 'targetStreet': targetStreet,
+        if (overrides.isNotEmpty) 'overrides': overrides,
+        if (tags.isNotEmpty) 'tags': tags,
+        if (tagMergeMode == MergeMode.override) 'tagMergeMode': 'override',
+        if (metadata.isNotEmpty) 'metadata': metadata,
+        if (metaMergeMode == MergeMode.override) 'metaMergeMode': 'override',
+      };
 }
 
 /// Strategy for merging list/map data when applying a [ConstraintSet].

--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -1,3 +1,7 @@
+import 'package:yaml/yaml.dart';
+
+import '../utils/yaml_utils.dart';
+import 'constraint_set.dart';
 import 'v2/training_pack_spot.dart';
 
 /// Defines a base spot and a list of variation rules that can be expanded
@@ -6,13 +10,36 @@ class TrainingPackTemplateSet {
   /// Shared logic and metadata for all generated spots.
   final TrainingPackSpot baseSpot;
 
-  /// Each variation is a map of property name to a list of values that should
-  /// be combined with other properties to produce the cartesian product of
-  /// all options.
-  final List<Map<String, List<dynamic>>> variations;
+  /// Each variation is represented by a [ConstraintSet] describing overrides
+  /// and additional tagging/metadata rules.
+  final List<ConstraintSet> variations;
 
   const TrainingPackTemplateSet({
     required this.baseSpot,
-    this.variations = const [],
-  });
+    List<ConstraintSet>? variations,
+  }) : variations = variations ?? const [];
+
+  factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
+    final baseMap = Map<String, dynamic>.from(
+      (json['baseSpot'] ?? json['base'] ?? const {}) as Map,
+    );
+    final base = TrainingPackSpot.fromJson(baseMap);
+    final vars = <ConstraintSet>[
+      for (final v in (json['variations'] as List? ?? []))
+        ConstraintSet.fromJson(Map<String, dynamic>.from(v as Map)),
+    ];
+    return TrainingPackTemplateSet(baseSpot: base, variations: vars);
+  }
+
+  factory TrainingPackTemplateSet.fromYaml(String yaml) {
+    final map = yamlToDart(loadYaml(yaml)) as Map<String, dynamic>;
+    return TrainingPackTemplateSet.fromJson(map);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'baseSpot': baseSpot.toJson(),
+        if (variations.isNotEmpty)
+          'variations': [for (final v in variations) v.toJson()],
+      };
 }
+

--- a/lib/models/v2/training_pack_template_v2.dart
+++ b/lib/models/v2/training_pack_template_v2.dart
@@ -15,6 +15,8 @@ import '../../services/training_spot_generator_service.dart';
 import '../../services/constraint_resolver_engine.dart';
 import '../../helpers/board_filtering_params_builder.dart';
 import '../../services/hand_group_tag_library_service.dart';
+import '../training_pack_template_set.dart' as spot_set;
+import '../../services/training_pack_template_expander_service.dart';
 
 class TrainingPackTemplateV2 {
   final String id;
@@ -225,10 +227,23 @@ class TrainingPackTemplateV2 {
           DynamicSpotTemplate.fromJson(Map<String, dynamic>.from(d)),
       ];
 
-      spots = <TrainingPackSpot>[
-        for (final s in (j['spots'] as List? ?? []))
-          TrainingPackSpot.fromJson(Map<String, dynamic>.from(s)),
-      ];
+      final rawSpots = j['spots'];
+      if (rawSpots is List) {
+        spots = [
+          for (final s in rawSpots)
+            TrainingPackSpot.fromJson(Map<String, dynamic>.from(s)),
+        ];
+      } else if (rawSpots is Map && rawSpots['variations'] is List) {
+        final set = spot_set.TrainingPackTemplateSet.fromJson(
+            Map<String, dynamic>.from(rawSpots));
+        spots = TrainingPackTemplateExpanderService().expand(set);
+      } else if (rawSpots is Map) {
+        spots = [
+          TrainingPackSpot.fromJson(Map<String, dynamic>.from(rawSpots)),
+        ];
+      } else {
+        spots = <TrainingPackSpot>[];
+      }
 
       if (dynamicList.isNotEmpty) {
         spots = <TrainingPackSpot>[];

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -1,7 +1,7 @@
 import '../models/training_pack_template_set.dart';
-import '../models/constraint_set.dart';
 import '../models/v2/training_pack_spot.dart';
 import 'constraint_resolver_engine_v2.dart';
+import 'auto_spot_theory_injector_service.dart';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
 /// [ConstraintResolverEngine].
@@ -12,15 +12,18 @@ import 'constraint_resolver_engine_v2.dart';
 /// applies them to the base spot, producing a unique spot for every combination.
 class TrainingPackTemplateExpanderService {
   final ConstraintResolverEngine _engine;
+  final AutoSpotTheoryInjectorService _injector;
 
-  const TrainingPackTemplateExpanderService({ConstraintResolverEngine? engine})
-      : _engine = engine ?? const ConstraintResolverEngine();
+  TrainingPackTemplateExpanderService({
+    ConstraintResolverEngine? engine,
+    AutoSpotTheoryInjectorService? injector,
+  })  : _engine = engine ?? const ConstraintResolverEngine(),
+        _injector = injector ?? AutoSpotTheoryInjectorService();
 
-  /// Generates all spots described by [set].
+  /// Generates all spots described by [set] and injects theory links.
   List<TrainingPackSpot> expand(TrainingPackTemplateSet set) {
-    final sets = [
-      for (final v in set.variations) ConstraintSet(overrides: v),
-    ];
-    return _engine.apply(set.baseSpot, sets);
+    final spots = _engine.apply(set.baseSpot, set.variations);
+    _injector.injectAll(spots);
+    return spots;
   }
 }

--- a/test/services/training_pack_template_expander_service_test.dart
+++ b/test/services/training_pack_template_expander_service_test.dart
@@ -1,37 +1,43 @@
 import 'package:test/test.dart';
 
 import 'package:poker_analyzer/models/training_pack_template_set.dart';
-import 'package:poker_analyzer/models/v2/hand_data.dart';
-import 'package:poker_analyzer/models/v2/hero_position.dart';
-import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/auto_spot_theory_injector_service.dart';
 import 'package:poker_analyzer/services/inline_theory_linker.dart';
 import 'package:poker_analyzer/services/training_pack_template_expander_service.dart';
 
+class _Linker extends InlineTheoryLinker {
+  _Linker();
+
+  @override
+  InlineTheoryLink? getLink(List<String> theoryTags) =>
+      InlineTheoryLink(title: 'lesson', onTap: () {});
+}
+
 void main() {
-  test('expand generates spots preserving tags and theory link', () {
-    final base = TrainingPackSpot(
-      id: 'base',
-      hand: HandData.fromSimpleInput('Ah Kh', HeroPosition.btn, 30),
-      tags: ['theory'],
-    )..theoryLink = InlineTheoryLink(title: 'lesson', onTap: () {});
+  test('expand generates spots and injects theory link', () {
+    const yaml = '''
+baseSpot:
+  id: base
+  hand:
+    heroCards: Ah Kh
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+  tags: [theory]
+variations:
+  - overrides:
+      board:
+        - [As, Kd, Qc]
+        - [7h, 7d, 2c]
+      heroStack: [10, 20]
+    tags: [cbet]
+''';
 
-    final set = TrainingPackTemplateSet(
-      baseSpot: base,
-      variations: [
-        {
-          'board': [
-            ['As', 'Kd', 'Qc'],
-            ['7h', '7d', '2c'],
-          ],
-          'heroStack': [10, 20],
-          'tags': [
-            ['cbet'],
-          ],
-        }
-      ],
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    final expander = TrainingPackTemplateExpanderService(
+      injector: AutoSpotTheoryInjectorService(linker: _Linker()),
     );
-
-    final expander = const TrainingPackTemplateExpanderService();
     final spots = expander.expand(set);
 
     expect(spots, hasLength(4));
@@ -41,10 +47,10 @@ void main() {
       expect(s.theoryLink?.title, 'lesson');
     }
 
-    final boards = spots.map((s) => s.board.join(','));
-    expect(boards.toSet(), {'As,Kd,Qc', '7h,7d,2c'});
+    final boards = spots.map((s) => s.board.join(',')).toSet();
+    expect(boards, {'As,Kd,Qc', '7h,7d,2c'});
 
-    final stacks = spots.map((s) => s.hand.stacks['0']);
-    expect(stacks.toSet(), {10.0, 20.0});
+    final stacks = spots.map((s) => s.hand.stacks['0']).toSet();
+    expect(stacks, {10.0, 20.0});
   });
 }


### PR DESCRIPTION
## Summary
- support TrainingPackTemplateSet with constraint-driven variations and YAML/JSON parsing
- expand template sets into spots with theory link injection
- handle spot template sets during pack template decoding

## Testing
- `flutter test test/services/training_pack_template_expander_service_test.dart` *(fails: command not found)*
- `dart test test/services/training_pack_template_expander_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688fe79b0e9c832a9f823b8b49f9b279