### PR TITLE
feat: add auto recall theory snippets

### DIFF
--- a/lib/services/decay_tag_retention_tracker_service.dart
+++ b/lib/services/decay_tag_retention_tracker_service.dart
@@ -116,4 +116,10 @@ class DecayTagRetentionTrackerService {
     }
     return result;
   }
+
+  /// Returns `true` if the [tag]'s decay in days exceeds [threshold].
+  Future<bool> isDecayed(String tag, {double threshold = 30}) async {
+    final days = await getDecayScore(tag);
+    return days > threshold;
+  }
 }

--- a/lib/services/learning_path_node_renderer_service.dart
+++ b/lib/services/learning_path_node_renderer_service.dart
@@ -5,18 +5,22 @@ import 'package:flutter/material.dart';
 import 'learning_path_entry_group_builder.dart';
 import 'learning_path_entry_renderer.dart';
 import 'learning_path_node_analytics_logger.dart';
+import 'theory_auto_recall_injector.dart';
 
 /// Renders groups of learning path entries into titled sections.
 class LearningPathNodeRendererService {
   final LearningPathEntryRenderer entryRenderer;
   final LearningPathNodeAnalyticsLogger analyticsLogger;
+  final TheoryAutoRecallInjector autoRecall;
 
   const LearningPathNodeRendererService({
     LearningPathEntryRenderer? entryRenderer,
     LearningPathNodeAnalyticsLogger? analyticsLogger,
+    TheoryAutoRecallInjector? autoRecall,
   })  : entryRenderer = entryRenderer ?? const LearningPathEntryRenderer(),
         analyticsLogger =
-            analyticsLogger ?? const LearningPathNodeAnalyticsLogger();
+            analyticsLogger ?? const LearningPathNodeAnalyticsLogger(),
+        autoRecall = autoRecall ?? const TheoryAutoRecallInjector();
 
   /// Builds a column widget displaying [groups] with headers and entry cards.
   Widget build(
@@ -47,8 +51,10 @@ class LearningPathNodeRendererService {
             ),
           ),
         ),
-        for (final entry in group.entries)
+        for (final entry in group.entries) ...[
           entryRenderer.build(context, entry),
+          autoRecall.build(context, entry),
+        ],
       ],
     );
   }

--- a/lib/services/theory_auto_recall_injector.dart
+++ b/lib/services/theory_auto_recall_injector.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Injects inline theory summaries for review entries with decayed tags.
+class TheoryAutoRecallInjector {
+  final DecayTagRetentionTrackerService retention;
+  final MiniLessonLibraryService lessons;
+
+  const TheoryAutoRecallInjector({
+    DecayTagRetentionTrackerService? retention,
+    MiniLessonLibraryService? lessons,
+  })  : retention = retention ?? const DecayTagRetentionTrackerService(),
+        lessons = lessons ?? MiniLessonLibraryService.instance;
+
+  /// Builds a widget that conditionally injects a theory snippet below [entry].
+  Widget build(BuildContext context, Object entry) {
+    return FutureBuilder<Widget?>(
+      future: _maybeBuildSnippet(entry),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done &&
+            snapshot.data != null) {
+          return snapshot.data!;
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+
+  Future<Widget?> _maybeBuildSnippet(Object entry) async {
+    final tags = _extractTags(entry);
+    if (tags.isEmpty) return null;
+
+    await lessons.loadAll();
+
+    for (final raw in tags) {
+      final tag = raw.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      if (!await retention.isDecayed(tag)) continue;
+      final lessonList = lessons.findByTags([tag]);
+      if (lessonList.isEmpty) continue;
+      final TheoryMiniLessonNode lesson = lessonList.first;
+      final summary = _shortSummary(lesson.resolvedContent);
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Divider(color: Colors.white24, height: 16),
+            Text(
+              lesson.resolvedTitle,
+              style:
+                  const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              summary,
+              style: const TextStyle(fontSize: 12, color: Colors.white70),
+            ),
+          ],
+        ),
+      );
+    }
+    return null;
+  }
+
+  List<String> _extractTags(Object entry) {
+    if (entry is TrainingPackSpot) return entry.tags;
+    return const [];
+  }
+
+  String _shortSummary(String text, {int max = 160}) {
+    final clean = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (clean.length <= max) return clean;
+    return '${clean.substring(0, max)}…';
+  }
+}

--- a/test/services/theory_auto_recall_injector_test.dart
+++ b/test/services/theory_auto_recall_injector_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_auto_recall_injector.dart';
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final bool decayed;
+  const _FakeRetention(this.decayed);
+  @override
+  Future<bool> isDecayed(String tag, {double threshold = 30}) async => decayed;
+}
+
+class _FakeLessonLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLessonLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => lessons.first);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) =>
+      [for (final l in lessons) if (l.tags.any(tags.contains)) l];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+
+  @override
+  List<String> linkedPacksFor(String lessonId) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('injects snippet for decayed tag', (tester) async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'Push fold basics',
+      content: 'Always shove with 10 BB from the button.',
+      tags: ['push'],
+      nextIds: [],
+    );
+    final spot = TrainingPackSpot(id: 's1', tags: ['push']);
+    final injector = TheoryAutoRecallInjector(
+      retention: const _FakeRetention(true),
+      lessons: _FakeLessonLibrary(const [lesson]),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => injector.build(context, spot),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Push fold basics'), findsOneWidget);
+    expect(find.textContaining('Always shove'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryAutoRecallInjector to append mini-lesson summaries after review entries when tags are decayed
- render inline theory snippets in LearningPathNodeRendererService using retention checks
- expose `isDecayed` helper on DecayTagRetentionTrackerService

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ada86118832a93eb814ace327ddb