### PR TITLE
feat: add theory engagement analytics service

### DIFF
--- a/lib/models/theory_lesson_engagement_stats.dart
+++ b/lib/models/theory_lesson_engagement_stats.dart
@@ -1,0 +1,14 @@
+class TheoryLessonEngagementStats {
+  final String lessonId;
+  final int manualOpens;
+  final int reviewViews;
+  final double successRate;
+
+  const TheoryLessonEngagementStats({
+    required this.lessonId,
+    required this.manualOpens,
+    required this.reviewViews,
+    required this.successRate,
+  });
+}
+

--- a/lib/services/theory_engagement_analytics_service.dart
+++ b/lib/services/theory_engagement_analytics_service.dart
@@ -1,0 +1,57 @@
+import '../models/theory_lesson_engagement_stats.dart';
+import 'recall_boost_interaction_logger.dart';
+import 'theory_mini_lesson_usage_tracker.dart';
+import 'theory_recall_efficiency_evaluator_service.dart';
+
+/// Aggregates usage, view, and success data for theory mini-lessons.
+class TheoryEngagementAnalyticsService {
+  final TheoryMiniLessonUsageTracker usageTracker;
+  final RecallBoostInteractionLogger viewLogger;
+  final TheoryRecallEfficiencyEvaluatorService efficiencyService;
+
+  const TheoryEngagementAnalyticsService({
+    TheoryMiniLessonUsageTracker? usageTracker,
+    RecallBoostInteractionLogger? viewLogger,
+    TheoryRecallEfficiencyEvaluatorService? efficiencyService,
+  })  : usageTracker = usageTracker ?? TheoryMiniLessonUsageTracker.instance,
+        viewLogger = viewLogger ?? RecallBoostInteractionLogger.instance,
+        efficiencyService =
+            efficiencyService ?? const TheoryRecallEfficiencyEvaluatorService();
+
+  /// Returns aggregated engagement stats for all known theory lessons.
+  Future<List<TheoryLessonEngagementStats>> getAllStats() async {
+    final manualLogs = await usageTracker.getRecent(limit: 200);
+    final manualCounts = <String, int>{};
+    for (final e in manualLogs) {
+      final id = e.lessonId;
+      manualCounts[id] = (manualCounts[id] ?? 0) + 1;
+    }
+
+    final viewLogs = await viewLogger.getLogs();
+    final viewCounts = <String, int>{};
+    for (final v in viewLogs) {
+      if (v.durationMs < 1000) continue;
+      final id = v.tag;
+      viewCounts[id] = (viewCounts[id] ?? 0) + 1;
+    }
+
+    final successRates = await efficiencyService.getEfficiencyScoresByTag();
+
+    final ids = <String>{
+      ...manualCounts.keys,
+      ...viewCounts.keys,
+      ...successRates.keys,
+    };
+
+    return [
+      for (final id in ids)
+        TheoryLessonEngagementStats(
+          lessonId: id,
+          manualOpens: manualCounts[id] ?? 0,
+          reviewViews: viewCounts[id] ?? 0,
+          successRate: successRates[id] ?? 0.0,
+        ),
+    ];
+  }
+}
+

--- a/test/services/theory_engagement_analytics_service_test.dart
+++ b/test/services/theory_engagement_analytics_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/recall_boost_interaction_logger.dart';
+import 'package:poker_analyzer/services/theory_engagement_analytics_service.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_usage_tracker.dart';
+import 'package:poker_analyzer/services/theory_recall_efficiency_evaluator_service.dart';
+
+class _FakeEfficiencyService extends TheoryRecallEfficiencyEvaluatorService {
+  final Map<String, double> scores;
+  _FakeEfficiencyService(this.scores) : super();
+
+  @override
+  Future<Map<String, double>> getEfficiencyScoresByTag() async => scores;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('aggregates engagement stats per lesson', () async {
+    final usageTracker = TheoryMiniLessonUsageTracker.instance;
+    await usageTracker.logManualOpen('lesson1', 'src');
+    await usageTracker.logManualOpen('lesson1', 'src');
+    await usageTracker.logManualOpen('lesson2', 'src');
+
+    final viewLogger = RecallBoostInteractionLogger.instance;
+    viewLogger.resetForTest();
+    await viewLogger.logView('lesson1', 'node1', 1500);
+    await viewLogger.logView('lesson1', 'node2', 500);
+    await viewLogger.logView('lesson2', 'node3', 2000);
+
+    final service = TheoryEngagementAnalyticsService(
+      usageTracker: usageTracker,
+      viewLogger: viewLogger,
+      efficiencyService: _FakeEfficiencyService({'lesson1': 0.5}),
+    );
+
+    final stats = await service.getAllStats();
+    expect(stats.length, 2);
+
+    final lesson1 = stats.firstWhere((s) => s.lessonId == 'lesson1');
+    expect(lesson1.manualOpens, 2);
+    expect(lesson1.reviewViews, 1);
+    expect(lesson1.successRate, closeTo(0.5, 0.0001));
+
+    final lesson2 = stats.firstWhere((s) => s.lessonId == 'lesson2');
+    expect(lesson2.manualOpens, 1);
+    expect(lesson2.reviewViews, 1);
+    expect(lesson2.successRate, 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `TheoryLessonEngagementStats` data class
- implement `TheoryEngagementAnalyticsService` aggregating manual opens, views, and success rates
- test engagement aggregation logic

## Testing
- `dart test test/services/theory_engagement_analytics_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ea4b2d64832a855163ecbdce88b8