### PR TITLE
feat: add constraint resolver v3

### DIFF
--- a/lib/models/constraint_set.dart
+++ b/lib/models/constraint_set.dart
@@ -1,4 +1,5 @@
 import '../services/inline_theory_linker.dart';
+import 'line_pattern.dart';
 
 /// Describes a set of constraints and mutation rules that can be applied to a
 /// base [TrainingPackSpot] to produce variations.
@@ -13,6 +14,14 @@ class ConstraintSet {
   final List<String> handGroup;
   final List<String> villainActions;
   final String? targetStreet;
+
+  /// Optional list of board generation constraints to expand into concrete
+  /// boards for this variation.
+  final List<Map<String, dynamic>> boardConstraints;
+
+  /// Optional action line pattern that should be applied to each generated
+  /// variation.
+  final LinePattern? linePattern;
 
   /// Property overrides where each key maps to a list of possible values. The
   /// resolver engine will expand the cartesian product of these lists.
@@ -42,6 +51,8 @@ class ConstraintSet {
     this.handGroup = const [],
     this.villainActions = const [],
     this.targetStreet,
+    this.boardConstraints = const [],
+    this.linePattern,
     this.overrides = const {},
     this.tags = const [],
     this.tagMergeMode = MergeMode.add,
@@ -73,6 +84,14 @@ class ConstraintSet {
         for (final a in (json['villainActions'] as List? ?? [])) a.toString(),
       ],
       targetStreet: json['targetStreet']?.toString(),
+      boardConstraints: [
+        if (json['boardConstraints'] is List)
+          for (final c in (json['boardConstraints'] as List))
+            Map<String, dynamic>.from(c as Map),
+      ],
+      linePattern: json['linePattern'] is Map
+          ? LinePattern.fromJson(Map<String, dynamic>.from(json['linePattern']))
+          : null,
       overrides: overrides,
       tags: [
         for (final t in (json['tags'] as List? ?? [])) t.toString(),
@@ -95,6 +114,8 @@ class ConstraintSet {
         if (handGroup.isNotEmpty) 'handGroup': handGroup,
         if (villainActions.isNotEmpty) 'villainActions': villainActions,
         if (targetStreet != null) 'targetStreet': targetStreet,
+        if (boardConstraints.isNotEmpty) 'boardConstraints': boardConstraints,
+        if (linePattern != null) 'linePattern': linePattern!.toJson(),
         if (overrides.isNotEmpty) 'overrides': overrides,
         if (tags.isNotEmpty) 'tags': tags,
         if (tagMergeMode == MergeMode.override) 'tagMergeMode': 'override',

--- a/lib/services/constraint_resolver_v3.dart
+++ b/lib/services/constraint_resolver_v3.dart
@@ -1,0 +1,230 @@
+import '../models/constraint_set.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/hero_position.dart';
+import 'full_board_generator_v2.dart';
+import 'line_graph_engine.dart';
+import 'package:uuid/uuid.dart';
+
+/// Resolves [ConstraintSet] variations against a base [TrainingPackSpot]
+/// producing fully realized training spots. Supports hybrid line pattern and
+/// board constraint expansion within the same variation block.
+class ConstraintResolverV3 {
+  final FullBoardGeneratorV2 _boardGenerator;
+  final LineGraphEngine _lineEngine;
+  final Uuid _uuid;
+
+  const ConstraintResolverV3({
+    FullBoardGeneratorV2? boardGenerator,
+    LineGraphEngine? lineEngine,
+    Uuid? uuid,
+  })  : _boardGenerator = boardGenerator ?? const FullBoardGeneratorV2(),
+        _lineEngine = lineEngine ?? const LineGraphEngine(),
+        _uuid = uuid ?? const Uuid();
+
+  /// Applies [sets] to [base] producing all valid [TrainingPackSpot]
+  /// variations. Each set may contain board generation rules via
+  /// [ConstraintSet.boardConstraints] and an optional [ConstraintSet.linePattern]
+  /// to describe action sequences. The cartesian product of override values is
+  /// expanded and combined with line pattern results.
+  List<TrainingPackSpot> apply(
+    TrainingPackSpot base,
+    List<ConstraintSet> sets,
+  ) {
+    if (sets.isEmpty) {
+      return [_cloneBase(base)];
+    }
+
+    final results = <TrainingPackSpot>[];
+    for (final set in sets) {
+      final expanded = _expandBoards(set);
+      final combos = _cartesian(expanded.overrides);
+      if (combos.isEmpty) combos.add({});
+      final lineResult = expanded.linePattern != null
+          ? _lineEngine.build(expanded.linePattern!)
+          : null;
+      final villainActions = <String>[];
+      if (lineResult != null) {
+        const order = ['preflop', 'flop', 'turn', 'river'];
+        for (final street in order) {
+          final nodes = lineResult.streets[street];
+          if (nodes == null) continue;
+          for (final node in nodes) {
+            if (node.actor.toLowerCase() == 'villain') {
+              villainActions.add(node.action);
+            }
+          }
+        }
+      }
+
+      for (final combo in combos) {
+        final spot = _cloneBase(base);
+        combo.forEach((key, value) {
+          switch (key) {
+            case 'board':
+              final board = [for (final c in value as List) c.toString()];
+              spot.board = board;
+              spot.hand.board = List<String>.from(board);
+              break;
+            case 'heroStack':
+              final stack = (value as num).toDouble();
+              spot.hand.stacks = {...spot.hand.stacks, '0': stack};
+              break;
+            case 'heroPosition':
+            case 'position':
+              spot.hand.position = parseHeroPosition(value.toString());
+              break;
+            case 'tags':
+              final tags = [for (final t in value as List) t.toString()];
+              spot.tags = _mergeTags(spot.tags, tags, set.tagMergeMode);
+              break;
+            default:
+              spot.meta[key] = value;
+          }
+        });
+
+        // Apply constant tag/meta overrides from the set.
+        spot.tags = _mergeTags(spot.tags, set.tags, set.tagMergeMode);
+        spot.meta = _mergeMeta(spot.meta, set.metadata, set.metaMergeMode);
+        if (set.theoryLink != null) {
+          spot.theoryLink = set.theoryLink;
+        }
+
+        // Apply line pattern results.
+        if (lineResult != null) {
+          spot.hand.position =
+              parseHeroPosition(lineResult.heroPosition.toString());
+          if (villainActions.isNotEmpty) {
+            spot.villainAction = villainActions.last;
+          }
+          if (lineResult.streets.containsKey('river')) {
+            spot.street = 3;
+          } else if (lineResult.streets.containsKey('turn')) {
+            spot.street = 2;
+          } else if (lineResult.streets.containsKey('flop')) {
+            spot.street = 1;
+          }
+          spot.tags = _mergeTags(spot.tags, lineResult.tags, MergeMode.add);
+        }
+
+        // Determine street override based on targetStreet if provided.
+        if (expanded.targetStreet != null) {
+          switch (expanded.targetStreet!.toLowerCase()) {
+            case 'flop':
+              spot.street = 1;
+              break;
+            case 'turn':
+              spot.street = 2;
+              break;
+            case 'river':
+              spot.street = 3;
+              break;
+          }
+        } else if (spot.street == 0 && spot.board.isNotEmpty) {
+          if (spot.board.length >= 5) {
+            spot.street = 3;
+          } else if (spot.board.length == 4) {
+            spot.street = 2;
+          } else if (spot.board.length == 3) {
+            spot.street = 1;
+          }
+        }
+
+        results.add(spot);
+      }
+    }
+    return results;
+  }
+
+  ConstraintSet _expandBoards(ConstraintSet set) {
+    if (set.boardConstraints.isEmpty) {
+      return set;
+    }
+    final overrides = Map<String, List<dynamic>>.from(set.overrides);
+    final boards = <List<String>>[];
+    String? streetOverride = set.targetStreet;
+    for (final params in set.boardConstraints) {
+      final map = Map<String, dynamic>.from(params);
+      final street = map.remove('targetStreet')?.toString().toLowerCase();
+      if (street != null) streetOverride = street;
+      final generated = _boardGenerator.generate(map);
+      if (street == 'turn') {
+        final seen = <String>{};
+        for (final b in generated) {
+          final combo = [...b.flop, b.turn];
+          final key = combo.join(',');
+          if (seen.add(key)) boards.add(combo);
+        }
+      } else {
+        for (final b in generated) {
+          boards.add([...b.flop, b.turn, b.river]);
+        }
+      }
+    }
+    overrides['board'] = boards;
+    return ConstraintSet(
+      boardTags: set.boardTags,
+      positions: set.positions,
+      handGroup: set.handGroup,
+      villainActions: set.villainActions,
+      targetStreet: streetOverride,
+      overrides: overrides,
+      tags: set.tags,
+      tagMergeMode: set.tagMergeMode,
+      metadata: set.metadata,
+      metaMergeMode: set.metaMergeMode,
+      theoryLink: set.theoryLink,
+      linePattern: set.linePattern,
+    );
+  }
+
+  TrainingPackSpot _cloneBase(TrainingPackSpot base) {
+    final json = Map<String, dynamic>.from(base.toJson());
+    json['id'] = _uuid.v4();
+    final copy = TrainingPackSpot.fromJson(json);
+    copy.templateSourceId = base.id;
+    copy.tags = List<String>.from(base.tags);
+    copy.theoryLink = base.theoryLink;
+    copy.meta = Map<String, dynamic>.from(base.meta);
+    return copy;
+  }
+
+  List<Map<String, dynamic>> _cartesian(Map<String, List<dynamic>> input) {
+    var result = <Map<String, dynamic>>[{}];
+    input.forEach((key, values) {
+      final next = <Map<String, dynamic>>[];
+      for (final combo in result) {
+        for (final v in values) {
+          final map = Map<String, dynamic>.from(combo);
+          map[key] = v;
+          next.add(map);
+        }
+      }
+      result = next;
+    });
+    return result;
+  }
+
+  List<String> _mergeTags(
+    List<String> base,
+    List<String> updates,
+    MergeMode mode,
+  ) {
+    final set = <String>{};
+    if (mode == MergeMode.add) {
+      set.addAll(base);
+    }
+    set.addAll(updates);
+    return set.toList();
+  }
+
+  Map<String, dynamic> _mergeMeta(
+    Map<String, dynamic> base,
+    Map<String, dynamic> updates,
+    MergeMode mode,
+  ) {
+    if (mode == MergeMode.override) {
+      return Map<String, dynamic>.from(updates);
+    }
+    return {...base, ...updates};
+  }
+}

--- a/test/services/constraint_resolver_v3_test.dart
+++ b/test/services/constraint_resolver_v3_test.dart
@@ -1,0 +1,40 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/line_pattern.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/services/constraint_resolver_v3.dart';
+
+void main() {
+  test('resolves hybrid line and board constraints', () {
+    final base = TrainingPackSpot(id: 'base', tags: ['base']);
+    final set = ConstraintSet(
+      boardConstraints: [
+        {
+          'targetStreet': 'river',
+          'requiredRanks': ['A', 'K', 'Q', 'J', 'T'],
+          'excludedRanks': ['2', '3', '4', '5', '6', '7', '8', '9'],
+          'requiredSuits': ['s'],
+          'excludedSuits': ['h', 'd', 'c'],
+        }
+      ],
+      linePattern: LinePattern(
+        startingPosition: 'sb',
+        streets: {
+          'flop': ['villainBet']
+        },
+      ),
+      tags: ['extra'],
+    );
+
+    final engine = ConstraintResolverV3();
+    final spots = engine.apply(base, [set]);
+    expect(spots, isNotEmpty);
+    final spot = spots.first;
+    expect(spot.templateSourceId, 'base');
+    expect(spot.hand.position, HeroPosition.sb);
+    expect(spot.villainAction, 'villainBet');
+    expect(spot.board.length, 5);
+    expect(spot.tags, containsAll(['base', 'extra', 'flopVillainBet']));
+  });
+}

--- a/test/training_pack_template_expander_full_board_test.dart
+++ b/test/training_pack_template_expander_full_board_test.dart
@@ -10,17 +10,15 @@ void main() {
   test('expands board constraints with tag filters to river', () {
     final base = TrainingPackSpot(id: 'base');
     final variation = ConstraintSet(
-      overrides: {
-        'boardConstraints': [
-          {
-            'targetStreet': 'river',
-            'requiredTextures': ['rainbow'],
-            'requiredRanks': ['A', 'K', 'Q', 'J', 'T'],
-            'requiredTags': ['broadwayHeavy'],
-            'excludedTags': ['paired'],
-          }
-        ]
-      },
+      boardConstraints: [
+        {
+          'targetStreet': 'river',
+          'requiredTextures': ['rainbow'],
+          'requiredRanks': ['A', 'K', 'Q', 'J', 'T'],
+          'requiredTags': ['broadwayHeavy'],
+          'excludedTags': ['paired'],
+        }
+      ],
     );
     final set = TrainingPackTemplateSet(baseSpot: base, variations: [variation]);
     final svc = TrainingPackTemplateExpanderService();


### PR DESCRIPTION
## Summary
- extend constraint sets with optional line patterns and board constraints
- add hybrid constraint resolver v3 to merge board and line variations
- adjust template expander and tests for new constraint fields

## Testing
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_6890016f0d44832a91fc15b3d34ddb47