### PR TITLE
feat: add inline theory recall banner

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -56,6 +56,7 @@ import '../services/training_progress_logger.dart';
 import 'training_session_completion_screen.dart';
 import '../services/inline_theory_linker_service.dart';
 import '../widgets/theory_quick_access_banner.dart';
+import '../widgets/inline_theory_recall_banner.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -751,6 +752,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                               orElse: () => spot.tags.first,
                             ),
                           ),
+                        InlineTheoryRecallBanner(spot: spot),
                         TheoryQuickAccessBannerWidget(tags: spot.tags),
                       ],
                       Text(

--- a/lib/widgets/inline_theory_recall_banner.dart
+++ b/lib/widgets/inline_theory_recall_banner.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../models/v2/training_pack_spot.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/theory_mini_lesson_navigator.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+class InlineTheoryRecallBanner extends StatelessWidget {
+  final TrainingPackSpot spot;
+  const InlineTheoryRecallBanner({super.key, required this.spot});
+
+  Future<TheoryMiniLessonNode?> _loadLesson(String id) async {
+    await MiniLessonLibraryService.instance.loadAll();
+    return MiniLessonLibraryService.instance.getById(id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final id = spot.meta['linkedTheoryId'];
+    if (id == null || id is! String) return const SizedBox.shrink();
+    return FutureBuilder<TheoryMiniLessonNode?>(
+      future: _loadLesson(id),
+      builder: (context, snapshot) {
+        final lesson = snapshot.data;
+        if (lesson == null) return const SizedBox.shrink();
+        return GestureDetector(
+          onTap: () =>
+              TheoryMiniLessonNavigator.instance.openLessonById(id),
+          child: Container(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.amber.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              '💡 Related Theory: ${lesson.resolvedTitle} →',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add InlineTheoryRecallBanner widget to surface linked mini-lessons for decayed spots
- show InlineTheoryRecallBanner in training session screen when a spot has linked theory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f47ab0f4832a8639d7637ec04563