### PR TITLE
feat: link inline theory to action nodes

### DIFF
--- a/lib/models/inline_theory_entry.dart
+++ b/lib/models/inline_theory_entry.dart
@@ -1,0 +1,9 @@
+class InlineTheoryEntry {
+  final String tag;
+  final String htmlSnippet;
+
+  const InlineTheoryEntry({
+    required this.tag,
+    required this.htmlSnippet,
+  });
+}

--- a/lib/models/line_graph_result.dart
+++ b/lib/models/line_graph_result.dart
@@ -1,12 +1,18 @@
+import 'inline_theory_entry.dart';
+
 class HandActionNode {
   final String actor;
   final String action;
+  final String? tag;
   final List<HandActionNode> next;
+  InlineTheoryEntry? theory;
 
   HandActionNode({
     required this.actor,
     required this.action,
+    this.tag,
     List<HandActionNode>? next,
+    this.theory,
   }) : next = next ?? [];
 }
 

--- a/lib/services/inline_theory_node_linker.dart
+++ b/lib/services/inline_theory_node_linker.dart
@@ -1,0 +1,44 @@
+import '../models/inline_theory_entry.dart';
+import '../models/line_graph_result.dart';
+
+class InlineTheoryNodeLinker {
+  const InlineTheoryNodeLinker();
+
+  LineGraphResult link(
+    LineGraphResult result,
+    Map<String, InlineTheoryEntry> theoryIndex,
+  ) {
+    for (final streetNodes in result.streets.values) {
+      for (final node in streetNodes) {
+        _attachTheory(node, theoryIndex);
+      }
+    }
+    return result;
+  }
+
+  void _attachTheory(
+    HandActionNode node,
+    Map<String, InlineTheoryEntry> theoryIndex,
+  ) {
+    final tag = node.tag;
+    if (tag != null) {
+      final entry = _findTheory(tag, theoryIndex);
+      if (entry != null) {
+        node.theory = entry;
+      }
+    }
+    for (final child in node.next) {
+      _attachTheory(child, theoryIndex);
+    }
+  }
+
+  InlineTheoryEntry? _findTheory(
+    String tag,
+    Map<String, InlineTheoryEntry> index,
+  ) {
+    if (index.containsKey(tag)) return index[tag];
+    final street = tag.replaceAll(RegExp(r'[A-Z].*'), '');
+    if (street != tag && index.containsKey(street)) return index[street];
+    return index['global'];
+  }
+}

--- a/lib/services/line_graph_engine.dart
+++ b/lib/services/line_graph_engine.dart
@@ -12,8 +12,9 @@ class LineGraphEngine {
       final nodes = <HandActionNode>[];
       for (final act in actions) {
         final actor = _inferActor(act);
-        nodes.add(HandActionNode(actor: actor, action: act));
-        tags.add('${street}${_capitalize(act)}');
+        final tag = '${street}${_capitalize(act)}';
+        nodes.add(HandActionNode(actor: actor, action: act, tag: tag));
+        tags.add(tag);
       }
       streets[street] = nodes;
     });

--- a/test/inline_theory_node_linker_test.dart
+++ b/test/inline_theory_node_linker_test.dart
@@ -1,0 +1,58 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/line_graph_result.dart';
+import 'package:poker_analyzer/models/inline_theory_entry.dart';
+import 'package:poker_analyzer/services/inline_theory_node_linker.dart';
+
+void main() {
+  test('links theory entry to matching action tag', () {
+    final node = HandActionNode(
+      actor: 'hero',
+      action: 'cbet',
+      tag: 'flopCbet',
+    );
+    final result = LineGraphResult(
+      heroPosition: 'btn',
+      streets: {'flop': [node]},
+      tags: ['flopCbet'],
+    );
+
+    const linker = InlineTheoryNodeLinker();
+    final theoryMap = {
+      'flopCbet': const InlineTheoryEntry(
+        tag: 'flopCbet',
+        htmlSnippet: '<p>C-bet theory</p>',
+      ),
+    };
+
+    linker.link(result, theoryMap);
+
+    expect(node.theory, isNotNull);
+    expect(node.theory!.htmlSnippet, contains('C-bet'));
+  });
+
+  test('falls back to street-level theory when exact tag missing', () {
+    final node = HandActionNode(
+      actor: 'hero',
+      action: 'call',
+      tag: 'riverCall',
+    );
+    final result = LineGraphResult(
+      heroPosition: 'bb',
+      streets: {'river': [node]},
+      tags: ['riverCall'],
+    );
+
+    const linker = InlineTheoryNodeLinker();
+    final theoryMap = {
+      'river': const InlineTheoryEntry(
+        tag: 'river',
+        htmlSnippet: '<p>River theory</p>',
+      ),
+    };
+
+    linker.link(result, theoryMap);
+
+    expect(node.theory, isNotNull);
+    expect(node.theory!.htmlSnippet, contains('River theory'));
+  });
+}


### PR DESCRIPTION
## Summary
- add model for inline theory snippets
- tag hand action nodes and build helper to attach theory entries
- cover theory linking with unit tests

## Testing
- `flutter test test/inline_theory_node_linker_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff3ce3c6c832a934e63558d3e37fd