### PR TITLE
feat: show training path node progress

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -38,6 +38,8 @@ import 'mistake_repeat_screen.dart';
 import 'goals_overview_screen.dart';
 import 'spot_of_the_day_screen.dart';
 import 'weakness_overview_screen.dart';
+import '../services/training_path_progress_tracker_service.dart';
+import '../services/training_path_node_definition_service.dart';
 import 'next_step_suggestion_dialog.dart';
 import '../widgets/mistake_review_button.dart';
 import '../services/streak_tracker_service.dart';
@@ -92,6 +94,14 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
   }
 
   Future<void> _finish() async {
+    final tracker = const TrainingPathProgressTrackerService();
+    final node = const TrainingPathNodeDefinitionService()
+        .getPath()
+        .firstWhereOrNull((n) => n.packIds.contains(widget.template.id));
+    if (node != null) {
+      await tracker.markCompleted(node.id);
+    }
+
     final registry = LearningPathRegistryService.instance;
     final templates = await registry.loadAll();
     final logs = context.read<SessionLogService>();

--- a/lib/widgets/training_path_node_list_widget.dart
+++ b/lib/widgets/training_path_node_list_widget.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
+
+import '../models/training_path_node.dart';
+import '../services/training_path_node_definition_service.dart';
+import '../services/training_path_progress_tracker_service.dart';
+
+/// Displays the list of training path nodes with visual lock/unlock state.
+///
+/// Nodes that are unlocked can be tapped. Locked nodes are disabled. Completed
+/// nodes show a checkmark.
+class TrainingPathNodeListWidget extends StatefulWidget {
+  const TrainingPathNodeListWidget({super.key, this.onNodeTap});
+
+  final void Function(TrainingPathNode node)? onNodeTap;
+
+  @override
+  State<TrainingPathNodeListWidget> createState() =>
+      _TrainingPathNodeListWidgetState();
+}
+
+class _TrainingPathNodeListWidgetState
+    extends State<TrainingPathNodeListWidget> {
+  final _definitions = const TrainingPathNodeDefinitionService();
+  final _progress = const TrainingPathProgressTrackerService();
+
+  late Future<_NodeStatusData> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<_NodeStatusData> _load() async {
+    final nodes = _definitions.getPath();
+    final completed = await _progress.getCompletedNodeIds();
+    final unlocked = await _progress.getUnlockedNodeIds();
+    return _NodeStatusData(
+      nodes: nodes,
+      completed: completed,
+      unlocked: unlocked,
+    );
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _future = _load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_NodeStatusData>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final data = snapshot.data!;
+        return RefreshIndicator(
+          onRefresh: _refresh,
+          child: ListView(
+            children: [
+              for (final node in data.nodes) _buildTile(node, data),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTile(TrainingPathNode node, _NodeStatusData data) {
+    final isCompleted = data.completed.contains(node.id);
+    final isUnlocked = data.unlocked.contains(node.id);
+    final icon = isCompleted
+        ? const Icon(Icons.check, color: Colors.green)
+        : isUnlocked
+            ? const Icon(Icons.lock_open)
+            : const Icon(Icons.lock);
+    return ListTile(
+      leading: icon,
+      title: Text(node.title),
+      enabled: isUnlocked,
+      onTap: isUnlocked ? () => widget.onNodeTap?.call(node) : null,
+    );
+  }
+}
+
+class _NodeStatusData {
+  final List<TrainingPathNode> nodes;
+  final Set<String> completed;
+  final Set<String> unlocked;
+
+  const _NodeStatusData({
+    required this.nodes,
+    required this.completed,
+    required this.unlocked,
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPathNodeListWidget` to display locked, unlocked and completed path nodes
- mark training path nodes as completed after finishing a training session

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689013e8326c832a97a71c89521c2cd4