### PR TITLE
feat: expand board presets in templates

### DIFF
--- a/lib/services/constraint_resolver_v3.dart
+++ b/lib/services/constraint_resolver_v3.dart
@@ -4,6 +4,7 @@ import '../models/v2/hero_position.dart';
 import 'full_board_generator_v2.dart';
 import 'line_graph_engine.dart';
 import 'package:uuid/uuid.dart';
+import 'board_texture_preset_library.dart';
 
 /// Resolves [ConstraintSet] variations against a base [TrainingPackSpot]
 /// producing fully realized training spots. Supports hybrid line pattern and
@@ -143,7 +144,13 @@ class ConstraintResolverV3 {
     final boards = <List<String>>[];
     String? streetOverride = set.targetStreet;
     for (final params in set.boardConstraints) {
-      final map = Map<String, dynamic>.from(params);
+      var map = Map<String, dynamic>.from(params);
+      final preset = map.remove('preset');
+      if (preset != null) {
+        final expanded =
+            BoardTexturePresetLibrary.get(preset.toString());
+        map = {...expanded, ...map};
+      }
       final street = map.remove('targetStreet')?.toString().toLowerCase();
       if (street != null) streetOverride = street;
       final generated = _boardGenerator.generate(map);

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -9,6 +9,7 @@ import 'auto_spot_theory_injector_service.dart';
 import 'full_board_generator_v2.dart';
 import 'line_graph_engine.dart';
 import 'inline_theory_node_linker.dart';
+import 'board_texture_preset_library.dart';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
 /// [ConstraintResolverEngine].
@@ -67,7 +68,13 @@ class TrainingPackTemplateExpanderService {
     final boards = <List<String>>[];
     String? streetOverride = set.targetStreet;
     for (final params in constraints) {
-      final map = Map<String, dynamic>.from(params);
+      var map = Map<String, dynamic>.from(params);
+      final preset = map.remove('preset');
+      if (preset != null) {
+        final expanded =
+            BoardTexturePresetLibrary.get(preset.toString());
+        map = {...expanded, ...map};
+      }
       final street = map.remove('targetStreet')?.toString().toLowerCase();
       if (street != null) streetOverride = street;
       final generated = _boardGenerator.generate(map);

--- a/test/services/constraint_resolver_v3_test.dart
+++ b/test/services/constraint_resolver_v3_test.dart
@@ -37,4 +37,30 @@ void main() {
     expect(spot.board.length, 5);
     expect(spot.tags, containsAll(['base', 'extra', 'flopVillainBet']));
   });
+
+  test('expands board presets with overrides', () {
+    final base = TrainingPackSpot(id: 'base');
+    final set = ConstraintSet(
+      boardConstraints: [
+        {
+          'preset': 'lowPaired',
+          'requiredTextures': ['paired', 'low', 'monotone'],
+          'targetStreet': 'flop',
+        }
+      ],
+    );
+
+    final engine = ConstraintResolverV3();
+    final spots = engine.apply(base, [set]);
+    expect(spots, isNotEmpty);
+    const lowRanks = {'2', '3', '4', '5', '6', '7', '8'};
+    for (final s in spots) {
+      expect(s.board.length, 5);
+      final suits = s.board.take(3).map((c) => c[1]).toSet();
+      expect(suits.length, 1);
+      final ranks = s.board.take(2).map((c) => c[0]).toSet();
+      expect(ranks.length, 1);
+      expect(lowRanks.containsAll(s.board.take(3).map((c) => c[0])), isTrue);
+    }
+  });
 }

--- a/test/services/training_pack_template_expander_service_test.dart
+++ b/test/services/training_pack_template_expander_service_test.dart
@@ -53,4 +53,35 @@ variations:
     final stacks = spots.map((s) => s.hand.stacks['0']).toSet();
     expect(stacks, {10.0, 20.0});
   });
+
+  test('expands board preset and merges overrides', () {
+    const yaml = '''
+baseSpot:
+  id: base
+  hand:
+    heroCards: Ah Kh
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - boardConstraints:
+      - preset: lowPaired
+        requiredTextures: [paired, low, monotone]
+''';
+
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    final svc = TrainingPackTemplateExpanderService();
+    final spots = svc.expand(set);
+    expect(spots, isNotEmpty);
+    const lowRanks = {'2', '3', '4', '5', '6', '7', '8'};
+    for (final s in spots) {
+      expect(s.board.length, 5);
+      final suits = s.board.take(3).map((c) => c[1]).toSet();
+      expect(suits.length, 1); // monotone override applied
+      final ranks = s.board.take(2).map((c) => c[0]).toSet();
+      expect(ranks.length, 1); // paired
+      expect(lowRanks.containsAll(s.board.take(3).map((c) => c[0])), isTrue);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- allow boardConstraints to reference named presets
- merge preset values with explicit constraint overrides
- cover preset expansion with new tests

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689006d9c060832a9152dd5a3ad5e9df