### PR TITLE
feat: launch training path nodes

### DIFF
--- a/lib/services/pack_library_template_loader.dart
+++ b/lib/services/pack_library_template_loader.dart
@@ -1,0 +1,13 @@
+import '../models/v2/training_pack_template.dart';
+import 'training_pack_asset_loader.dart';
+
+/// Loads training pack templates from the local pack library.
+class PackLibraryTemplateLoader {
+  const PackLibraryTemplateLoader._();
+
+  /// Loads the template with [id] from the library.
+  static Future<TrainingPackTemplate?> load(String id) async {
+    await TrainingPackAssetLoader.instance.loadAll();
+    return TrainingPackAssetLoader.instance.getById(id);
+  }
+}

--- a/lib/services/training_path_node_launcher_service.dart
+++ b/lib/services/training_path_node_launcher_service.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_path_node.dart';
+import '../screens/v2/training_pack_play_screen.dart';
+import 'pack_library_template_loader.dart';
+
+/// Launches the first available training pack for a [TrainingPathNode].
+class TrainingPathNodeLauncherService {
+  const TrainingPathNodeLauncherService();
+
+  /// Finds the first pack in [node] and opens it in [TrainingPackPlayScreen].
+  Future<void> launchNode(BuildContext context, TrainingPathNode node) async {
+    if (node.packIds.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Training pack not found')));
+      return;
+    }
+
+    final template = await PackLibraryTemplateLoader.load(node.packIds.first);
+    if (template == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Training pack not found')));
+      return;
+    }
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TrainingPackPlayScreen(template: template),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PackLibraryTemplateLoader to load templates from asset library
- implement TrainingPathNodeLauncherService to open first pack of a training path node and navigate to TrainingPackPlayScreen

## Testing
- `flutter analyze` *(fails: 3905 issues found)*
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68901519b740832a9dc46d81afbe4d83