### PR TITLE
feat: add pattern-based line graph engine

### DIFF
--- a/lib/models/line_graph_result.dart
+++ b/lib/models/line_graph_result.dart
@@ -1,0 +1,23 @@
+class HandActionNode {
+  final String actor;
+  final String action;
+  final List<HandActionNode> next;
+
+  HandActionNode({
+    required this.actor,
+    required this.action,
+    List<HandActionNode>? next,
+  }) : next = next ?? [];
+}
+
+class LineGraphResult {
+  final String heroPosition;
+  final Map<String, List<HandActionNode>> streets;
+  final List<String> tags;
+
+  LineGraphResult({
+    required this.heroPosition,
+    required this.streets,
+    required this.tags,
+  });
+}

--- a/lib/models/line_pattern.dart
+++ b/lib/models/line_pattern.dart
@@ -1,0 +1,13 @@
+class LinePattern {
+  final Map<String, List<String>> streets;
+  final String? startingPosition;
+  final String? boardTexture;
+  final String? potType;
+
+  LinePattern({
+    required this.streets,
+    this.startingPosition,
+    this.boardTexture,
+    this.potType,
+  });
+}

--- a/test/line_graph_engine_test.dart
+++ b/test/line_graph_engine_test.dart
@@ -1,28 +1,24 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/services/line_graph_engine.dart';
-import 'package:poker_analyzer/models/spot_seed_format.dart';
-import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/line_pattern.dart';
 
 void main() {
-  test('build extracts normalized actions by street', () {
-    final seed = SpotSeedFormat(
-      player: 'hero',
-      handGroup: const ['broadways'],
-      position: 'btn',
-      board: [
-        CardModel(rank: '2', suit: 'h'),
-        CardModel(rank: '2', suit: 'c'),
-        CardModel(rank: '9', suit: 'd'),
-      ],
-      villainActions: const ['bet 50', 'call'],
+  test('build creates multi-street hand line from pattern', () {
+    final pattern = LinePattern(
+      startingPosition: 'btn',
+      streets: {
+        'flop': ['cbet'],
+        'turn': ['check'],
+        'river': ['shove'],
+      },
     );
+
     final engine = const LineGraphEngine();
-    final graph = engine.build(seed);
-    expect(graph.heroPosition, 'btn');
-    expect(graph.streets.length, 1);
-    final street = graph.streets.first;
-    expect(street.street, 'flop');
-    expect(street.actions.map((a) => a.action).toList(), ['bet', 'call']);
-    expect(street.actions.every((a) => a.position == 'villain'), isTrue);
+    final result = engine.build(pattern);
+
+    expect(result.heroPosition, 'btn');
+    expect(result.streets.length, 3);
+    expect(result.streets['flop']!.first.action, 'cbet');
+    expect(result.tags, containsAll(['flopCbet', 'turnCheck', 'riverShove']));
   });
 }


### PR DESCRIPTION
## Summary
- implement line graph engine that builds multi-street action sequences from patterns
- define LinePattern, HandActionNode, and LineGraphResult models
- cover engine with a unit test

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688ff28f2208832abed52446997b1369