### PR TITLE
feat: add booster completion banner

### DIFF
--- a/lib/screens/booster_progress_chart_screen.dart
+++ b/lib/screens/booster_progress_chart_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import '../widgets/booster_progress_chart_widget.dart';
+
+class BoosterProgressChartScreen extends StatelessWidget {
+  static const route = '/booster/progress_chart';
+  final List<String> tags;
+
+  const BoosterProgressChartScreen({super.key, required this.tags});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Booster Progress')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: BoosterProgressChartWidget(tags: tags),
+      ),
+    );
+  }
+}

--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -48,6 +48,8 @@ import '../widgets/confetti_overlay.dart';
 import '../services/overlay_booster_manager.dart';
 import '../widgets/decay_recall_stats_card.dart';
 import '../services/decay_session_tag_impact_recorder.dart';
+import '../widgets/booster_completion_banner.dart';
+import '../models/training_pack.dart';
 
 class TrainingSessionSummaryScreen extends StatefulWidget {
   final TrainingSession session;
@@ -71,10 +73,12 @@ class TrainingSessionSummaryScreen extends StatefulWidget {
   });
 
   @override
-  State<TrainingSessionSummaryScreen> createState() => _TrainingSessionSummaryScreenState();
+  State<TrainingSessionSummaryScreen> createState() =>
+      _TrainingSessionSummaryScreenState();
 }
 
-class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScreen> {
+class _TrainingSessionSummaryScreenState
+    extends State<TrainingSessionSummaryScreen> {
   final _shareBoundaryKey = GlobalKey();
   TrainingPackTemplate? _weakPack;
   bool _autoReview = true;
@@ -107,8 +111,9 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
     final logs = context.read<SessionLogService>();
     await logs.load();
     for (final path in templates) {
-      final stage =
-          path.stages.firstWhereOrNull((s) => s.packId == widget.template.id);
+      final stage = path.stages.firstWhereOrNull(
+        (s) => s.packId == widget.template.id,
+      );
       if (stage == null) continue;
       final progress = TrainingPathProgressServiceV2(logs: logs);
       await progress.loadProgress(path.id);
@@ -159,8 +164,26 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       await context.read<OverlayBoosterManager>().onAfterXpScreen();
       if (widget.template.tags.contains('decayBooster') &&
           widget.tagDeltas.isNotEmpty) {
-        unawaited(DecaySessionTagImpactRecorder.instance
-            .recordSession(widget.tagDeltas, DateTime.now()));
+        unawaited(
+          DecaySessionTagImpactRecorder.instance.recordSession(
+            widget.tagDeltas,
+            DateTime.now(),
+          ),
+        );
+      }
+      if (widget.template.tags.any((t) => t.contains('booster'))) {
+        final result = TrainingSessionResult(
+          date: DateTime.now(),
+          total: widget.session.results.length,
+          correct: widget.session.results.values.where((e) => e).length,
+        );
+        ScaffoldMessenger.of(context).showSnackBar(
+          BoosterCompletionBanner(
+            context: context,
+            template: widget.template,
+            result: result,
+          ),
+        );
       }
     });
     _loadWeakPack();
@@ -188,7 +211,8 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
     final lastStr = prefs.getString(key);
     if (lastStr != null) {
       final last = DateTime.tryParse(lastStr);
-      if (last != null && DateTime.now().difference(last) < const Duration(days: 1)) {
+      if (last != null &&
+          DateTime.now().difference(last) < const Duration(days: 1)) {
         return;
       }
     }
@@ -197,15 +221,21 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-              'Want to improve your ${rec.position.label}? Try ${_weakPack!.name}.'),
+            'Want to improve your ${rec.position.label}? Try ${_weakPack!.name}.',
+          ),
           action: SnackBarAction(
             label: 'Train',
             onPressed: () async {
-              await context.read<TrainingSessionService>().startSession(_weakPack!, persist: false);
+              await context.read<TrainingSessionService>().startSession(
+                _weakPack!,
+                persist: false,
+              );
               if (!context.mounted) return;
               Navigator.pushReplacement(
                 context,
-                MaterialPageRoute(builder: (_) => const TrainingSessionScreen()),
+                MaterialPageRoute(
+                  builder: (_) => const TrainingSessionScreen(),
+                ),
               );
             },
           ),
@@ -218,13 +248,22 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
   void _open(String route) {
     switch (route) {
       case '/mistake_repeat':
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const MistakeRepeatScreen()));
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const MistakeRepeatScreen()),
+        );
         break;
       case '/goals':
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const GoalsOverviewScreen()));
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const GoalsOverviewScreen()),
+        );
         break;
       case '/spot_of_the_day':
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const SpotOfTheDayScreen()));
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const SpotOfTheDayScreen()),
+        );
         break;
     }
   }
@@ -242,7 +281,10 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
         ),
         content: Text(s.message),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Later')),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Later'),
+          ),
           TextButton(
             onPressed: () {
               Navigator.pop(context);
@@ -257,13 +299,15 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
 
   Future<void> _share(BuildContext context) async {
     final boundary =
-        _shareBoundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+        _shareBoundaryKey.currentContext?.findRenderObject()
+            as RenderRepaintBoundary?;
     if (boundary == null) return;
     final bytes = await PngExporter.captureBoundary(boundary);
     if (bytes == null) return;
     final dir = await getTemporaryDirectory();
     final file = File(
-        '${dir.path}/summary_${DateTime.now().millisecondsSinceEpoch}.png');
+      '${dir.path}/summary_${DateTime.now().millisecondsSinceEpoch}.png',
+    );
     await file.writeAsBytes(bytes, flush: true);
     await Share.shareXFiles([XFile(file.path)]);
   }
@@ -277,331 +321,379 @@ class _TrainingSessionSummaryScreenState extends State<TrainingSessionSummaryScr
     final accuracy = total == 0 ? 0.0 : correct * 100 / total;
     final tTotal = widget.template.spots.length;
     final evPct = tTotal == 0 ? 0.0 : widget.template.evCovered * 100 / tTotal;
-    final icmPct = tTotal == 0 ? 0.0 : widget.template.icmCovered * 100 / tTotal;
+    final icmPct = tTotal == 0
+        ? 0.0
+        : widget.template.icmCovered * 100 / tTotal;
     final mistakes = [
       for (final id in widget.session.results.keys)
         if (widget.session.results[id] == false)
           widget.template.spots.firstWhere(
             (s) => s.id == id,
             orElse: () => TrainingPackSpot(id: ''),
-          )
+          ),
     ].where((s) => s.id.isNotEmpty).toList();
     return RepaintBoundary(
       key: _shareBoundaryKey,
       child: Scaffold(
         appBar: AppBar(
           title: Text(l.trainingSummary),
-          actions: [IconButton(onPressed: () => _share(context), icon: const Icon(Icons.share))],
+          actions: [
+            IconButton(
+              onPressed: () => _share(context),
+              icon: const Icon(Icons.share),
+            ),
+          ],
         ),
         backgroundColor: AppColors.background,
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: Text(
-                '${accuracy.toStringAsFixed(1)}%',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 48,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            CombinedProgressBar(widget.preEvPct, widget.preIcmPct),
-            const SizedBox(height: 4),
-            CombinedProgressChangeBar(
-              prevEvPct: widget.preEvPct,
-              prevIcmPct: widget.preIcmPct,
-              evPct: evPct,
-              icmPct: icmPct,
-            ),
-            const SizedBox(height: 12),
-            const EvIcmHistoryChart(),
-            const EvIcmImprovementRow(),
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (widget.xpMultiplier > 1.0)
-                    const Text('🔥', style: TextStyle(fontSize: 16)),
-                  const SizedBox(width: 4),
-                  Text('XP +${widget.xpEarned}',
-                      style: const TextStyle(color: Colors.orange)),
-                  if (widget.xpMultiplier > 1.0)
-                    Text(' x${widget.xpMultiplier.toStringAsFixed(1)}',
-                        style: const TextStyle(color: Colors.orange)),
-                ],
-              ),
-            ),
-            if (widget.streakMultiplier > 1.0)
-              Padding(
-                padding: const EdgeInsets.only(top: 4),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
                 child: Text(
-                  '🔥 Бонус за стрик: +${((widget.streakMultiplier - 1) * 100).round()}% XP',
-                  style: const TextStyle(color: Colors.orange),
+                  '${accuracy.toStringAsFixed(1)}%',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 48,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
-            if (widget.template.tags.contains('decayBooster'))
-              DecayRecallStatsCard(
-                tagDeltas: widget.tagDeltas,
-                spotCount: widget.session.results.length,
-              ),
-            const SizedBox(height: 16),
-            if (widget.tagDeltas.isNotEmpty) ...[
-              const Text('Skill Gains',
-                  style: TextStyle(
-                      color: Colors.white, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 16),
+              CombinedProgressBar(widget.preEvPct, widget.preIcmPct),
               const SizedBox(height: 4),
-              for (final e in (widget.tagDeltas.entries.toList()
-                ..sort((a, b) => b.value.abs().compareTo(a.value.abs()))))
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 2),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(e.key, style: const TextStyle(color: Colors.white70)),
+              CombinedProgressChangeBar(
+                prevEvPct: widget.preEvPct,
+                prevIcmPct: widget.preIcmPct,
+                evPct: evPct,
+                icmPct: icmPct,
+              ),
+              const SizedBox(height: 12),
+              const EvIcmHistoryChart(),
+              const EvIcmImprovementRow(),
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (widget.xpMultiplier > 1.0)
+                      const Text('🔥', style: TextStyle(fontSize: 16)),
+                    const SizedBox(width: 4),
+                    Text(
+                      'XP +${widget.xpEarned}',
+                      style: const TextStyle(color: Colors.orange),
+                    ),
+                    if (widget.xpMultiplier > 1.0)
                       Text(
-                        '${e.value >= 0 ? '+' : '-'}${(e.value.abs() * 100).toStringAsFixed(2)}%',
-                        style: TextStyle(
-                          color: e.value > 0
-                              ? Colors.green
-                              : (e.value < 0 ? Colors.red : Colors.grey),
-                        ),
+                        ' x${widget.xpMultiplier.toStringAsFixed(1)}',
+                        style: const TextStyle(color: Colors.orange),
                       ),
-                    ],
+                  ],
+                ),
+              ),
+              if (widget.streakMultiplier > 1.0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    '🔥 Бонус за стрик: +${((widget.streakMultiplier - 1) * 100).round()}% XP',
+                    style: const TextStyle(color: Colors.orange),
                   ),
+                ),
+              if (widget.template.tags.contains('decayBooster'))
+                DecayRecallStatsCard(
+                  tagDeltas: widget.tagDeltas,
+                  spotCount: widget.session.results.length,
                 ),
               const SizedBox(height: 16),
-            ],
-            Builder(
-              builder: (context) {
-                final adv = <String>{};
-                for (final m in mistakes) {
-                  for (final t in m.tags) {
-                    final a = kMistakeAdvice[t];
-                    if (a != null) adv.add(a);
-                  }
-                  final pos = m.hand.position.label;
-                  final pAdv = kMistakeAdvice[pos];
-                  if (pAdv != null) adv.add(pAdv);
-                  int street = 0;
-                  final b = m.hand.board.length;
-                  if (b >= 5) {
-                    street = 3;
-                  } else if (b == 4) street = 2;
-                  else if (b == 3) street = 1;
-                  final sAdv = kMistakeAdvice[streetName(street)];
-                  if (sAdv != null) adv.add(sAdv);
-                }
-                final deltaEv = evPct - widget.preEvPct;
-                final deltaIcm = icmPct - widget.preIcmPct;
-                adv.add('Прогресс EV ${deltaEv >= 0 ? '+' : ''}${deltaEv.toStringAsFixed(1)}%, ICM ${deltaIcm >= 0 ? '+' : ''}${deltaIcm.toStringAsFixed(1)}%');
-                final packs = context.watch<AdaptiveTrainingService>().recommended;
-                final list = <TrainingPackTemplate>[];
-                if (_weakPack != null) list.add(_weakPack!);
-                for (final p in packs) {
-                  if (list.length >= 3) break;
-                  list.add(p);
-                }
-                if (adv.isEmpty && list.isEmpty) return const SizedBox.shrink();
-                return Container(
-                  margin: const EdgeInsets.only(bottom: 16),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Colors.grey[850],
-                    borderRadius: BorderRadius.circular(8),
+              if (widget.tagDeltas.isNotEmpty) ...[
+                const Text(
+                  'Skill Gains',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      for (final a in adv)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child:
-                              Text(a, style: const TextStyle(color: Colors.white)),
+                ),
+                const SizedBox(height: 4),
+                for (final e
+                    in (widget.tagDeltas.entries.toList()
+                      ..sort((a, b) => b.value.abs().compareTo(a.value.abs()))))
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          e.key,
+                          style: const TextStyle(color: Colors.white70),
                         ),
-                      if (list.isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        Text(l.recommendedPacks,
-                            style: const TextStyle(color: Colors.white)),
-                        const SizedBox(height: 4),
-                        for (final p in list)
-                          Text(p.name,
-                              style:
-                                  const TextStyle(color: Colors.white70)),
+                        Text(
+                          '${e.value >= 0 ? '+' : '-'}${(e.value.abs() * 100).toStringAsFixed(2)}%',
+                          style: TextStyle(
+                            color: e.value > 0
+                                ? Colors.green
+                                : (e.value < 0 ? Colors.red : Colors.grey),
+                          ),
+                        ),
                       ],
-                    ],
+                    ),
                   ),
-                );
-              },
-            ),
-            Builder(
-              builder: (context) {
-                final service = context.watch<MistakeReviewPackService>();
-                if (!service.hasMistakes()) return const SizedBox.shrink();
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 16),
-                  child: ElevatedButton(
-                    onPressed: () async {
-                      final tpl = await service.buildPack(context);
-                      if (tpl == null) return;
-                      await context
-                          .read<TrainingSessionService>()
-                          .startSession(tpl, persist: false);
-                      if (!context.mounted) return;
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                            builder: (_) => const TrainingSessionScreen()),
-                      );
-                    },
-                    child: Text(l.repeatMistakes),
-                  ),
-                );
-              },
-            ),
-            if (tip.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 16),
-                child: Dismissible(
-                  key: const ValueKey('dailyTip'),
-                  direction: DismissDirection.up,
-                  onDismissed: (_) =>
-                      context.read<DailyTipService>().ensureTodayTip(),
-                  child: Container(
+                const SizedBox(height: 16),
+              ],
+              Builder(
+                builder: (context) {
+                  final adv = <String>{};
+                  for (final m in mistakes) {
+                    for (final t in m.tags) {
+                      final a = kMistakeAdvice[t];
+                      if (a != null) adv.add(a);
+                    }
+                    final pos = m.hand.position.label;
+                    final pAdv = kMistakeAdvice[pos];
+                    if (pAdv != null) adv.add(pAdv);
+                    int street = 0;
+                    final b = m.hand.board.length;
+                    if (b >= 5) {
+                      street = 3;
+                    } else if (b == 4)
+                      street = 2;
+                    else if (b == 3)
+                      street = 1;
+                    final sAdv = kMistakeAdvice[streetName(street)];
+                    if (sAdv != null) adv.add(sAdv);
+                  }
+                  final deltaEv = evPct - widget.preEvPct;
+                  final deltaIcm = icmPct - widget.preIcmPct;
+                  adv.add(
+                    'Прогресс EV ${deltaEv >= 0 ? '+' : ''}${deltaEv.toStringAsFixed(1)}%, ICM ${deltaIcm >= 0 ? '+' : ''}${deltaIcm.toStringAsFixed(1)}%',
+                  );
+                  final packs = context
+                      .watch<AdaptiveTrainingService>()
+                      .recommended;
+                  final list = <TrainingPackTemplate>[];
+                  if (_weakPack != null) list.add(_weakPack!);
+                  for (final p in packs) {
+                    if (list.length >= 3) break;
+                    list.add(p);
+                  }
+                  if (adv.isEmpty && list.isEmpty)
+                    return const SizedBox.shrink();
+                  return Container(
+                    margin: const EdgeInsets.only(bottom: 16),
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
                       color: Colors.grey[850],
                       borderRadius: BorderRadius.circular(8),
                     ),
-                    child: Row(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Icon(Icons.lightbulb, color: Colors.greenAccent),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(tip,
-                              style: const TextStyle(color: Colors.white)),
-                        ),
+                        for (final a in adv)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 4),
+                            child: Text(
+                              a,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                          ),
+                        if (list.isNotEmpty) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            l.recommendedPacks,
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          const SizedBox(height: 4),
+                          for (final p in list)
+                            Text(
+                              p.name,
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                        ],
                       ],
-                    ),
-                  ),
-                ),
-              ),
-            if (mistakes.isNotEmpty)
-              Expanded(
-                child: ListView.builder(
-                  itemCount: mistakes.length,
-                  itemBuilder: (context, index) {
-                    final s = mistakes[index];
-                    return ListTile(
-                      title: Text(s.title,
-                          style: const TextStyle(color: Colors.white)),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.replay, color: Colors.orange),
-                        onPressed: () => showSpotViewerDialog(context, s),
-                      ),
-                    );
-                  },
-                ),
-              )
-            else
-              Expanded(
-                  child: Center(
-                      child: Text(l.noMistakes,
-                          style: const TextStyle(color: Colors.white70)))),
-            const SizedBox(height: 16),
-            if (mistakes.isNotEmpty) ...[
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => TrainingPackPlayScreen(
-                        template: MistakeReviewPackService.cachedTemplate!,
-                        original: null,
-                      ),
                     ),
                   );
                 },
-                child: Text(l.reviewMistakes),
               ),
-              const SizedBox(height: 8),
-              SwitchListTile(
-                value: _autoReview,
-                onChanged: (v) => setState(() => _autoReview = v),
-                title: const Text('Auto review mistakes',
-                    style: TextStyle(color: Colors.white)),
-                activeColor: Colors.orange,
-                contentPadding: EdgeInsets.zero,
-              ),
-            ],
-            Row(
-              children: [
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () async {
-                      final service =
-                          context.read<TrainingSessionService>();
-                      final newSession = await service.startFromMistakes();
-                      if (!context.mounted) return;
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => TrainingSessionScreen(
-                            session: newSession,
+              Builder(
+                builder: (context) {
+                  final service = context.watch<MistakeReviewPackService>();
+                  if (!service.hasMistakes()) return const SizedBox.shrink();
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        final tpl = await service.buildPack(context);
+                        if (tpl == null) return;
+                        await context
+                            .read<TrainingSessionService>()
+                            .startSession(tpl, persist: false);
+                        if (!context.mounted) return;
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const TrainingSessionScreen(),
                           ),
+                        );
+                      },
+                      child: Text(l.repeatMistakes),
+                    ),
+                  );
+                },
+              ),
+              if (tip.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Dismissible(
+                    key: const ValueKey('dailyTip'),
+                    direction: DismissDirection.up,
+                    onDismissed: (_) =>
+                        context.read<DailyTipService>().ensureTodayTip(),
+                    child: Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.grey[850],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          const Icon(
+                            Icons.lightbulb,
+                            color: Colors.greenAccent,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              tip,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              if (mistakes.isNotEmpty)
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: mistakes.length,
+                    itemBuilder: (context, index) {
+                      final s = mistakes[index];
+                      return ListTile(
+                        title: Text(
+                          s.title,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.replay, color: Colors.orange),
+                          onPressed: () => showSpotViewerDialog(context, s),
                         ),
                       );
                     },
-                    child: Text(l.repeatMistakes),
+                  ),
+                )
+              else
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      l.noMistakes,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
                   ),
                 ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () async {
-                      final reviewService =
-                          context.read<MistakeReviewPackService>();
-                      if (_autoReview && reviewService.hasMistakes()) {
-                        final tpl = await reviewService.buildPack(context);
-                        if (tpl != null) {
-                          await context
-                              .read<TrainingSessionService>()
-                              .startSession(tpl, persist: false);
-                          if (!context.mounted) return;
-                          Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(
-                                builder: (_) => const TrainingSessionScreen()),
-                          );
-                          return;
-                        }
-                      }
-                      await _finish();
-                    },
-                    child: const Text('Finish'),
+              const SizedBox(height: 16),
+              if (mistakes.isNotEmpty) ...[
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TrainingPackPlayScreen(
+                          template: MistakeReviewPackService.cachedTemplate!,
+                          original: null,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Text(l.reviewMistakes),
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  value: _autoReview,
+                  onChanged: (v) => setState(() => _autoReview = v),
+                  title: const Text(
+                    'Auto review mistakes',
+                    style: TextStyle(color: Colors.white),
                   ),
+                  activeColor: Colors.orange,
+                  contentPadding: EdgeInsets.zero,
                 ),
               ],
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const WeaknessOverviewScreen(),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        final service = context.read<TrainingSessionService>();
+                        final newSession = await service.startFromMistakes();
+                        if (!context.mounted) return;
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                TrainingSessionScreen(session: newSession),
+                          ),
+                        );
+                      },
+                      child: Text(l.repeatMistakes),
+                    ),
                   ),
-                );
-              },
-              child: Text(l.exportWeaknessReport),
-            ),
-            MistakeReviewButton(session: widget.session, template: widget.template),
-          ],
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () async {
+                        final reviewService = context
+                            .read<MistakeReviewPackService>();
+                        if (_autoReview && reviewService.hasMistakes()) {
+                          final tpl = await reviewService.buildPack(context);
+                          if (tpl != null) {
+                            await context
+                                .read<TrainingSessionService>()
+                                .startSession(tpl, persist: false);
+                            if (!context.mounted) return;
+                            Navigator.pushReplacement(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => const TrainingSessionScreen(),
+                              ),
+                            );
+                            return;
+                          }
+                        }
+                        await _finish();
+                      },
+                      child: const Text('Finish'),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const WeaknessOverviewScreen(),
+                    ),
+                  );
+                },
+                child: Text(l.exportWeaknessReport),
+              ),
+              MistakeReviewButton(
+                session: widget.session,
+                template: widget.template,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/booster_completion_banner.dart
+++ b/lib/widgets/booster_completion_banner.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import '../models/v2/training_pack_template.dart';
+import '../models/training_pack.dart';
+import '../services/booster_stats_tracker_service.dart';
+import '../screens/booster_progress_chart_screen.dart';
+
+class BoosterCompletionBanner extends SnackBar {
+  BoosterCompletionBanner({
+    super.key,
+    required BuildContext context,
+    required TrainingPackTemplate template,
+    required TrainingSessionResult result,
+    BoosterStatsTrackerService? service,
+  }) : super(
+         duration: const Duration(seconds: 5),
+         behavior: SnackBarBehavior.floating,
+         content: _BoosterCompletionContent(
+           template: template,
+           result: result,
+           service: service ?? BoosterStatsTrackerService(),
+           onClose: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
+         ),
+         action: SnackBarAction(
+           label: 'View Progress Chart',
+           onPressed: () {
+             Navigator.of(context).push(
+               MaterialPageRoute(
+                 builder: (_) =>
+                     BoosterProgressChartScreen(tags: template.tags),
+               ),
+             );
+           },
+         ),
+       );
+}
+
+class _BoosterCompletionContent extends StatefulWidget {
+  final TrainingPackTemplate template;
+  final TrainingSessionResult result;
+  final BoosterStatsTrackerService service;
+  final VoidCallback onClose;
+
+  const _BoosterCompletionContent({
+    required this.template,
+    required this.result,
+    required this.service,
+    required this.onClose,
+  });
+
+  @override
+  State<_BoosterCompletionContent> createState() =>
+      _BoosterCompletionContentState();
+}
+
+class _BoosterCompletionContentState extends State<_BoosterCompletionContent> {
+  late Future<Map<String, double>> _deltas;
+
+  @override
+  void initState() {
+    super.initState();
+    _deltas = _load();
+  }
+
+  Future<Map<String, double>> _load() async {
+    await widget.service.logBoosterResult(widget.template, widget.result);
+    final map = <String, double>{};
+    for (final tag in widget.template.tags) {
+      final history = await widget.service.getProgressForTag(tag);
+      if (history.length >= 2) {
+        final before = history[history.length - 2].accuracy;
+        final after = history.last.accuracy;
+        map[tag] = (after - before) * 100;
+      }
+    }
+    return map;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Map<String, double>>(
+      future: _deltas,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        final entries = snapshot.data!.entries.map((e) {
+          final delta = e.value;
+          final icon = delta >= 0 ? Icons.arrow_upward : Icons.arrow_downward;
+          final color = delta >= 0 ? Colors.green : Colors.red;
+          final deltaStr =
+              '${delta >= 0 ? '+' : ''}${delta.toStringAsFixed(0)}%';
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(e.key),
+              const SizedBox(width: 4),
+              Icon(icon, size: 16, color: color),
+              Text(deltaStr, style: TextStyle(color: color)),
+            ],
+          );
+        }).toList();
+        return Row(
+          children: [
+            Expanded(child: Wrap(spacing: 8, runSpacing: 4, children: entries)),
+            IconButton(
+              icon: const Icon(Icons.close, color: Colors.white),
+              onPressed: widget.onClose,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show short-lived booster completion banner with tag accuracy deltas
- add screen for booster progress chart and link banner to it
- trigger banner after booster sessions on training session summary screen

## Testing
- `dart format lib/widgets/booster_completion_banner.dart lib/screens/booster_progress_chart_screen.dart lib/screens/training_session_summary_screen.dart`
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68916af054ac832aa6a8415d1c24eed7