### PR TITLE
feat: add line pattern tags to seed expansion

### DIFF
--- a/lib/models/spot_seed_format.dart
+++ b/lib/models/spot_seed_format.dart
@@ -6,6 +6,7 @@ class SpotSeedFormat {
   final String position;
   final List<CardModel> board;
   final List<String> villainActions;
+  final List<String> tags;
 
   SpotSeedFormat({
     required this.player,
@@ -13,18 +14,22 @@ class SpotSeedFormat {
     required this.position,
     List<CardModel>? board,
     List<String>? villainActions,
+    List<String>? tags,
   })  : board = board ?? [],
-        villainActions = villainActions ?? [];
+        villainActions = villainActions ?? [],
+        tags = tags ?? [];
 
   SpotSeedFormat copyWith({
     List<CardModel>? board,
     List<String>? villainActions,
+    List<String>? tags,
   }) => SpotSeedFormat(
         player: player,
         handGroup: handGroup,
         position: position,
         board: board ?? this.board,
         villainActions: villainActions ?? this.villainActions,
+        tags: tags ?? this.tags,
       );
 
   /// Returns the street name based on current board length.

--- a/lib/models/v2/training_pack_template_set.dart
+++ b/lib/models/v2/training_pack_template_set.dart
@@ -2,6 +2,7 @@ import 'package:yaml/yaml.dart';
 
 import '../../utils/yaml_utils.dart';
 import '../constraint_set.dart';
+import '../line_pattern.dart';
 import 'training_pack_template_v2.dart';
 
 /// Defines a template with variant parameters that can be expanded into
@@ -16,18 +17,27 @@ class TrainingPackTemplateSet {
   /// template.
   List<TemplateSetEntry> entries;
 
+  /// Optional action line patterns describing multi-street sequences.
+  List<LinePattern> linePatterns;
+
   TrainingPackTemplateSet({
     required this.template,
     List<Map<String, dynamic>>? variants,
     List<TemplateSetEntry>? entries,
+    List<LinePattern>? linePatterns,
   }) : variants = variants ?? [],
-       entries = entries ?? [];
+       entries = entries ?? [],
+       linePatterns = linePatterns ?? [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     // Support multiple input structures:
     // 1) Legacy format with `template` + `variants` or `templateSet`.
     // 2) Simplified format with `base` + `variations` fields.
     final map = Map<String, dynamic>.from(json);
+    final patterns = <LinePattern>[
+      for (final p in (map['linePatterns'] as List? ?? []))
+        LinePattern.fromJson(Map<String, dynamic>.from(p as Map)),
+    ];
 
     // New `base` + `variations` structure.
     if (map['base'] is Map && map['variations'] is List) {
@@ -63,7 +73,11 @@ class TrainingPackTemplateSet {
           ),
         );
       }
-      return TrainingPackTemplateSet(template: tpl, entries: entries);
+      return TrainingPackTemplateSet(
+        template: tpl,
+        entries: entries,
+        linePatterns: patterns,
+      );
     }
 
     // Legacy structures.
@@ -86,6 +100,7 @@ class TrainingPackTemplateSet {
         for (final e in (json['templateSet'] as List? ?? []))
           TemplateSetEntry.fromJson(Map<String, dynamic>.from(e as Map)),
       ],
+      linePatterns: patterns,
     );
   }
 

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -135,6 +135,7 @@ class TrainingPackTemplateExpanderService {
           position: result.heroPosition,
           board: board,
           villainActions: villainActions,
+          tags: result.tags,
         ),
       );
     }

--- a/lib/services/training_pack_template_set_generator.dart
+++ b/lib/services/training_pack_template_set_generator.dart
@@ -83,6 +83,7 @@ class TrainingPackTemplateSetGenerator {
       position: heroPos,
       board: board,
       villainActions: actions,
+      tags: spot.tags,
     );
   }
 

--- a/test/services/training_pack_template_expander_line_patterns_test.dart
+++ b/test/services/training_pack_template_expander_line_patterns_test.dart
@@ -25,5 +25,6 @@ void main() {
     expect(seed.position, 'btn');
     expect(seed.villainActions, ['villainBet', 'villainBet']);
     expect(seed.currentStreet, 'turn');
+    expect(seed.tags, ['flopVillainBet', 'flopHeroCall', 'turnVillainBet']);
   });
 }


### PR DESCRIPTION
## Summary
- support `linePatterns` in v2 `TrainingPackTemplateSet`
- carry action tags on `SpotSeedFormat`
- propagate line pattern tags during expansion

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688ffd0bd3f0832abb2be217f23f0e35