### PR TITLE
feat: analyze booster effectiveness

### DIFF
--- a/lib/services/booster_effectiveness_analyzer_service.dart
+++ b/lib/services/booster_effectiveness_analyzer_service.dart
@@ -1,0 +1,75 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'booster_stats_tracker_service.dart';
+
+/// Analyzes accuracy gains for booster sessions per tag.
+class BoosterEffectivenessAnalyzerService {
+  final BoosterStatsTrackerService tracker;
+
+  BoosterEffectivenessAnalyzerService({BoosterStatsTrackerService? tracker})
+      : tracker = tracker ?? BoosterStatsTrackerService();
+
+  static const String _boxName = 'booster_stats_box';
+
+  Future<Box<dynamic>> _openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.initFlutter();
+      return await Hive.openBox(_boxName);
+    }
+    return Hive.box(_boxName);
+  }
+
+  /// Returns the average accuracy gain across booster sessions for [tag].
+  ///
+  /// Returns `null` if there are fewer than two sessions logged.
+  Future<double?> getAverageGain(String tag) async {
+    final progress = await tracker.getProgressForTag(tag);
+    if (progress.length < 2) return null;
+    double total = 0.0;
+    for (var i = 1; i < progress.length; i++) {
+      total += progress[i].accuracy - progress[i - 1].accuracy;
+    }
+    return total / (progress.length - 1);
+  }
+
+  /// Returns tags with highest average accuracy gains.
+  ///
+  /// Only tags with at least [minSessions] logged sessions are included.
+  /// The returned map is ordered by descending effectiveness.
+  Future<Map<String, double>> getTopEffectiveTags({int minSessions = 3}) async {
+    final box = await _openBox();
+    final tagProgress = <String, List<BoosterTagProgress>>{};
+
+    for (var i = 0; i < box.length; i++) {
+      final raw = box.getAt(i);
+      if (raw is! Map) continue;
+      final data = Map<String, dynamic>.from(raw as Map);
+      final accMap = Map<String, dynamic>.from(data['accuracyPerTag'] ?? {});
+      final ts = DateTime.fromMillisecondsSinceEpoch(
+          (data['date'] as num?)?.toInt() ?? 0);
+      accMap.forEach((tag, acc) {
+        final t = tag.toString().trim().toLowerCase();
+        final a = (acc as num?)?.toDouble();
+        if (t.isEmpty || a == null) return;
+        tagProgress
+            .putIfAbsent(t, () => [])
+            .add(BoosterTagProgress(date: ts, accuracy: a));
+      });
+    }
+
+    final gains = <String, double>{};
+    tagProgress.forEach((tag, list) {
+      list.sort((a, b) => a.date.compareTo(b.date));
+      if (list.length < minSessions) return;
+      double total = 0.0;
+      for (var i = 1; i < list.length; i++) {
+        total += list[i].accuracy - list[i - 1].accuracy;
+      }
+      gains[tag] = total / (list.length - 1);
+    });
+
+    final sorted = gains.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return {for (final e in sorted) e.key: e.value};
+  }
+}

--- a/test/services/booster_effectiveness_analyzer_service_test.dart
+++ b/test/services/booster_effectiveness_analyzer_service_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:poker_analyzer/models/training_pack.dart';
+import 'package:poker_analyzer/models/training_pack_template.dart';
+import 'package:poker_analyzer/services/booster_effectiveness_analyzer_service.dart';
+import 'package:poker_analyzer/services/booster_stats_tracker_service.dart';
+
+class _TestPathProvider extends PathProviderPlatform {
+  _TestPathProvider(this.path);
+  final String path;
+  @override
+  Future<String?> getTemporaryPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+  @override
+  Future<String?> getLibraryPath() async => path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationCachePath() async => path;
+  @override
+  Future<String?> getExternalStoragePath() async => path;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => [path];
+  @override
+  Future<List<String>?> getExternalStoragePaths(
+          {StorageDirectory? type}) async =>
+      [path];
+  @override
+  Future<String?> getDownloadsPath() async => path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('computes average gains and top tags', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _TestPathProvider(dir.path);
+    await Hive.initFlutter();
+    await Hive.openBox('booster_stats_box');
+
+    final tracker = BoosterStatsTrackerService();
+    final analyzer = BoosterEffectivenessAnalyzerService(tracker: tracker);
+
+    final tpl1 = TrainingPackTemplate(
+      id: 'b1',
+      name: 'B1',
+      gameType: 'g',
+      description: '',
+      hands: const [],
+      tags: const ['tag1'],
+    );
+    final tpl2 = TrainingPackTemplate(
+      id: 'b2',
+      name: 'B2',
+      gameType: 'g',
+      description: '',
+      hands: const [],
+      tags: const ['tag2'],
+    );
+    final tpl3 = TrainingPackTemplate(
+      id: 'b3',
+      name: 'B3',
+      gameType: 'g',
+      description: '',
+      hands: const [],
+      tags: const ['tag3'],
+    );
+
+    // tag1 sessions: 0.5 -> 0.8 -> 0.9 (avg gain 0.2)
+    await tracker.logBoosterResult(
+        tpl1,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 1), total: 10, correct: 5));
+    await tracker.logBoosterResult(
+        tpl1,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 2), total: 10, correct: 8));
+    await tracker.logBoosterResult(
+        tpl1,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 3), total: 10, correct: 9));
+
+    // tag2 sessions: 0.7 -> 0.8 -> 0.8 (avg gain 0.05)
+    await tracker.logBoosterResult(
+        tpl2,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 1), total: 10, correct: 7));
+    await tracker.logBoosterResult(
+        tpl2,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 2), total: 10, correct: 8));
+    await tracker.logBoosterResult(
+        tpl2,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 3), total: 10, correct: 8));
+
+    // tag3 sessions: only two, should be excluded from top tags
+    await tracker.logBoosterResult(
+        tpl3,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 1), total: 10, correct: 4));
+    await tracker.logBoosterResult(
+        tpl3,
+        TrainingSessionResult(
+            date: DateTime(2024, 1, 2), total: 10, correct: 6));
+
+    final gainTag1 = await analyzer.getAverageGain('tag1');
+    expect(gainTag1, isNotNull);
+    expect(gainTag1!, closeTo(0.2, 0.001));
+
+    final top = await analyzer.getTopEffectiveTags();
+    expect(top.keys.toList(), ['tag1', 'tag2']);
+    expect(top['tag1'], closeTo(0.2, 0.001));
+    expect(top['tag2'], closeTo(0.05, 0.001));
+    expect(top.containsKey('tag3'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add BoosterEffectivenessAnalyzerService to compute average accuracy gains from booster sessions
- test booster effectiveness analyzer against sample booster histories

## Testing
- `flutter test` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, but it does not provide an inline implementation. ... lib/services/auto_decay_spot_generator.dart:14:3: Error: A const constructor can't have a body.)*

------
https://chatgpt.com/codex/tasks/task_e_68916e048fb0832aa174285c90ba44ae