### PR TITLE
feat: add recent auto injection analytics panel

### DIFF
--- a/lib/screens/dev_menu/debug_tools_section.dart
+++ b/lib/screens/dev_menu/debug_tools_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import '../../services/learning_path_node_graph_snapshot_service.dart';
 import '../../services/learning_graph_engine.dart';
+import '../recent_auto_injections_screen.dart';
 
 class DebugToolsSection extends StatefulWidget {
   const DebugToolsSection({super.key});
@@ -20,8 +21,9 @@ class _DebugToolsSectionState extends State<DebugToolsSection> {
     final engine = LearningPathEngine.instance.engine;
     if (engine == null) return;
     setState(() => _dumping = true);
-    final text =
-        LearningPathNodeGraphSnapshotService(engine: engine).debugSnapshot();
+    final text = LearningPathNodeGraphSnapshotService(
+      engine: engine,
+    ).debugSnapshot();
     if (!mounted) return;
     setState(() => _dumping = false);
     await showDialog(
@@ -29,9 +31,7 @@ class _DebugToolsSectionState extends State<DebugToolsSection> {
       builder: (_) => AlertDialog(
         backgroundColor: const Color(0xFF121212),
         title: const Text('Learning Path Graph'),
-        content: SingleChildScrollView(
-          child: SelectableText(text),
-        ),
+        content: SingleChildScrollView(child: SelectableText(text)),
         actions: [
           TextButton(
             onPressed: () {
@@ -58,8 +58,18 @@ class _DebugToolsSectionState extends State<DebugToolsSection> {
             title: const Text('🧠 Dump Learning Path Graph'),
             onTap: _dumping ? null : _dumpGraph,
           ),
+        ListTile(
+          title: const Text('Recent Auto Theory Injections'),
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const RecentAutoInjectionsScreen(),
+              ),
+            );
+          },
+        ),
       ],
     );
   }
 }
-

--- a/lib/screens/recent_auto_injections_screen.dart
+++ b/lib/screens/recent_auto_injections_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/recent_theory_auto_injections_panel.dart';
+
+/// Temporary debug screen showing recent theory auto-injection events.
+class RecentAutoInjectionsScreen extends StatelessWidget {
+  const RecentAutoInjectionsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Recent Auto Injections')),
+      backgroundColor: const Color(0xFF121212),
+      body: const RecentTheoryAutoInjectionsPanel(),
+    );
+  }
+}

--- a/lib/widgets/recent_theory_auto_injections_panel.dart
+++ b/lib/widgets/recent_theory_auto_injections_panel.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import '../services/theory_auto_injection_logger_service.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../models/theory_auto_injection_log_entry.dart';
+
+/// Displays recent theory auto-injection events for debugging/analytics.
+class RecentTheoryAutoInjectionsPanel extends StatefulWidget {
+  const RecentTheoryAutoInjectionsPanel({super.key});
+
+  @override
+  State<RecentTheoryAutoInjectionsPanel> createState() =>
+      _RecentTheoryAutoInjectionsPanelState();
+}
+
+class _RecentTheoryAutoInjectionsPanelState
+    extends State<RecentTheoryAutoInjectionsPanel> {
+  bool _loading = true;
+  List<TheoryAutoInjectionLogEntry> _logs = [];
+  final Map<String, String> _titles = {};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final logs = await TheoryAutoInjectionLoggerService.instance.getRecentLogs(
+      limit: 10,
+    );
+    _logs = logs;
+    if (_logs.isNotEmpty) {
+      await MiniLessonLibraryService.instance.loadAll();
+      for (final l in _logs) {
+        final lesson = MiniLessonLibraryService.instance.getById(l.lessonId);
+        _titles[l.lessonId] = lesson?.resolvedTitle ?? l.lessonId;
+      }
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_logs.isEmpty) {
+      return const Center(child: Text('No recent injections'));
+    }
+    return ListView.builder(
+      itemCount: _logs.length,
+      itemBuilder: (context, index) {
+        final log = _logs[index];
+        final title = _titles[log.lessonId] ?? log.lessonId;
+        return ListTile(
+          title: Text(title),
+          subtitle: Text('Spot: ${log.spotId}'),
+          trailing: Text(
+            timeago.format(
+              log.timestamp,
+              allowFromNow: true,
+              locale: 'en_short',
+            ),
+            style: const TextStyle(fontSize: 12, color: Colors.white70),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show recent auto-injected theory lessons with spot id, title and relative time
- expose a debug screen to view recent auto injections
- link debug tools menu to the new auto injection panel

## Testing
- `dart test` *(fails: Flutter SDK is not available)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f7bc4170832aafa43b0516c81105