### PR TITLE
feat: track manual mini lesson opens

### DIFF
--- a/lib/models/theory_mini_lesson_usage_event.dart
+++ b/lib/models/theory_mini_lesson_usage_event.dart
@@ -1,0 +1,25 @@
+class TheoryMiniLessonUsageEvent {
+  final String lessonId;
+  final String source;
+  final DateTime timestamp;
+
+  const TheoryMiniLessonUsageEvent({
+    required this.lessonId,
+    required this.source,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'source': source,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory TheoryMiniLessonUsageEvent.fromJson(Map<String, dynamic> json) =>
+      TheoryMiniLessonUsageEvent(
+        lessonId: json['lessonId'] as String? ?? '',
+        source: json['source'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+            DateTime.now(),
+      );
+}

--- a/lib/services/theory_mini_lesson_usage_tracker.dart
+++ b/lib/services/theory_mini_lesson_usage_tracker.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_usage_event.dart';
+
+/// Tracks when users manually open theory mini-lessons.
+class TheoryMiniLessonUsageTracker {
+  TheoryMiniLessonUsageTracker._();
+  static final TheoryMiniLessonUsageTracker instance =
+      TheoryMiniLessonUsageTracker._();
+
+  static const _prefsKey = 'theory_mini_lesson_usage_log';
+
+  Future<List<TheoryMiniLessonUsageEvent>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_prefsKey);
+    if (str == null) return [];
+    try {
+      final data = jsonDecode(str);
+      if (data is List) {
+        return [
+          for (final e in data)
+            if (e is Map)
+              TheoryMiniLessonUsageEvent.fromJson(
+                Map<String, dynamic>.from(e),
+              ),
+        ];
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  Future<void> _save(List<TheoryMiniLessonUsageEvent> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode([for (final e in list) e.toJson()]),
+    );
+  }
+
+  /// Logs a manual open event for a theory mini-lesson.
+  Future<void> logManualOpen(String lessonId, String source) async {
+    final list = await _load();
+    list.insert(
+      0,
+      TheoryMiniLessonUsageEvent(
+        lessonId: lessonId,
+        source: source,
+        timestamp: DateTime.now(),
+      ),
+    );
+    while (list.length > 200) {
+      list.removeLast();
+    }
+    await _save(list);
+  }
+
+  /// Returns up to [limit] recent manual open events.
+  Future<List<TheoryMiniLessonUsageEvent>> getRecent({int limit = 50}) async {
+    final list = await _load();
+    return list.take(limit).toList();
+  }
+}


### PR DESCRIPTION
## Summary
- log manual theory mini-lesson opens with lesson id, source and timestamp
- persist recent events for analytics via shared preferences

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d577e1c8832aa0169f0da3666134