### PR TITLE
feat: store completed training packs

### DIFF
--- a/lib/services/completed_training_pack_registry.dart
+++ b/lib/services/completed_training_pack_registry.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_pack_fingerprint_generator.dart';
+
+/// Persists completed training packs keyed by their deterministic fingerprints.
+///
+/// Each entry stores the original YAML along with completion metadata so that
+/// sessions can be reconstructed and progress analyzed.
+class CompletedTrainingPackRegistry {
+  CompletedTrainingPackRegistry({
+    SharedPreferences? prefs,
+    TrainingPackFingerprintGenerator? fingerprintGenerator,
+  }) : _prefs = prefs,
+       _fingerprintGenerator =
+           fingerprintGenerator ?? const TrainingPackFingerprintGenerator();
+
+  SharedPreferences? _prefs;
+  final TrainingPackFingerprintGenerator _fingerprintGenerator;
+
+  static const _prefix = 'completed_pack_';
+
+  Future<SharedPreferences> get _sp async =>
+      _prefs ??= await SharedPreferences.getInstance();
+
+  /// Stores [pack] as a completed training pack, capturing its YAML and
+  /// metadata such as completion timestamp, training type and accuracy.
+  Future<void> storeCompletedPack(
+    TrainingPackTemplateV2 pack, {
+    DateTime? completedAt,
+    double? accuracy,
+  }) async {
+    final prefs = await _sp;
+    final fingerprint = _fingerprintGenerator.generate(pack);
+    final data = <String, dynamic>{
+      'yaml': pack.toYamlString(),
+      'timestamp': (completedAt ?? DateTime.now()).toIso8601String(),
+      'type': pack.trainingType.name,
+      if (accuracy != null) 'accuracy': accuracy,
+    };
+    await prefs.setString('$_prefix$fingerprint', jsonEncode(data));
+  }
+
+  /// Returns stored data for [fingerprint] or `null` if absent.
+  Future<Map<String, dynamic>?> getCompletedPackData(String fingerprint) async {
+    final prefs = await _sp;
+    final raw = prefs.getString('$_prefix$fingerprint');
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        return Map<String, dynamic>.from(data as Map);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// Lists fingerprints of all completed packs persisted in the registry.
+  Future<List<String>> listCompletedFingerprints() async {
+    final prefs = await _sp;
+    final list = <String>[];
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(_prefix)) {
+        list.add(key.substring(_prefix.length));
+      }
+    }
+    return list;
+  }
+}

--- a/test/services/completed_training_pack_registry_test.dart
+++ b/test/services/completed_training_pack_registry_test.dart
@@ -1,0 +1,46 @@
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
+import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 buildPack(String id) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: 'Pack $id',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+  }
+
+  test('store and retrieve completed pack data', () async {
+    final registry = CompletedTrainingPackRegistry();
+    final pack = buildPack('p1');
+    final completedAt = DateTime.utc(2024, 1, 1);
+    await registry.storeCompletedPack(
+      pack,
+      completedAt: completedAt,
+      accuracy: 0.85,
+    );
+
+    final fp = const TrainingPackFingerprintGenerator().generate(pack);
+    final data = await registry.getCompletedPackData(fp);
+    expect(data, isNotNull);
+    expect(data!['yaml'], equals(pack.toYamlString()));
+    expect(DateTime.parse(data['timestamp'] as String), completedAt);
+    expect(data['type'], equals('quiz'));
+    expect((data['accuracy'] as num).toDouble(), closeTo(0.85, 1e-9));
+
+    final all = await registry.listCompletedFingerprints();
+    expect(all, contains(fp));
+  });
+}


### PR DESCRIPTION
## Summary
- add `CompletedTrainingPackRegistry` to persist finished packs by fingerprint
- test storing and retrieving completed pack metadata

## Testing
- `flutter test` *(fails: constant evaluation error)*

------
https://chatgpt.com/codex/tasks/task_e_689137c40a5c832a86b7f371c59f889d