### PR TITLE
feat: add training pack index service

### DIFF
--- a/lib/models/training_pack_meta.dart
+++ b/lib/models/training_pack_meta.dart
@@ -1,0 +1,17 @@
+import '../core/training/engine/training_type_engine.dart';
+
+class TrainingPackMeta {
+  final String id;
+  final String title;
+  final String skillLevel; // e.g. beginner, intermediate, advanced
+  final List<String> tags;
+  final TrainingType trainingType;
+
+  const TrainingPackMeta({
+    required this.id,
+    required this.title,
+    required this.skillLevel,
+    required this.tags,
+    required this.trainingType,
+  });
+}

--- a/lib/services/training_pack_index_service.dart
+++ b/lib/services/training_pack_index_service.dart
@@ -1,0 +1,32 @@
+import '../generated/pack_library.g.dart';
+import '../models/training_pack_meta.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+class TrainingPackIndexService {
+  TrainingPackIndexService._();
+  static final instance = TrainingPackIndexService._();
+
+  static final Map<String, TrainingPackMeta> _index = {
+    'starter_pushfold_10bb': const TrainingPackMeta(
+      id: 'starter_pushfold_10bb',
+      title: 'Starter Push/Fold 10bb',
+      skillLevel: 'beginner',
+      tags: ['starter', 'pushfold'],
+      trainingType: TrainingType.pushFold,
+    ),
+  };
+
+  TrainingPackMeta? getMeta(String id) {
+    if (!packLibrary.containsKey(id)) return null;
+    return _index[id];
+  }
+
+  List<TrainingPackMeta> getAll() {
+    final result = <TrainingPackMeta>[];
+    for (final id in packLibrary.keys) {
+      final meta = _index[id];
+      if (meta != null) result.add(meta);
+    }
+    return result;
+  }
+}

--- a/test/services/training_pack_index_service_test.dart
+++ b/test/services/training_pack_index_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_index_service.dart';
+import 'package:poker_analyzer/generated/pack_library.g.dart';
+
+void main() {
+  tearDown(() => packLibrary.clear());
+
+  test('getMeta returns metadata when id exists', () {
+    packLibrary['starter_pushfold_10bb'] = [];
+    final service = TrainingPackIndexService.instance;
+    final meta = service.getMeta('starter_pushfold_10bb');
+    expect(meta, isNotNull);
+    expect(meta!.title, 'Starter Push/Fold 10bb');
+    final all = service.getAll();
+    expect(all.map((m) => m.id), contains('starter_pushfold_10bb'));
+  });
+
+  test('getMeta returns null when id missing', () {
+    final service = TrainingPackIndexService.instance;
+    final meta = service.getMeta('missing');
+    expect(meta, isNull);
+    expect(service.getAll(), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackMeta` model for pack metadata
- introduce `TrainingPackIndexService` to expose pack metadata via `getMeta` and `getAll`
- cover service behavior with unit tests

## Testing
- `dart test test/services/training_pack_index_service_test.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68900ca76780832a92e5e590cf384c81