### PR TITLE
Add training session fingerprint recorder

### DIFF
--- a/lib/services/training_session_fingerprint_recorder.dart
+++ b/lib/services/training_session_fingerprint_recorder.dart
@@ -1,0 +1,44 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists fingerprints of completed training sessions.
+///
+/// This allows the app to track which training packs were already completed
+/// and avoid presenting duplicates in the future.
+class TrainingSessionFingerprintRecorder {
+  TrainingSessionFingerprintRecorder._();
+
+  /// Singleton instance.
+  static final TrainingSessionFingerprintRecorder instance =
+      TrainingSessionFingerprintRecorder._();
+
+  static const _key = 'completed_training_pack_fingerprints';
+
+  /// Stores [fingerprint] in persistent storage.
+  Future<void> recordCompletion(String fingerprint) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    if (!list.contains(fingerprint)) {
+      list.add(fingerprint);
+      await prefs.setStringList(_key, list);
+    }
+  }
+
+  /// Returns whether [fingerprint] was already recorded as completed.
+  Future<bool> isCompleted(String fingerprint) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key) ?? <String>[];
+    return list.contains(fingerprint);
+  }
+
+  /// Returns all stored fingerprints.
+  Future<List<String>> getAllFingerprints() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_key) ?? <String>[];
+  }
+
+  /// Clears all stored fingerprints. Useful for tests.
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/test/services/training_session_fingerprint_recorder_test.dart
+++ b/test/services/training_session_fingerprint_recorder_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/training_session_fingerprint_recorder.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('records and checks completion', () async {
+    final recorder = TrainingSessionFingerprintRecorder.instance;
+    const fp = 'abc123';
+
+    expect(await recorder.isCompleted(fp), isFalse);
+    await recorder.recordCompletion(fp);
+    expect(await recorder.isCompleted(fp), isTrue);
+    expect(await recorder.getAllFingerprints(), [fp]);
+  });
+
+  test('does not duplicate fingerprints', () async {
+    final recorder = TrainingSessionFingerprintRecorder.instance;
+    const fp = 'xyz';
+
+    await recorder.recordCompletion(fp);
+    await recorder.recordCompletion(fp);
+    final all = await recorder.getAllFingerprints();
+    expect(all, [fp]);
+  });
+}


### PR DESCRIPTION
## Summary
- track completed training packs in a new TrainingSessionFingerprintRecorder service
- persist fingerprints using SharedPreferences and expose query helpers
- cover recorder behavior with unit tests

## Testing
- `dart analyze lib/services/training_session_fingerprint_recorder.dart test/services/training_session_fingerprint_recorder_test.dart`
- `flutter test` *(fails: Not found: 'package:flutter_gen/gen_l10n/app_localizations.dart', etc.)*
- `flutter test test/services/training_session_fingerprint_recorder_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689135d7a424832a8f73c32304655b1b