### PR TITLE
Store training session duration

### DIFF
--- a/lib/services/completed_training_pack_registry.dart
+++ b/lib/services/completed_training_pack_registry.dart
@@ -31,6 +31,7 @@ class CompletedTrainingPackRegistry {
     TrainingPackTemplateV2 pack, {
     DateTime? completedAt,
     double? accuracy,
+    Duration? duration,
   }) async {
     final prefs = await _sp;
     final fingerprint = _fingerprintGenerator.generate(pack);
@@ -39,6 +40,7 @@ class CompletedTrainingPackRegistry {
       'timestamp': (completedAt ?? DateTime.now()).toIso8601String(),
       'type': pack.trainingType.name,
       if (accuracy != null) 'accuracy': accuracy,
+      if (duration != null) 'durationMs': duration.inMilliseconds,
     };
     await prefs.setString('$_prefix$fingerprint', jsonEncode(data));
   }

--- a/test/services/completed_training_pack_registry_test.dart
+++ b/test/services/completed_training_pack_registry_test.dart
@@ -30,6 +30,7 @@ void main() {
       pack,
       completedAt: completedAt,
       accuracy: 0.85,
+      duration: const Duration(seconds: 30),
     );
 
     final fp = const TrainingPackFingerprintGenerator().generate(pack);
@@ -39,6 +40,7 @@ void main() {
     expect(DateTime.parse(data['timestamp'] as String), completedAt);
     expect(data['type'], equals('quiz'));
     expect((data['accuracy'] as num).toDouble(), closeTo(0.85, 1e-9));
+    expect(data['durationMs'], 30000);
 
     final all = await registry.listCompletedFingerprints();
     expect(all, contains(fp));

--- a/test/services/training_session_completion_stats_service_test.dart
+++ b/test/services/training_session_completion_stats_service_test.dart
@@ -1,11 +1,8 @@
-import 'dart:convert';
-
 import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
 import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
-import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart';
 import 'package:poker_analyzer/services/training_session_completion_stats_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
@@ -30,22 +27,18 @@ void main() {
     final pack1 = buildPack('p1');
     final pack2 = buildPack('p2');
 
-    await registry.storeCompletedPack(pack1, accuracy: 0.8);
-    await registry.storeCompletedPack(pack2, accuracy: 0.6);
+    await registry.storeCompletedPack(
+      pack1,
+      accuracy: 0.8,
+      duration: const Duration(minutes: 1),
+    );
+    await registry.storeCompletedPack(
+      pack2,
+      accuracy: 0.6,
+      duration: const Duration(minutes: 2),
+    );
 
-    // Inject durations into stored data.
-    final fp1 = const TrainingPackFingerprintGenerator().generate(pack1);
-    final fp2 = const TrainingPackFingerprintGenerator().generate(pack2);
-    final prefs = await SharedPreferences.getInstance();
-    final data1 = jsonDecode(prefs.getString('completed_pack_$fp1')!) as Map;
-    data1['durationMs'] = 60000;
-    await prefs.setString('completed_pack_$fp1', jsonEncode(data1));
-    final data2 = jsonDecode(prefs.getString('completed_pack_$fp2')!) as Map;
-    data2['durationMs'] = 120000;
-    await prefs.setString('completed_pack_$fp2', jsonEncode(data2));
-
-    final service =
-        TrainingSessionCompletionStatsService(registry: registry);
+    final service = TrainingSessionCompletionStatsService(registry: registry);
     final stats = await service.computeStats();
 
     expect(stats.totalSessions, 2);


### PR DESCRIPTION
## Summary
- persist optional session duration alongside completed training packs
- test duration handling in registry and completion stats

## Testing
- `flutter test --suppress-analytics` *(fails: Not found: `package:flutter_gen/gen_l10n/app_localizations.dart`)*

------
https://chatgpt.com/codex/tasks/task_e_6891545f4eb0832aa8796cecbefb3fae