### PR TITLE
feat: enable replaying training packs

### DIFF
--- a/lib/services/training_session_launcher.dart
+++ b/lib/services/training_session_launcher.dart
@@ -45,8 +45,9 @@ class TrainingSessionLauncher {
 
     if (lessonId != null) {
       await MiniLessonLibraryService.instance.loadAll();
-      final completed =
-          await TheoryLessonCompletionLogger.instance.isCompleted(lessonId);
+      final completed = await TheoryLessonCompletionLogger.instance.isCompleted(
+        lessonId,
+      );
       if (!completed) {
         final lesson = MiniLessonLibraryService.instance.getById(lessonId);
         if (lesson != null) {
@@ -74,7 +75,9 @@ class TrainingSessionLauncher {
     }
 
     final statBefore = await TrainingPackStatsService.getStats(template.id);
-    final handsBefore = await TrainingPackStatsService.getHandsCompleted(template.id);
+    final handsBefore = await TrainingPackStatsService.getHandsCompleted(
+      template.id,
+    );
 
     if (!kDebugMode) {
       final unmet = <String>[];
@@ -90,8 +93,9 @@ class TrainingSessionLauncher {
       }
 
       if (template.requiresTheoryCompleted && lessonId != null) {
-        final done =
-            await TheoryLessonCompletionLogger.instance.isCompleted(lessonId);
+        final done = await TheoryLessonCompletionLogger.instance.isCompleted(
+          lessonId,
+        );
         if (!done) {
           unmet.add('пройти теорию');
         }
@@ -126,7 +130,9 @@ class TrainingSessionLauncher {
     unawaited(AchievementsEngine.instance.checkAll());
 
     final statAfter = await TrainingPackStatsService.getStats(template.id);
-    final handsAfter = await TrainingPackStatsService.getHandsCompleted(template.id);
+    final handsAfter = await TrainingPackStatsService.getHandsCompleted(
+      template.id,
+    );
     if (template.requiredAccuracy != null || template.minHands != null) {
       await showUnlockProgressDialog(
         ctx,
@@ -138,6 +144,16 @@ class TrainingSessionLauncher {
         minHands: template.minHands,
       );
     }
+  }
+
+  /// Parses a YAML string and launches a session for the resulting pack.
+  Future<void> launchFromYaml(
+    String yaml, {
+    int startIndex = 0,
+    List<String>? sessionTags,
+  }) async {
+    final tpl = TrainingPackTemplateV2.fromYamlString(yaml);
+    await launch(tpl, startIndex: startIndex, sessionTags: sessionTags);
   }
 
   /// Finds and launches a booster drill relevant to [lesson].

--- a/lib/widgets/training_pack_history_list_widget.dart
+++ b/lib/widgets/training_pack_history_list_widget.dart
@@ -2,9 +2,17 @@ import 'package:flutter/material.dart';
 import '../services/completed_training_pack_registry.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../helpers/date_utils.dart';
+import '../services/training_session_launcher.dart';
 
 class TrainingPackHistoryListWidget extends StatefulWidget {
-  const TrainingPackHistoryListWidget({super.key});
+  const TrainingPackHistoryListWidget({
+    super.key,
+    this.registry,
+    this.launcher = const TrainingSessionLauncher(),
+  });
+
+  final CompletedTrainingPackRegistry? registry;
+  final TrainingSessionLauncher launcher;
 
   @override
   State<TrainingPackHistoryListWidget> createState() =>
@@ -13,13 +21,14 @@ class TrainingPackHistoryListWidget extends StatefulWidget {
 
 class _TrainingPackHistoryListWidgetState
     extends State<TrainingPackHistoryListWidget> {
-  final _registry = CompletedTrainingPackRegistry();
+  late final CompletedTrainingPackRegistry _registry;
   var _items = <_HistoryItem>[];
   var _loading = true;
 
   @override
   void initState() {
     super.initState();
+    _registry = widget.registry ?? CompletedTrainingPackRegistry();
     _load();
   }
 
@@ -45,13 +54,17 @@ class _TrainingPackHistoryListWidgetState
       if (timestamp == null) continue;
       final acc = (data['accuracy'] as num?)?.toDouble();
       final durationMs = (data['durationMs'] as num?)?.toInt();
-      list.add(_HistoryItem(
-        name: name,
-        timestamp: timestamp,
-        accuracy: acc,
-        duration:
-            durationMs != null ? Duration(milliseconds: durationMs) : null,
-      ));
+      list.add(
+        _HistoryItem(
+          fingerprint: fp,
+          name: name,
+          timestamp: timestamp,
+          accuracy: acc,
+          duration: durationMs != null
+              ? Duration(milliseconds: durationMs)
+              : null,
+        ),
+      );
     }
     list.sort((a, b) => b.timestamp.compareTo(a.timestamp));
     if (!mounted) return;
@@ -73,6 +86,30 @@ class _TrainingPackHistoryListWidgetState
     return subtitle;
   }
 
+  Future<void> _replay(_HistoryItem item) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Repeat this training pack?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Replay'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    final data = await _registry.getCompletedPackData(item.fingerprint);
+    final yaml = data?['yaml'];
+    if (yaml is! String) return;
+    await widget.launcher.launchFromYaml(yaml);
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -86,9 +123,12 @@ class _TrainingPackHistoryListWidgetState
       itemBuilder: (context, index) {
         final item = _items[index];
         return ListTile(
-          title: Text(item.name,
-              style: const TextStyle(fontWeight: FontWeight.bold)),
+          title: Text(
+            item.name,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
           subtitle: Text(_buildSubtitle(item)),
+          onTap: () => _replay(item),
         );
       },
     );
@@ -96,11 +136,13 @@ class _TrainingPackHistoryListWidgetState
 }
 
 class _HistoryItem {
+  final String fingerprint;
   final String name;
   final DateTime timestamp;
   final double? accuracy;
   final Duration? duration;
   _HistoryItem({
+    required this.fingerprint,
     required this.name,
     required this.timestamp,
     this.accuracy,


### PR DESCRIPTION
## Summary
- allow relaunching completed training packs from history list via confirmation dialog
- add `TrainingSessionLauncher.launchFromYaml` helper
- cover replay interaction with widget test

## Testing
- `flutter test test/widgets/training_pack_history_list_widget_test.dart` *(fails: file_picker plugin missing inline implementations and numerous missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68915a70c9f0832ab75be93ae16441cf