### PR TITLE
feat: log learning path section views

### DIFF
--- a/lib/screens/skill_tree_node_detail_screen.dart
+++ b/lib/screens/skill_tree_node_detail_screen.dart
@@ -194,7 +194,7 @@ class _SkillTreeNodeDetailScreenState extends State<SkillTreeNodeDetailScreen> {
                       Padding(
                         padding: const EdgeInsets.only(top: 16),
                         child: LearningPathNodeRendererService()
-                            .build(context, _groups),
+                            .build(context, widget.node.id, _groups),
                       ),
                     const Spacer(),
                     Tooltip(

--- a/lib/services/learning_path_node_analytics_logger.dart
+++ b/lib/services/learning_path_node_analytics_logger.dart
@@ -1,0 +1,17 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Logs when sections within a learning path node are viewed.
+class LearningPathNodeAnalyticsLogger {
+  const LearningPathNodeAnalyticsLogger();
+
+  static const _storeKey = 'learning_path_group_views';
+
+  /// Records that a group [title] for [nodeId] was viewed at [timestamp].
+  Future<void> logGroupViewed(String nodeId, String title) async {
+    final prefs = await SharedPreferences.getInstance();
+    final events = prefs.getStringList(_storeKey) ?? <String>[];
+    final ts = DateTime.now().millisecondsSinceEpoch;
+    events.add('$nodeId|$title|$ts');
+    await prefs.setStringList(_storeKey, events);
+  }
+}

--- a/lib/services/learning_path_node_renderer_service.dart
+++ b/lib/services/learning_path_node_renderer_service.dart
@@ -1,36 +1,54 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'learning_path_entry_group_builder.dart';
 import 'learning_path_entry_renderer.dart';
+import 'learning_path_node_analytics_logger.dart';
 
 /// Renders groups of learning path entries into titled sections.
 class LearningPathNodeRendererService {
   final LearningPathEntryRenderer entryRenderer;
+  final LearningPathNodeAnalyticsLogger analyticsLogger;
 
   const LearningPathNodeRendererService({
     LearningPathEntryRenderer? entryRenderer,
-  }) : entryRenderer = entryRenderer ?? const LearningPathEntryRenderer();
+    LearningPathNodeAnalyticsLogger? analyticsLogger,
+  })  : entryRenderer = entryRenderer ?? const LearningPathEntryRenderer(),
+        analyticsLogger =
+            analyticsLogger ?? const LearningPathNodeAnalyticsLogger();
 
   /// Builds a column widget displaying [groups] with headers and entry cards.
-  Widget build(BuildContext context, List<LearningPathEntryGroup> groups) {
+  Widget build(
+      BuildContext context, String nodeId, List<LearningPathEntryGroup> groups) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (final group in groups) ...[
-          Padding(
-            padding: const EdgeInsets.only(
-                top: 16, left: 16, right: 16, bottom: 8),
-            child: Text(
-              group.title,
-              style: const TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
+        for (final group in groups)
+          _buildGroup(context, nodeId, group),
+      ],
+    );
+  }
+
+  Widget _buildGroup(
+      BuildContext context, String nodeId, LearningPathEntryGroup group) {
+    unawaited(analyticsLogger.logGroupViewed(nodeId, group.title));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding:
+              const EdgeInsets.only(top: 16, left: 16, right: 16, bottom: 8),
+          child: Text(
+            group.title,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
             ),
           ),
-          for (final entry in group.entries)
-            entryRenderer.build(context, entry),
-        ],
+        ),
+        for (final entry in group.entries)
+          entryRenderer.build(context, entry),
       ],
     );
   }

--- a/test/services/learning_path_node_renderer_service_test.dart
+++ b/test/services/learning_path_node_renderer_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
 import 'package:poker_analyzer/services/learning_path_entry_group_builder.dart';
+import 'package:poker_analyzer/services/learning_path_node_analytics_logger.dart';
 import 'package:poker_analyzer/services/learning_path_node_renderer_service.dart';
 
 void main() {
@@ -16,16 +17,32 @@ void main() {
       nextIds: [],
     );
     final group = LearningPathEntryGroup(title: 'Review', entries: const [lesson]);
-    final service = LearningPathNodeRendererService();
+    final logger = _FakeLogger();
+    final service =
+        LearningPathNodeRendererService(analyticsLogger: logger);
 
     await tester.pumpWidget(MaterialApp(
       home: Builder(
-        builder: (context) => service.build(context, [group]),
+        builder: (context) => service.build(context, 'n1', [group]),
       ),
     ));
     await tester.pump();
 
     expect(find.text('Review'), findsOneWidget);
     expect(find.text('Lesson A'), findsOneWidget);
+    expect(logger.logged.length, 1);
+    expect(logger.logged.first['nodeId'], 'n1');
+    expect(logger.logged.first['title'], 'Review');
   });
+}
+
+class _FakeLogger extends LearningPathNodeAnalyticsLogger {
+  _FakeLogger();
+
+  final List<Map<String, String>> logged = [];
+
+  @override
+  Future<void> logGroupViewed(String nodeId, String title) async {
+    logged.add({'nodeId': nodeId, 'title': title});
+  }
 }


### PR DESCRIPTION
## Summary
- add `LearningPathNodeAnalyticsLogger` for tracking viewed learning path groups
- log group views when rendering skill tree node detail sections

## Testing
- `flutter test test/services/learning_path_node_renderer_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890ac35239c832a9ee11120e3a89ea2