### PR TITLE
feat: implement full board generator

### DIFF
--- a/lib/models/board_stages.dart
+++ b/lib/models/board_stages.dart
@@ -1,0 +1,11 @@
+class BoardStages {
+  final List<String> flop;
+  final String turn;
+  final String river;
+
+  const BoardStages({
+    required this.flop,
+    required this.turn,
+    required this.river,
+  });
+}

--- a/lib/services/full_board_generator.dart
+++ b/lib/services/full_board_generator.dart
@@ -1,0 +1,85 @@
+import '../models/board_stages.dart';
+import '../models/card_model.dart';
+import '../helpers/board_filtering_params_builder.dart';
+import 'board_texture_filter_service.dart';
+import 'card_deck_service.dart';
+
+class FullBoardGenerator {
+  const FullBoardGenerator({
+    CardDeckService? deckService,
+    BoardTextureFilterService? textureFilter,
+  })  : _deckService = deckService ?? const CardDeckService(),
+        _textureFilter = textureFilter ?? const BoardTextureFilterService();
+
+  final CardDeckService _deckService;
+  final BoardTextureFilterService _textureFilter;
+
+  /// Generates all possible flop-turn-river combinations that satisfy
+  /// [constraints].
+  ///
+  /// Supported constraint keys include:
+  /// * `texture` (e.g. `paired`)
+  /// * `rainbow` (bool)
+  /// * `broadwayHeavy` (bool)
+  /// * `drawy` (bool)
+  /// * `low` (bool)
+  /// * `paired` (bool)
+  /// * `aceHigh` (bool)
+  /// * `requiredRanks` (List<String>)
+  /// * `requiredSuits` (List<String>)
+  List<BoardStages> generate(Map<String, dynamic> constraints) {
+    final tags = <String>[];
+    final requiredRanks = <String>[
+      for (final r in (constraints['requiredRanks'] as List? ?? []))
+        r.toString().toUpperCase(),
+    ];
+    final requiredSuits = <String>[
+      for (final s in (constraints['requiredSuits'] as List? ?? []))
+        s.toString(),
+    ];
+
+    final texture = constraints['texture'];
+    if (texture != null) tags.add(texture.toString());
+    if (constraints['rainbow'] == true) tags.add('rainbow');
+    if (constraints['broadwayHeavy'] == true) tags.add('broadway');
+    if (constraints['drawy'] == true) tags.add('connected');
+    if (constraints['low'] == true) tags.add('low');
+    if (constraints['paired'] == true) tags.add('paired');
+    if (constraints['aceHigh'] == true) tags.add('aceHigh');
+
+    final filter = BoardFilteringParamsBuilder.build(tags);
+    if (requiredRanks.isNotEmpty) filter['requiredRanks'] = requiredRanks;
+    if (requiredSuits.isNotEmpty) filter['requiredSuits'] = requiredSuits;
+
+    final deck = _deckService.buildDeck();
+    final results = <BoardStages>[];
+
+    for (var i = 0; i < deck.length - 2; i++) {
+      for (var j = i + 1; j < deck.length - 1; j++) {
+        for (var k = j + 1; k < deck.length; k++) {
+          final flop = [deck[i], deck[j], deck[k]];
+          if (!_textureFilter.isMatch(flop, filter)) {
+            continue;
+          }
+          final remaining = [
+            for (final c in deck)
+              if (!flop.contains(c)) c
+          ];
+          for (var t = 0; t < remaining.length - 1; t++) {
+            for (var r = t + 1; r < remaining.length; r++) {
+              final turn = remaining[t];
+              final river = remaining[r];
+              results.add(BoardStages(
+                flop: flop.map((c) => c.toString()).toList(),
+                turn: turn.toString(),
+                river: river.toString(),
+              ));
+            }
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+}

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -1,7 +1,9 @@
 import '../models/training_pack_template_set.dart';
 import '../models/v2/training_pack_spot.dart';
+import '../models/constraint_set.dart';
 import 'constraint_resolver_engine_v2.dart';
 import 'auto_spot_theory_injector_service.dart';
+import 'full_board_generator.dart';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
 /// [ConstraintResolverEngine].
@@ -13,17 +15,55 @@ import 'auto_spot_theory_injector_service.dart';
 class TrainingPackTemplateExpanderService {
   final ConstraintResolverEngine _engine;
   final AutoSpotTheoryInjectorService _injector;
+  final FullBoardGenerator _boardGenerator;
 
   TrainingPackTemplateExpanderService({
     ConstraintResolverEngine? engine,
     AutoSpotTheoryInjectorService? injector,
+    FullBoardGenerator? boardGenerator,
   })  : _engine = engine ?? const ConstraintResolverEngine(),
-        _injector = injector ?? AutoSpotTheoryInjectorService();
+        _injector = injector ?? AutoSpotTheoryInjectorService(),
+        _boardGenerator = boardGenerator ?? const FullBoardGenerator();
 
   /// Generates all spots described by [set] and injects theory links.
   List<TrainingPackSpot> expand(TrainingPackTemplateSet set) {
-    final spots = _engine.apply(set.baseSpot, set.variations);
+    final processed = [
+      for (final v in set.variations) _expandBoards(v),
+    ];
+    final spots = _engine.apply(set.baseSpot, processed);
     _injector.injectAll(spots);
     return spots;
+  }
+
+  ConstraintSet _expandBoards(ConstraintSet set) {
+    final constraintKey = 'boardConstraints';
+    if (!set.overrides.containsKey(constraintKey)) {
+      return set;
+    }
+    final overrides = Map<String, List<dynamic>>.from(set.overrides);
+    final constraintValues = overrides.remove(constraintKey)!;
+    final boards = <List<String>>[];
+    for (final c in constraintValues) {
+      if (c is Map<String, dynamic>) {
+        final generated = _boardGenerator.generate(c);
+        for (final b in generated) {
+          boards.add([...b.flop, b.turn, b.river]);
+        }
+      }
+    }
+    overrides['board'] = boards;
+    return ConstraintSet(
+      boardTags: set.boardTags,
+      positions: set.positions,
+      handGroup: set.handGroup,
+      villainActions: set.villainActions,
+      targetStreet: set.targetStreet,
+      overrides: overrides,
+      tags: set.tags,
+      tagMergeMode: set.tagMergeMode,
+      metadata: set.metadata,
+      metaMergeMode: set.metaMergeMode,
+      theoryLink: set.theoryLink,
+    );
   }
 }

--- a/test/full_board_generator_test.dart
+++ b/test/full_board_generator_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/full_board_generator.dart';
+
+void main() {
+  test('generates boards matching constraints', () {
+    const generator = FullBoardGenerator();
+    final boards = generator.generate({
+      'paired': true,
+      'aceHigh': true,
+      'rainbow': true,
+      'drawy': true,
+      'requiredRanks': ['A', 'K'],
+      'requiredSuits': ['♠', '♥', '♦'],
+    });
+    // There should be exactly 6 flops matching these filters.
+    // Each flop has 1176 turn/river combinations.
+    expect(boards.length, 6 * 1176);
+    // Ensure uniqueness
+    final unique = {
+      for (final b in boards) [...b.flop, b.turn, b.river].join(' ')
+    };
+    expect(unique.length, boards.length);
+  });
+}

--- a/test/training_pack_template_expander_full_board_test.dart
+++ b/test/training_pack_template_expander_full_board_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/training_pack_template_expander_service.dart';
+
+void main() {
+  test('expands board constraints into full boards', () {
+    final base = TrainingPackSpot(id: 'base');
+    final variation = ConstraintSet(
+      overrides: {
+        'boardConstraints': [
+          {
+            'paired': true,
+            'aceHigh': true,
+            'rainbow': true,
+            'drawy': true,
+            'requiredRanks': ['A', 'K'],
+            'requiredSuits': ['♠', '♥', '♦'],
+          }
+        ]
+      },
+    );
+    final set = TrainingPackTemplateSet(baseSpot: base, variations: [variation]);
+    final svc = TrainingPackTemplateExpanderService();
+    final spots = svc.expand(set);
+    // Should expand to all generated boards.
+    expect(spots.length, 6 * 1176);
+    // Each spot's board should have five cards.
+    expect(spots.every((s) => s.board.length == 5), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoardStages model and FullBoardGenerator service for enumerating full board runouts based on constraints
- integrate generator into TrainingPackTemplateExpanderService to expand board constraints
- cover generator and service integration with tests

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fea4a76ac832ab51cbb002af68a3c