### PR TITLE
feat: support line patterns in template expansion

### DIFF
--- a/lib/models/line_pattern.dart
+++ b/lib/models/line_pattern.dart
@@ -10,4 +10,28 @@ class LinePattern {
     this.boardTexture,
     this.potType,
   });
+
+  factory LinePattern.fromJson(Map<String, dynamic> json) {
+    final streets = <String, List<String>>{};
+    if (json['streets'] is Map) {
+      (json['streets'] as Map).forEach((key, value) {
+        streets[key.toString()] = [
+          for (final v in (value as List? ?? [])) v.toString(),
+        ];
+      });
+    }
+    return LinePattern(
+      streets: streets,
+      startingPosition: json['startingPosition']?.toString(),
+      boardTexture: json['boardTexture']?.toString(),
+      potType: json['potType']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'streets': streets,
+    if (startingPosition != null) 'startingPosition': startingPosition,
+    if (boardTexture != null) 'boardTexture': boardTexture,
+    if (potType != null) 'potType': potType,
+  };
 }

--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -3,6 +3,7 @@ import 'package:yaml/yaml.dart';
 import '../utils/yaml_utils.dart';
 import 'constraint_set.dart';
 import 'v2/training_pack_spot.dart';
+import 'line_pattern.dart';
 
 /// Defines a base spot and a list of variation rules that can be expanded
 /// into multiple [TrainingPackSpot]s.
@@ -14,10 +15,15 @@ class TrainingPackTemplateSet {
   /// and additional tagging/metadata rules.
   final List<ConstraintSet> variations;
 
+  /// Optional structured action sequences to generate additional line data.
+  final List<LinePattern> linePatterns;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
-  }) : variations = variations ?? const [];
+    List<LinePattern>? linePatterns,
+  }) : variations = variations ?? const [],
+       linePatterns = linePatterns ?? const [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     final baseMap = Map<String, dynamic>.from(
@@ -28,7 +34,15 @@ class TrainingPackTemplateSet {
       for (final v in (json['variations'] as List? ?? []))
         ConstraintSet.fromJson(Map<String, dynamic>.from(v as Map)),
     ];
-    return TrainingPackTemplateSet(baseSpot: base, variations: vars);
+    final lines = <LinePattern>[
+      for (final p in (json['linePatterns'] as List? ?? []))
+        LinePattern.fromJson(Map<String, dynamic>.from(p as Map)),
+    ];
+    return TrainingPackTemplateSet(
+      baseSpot: base,
+      variations: vars,
+      linePatterns: lines,
+    );
   }
 
   factory TrainingPackTemplateSet.fromYaml(String yaml) {
@@ -37,9 +51,10 @@ class TrainingPackTemplateSet {
   }
 
   Map<String, dynamic> toJson() => {
-        'baseSpot': baseSpot.toJson(),
-        if (variations.isNotEmpty)
-          'variations': [for (final v in variations) v.toJson()],
-      };
+    'baseSpot': baseSpot.toJson(),
+    if (variations.isNotEmpty)
+      'variations': [for (final v in variations) v.toJson()],
+    if (linePatterns.isNotEmpty)
+      'linePatterns': [for (final p in linePatterns) p.toJson()],
+  };
 }
-

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -1,9 +1,14 @@
 import '../models/training_pack_template_set.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../models/constraint_set.dart';
+import '../models/line_pattern.dart';
+import '../models/spot_seed_format.dart';
+import '../models/inline_theory_entry.dart';
 import 'constraint_resolver_engine_v2.dart';
 import 'auto_spot_theory_injector_service.dart';
 import 'full_board_generator.dart';
+import 'line_graph_engine.dart';
+import 'inline_theory_node_linker.dart';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
 /// [ConstraintResolverEngine].
@@ -16,23 +21,60 @@ class TrainingPackTemplateExpanderService {
   final ConstraintResolverEngine _engine;
   final AutoSpotTheoryInjectorService _injector;
   final FullBoardGenerator _boardGenerator;
+  final LineGraphEngine _lineEngine;
+  final InlineTheoryNodeLinker _linker;
 
   TrainingPackTemplateExpanderService({
     ConstraintResolverEngine? engine,
     AutoSpotTheoryInjectorService? injector,
     FullBoardGenerator? boardGenerator,
-  })  : _engine = engine ?? const ConstraintResolverEngine(),
-        _injector = injector ?? AutoSpotTheoryInjectorService(),
-        _boardGenerator = boardGenerator ?? const FullBoardGenerator();
+    LineGraphEngine? lineEngine,
+    InlineTheoryNodeLinker? linker,
+  }) : _engine = engine ?? const ConstraintResolverEngine(),
+       _injector = injector ?? AutoSpotTheoryInjectorService(),
+       _boardGenerator = boardGenerator ?? const FullBoardGenerator(),
+       _lineEngine = lineEngine ?? const LineGraphEngine(),
+       _linker = linker ?? const InlineTheoryNodeLinker();
 
   /// Generates all spots described by [set] and injects theory links.
   List<TrainingPackSpot> expand(TrainingPackTemplateSet set) {
-    final processed = [
-      for (final v in set.variations) _expandBoards(v),
-    ];
+    final processed = [for (final v in set.variations) _expandBoards(v)];
     final spots = _engine.apply(set.baseSpot, processed);
     _injector.injectAll(spots);
     return spots;
+  }
+
+  /// Converts [set.linePatterns] into [SpotSeedFormat] sequences.
+  List<SpotSeedFormat> expandLines(
+    TrainingPackTemplateSet set, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) {
+    final seeds = <SpotSeedFormat>[];
+    for (final LinePattern p in set.linePatterns) {
+      var result = _lineEngine.build(p);
+      if (theoryIndex.isNotEmpty) {
+        result = _linker.link(result, theoryIndex);
+      }
+      final actions = <String>[];
+      for (final street in ['preflop', 'flop', 'turn', 'river']) {
+        final nodes = result.streets[street];
+        if (nodes == null) continue;
+        for (final n in nodes) {
+          if (n.actor == 'villain') {
+            actions.add(n.action);
+          }
+        }
+      }
+      seeds.add(
+        SpotSeedFormat(
+          player: 'hero',
+          handGroup: const [],
+          position: result.heroPosition,
+          villainActions: actions,
+        ),
+      );
+    }
+    return seeds;
   }
 
   ConstraintSet _expandBoards(ConstraintSet set) {

--- a/test/services/training_pack_template_expander_service_line_patterns_test.dart
+++ b/test/services/training_pack_template_expander_service_line_patterns_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/services/training_pack_template_expander_service.dart';
+
+void main() {
+  test('expandLines builds seeds from line patterns', () {
+    const yaml = '''
+baseSpot:
+  id: base
+linePatterns:
+  - startingPosition: btn
+    streets:
+      flop: [villainBet, heroCall]
+      turn: [check]
+''';
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    final svc = TrainingPackTemplateExpanderService();
+    final seeds = svc.expandLines(set);
+    expect(seeds, hasLength(1));
+    final seed = seeds.first;
+    expect(seed.position, 'btn');
+    expect(seed.villainActions, ['villainBet']);
+  });
+}


### PR DESCRIPTION
## Summary
- add JSON/serialization helpers for `LinePattern`
- allow `TrainingPackTemplateSet` to carry `linePatterns`
- extend `TrainingPackTemplateExpanderService` to generate `SpotSeedFormat` from line patterns
- cover line pattern expansion with tests

## Testing
- `flutter test` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, but it does not provide an inline implementation...)*

------
https://chatgpt.com/codex/tasks/task_e_688ff640e2a0832a904fa7d5125ed5a3