### PR TITLE
feat: add pack library generator service

### DIFF
--- a/lib/services/pack_library_generator_service.dart
+++ b/lib/services/pack_library_generator_service.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_template_compiler.dart';
+
+/// Generates a Dart library that embeds precompiled training pack spots.
+///
+/// Given a list of YAML file paths, this service compiles the templates into
+/// concrete [TrainingPackSpot]s and writes them to `pack_library.g.dart` as a
+/// `Map<String, List<TrainingPackSpot>>` named [packLibrary]. The generated
+/// file uses JSON serialization to reconstruct each spot at runtime.
+class PackLibraryGeneratorService {
+  final TrainingPackTemplateCompiler _compiler;
+
+  const PackLibraryGeneratorService({TrainingPackTemplateCompiler? compiler})
+    : _compiler = compiler ?? const TrainingPackTemplateCompiler();
+
+  /// Compiles [paths] and writes the resulting map to [outPath].
+  Future<void> generate(
+    List<String> paths, {
+    String outPath = 'lib/generated/pack_library.g.dart',
+  }) async {
+    final grouped = await _compiler.compileFilesGrouped(paths);
+    final keys = grouped.keys.toList()..sort();
+    final buffer = StringBuffer()
+      ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
+      ..writeln('')
+      ..writeln("import 'dart:convert';")
+      ..writeln(
+        "import 'package:poker_analyzer/models/v2/training_pack_spot.dart';",
+      )
+      ..writeln('')
+      ..writeln('final Map<String, List<TrainingPackSpot>> packLibrary = {');
+
+    for (final key in keys) {
+      final spots = grouped[key]!;
+      buffer.writeln("  '$key': [");
+      for (final spot in spots) {
+        final jsonStr = jsonEncode(spot.toJson());
+        buffer.writeln(
+          "    TrainingPackSpot.fromJson(jsonDecode(r'''$jsonStr''') as Map<String, dynamic>),",
+        );
+      }
+      buffer.writeln('  ],');
+    }
+    buffer.writeln('};');
+
+    final file = File(outPath);
+    await file.create(recursive: true);
+    await file.writeAsString(buffer.toString());
+  }
+}

--- a/test/services/pack_library_generator_service_test.dart
+++ b/test/services/pack_library_generator_service_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/pack_library_generator_service.dart';
+
+void main() {
+  const yamlA = '''
+baseSpot:
+  id: a
+  hand:
+    heroCards: Ah Kh
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - overrides:
+      board:
+        - [As, Kd, Qc]
+''';
+
+  const yamlB = '''
+baseSpot:
+  id: b
+  hand:
+    heroCards: Qh Qd
+    position: sb
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - overrides:
+      board:
+        - [2h, 2c, 9d]
+''';
+
+  test('generate writes pack_library.g.dart', () async {
+    final dir = await Directory.systemTemp.createTemp('libgen');
+    final fileA = File('${dir.path}/a.yaml')..writeAsStringSync(yamlA);
+    final fileB = File('${dir.path}/b.yaml')..writeAsStringSync(yamlB);
+    final outPath = '${dir.path}/pack_library.g.dart';
+
+    final generator = PackLibraryGeneratorService();
+    await generator.generate([fileA.path, fileB.path], outPath: outPath);
+
+    final generated = await File(outPath).readAsString();
+    expect(generated.contains('packLibrary'), isTrue);
+    expect(generated.contains('TrainingPackSpot.fromJson'), isTrue);
+
+    final entry = File('${dir.path}/main.dart');
+    entry.writeAsStringSync('''
+import 'dart:convert';
+import 'pack_library.g.dart';
+
+void main() {
+  final keys = packLibrary.keys.toList()..sort();
+  print(jsonEncode(keys));
+  final spot = packLibrary['a']!.first;
+  print(spot.templateSourceId);
+  print(jsonEncode(spot.board));
+}
+''');
+
+    final result = await Process.run('dart', [entry.path]);
+    expect(result.exitCode, 0);
+    final lines = (result.stdout as String).trim().split('\n');
+    expect(lines[0], '["a","b"]');
+    expect(lines[1], 'a');
+    expect(lines[2], '["As","Kd","Qc"]');
+  });
+}


### PR DESCRIPTION
## Summary
- add PackLibraryGeneratorService to compile YAML pack templates and emit `pack_library.g.dart`
- cover code generation workflow with unit test using temporary YAML files

## Testing
- `dart test test/services/pack_library_generator_service_test.dart test/services/training_pack_template_compiler_test.dart` *(fails: Flutter SDK not available)*


------
https://chatgpt.com/codex/tasks/task_e_6890099fe2a8832abd39562e6cff771a