### PR TITLE
feat: implement training pack search suggestions

### DIFF
--- a/lib/services/training_pack_index_service.dart
+++ b/lib/services/training_pack_index_service.dart
@@ -14,6 +14,20 @@ class TrainingPackIndexService {
       tags: ['starter', 'pushfold'],
       trainingType: TrainingType.pushFold,
     ),
+    'starter_postflop_basics': const TrainingPackMeta(
+      id: 'starter_postflop_basics',
+      title: 'Starter Postflop Basics',
+      skillLevel: 'beginner',
+      tags: ['starter', 'postflop'],
+      trainingType: TrainingType.postflop,
+    ),
+    'advanced_pushfold_15bb': const TrainingPackMeta(
+      id: 'advanced_pushfold_15bb',
+      title: 'Advanced Push/Fold 15bb',
+      skillLevel: 'advanced',
+      tags: ['advanced', 'pushfold'],
+      trainingType: TrainingType.pushFold,
+    ),
   };
 
   TrainingPackMeta? getMeta(String id) {

--- a/lib/services/training_pack_library_search_suggestions_service.dart
+++ b/lib/services/training_pack_library_search_suggestions_service.dart
@@ -1,0 +1,38 @@
+import '../models/training_pack_meta.dart';
+import 'training_pack_index_service.dart';
+
+/// Provides search suggestions based on available training packs.
+class TrainingPackLibrarySearchSuggestionsService {
+  final TrainingPackIndexService _indexService;
+
+  const TrainingPackLibrarySearchSuggestionsService({
+    TrainingPackIndexService? indexService,
+  }) : _indexService = indexService ?? TrainingPackIndexService.instance;
+
+  /// Returns tags ordered by popularity across all packs.
+  List<String> getSuggestedTags({int limit = 5}) {
+    final counts = <String, int>{};
+    for (final pack in _indexService.getAll()) {
+      for (final tag in pack.tags) {
+        counts[tag] = (counts[tag] ?? 0) + 1;
+      }
+    }
+    final sorted = counts.entries.toList()
+      ..sort((a, b) {
+        final cmp = b.value.compareTo(a.value);
+        if (cmp != 0) return cmp;
+        return a.key.compareTo(b.key);
+      });
+    return sorted.map((e) => e.key).take(limit).toList();
+  }
+
+  /// Returns starter packs intended for onboarding.
+  List<TrainingPackMeta> getSuggestedStarterPacks() {
+    final packs = _indexService
+        .getAll()
+        .where((p) => p.tags.contains('starter'))
+        .toList();
+    packs.sort((a, b) => a.title.compareTo(b.title));
+    return packs;
+  }
+}

--- a/test/services/training_pack_library_search_suggestions_service_test.dart
+++ b/test/services/training_pack_library_search_suggestions_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/generated/pack_library.g.dart';
+import 'package:poker_analyzer/services/training_pack_library_search_suggestions_service.dart';
+import 'package:poker_analyzer/services/training_pack_index_service.dart';
+
+void main() {
+  late TrainingPackLibrarySearchSuggestionsService service;
+
+  setUp(() {
+    packLibrary.addAll({
+      'starter_pushfold_10bb': [],
+      'starter_postflop_basics': [],
+      'advanced_pushfold_15bb': [],
+    });
+    service = TrainingPackLibrarySearchSuggestionsService(
+      indexService: TrainingPackIndexService.instance,
+    );
+  });
+
+  tearDown(() => packLibrary.clear());
+
+  test('returns most popular tags', () {
+    final tags = service.getSuggestedTags(limit: 2);
+    expect(tags.length, 2);
+    expect(tags, containsAll(['starter', 'pushfold']));
+  });
+
+  test('returns starter packs for onboarding', () {
+    final packs = service.getSuggestedStarterPacks();
+    expect(packs.map((m) => m.id), [
+      'starter_postflop_basics',
+      'starter_pushfold_10bb',
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary
- extend training pack index with starter and advanced packs for richer metadata
- add TrainingPackLibrarySearchSuggestionsService to surface popular tags and starter packs
- cover new service with tests

## Testing
- `dart analyze` *(fails: 77059 issues found)*
- `dart test test/services/training_pack_index_service_test.dart test/services/training_pack_library_search_service_test.dart test/services/training_pack_library_search_suggestions_service_test.dart` *(fails: Flutter SDK not available)*
- `flutter test test/services/training_pack_index_service_test.dart test/services/training_pack_library_search_service_test.dart test/services/training_pack_library_search_suggestions_service_test.dart` *(fails: multiple missing files and plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68900f65ba44832a96948539d13b6857