### PR TITLE
feat: track recalled mini lessons

### DIFF
--- a/lib/services/theory_recall_impact_tracker.dart
+++ b/lib/services/theory_recall_impact_tracker.dart
@@ -1,0 +1,61 @@
+/// Tracks which theory mini-lessons were recalled during a session.
+class TheoryRecallImpactTracker {
+  TheoryRecallImpactTracker._();
+
+  /// Singleton instance.
+  static final TheoryRecallImpactTracker instance =
+      TheoryRecallImpactTracker._();
+
+  final List<_Entry> _logs = <_Entry>[];
+
+  /// Records that a lesson [lessonId] for [tag] was viewed.
+  void record(String tag, String lessonId) {
+    final norm = tag.trim();
+    if (norm.isEmpty) return;
+    _logs.add(_Entry(tag: norm, lessonId: lessonId, timestamp: DateTime.now()));
+  }
+
+  /// Returns a map from tag to list of lesson ids viewed for that tag.
+  Map<String, List<String>> get tagToLessons {
+    final Map<String, List<String>> result = <String, List<String>>{};
+    for (final e in _logs) {
+      result.putIfAbsent(e.tag, () => <String>[]).add(e.lessonId);
+    }
+    return result;
+  }
+
+  /// Returns the recorded entries in order of occurrence.
+  List<TheoryRecallImpactEntry> get entries =>
+      _logs.map((e) => TheoryRecallImpactEntry.fromEntry(e)).toList();
+
+  /// Clears recorded data. Intended for testing.
+  void reset() => _logs.clear();
+}
+
+/// Public view of a recall impact entry.
+class TheoryRecallImpactEntry {
+  TheoryRecallImpactEntry({
+    required this.tag,
+    required this.lessonId,
+    required this.timestamp,
+  });
+
+  final String tag;
+  final String lessonId;
+  final DateTime timestamp;
+
+  factory TheoryRecallImpactEntry.fromEntry(_Entry e) =>
+      TheoryRecallImpactEntry(
+        tag: e.tag,
+        lessonId: e.lessonId,
+        timestamp: e.timestamp,
+      );
+}
+
+class _Entry {
+  _Entry({required this.tag, required this.lessonId, required this.timestamp});
+
+  final String tag;
+  final String lessonId;
+  final DateTime timestamp;
+}

--- a/test/services/theory_recall_impact_tracker_test.dart
+++ b/test/services/theory_recall_impact_tracker_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/screens/mini_lesson_screen.dart';
+import 'package:poker_analyzer/services/theory_recall_impact_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    TheoryRecallImpactTracker.instance.reset();
+  });
+
+  test('records lessons and groups by tag', () {
+    final tracker = TheoryRecallImpactTracker.instance;
+    tracker.record('a', 'l1');
+    tracker.record('a', 'l2');
+    tracker.record('b', 'l3');
+    final map = tracker.tagToLessons;
+    expect(map['a'], ['l1', 'l2']);
+    expect(map['b'], ['l3']);
+  });
+
+  testWidgets('MiniLessonScreen logs lesson', (tester) async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'Intro',
+      content: '',
+      tags: [],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MiniLessonScreen(lesson: lesson, recapTag: 'tag1'),
+      ),
+    );
+    expect(TheoryRecallImpactTracker.instance.tagToLessons['tag1'], ['l1']);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryRecallImpactTracker to log mini lessons viewed by tag during session
- hook MiniLessonScreen to record recalled lessons
- cover tracker with unit and widget tests

## Testing
- `flutter test` *(fails: Error when reading 'lib/core/models/v2/training_pack_template_v2.dart': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68917bd797ac832aa175c1c954d41041