### PR TITLE
feat: add auto mistake drill banner

### DIFF
--- a/lib/screens/main_navigation_screen.dart
+++ b/lib/screens/main_navigation_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/ev_goal_banner.dart';
 import '../widgets/repeat_last_corrected_card.dart';
 import '../widgets/repeat_corrected_drill_card.dart';
 import '../widgets/streak_mini_card.dart';
+import '../widgets/auto_mistake_drill_banner_widget.dart';
 import '../widgets/streak_chart.dart';
 import '../widgets/continue_training_button.dart';
 import '../widgets/spot_of_the_day_card.dart';
@@ -322,6 +323,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen>
         const DecayBoosterReminderBanner(),
         const DecayBoosterShortcutBanner(),
         const GoalReminderBanner(),
+        const AutoMistakeDrillBannerWidget(),
         const SmartGoalBanner(),
         const NextBestStepBanner(),
         const SpotOfTheDayCard(),

--- a/lib/services/mistake_drill_launcher_service.dart
+++ b/lib/services/mistake_drill_launcher_service.dart
@@ -35,6 +35,15 @@ class MistakeDrillLauncherService {
     return true;
   }
 
+  /// Marks the auto drill as shown to enforce cooldown without launching.
+  Future<void> markShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      _cooldownKey,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
   /// Generates a drill from recent mistakes and launches training if possible.
   Future<void> maybeLaunch() async {
     if (!await shouldTriggerAutoDrill()) return;

--- a/lib/widgets/auto_mistake_drill_banner_widget.dart
+++ b/lib/widgets/auto_mistake_drill_banner_widget.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/mistake_history_entry.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../services/mistake_drill_launcher_service.dart';
+import '../services/mistake_driven_drill_pack_generator.dart';
+import '../services/mistake_history_query_service.dart';
+import '../services/template_storage_service.dart';
+import '../services/mistake_review_pack_service.dart';
+
+class AutoMistakeDrillBannerWidget extends StatefulWidget {
+  const AutoMistakeDrillBannerWidget({super.key});
+
+  @override
+  State<AutoMistakeDrillBannerWidget> createState() => _AutoMistakeDrillBannerWidgetState();
+}
+
+class _AutoMistakeDrillBannerWidgetState extends State<AutoMistakeDrillBannerWidget> {
+  bool _show = false;
+  late final MistakeDrillLauncherService _service;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = MistakeDrillLauncherService(
+      generator: MistakeDrivenDrillPackGenerator(
+        history: _MistakePackHistory(context.read<MistakeReviewPackService>()),
+        loadSpot: _loadSpot,
+      ),
+    );
+    _prepare();
+  }
+
+  Future<void> _prepare() async {
+    if (!await _service.shouldTriggerAutoDrill()) return;
+    final pack = await _service.generator.generate(limit: 5);
+    if (pack == null || pack.spots.isEmpty) return;
+    await _service.markShown();
+    if (mounted) setState(() => _show = true);
+  }
+
+  Future<TrainingPackSpot?> _loadSpot(String id) async {
+    final templates = context.read<TemplateStorageService>().templates;
+    for (final t in templates) {
+      for (final s in t.spots) {
+        if (s.id == id) {
+          return TrainingPackSpot.fromJson(s.toJson());
+        }
+      }
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_show) return const SizedBox.shrink();
+    return Card(
+      margin: const EdgeInsets.all(8),
+      child: ListTile(
+        title: const Text('Fix Your Mistakes'),
+        subtitle: const Text('You have mistakes to correct'),
+        trailing: TextButton(
+          onPressed: () {
+            _service.maybeLaunch();
+          },
+          child: const Text('Train Now'),
+        ),
+      ),
+    );
+  }
+}
+
+class _MistakePackHistory extends MistakeHistoryQueryService {
+  final MistakeReviewPackService _source;
+  _MistakePackHistory(this._source)
+      : super(
+          loadSpottings: () async => [],
+          resolveTags: (_) async => [],
+          resolveStreet: (_) async => null,
+        );
+
+  @override
+  Future<List<MistakeHistoryEntry>> queryMistakes({
+    String? tag,
+    String? street,
+    String? spotIdPattern,
+    int limit = 20,
+  }) async {
+    final entries = <MistakeHistoryEntry>[];
+    for (final pack in _source.packs) {
+      for (final id in pack.spotIds) {
+        entries.add(MistakeHistoryEntry(
+          spotId: id,
+          timestamp: pack.createdAt,
+          decayStage: '',
+          tag: '',
+          wasRecovered: false,
+        ));
+      }
+    }
+    entries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    return entries.take(limit).toList();
+  }
+}


### PR DESCRIPTION
## Summary
- add AutoMistakeDrillBannerWidget to suggest drills when fresh mistakes exist
- allow MistakeDrillLauncherService to record banner display
- surface banner on main screen when auto-drill is available

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911a40591c832abfcd0993c0438121