### PR TITLE
feat: link spots to theory mini-lessons

### DIFF
--- a/lib/models/spot_model.dart
+++ b/lib/models/spot_model.dart
@@ -1,0 +1,4 @@
+/// Minimal interface for a training spot exposing its tag list.
+abstract class SpotModel {
+  List<String> get tags;
+}

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -3,12 +3,13 @@ import '../evaluation_result.dart';
 import '../copy_with_mixin.dart';
 import '../action_entry.dart';
 import '../training_spot.dart';
+import '../spot_model.dart';
 import 'hero_position.dart';
 import '../card_model.dart';
 import 'package:uuid/uuid.dart';
 import '../../services/inline_theory_linker.dart';
 
-class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> {
+class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> implements SpotModel {
   final String id;
   String type;
   String title;

--- a/lib/services/inline_theory_linker_service.dart
+++ b/lib/services/inline_theory_linker_service.dart
@@ -2,18 +2,23 @@ import 'package:flutter/material.dart';
 
 import '../models/inline_theory_linked_text.dart';
 import '../models/theory_mini_lesson_node.dart';
+import '../models/spot_model.dart';
 import 'mini_lesson_library_service.dart';
 import 'theory_mini_lesson_navigator.dart';
+import 'theory_engagement_analytics_service.dart';
 
 class InlineTheoryLinkerService {
   InlineTheoryLinkerService({
     MiniLessonLibraryService? library,
     TheoryMiniLessonNavigator? navigator,
+    TheoryEngagementAnalyticsService? analytics,
   }) : _library = library ?? MiniLessonLibraryService.instance,
-       _navigator = navigator ?? TheoryMiniLessonNavigator.instance;
+       _navigator = navigator ?? TheoryMiniLessonNavigator.instance,
+       _analytics = analytics ?? const TheoryEngagementAnalyticsService();
 
   final MiniLessonLibraryService _library;
   final TheoryMiniLessonNavigator _navigator;
+  final TheoryEngagementAnalyticsService _analytics;
 
   /// Parses [description] and converts matching keywords to inline links.
   ///
@@ -92,6 +97,36 @@ class InlineTheoryLinkerService {
   ) async {
     await _library.loadAll();
     return _library.findByTags(tags);
+  }
+
+  /// Returns up to 3 lesson ids that best match [spot] based on tag overlap
+  /// and success rate analytics.
+  Future<List<String>> getLinkedLessonIdsForSpot(SpotModel spot) async {
+    await _library.loadAll();
+    final spotTags =
+        spot.tags.map((t) => t.trim().toLowerCase()).toSet()..removeWhere((t) => t.isEmpty);
+    if (spotTags.isEmpty) return const [];
+
+    final lessons = _library.findByTags(spotTags.toList());
+    if (lessons.isEmpty) return const [];
+
+    final stats = await _analytics.getAllStats();
+    final success = <String, double>{
+      for (final s in stats) s.lessonId: s.successRate,
+    };
+
+    lessons.sort((a, b) {
+      final tagsA = a.tags.map((t) => t.toLowerCase()).toSet();
+      final tagsB = b.tags.map((t) => t.toLowerCase()).toSet();
+      final overlapA = tagsA.intersection(spotTags).length;
+      final overlapB = tagsB.intersection(spotTags).length;
+      if (overlapA != overlapB) return overlapB - overlapA;
+      final rateA = success[a.id] ?? 0.0;
+      final rateB = success[b.id] ?? 0.0;
+      return rateB.compareTo(rateA);
+    });
+
+    return lessons.take(3).map((l) => l.id).toList();
   }
 }
 


### PR DESCRIPTION
## Summary
- allow training spots to implement new SpotModel interface
- extend InlineTheoryLinkerService to rank theory lessons for a spot
- add unit test for spot-to-lesson linking

## Testing
- `dart format lib/models/v2/training_pack_spot.dart lib/models/spot_model.dart lib/services/inline_theory_linker_service.dart test/services/inline_theory_linker_service_test.dart` *(fails: command not found)*
- `flutter test test/services/inline_theory_linker_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f006a3a0832a9862920a4c5ceb0d