### PR TITLE
feat: add unique pack replay blocker service

### DIFF
--- a/lib/services/unique_pack_replay_blocker_service.dart
+++ b/lib/services/unique_pack_replay_blocker_service.dart
@@ -1,0 +1,46 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'training_pack_fingerprint_generator.dart';
+import 'training_session_fingerprint_recorder.dart';
+
+/// Blocks replaying a training pack if it was already completed and
+/// unique-session mode is enabled.
+class UniquePackReplayBlockerService {
+  UniquePackReplayBlockerService({
+    SharedPreferences? prefs,
+    TrainingPackFingerprintGenerator? fingerprintGenerator,
+    TrainingSessionFingerprintRecorder? recorder,
+  })  : _prefs = prefs,
+        _fingerprintGenerator =
+            fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
+        _recorder = recorder ?? TrainingSessionFingerprintRecorder.instance;
+
+  SharedPreferences? _prefs;
+  final TrainingPackFingerprintGenerator _fingerprintGenerator;
+  final TrainingSessionFingerprintRecorder _recorder;
+
+  static const _flagKey = 'unique_pack_replay_blocking_enabled';
+
+  Future<SharedPreferences> get _sp async =>
+      _prefs ??= await SharedPreferences.getInstance();
+
+  /// Enables or disables the unique session mode.
+  Future<void> setBlockingEnabled(bool value) async {
+    final prefs = await _sp;
+    await prefs.setBool(_flagKey, value);
+  }
+
+  Future<bool> _isBlockingEnabled() async {
+    final prefs = await _sp;
+    return prefs.getBool(_flagKey) ?? false;
+  }
+
+  /// Returns `true` if replaying [pack] is blocked due to prior completion.
+  Future<bool> isReplayBlocked(TrainingPackTemplateV2 pack) async {
+    if (!await _isBlockingEnabled()) return false;
+    final fp = _fingerprintGenerator.generate(pack);
+    return _recorder.isCompleted(fp);
+  }
+}
+

--- a/test/services/unique_pack_replay_blocker_service_test.dart
+++ b/test/services/unique_pack_replay_blocker_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart';
+import 'package:poker_analyzer/services/training_session_fingerprint_recorder.dart';
+import 'package:poker_analyzer/services/unique_pack_replay_blocker_service.dart';
+
+void main() {
+  late UniquePackReplayBlockerService blocker;
+  late TrainingPackTemplateV2 pack;
+  const gen = TrainingPackFingerprintGenerator();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    blocker = UniquePackReplayBlockerService();
+    pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Test',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+  });
+
+  test('returns false when blocking disabled', () async {
+    expect(await blocker.isReplayBlocked(pack), isFalse);
+  });
+
+  test('does not block when enabled but pack not completed', () async {
+    await blocker.setBlockingEnabled(true);
+    expect(await blocker.isReplayBlocked(pack), isFalse);
+  });
+
+  test('blocks replay when enabled and completed', () async {
+    await blocker.setBlockingEnabled(true);
+    final fp = gen.generate(pack);
+    await TrainingSessionFingerprintRecorder.instance.recordCompletion(fp);
+    expect(await blocker.isReplayBlocked(pack), isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- introduce UniquePackReplayBlockerService to prevent replaying completed packs when unique session mode enabled
- add tests verifying blocker behavior

## Testing
- `flutter format lib/services/unique_pack_replay_blocker_service.dart test/services/unique_pack_replay_blocker_service_test.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test test/services/unique_pack_replay_blocker_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68913a748b9c832a95c76f6fe630ac41