### PR TITLE
feat: track learning path node progress

### DIFF
--- a/lib/services/training_path_progress_tracker_service.dart
+++ b/lib/services/training_path_progress_tracker_service.dart
@@ -1,0 +1,52 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'training_path_node_definition_service.dart';
+
+/// Tracks completion status for training path nodes and computes which
+/// nodes are currently unlocked based on prerequisites.
+class TrainingPathProgressTrackerService {
+  static const _prefsKey = 'training_path_completed_nodes';
+
+  final TrainingPathNodeDefinitionService definitions;
+  final SharedPreferences? _prefsOverride;
+
+  const TrainingPathProgressTrackerService({
+    this.definitions = const TrainingPathNodeDefinitionService(),
+    SharedPreferences? prefs,
+  }) : _prefsOverride = prefs;
+
+  Future<SharedPreferences> get _prefs async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  /// Marks the given [nodeId] as completed and persists the change.
+  Future<void> markCompleted(String nodeId) async {
+    final prefs = await _prefs;
+    final current = prefs.getStringList(_prefsKey) ?? <String>[];
+    if (!current.contains(nodeId)) {
+      current.add(nodeId);
+      await prefs.setStringList(_prefsKey, current);
+    }
+  }
+
+  /// Returns the set of completed node IDs.
+  Future<Set<String>> getCompletedNodeIds() async {
+    final prefs = await _prefs;
+    final list = prefs.getStringList(_prefsKey) ?? <String>[];
+    return list.toSet();
+  }
+
+  /// Computes the set of unlocked node IDs based on prerequisites.
+  ///
+  /// A node is unlocked if all of its prerequisites have been completed.
+  Future<Set<String>> getUnlockedNodeIds() async {
+    final completed = await getCompletedNodeIds();
+    final nodes = definitions.getPath();
+    final unlocked = <String>{};
+    for (final node in nodes) {
+      if (node.prerequisiteNodeIds.every(completed.contains)) {
+        unlocked.add(node.id);
+      }
+    }
+    return unlocked;
+  }
+}

--- a/test/services/training_path_progress_tracker_service_test.dart
+++ b/test/services/training_path_progress_tracker_service_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/training_path_progress_tracker_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late TrainingPathProgressTrackerService service;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    service = const TrainingPathProgressTrackerService();
+  });
+
+  test('marks nodes as completed', () async {
+    await service.markCompleted('starter_pushfold_10bb');
+    final completed = await service.getCompletedNodeIds();
+    expect(completed, {'starter_pushfold_10bb'});
+  });
+
+  test('computes unlocked nodes based on prerequisites', () async {
+    // Initially only the first node should be unlocked
+    var unlocked = await service.getUnlockedNodeIds();
+    expect(unlocked, {'starter_pushfold_10bb'});
+
+    // Complete first node -> second unlocks
+    await service.markCompleted('starter_pushfold_10bb');
+    unlocked = await service.getUnlockedNodeIds();
+    expect(unlocked.contains('starter_postflop_basics'), isTrue);
+
+    // Complete second node -> third unlocks
+    await service.markCompleted('starter_postflop_basics');
+    unlocked = await service.getUnlockedNodeIds();
+    expect(
+      unlocked.containsAll({
+        'starter_pushfold_10bb',
+        'starter_postflop_basics',
+        'advanced_pushfold_15bb',
+      }),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingPathProgressTrackerService to persist completed node ids and compute unlocked nodes
- cover progress tracking logic with unit tests

## Testing
- `flutter test test/services/training_path_progress_tracker_service_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6890131c90ec832aabc45cd53cb01bb0