### PR TITLE
feat: add pack review stats exporter

### DIFF
--- a/lib/services/pack_review_stats_exporter.dart
+++ b/lib/services/pack_review_stats_exporter.dart
@@ -1,0 +1,59 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/training_pack.dart';
+import '../models/v2/training_pack_template.dart';
+
+class PackReviewStatsExporter {
+  static const _boxName = 'pack_review_stats_box';
+
+  const PackReviewStatsExporter();
+
+  Future<Box<dynamic>> _openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.initFlutter();
+      return await Hive.openBox(_boxName);
+    }
+    return Hive.box(_boxName);
+  }
+
+  Future<void> exportSessionStats(
+    TrainingPackTemplate template,
+    TrainingSessionResult result,
+    Duration elapsed,
+  ) async {
+    final box = await _openBox();
+
+    final tagStats = <String, Map<String, int>>{};
+    final len =
+        result.tasks.length < template.spots.length ? result.tasks.length : template.spots.length;
+    for (var i = 0; i < len; i++) {
+      final spot = template.spots[i];
+      final task = result.tasks[i];
+      for (final tag in spot.tags) {
+        final stat = tagStats.putIfAbsent(tag, () => {'total': 0, 'correct': 0});
+        stat['total'] = (stat['total'] ?? 0) + 1;
+        if (task.correct) {
+          stat['correct'] = (stat['correct'] ?? 0) + 1;
+        }
+      }
+    }
+
+    final accuracy = result.total == 0 ? 0.0 : result.correct / result.total;
+    final record = {
+      'templateId': template.id,
+      'templateName': template.name,
+      'date': result.date.toIso8601String(),
+      'accuracy': accuracy,
+      'totalHands': result.total,
+      'correctHands': result.correct,
+      'durationSeconds': elapsed.inSeconds,
+      'tagBreakdown': tagStats,
+      'outcomes': {
+        'correct': result.correct,
+        'incorrect': result.total - result.correct,
+      },
+    };
+    await box.add(record);
+  }
+}
+

--- a/test/services/pack_review_stats_exporter_test.dart
+++ b/test/services/pack_review_stats_exporter_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/models/session_task_result.dart';
+import 'package:poker_analyzer/models/training_pack.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+import 'package:poker_analyzer/services/pack_review_stats_exporter.dart';
+
+class _TestPathProvider extends PathProviderPlatform {
+  _TestPathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+  @override
+  Future<String?> getLibraryPath() async => path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationCachePath() async => path;
+  @override
+  Future<String?> getExternalStoragePath() async => path;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => [path];
+  @override
+  Future<List<String>?> getExternalStoragePaths({StorageDirectory? type}) async => [path];
+  @override
+  Future<String?> getDownloadsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exportSessionStats stores session statistics', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+
+    final exporter = PackReviewStatsExporter();
+    final template = TrainingPackTemplate(
+      id: 'tpl1',
+      name: 'Test Pack',
+      spots: [
+        TrainingPackSpot(id: 's1', tags: ['tagA']),
+        TrainingPackSpot(id: 's2', tags: ['tagA', 'tagB']),
+      ],
+    );
+    final result = TrainingSessionResult(
+      date: DateTime(2024, 1, 1),
+      total: 2,
+      correct: 1,
+      tasks: [
+        SessionTaskResult(question: 's1', selectedAnswer: 'a', correctAnswer: 'a', correct: true),
+        SessionTaskResult(question: 's2', selectedAnswer: 'a', correctAnswer: 'b', correct: false),
+      ],
+    );
+    await exporter.exportSessionStats(template, result, const Duration(seconds: 30));
+
+    final box = Hive.box('pack_review_stats_box');
+    expect(box.length, 1);
+    final data = Map<String, dynamic>.from(box.values.first);
+    expect(data['templateId'], 'tpl1');
+    expect(data['totalHands'], 2);
+    expect(data['correctHands'], 1);
+    expect(data['durationSeconds'], 30);
+    final tags = Map<String, dynamic>.from(data['tagBreakdown']);
+    final tagA = Map<String, dynamic>.from(tags['tagA']);
+    expect(tagA['total'], 2);
+    expect(tagA['correct'], 1);
+    final tagB = Map<String, dynamic>.from(tags['tagB']);
+    expect(tagB['total'], 1);
+    expect(tagB['correct'], 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add PackReviewStatsExporter to persist training pack session stats to Hive
- cover exporter with a unit test capturing per-tag performance

## Testing
- `flutter test test/services/pack_review_stats_exporter_test.dart` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68915e930398832ab03eb6539220e072