### PR TITLE
feat: precompile training pack templates

### DIFF
--- a/lib/services/precompiled_pack_cache_generator.dart
+++ b/lib/services/precompiled_pack_cache_generator.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+import '../utils/training_pack_yaml_codec_v2.dart';
+import 'training_pack_template_service.dart';
+
+/// Generates precompiled training packs and stores them as YAML files
+/// under `assets/precompiled_packs/`.
+class PrecompiledPackCacheGenerator {
+  const PrecompiledPackCacheGenerator();
+
+  /// Generates YAML files for all available [TrainingPackTemplate]s.
+  Future<void> generateAll() async {
+    final templates = TrainingPackTemplateService.getAllTemplates();
+    final dir = Directory('assets/precompiled_packs');
+    await dir.create(recursive: true);
+    const codec = TrainingPackYamlCodecV2();
+
+    for (final tpl in templates) {
+      try {
+        final spots = await tpl.generateSpots();
+        final expanded = tpl.copyWith({
+          'spots': spots,
+          'spotCount': spots.length,
+        });
+        final v2 = TrainingPackTemplateV2.fromTemplate(
+          expanded,
+          type: TrainingType.pushFold,
+        );
+        v2.trainingType = const TrainingTypeEngine().detectTrainingType(v2);
+        final yaml = codec.encode(v2);
+        final file = File('${dir.path}/${tpl.id}.yaml');
+        await file.writeAsString(yaml);
+      } catch (_) {
+        // Ignore failures for individual templates.
+      }
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -142,6 +142,7 @@ flutter:
     - assets/images/
     - assets/skills/cash/
     - assets/paths/
+    - assets/precompiled_packs/
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo


### PR DESCRIPTION
## Summary
- add generator for precompiled training packs
- register precompiled pack assets path

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff511c7a4832a99e16e4d2e849fd9