### PR TITLE
feat: show booster recap for decayed tags

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -47,6 +47,7 @@ import '../services/streak_milestone_queue_service.dart';
 import '../widgets/confetti_overlay.dart';
 import '../services/overlay_booster_manager.dart';
 import '../widgets/decay_recall_stats_card.dart';
+import '../widgets/decay_review_recap_banner.dart';
 import '../services/decay_session_tag_impact_recorder.dart';
 import '../widgets/booster_completion_banner.dart';
 import '../models/training_pack.dart';
@@ -405,6 +406,7 @@ class _TrainingSessionSummaryScreenState
                   tagDeltas: widget.tagDeltas,
                   spotCount: widget.session.results.length,
                 ),
+              const DecayReviewRecapBanner(),
               const SizedBox(height: 16),
               if (widget.tagDeltas.isNotEmpty) ...[
                 const Text(

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -140,6 +140,7 @@ class TrainingSessionService extends ChangeNotifier {
   }
 
   List<TrainingAction> get actionLog => List.unmodifiable(_actions);
+  List<TrainingAction> get completedAttempts => List.unmodifiable(_actions);
   List<TrainingPackSpot> get spots => List.unmodifiable(_spots);
   TrainingPackTemplate? get template => _template;
 

--- a/lib/widgets/decay_review_recap_banner.dart
+++ b/lib/widgets/decay_review_recap_banner.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/theory_lesson_node.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../services/effective_theory_injector_service.dart';
+import '../services/training_session_service.dart';
+
+class DecayReviewRecapBanner extends StatefulWidget {
+  const DecayReviewRecapBanner({super.key});
+
+  @override
+  State<DecayReviewRecapBanner> createState() => _DecayReviewRecapBannerState();
+}
+
+class _DecayReviewRecapBannerState extends State<DecayReviewRecapBanner> {
+  final _injector = EffectiveTheoryInjectorService();
+  final Map<String, List<TheoryLessonNode>> _boosters = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    final session = context.read<TrainingSessionService>();
+    final tags = <String>{};
+    for (final a in session.completedAttempts) {
+      final spot = session.spots.firstWhere(
+        (s) => s.id == a.spotId,
+        orElse: () => TrainingPackSpot(id: ''),
+      );
+      for (final t in spot.tags) {
+        if (!t.startsWith('cat:')) tags.add(t);
+      }
+    }
+    for (final tag in tags) {
+      final lessons = await _injector.getInjectableLessonsForTag(tag);
+      if (lessons.isNotEmpty) {
+        _boosters[tag] = lessons;
+      }
+    }
+    if (mounted) {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _boosters.isEmpty) return const SizedBox.shrink();
+    final accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Восстановленные навыки',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final entry in _boosters.entries)
+            ExpansionTile(
+              tilePadding: EdgeInsets.zero,
+              iconColor: accent,
+              collapsedIconColor: accent,
+              title: Row(
+                children: [
+                  const Icon(Icons.bolt, color: Colors.orange, size: 16),
+                  const SizedBox(width: 4),
+                  Text(
+                    entry.key,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ],
+              ),
+              children: [
+                for (final lesson in entry.value)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 24, bottom: 4),
+                    child: Text(
+                      '• ${lesson.resolvedTitle}',
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- expose `completedAttempts` in `TrainingSessionService`
- add `DecayReviewRecapBanner` widget to show reviewed decayed tags and booster lessons
- display recap banner on training session summary screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68917a646024832a9211dc42a400398e