### PR TITLE
feat: add recall hotspot examples screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'screens/decay_heatmap_screen.dart';
 import 'screens/decay_stats_dashboard_screen.dart';
 import 'screens/decay_analytics_screen.dart';
 import 'screens/decay_adaptation_insight_screen.dart';
+import 'screens/recall_hotspot_examples_screen.dart';
 import 'screens/skill_tree_learning_map_screen.dart';
 import 'screens/skill_tree_track_map_screen.dart';
 import 'screens/skill_tree_track_list_screen.dart';
@@ -411,6 +412,8 @@ class _PokerAIAnalyzerAppState extends State<PokerAIAnalyzerApp> {
               SkillTreeTrackListScreen.route: (_) =>
                   const SkillTreeTrackListScreen(),
               RewardGalleryScreen.route: (_) => const RewardGalleryScreen(),
+              RecallHotspotExamplesScreen.route: (_) =>
+                  const RecallHotspotExamplesScreen(),
             },
             localeResolutionCallback: (locale, supportedLocales) {
               if (locale == null) return const Locale('ru');

--- a/lib/models/recall_failure_spotting.dart
+++ b/lib/models/recall_failure_spotting.dart
@@ -1,0 +1,26 @@
+class RecallFailureSpotting {
+  final String spotId;
+  final DateTime timestamp;
+  final String decayStage;
+
+  const RecallFailureSpotting({
+    required this.spotId,
+    required this.timestamp,
+    required this.decayStage,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'spotId': spotId,
+        'timestamp': timestamp.toIso8601String(),
+        'decayStage': decayStage,
+      };
+
+  factory RecallFailureSpotting.fromJson(Map<String, dynamic> json) =>
+      RecallFailureSpotting(
+        spotId: json['spotId'] as String? ?? '',
+        timestamp:
+            DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+                DateTime.fromMillisecondsSinceEpoch(0),
+        decayStage: json['decayStage'] as String? ?? '',
+      );
+}

--- a/lib/screens/recall_hotspot_examples_screen.dart
+++ b/lib/screens/recall_hotspot_examples_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../models/recall_failure_spotting.dart';
+import '../services/recall_failure_log_service.dart';
+
+/// Displays a list of recall failure spottings for a given hotspot.
+class RecallHotspotExamplesScreen extends StatefulWidget {
+  static const route = '/recallHotspotExamples';
+  const RecallHotspotExamplesScreen({super.key});
+
+  @override
+  State<RecallHotspotExamplesScreen> createState() =>
+      _RecallHotspotExamplesScreenState();
+}
+
+class _RecallHotspotExamplesScreenState
+    extends State<RecallHotspotExamplesScreen> {
+  late Future<List<RecallFailureSpotting>> _future;
+  late String _mode;
+  late String _id;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is Map) {
+      _mode = args['mode'] as String? ?? 'tag';
+      _id = args['id'] as String? ?? '';
+    } else {
+      _mode = 'tag';
+      _id = '';
+    }
+    _future = RecallFailureLogService.instance
+        .getSpottingsForHotspot(_mode, _id);
+  }
+
+  void _openAnalyzer(String spotId) {
+    Navigator.of(context)
+        .pushNamed('/analyzer', arguments: {'spotId': spotId});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Hotspot Examples')),
+      body: FutureBuilder<List<RecallFailureSpotting>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final data = snapshot.data ?? [];
+          if (data.isEmpty) {
+            return const Center(child: Text('No spottings found'));
+          }
+          return ListView.separated(
+            itemCount: data.length,
+            separatorBuilder: (_, __) => const Divider(),
+            itemBuilder: (context, index) {
+              final s = data[index];
+              return ListTile(
+                title: Text(s.spotId),
+                subtitle:
+                    Text('${_formatDate(s.timestamp)} • ${s.decayStage}'),
+                trailing: TextButton(
+                  onPressed: () => _openAnalyzer(s.spotId),
+                  child: const Text('Open in Analyzer'),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/services/recall_failure_log_service.dart
+++ b/lib/services/recall_failure_log_service.dart
@@ -1,0 +1,16 @@
+import '../models/recall_failure_spotting.dart';
+
+/// Provides access to recall failure spottings used for hotspot drilldowns.
+class RecallFailureLogService {
+  RecallFailureLogService._();
+
+  static final RecallFailureLogService instance =
+      RecallFailureLogService._();
+
+  /// Returns logged spottings for a hotspot identified by [mode] and [id].
+  Future<List<RecallFailureSpotting>> getSpottingsForHotspot(
+      String mode, String id) async {
+    // Placeholder implementation.
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add screen to browse recall failure spottings for hotspot tags or spots
- stub recall failure log service and model for hotspot spotting entries
- register new screen route in the app

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689102a16380832a9c06e6c4e7baf372