### PR TITLE
Track mini lesson review completions

### DIFF
--- a/lib/screens/mini_lesson_screen.dart
+++ b/lib/screens/mini_lesson_screen.dart
@@ -9,6 +9,7 @@ import '../services/theory_streak_service.dart';
 import '../services/theory_booster_recall_engine.dart';
 import '../services/pinned_learning_service.dart';
 import '../services/theory_lesson_completion_logger.dart';
+import '../services/review_completion_logger.dart';
 
 /// Simple viewer for a [TheoryMiniLessonNode].
 class MiniLessonScreen extends StatefulWidget {
@@ -30,6 +31,7 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
   late DateTime _started;
   late final ScrollController _controller;
   bool _pinned = false;
+  bool _isReview = false;
 
   @override
   void initState() {
@@ -67,6 +69,17 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is bool && args) {
+      _isReview = true;
+    } else if (args is Map && args['isReview'] == true) {
+      _isReview = true;
+    }
+  }
+
+  @override
   void dispose() {
     final tag = widget.recapTag;
     if (tag != null) {
@@ -83,6 +96,10 @@ class _MiniLessonScreenState extends State<MiniLessonScreen> {
     PinnedLearningService.instance.removeListener(_updatePinned);
     unawaited(
         TheoryLessonCompletionLogger.instance.markCompleted(widget.lesson.id));
+    if (_isReview) {
+      unawaited(
+          ReviewCompletionLogger.instance.logReview(widget.lesson.id));
+    }
     super.dispose();
   }
 

--- a/lib/services/review_completion_logger.dart
+++ b/lib/services/review_completion_logger.dart
@@ -1,0 +1,12 @@
+import 'review_scheduler_service.dart';
+
+/// Logs completed reviews and updates the review schedule.
+class ReviewCompletionLogger {
+  ReviewCompletionLogger._();
+  static final ReviewCompletionLogger instance = ReviewCompletionLogger._();
+
+  /// Increments the review count for [lessonId].
+  Future<void> logReview(String lessonId) async {
+    await ReviewSchedulerService.instance.markReviewed(lessonId);
+  }
+}

--- a/lib/widgets/theory_quick_access_banner.dart
+++ b/lib/widgets/theory_quick_access_banner.dart
@@ -72,7 +72,10 @@ class _TheoryQuickAccessBannerWidgetState
     if (lesson == null) return;
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+      MaterialPageRoute(
+        builder: (_) => MiniLessonScreen(lesson: lesson),
+        settings: RouteSettings(arguments: _isReview),
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- add ReviewCompletionLogger to update review schedule
- flag review intent via route arguments in MiniLessonScreen
- send review flag from TheoryQuickAccessBannerWidget

## Testing
- `flutter test` *(fails: command not found)*
- `flutter format lib/services/review_completion_logger.dart lib/screens/mini_lesson_screen.dart lib/widgets/theory_quick_access_banner.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a14d4e98832a97268df69738d0c4