### PR TITLE
feat: centralize app constants

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -1,0 +1,16 @@
+class AppConstants {
+  static const double defaultPadding = 16.0;
+  static const Duration fadeDuration = Duration(milliseconds: 300);
+  static const double cardCornerRadius = 8.0;
+
+  // Font sizes
+  static const double fontSize12 = 12.0;
+  static const double fontSize14 = 14.0;
+  static const double fontSize16 = 16.0;
+  static const double fontSize18 = 18.0;
+  static const double fontSize20 = 20.0;
+
+  // Preference keys
+  static const String prefsThemeMode = 'theme_mode';
+  static const String prefsAccentColor = 'accent_color';
+}

--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -28,6 +28,7 @@ import '../widgets/next_steps_modal.dart';
 import '../widgets/stage_progress_chip.dart';
 import '../widgets/stage_preview_dialog.dart';
 import '../widgets/stage_completed_dialog.dart';
+import '../constants/app_constants.dart';
 
 /// Displays all stages of a learning path and allows launching each pack.
 class LearningPathScreen extends StatefulWidget {
@@ -373,7 +374,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     _scrollDone = true;
     Scrollable.ensureVisible(
       context,
-      duration: const Duration(milliseconds: 300),
+      duration: AppConstants.fadeDuration,
     );
   }
 
@@ -401,7 +402,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     _scrollDone = true;
     _scrollController.animateTo(
       offset,
-      duration: const Duration(milliseconds: 300),
+      duration: AppConstants.fadeDuration,
       curve: Curves.easeInOut,
     );
   }
@@ -414,9 +415,11 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
   ) {
     final progress = total == 0 ? 0.0 : done / total;
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      margin: const EdgeInsets.symmetric(
+          horizontal: AppConstants.defaultPadding,
+          vertical: AppConstants.defaultPadding / 2),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(AppConstants.defaultPadding),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -536,7 +539,9 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
     final key = _stageKeys.putIfAbsent(stage.id, () => GlobalKey());
     return Card(
       key: key,
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      margin: const EdgeInsets.symmetric(
+          horizontal: AppConstants.defaultPadding,
+          vertical: AppConstants.defaultPadding / 2 - 2),
       shape: border,
       color: highlight
           ? Colors.amber.withOpacity(0.2)
@@ -612,10 +617,10 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
       });
     } else {
       hud = AnimatedContainer(
-        duration: const Duration(milliseconds: 300),
+        duration: AppConstants.fadeDuration,
         height: _hudVisible ? _hudHeight! : 0,
         child: AnimatedOpacity(
-          duration: const Duration(milliseconds: 300),
+          duration: AppConstants.fadeDuration,
           opacity: _hudVisible ? 1 : 0,
           child: hud,
         ),
@@ -705,7 +710,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
                             _buildStageTile(template.stages[i], i),
                           if (tags.isNotEmpty)
                             Padding(
-                              padding: const EdgeInsets.all(16),
+                              padding: const EdgeInsets.all(AppConstants.defaultPadding),
                               child: Wrap(
                                 spacing: 8,
                                 children: [

--- a/lib/screens/learning_path_week_planner_screen.dart
+++ b/lib/screens/learning_path_week_planner_screen.dart
@@ -16,6 +16,7 @@ import '../widgets/learning_path_stage_progress_card.dart';
 import '../widgets/tag_badge.dart';
 import 'learning_path_stage_preview_screen.dart';
 import 'training_pack_preview_screen.dart';
+import '../constants/app_constants.dart';
 
 class LearningPathWeekPlannerScreen extends StatefulWidget {
   const LearningPathWeekPlannerScreen({super.key});
@@ -159,7 +160,7 @@ class _LearningPathWeekPlannerScreenState
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : ListView(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(AppConstants.defaultPadding),
               children: [
                 ValueListenableBuilder<double>(
                   valueListenable: _overallProgress,
@@ -171,7 +172,7 @@ class _LearningPathWeekPlannerScreenState
                       children: [
                         TweenAnimationBuilder<double>(
                           tween: Tween<double>(begin: 0, end: value.clamp(0.0, 1.0)),
-                          duration: const Duration(milliseconds: 300),
+                          duration: AppConstants.fadeDuration,
                           builder: (context, val, __) {
                             return ClipRRect(
                               borderRadius: BorderRadius.circular(4),

--- a/lib/screens/mistake_overview_screen.dart
+++ b/lib/screens/mistake_overview_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../services/ignored_mistake_service.dart';
 
 import 'tag_mistake_overview_screen.dart';

--- a/lib/screens/my_achievements_screen.dart
+++ b/lib/screens/my_achievements_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../utils/responsive.dart';
+import '../constants/app_constants.dart';
 
 import '../services/goals_service.dart';
 import '../widgets/sync_status_widget.dart';
@@ -33,7 +34,7 @@ class MyAchievementsScreen extends StatelessWidget {
             builder: (context, constraints) {
               final compact = constraints.maxWidth < 360;
               return GridView.builder(
-                padding: responsiveAll(context, 16),
+                padding: responsiveAll(context, AppConstants.defaultPadding),
                 itemCount: completed.length,
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: compact ? 1 : 2,
@@ -44,10 +45,10 @@ class MyAchievementsScreen extends StatelessWidget {
                 itemBuilder: (context, index) {
                   final item = completed[index];
                   return Container(
-                    padding: responsiveAll(context, 12),
+                    padding: responsiveAll(context, AppConstants.defaultPadding * 0.75),
                     decoration: BoxDecoration(
                       color: Colors.grey[850],
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: BorderRadius.circular(AppConstants.cardCornerRadius),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/position_mistake_overview_screen.dart
+++ b/lib/screens/position_mistake_overview_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/mistake_summary_section.dart';
 import '../widgets/mistake_empty_state.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
+import '../constants/app_constants.dart';
 
 /// Displays a list of hero positions sorted by mistake count.
 ///
@@ -176,13 +177,18 @@ class _PositionMistakeOverviewScreenState extends State<PositionMistakeOverviewS
           ],
         ),
         SliverPadding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(AppConstants.defaultPadding),
           sliver: SliverToBoxAdapter(
             child: MistakeSummarySection(summary: summary),
           ),
         ),
         SliverPadding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          padding: const EdgeInsets.fromLTRB(
+            AppConstants.defaultPadding,
+            0,
+            AppConstants.defaultPadding,
+            AppConstants.defaultPadding / 2,
+          ),
           sliver: SliverToBoxAdapter(
             child: Align(
               alignment: Alignment.centerRight,
@@ -211,7 +217,7 @@ class _PositionMistakeOverviewScreenState extends State<PositionMistakeOverviewS
           )
         else
           SliverPadding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(AppConstants.defaultPadding),
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate(
                 (context, index) {

--- a/lib/screens/saved_hand_history_screen.dart
+++ b/lib/screens/saved_hand_history_screen.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/saved_hand.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';

--- a/lib/screens/saved_hands_screen.dart
+++ b/lib/screens/saved_hands_screen.dart
@@ -8,7 +8,7 @@ import '../services/saved_hand_stats_service.dart';
 import '../services/saved_hand_export_service.dart';
 import '../services/saved_hand_import_export_service.dart';
 import 'package:share_plus/share_plus.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../widgets/saved_hand_list_view.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../helpers/poker_street_helper.dart';

--- a/lib/screens/session_analysis_screen.dart
+++ b/lib/screens/session_analysis_screen.dart
@@ -17,7 +17,7 @@ import 'session_replay_screen.dart';
 import '../widgets/common/animated_line_chart.dart';
 import '../theme/app_colors.dart';
 import '../utils/responsive.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../services/session_note_service.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';

--- a/lib/screens/session_hands_screen.dart
+++ b/lib/screens/session_hands_screen.dart
@@ -13,7 +13,7 @@ import '../services/session_manager.dart';
 import '../widgets/saved_hand_tile.dart';
 import '../helpers/date_utils.dart';
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../widgets/saved_hand_viewer_dialog.dart';
 import '../widgets/sync_status_widget.dart';
 

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 
 class ThemeService extends ChangeNotifier {
-  static const _key = 'theme_mode';
-  static const _accentKey = 'accent_color';
   ThemeMode _mode = ThemeMode.dark;
   Color _accent = AppColors.accent;
 
@@ -60,13 +58,14 @@ class ThemeService extends ChangeNotifier {
 
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
-    final name = prefs.getString(_key);
+    final name = prefs.getString(AppConstants.prefsThemeMode);
     if (name == ThemeMode.light.name) {
       _mode = ThemeMode.light;
     } else {
       _mode = ThemeMode.dark;
     }
-    _accent = Color(prefs.getInt(_accentKey) ?? AppColors.accent.value);
+    _accent =
+        Color(prefs.getInt(AppConstants.prefsAccentColor) ?? AppColors.accent.value);
     AppColors.accent = _accent;
     notifyListeners();
   }
@@ -74,7 +73,7 @@ class ThemeService extends ChangeNotifier {
   Future<void> toggle() async {
     _mode = _mode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, _mode.name);
+    await prefs.setString(AppConstants.prefsThemeMode, _mode.name);
     notifyListeners();
   }
 
@@ -83,7 +82,7 @@ class ThemeService extends ChangeNotifier {
     _accent = color;
     AppColors.accent = color;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_accentKey, color.value);
+    await prefs.setInt(AppConstants.prefsAccentColor, color.value);
     notifyListeners();
   }
 }

--- a/lib/theme/constants.dart
+++ b/lib/theme/constants.dart
@@ -1,9 +1,0 @@
-class AppConstants {
-  static const double padding16 = 16.0;
-  static const double radius8 = 8.0;
-  static const double fontSize14 = 14.0;
-  static const double fontSize16 = 16.0;
-  static const double fontSize20 = 20.0;
-  static const double fontSize12 = 12.0;
-  static const double fontSize18 = 18.0;
-}

--- a/lib/widgets/bet_chips_on_table.dart
+++ b/lib/widgets/bet_chips_on_table.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'chip_trail.dart';
+import '../constants/app_constants.dart';
 
 /// Displays a small row of chips on the table along the betting trail.
 class BetChipsOnTable extends StatelessWidget {
@@ -53,8 +54,9 @@ class BetChipsOnTable extends StatelessWidget {
             child: Transform.rotate(
               angle: angle,
               child: AnimatedSwitcher(
-                duration:
-                    animate ? const Duration(milliseconds: 300) : Duration.zero,
+                duration: animate
+                    ? AppConstants.fadeDuration
+                    : Duration.zero,
                 transitionBuilder: (child, animation) => FadeTransition(
                   opacity: animation,
                   child: ScaleTransition(scale: animation, child: child),

--- a/lib/widgets/mistake_summary_card.dart
+++ b/lib/widgets/mistake_summary_card.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import '../helpers/poker_street_helper.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 
 class MistakeSummaryCard extends StatelessWidget {
   const MistakeSummaryCard({super.key});

--- a/lib/widgets/mistake_summary_section.dart
+++ b/lib/widgets/mistake_summary_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_colors.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../models/summary_result.dart';
 
 class MistakeSummarySection extends StatelessWidget {

--- a/lib/widgets/saved_hand_list_view.dart
+++ b/lib/widgets/saved_hand_list_view.dart
@@ -10,7 +10,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/saved_hand.dart';
-import '../theme/constants.dart';
+import '../constants/app_constants.dart';
 import '../services/evaluation_executor_service.dart';
 import '../helpers/mistake_advice.dart';
 import 'saved_hand_tile.dart';

--- a/lib/widgets/streak_widget.dart
+++ b/lib/widgets/streak_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/streak_service.dart';
+import '../constants/app_constants.dart';
 
 class StreakWidget extends StatefulWidget {
   const StreakWidget({super.key});
@@ -46,7 +47,7 @@ class _StreakWidgetState extends State<StreakWidget>
         final accent = Theme.of(context).colorScheme.secondary;
         return AnimatedOpacity(
           opacity: value > 0 ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 300),
+          duration: AppConstants.fadeDuration,
           child: AnimatedBuilder(
             animation: _scale,
             builder: (context, child) => AnimatedScale(


### PR DESCRIPTION
## Summary
- centralize shared configuration in new `AppConstants`
- replace hardcoded padding, durations, radius and pref keys with constants across screens, widgets and services
- remove obsolete `theme/constants.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f98fb5e5c832aacc5927c4384cbf2