### PR TITLE
feat: add presenter for completed session history

### DIFF
--- a/lib/presenters/completed_session_history_presenter.dart
+++ b/lib/presenters/completed_session_history_presenter.dart
@@ -1,0 +1,61 @@
+import 'package:intl/intl.dart';
+import 'package:poker_analyzer/services/completed_session_summary_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class CompletedSessionDisplayItem {
+  final String title;
+  final String subtitle;
+  final String fingerprint;
+  final DateTime timestamp;
+
+  const CompletedSessionDisplayItem({
+    required this.title,
+    required this.subtitle,
+    required this.fingerprint,
+    required this.timestamp,
+  });
+}
+
+class CompletedSessionHistoryPresenter {
+  const CompletedSessionHistoryPresenter();
+
+  List<CompletedSessionDisplayItem> present(
+    List<CompletedSessionSummary> summaries,
+  ) {
+    return summaries.map(_buildItem).toList();
+  }
+
+  CompletedSessionDisplayItem _buildItem(CompletedSessionSummary summary) {
+    String packName = 'Unknown Pack';
+    try {
+      packName = TrainingPackTemplateV2.fromYamlString(summary.yaml).name;
+    } catch (_) {}
+
+    TrainingType? typeEnum;
+    try {
+      typeEnum = TrainingType.values.firstWhere(
+        (t) => t.name == summary.trainingType,
+      );
+    } catch (_) {}
+    final typeLabel = typeEnum?.label ?? summary.trainingType;
+
+    final title = '$typeLabel Pack: $packName';
+
+    final dateStr = DateFormat.yMMMd(
+      Intl.getCurrentLocale(),
+    ).format(summary.timestamp);
+    var subtitle = 'Completed on $dateStr';
+    if (summary.accuracy != null) {
+      final percent = (summary.accuracy! * 100).toStringAsFixed(0);
+      subtitle += ', Accuracy: $percent%';
+    }
+
+    return CompletedSessionDisplayItem(
+      title: title,
+      subtitle: subtitle,
+      fingerprint: summary.fingerprint,
+      timestamp: summary.timestamp,
+    );
+  }
+}

--- a/test/presenters/completed_session_history_presenter_test.dart
+++ b/test/presenters/completed_session_history_presenter_test.dart
@@ -1,0 +1,39 @@
+import 'package:intl/intl.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/completed_session_summary_service.dart';
+import 'package:poker_analyzer/presenters/completed_session_history_presenter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Intl.defaultLocale = 'en_US';
+
+  test('presenter converts summaries to display items', () {
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Push/Fold SB vs BB',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+
+    final summary = CompletedSessionSummary(
+      fingerprint: 'fp1',
+      trainingType: 'quiz',
+      accuracy: 0.88,
+      timestamp: DateTime.utc(2024, 7, 2),
+      yaml: pack.toYamlString(),
+    );
+
+    const presenter = CompletedSessionHistoryPresenter();
+    final items = presenter.present([summary]);
+
+    expect(items, hasLength(1));
+    expect(items.first.title, 'Quiz Pack: Push/Fold SB vs BB');
+    expect(items.first.subtitle, 'Completed on Jul 2, 2024, Accuracy: 88%');
+    expect(items.first.fingerprint, 'fp1');
+    expect(items.first.timestamp, DateTime.utc(2024, 7, 2));
+  });
+}


### PR DESCRIPTION
## Summary
- add `CompletedSessionHistoryPresenter` to format session summaries for display
- test presenter formatting logic

## Testing
- `dart analyze lib/presenters/completed_session_history_presenter.dart test/presenters/completed_session_history_presenter_test.dart`
- `flutter test` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, but it does not provide an inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68913e480240832a821b6e2311326ed8