### PR TITLE
feat: support structured line patterns for training packs

### DIFF
--- a/lib/models/line_pattern.dart
+++ b/lib/models/line_pattern.dart
@@ -10,4 +10,27 @@ class LinePattern {
     this.boardTexture,
     this.potType,
   });
+
+  factory LinePattern.fromJson(Map<String, dynamic> json) {
+    final streetMap = <String, List<String>>{};
+    final rawStreets = json['streets'] as Map? ?? const {};
+    rawStreets.forEach((key, value) {
+      streetMap[key.toString()] = [
+        for (final a in (value as List? ?? const [])) a.toString(),
+      ];
+    });
+    return LinePattern(
+      streets: streetMap,
+      startingPosition: json['startingPosition']?.toString(),
+      boardTexture: json['boardTexture']?.toString(),
+      potType: json['potType']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'streets': streets,
+    if (startingPosition != null) 'startingPosition': startingPosition,
+    if (boardTexture != null) 'boardTexture': boardTexture,
+    if (potType != null) 'potType': potType,
+  };
 }

--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -3,6 +3,7 @@ import 'package:yaml/yaml.dart';
 import '../utils/yaml_utils.dart';
 import 'constraint_set.dart';
 import 'v2/training_pack_spot.dart';
+import 'line_pattern.dart';
 
 /// Defines a base spot and a list of variation rules that can be expanded
 /// into multiple [TrainingPackSpot]s.
@@ -29,15 +30,20 @@ class TrainingPackTemplateSet {
   /// list. When empty, the original stack depth is used.
   final List<int> stackDepthMods;
 
+  /// Optional action line patterns describing multi-street sequences.
+  final List<LinePattern> linePatterns;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
     List<String>? playerTypeVariations,
     this.suitAlternation = false,
     List<int>? stackDepthMods,
-  })  : variations = variations ?? const [],
-        playerTypeVariations = playerTypeVariations ?? const [],
-        stackDepthMods = stackDepthMods ?? const [];
+    List<LinePattern>? linePatterns,
+  }) : variations = variations ?? const [],
+       playerTypeVariations = playerTypeVariations ?? const [],
+       stackDepthMods = stackDepthMods ?? const [],
+       linePatterns = linePatterns ?? const [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     final baseMap = Map<String, dynamic>.from(
@@ -57,12 +63,17 @@ class TrainingPackTemplateSet {
       for (final m in (json['stackDepthMods'] as List? ?? []))
         (m as num).toInt(),
     ];
+    final patterns = <LinePattern>[
+      for (final p in (json['linePatterns'] as List? ?? []))
+        LinePattern.fromJson(Map<String, dynamic>.from(p as Map)),
+    ];
     return TrainingPackTemplateSet(
       baseSpot: base,
       variations: vars,
       playerTypeVariations: pTypes,
       suitAlternation: suitAlt,
       stackDepthMods: depthMods,
+      linePatterns: patterns,
     );
   }
 
@@ -72,13 +83,14 @@ class TrainingPackTemplateSet {
   }
 
   Map<String, dynamic> toJson() => {
-        'baseSpot': baseSpot.toJson(),
-        if (variations.isNotEmpty)
-          'variations': [for (final v in variations) v.toJson()],
-        if (playerTypeVariations.isNotEmpty)
-          'playerTypeVariations': playerTypeVariations,
-        if (suitAlternation) 'suitAlternation': true,
-        if (stackDepthMods.isNotEmpty) 'stackDepthMods': stackDepthMods,
-      };
+    'baseSpot': baseSpot.toJson(),
+    if (variations.isNotEmpty)
+      'variations': [for (final v in variations) v.toJson()],
+    if (playerTypeVariations.isNotEmpty)
+      'playerTypeVariations': playerTypeVariations,
+    if (suitAlternation) 'suitAlternation': true,
+    if (stackDepthMods.isNotEmpty) 'stackDepthMods': stackDepthMods,
+    if (linePatterns.isNotEmpty)
+      'linePatterns': [for (final p in linePatterns) p.toJson()],
+  };
 }
-

--- a/test/services/training_pack_template_expander_line_patterns_test.dart
+++ b/test/services/training_pack_template_expander_line_patterns_test.dart
@@ -1,0 +1,29 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/line_pattern.dart';
+import 'package:poker_analyzer/services/training_pack_template_expander_service.dart';
+
+void main() {
+  test('expandLinePatterns converts patterns to spot seeds', () {
+    final base = TrainingPackSpot(id: 'base');
+    final pattern = LinePattern(
+      startingPosition: 'btn',
+      streets: {
+        'flop': ['villainBet', 'heroCall'],
+        'turn': ['villainBet'],
+      },
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      linePatterns: [pattern],
+    );
+    final svc = TrainingPackTemplateExpanderService();
+    final seeds = svc.expandLinePatterns(set);
+    expect(seeds, hasLength(1));
+    final seed = seeds.first;
+    expect(seed.position, 'btn');
+    expect(seed.villainActions, ['villainBet', 'villainBet']);
+    expect(seed.currentStreet, 'turn');
+  });
+}


### PR DESCRIPTION
## Summary
- add JSON helpers for LinePattern model
- allow TrainingPackTemplateSet to define reusable linePatterns
- expand line patterns into SpotSeedFormat sequences with LineGraphEngine

## Testing
- `dart format lib/models/line_pattern.dart lib/models/training_pack_template_set.dart lib/services/training_pack_template_expander_service.dart test/services/training_pack_template_expander_line_patterns_test.dart`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_688ff9b8d2a8832aa8c9f21725e693f4