### PR TITLE
feat: add theory quick access banner

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -55,6 +55,7 @@ import '../services/mistake_booster_progress_tracker.dart';
 import '../services/training_progress_logger.dart';
 import 'training_session_completion_screen.dart';
 import '../services/inline_theory_linker_service.dart';
+import '../widgets/theory_quick_access_banner.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -750,6 +751,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                               orElse: () => spot.tags.first,
                             ),
                           ),
+                        TheoryQuickAccessBannerWidget(tags: spot.tags),
                       ],
                       Text(
                         'Elapsed: ${_format(service.elapsedTime)}',

--- a/lib/services/inline_theory_linker_service.dart
+++ b/lib/services/inline_theory_linker_service.dart
@@ -85,6 +85,14 @@ class InlineTheoryLinkerService {
     }
     return InlineTheoryLinkedText(chunks);
   }
+
+  /// Returns lessons related to the provided [tags].
+  Future<List<TheoryMiniLessonNode>> extractRelevantLessons(
+    List<String> tags,
+  ) async {
+    await _library.loadAll();
+    return _library.findByTags(tags);
+  }
 }
 
 class _Match {

--- a/lib/widgets/theory_quick_access_banner.dart
+++ b/lib/widgets/theory_quick_access_banner.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/inline_theory_linker_service.dart';
+import '../services/theory_lesson_completion_logger.dart';
+import '../screens/mini_lesson_screen.dart';
+
+class TheoryQuickAccessBannerWidget extends StatefulWidget {
+  final List<String> tags;
+  const TheoryQuickAccessBannerWidget({super.key, required this.tags});
+
+  @override
+  State<TheoryQuickAccessBannerWidget> createState() =>
+      _TheoryQuickAccessBannerWidgetState();
+}
+
+class _TheoryQuickAccessBannerWidgetState
+    extends State<TheoryQuickAccessBannerWidget> {
+  final _linker = InlineTheoryLinkerService();
+  TheoryMiniLessonNode? _lesson;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void didUpdateWidget(covariant TheoryQuickAccessBannerWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!listEquals(oldWidget.tags, widget.tags)) {
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _lesson = null;
+    });
+    final lessons = await _linker.extractRelevantLessons(widget.tags);
+    for (final l in lessons) {
+      final completed =
+          await TheoryLessonCompletionLogger.instance.isCompleted(l.id);
+      if (!completed) {
+        _lesson = l;
+        break;
+      }
+    }
+    if (mounted) {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  void _openLesson() {
+    final lesson = _lesson;
+    if (lesson == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _lesson == null) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.lightBlueAccent.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.school, color: Colors.lightBlueAccent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _lesson!.resolvedTitle,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Новая концепция',
+                  style: TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: _openLesson,
+            child: const Text('Изучить'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- show quick-access theory banner in training session when relevant mini lesson is available
- allow InlineTheoryLinkerService to fetch lessons by tag

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909e28b124832aa07a748fce839d0d