### PR TITLE
feat: add mistake history query service

### DIFF
--- a/lib/models/mistake_history_entry.dart
+++ b/lib/models/mistake_history_entry.dart
@@ -1,0 +1,16 @@
+class MistakeHistoryEntry {
+  final String spotId;
+  final DateTime timestamp;
+  final String decayStage;
+  final String tag;
+  final bool wasRecovered;
+
+  const MistakeHistoryEntry({
+    required this.spotId,
+    required this.timestamp,
+    required this.decayStage,
+    required this.tag,
+    required this.wasRecovered,
+  });
+}
+

--- a/lib/services/mistake_history_query_service.dart
+++ b/lib/services/mistake_history_query_service.dart
@@ -1,0 +1,91 @@
+import '../models/recall_failure_spotting.dart';
+import '../models/recall_success_entry.dart';
+import '../models/mistake_history_entry.dart';
+import 'decay_hotspot_stats_aggregator_service.dart'
+    show RecallFailureSpottingLoader, SpotTagResolver, RecallSuccessLoader;
+
+typedef SpotStreetResolver = Future<String?> Function(String spotId);
+
+class MistakeHistoryQueryService {
+  final RecallFailureSpottingLoader loadSpottings;
+  final SpotTagResolver resolveTags;
+  final SpotStreetResolver resolveStreet;
+  final RecallSuccessLoader? loadSuccesses;
+
+  const MistakeHistoryQueryService({
+    required this.loadSpottings,
+    required this.resolveTags,
+    required this.resolveStreet,
+    this.loadSuccesses,
+  });
+
+  Future<List<MistakeHistoryEntry>> queryMistakes({
+    String? tag,
+    String? street,
+    String? spotIdPattern,
+    int limit = 20,
+  }) async {
+    if (limit <= 0) return [];
+    final spottings = await loadSpottings();
+    final successes =
+        loadSuccesses != null ? await loadSuccesses!() : <RecallSuccessEntry>[];
+
+    final successMap = <String, List<DateTime>>{};
+    for (final s in successes) {
+      final t = s.tag.trim().toLowerCase();
+      if (t.isEmpty) continue;
+      successMap.putIfAbsent(t, () => []).add(s.timestamp);
+    }
+
+    final normTag = tag?.trim().toLowerCase();
+    final normStreet = street?.trim().toLowerCase();
+    final normPattern = spotIdPattern?.trim().toLowerCase();
+
+    final List<MistakeHistoryEntry> entries = [];
+
+    for (final s in spottings) {
+      if (entries.length >= limit) break;
+      final spotTags = (await resolveTags(s.spotId))
+          .map((e) => e.trim().toLowerCase())
+          .where((e) => e.isNotEmpty)
+          .toList();
+      if (spotTags.isEmpty) continue;
+
+      String? spotStreet;
+      if (normStreet != null && normStreet.isNotEmpty) {
+        spotStreet = (await resolveStreet(s.spotId))?.trim().toLowerCase();
+        if (spotStreet != normStreet) continue;
+      }
+
+      if (normPattern != null && normPattern.isNotEmpty) {
+        if (!s.spotId.toLowerCase().contains(normPattern)) continue;
+      }
+
+      for (final t in spotTags) {
+        if (normTag != null && normTag.isNotEmpty && t != normTag) {
+          continue;
+        }
+        final successesForTag = successMap[t];
+        bool recovered = false;
+        if (successesForTag != null) {
+          recovered = successesForTag.any((ts) => ts.isAfter(s.timestamp));
+        }
+        entries.add(MistakeHistoryEntry(
+          spotId: s.spotId,
+          timestamp: s.timestamp,
+          decayStage: s.decayStage,
+          tag: t,
+          wasRecovered: recovered,
+        ));
+        if (entries.length >= limit) break;
+      }
+    }
+
+    entries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    if (entries.length > limit) {
+      return entries.take(limit).toList();
+    }
+    return entries;
+  }
+}
+

--- a/test/services/mistake_history_query_service_test.dart
+++ b/test/services/mistake_history_query_service_test.dart
@@ -1,0 +1,100 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/recall_failure_spotting.dart';
+import 'package:poker_analyzer/models/recall_success_entry.dart';
+import 'package:poker_analyzer/services/mistake_history_query_service.dart';
+
+void main() {
+  test('filters by tag, street and pattern and marks recovery', () async {
+    final spottings = [
+      RecallFailureSpotting(
+        spotId: 's1',
+        timestamp: DateTime(2023, 1, 1),
+        decayStage: 'early',
+      ),
+      RecallFailureSpotting(
+        spotId: 's2',
+        timestamp: DateTime(2023, 1, 3),
+        decayStage: 'mid',
+      ),
+      RecallFailureSpotting(
+        spotId: 'x3',
+        timestamp: DateTime(2023, 1, 2),
+        decayStage: 'late',
+      ),
+    ];
+
+    final tags = {
+      's1': ['TagA'],
+      's2': ['TagB'],
+      'x3': ['TagA'],
+    };
+
+    final streets = {
+      's1': 'flop',
+      's2': 'turn',
+      'x3': 'flop',
+    };
+
+    final successes = [
+      RecallSuccessEntry(tag: 'TagA', timestamp: DateTime(2023, 1, 4)),
+    ];
+
+    final service = MistakeHistoryQueryService(
+      loadSpottings: () async => spottings,
+      resolveTags: (id) async => tags[id] ?? [],
+      resolveStreet: (id) async => streets[id],
+      loadSuccesses: () async => successes,
+    );
+
+    final res = await service.queryMistakes(
+      tag: 'TagA',
+      street: 'flop',
+      spotIdPattern: 's',
+      limit: 5,
+    );
+
+    expect(res.length, 1);
+    expect(res.first.spotId, 's1');
+    expect(res.first.wasRecovered, true);
+  });
+
+  test('applies limit and orders by timestamp', () async {
+    final spottings = [
+      RecallFailureSpotting(
+        spotId: 'a',
+        timestamp: DateTime(2023, 1, 1),
+        decayStage: 'early',
+      ),
+      RecallFailureSpotting(
+        spotId: 'b',
+        timestamp: DateTime(2023, 1, 3),
+        decayStage: 'mid',
+      ),
+      RecallFailureSpotting(
+        spotId: 'c',
+        timestamp: DateTime(2023, 1, 2),
+        decayStage: 'late',
+      ),
+    ];
+
+    final tags = {
+      'a': ['T'],
+      'b': ['T'],
+      'c': ['T'],
+    };
+
+    final service = MistakeHistoryQueryService(
+      loadSpottings: () async => spottings,
+      resolveTags: (id) async => tags[id] ?? [],
+      resolveStreet: (id) async => null,
+      loadSuccesses: () async => [],
+    );
+
+    final res = await service.queryMistakes(tag: 'T', limit: 2);
+
+    expect(res.length, 2);
+    expect(res[0].spotId, 'b');
+    expect(res[1].spotId, 'c');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add MistakeHistoryEntry model
- implement MistakeHistoryQueryService to filter past mistakes and check recovery
- cover service with unit tests

## Testing
- `dart format lib/models/mistake_history_entry.dart lib/services/mistake_history_query_service.dart test/services/mistake_history_query_service_test.dart` (fails: command not found)
- `dart analyze lib/services/mistake_history_query_service.dart lib/models/mistake_history_entry.dart test/services/mistake_history_query_service_test.dart` (fails: command not found)
- `dart test test/services/mistake_history_query_service_test.dart` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68911130bb58832ab34943f834957353