### PR TITLE
chore: automate training pack precompilation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Precompile Training Packs
+        run: dart tools/precompile_all_packs.dart
+
       # Временно отключаем анализ, чтобы не мешал Codex
       # - name: Analyze
       #   run: flutter analyze

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Poker Analyzer aims to be a universal tool for improving decision making at the 
 1. Install Flutter 3.0 or higher.
 2. Run `flutter pub get` to install dependencies.
 3. Run `flutter gen-l10n` to generate localization files.
-4. Launch with `flutter run`.
+4. Precompile training packs with `dart tools/precompile_all_packs.dart`.
+5. Launch with `flutter run`.
 
 ## Demo Build
 
@@ -140,6 +141,14 @@ dart tools/validate_training_content.dart --fix
 ```
 
 Use `--ci` to exit with a non-zero code on errors.
+
+## Precompile Training Packs
+
+Regenerate the precompiled YAML packs before running the app or building a release:
+
+```bash
+dart tools/precompile_all_packs.dart
+```
 
 ## Path YAML Visualizer
 

--- a/tools/precompile_all_packs.dart
+++ b/tools/precompile_all_packs.dart
@@ -1,0 +1,5 @@
+import 'package:poker_analyzer/services/precompiled_pack_cache_generator.dart';
+
+Future<void> main() async {
+  await const PrecompiledPackCacheGenerator().generateAll();
+}


### PR DESCRIPTION
## Summary
- add precompile_all_packs.dart to generate YAML packs
- document precompile step in README
- run precompile script in CI workflow

## Testing
- `dart format tools/precompile_all_packs.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart tools/precompile_all_packs.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff9eb07b8832a95cc190faab4b785