### PR TITLE
chore: automate precompiled pack generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Precompile training packs
+        run: dart tools/precompile_all_packs.dart
+
       - name: Validate training content
         run: dart tools/validate_training_content.dart --ci
       # TODO: Re-enable after packs are fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Poker Analyzer aims to be a universal tool for improving decision making at the 
 1. Install Flutter 3.0 or higher.
 2. Run `flutter pub get` to install dependencies.
 3. Run `flutter gen-l10n` to generate localization files.
-4. Launch with `flutter run`.
+4. Precompile training packs:
+
+   ```bash
+   dart tools/precompile_all_packs.dart
+   ```
+
+5. Launch with `flutter run`.
 
 ## Demo Build
 

--- a/tools/precompile_all_packs.dart
+++ b/tools/precompile_all_packs.dart
@@ -1,0 +1,5 @@
+import 'package:poker_analyzer/services/precompiled_pack_cache_generator.dart';
+
+Future<void> main() async {
+  await const PrecompiledPackCacheGenerator().generateAll();
+}


### PR DESCRIPTION
## Summary
- add script to precompile all training packs
- document how to run the precompilation script
- run precompilation during CI builds

## Testing
- `dart format tools/precompile_all_packs.dart`
- `flutter pub get` *(fails: The current Dart SDK version is 3.4.1. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0, version solving failed.)*
- `flutter test` *(fails: The current Dart SDK version is 3.4.1. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_688ff6a5f478832abe14d6d2cb45290b