### PR TITLE
feat: add decay hotspot stats aggregator

### DIFF
--- a/lib/models/decay_hotspot_stats.dart
+++ b/lib/models/decay_hotspot_stats.dart
@@ -1,0 +1,26 @@
+class DecayHotspotStat {
+  final String id;
+  final int count;
+  final double? successRate;
+  final DateTime lastSeen;
+  final Map<String, int> decayStageDistribution;
+
+  const DecayHotspotStat({
+    required this.id,
+    required this.count,
+    this.successRate,
+    required this.lastSeen,
+    required this.decayStageDistribution,
+  });
+}
+
+class DecayHotspotStats {
+  final List<DecayHotspotStat> topTags;
+  final List<DecayHotspotStat> topSpotIds;
+
+  const DecayHotspotStats({
+    required this.topTags,
+    required this.topSpotIds,
+  });
+}
+

--- a/lib/services/decay_hotspot_stats_aggregator_service.dart
+++ b/lib/services/decay_hotspot_stats_aggregator_service.dart
@@ -1,0 +1,101 @@
+import '../models/recall_failure_spotting.dart';
+import '../models/recall_success_entry.dart';
+import '../models/decay_hotspot_stats.dart';
+
+typedef RecallFailureSpottingLoader = Future<List<RecallFailureSpotting>> Function();
+typedef SpotTagResolver = Future<List<String>> Function(String spotId);
+typedef RecallSuccessLoader = Future<List<RecallSuccessEntry>> Function();
+
+class DecayHotspotStatsAggregatorService {
+  final RecallFailureSpottingLoader loadSpottings;
+  final SpotTagResolver resolveTags;
+  final RecallSuccessLoader? loadSuccesses;
+
+  const DecayHotspotStatsAggregatorService({
+    required this.loadSpottings,
+    required this.resolveTags,
+    this.loadSuccesses,
+  });
+
+  Future<DecayHotspotStats> generateStats({int top = 5}) async {
+    if (top <= 0) {
+      return const DecayHotspotStats(topTags: [], topSpotIds: []);
+    }
+    final spottings = await loadSpottings();
+    final tagMap = <String, _StatCollector>{};
+    final spotMap = <String, _StatCollector>{};
+    final tagCache = <String, List<String>>{};
+
+    for (final s in spottings) {
+      final spotCollector = spotMap.putIfAbsent(s.spotId, () => _StatCollector())
+        ..add(s);
+      final tags = tagCache[s.spotId] ??= await resolveTags(s.spotId);
+      for (final t in tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        tagMap.putIfAbsent(key, () => _StatCollector()).add(s);
+      }
+    }
+
+    final successCount = <String, int>{};
+    if (loadSuccesses != null) {
+      final successes = await loadSuccesses!();
+      for (final e in successes) {
+        final tag = e.tag.trim().toLowerCase();
+        if (tag.isEmpty) continue;
+        successCount.update(tag, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+
+    final tagStats = tagMap.entries
+        .map((e) {
+          final failures = e.value.count;
+          final successes = successCount[e.key] ?? 0;
+          final total = successes + failures;
+          final rate = total > 0 ? successes / total : null;
+          return DecayHotspotStat(
+            id: e.key,
+            count: failures,
+            successRate: rate,
+            lastSeen: e.value.lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0),
+            decayStageDistribution: Map.unmodifiable(e.value.decayStages),
+          );
+        })
+        .toList()
+      ..sort((a, b) => b.count.compareTo(a.count));
+
+    final spotStats = spotMap.entries
+        .map((e) => DecayHotspotStat(
+              id: e.key,
+              count: e.value.count,
+              successRate: null,
+              lastSeen: e.value.lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0),
+              decayStageDistribution: Map.unmodifiable(e.value.decayStages),
+            ))
+        .toList()
+      ..sort((a, b) => b.count.compareTo(a.count));
+
+    return DecayHotspotStats(
+      topTags: tagStats.take(top).toList(),
+      topSpotIds: spotStats.take(top).toList(),
+    );
+  }
+}
+
+class _StatCollector {
+  int count = 0;
+  DateTime? lastSeen;
+  final Map<String, int> decayStages = {};
+
+  void add(RecallFailureSpotting s) {
+    count += 1;
+    if (lastSeen == null || s.timestamp.isAfter(lastSeen!)) {
+      lastSeen = s.timestamp;
+    }
+    final stage = s.decayStage.trim();
+    if (stage.isNotEmpty) {
+      decayStages.update(stage, (v) => v + 1, ifAbsent: () => 1);
+    }
+  }
+}
+

--- a/test/services/decay_hotspot_stats_aggregator_service_test.dart
+++ b/test/services/decay_hotspot_stats_aggregator_service_test.dart
@@ -1,0 +1,57 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/recall_failure_spotting.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+import 'package:poker_analyzer/services/decay_hotspot_stats_aggregator_service.dart';
+import 'package:poker_analyzer/models/decay_hotspot_stats.dart';
+
+void main() {
+  test('aggregates decay stats by tag and spotId', () async {
+    final spottings = [
+      RecallFailureSpotting(
+        spotId: 's1',
+        timestamp: DateTime(2023, 1, 1),
+        decayStage: 'late',
+      ),
+      RecallFailureSpotting(
+        spotId: 's1',
+        timestamp: DateTime(2023, 1, 2),
+        decayStage: 'early',
+      ),
+      RecallFailureSpotting(
+        spotId: 's2',
+        timestamp: DateTime(2023, 1, 3),
+        decayStage: 'mid',
+      ),
+    ];
+
+    final tags = {
+      's1': ['TagA'],
+      's2': ['TagB'],
+    };
+
+    final successes = [
+      RecallSuccessEntry(tag: 'TagA', timestamp: DateTime(2023, 1, 4)),
+    ];
+
+    final service = DecayHotspotStatsAggregatorService(
+      loadSpottings: () async => spottings,
+      resolveTags: (id) async => tags[id] ?? [],
+      loadSuccesses: () async => successes,
+    );
+
+    final report = await service.generateStats(top: 5);
+
+    expect(report.topTags.length, 2);
+    final tagA = report.topTags.firstWhere((e) => e.id == 'taga');
+    expect(tagA.count, 2);
+    expect(tagA.successRate, closeTo(1 / 3, 0.0001));
+    expect(tagA.decayStageDistribution['late'], 1);
+    expect(tagA.decayStageDistribution['early'], 1);
+    expect(tagA.lastSeen, DateTime(2023, 1, 2));
+
+    expect(report.topSpotIds.first.id, 's1');
+    expect(report.topSpotIds.first.count, 2);
+    expect(report.topSpotIds.first.decayStageDistribution['late'], 1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add data structures for decay hotspot statistics
- implement DecayHotspotStatsAggregatorService to compute tag and spot hotspots
- cover aggregation logic with unit test

## Testing
- `dart test test/services/decay_hotspot_stats_aggregator_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68910aee44f4832a8eba28692f698aa3