### PR TITLE
feat: add training pack template compiler

### DIFF
--- a/lib/services/training_pack_template_compiler.dart
+++ b/lib/services/training_pack_template_compiler.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import '../models/training_pack_template_set.dart';
+import '../models/inline_theory_entry.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_generator_engine_v2.dart';
+
+/// Compiles multiple [TrainingPackTemplateSet] YAML sources into concrete
+/// [TrainingPackSpot]s at build time.
+///
+/// Each provided YAML string or file path is parsed into a
+/// [TrainingPackTemplateSet] which is then expanded by
+/// [TrainingPackGeneratorEngineV2]. The resulting spots can be returned as a
+/// flat list or grouped by the template's base spot id.
+class TrainingPackTemplateCompiler {
+  final TrainingPackGeneratorEngineV2 _engine;
+
+  const TrainingPackTemplateCompiler({
+    TrainingPackGeneratorEngineV2? engine,
+  }) : _engine = engine ?? const TrainingPackGeneratorEngineV2();
+
+  /// Compiles template sets from YAML [sources].
+  ///
+  /// Each entry in [sources] should be a raw YAML string. The method returns a
+  /// flat list of all generated [TrainingPackSpot]s.
+  List<TrainingPackSpot> compileYamls(
+    List<String> sources, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) {
+    final result = <TrainingPackSpot>[];
+    for (final yaml in sources) {
+      final set = TrainingPackTemplateSet.fromYaml(yaml);
+      final spots = _engine.generate(set, theoryIndex: theoryIndex);
+      result.addAll(spots);
+    }
+    return result;
+  }
+
+  /// Compiles template sets from YAML files at the given [paths].
+  ///
+  /// Returns a flat list of all generated [TrainingPackSpot]s.
+  Future<List<TrainingPackSpot>> compileFiles(
+    List<String> paths, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) async {
+    final yamls = <String>[];
+    for (final p in paths) {
+      yamls.add(await File(p).readAsString());
+    }
+    return compileYamls(yamls, theoryIndex: theoryIndex);
+  }
+
+  /// Compiles template sets from YAML [sources] and groups the resulting spots
+  /// by the base spot id.
+  Map<String, List<TrainingPackSpot>> compileYamlsGrouped(
+    List<String> sources, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) {
+    final result = <String, List<TrainingPackSpot>>{};
+    for (final yaml in sources) {
+      final set = TrainingPackTemplateSet.fromYaml(yaml);
+      final spots = _engine.generate(set, theoryIndex: theoryIndex);
+      result.putIfAbsent(set.baseSpot.id, () => []).addAll(spots);
+    }
+    return result;
+  }
+
+  /// Compiles template sets from YAML files at [paths] and groups the results
+  /// by the base spot id.
+  Future<Map<String, List<TrainingPackSpot>>> compileFilesGrouped(
+    List<String> paths, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) async {
+    final yamls = <String>[];
+    for (final p in paths) {
+      yamls.add(await File(p).readAsString());
+    }
+    return compileYamlsGrouped(yamls, theoryIndex: theoryIndex);
+  }
+}
+

--- a/test/services/training_pack_template_compiler_test.dart
+++ b/test/services/training_pack_template_compiler_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_template_compiler.dart';
+
+void main() {
+  const yamlA = '''
+baseSpot:
+  id: a
+  hand:
+    heroCards: Ah Kh
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - overrides:
+      board:
+        - [As, Kd, Qc]
+''';
+
+  const yamlB = '''
+baseSpot:
+  id: b
+  hand:
+    heroCards: Qh Qd
+    position: sb
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - overrides:
+      board:
+        - [2h, 2c, 9d]
+''';
+
+  test('compileYamls expands multiple sets', () {
+    final compiler = TrainingPackTemplateCompiler();
+    final spots = compiler.compileYamls([yamlA, yamlB]);
+    expect(spots, hasLength(2));
+    final ids = spots.map((s) => s.templateSourceId).toSet();
+    expect(ids, {'a', 'b'});
+  });
+
+  test('compileYamlsGrouped groups by base id', () {
+    final compiler = TrainingPackTemplateCompiler();
+    final grouped = compiler.compileYamlsGrouped([yamlA, yamlB]);
+    expect(grouped.keys.toSet(), {'a', 'b'});
+    expect(grouped['a'], hasLength(1));
+    expect(grouped['b'], hasLength(1));
+  });
+
+  test('compileFiles reads from disk', () async {
+    final dir = await Directory.systemTemp.createTemp('tpl');
+    final fileA = File('${dir.path}/a.yaml')..writeAsStringSync(yamlA);
+    final fileB = File('${dir.path}/b.yaml')..writeAsStringSync(yamlB);
+    final compiler = TrainingPackTemplateCompiler();
+    final spots = await compiler.compileFiles([fileA.path, fileB.path]);
+    expect(spots, hasLength(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingPackTemplateCompiler to precompile YAML template sets into TrainingPackSpots
- test compiler handling of multiple YAML sources, grouping, and file-based compilation

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890087ea524832ab130819cb7c0fc33