### PR TITLE
feat: suggest effective theory boosters

### DIFF
--- a/lib/services/effective_theory_injector_service.dart
+++ b/lib/services/effective_theory_injector_service.dart
@@ -1,0 +1,86 @@
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'mini_lesson_library_service.dart';
+import 'theory_lesson_effectiveness_analyzer_service.dart';
+
+/// Selects highly effective theory lessons for decayed tags.
+///
+/// This service leverages [TheoryLessonEffectivenessAnalyzerService] to find
+/// lessons with strong historical impact on recall. For the most decayed tags
+/// reported by [DecayTagRetentionTrackerService] it suggests the top lessons so
+/// they can be injected as boosters.
+class EffectiveTheoryInjectorService {
+  final TheoryLessonEffectivenessAnalyzerService analyzer;
+  final DecayTagRetentionTrackerService retention;
+  final MiniLessonLibraryService library;
+
+  EffectiveTheoryInjectorService({
+    TheoryLessonEffectivenessAnalyzerService? analyzer,
+    DecayTagRetentionTrackerService? retention,
+    MiniLessonLibraryService? library,
+  })  : analyzer = analyzer ?? TheoryLessonEffectivenessAnalyzerService(),
+        retention = retention ?? DecayTagRetentionTrackerService(),
+        library = library ?? MiniLessonLibraryService.instance;
+
+  /// Returns up to two [TheoryLessonNode]s for [tag] that have high historical
+  /// effectiveness. The lessons are ordered by their average gain in descending
+  /// order. Returns an empty list when no suitable lessons are found.
+  Future<List<TheoryLessonNode>> getInjectableLessonsForTag(String tag) async {
+    final norm = tag.trim().toLowerCase();
+    if (norm.isEmpty) return const [];
+    await library.loadAll();
+    final lessons = library.all.where((l) {
+      return l.tags.any((t) => t.toLowerCase() == norm);
+    }).toList();
+    if (lessons.isEmpty) return const [];
+
+    final gains = await analyzer.getTopEffectiveLessons(minSessions: 1);
+    final candidates = <_Entry>[];
+    for (final l in lessons) {
+      final gain = gains[l.id];
+      if (gain != null && gain > 0) {
+        candidates.add(_Entry(l, gain));
+      }
+    }
+    if (candidates.isEmpty) return const [];
+    candidates.sort((a, b) => b.gain.compareTo(a.gain));
+    return [
+      for (final e in candidates.take(2))
+        TheoryLessonNode(
+          id: e.lesson.id,
+          refId: e.lesson.refId,
+          title: e.lesson.title,
+          content: e.lesson.content,
+          nextIds: const [],
+          recoveredFromMistake: e.lesson.recoveredFromMistake,
+        ),
+    ];
+  }
+
+  /// Returns a map of decayed tags to their top theory lessons.
+  ///
+  /// Only tags that have at least one effective lesson are included. The
+  /// [limit] parameter controls the maximum number of tags to return.
+  Future<Map<String, List<TheoryLessonNode>>> getTopTheoryBoosters({
+    int limit = 3,
+  }) async {
+    if (limit <= 0) return <String, List<TheoryLessonNode>>{};
+    final decayed = await retention.getMostDecayedTags(limit * 2);
+    final result = <String, List<TheoryLessonNode>>{};
+    for (final entry in decayed) {
+      if (result.length >= limit) break;
+      final lessons = await getInjectableLessonsForTag(entry.key);
+      if (lessons.isNotEmpty) {
+        result[entry.key] = lessons;
+      }
+    }
+    return result;
+  }
+}
+
+class _Entry {
+  final TheoryMiniLessonNode lesson;
+  final double gain;
+  _Entry(this.lesson, this.gain);
+}

--- a/test/services/effective_theory_injector_service_test.dart
+++ b/test/services/effective_theory_injector_service_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/services/effective_theory_injector_service.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_lesson_effectiveness_analyzer_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+  @override
+  List<TheoryMiniLessonNode> get all => items;
+  @override
+  TheoryMiniLessonNode? getById(String id) {
+    for (final l in items) {
+      if (l.id == id) return l;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> loadAll() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) =>
+      items.where((e) => e.tags.any(tags.contains)).toList();
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+  @override
+  List<String> linkedPacksFor(String lessonId) => const [];
+}
+
+class _FakeAnalyzer extends TheoryLessonEffectivenessAnalyzerService {
+  final Map<String, double> gains;
+  _FakeAnalyzer(this.gains)
+      : super(retention: DecayTagRetentionTrackerService());
+  @override
+  Future<Map<String, double>> getTopEffectiveLessons({
+    int minSessions = 3,
+  }) async =>
+      gains;
+}
+
+class _FakeRetention extends DecayTagRetentionTrackerService {
+  final List<MapEntry<String, double>> tags;
+  const _FakeRetention(this.tags) : super();
+  @override
+  Future<List<MapEntry<String, double>>> getMostDecayedTags(
+    int limit, {
+    DateTime? now,
+  }) async {
+    final list = List<MapEntry<String, double>>.from(tags);
+    list.sort((a, b) => b.value.compareTo(a.value));
+    if (list.length > limit) {
+      return list.sublist(0, limit);
+    }
+    return list;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final lesson1 = TheoryMiniLessonNode(
+    id: 'l1',
+    title: 'L1',
+    content: '',
+    tags: const ['icm'],
+    nextIds: const [],
+  );
+  final lesson2 = TheoryMiniLessonNode(
+    id: 'l2',
+    title: 'L2',
+    content: '',
+    tags: const ['icm'],
+    nextIds: const [],
+  );
+
+  test('getInjectableLessonsForTag ranks by gain', () async {
+    final library = _FakeLibrary([lesson1, lesson2]);
+    final analyzer = _FakeAnalyzer({'l1': 5.0, 'l2': 2.0});
+    final service = EffectiveTheoryInjectorService(
+      analyzer: analyzer,
+      library: library,
+      retention: DecayTagRetentionTrackerService(),
+    );
+
+    final result = await service.getInjectableLessonsForTag('icm');
+    expect(result.length, 2);
+    expect(result.first.id, 'l1');
+    expect(result.last.id, 'l2');
+    expect(result.first, isA<TheoryLessonNode>());
+  });
+
+  test('getTopTheoryBoosters returns map of tags to lessons', () async {
+    final library = _FakeLibrary([lesson1]);
+    final analyzer = _FakeAnalyzer({'l1': 4.0});
+    final retention = _FakeRetention([
+      const MapEntry('icm', 0.9),
+      const MapEntry('math', 0.8),
+    ]);
+    final service = EffectiveTheoryInjectorService(
+      analyzer: analyzer,
+      library: library,
+      retention: retention,
+    );
+    final map = await service.getTopTheoryBoosters(limit: 2);
+    expect(map.length, 1);
+    expect(map.containsKey('icm'), isTrue);
+    expect(map['icm']!.first.id, 'l1');
+  });
+}


### PR DESCRIPTION
## Summary
- add EffectiveTheoryInjectorService to surface high-gain theory lessons for decayed tags
- cover service with unit tests

## Testing
- `flutter test test/services/effective_theory_injector_service_test.dart` *(fails: file_picker plugin missing; core models not found)*

------
https://chatgpt.com/codex/tasks/task_e_689172d49a14832aa3379c29c04f7ab4