### PR TITLE
feat: add breadcrumb service for training path

### DIFF
--- a/lib/services/training_path_breadcrumb_service.dart
+++ b/lib/services/training_path_breadcrumb_service.dart
@@ -1,0 +1,36 @@
+import '../models/training_path_node.dart';
+import 'training_path_node_definition_service.dart';
+
+/// Builds a breadcrumb trail for a [TrainingPathNode] based on its
+/// prerequisites.
+class TrainingPathBreadcrumbService {
+  final TrainingPathNodeDefinitionService definitions;
+
+  const TrainingPathBreadcrumbService({
+    this.definitions = const TrainingPathNodeDefinitionService(),
+  });
+
+  /// Returns the breadcrumb path from the root to [node], including [node].
+  List<TrainingPathNode> getBreadcrumb(TrainingPathNode node) {
+    final result = <TrainingPathNode>[];
+    final visited = <String>{};
+
+    void visit(TrainingPathNode current) {
+      if (!visited.add(current.id)) return;
+      if (current.prerequisiteNodeIds.isEmpty) {
+        result.add(current);
+        return;
+      }
+      for (final parentId in current.prerequisiteNodeIds) {
+        final parent = definitions.getNode(parentId);
+        if (parent != null) {
+          visit(parent);
+        }
+      }
+      result.add(current);
+    }
+
+    visit(node);
+    return result;
+  }
+}

--- a/test/services/training_path_breadcrumb_service_test.dart
+++ b/test/services/training_path_breadcrumb_service_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_path_node.dart';
+import 'package:poker_analyzer/services/training_path_breadcrumb_service.dart';
+import 'package:poker_analyzer/services/training_path_node_definition_service.dart';
+
+void main() {
+  const definitions = TrainingPathNodeDefinitionService();
+  const service = TrainingPathBreadcrumbService();
+
+  final root = definitions.getNode('starter_pushfold_10bb')!;
+  final mid = definitions.getNode('starter_postflop_basics')!;
+  final leaf = definitions.getNode('advanced_pushfold_15bb')!;
+
+  test('breadcrumb for root node includes only itself', () {
+    expect(service.getBreadcrumb(root).map((e) => e.id), [root.id]);
+  });
+
+  test('breadcrumb for intermediate node follows prerequisite chain', () {
+    expect(service.getBreadcrumb(mid).map((e) => e.id), [root.id, mid.id]);
+  });
+
+  test('breadcrumb for leaf node includes all ancestors', () {
+    expect(service.getBreadcrumb(leaf).map((e) => e.id), [
+      root.id,
+      mid.id,
+      leaf.id,
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingPathBreadcrumbService` for building prerequisite breadcrumbs
- test breadcrumb generation for root, intermediate, and leaf nodes

## Testing
- `flutter test` *(fails: numerous missing dependencies and compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68901affdba4832a98015c3cc543cb67