### PR TITLE
feat: add completed session summary service

### DIFF
--- a/lib/services/completed_session_summary_service.dart
+++ b/lib/services/completed_session_summary_service.dart
@@ -1,0 +1,62 @@
+import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
+
+/// Summary of a completed training session.
+class CompletedSessionSummary {
+  final String fingerprint;
+  final String trainingType;
+  final double? accuracy;
+  final DateTime timestamp;
+  final String yaml;
+
+  const CompletedSessionSummary({
+    required this.fingerprint,
+    required this.trainingType,
+    this.accuracy,
+    required this.timestamp,
+    required this.yaml,
+  });
+}
+
+/// Loads and summarizes completed training sessions.
+class CompletedSessionSummaryService {
+  final CompletedTrainingPackRegistry registry;
+
+  const CompletedSessionSummaryService({
+    CompletedTrainingPackRegistry? registry,
+  }) : registry = registry ?? CompletedTrainingPackRegistry();
+
+  /// Returns summaries for all completed sessions sorted by most recent.
+  Future<List<CompletedSessionSummary>> loadSummaries() async {
+    final fingerprints = await registry.listCompletedFingerprints();
+    final summaries = <CompletedSessionSummary>[];
+    for (final fp in fingerprints) {
+      final data = await registry.getCompletedPackData(fp);
+      if (data == null) continue;
+      final yaml = data['yaml'];
+      final timestampStr = data['timestamp'];
+      final type = data['type'];
+      if (yaml is! String || timestampStr is! String || type is! String) {
+        continue;
+      }
+      DateTime? ts;
+      try {
+        ts = DateTime.parse(timestampStr);
+      } catch (_) {}
+      if (ts == null) continue;
+      double? accuracy;
+      final acc = data['accuracy'];
+      if (acc is num) accuracy = acc.toDouble();
+      summaries.add(
+        CompletedSessionSummary(
+          fingerprint: fp,
+          trainingType: type,
+          accuracy: accuracy,
+          timestamp: ts,
+          yaml: yaml,
+        ),
+      );
+    }
+    summaries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    return summaries;
+  }
+}

--- a/test/services/completed_session_summary_service_test.dart
+++ b/test/services/completed_session_summary_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/completed_session_summary_service.dart';
+import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
+import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 buildPack(String id) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: 'Pack $id',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+  }
+
+  test('load summaries sorted by timestamp', () async {
+    final registry = CompletedTrainingPackRegistry();
+    final pack1 = buildPack('p1');
+    final pack2 = buildPack('p2');
+    final time1 = DateTime.utc(2024, 1, 1);
+    final time2 = DateTime.utc(2024, 2, 1);
+
+    await registry.storeCompletedPack(pack1, completedAt: time1, accuracy: 0.8);
+    await registry.storeCompletedPack(pack2, completedAt: time2, accuracy: 0.9);
+
+    final service = CompletedSessionSummaryService(registry: registry);
+    final summaries = await service.loadSummaries();
+
+    expect(summaries, hasLength(2));
+    final fp1 = const TrainingPackFingerprintGenerator().generate(pack1);
+    final fp2 = const TrainingPackFingerprintGenerator().generate(pack2);
+
+    expect(summaries[0].fingerprint, fp2);
+    expect(summaries[0].timestamp, time2);
+    expect(summaries[0].trainingType, 'quiz');
+    expect(summaries[0].accuracy, closeTo(0.9, 1e-9));
+    expect(summaries[0].yaml, pack2.toYamlString());
+
+    expect(summaries[1].fingerprint, fp1);
+    expect(summaries[1].timestamp, time1);
+    expect(summaries[1].trainingType, 'quiz');
+    expect(summaries[1].accuracy, closeTo(0.8, 1e-9));
+    expect(summaries[1].yaml, pack1.toYamlString());
+  });
+}


### PR DESCRIPTION
## Summary
- add `CompletedSessionSummary` data model and `CompletedSessionSummaryService`
- expose ordered summaries of stored training sessions
- cover session summary logic with unit test

## Testing
- `flutter test test/services/completed_session_summary_service_test.dart` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_set.dart')*


------
https://chatgpt.com/codex/tasks/task_e_68913bab90b8832a95aa0577a6363c57