### PR TITLE
Add training pack history list widget

### DIFF
--- a/lib/widgets/training_pack_history_list_widget.dart
+++ b/lib/widgets/training_pack_history_list_widget.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import '../services/completed_training_pack_registry.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../helpers/date_utils.dart';
+
+class TrainingPackHistoryListWidget extends StatefulWidget {
+  const TrainingPackHistoryListWidget({super.key});
+
+  @override
+  State<TrainingPackHistoryListWidget> createState() =>
+      _TrainingPackHistoryListWidgetState();
+}
+
+class _TrainingPackHistoryListWidgetState
+    extends State<TrainingPackHistoryListWidget> {
+  final _registry = CompletedTrainingPackRegistry();
+  var _items = <_HistoryItem>[];
+  var _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final fingerprints = await _registry.listCompletedFingerprints();
+    final list = <_HistoryItem>[];
+    for (final fp in fingerprints) {
+      final data = await _registry.getCompletedPackData(fp);
+      if (data == null) continue;
+      final yaml = data['yaml'];
+      if (yaml is! String) continue;
+      String name = 'Unknown Pack';
+      try {
+        name = TrainingPackTemplateV2.fromYamlString(yaml).name;
+      } catch (_) {}
+      final tsStr = data['timestamp'];
+      DateTime? timestamp;
+      if (tsStr is String) {
+        try {
+          timestamp = DateTime.parse(tsStr);
+        } catch (_) {}
+      }
+      if (timestamp == null) continue;
+      final acc = (data['accuracy'] as num?)?.toDouble();
+      final durationMs = (data['durationMs'] as num?)?.toInt();
+      list.add(_HistoryItem(
+        name: name,
+        timestamp: timestamp,
+        accuracy: acc,
+        duration:
+            durationMs != null ? Duration(milliseconds: durationMs) : null,
+      ));
+    }
+    list.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    if (!mounted) return;
+    setState(() {
+      _items = list;
+      _loading = false;
+    });
+  }
+
+  String _buildSubtitle(_HistoryItem item) {
+    var subtitle = 'Completed on ${formatDateTime(item.timestamp)}';
+    if (item.accuracy != null) {
+      final pct = (item.accuracy! * 100).toStringAsFixed(0);
+      subtitle += ', Accuracy: $pct%';
+    }
+    if (item.duration != null) {
+      subtitle += ', Duration: ${formatDuration(item.duration!)}';
+    }
+    return subtitle;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_items.isEmpty) {
+      return const Center(child: Text('No completed packs yet'));
+    }
+    return ListView.builder(
+      itemCount: _items.length,
+      itemBuilder: (context, index) {
+        final item = _items[index];
+        return ListTile(
+          title: Text(item.name,
+              style: const TextStyle(fontWeight: FontWeight.bold)),
+          subtitle: Text(_buildSubtitle(item)),
+        );
+      },
+    );
+  }
+}
+
+class _HistoryItem {
+  final String name;
+  final DateTime timestamp;
+  final double? accuracy;
+  final Duration? duration;
+  _HistoryItem({
+    required this.name,
+    required this.timestamp,
+    this.accuracy,
+    this.duration,
+  });
+}

--- a/test/widgets/training_pack_history_list_widget_test.dart
+++ b/test/widgets/training_pack_history_list_widget_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/training_pack_history_list_widget.dart';
+import 'package:poker_analyzer/services/completed_training_pack_registry.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 buildPack(String id) {
+    return TrainingPackTemplateV2(
+      id: id,
+      name: 'Pack $id',
+      trainingType: TrainingType.quiz,
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+    );
+  }
+
+  testWidgets('shows completed pack history', (tester) async {
+    final registry = CompletedTrainingPackRegistry();
+    final pack = buildPack('p1');
+    await registry.storeCompletedPack(
+      pack,
+      completedAt: DateTime.utc(2024, 1, 1),
+      accuracy: 0.9,
+      duration: const Duration(minutes: 5),
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: TrainingPackHistoryListWidget()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pack p1'), findsOneWidget);
+    expect(find.textContaining('Accuracy: 90%'), findsOneWidget);
+    expect(find.textContaining('Duration'), findsOneWidget);
+  });
+
+  testWidgets('shows placeholder when no history', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: TrainingPackHistoryListWidget()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No completed packs yet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingPackHistoryListWidget to show completed pack metadata in a scrollable list
- test TrainingPackHistoryListWidget history display and empty state

## Testing
- `flutter test test/widgets/training_pack_history_list_widget_test.dart` *(fails: command not found)*
- `dart test test/widgets/training_pack_history_list_widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689158d4c944832aa1d2b937a039386e