### PR TITLE
feat: add board texture preset library

### DIFF
--- a/lib/services/board_texture_preset_library.dart
+++ b/lib/services/board_texture_preset_library.dart
@@ -1,0 +1,34 @@
+import '../models/constraint_set.dart';
+
+/// Provides predefined board texture presets that expand to board constraint
+/// parameter maps suitable for [ConstraintSet.boardConstraints].
+class BoardTexturePresetLibrary {
+  static final Map<String, Map<String, dynamic>> _presets = {
+    'lowpaired': {
+      'requiredTextures': ['paired', 'low', 'rainbow'],
+    },
+    'dryacehigh': {
+      'requiredTextures': ['aceHigh', 'rainbow'],
+      'excludedTags': ['straightDrawHeavy'],
+    },
+    'connectedmono': {
+      'requiredTextures': ['connected', 'monotone'],
+    },
+    'broadwayrainbow': {
+      'requiredTextures': ['broadway', 'rainbow'],
+    },
+  };
+
+  /// Returns a constraint map for the given [presetName].
+  ///
+  /// Throws [ArgumentError] if [presetName] is not a supported preset.
+  static Map<String, dynamic> get(String presetName) {
+    final key = presetName.toLowerCase();
+    final preset = _presets[key];
+    if (preset == null) {
+      throw ArgumentError('Unknown board texture preset: $presetName');
+    }
+    // Return a copy to prevent external mutation.
+    return Map<String, dynamic>.from(preset);
+  }
+}

--- a/test/services/board_texture_preset_library_test.dart
+++ b/test/services/board_texture_preset_library_test.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/board_texture_preset_library.dart';
+
+void main() {
+  test('returns preset map for lowPaired', () {
+    final preset = BoardTexturePresetLibrary.get('lowPaired');
+    expect(preset['requiredTextures'], ['paired', 'low', 'rainbow']);
+  });
+
+  test('throws on unknown preset', () {
+    expect(() => BoardTexturePresetLibrary.get('unknown'), throwsArgumentError);
+  });
+}


### PR DESCRIPTION
## Summary
- provide BoardTexturePresetLibrary for common board constraint presets
- add tests for preset retrieval and invalid name handling

## Testing
- `dart test test/services/board_texture_preset_library_test.dart` *(fails: No tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68900401d40c832a864ba4150dac0678