### PR TITLE
Add recall failure hotspot detector service

### DIFF
--- a/lib/models/recall_failure_log_entry.dart
+++ b/lib/models/recall_failure_log_entry.dart
@@ -1,0 +1,22 @@
+class RecallFailureLogEntry {
+  final String? tag;
+  final String? spotId;
+  final DateTime timestamp;
+
+  const RecallFailureLogEntry({this.tag, this.spotId, required this.timestamp});
+
+  Map<String, dynamic> toJson() => {
+    if (tag != null && tag!.isNotEmpty) 'tag': tag,
+    if (spotId != null && spotId!.isNotEmpty) 'spotId': spotId,
+    'timestamp': timestamp.toIso8601String(),
+  };
+
+  factory RecallFailureLogEntry.fromJson(Map<String, dynamic> json) =>
+      RecallFailureLogEntry(
+        tag: json['tag'] as String?,
+        spotId: json['spotId'] as String?,
+        timestamp:
+            DateTime.tryParse(json['timestamp']?.toString() ?? '') ??
+            DateTime.now(),
+      );
+}

--- a/lib/models/recall_hotspot_report.dart
+++ b/lib/models/recall_hotspot_report.dart
@@ -1,0 +1,13 @@
+class RecallHotspotEntry {
+  final String id;
+  final int count;
+
+  const RecallHotspotEntry({required this.id, required this.count});
+}
+
+class RecallHotspotReport {
+  final List<RecallHotspotEntry> topTags;
+  final List<RecallHotspotEntry> topSpotIds;
+
+  const RecallHotspotReport({required this.topTags, required this.topSpotIds});
+}

--- a/lib/services/theory_recall_failure_hotspot_detector_service.dart
+++ b/lib/services/theory_recall_failure_hotspot_detector_service.dart
@@ -1,0 +1,43 @@
+import '../models/recall_failure_log_entry.dart';
+import '../models/recall_hotspot_report.dart';
+
+typedef RecallFailureLogLoader = Future<List<RecallFailureLogEntry>> Function();
+
+class TheoryRecallFailureHotspotDetectorService {
+  final RecallFailureLogLoader loadLogs;
+
+  const TheoryRecallFailureHotspotDetectorService({required this.loadLogs});
+
+  Future<RecallHotspotReport> generateHotspotReport({int top = 5}) async {
+    if (top <= 0) {
+      return const RecallHotspotReport(topTags: [], topSpotIds: []);
+    }
+    final logs = await loadLogs();
+    final tagCounts = <String, int>{};
+    final spotCounts = <String, int>{};
+    for (final log in logs) {
+      final tag = log.tag?.trim().toLowerCase();
+      if (tag != null && tag.isNotEmpty) {
+        tagCounts.update(tag, (v) => v + 1, ifAbsent: () => 1);
+      }
+      final spot = log.spotId?.trim();
+      if (spot != null && spot.isNotEmpty) {
+        spotCounts.update(spot, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    final tags =
+        tagCounts.entries
+            .map((e) => RecallHotspotEntry(id: e.key, count: e.value))
+            .toList()
+          ..sort((a, b) => b.count.compareTo(a.count));
+    final spots =
+        spotCounts.entries
+            .map((e) => RecallHotspotEntry(id: e.key, count: e.value))
+            .toList()
+          ..sort((a, b) => b.count.compareTo(a.count));
+    return RecallHotspotReport(
+      topTags: tags.take(top).toList(),
+      topSpotIds: spots.take(top).toList(),
+    );
+  }
+}

--- a/test/services/theory_recall_failure_hotspot_detector_service_test.dart
+++ b/test/services/theory_recall_failure_hotspot_detector_service_test.dart
@@ -1,0 +1,29 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/models/recall_failure_log_entry.dart';
+import 'package:poker_analyzer/services/theory_recall_failure_hotspot_detector_service.dart';
+
+void main() {
+  test('generateHotspotReport returns top tags and spotIds', () async {
+    final logs = [
+      RecallFailureLogEntry(tag: 'a', spotId: 's1', timestamp: DateTime.now()),
+      RecallFailureLogEntry(tag: 'a', spotId: 's1', timestamp: DateTime.now()),
+      RecallFailureLogEntry(tag: 'b', spotId: 's2', timestamp: DateTime.now()),
+      RecallFailureLogEntry(tag: 'b', spotId: 's3', timestamp: DateTime.now()),
+      RecallFailureLogEntry(tag: 'c', spotId: 's2', timestamp: DateTime.now()),
+    ];
+
+    final service = TheoryRecallFailureHotspotDetectorService(
+      loadLogs: () async => logs,
+    );
+
+    final report = await service.generateHotspotReport(top: 2);
+
+    expect(report.topTags.length, 2);
+    expect(report.topTags.first.id, 'a');
+    expect(report.topTags.first.count, 2);
+    expect(report.topSpotIds.length, 2);
+    expect(report.topSpotIds.first.id, 's1');
+    expect(report.topSpotIds.first.count, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add `RecallFailureLogEntry` and hotspot report models
- implement `TheoryRecallFailureHotspotDetectorService`
- add unit test for hotspot detection

## Testing
- `dart pub get` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6890ff485110832ab2e5a0a5e2552ad1