### PR TITLE
feat: add training pack template set generator

### DIFF
--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -14,10 +14,30 @@ class TrainingPackTemplateSet {
   /// and additional tagging/metadata rules.
   final List<ConstraintSet> variations;
 
+  /// Optional player type variants to apply to generated templates.
+  ///
+  /// Each entry is written to `spot.meta['playerType']` for the resulting
+  /// templates. When empty, the base player type is preserved.
+  final List<String> playerTypeVariations;
+
+  /// When `true` an additional template with the hero cards' suits toggled
+  /// (suited ↔ offsuit) is produced for every generated spot.
+  final bool suitAlternation;
+
+  /// Relative adjustments in big blinds applied to the hero stack depth and the
+  /// template's `bb` value. A template is generated for each offset in this
+  /// list. When empty, the original stack depth is used.
+  final List<int> stackDepthMods;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
-  }) : variations = variations ?? const [];
+    List<String>? playerTypeVariations,
+    this.suitAlternation = false,
+    List<int>? stackDepthMods,
+  })  : variations = variations ?? const [],
+        playerTypeVariations = playerTypeVariations ?? const [],
+        stackDepthMods = stackDepthMods ?? const [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     final baseMap = Map<String, dynamic>.from(
@@ -28,7 +48,22 @@ class TrainingPackTemplateSet {
       for (final v in (json['variations'] as List? ?? []))
         ConstraintSet.fromJson(Map<String, dynamic>.from(v as Map)),
     ];
-    return TrainingPackTemplateSet(baseSpot: base, variations: vars);
+    final pTypes = <String>[
+      for (final t in (json['playerTypeVariations'] as List? ?? []))
+        t.toString(),
+    ];
+    final suitAlt = json['suitAlternation'] == true;
+    final depthMods = <int>[
+      for (final m in (json['stackDepthMods'] as List? ?? []))
+        (m as num).toInt(),
+    ];
+    return TrainingPackTemplateSet(
+      baseSpot: base,
+      variations: vars,
+      playerTypeVariations: pTypes,
+      suitAlternation: suitAlt,
+      stackDepthMods: depthMods,
+    );
   }
 
   factory TrainingPackTemplateSet.fromYaml(String yaml) {
@@ -40,6 +75,10 @@ class TrainingPackTemplateSet {
         'baseSpot': baseSpot.toJson(),
         if (variations.isNotEmpty)
           'variations': [for (final v in variations) v.toJson()],
+        if (playerTypeVariations.isNotEmpty)
+          'playerTypeVariations': playerTypeVariations,
+        if (suitAlternation) 'suitAlternation': true,
+        if (stackDepthMods.isNotEmpty) 'stackDepthMods': stackDepthMods,
       };
 }
 

--- a/lib/services/training_pack_template_variation_generator.dart
+++ b/lib/services/training_pack_template_variation_generator.dart
@@ -1,0 +1,118 @@
+// Generates multiple TrainingPackTemplateV2 objects from a base template
+// and a [TrainingPackTemplateSet] describing variation rules.
+import '../models/training_pack_template_set.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_template_expander_service.dart';
+
+class TrainingPackTemplateSetGenerator {
+  final TrainingPackTemplateExpanderService _expander;
+
+  TrainingPackTemplateSetGenerator({
+    TrainingPackTemplateExpanderService? expander,
+  }) : _expander = expander ?? TrainingPackTemplateExpanderService();
+
+  /// Generates pack templates based on [base] and variation rules in [set].
+  ///
+  /// The generator expands [set] into concrete [TrainingPackSpot]s and then
+  /// applies player type, suit and stack depth variations. Each resulting spot
+  /// is wrapped into a copy of [base] producing a distinct
+  /// [TrainingPackTemplateV2].
+  List<TrainingPackTemplateV2> generate({
+    required TrainingPackTemplateV2 base,
+    required TrainingPackTemplateSet set,
+  }) {
+    final expandedSpots = _expander.expand(set);
+    final templates = <TrainingPackTemplateV2>[];
+    var counter = 0;
+    for (final spot in expandedSpots) {
+      final playerTypes = set.playerTypeVariations.isNotEmpty
+          ? set.playerTypeVariations
+          : <String?>[null];
+      final stackMods = set.stackDepthMods.isNotEmpty
+          ? set.stackDepthMods
+          : <int>[0];
+      final suitFlags = set.suitAlternation ? [false, true] : [false];
+
+      for (final pt in playerTypes) {
+        for (final mod in stackMods) {
+          for (final suit in suitFlags) {
+            final newSpot = TrainingPackSpot.fromJson(spot.toJson());
+            if (pt != null) {
+              newSpot.meta['playerType'] = pt;
+            }
+            if (mod != 0) {
+              final current = newSpot.hand.stacks['0'] ?? base.bb.toDouble();
+              newSpot.hand.stacks = {
+                ...newSpot.hand.stacks,
+                '0': current + mod,
+              };
+            }
+            if (suit) {
+              newSpot.hand.heroCards = _alternateSuits(newSpot.hand.heroCards);
+            }
+
+            templates.add(_cloneBase(base,
+                idSuffix: counter++, spot: newSpot, stackMod: mod));
+          }
+        }
+      }
+    }
+    return templates;
+  }
+
+  TrainingPackTemplateV2 _cloneBase(
+    TrainingPackTemplateV2 base, {
+    required int idSuffix,
+    required TrainingPackSpot spot,
+    required int stackMod,
+  }) {
+    return TrainingPackTemplateV2(
+      id: '${base.id}_$idSuffix',
+      name: base.name,
+      description: base.description,
+      goal: base.goal,
+      audience: base.audience,
+      theme: base.theme,
+      tags: List<String>.from(base.tags),
+      category: base.category,
+      trainingType: base.trainingType,
+      spots: [spot],
+      spotCount: 1,
+      dynamicSpots: const [],
+      created: base.created,
+      gameType: base.gameType,
+      bb: base.bb + stackMod,
+      positions: List<String>.from(base.positions),
+      meta: Map<String, dynamic>.from(base.meta),
+      recommended: base.recommended,
+      requiresTheoryCompleted: base.requiresTheoryCompleted,
+      targetStreet: base.targetStreet,
+      unlockRules: base.unlockRules,
+      requiredAccuracy: base.requiredAccuracy,
+      minHands: base.minHands,
+      isGeneratedPack: true,
+      isSampledPack: base.isSampledPack,
+    );
+  }
+
+  String _alternateSuits(String cards) {
+    final parts = cards.trim().split(RegExp(r'\s+'));
+    if (parts.length < 2) return cards;
+    final c1 = parts[0];
+    var c2 = parts[1];
+    if (c1.length < 2 || c2.length < 2) return cards;
+    final s1 = c1.substring(1, 2);
+    final s2 = c2.substring(1, 2);
+    const suits = ['s', 'h', 'd', 'c'];
+    if (s1 == s2) {
+      // Make offsuit by picking any suit different from the first.
+      final alt = suits.firstWhere((s) => s != s1, orElse: () => s1);
+      c2 = c2[0] + alt;
+    } else {
+      // Make suited by copying the first suit.
+      c2 = c2[0] + s1;
+    }
+    return '$c1 $c2';
+  }
+}

--- a/test/services/training_pack_template_set_generator_test.dart
+++ b/test/services/training_pack_template_set_generator_test.dart
@@ -1,0 +1,64 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/services/training_pack_template_variation_generator.dart';
+
+void main() {
+  test('generator produces distinct template variations', () {
+    final baseSpot = TrainingPackSpot(
+      id: 's1',
+      hand: HandData(
+        heroCards: 'As Ks',
+        position: HeroPosition.btn,
+        stacks: {'0': 20.0, '1': 20.0},
+        playerCount: 2,
+      ),
+    );
+
+    final set = TrainingPackTemplateSet(
+      baseSpot: baseSpot,
+      playerTypeVariations: const ['reg', 'fish'],
+      suitAlternation: true,
+      stackDepthMods: const [1, -1],
+    );
+
+    final baseTemplate = TrainingPackTemplateV2(
+      id: 'tpl',
+      name: 'Base',
+      trainingType: TrainingType.pushFold,
+      spots: [],
+      spotCount: 0,
+      dynamicSpots: const [],
+      gameType: GameType.cash,
+      bb: 20,
+      positions: const ['btn'],
+    );
+
+    final gen = TrainingPackTemplateSetGenerator();
+    final templates = gen.generate(base: baseTemplate, set: set);
+
+    expect(templates, hasLength(8));
+    // Unique ids
+    expect(templates.map((t) => t.id).toSet().length, 8);
+
+    // Stack depth mods applied
+    final bbValues = templates.map((t) => t.bb).toSet();
+    expect(bbValues, {21, 19});
+
+    // Player type variations
+    final pTypes =
+        templates.map((t) => t.spots.first.meta['playerType']).toSet();
+    expect(pTypes, {'reg', 'fish'});
+
+    // Suit alternation
+    final heroCards =
+        templates.map((t) => t.spots.first.hand.heroCards).toSet();
+    expect(heroCards, {'As Ks', 'As Kh'});
+  });
+}


### PR DESCRIPTION
## Summary
- extend TrainingPackTemplateSet with variation rules for player types, suit swaps, and stack depth adjustments
- add TrainingPackTemplateSetGenerator to build pack variations from a base template
- cover generator with tests

## Testing
- `dart format lib/models/training_pack_template_set.dart lib/services/training_pack_template_variation_generator.dart test/services/training_pack_template_set_generator_test.dart` (fails: command not found)
- `dart test` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_688ff518e418832ab3f913debef1d7fc