### PR TITLE
Implement weak tag booster generator service

### DIFF
--- a/lib/core/training/engine/training_type_engine.dart
+++ b/lib/core/training/engine/training_type_engine.dart
@@ -13,6 +13,7 @@ enum TrainingType {
   quiz,
   openingMTT,
   theory,
+  booster,
 }
 
 abstract class TrainingPackBuilder {
@@ -111,6 +112,8 @@ extension TrainingTypeInfo on TrainingType {
         return 'Opening MTT';
       case TrainingType.theory:
         return 'Theory';
+      case TrainingType.booster:
+        return 'Booster';
       case TrainingType.custom:
       default:
         return 'Custom';
@@ -133,6 +136,8 @@ extension TrainingTypeInfo on TrainingType {
         return Icons.play_circle_outline;
       case TrainingType.theory:
         return Icons.book;
+      case TrainingType.booster:
+        return Icons.flash_on;
       case TrainingType.custom:
       default:
         return Icons.extension;

--- a/lib/services/weak_tag_booster_generator_service.dart
+++ b/lib/services/weak_tag_booster_generator_service.dart
@@ -1,0 +1,58 @@
+import 'dart:math';
+
+import '../core/training/engine/training_type_engine.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/game_type.dart';
+import '../repositories/training_pack_repository.dart';
+import 'tag_weakness_detector_service.dart';
+
+/// Generates a booster training pack from the user's weakest tags.
+class WeakTagBoosterGeneratorService {
+  final TagWeaknessDetectorService weaknessDetector;
+  final TrainingPackRepository spotLibrary;
+  final Random _rng;
+
+  WeakTagBoosterGeneratorService({
+    TagWeaknessDetectorService? weaknessDetector,
+    TrainingPackRepository? spotLibrary,
+    Random? random,
+  })  : weaknessDetector = weaknessDetector ?? TagWeaknessDetectorService(),
+        spotLibrary = spotLibrary ?? const TrainingPackRepository(),
+        _rng = random ?? Random();
+
+  /// Builds a [TrainingPackTemplateV2] by sampling spots from the weakest tags.
+  Future<TrainingPackTemplateV2> generateWeakTagBooster() async {
+    final weakTags = await weaknessDetector.getWeakTags(maxSessions: 20);
+    final selectedTags = weakTags.take(5).toList();
+
+    final spots = <TrainingPackSpot>[];
+    final used = <String>{};
+
+    for (final tag in selectedTags) {
+      final list = await spotLibrary.getSpotsByTag(tag);
+      if (list.isEmpty) continue;
+      list.shuffle(_rng);
+      final maxCount = min(5, list.length);
+      final count = maxCount < 3 ? maxCount : 3 + _rng.nextInt(maxCount - 2);
+      for (final spot in list.take(count)) {
+        if (used.add(spot.id)) {
+          spots.add(TrainingPackSpot.fromJson(spot.toJson()));
+        }
+      }
+    }
+
+    final now = DateTime.now();
+    return TrainingPackTemplateV2(
+      id: 'booster_${now.millisecondsSinceEpoch}',
+      name: 'Weak Tag Booster',
+      trainingType: TrainingType.booster,
+      spots: spots,
+      spotCount: spots.length,
+      tags: selectedTags,
+      created: now,
+      gameType: GameType.tournament,
+      meta: const {'type': 'booster'},
+    );
+  }
+}

--- a/test/services/weak_tag_booster_generator_service_test.dart
+++ b/test/services/weak_tag_booster_generator_service_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/tag_weakness_detector_service.dart';
+import 'package:poker_analyzer/services/weak_tag_booster_generator_service.dart';
+import 'package:poker_analyzer/repositories/training_pack_repository.dart';
+
+class _TestPathProvider extends PathProviderPlatform {
+  _TestPathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+  @override
+  Future<String?> getLibraryPath() async => path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationCachePath() async => path;
+  @override
+  Future<String?> getExternalStoragePath() async => path;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => [path];
+  @override
+  Future<List<String>?> getExternalStoragePaths({StorageDirectory? type}) async => [path];
+  @override
+  Future<String?> getDownloadsPath() async => path;
+}
+
+class _FakeRepo extends TrainingPackRepository {
+  final Map<String, List<TrainingPackSpot>> _map;
+  const _FakeRepo(this._map);
+
+  @override
+  Future<List<TrainingPackSpot>> getSpotsByTag(String tag) async =>
+      _map[tag] ?? [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('generateWeakTagBooster builds pack from weakest tags', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+    await Hive.initFlutter();
+    final box = await Hive.openBox('pack_review_stats_box');
+    await box.add({'tagBreakdown': {'A': {'total': 3, 'correct': 1}}});
+    await box.add({'tagBreakdown': {'B': {'total': 3, 'correct': 1}}});
+
+    final repo = _FakeRepo({
+      'A': [for (var i = 0; i < 5; i++) TrainingPackSpot(id: 'A$i', tags: ['A'])],
+      'B': [for (var i = 0; i < 5; i++) TrainingPackSpot(id: 'B$i', tags: ['B'])],
+    });
+
+    final service = WeakTagBoosterGeneratorService(
+      weaknessDetector: TagWeaknessDetectorService(),
+      spotLibrary: repo,
+      random: Random(1),
+    );
+
+    final tpl = await service.generateWeakTagBooster();
+
+    expect(tpl.name, 'Weak Tag Booster');
+    expect(tpl.trainingType, TrainingType.booster);
+    expect(tpl.meta['type'], 'booster');
+    expect(tpl.tags, ['A', 'B']);
+    expect(tpl.spots.length, inInclusiveRange(6, 10));
+    for (final tag in tpl.tags) {
+      final count = tpl.spots.where((s) => s.tags.contains(tag)).length;
+      expect(count, greaterThan(0));
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `WeakTagBoosterGeneratorService` that builds booster packs from weakest tags
- add `booster` entry to `TrainingType` with label and icon

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart test test/services/weak_tag_booster_generator_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689163d01e0c832aa863c6bc3c4c7d52