### PR TITLE
Add SpotSeedFilterService for constraint-based spot filtering

### DIFF
--- a/lib/services/spot_seed_filter_service.dart
+++ b/lib/services/spot_seed_filter_service.dart
@@ -1,0 +1,58 @@
+import '../models/constraint_set.dart';
+import '../models/spot_seed_format.dart';
+import '../models/card_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'constraint_resolver_engine_v2.dart';
+
+class SpotSeedFilterService {
+  final ConstraintResolverEngine _engine;
+
+  const SpotSeedFilterService({ConstraintResolverEngine? engine})
+    : _engine = engine ?? const ConstraintResolverEngine();
+
+  /// Filters [spots] returning only those that satisfy [constraints].
+  ///
+  /// Each [TrainingPackSpot] is converted to a [SpotSeedFormat] and validated
+  /// using [ConstraintResolverEngine.isValid].
+  List<TrainingPackSpot> filter(
+    List<TrainingPackSpot> spots,
+    ConstraintSet constraints,
+  ) {
+    return [
+      for (final spot in spots)
+        if (_matches(spot, constraints)) spot,
+    ];
+  }
+
+  bool _matches(TrainingPackSpot spot, ConstraintSet constraints) {
+    if (constraints.tags.isNotEmpty) {
+      final tags = spot.tags.map((t) => t.toLowerCase()).toSet();
+      final required = constraints.tags.map((t) => t.toLowerCase()).toList();
+      if (!required.every(tags.contains)) {
+        return false;
+      }
+    }
+    final seed = _toSeed(spot);
+    return _engine.isValid(seed, constraints);
+  }
+
+  SpotSeedFormat _toSeed(TrainingPackSpot spot) {
+    final board = [
+      for (final c in spot.board)
+        CardModel(rank: c[0], suit: c.length > 1 ? c[1] : ''),
+    ];
+    final heroPos = spot.hand.position.name;
+    final actions = <String>[];
+    if (spot.villainAction != null && spot.villainAction!.isNotEmpty) {
+      actions.add(spot.villainAction!.split(' ').first);
+    }
+    return SpotSeedFormat(
+      player: 'hero',
+      handGroup: const [],
+      position: heroPos,
+      board: board,
+      villainActions: actions,
+      tags: spot.tags,
+    );
+  }
+}

--- a/test/services/spot_seed_filter_service_test.dart
+++ b/test/services/spot_seed_filter_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/spot_seed_filter_service.dart';
+
+void main() {
+  final service = SpotSeedFilterService();
+
+  TrainingPackSpot buildSpot({
+    String id = '1',
+    HeroPosition position = HeroPosition.btn,
+    List<String>? board,
+    String? villainAction,
+    List<String>? tags,
+  }) {
+    return TrainingPackSpot(
+      id: id,
+      hand: HandData(position: position),
+      board: board ?? const [],
+      villainAction: villainAction,
+      tags: tags,
+    );
+  }
+
+  test('filters spots matching all constraints', () {
+    final spots = [
+      buildSpot(
+        id: 'a',
+        position: HeroPosition.btn,
+        board: ['2h', '2c', '9d'],
+        villainAction: 'check',
+        tags: ['test'],
+      ),
+      buildSpot(
+        id: 'b',
+        position: HeroPosition.co,
+        board: ['Ah', 'Kd', '2d'],
+        villainAction: 'bet',
+        tags: ['other'],
+      ),
+    ];
+
+    final set = ConstraintSet(
+      positions: ['btn'],
+      boardTags: ['paired'],
+      villainActions: ['check'],
+      tags: ['test'],
+    );
+
+    final result = service.filter(spots, set);
+    expect(result.map((e) => e.id), ['a']);
+  });
+
+  test('filters by tags when provided', () {
+    final spots = [
+      buildSpot(id: 'a', tags: ['keep']),
+      buildSpot(id: 'b', tags: ['discard']),
+    ];
+    final set = ConstraintSet(tags: ['keep']);
+    final result = service.filter(spots, set);
+    expect(result.map((e) => e.id), ['a']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SpotSeedFilterService` to filter `TrainingPackSpot` lists using `ConstraintSet` and `ConstraintResolverEngine`
- cover filtering logic with unit tests

## Testing
- `dart test test/services/spot_seed_filter_service_test.dart` *(fails: Flutter SDK missing)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6891320ca884832aaba13720a92c8ba6