### PR TITLE
Add drill-down auto-injection log screen with chart interactions

### DIFF
--- a/lib/screens/drill_down_auto_injection_log_screen.dart
+++ b/lib/screens/drill_down_auto_injection_log_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import '../models/theory_auto_injection_log_entry.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../services/theory_auto_injection_logger_service.dart';
+
+/// Displays detailed log entries for a specific day or lesson.
+class DrillDownAutoInjectionLogScreen extends StatefulWidget {
+  final DateTime? date;
+  final String? lessonId;
+
+  const DrillDownAutoInjectionLogScreen.date(this.date, {super.key})
+      : lessonId = null;
+  const DrillDownAutoInjectionLogScreen.lesson(this.lessonId, {super.key})
+      : date = null;
+
+  @override
+  State<DrillDownAutoInjectionLogScreen> createState() =>
+      _DrillDownAutoInjectionLogScreenState();
+}
+
+class _DrillDownAutoInjectionLogScreenState
+    extends State<DrillDownAutoInjectionLogScreen> {
+  bool _loading = true;
+  final List<TheoryAutoInjectionLogEntry> _logs = [];
+  final Map<String, String> _titles = {};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    var logs = await TheoryAutoInjectionLoggerService.instance.getRecentLogs(
+      limit: 200,
+    );
+    if (widget.date != null) {
+      final d = widget.date!;
+      logs = logs
+          .where((l) =>
+              l.timestamp.year == d.year &&
+              l.timestamp.month == d.month &&
+              l.timestamp.day == d.day)
+          .toList();
+    } else if (widget.lessonId != null) {
+      logs = logs.where((l) => l.lessonId == widget.lessonId).toList();
+    }
+    if (logs.isNotEmpty) {
+      await MiniLessonLibraryService.instance.loadAll();
+      for (final l in logs) {
+        final lesson = MiniLessonLibraryService.instance.getById(l.lessonId);
+        _titles[l.lessonId] = lesson?.resolvedTitle ?? l.lessonId;
+      }
+    }
+    _logs.addAll(logs);
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = widget.date != null
+        ? 'Injections on ${widget.date!.month}/${widget.date!.day}'
+        : _titles[widget.lessonId!] ?? widget.lessonId!;
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      backgroundColor: const Color(0xFF121212),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _logs.isEmpty
+              ? const Center(child: Text('No injections'))
+              : ListView.builder(
+                  itemCount: _logs.length,
+                  itemBuilder: (context, index) {
+                    final log = _logs[index];
+                    final lessonTitle = _titles[log.lessonId] ?? log.lessonId;
+                    return ListTile(
+                      title: Text(lessonTitle),
+                      subtitle: Text('Spot: ${log.spotId}'),
+                      trailing: Text(
+                        timeago.format(
+                          log.timestamp,
+                          allowFromNow: true,
+                          locale: 'en_short',
+                        ),
+                        style: const TextStyle(
+                            fontSize: 12, color: Colors.white70),
+                      ),
+                    );
+                  },
+                ),
+    );
+  }
+}
+

--- a/lib/widgets/theory_auto_injection_analytics_panel.dart
+++ b/lib/widgets/theory_auto_injection_analytics_panel.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 
 import '../services/theory_auto_injection_logger_service.dart';
 import '../services/mini_lesson_library_service.dart';
+import '../screens/drill_down_auto_injection_log_screen.dart';
 
 /// Displays analytics for automatic theory injections.
 class TheoryAutoInjectionAnalyticsPanel extends StatefulWidget {
@@ -106,6 +107,24 @@ class _TheoryAutoInjectionAnalyticsPanelState
             height: 150,
             child: LineChart(
               LineChartData(
+                lineTouchData: LineTouchData(
+                  touchCallback: (event, response) {
+                    if (event is FlTapUpEvent &&
+                        response?.lineBarSpots != null &&
+                        response!.lineBarSpots!.isNotEmpty) {
+                      final index = response.lineBarSpots!.first.x.toInt();
+                      if (index >= 0 && index < _daily.length) {
+                        final date = _daily[index].date;
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                DrillDownAutoInjectionLogScreen.date(date),
+                          ),
+                        );
+                      }
+                    }
+                  },
+                ),
                 minY: 0,
                 maxY: (maxY < 1 ? 1 : maxY).toDouble(),
                 gridData: const FlGridData(show: false),
@@ -207,6 +226,23 @@ class _TheoryAutoInjectionAnalyticsPanelState
             height: 200,
             child: BarChart(
               BarChartData(
+                barTouchData: BarTouchData(
+                  touchCallback: (event, response) {
+                    final spot = response?.spot;
+                    if (event is FlTapUpEvent && spot != null) {
+                      final index = spot.touchedBarGroupIndex;
+                      if (index >= 0 && index < _topLessons.length) {
+                        final lessonId = _topLessons[index].id;
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                DrillDownAutoInjectionLogScreen.lesson(lessonId),
+                          ),
+                        );
+                      }
+                    }
+                  },
+                ),
                 maxY: (maxY < 1 ? 1 : maxY).toDouble(),
                 gridData: const FlGridData(show: false),
                 titlesData: FlTitlesData(


### PR DESCRIPTION
## Summary
- add DrillDownAutoInjectionLogScreen to inspect logs for a specific day or lesson
- enable tapping line chart and bar chart in TheoryAutoInjectionAnalyticsPanel to open drill-down logs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890fc62b218832a86e53f5d5367d9f4