### PR TITLE
feat: add training path node detail screen

### DIFF
--- a/lib/screens/training_path_node_detail_screen.dart
+++ b/lib/screens/training_path_node_detail_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_path_node.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/pack_library_template_loader.dart';
+import '../services/training_path_node_launcher_service.dart';
+import '../services/training_path_progress_tracker_service.dart';
+import '../widgets/training_pack_template_card.dart';
+
+class TrainingPathNodeDetailScreen extends StatefulWidget {
+  final TrainingPathNode node;
+  const TrainingPathNodeDetailScreen({super.key, required this.node});
+
+  @override
+  State<TrainingPathNodeDetailScreen> createState() =>
+      _TrainingPathNodeDetailScreenState();
+}
+
+class _TrainingPathNodeDetailScreenState
+    extends State<TrainingPathNodeDetailScreen> {
+  final _tracker = const TrainingPathProgressTrackerService();
+  final _launcher = const TrainingPathNodeLauncherService();
+
+  late Future<_NodeDetailData> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<_NodeDetailData> _load() async {
+    final templates = <TrainingPackTemplate>[];
+    for (final id in widget.node.packIds) {
+      final tpl = await PackLibraryTemplateLoader.load(id);
+      if (tpl != null) templates.add(tpl);
+    }
+    final completed = await _tracker.getCompletedNodeIds();
+    final unlocked = await _tracker.getUnlockedNodeIds();
+    final isCompleted = completed.contains(widget.node.id);
+    final isUnlocked = unlocked.contains(widget.node.id);
+    return _NodeDetailData(
+      templates: templates,
+      isCompleted: isCompleted,
+      isUnlocked: isUnlocked,
+    );
+  }
+
+  Future<void> _startTraining() async {
+    await _launcher.launchNode(context, widget.node);
+    setState(() {
+      _future = _load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_NodeDetailData>(
+      future: _future,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        return Scaffold(
+          appBar: AppBar(title: Text(widget.node.title)),
+          body: snapshot.connectionState != ConnectionState.done
+              ? const Center(child: CircularProgressIndicator())
+              : ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    _buildStatusChip(data!),
+                    const SizedBox(height: 16),
+                    if (data.templates.isNotEmpty) ...[
+                      const Text('Паки',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 8),
+                      for (final tpl in data.templates)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: TrainingPackTemplateCard(template: tpl),
+                        ),
+                    ] else
+                      const Text('No training packs found'),
+                  ],
+                ),
+          bottomNavigationBar: snapshot.connectionState !=
+                      ConnectionState.done ||
+                  !(data?.isUnlocked ?? false)
+              ? null
+              : SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: ElevatedButton(
+                      onPressed: _startTraining,
+                      child: const Text('Start Training'),
+                    ),
+                  ),
+                ),
+        );
+      },
+    );
+  }
+
+  Widget _buildStatusChip(_NodeDetailData data) {
+    String label;
+    Color color;
+    if (data.isCompleted) {
+      label = 'Completed';
+      color = Colors.green;
+    } else if (data.isUnlocked) {
+      label = 'Unlocked';
+      color = Colors.blueGrey;
+    } else {
+      label = 'Locked';
+      color = Colors.grey;
+    }
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Chip(
+        label: Text(label),
+        backgroundColor: color,
+      ),
+    );
+  }
+}
+
+class _NodeDetailData {
+  final List<TrainingPackTemplate> templates;
+  final bool isCompleted;
+  final bool isUnlocked;
+
+  const _NodeDetailData({
+    required this.templates,
+    required this.isCompleted,
+    required this.isUnlocked,
+  });
+}
+

--- a/lib/widgets/training_path_node_list_widget.dart
+++ b/lib/widgets/training_path_node_list_widget.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:collection/collection.dart';
 
 import '../models/training_path_node.dart';
 import '../services/training_path_node_definition_service.dart';
-import '../services/training_path_node_launcher_service.dart';
 import '../services/training_path_progress_tracker_service.dart';
+import '../screens/training_path_node_detail_screen.dart';
 
 /// Displays the list of training path nodes with visual lock/unlock state.
 ///
@@ -22,7 +21,6 @@ class _TrainingPathNodeListWidgetState
     extends State<TrainingPathNodeListWidget> {
   final _definitions = const TrainingPathNodeDefinitionService();
   final _progress = const TrainingPathProgressTrackerService();
-  final _launcher = const TrainingPathNodeLauncherService();
 
   late Future<_NodeStatusData> _future;
 
@@ -81,8 +79,15 @@ class _TrainingPathNodeListWidgetState
     return ListTile(
       leading: icon,
       title: Text(node.title),
-      enabled: isUnlocked,
-      onTap: isUnlocked ? () => _launcher.launchNode(context, node) : null,
+      onTap: () async {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TrainingPathNodeDetailScreen(node: node),
+          ),
+        );
+        _refresh();
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- add TrainingPathNodeDetailScreen with pack previews, status display, and start training button
- update TrainingPathNodeListWidget to navigate to detail screen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689019a5d8ac832a844d8075384b6f43