### PR TITLE
feat: add app info service

### DIFF
--- a/lib/providers/core_providers.dart
+++ b/lib/providers/core_providers.dart
@@ -6,6 +6,7 @@ import '../services/remote_config_service.dart';
 import '../services/ab_test_engine.dart';
 import '../services/theme_service.dart';
 import '../services/cloud_sync_service.dart';
+import '../services/app_info_service.dart';
 import '../widgets/player_zone_widget.dart';
 import 'provider_globals.dart';
 import '../utils/loadable_extension.dart';
@@ -19,5 +20,6 @@ List<SingleChildWidget> buildCoreProviders(CloudSyncService cloud) {
     ChangeNotifierProvider(create: (_) => ThemeService()..init()),
     Provider<CloudSyncService>.value(value: cloud),
     Provider(create: (_) => PlayerZoneRegistry()),
+    Provider(create: (_) => AppInfoService()),
   ];
 }

--- a/lib/services/app_info_service.dart
+++ b/lib/services/app_info_service.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Provides metadata about the application such as version and build mode.
+class AppInfoService {
+  /// Returns the application version obtained from the underlying platform.
+  Future<String> getAppVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    return info.version;
+  }
+
+  /// Whether the app is running in debug mode.
+  bool isDebugMode() => !kReleaseMode;
+
+  /// Whether the app is running in release mode.
+  bool isReleaseMode() => kReleaseMode;
+}
+


### PR DESCRIPTION
## Summary
- add AppInfoService for version and build mode metadata
- register AppInfoService through provider injection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f990cdcc8832a9a0d1715c5a8c744