### PR TITLE
chore: remove unused assets images directory

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -139,7 +139,6 @@ flutter:
     - assets/learning_tracks/
     - assets/learning_path_tracks.yaml
     - assets/animations/congrats.json
-    - assets/images/
     - assets/skills/cash/
     - assets/paths/
     - assets/precompiled_packs/


### PR DESCRIPTION
## Summary
- remove unused `assets/images/` path from asset list

## Testing
- `flutter pub get`
- `flutter build apk` *(fails: No Android SDK found)*

------
https://chatgpt.com/codex/tasks/task_e_688ffafdae98832a99f15322c42b5e14