### PR TITLE
feat: wire training path node list widget to launcher

### DIFF
--- a/lib/widgets/training_path_node_list_widget.dart
+++ b/lib/widgets/training_path_node_list_widget.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 
 import '../models/training_path_node.dart';
 import '../services/training_path_node_definition_service.dart';
+import '../services/training_path_node_launcher_service.dart';
 import '../services/training_path_progress_tracker_service.dart';
 
 /// Displays the list of training path nodes with visual lock/unlock state.
@@ -10,9 +11,7 @@ import '../services/training_path_progress_tracker_service.dart';
 /// Nodes that are unlocked can be tapped. Locked nodes are disabled. Completed
 /// nodes show a checkmark.
 class TrainingPathNodeListWidget extends StatefulWidget {
-  const TrainingPathNodeListWidget({super.key, this.onNodeTap});
-
-  final void Function(TrainingPathNode node)? onNodeTap;
+  const TrainingPathNodeListWidget({super.key});
 
   @override
   State<TrainingPathNodeListWidget> createState() =>
@@ -23,6 +22,7 @@ class _TrainingPathNodeListWidgetState
     extends State<TrainingPathNodeListWidget> {
   final _definitions = const TrainingPathNodeDefinitionService();
   final _progress = const TrainingPathProgressTrackerService();
+  final _launcher = const TrainingPathNodeLauncherService();
 
   late Future<_NodeStatusData> _future;
 
@@ -82,7 +82,7 @@ class _TrainingPathNodeListWidgetState
       leading: icon,
       title: Text(node.title),
       enabled: isUnlocked,
-      onTap: isUnlocked ? () => widget.onNodeTap?.call(node) : null,
+      onTap: isUnlocked ? () => _launcher.launchNode(context, node) : null,
     );
   }
 }


### PR DESCRIPTION
## Summary
- route taps on unlocked training nodes through `TrainingPathNodeLauncherService`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890189b7490832aa09e0387c47223c7