### PR TITLE
feat: add tag weakness detector service

### DIFF
--- a/lib/services/tag_weakness_detector_service.dart
+++ b/lib/services/tag_weakness_detector_service.dart
@@ -1,0 +1,57 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+class TagWeaknessDetectorService {
+  static const _boxName = 'pack_review_stats_box';
+
+  Future<Box<dynamic>> _openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.initFlutter();
+      return await Hive.openBox(_boxName);
+    }
+    return Hive.box(_boxName);
+  }
+
+  Future<List<String>> getWeakTags({int maxSessions = 20}) async {
+    final box = await _openBox();
+    final start = box.length > maxSessions ? box.length - maxSessions : 0;
+    final Map<String, _TagStats> stats = {};
+
+    for (var i = start; i < box.length; i++) {
+      final record = Map<String, dynamic>.from(box.getAt(i));
+      final tags = Map<String, dynamic>.from(record['tagBreakdown'] ?? {});
+      for (final entry in tags.entries) {
+        final tag = entry.key;
+        final data = Map<String, dynamic>.from(entry.value);
+        final total = data['total'] as int? ?? 0;
+        final correct = data['correct'] as int? ?? 0;
+        final s = stats.putIfAbsent(tag, () => _TagStats());
+        s.total += total;
+        s.correct += correct;
+      }
+    }
+
+    final weakTags = <String>[];
+    stats.forEach((tag, s) {
+      if (s.total >= 3) {
+        final accuracy = s.correct / s.total;
+        if (accuracy < 0.7) {
+          weakTags.add(tag);
+        }
+      }
+    });
+
+    weakTags.sort((a, b) {
+      final accA = stats[a]!.correct / stats[a]!.total;
+      final accB = stats[b]!.correct / stats[b]!.total;
+      return accA.compareTo(accB);
+    });
+
+    return weakTags;
+  }
+}
+
+class _TagStats {
+  int total = 0;
+  int correct = 0;
+}
+

--- a/test/services/tag_weakness_detector_service_test.dart
+++ b/test/services/tag_weakness_detector_service_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/services/tag_weakness_detector_service.dart';
+
+class _TestPathProvider extends PathProviderPlatform {
+  _TestPathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+  @override
+  Future<String?> getLibraryPath() async => path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationCachePath() async => path;
+  @override
+  Future<String?> getExternalStoragePath() async => path;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => [path];
+  @override
+  Future<List<String>?> getExternalStoragePaths({StorageDirectory? type}) async => [path];
+  @override
+  Future<String?> getDownloadsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('getWeakTags returns underperforming tags', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+    await Hive.initFlutter();
+    final box = await Hive.openBox('pack_review_stats_box');
+
+    await box.add({
+      'tagBreakdown': {
+        'A': {'total': 1, 'correct': 0},
+        'B': {'total': 1, 'correct': 0},
+        'D': {'total': 1, 'correct': 1},
+      }
+    });
+    await box.add({
+      'tagBreakdown': {
+        'A': {'total': 1, 'correct': 0},
+        'D': {'total': 1, 'correct': 1},
+      }
+    });
+    await box.add({
+      'tagBreakdown': {
+        'A': {'total': 1, 'correct': 1},
+        'D': {'total': 1, 'correct': 0},
+      }
+    });
+
+    final service = TagWeaknessDetectorService();
+    final weak = await service.getWeakTags();
+    expect(weak, ['A', 'D']);
+  });
+
+  test('getWeakTags respects maxSessions', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+    await Hive.initFlutter();
+    final box = await Hive.openBox('pack_review_stats_box');
+
+    await box.add({'tagBreakdown': {'A': {'total': 1, 'correct': 0}}});
+    await box.add({'tagBreakdown': {'A': {'total': 1, 'correct': 0}}});
+    await box.add({'tagBreakdown': {'A': {'total': 1, 'correct': 1}}});
+
+    final service = TagWeaknessDetectorService();
+    final weak = await service.getWeakTags(maxSessions: 2);
+    expect(weak, isEmpty);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TagWeaknessDetectorService to scan pack review stats and return weak tags
- test weak tag detection and session limit logic

## Testing
- `flutter test test/services/tag_weakness_detector_service_test.dart` *(fails: command not found)*
- `dart test test/services/tag_weakness_detector_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689162a10200832aa1489e3cfc2df74b