### PR TITLE
feat: add training session completion stats service

### DIFF
--- a/lib/services/training_session_completion_stats_service.dart
+++ b/lib/services/training_session_completion_stats_service.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'completed_training_pack_registry.dart';
+
+/// Aggregated statistics of completed training sessions.
+class CompletionStats {
+  final int totalSessions;
+  final double averageAccuracy;
+  final Duration? averageDuration;
+
+  const CompletionStats({
+    required this.totalSessions,
+    required this.averageAccuracy,
+    this.averageDuration,
+  });
+}
+
+/// Summarizes completed training sessions using stored fingerprints.
+class TrainingSessionCompletionStatsService {
+  final CompletedTrainingPackRegistry registry;
+
+  const TrainingSessionCompletionStatsService({
+    CompletedTrainingPackRegistry? registry,
+  }) : registry = registry ?? CompletedTrainingPackRegistry();
+
+  /// Computes aggregated statistics across all completed sessions.
+  Future<CompletionStats> computeStats() async {
+    final fingerprints = await registry.listCompletedFingerprints();
+    int total = 0;
+    double accuracySum = 0;
+    int accuracyCount = 0;
+    int durationSumMs = 0;
+    int durationCount = 0;
+
+    for (final fp in fingerprints) {
+      final data = await registry.getCompletedPackData(fp);
+      if (data == null) continue;
+      total++;
+
+      final acc = data['accuracy'];
+      if (acc is num) {
+        accuracySum += acc.toDouble();
+        accuracyCount++;
+      }
+
+      final dur = data['durationMs'] ?? data['duration'];
+      if (dur is num) {
+        durationSumMs += dur.toInt();
+        durationCount++;
+      } else if (dur is String) {
+        // Attempt to parse numeric string or ISO8601 duration.
+        final parsed = int.tryParse(dur);
+        if (parsed != null) {
+          durationSumMs += parsed;
+          durationCount++;
+        } else {
+          try {
+            final iso = Duration.parse(dur);
+            durationSumMs += iso.inMilliseconds;
+            durationCount++;
+          } catch (_) {}
+        }
+      }
+    }
+
+    final avgAcc = accuracyCount > 0 ? accuracySum / accuracyCount : 0;
+    final avgDur = durationCount > 0
+        ? Duration(milliseconds: (durationSumMs / durationCount).round())
+        : null;
+
+    return CompletionStats(
+      totalSessions: total,
+      averageAccuracy: avgAcc,
+      averageDuration: avgDur,
+    );
+  }
+}
+

--- a/test/services/training_session_completion_stats_service_test.dart
+++ b/test/services/training_session_completion_stats_service_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
+import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart';
+import 'package:poker_analyzer/services/training_session_completion_stats_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 buildPack(String id) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: 'Pack $id',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+  }
+
+  test('computes aggregate stats for completed sessions', () async {
+    final registry = CompletedTrainingPackRegistry();
+    final pack1 = buildPack('p1');
+    final pack2 = buildPack('p2');
+
+    await registry.storeCompletedPack(pack1, accuracy: 0.8);
+    await registry.storeCompletedPack(pack2, accuracy: 0.6);
+
+    // Inject durations into stored data.
+    final fp1 = const TrainingPackFingerprintGenerator().generate(pack1);
+    final fp2 = const TrainingPackFingerprintGenerator().generate(pack2);
+    final prefs = await SharedPreferences.getInstance();
+    final data1 = jsonDecode(prefs.getString('completed_pack_$fp1')!) as Map;
+    data1['durationMs'] = 60000;
+    await prefs.setString('completed_pack_$fp1', jsonEncode(data1));
+    final data2 = jsonDecode(prefs.getString('completed_pack_$fp2')!) as Map;
+    data2['durationMs'] = 120000;
+    await prefs.setString('completed_pack_$fp2', jsonEncode(data2));
+
+    final service =
+        TrainingSessionCompletionStatsService(registry: registry);
+    final stats = await service.computeStats();
+
+    expect(stats.totalSessions, 2);
+    expect(stats.averageAccuracy, closeTo(0.7, 1e-9));
+    expect(stats.averageDuration, const Duration(minutes: 1, seconds: 30));
+  });
+}


### PR DESCRIPTION
## Summary
- add `TrainingSessionCompletionStatsService` to compute totals, average accuracy, and optional duration for completed sessions
- cover service with unit test using mock `CompletedTrainingPackRegistry`

## Testing
- `dart format lib/services/training_session_completion_stats_service.dart` *(failed: command not found)*
- `dart test test/services/training_session_completion_stats_service_test.dart` *(failed: command not found)*
- `apt-get install -y dart` *(failed: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6891510fb1a0832a8607634a4f2783f4