### PR TITLE
feat: add node recommendation service

### DIFF
--- a/lib/services/node_recommendation_service.dart
+++ b/lib/services/node_recommendation_service.dart
@@ -1,0 +1,56 @@
+import '../models/training_path_node.dart';
+import 'training_path_node_definition_service.dart';
+import 'training_path_progress_tracker_service.dart';
+
+/// Provides training path node recommendations based on current progress
+/// and prerequisite relationships.
+class NodeRecommendationService {
+  final TrainingPathNodeDefinitionService definitions;
+  final TrainingPathProgressTrackerService progress;
+
+  const NodeRecommendationService({
+    this.definitions = const TrainingPathNodeDefinitionService(),
+    this.progress = const TrainingPathProgressTrackerService(),
+  });
+
+  /// Returns recommended nodes for [currentNode].
+  ///
+  /// Recommendations include:
+  ///  * Prerequisite nodes for [currentNode] that haven't been completed.
+  ///  * Sibling nodes sharing the same prerequisites that are unlocked and
+  ///    not yet completed.
+  Future<List<TrainingPathNode>> getRecommendations(
+    TrainingPathNode currentNode,
+  ) async {
+    final completed = await progress.getCompletedNodeIds();
+    final unlocked = await progress.getUnlockedNodeIds();
+    final allNodes = definitions.getPath();
+
+    final result = <TrainingPathNode>{};
+
+    // Direct prerequisites that aren't completed yet.
+    for (final prereqId in currentNode.prerequisiteNodeIds) {
+      if (!completed.contains(prereqId)) {
+        final node = definitions.getNode(prereqId);
+        if (node != null) result.add(node);
+      }
+    }
+
+    // Siblings with the same prerequisite set that are unlocked and incomplete.
+    for (final node in allNodes) {
+      if (node.id == currentNode.id) continue;
+      if (completed.contains(node.id) || !unlocked.contains(node.id)) continue;
+      if (_samePrerequisites(node, currentNode)) {
+        result.add(node);
+      }
+    }
+
+    return result.toList();
+  }
+
+  bool _samePrerequisites(TrainingPathNode a, TrainingPathNode b) {
+    final aSet = a.prerequisiteNodeIds.toSet();
+    final bSet = b.prerequisiteNodeIds.toSet();
+    return aSet.length == bSet.length && aSet.containsAll(bSet);
+  }
+}

--- a/test/services/node_recommendation_service_test.dart
+++ b/test/services/node_recommendation_service_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_path_node.dart';
+import 'package:poker_analyzer/services/node_recommendation_service.dart';
+import 'package:poker_analyzer/services/training_path_node_definition_service.dart';
+import 'package:poker_analyzer/services/training_path_progress_tracker_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _TestDefinitions extends TrainingPathNodeDefinitionService {
+  final List<TrainingPathNode> _nodes;
+  const _TestDefinitions(this._nodes);
+
+  @override
+  List<TrainingPathNode> getPath() => _nodes;
+
+  @override
+  TrainingPathNode? getNode(String id) {
+    for (final n in _nodes) {
+      if (n.id == id) return n;
+    }
+    return null;
+  }
+}
+
+void main() {
+  final nodes = [
+    const TrainingPathNode(
+      id: 'a',
+      title: 'A',
+      packIds: ['a'],
+      prerequisiteNodeIds: [],
+    ),
+    const TrainingPathNode(
+      id: 'b',
+      title: 'B',
+      packIds: ['b'],
+      prerequisiteNodeIds: ['a'],
+    ),
+    const TrainingPathNode(
+      id: 'c',
+      title: 'C',
+      packIds: ['c'],
+      prerequisiteNodeIds: ['a'],
+    ),
+    const TrainingPathNode(
+      id: 'd',
+      title: 'D',
+      packIds: ['d'],
+      prerequisiteNodeIds: ['b'],
+    ),
+  ];
+
+  final definitions = _TestDefinitions(nodes);
+
+  late NodeRecommendationService service;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final progress = TrainingPathProgressTrackerService(
+      definitions: definitions,
+      prefs: prefs,
+    );
+    service = NodeRecommendationService(
+      definitions: definitions,
+      progress: progress,
+    );
+    await progress.markCompleted('a');
+  });
+
+  test('recommends sibling nodes with same prerequisites', () async {
+    final recs = await service.getRecommendations(nodes[1]); // node b
+    expect(recs.map((e) => e.id), ['c']);
+  });
+
+  test('recommends unmet prerequisite nodes', () async {
+    final recs = await service.getRecommendations(nodes[3]); // node d
+    expect(recs.map((e) => e.id), ['b']);
+  });
+}


### PR DESCRIPTION
## Summary
- add NodeRecommendationService to suggest training nodes based on progress
- cover recommendation heuristics with tests

## Testing
- `flutter test test/services/node_recommendation_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68908eb52864832aa9f81a59a280384a