### PR TITLE
feat: link pack descriptions to theory

### DIFF
--- a/lib/widgets/training_pack_template_card.dart
+++ b/lib/widgets/training_pack_template_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/v2/training_pack_template.dart';
 import '../services/thumbnail_cache_service.dart';
 import '../services/training_pack_stats_service.dart';
+import '../services/inline_theory_linker_service.dart';
 
 class TrainingPackTemplateCard extends StatefulWidget {
   final TrainingPackTemplate template;
@@ -19,6 +20,7 @@ class _TrainingPackTemplateCardState extends State<TrainingPackTemplateCard> {
   bool inProgress = false;
   TrainingPackStat? _stat;
   double _progress = 0;
+  final _linker = InlineTheoryLinkerService();
   @override
   void initState() {
     super.initState();
@@ -62,6 +64,22 @@ class _TrainingPackTemplateCardState extends State<TrainingPackTemplateCard> {
         style: const TextStyle(fontWeight: FontWeight.bold),
       ),
     ];
+    if (widget.template.description.isNotEmpty) {
+      lines.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: _linker
+              .link(
+                widget.template.description,
+                contextTags: widget.template.tags,
+              )
+              .toRichText(
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                linkStyle: const TextStyle(color: Colors.lightBlueAccent),
+              ),
+        ),
+      );
+    }
     if (_stat != null && _progress > 0) {
       final ev = _stat!.postEvPct > 0 ? _stat!.postEvPct : _stat!.preEvPct;
       final icm = _stat!.postIcmPct > 0 ? _stat!.postIcmPct : _stat!.preIcmPct;


### PR DESCRIPTION
## Summary
- enrich TrainingPackTemplateCard descriptions with inline theory links

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6890971c1908832a89cd40dcca263510