### PR TITLE
chore: remove unused images directory

### DIFF
--- a/CLEANUP_CANDIDATES.md
+++ b/CLEANUP_CANDIDATES.md
@@ -12,7 +12,6 @@ This document lists files and directories that appear unused in production code 
 - `flutter_08.png` — not referenced anywhere in the repository.
 - `flutter_09.png` — not referenced anywhere in the repository.
 - `flutter_11.png` — not referenced anywhere in the repository.
-- `assets/images/` — empty directory; no referenced images.
 
 ## Mocks / Test Data
 - `tool/example_spots/btn_10bb.json` — sample spot file not referenced in production code.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -139,7 +139,6 @@ flutter:
     - assets/learning_tracks/
     - assets/learning_path_tracks.yaml
     - assets/animations/congrats.json
-    - assets/images/
     - assets/skills/cash/
     - assets/paths/
 


### PR DESCRIPTION
## Summary
- remove empty `assets/images` directory
- drop `assets/images/` from `pubspec.yaml`
- tidy cleanup candidates doc

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: Unsupported value for "targets" in build.yaml)*
- `flutter test` *(fails: syntax error in learning_path_promoter_test.dart)*

------
https://chatgpt.com/codex/tasks/task_e_688ff61c142c832ab4bf56902e062b64