### PR TITLE
feat: explain node recommendations

### DIFF
--- a/lib/screens/training_path_node_detail_screen.dart
+++ b/lib/screens/training_path_node_detail_screen.dart
@@ -98,7 +98,7 @@ class _TrainingPathNodeDetailScreenState
                       const Text('No training packs found'),
                     const SizedBox(height: 24),
                     NodeRecommendationSectionWidget(
-                      nodes: data.recommendations,
+                      recommendations: data.recommendations,
                       unlockedNodeIds: data.unlockedNodeIds,
                       completedNodeIds: data.completedNodeIds,
                       title: 'Recommended Next Steps',
@@ -215,7 +215,7 @@ class _NodeDetailData {
   final List<TrainingPathNode> breadcrumb;
   final Set<String> unlockedNodeIds;
   final Set<String> completedNodeIds;
-  final List<TrainingPathNode> recommendations;
+  final List<NodeRecommendation> recommendations;
 
   const _NodeDetailData({
     required this.templates,

--- a/lib/services/node_recommendation_service.dart
+++ b/lib/services/node_recommendation_service.dart
@@ -2,6 +2,15 @@ import '../models/training_path_node.dart';
 import 'training_path_node_definition_service.dart';
 import 'training_path_progress_tracker_service.dart';
 
+/// Represents a recommendation for a training path node along with a reason why
+/// it is suggested.
+class NodeRecommendation {
+  final TrainingPathNode node;
+  final String reason;
+
+  const NodeRecommendation({required this.node, required this.reason});
+}
+
 /// Provides training path node recommendations based on current progress
 /// and prerequisite relationships.
 class NodeRecommendationService {
@@ -19,20 +28,25 @@ class NodeRecommendationService {
   ///  * Prerequisite nodes for [currentNode] that haven't been completed.
   ///  * Sibling nodes sharing the same prerequisites that are unlocked and
   ///    not yet completed.
-  Future<List<TrainingPathNode>> getRecommendations(
+  Future<List<NodeRecommendation>> getRecommendations(
     TrainingPathNode currentNode,
   ) async {
     final completed = await progress.getCompletedNodeIds();
     final unlocked = await progress.getUnlockedNodeIds();
     final allNodes = definitions.getPath();
 
-    final result = <TrainingPathNode>{};
+    final recommendations = <NodeRecommendation>[];
+    final seenIds = <String>{};
 
     // Direct prerequisites that aren't completed yet.
     for (final prereqId in currentNode.prerequisiteNodeIds) {
       if (!completed.contains(prereqId)) {
         final node = definitions.getNode(prereqId);
-        if (node != null) result.add(node);
+        if (node != null && seenIds.add(node.id)) {
+          recommendations.add(
+            NodeRecommendation(node: node, reason: 'unmet prerequisite'),
+          );
+        }
       }
     }
 
@@ -40,12 +54,14 @@ class NodeRecommendationService {
     for (final node in allNodes) {
       if (node.id == currentNode.id) continue;
       if (completed.contains(node.id) || !unlocked.contains(node.id)) continue;
-      if (_samePrerequisites(node, currentNode)) {
-        result.add(node);
+      if (_samePrerequisites(node, currentNode) && seenIds.add(node.id)) {
+        recommendations.add(
+          NodeRecommendation(node: node, reason: 'parallel topic'),
+        );
       }
     }
 
-    return result.toList();
+    return recommendations;
   }
 
   bool _samePrerequisites(TrainingPathNode a, TrainingPathNode b) {

--- a/lib/widgets/node_recommendation_section_widget.dart
+++ b/lib/widgets/node_recommendation_section_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/training_path_node.dart';
+import '../services/node_recommendation_service.dart';
 import 'training_node_summary_card.dart';
 
 /// Displays a compact section of recommended training path nodes.
@@ -9,7 +10,7 @@ import 'training_node_summary_card.dart';
 /// Tapping a card is only enabled when the node is unlocked. An optional
 /// [onNodeTap] callback can be provided to handle taps.
 class NodeRecommendationSectionWidget extends StatelessWidget {
-  final List<TrainingPathNode> nodes;
+  final List<NodeRecommendation> recommendations;
   final Set<String> unlockedNodeIds;
   final Set<String> completedNodeIds;
   final String title;
@@ -17,7 +18,7 @@ class NodeRecommendationSectionWidget extends StatelessWidget {
 
   const NodeRecommendationSectionWidget({
     super.key,
-    required this.nodes,
+    required this.recommendations,
     required this.unlockedNodeIds,
     required this.completedNodeIds,
     required this.title,
@@ -26,23 +27,33 @@ class NodeRecommendationSectionWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayNodes = nodes.take(3).toList();
-    if (displayNodes.isEmpty) return const SizedBox.shrink();
+    final displayRecs = recommendations.take(3).toList();
+    if (displayRecs.isEmpty) return const SizedBox.shrink();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(title, style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 8),
-        for (final node in displayNodes)
+        for (final rec in displayRecs) ...[
           TrainingNodeSummaryCard(
-            node: node,
-            isUnlocked: unlockedNodeIds.contains(node.id),
-            isCompleted: completedNodeIds.contains(node.id),
-            onTap: unlockedNodeIds.contains(node.id)
-                ? () => onNodeTap?.call(node)
+            node: rec.node,
+            isUnlocked: unlockedNodeIds.contains(rec.node.id),
+            isCompleted: completedNodeIds.contains(rec.node.id),
+            onTap: unlockedNodeIds.contains(rec.node.id)
+                ? () => onNodeTap?.call(rec.node)
                 : null,
           ),
+          const SizedBox(height: 4),
+          Text(
+            rec.reason,
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: Colors.grey),
+          ),
+          const SizedBox(height: 8),
+        ],
       ],
     );
   }

--- a/test/services/node_recommendation_service_test.dart
+++ b/test/services/node_recommendation_service_test.dart
@@ -69,11 +69,13 @@ void main() {
 
   test('recommends sibling nodes with same prerequisites', () async {
     final recs = await service.getRecommendations(nodes[1]); // node b
-    expect(recs.map((e) => e.id), ['c']);
+    expect(recs.map((e) => e.node.id), ['c']);
+    expect(recs.first.reason, 'parallel topic');
   });
 
   test('recommends unmet prerequisite nodes', () async {
     final recs = await service.getRecommendations(nodes[3]); // node d
-    expect(recs.map((e) => e.id), ['b']);
+    expect(recs.map((e) => e.node.id), ['b']);
+    expect(recs.first.reason, 'unmet prerequisite');
   });
 }


### PR DESCRIPTION
## Summary
- return annotated training path node recommendations with reasons
- show explanation text under recommended nodes in the detail screen

## Testing
- `dart format lib/services/node_recommendation_service.dart lib/widgets/node_recommendation_section_widget.dart lib/screens/training_path_node_detail_screen.dart test/services/node_recommendation_service_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689091cd2dd0832a9e5a69a4c317ef33