### PR TITLE
feat: persist theory recall logs

### DIFF
--- a/lib/screens/theory_recall_stats_dashboard_screen.dart
+++ b/lib/screens/theory_recall_stats_dashboard_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -58,8 +60,8 @@ class _TheoryRecallStatsDashboardScreenState
     });
   }
 
-  void _reset() {
-    TheoryRecallImpactTracker.instance.reset();
+  Future<void> _reset() async {
+    await TheoryRecallImpactTracker.instance.clear();
     _load();
   }
 

--- a/test/services/theory_recall_impact_tracker_test.dart
+++ b/test/services/theory_recall_impact_tracker_test.dart
@@ -28,12 +28,20 @@ void main() {
   test('persists logs across sessions', () async {
     final tracker = TheoryRecallImpactTracker.instance;
     await tracker.record('tag', 'l1');
-    tracker.reset(clearPrefs: false);
+    tracker.reset();
     await tracker.init();
     expect(tracker.entries.length, 1);
     final entry = tracker.entries.first;
     expect(entry.tag, 'tag');
     expect(entry.lessonId, 'l1');
+  });
+
+  test('clear removes persisted logs', () async {
+    final tracker = TheoryRecallImpactTracker.instance;
+    await tracker.record('tag', 'l1');
+    await tracker.clear();
+    await tracker.init();
+    expect(tracker.entries, isEmpty);
   });
 
   testWidgets('MiniLessonScreen logs lesson', (tester) async {


### PR DESCRIPTION
## Summary
- persist theory recall impact logs via SharedPreferences across sessions
- add clear and persist helpers and use ISO timestamps
- update debug dashboard and tests for new persistence behavior

## Testing
- `flutter test test/services/theory_recall_impact_tracker_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6891d91b0120832abba3cd631475b749