### PR TITLE
feat: add training pack library search

### DIFF
--- a/lib/services/training_pack_library_search_service.dart
+++ b/lib/services/training_pack_library_search_service.dart
@@ -1,0 +1,31 @@
+import '../models/training_pack_meta.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'training_pack_index_service.dart';
+
+/// Provides search capabilities over indexed training packs.
+class TrainingPackLibrarySearchService {
+  final TrainingPackIndexService _indexService;
+
+  const TrainingPackLibrarySearchService({
+    TrainingPackIndexService? indexService,
+  }) : _indexService = indexService ?? TrainingPackIndexService.instance;
+
+  /// Returns all training packs that match the provided filters.
+  ///
+  /// [includeTags] - All tags that must be present on a pack.
+  /// [skillLevel] - Skill level filter.
+  /// [trainingType] - Training type filter.
+  List<TrainingPackMeta> search({
+    List<String> includeTags = const [],
+    String? skillLevel,
+    TrainingType? trainingType,
+  }) {
+    return _indexService.getAll().where((pack) {
+      final matchesTags = includeTags.every((t) => pack.tags.contains(t));
+      final matchesSkill = skillLevel == null || pack.skillLevel == skillLevel;
+      final matchesType =
+          trainingType == null || pack.trainingType == trainingType;
+      return matchesTags && matchesSkill && matchesType;
+    }).toList();
+  }
+}

--- a/test/services/training_pack_library_search_service_test.dart
+++ b/test/services/training_pack_library_search_service_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_library_search_service.dart';
+import 'package:poker_analyzer/services/training_pack_index_service.dart';
+import 'package:poker_analyzer/generated/pack_library.g.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  late TrainingPackLibrarySearchService service;
+
+  setUp(() {
+    packLibrary['starter_pushfold_10bb'] = [];
+    service = TrainingPackLibrarySearchService(
+      indexService: TrainingPackIndexService.instance,
+    );
+  });
+
+  tearDown(() => packLibrary.clear());
+
+  test('returns all packs when no filters provided', () {
+    final result = service.search();
+    expect(result.map((m) => m.id), contains('starter_pushfold_10bb'));
+  });
+
+  test('filters by includeTags', () {
+    final match = service.search(includeTags: ['starter', 'pushfold']);
+    expect(match.map((m) => m.id), ['starter_pushfold_10bb']);
+
+    final noMatch = service.search(includeTags: ['starter', 'missing']);
+    expect(noMatch, isEmpty);
+  });
+
+  test('filters by skill level and training type', () {
+    final match = service.search(
+      skillLevel: 'beginner',
+      trainingType: TrainingType.pushFold,
+    );
+    expect(match.map((m) => m.id), ['starter_pushfold_10bb']);
+
+    expect(service.search(skillLevel: 'advanced'), isEmpty);
+    expect(service.search(trainingType: TrainingType.postflop), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackLibrarySearchService` for tag, skill level, and training type filtering
- cover service with unit tests

## Testing
- `dart test` *(fails: Flutter SDK not available)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*

------
https://chatgpt.com/codex/tasks/task_e_68900def5244832a97a3c6a3900bdba7