### PR TITLE
feat: render learning path groups

### DIFF
--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -10,6 +10,8 @@ import '../services/skill_tree_category_banner_service.dart';
 import '../services/skill_tree_node_progress_tracker.dart';
 import '../services/training_progress_service.dart';
 import '../services/skill_tree_node_celebration_service.dart';
+import '../services/learning_path_entry_group_builder.dart';
+import '../services/learning_path_node_renderer_service.dart';
 import '../widgets/tag_badge.dart';
 import '../widgets/skill_tree_node_detail_hint_widget.dart';
 import 'theory_lesson_viewer_screen.dart';
@@ -40,6 +42,7 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
   TheoryMiniLessonNode? _lesson;
   double _progress = 0.0;
   bool _loading = true;
+  List<LearningPathEntryGroup> _groups = [];
 
   @override
   void initState() {
@@ -61,6 +64,7 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
           .isCompleted(widget.node.id);
       if (done) _progress = 1.0;
     }
+    _groups = await LearningPathEntryGroupBuilder().build(widget.node);
     if (mounted) setState(() => _loading = false);
   }
 
@@ -185,6 +189,12 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                         track: widget.track!,
                         unlocked: widget.unlockedNodeIds!,
                         completed: widget.completedNodeIds!,
+                      ),
+                    if (_groups.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16),
+                        child: LearningPathNodeRendererService()
+                            .build(context, _groups),
                       ),
                     const Spacer(),
                     Tooltip(

--- a/lib/services/learning_path_entry_renderer.dart
+++ b/lib/services/learning_path_entry_renderer.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_preview_spot.dart';
+import '../models/v2/hero_position.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../services/training_session_launcher.dart';
+import '../widgets/theory_lesson_preview_tile.dart';
+import '../widgets/training_pack_preview_card.dart';
+import '../widgets/pack_card.dart';
+
+/// Renders individual [LearningPathEntry] items into widgets.
+class LearningPathEntryRenderer {
+  const LearningPathEntryRenderer();
+
+  /// Builds a widget for a single [entry].
+  ///
+  /// Supported entry types:
+  /// * [TheoryMiniLessonNode] – rendered via [TheoryLessonPreviewTile]
+  /// * [TrainingPackSpot] – rendered via [TrainingPackPreviewCard]
+  /// * [TrainingPackTemplateV2] – rendered via [PackCard]
+  Widget build(BuildContext context, Object entry) {
+    if (entry is TheoryMiniLessonNode) {
+      return TheoryLessonPreviewTile(
+        node: entry,
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => MiniLessonScreen(lesson: entry),
+            ),
+          );
+        },
+      );
+    } else if (entry is TrainingPackTemplateV2) {
+      return PackCard(
+        template: entry,
+        onTap: () => const TrainingSessionLauncher().launch(entry),
+      );
+    } else if (entry is TrainingPackSpot) {
+      final preview = TrainingPackPreviewSpot(
+        hand: entry.hand.heroCards,
+        position: entry.hand.position.label,
+        action: entry.correctAction ?? '',
+      );
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: TrainingPackPreviewCard(spot: preview),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+}
+

--- a/lib/services/learning_path_node_renderer_service.dart
+++ b/lib/services/learning_path_node_renderer_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'learning_path_entry_group_builder.dart';
+import 'learning_path_entry_renderer.dart';
+
+/// Renders groups of learning path entries into titled sections.
+class LearningPathNodeRendererService {
+  final LearningPathEntryRenderer entryRenderer;
+
+  const LearningPathNodeRendererService({
+    LearningPathEntryRenderer? entryRenderer,
+  }) : entryRenderer = entryRenderer ?? const LearningPathEntryRenderer();
+
+  /// Builds a column widget displaying [groups] with headers and entry cards.
+  Widget build(BuildContext context, List<LearningPathEntryGroup> groups) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final group in groups) ...[
+          Padding(
+            padding: const EdgeInsets.only(
+                top: 16, left: 16, right: 16, bottom: 8),
+            child: Text(
+              group.title,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          for (final entry in group.entries)
+            entryRenderer.build(context, entry),
+        ],
+      ],
+    );
+  }
+}
+

--- a/test/services/learning_path_node_renderer_service_test.dart
+++ b/test/services/learning_path_node_renderer_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/learning_path_entry_group_builder.dart';
+import 'package:poker_analyzer/services/learning_path_node_renderer_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders group headers and entries', (tester) async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'Lesson A',
+      content: '',
+      tags: [],
+      nextIds: [],
+    );
+    final group = LearningPathEntryGroup(title: 'Review', entries: const [lesson]);
+    final service = LearningPathNodeRendererService();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => service.build(context, [group]),
+      ),
+    ));
+    await tester.pump();
+
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Lesson A'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add LearningPathEntryRenderer to turn mini lessons, booster spots, and packs into widgets
- introduce LearningPathNodeRendererService to display grouped learning path sections
- show learning path under unlock hints in SkillTreeNodeDetailScreen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6890aa570198832aa513f8f607759b52