### PR TITLE
feat: add inline theory booster display

### DIFF
--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -57,6 +57,7 @@ import 'training_session_completion_screen.dart';
 import '../services/inline_theory_linker_service.dart';
 import '../widgets/theory_quick_access_banner.dart';
 import '../widgets/inline_theory_recall_banner.dart';
+import '../widgets/inline_theory_booster_display.dart';
 
 class _EndlessStats {
   int total = 0;
@@ -884,6 +885,16 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                               child: const Text('Next'),
                             ),
                           ],
+                        ),
+                        Builder(
+                          builder: (context) {
+                            final tag = spot.tags.firstWhere(
+                              (t) => !t.startsWith('cat:'),
+                              orElse: () => '',
+                            );
+                            if (tag.isEmpty) return const SizedBox.shrink();
+                            return InlineTheoryBoosterDisplay(tag: tag);
+                          },
                         ),
                         if (showCategory)
                           Padding(

--- a/lib/widgets/inline_theory_booster_display.dart
+++ b/lib/widgets/inline_theory_booster_display.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import '../services/effective_theory_injector_service.dart';
+import '../models/theory_lesson_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/mini_lesson_screen.dart';
+
+/// Displays up to two theory booster lessons for a given tag inside the
+/// training flow.
+///
+/// Lessons are loaded via [EffectiveTheoryInjectorService]. When no lessons are
+/// available an empty widget is rendered.
+class InlineTheoryBoosterDisplay extends StatefulWidget {
+  final String tag;
+  final EffectiveTheoryInjectorService injector;
+
+  const InlineTheoryBoosterDisplay({
+    super.key,
+    required this.tag,
+    EffectiveTheoryInjectorService? injector,
+  }) : injector = injector ?? EffectiveTheoryInjectorService();
+
+  @override
+  State<InlineTheoryBoosterDisplay> createState() =>
+      _InlineTheoryBoosterDisplayState();
+}
+
+class _InlineTheoryBoosterDisplayState
+    extends State<InlineTheoryBoosterDisplay> {
+  late Future<List<TheoryLessonNode>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.injector.getInjectableLessonsForTag(widget.tag);
+  }
+
+  @override
+  void didUpdateWidget(covariant InlineTheoryBoosterDisplay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.tag != widget.tag) {
+      _future = widget.injector.getInjectableLessonsForTag(widget.tag);
+    }
+  }
+
+  void _openLesson(TheoryLessonNode lesson) {
+    final mini = TheoryMiniLessonNode(
+      id: lesson.id,
+      refId: lesson.refId,
+      title: lesson.title,
+      content: lesson.content,
+      nextIds: lesson.nextIds,
+      recoveredFromMistake: lesson.recoveredFromMistake,
+    );
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: mini)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<TheoryLessonNode>>(
+      future: _future,
+      builder: (context, snapshot) {
+        final lessons = snapshot.data;
+        if (lessons == null || lessons.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          child: ExpansionTile(
+            title: const Text('📘 Theory Boosters'),
+            children: [
+              for (final l in lessons)
+                ListTile(
+                  title: Text(l.resolvedTitle),
+                  trailing: TextButton(
+                    onPressed: () => _openLesson(l),
+                    child: const Text('Open'),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- show top theory boosters inline during training via new InlineTheoryBoosterDisplay widget
- integrate inline booster widget into TrainingSessionScreen results flow

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689178feb5e0832a88b68cd47601e0ff