### PR TITLE
feat: add inline theory linker service

### DIFF
--- a/lib/models/inline_theory_linked_text.dart
+++ b/lib/models/inline_theory_linked_text.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// Represents a piece of text that may be plain or linked.
+class InlineTextChunk {
+  final String text;
+  final VoidCallback? onTap;
+
+  const InlineTextChunk({required this.text, this.onTap});
+
+  bool get isLink => onTap != null;
+}
+
+/// A sequence of [InlineTextChunk]s that can render as [RichText].
+class InlineTheoryLinkedText {
+  final List<InlineTextChunk> chunks;
+
+  const InlineTheoryLinkedText(this.chunks);
+
+  /// Builds a [RichText] widget representing this linked text.
+  RichText toRichText({TextStyle? style, TextStyle? linkStyle}) {
+    final defaultLinkStyle = linkStyle ?? const TextStyle(color: Colors.blue);
+    return RichText(
+      text: TextSpan(
+        style: style,
+        children: [
+          for (final c in chunks)
+            c.isLink
+                ? TextSpan(
+                    text: c.text,
+                    style: defaultLinkStyle,
+                    recognizer: TapGestureRecognizer()..onTap = c.onTap,
+                  )
+                : TextSpan(text: c.text),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/inline_theory_linker_service.dart
+++ b/lib/services/inline_theory_linker_service.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../models/inline_theory_linked_text.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+import 'theory_mini_lesson_navigator.dart';
+
+class InlineTheoryLinkerService {
+  InlineTheoryLinkerService({
+    MiniLessonLibraryService? library,
+    TheoryMiniLessonNavigator? navigator,
+  }) : _library = library ?? MiniLessonLibraryService.instance,
+       _navigator = navigator ?? TheoryMiniLessonNavigator.instance;
+
+  final MiniLessonLibraryService _library;
+  final TheoryMiniLessonNavigator _navigator;
+
+  /// Parses [description] and converts matching keywords to inline links.
+  ///
+  /// Only lessons sharing at least one of [contextTags] are considered.
+  InlineTheoryLinkedText link(
+    String description, {
+    List<String> contextTags = const [],
+  }) {
+    final candidates = _library.all.where((l) {
+      if (contextTags.isEmpty) return true;
+      return l.tags.any((t) => contextTags.contains(t));
+    }).toList();
+
+    final matches = <_Match>[];
+    for (final lesson in candidates) {
+      if (lesson.tags.isEmpty) continue;
+      for (final tag in lesson.tags) {
+        final regex = RegExp(
+          '\\b' + RegExp.escape(tag) + '\\b',
+          caseSensitive: false,
+        );
+        for (final m in regex.allMatches(description)) {
+          matches.add(_Match(m.start, m.end, tag));
+        }
+      }
+      // keyword match using lesson title
+      final keywords = lesson.title.split(RegExp('\\s+'));
+      for (final k in keywords) {
+        if (k.isEmpty) continue;
+        final regex = RegExp(
+          '\\b' + RegExp.escape(k) + '\\b',
+          caseSensitive: false,
+        );
+        for (final m in regex.allMatches(description)) {
+          matches.add(_Match(m.start, m.end, lesson.tags.first));
+        }
+      }
+    }
+
+    matches.sort((a, b) => a.start.compareTo(b.start));
+    final filtered = <_Match>[];
+    int lastEnd = -1;
+    for (final m in matches) {
+      if (m.start >= lastEnd) {
+        filtered.add(m);
+        lastEnd = m.end;
+      }
+    }
+
+    final chunks = <InlineTextChunk>[];
+    int index = 0;
+    for (final m in filtered) {
+      if (m.start > index) {
+        chunks.add(
+          InlineTextChunk(text: description.substring(index, m.start)),
+        );
+      }
+      final text = description.substring(m.start, m.end);
+      chunks.add(
+        InlineTextChunk(
+          text: text,
+          onTap: () => _navigator.openLessonByTag(m.tag),
+        ),
+      );
+      index = m.end;
+    }
+    if (index < description.length) {
+      chunks.add(InlineTextChunk(text: description.substring(index)));
+    }
+    return InlineTheoryLinkedText(chunks);
+  }
+}
+
+class _Match {
+  final int start;
+  final int end;
+  final String tag;
+  _Match(this.start, this.end, this.tag);
+}

--- a/test/services/inline_theory_linker_service_test.dart
+++ b/test/services/inline_theory_linker_service_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/inline_theory_linked_text.dart';
+import 'package:poker_analyzer/services/inline_theory_linker_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_navigator.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => [];
+}
+
+class _FakeNavigator extends TheoryMiniLessonNavigator {
+  String? openedTag;
+
+  @override
+  Future<void> openLessonByTag(String tag, [context]) async {
+    openedTag = tag;
+  }
+}
+
+void main() {
+  test('links keywords in description and opens lesson', () {
+    final library = _FakeLibrary([
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'CBet',
+        content: '',
+        tags: ['cbet'],
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'Probe',
+        content: '',
+        tags: ['probe'],
+      ),
+    ]);
+    final navigator = _FakeNavigator();
+    final service = InlineTheoryLinkerService(
+      library: library,
+      navigator: navigator,
+    );
+    final linked = service.link(
+      'Study cbet and probe strategies.',
+      contextTags: ['cbet', 'probe'],
+    );
+    expect(linked.chunks.length, 5);
+    expect(linked.chunks[1].text.toLowerCase(), 'cbet');
+    expect(linked.chunks[1].isLink, isTrue);
+    linked.chunks[1].onTap?.call();
+    expect(navigator.openedTag, 'cbet');
+    linked.chunks[3].onTap?.call();
+    expect(navigator.openedTag, 'probe');
+  });
+
+  test('respects context tags', () {
+    final library = _FakeLibrary([
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'CBet',
+        content: '',
+        tags: ['cbet'],
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'Probe',
+        content: '',
+        tags: ['probe'],
+      ),
+    ]);
+    final service = InlineTheoryLinkerService(library: library);
+    final linked = service.link('cbet and probe', contextTags: ['cbet']);
+    expect(linked.chunks.where((c) => c.isLink).length, 1);
+    expect(linked.chunks[1].text.toLowerCase(), 'cbet');
+  });
+}


### PR DESCRIPTION
## Summary
- add `InlineTheoryLinkedText` model for rendering linked text
- implement `InlineTheoryLinkerService` to embed theory lesson links in descriptions
- cover service with unit tests

## Testing
- `flutter test` *(fails: multiple compile errors e.g. missing parameters and undefined classes)*

------
https://chatgpt.com/codex/tasks/task_e_689093665720832a81818909a99cf42d