### PR TITLE
feat: add learning path entry grouping

### DIFF
--- a/lib/services/learning_path_entry_group_builder.dart
+++ b/lib/services/learning_path_entry_group_builder.dart
@@ -1,0 +1,56 @@
+import '../models/skill_tree_node_model.dart';
+import '../services/skill_node_decay_review_injector.dart';
+import '../services/inline_theory_linker_service.dart';
+import '../services/pack_library_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Groups [LearningPathEntry] items for a [SkillTreeNodeModel] into
+/// logical learning stages (review -> theory -> practice).
+class LearningPathEntryGroupBuilder {
+  final SkillNodeDecayReviewInjector decayInjector;
+  final InlineTheoryLinkerService linker;
+  final PackLibraryService packLibrary;
+
+  LearningPathEntryGroupBuilder({
+    SkillNodeDecayReviewInjector? decayInjector,
+    InlineTheoryLinkerService? linker,
+    PackLibraryService? packLibrary,
+  }) : decayInjector = decayInjector ?? SkillNodeDecayReviewInjector(),
+       linker = linker ?? InlineTheoryLinkerService(),
+       packLibrary = packLibrary ?? PackLibraryService.instance;
+
+  /// Returns ordered groups of learning path entries for [node].
+  Future<List<LearningPathEntryGroup>> build(SkillTreeNodeModel node) async {
+    final groups = <LearningPathEntryGroup>[];
+
+    final review = await decayInjector.injectDecayReviews(node);
+    if (review.isNotEmpty) {
+      groups.add(LearningPathEntryGroup(title: 'Review', entries: review));
+    }
+
+    final TrainingPackTemplateV2? pack = await packLibrary.getById(
+      node.trainingPackId,
+    );
+
+    final theory = pack != null
+        ? await linker.extractRelevantLessons(pack.tags)
+        : [];
+    if (theory.isNotEmpty) {
+      groups.add(LearningPathEntryGroup(title: 'Theory', entries: theory));
+    }
+
+    if (pack != null) {
+      groups.add(LearningPathEntryGroup(title: 'Practice', entries: [pack]));
+    }
+
+    return groups;
+  }
+}
+
+/// Container for grouped learning path entries.
+class LearningPathEntryGroup {
+  final String title;
+  final List<LearningPathEntry> entries;
+
+  const LearningPathEntryGroup({required this.title, required this.entries});
+}

--- a/test/services/learning_path_entry_group_builder_test.dart
+++ b/test/services/learning_path_entry_group_builder_test.dart
@@ -1,0 +1,83 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/learning_path_entry_group_builder.dart';
+import 'package:poker_analyzer/services/skill_node_decay_review_injector.dart';
+import 'package:poker_analyzer/services/inline_theory_linker_service.dart';
+import 'package:poker_analyzer/services/pack_library_service.dart';
+import 'package:poker_analyzer/models/skill_tree_node_model.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+class _FakeDecayInjector extends SkillNodeDecayReviewInjector {
+  @override
+  Future<List<LearningPathEntry>> injectDecayReviews(
+    SkillTreeNodeModel node, {
+    double thresholdDays = 30,
+  }) async {
+    return ['review'];
+  }
+}
+
+class _FakeTheoryLinker extends InlineTheoryLinkerService {
+  @override
+  Future<List<TheoryMiniLessonNode>> extractRelevantLessons(
+    List<String> tags,
+  ) async {
+    return [const TheoryMiniLessonNode(id: 't1', title: 'Lesson', content: '')];
+  }
+}
+
+class _FakePackLibraryService implements PackLibraryService {
+  final TrainingPackTemplateV2 pack;
+
+  _FakePackLibraryService(this.pack);
+
+  @override
+  Future<TrainingPackTemplateV2?> getById(String id) async => pack;
+
+  @override
+  List<TrainingPackSpot> getPack(String id) => const [];
+
+  @override
+  List<String> getAvailablePackIds() => const [];
+
+  @override
+  Future<TrainingPackTemplateV2?> recommendedStarter() async => null;
+
+  @override
+  Future<TrainingPackTemplateV2?> findByTag(String tag) async => null;
+
+  @override
+  Future<List<String>> findBoosterCandidates(String tag) async => const [];
+}
+
+void main() {
+  test('builds groups in expected order', () async {
+    const node = SkillTreeNodeModel(
+      id: 'n1',
+      title: 'Node',
+      category: 'cat',
+      trainingPackId: 'pack',
+    );
+    const pack = TrainingPackTemplateV2(
+      id: 'pack',
+      name: 'Practice',
+      trainingType: TrainingType.pushFold,
+      tags: ['tag1'],
+    );
+    final builder = LearningPathEntryGroupBuilder(
+      decayInjector: _FakeDecayInjector(),
+      linker: _FakeTheoryLinker(),
+      packLibrary: _FakePackLibraryService(pack),
+    );
+
+    final groups = await builder.build(node);
+
+    expect(groups.length, 3);
+    expect(groups[0].title, 'Review');
+    expect(groups[1].title, 'Theory');
+    expect(groups[2].title, 'Practice');
+    expect(groups[2].entries.first, pack);
+  });
+}


### PR DESCRIPTION
## Summary
- group skill tree learning path entries into review, theory, and practice stages
- add unit test to verify grouping order

## Testing
- `dart test test/services/learning_path_entry_group_builder_test.dart` *(fails: Offset not found, Some tests failed)*
- `flutter test test/services/learning_path_entry_group_builder_test.dart` *(fails: missing files and types, No tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6890a712eda4832ab9eeecedb43663b4