### PR TITLE
feat: show pack review summary after training

### DIFF
--- a/lib/screens/pack_review_summary_screen.dart
+++ b/lib/screens/pack_review_summary_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import '../models/training_pack.dart';
+import '../models/session_task_result.dart';
+import '../models/v2/training_pack_template.dart';
+import '../services/training_session_launcher.dart';
+import '../theme/app_colors.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class PackReviewSummaryScreen extends StatelessWidget {
+  final TrainingPackTemplate template;
+  final TrainingSessionResult result;
+  final Duration elapsed;
+  const PackReviewSummaryScreen({
+    super.key,
+    required this.template,
+    required this.result,
+    required this.elapsed,
+  });
+
+  String _format(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = result.total == 0 ? 0.0 : result.correct * 100 / result.total;
+    return Scaffold(
+      appBar: AppBar(title: Text(template.name)),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('${result.correct} / ${result.total}',
+                      style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 8),
+                  Text('Accuracy: ${accuracy.toStringAsFixed(1)}%',
+                      style: const TextStyle(color: Colors.white70)),
+                  const SizedBox(height: 8),
+                  Text('Time: ${_format(elapsed)}',
+                      style: const TextStyle(color: Colors.white70)),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: result.tasks.length,
+                itemBuilder: (context, index) {
+                  final t = result.tasks[index];
+                  return ListTile(
+                    leading: Icon(
+                      t.correct ? Icons.check : Icons.close,
+                      color: t.correct ? Colors.green : Colors.red,
+                    ),
+                    title: Text(t.question,
+                        style: const TextStyle(color: Colors.white)),
+                    subtitle: Text(
+                      'Your: ${t.selectedAnswer} • Correct: ${t.correctAnswer}',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  const TrainingSessionLauncher().launch(
+                    TrainingPackTemplateV2.fromTemplate(template),
+                  );
+                },
+                child: const Text('Repeat this pack'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Back to history'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -8,7 +8,9 @@ import '../helpers/hand_utils.dart';
 import '../helpers/hand_type_utils.dart';
 import '../helpers/training_pack_storage.dart';
 import '../screens/training_session_summary_screen.dart';
-import '../screens/training_session_completion_screen.dart';
+import '../screens/pack_review_summary_screen.dart';
+import '../models/session_task_result.dart';
+import '../models/training_pack.dart';
 import 'mistake_review_pack_service.dart';
 import 'smart_review_service.dart';
 import 'training_progress_logger.dart';
@@ -662,11 +664,34 @@ class TrainingSessionService extends ChangeNotifier {
             requiredAccuracy: _template!.requiredAccuracy,
             minHands: _template!.minHands,
           ));
+          final correctHands =
+              _session!.results.values.where((e) => e).length;
+          final tasks = [
+            for (final a in _actions)
+              (() {
+                final spot = _spots.firstWhere(
+                    (s) => s.id == a.spotId,
+                    orElse: () => TrainingPackSpot(id: ''));
+                return SessionTaskResult(
+                  question: spot.title.isNotEmpty ? spot.title : spot.id,
+                  selectedAnswer: a.chosenAction,
+                  correctAnswer: _expectedAction(spot) ?? '',
+                  correct: a.isCorrect,
+                );
+              })(),
+          ];
+          final result = TrainingSessionResult(
+            date: DateTime.now(),
+            total: totalHands,
+            correct: correctHands,
+            tasks: tasks,
+          );
           unawaited(complete(
             ctx,
-            resultBuilder: (_) => TrainingSessionCompletionScreen(
+            resultBuilder: (_) => PackReviewSummaryScreen(
               template: _template!,
-              hands: totalHands,
+              result: result,
+              elapsed: elapsedTime,
             ),
           ));
         }


### PR DESCRIPTION
## Summary
- add `PackReviewSummaryScreen` to display per-hand outcomes, accuracy, time and actions
- hook training session completion to show this review summary

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68915cd13374832a909d80b282d4951c