### PR TITLE
feat: add pack library service

### DIFF
--- a/lib/generated/pack_library.g.dart
+++ b/lib/generated/pack_library.g.dart
@@ -1,0 +1,7 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'dart:convert';
+
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+final Map<String, List<TrainingPackSpot>> packLibrary = {};

--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -1,11 +1,26 @@
 import '../core/training/library/training_pack_library_v2.dart';
 import '../core/training/engine/training_type_engine.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../generated/pack_library.g.dart';
 import 'package:collection/collection.dart';
 
 class PackLibraryService {
   PackLibraryService._();
   static final instance = PackLibraryService._();
+
+  /// Returns spots for the pack identified by [id].
+  ///
+  /// If the [id] is unknown, an empty list is returned.
+  List<TrainingPackSpot> getPack(String id) {
+    final spots = packLibrary[id];
+    return spots == null ? const [] : List<TrainingPackSpot>.unmodifiable(spots);
+  }
+
+  /// Lists all pack ids available in the precompiled [packLibrary].
+  List<String> getAvailablePackIds() {
+    return List<String>.unmodifiable(packLibrary.keys);
+  }
 
   Future<TrainingPackTemplateV2?> recommendedStarter() async {
     await TrainingPackLibraryV2.instance.loadFromFolder();

--- a/test/services/pack_library_service_test.dart
+++ b/test/services/pack_library_service_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/generated/pack_library.g.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+void main() {
+  tearDown(() => packLibrary.clear());
+
+  test('getPack returns empty list for unknown id', () {
+    final result = PackLibraryService.instance.getPack('missing');
+    expect(result, isEmpty);
+  });
+
+  test('getPack returns spots when id exists', () {
+    final spot = TrainingPackSpot(id: 's1');
+    packLibrary['sample'] = [spot];
+    final service = PackLibraryService.instance;
+    final spots = service.getPack('sample');
+    expect(spots, hasLength(1));
+    expect(spots.first.id, 's1');
+    expect(service.getAvailablePackIds(), contains('sample'));
+  });
+}


### PR DESCRIPTION
## Summary
- expose precompiled pack library through `PackLibraryService` with synchronous accessors
- scaffold generated `packLibrary` map and cover with unit tests

## Testing
- `dart format lib/services/pack_library_service.dart lib/generated/pack_library.g.dart test/services/pack_library_service_test.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68900b53b294832a8ab5c3c61d503d78