### PR TITLE
feat: track booster tag progress

### DIFF
--- a/lib/services/booster_stats_tracker_service.dart
+++ b/lib/services/booster_stats_tracker_service.dart
@@ -1,0 +1,65 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/training_pack.dart';
+import '../models/training_pack_template.dart';
+
+class BoosterTagProgress {
+  final DateTime date;
+  final double accuracy;
+
+  BoosterTagProgress({required this.date, required this.accuracy});
+}
+
+/// Records booster session performance and retrieves progress over time.
+class BoosterStatsTrackerService {
+  static const _boxName = 'booster_stats_box';
+
+  Future<Box<dynamic>> _openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.initFlutter();
+      return await Hive.openBox(_boxName);
+    }
+    return Hive.box(_boxName);
+  }
+
+  /// Logs the [result] of a booster session for [tpl].
+  Future<void> logBoosterResult(
+    TrainingPackTemplate tpl,
+    TrainingSessionResult result,
+  ) async {
+    final box = await _openBox();
+    final tags = tpl.tags.map((e) => e.trim().toLowerCase()).toList();
+    final totalAccuracy =
+        result.total > 0 ? result.correct / result.total : 0.0;
+    final accuracyPerTag = {for (final t in tags) t: totalAccuracy};
+    await box.add({
+      'date': result.date.millisecondsSinceEpoch,
+      'tags': tags,
+      'accuracyPerTag': accuracyPerTag,
+      'totalAccuracy': totalAccuracy,
+    });
+  }
+
+  /// Returns historical accuracy for [tag] ordered by date.
+  Future<List<BoosterTagProgress>> getProgressForTag(String tag) async {
+    final box = await _openBox();
+    final normTag = tag.trim().toLowerCase();
+    final list = <BoosterTagProgress>[];
+    for (var i = 0; i < box.length; i++) {
+      final raw = box.getAt(i);
+      if (raw is Map) {
+        final data = Map<String, dynamic>.from(raw);
+        final accMap = Map<String, dynamic>.from(data['accuracyPerTag'] ?? {});
+        final acc = (accMap[normTag] as num?)?.toDouble();
+        if (acc != null) {
+          final ts = DateTime.fromMillisecondsSinceEpoch(
+              (data['date'] as num?)?.toInt() ?? 0);
+          list.add(BoosterTagProgress(date: ts, accuracy: acc));
+        }
+      }
+    }
+    list.sort((a, b) => a.date.compareTo(b.date));
+    return list;
+  }
+}
+

--- a/test/services/booster_stats_tracker_service_test.dart
+++ b/test/services/booster_stats_tracker_service_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/models/training_pack.dart';
+import 'package:poker_analyzer/models/training_pack_template.dart';
+import 'package:poker_analyzer/services/booster_stats_tracker_service.dart';
+
+class _TestPathProvider extends PathProviderPlatform {
+  _TestPathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+  @override
+  Future<String?> getLibraryPath() async => path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationCachePath() async => path;
+  @override
+  Future<String?> getExternalStoragePath() async => path;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => [path];
+  @override
+  Future<List<String>?> getExternalStoragePaths({StorageDirectory? type}) async => [path];
+  @override
+  Future<String?> getDownloadsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('logs and retrieves booster progress', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+    await Hive.initFlutter();
+    await Hive.openBox('booster_stats_box');
+
+    final service = BoosterStatsTrackerService();
+    final tpl = TrainingPackTemplate(
+      id: 'b1',
+      name: 'B',
+      gameType: 'game',
+      description: '',
+      hands: const [],
+      tags: const ['tag1'],
+    );
+    final r1 = TrainingSessionResult(date: DateTime(2024, 1, 1), total: 10, correct: 5);
+    final r2 = TrainingSessionResult(date: DateTime(2024, 1, 2), total: 10, correct: 8);
+
+    await service.logBoosterResult(tpl, r1);
+    await service.logBoosterResult(tpl, r2);
+
+    final progress = await service.getProgressForTag('tag1');
+    expect(progress.length, 2);
+    expect(progress[0].accuracy, closeTo(0.5, 0.001));
+    expect(progress[1].accuracy, closeTo(0.8, 0.001));
+    expect(progress[0].date, r1.date);
+    expect(progress[1].date, r2.date);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add BoosterStatsTrackerService to log booster drill results
- expose tag progress over time via getProgressForTag
- cover tracker with unit test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891681f63cc832aba708aadb075f6c3