### PR TITLE
feat: add mistake-driven drill pack generator

### DIFF
--- a/lib/services/mistake_driven_drill_pack_generator.dart
+++ b/lib/services/mistake_driven_drill_pack_generator.dart
@@ -1,0 +1,66 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/mistake_history_entry.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/hero_position.dart';
+import '../models/game_type.dart';
+import '../core/training/engine/training_type_engine.dart';
+import 'mistake_history_query_service.dart';
+
+/// Builds a training pack from recent unrecovered mistakes.
+class MistakeDrivenDrillPackGenerator {
+  final MistakeHistoryQueryService history;
+  final Future<TrainingPackSpot?> Function(String spotId) loadSpot;
+
+  const MistakeDrivenDrillPackGenerator({
+    required this.history,
+    required this.loadSpot,
+  });
+
+  /// Generates a pack titled "Fix Your Mistakes" containing up to [limit]
+  /// recent mistakes that haven't been recovered yet.
+  Future<TrainingPackTemplateV2?> generate({int limit = 10}) async {
+    if (limit <= 0) return null;
+    final entries = await history.queryMistakes(limit: limit * 3);
+    final added = <String>{};
+    final spots = <TrainingPackSpot>[];
+    final tags = <String>{};
+
+    for (final e in entries) {
+      if (spots.length >= limit) break;
+      if (e.wasRecovered) continue;
+      if (!added.add(e.spotId)) continue;
+      final spot = await loadSpot(e.spotId);
+      if (spot == null) continue;
+      spots.add(TrainingPackSpot.fromJson(spot.toJson()));
+      tags.add(e.tag);
+    }
+
+    if (spots.isEmpty) return null;
+
+    final positions = <HeroPosition>{for (final s in spots) s.hand.position};
+    final engine = const TrainingTypeEngine();
+    final trainingType = engine.detectTrainingType(
+      TrainingPackTemplateV2(
+        id: '',
+        name: '',
+        trainingType: TrainingType.pushFold,
+        spots: spots,
+      ),
+    );
+
+    return TrainingPackTemplateV2(
+      id: const Uuid().v4(),
+      name: 'Fix Your Mistakes',
+      trainingType: trainingType,
+      tags: tags.toList(),
+      spots: spots,
+      spotCount: spots.length,
+      created: DateTime.now(),
+      gameType: GameType.tournament,
+      positions: [for (final p in positions) p.name],
+      meta: const {'origin': 'mistake-drill'},
+    );
+  }
+}

--- a/test/services/mistake_driven_drill_pack_generator_test.dart
+++ b/test/services/mistake_driven_drill_pack_generator_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/mistake_driven_drill_pack_generator.dart';
+import 'package:poker_analyzer/services/mistake_history_query_service.dart';
+import 'package:poker_analyzer/models/mistake_history_entry.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+
+class _StubHistoryService extends MistakeHistoryQueryService {
+  final List<MistakeHistoryEntry> entries;
+  _StubHistoryService(this.entries)
+    : super(
+        loadSpottings: () async => [],
+        resolveTags: (_) async => [],
+        resolveStreet: (_) async => null,
+      );
+  @override
+  Future<List<MistakeHistoryEntry>> queryMistakes({
+    String? tag,
+    String? street,
+    String? spotIdPattern,
+    int limit = 20,
+  }) async {
+    final list = List<MistakeHistoryEntry>.from(entries)
+      ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    return list.take(limit).toList();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generates pack from recent unrecovered mistakes', () async {
+    final history = _StubHistoryService([
+      MistakeHistoryEntry(
+        spotId: 'a',
+        timestamp: DateTime(2023, 1, 3),
+        decayStage: 'x',
+        tag: 'T1',
+        wasRecovered: false,
+      ),
+      MistakeHistoryEntry(
+        spotId: 'b',
+        timestamp: DateTime(2023, 1, 2),
+        decayStage: 'x',
+        tag: 'T2',
+        wasRecovered: false,
+      ),
+      MistakeHistoryEntry(
+        spotId: 'c',
+        timestamp: DateTime(2023, 1, 1),
+        decayStage: 'x',
+        tag: 'T3',
+        wasRecovered: true,
+      ),
+    ]);
+
+    final spotMap = {
+      'a': TrainingPackSpot(id: 'a', hand: HandData()),
+      'b': TrainingPackSpot(id: 'b', hand: HandData()),
+      'c': TrainingPackSpot(id: 'c', hand: HandData()),
+    };
+
+    final generator = MistakeDrivenDrillPackGenerator(
+      history: history,
+      loadSpot: (id) async => spotMap[id],
+    );
+
+    final pack = await generator.generate(limit: 5);
+    expect(pack, isNotNull);
+    expect(pack!.name, 'Fix Your Mistakes');
+    expect(pack.meta['origin'], 'mistake-drill');
+    expect(pack.spots.length, 2);
+    expect(pack.spots.first.id, 'a');
+  });
+}


### PR DESCRIPTION
## Summary
- add MistakeDrivenDrillPackGenerator to build drill packs from recent mistakes
- test MistakeDrivenDrillPackGenerator

## Testing
- `flutter test test/services/mistake_driven_drill_pack_generator_test.dart` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart')*


------
https://chatgpt.com/codex/tasks/task_e_689112ef4250832aa05619c2effecf3c