### PR TITLE
feat: add constraint resolver engine

### DIFF
--- a/lib/models/constraint_set.dart
+++ b/lib/models/constraint_set.dart
@@ -15,6 +15,28 @@ class ConstraintSet {
   final List<String> villainActions;
   final String? targetStreet;
 
+  /// Optional tag requirements for the generated spot.
+  final List<String> requiredTags;
+
+  /// Tags that must not be present on the generated spot.
+  final List<String> excludedTags;
+
+  /// Specific hero position requirement. Takes precedence over [positions]
+  /// when provided.
+  final String? position;
+
+  /// Optional opponent position requirement.
+  final String? opponentPosition;
+
+  /// Board texture constraints expressed as required/excluded tags.
+  final Map<String, dynamic>? boardTexture;
+
+  /// Minimum allowed hero stack size (in BB).
+  final double? minStack;
+
+  /// Maximum allowed hero stack size (in BB).
+  final double? maxStack;
+
   /// Optional list of board generation constraints to expand into concrete
   /// boards for this variation.
   final List<Map<String, dynamic>> boardConstraints;
@@ -51,6 +73,13 @@ class ConstraintSet {
     this.handGroup = const [],
     this.villainActions = const [],
     this.targetStreet,
+    this.requiredTags = const [],
+    this.excludedTags = const [],
+    this.position,
+    this.opponentPosition,
+    this.boardTexture,
+    this.minStack,
+    this.maxStack,
     this.boardConstraints = const [],
     this.linePattern,
     this.overrides = const {},
@@ -84,6 +113,19 @@ class ConstraintSet {
         for (final a in (json['villainActions'] as List? ?? [])) a.toString(),
       ],
       targetStreet: json['targetStreet']?.toString(),
+      requiredTags: [
+        for (final t in (json['requiredTags'] as List? ?? [])) t.toString(),
+      ],
+      excludedTags: [
+        for (final t in (json['excludedTags'] as List? ?? [])) t.toString(),
+      ],
+      position: json['position']?.toString(),
+      opponentPosition: json['opponentPosition']?.toString(),
+      boardTexture: json['boardTexture'] is Map
+          ? Map<String, dynamic>.from(json['boardTexture'])
+          : null,
+      minStack: (json['minStack'] as num?)?.toDouble(),
+      maxStack: (json['maxStack'] as num?)?.toDouble(),
       boardConstraints: [
         if (json['boardConstraints'] is List)
           for (final c in (json['boardConstraints'] as List))
@@ -114,6 +156,14 @@ class ConstraintSet {
         if (handGroup.isNotEmpty) 'handGroup': handGroup,
         if (villainActions.isNotEmpty) 'villainActions': villainActions,
         if (targetStreet != null) 'targetStreet': targetStreet,
+        if (requiredTags.isNotEmpty) 'requiredTags': requiredTags,
+        if (excludedTags.isNotEmpty) 'excludedTags': excludedTags,
+        if (position != null) 'position': position,
+        if (opponentPosition != null) 'opponentPosition': opponentPosition,
+        if (boardTexture != null && boardTexture!.isNotEmpty)
+          'boardTexture': boardTexture,
+        if (minStack != null) 'minStack': minStack,
+        if (maxStack != null) 'maxStack': maxStack,
         if (boardConstraints.isNotEmpty) 'boardConstraints': boardConstraints,
         if (linePattern != null) 'linePattern': linePattern!.toJson(),
         if (overrides.isNotEmpty) 'overrides': overrides,

--- a/lib/models/spot_seed_format.dart
+++ b/lib/models/spot_seed_format.dart
@@ -4,6 +4,8 @@ class SpotSeedFormat {
   final String player;
   final List<String> handGroup;
   final String position;
+  final String? opponentPosition;
+  final double? heroStack;
   final List<CardModel> board;
   final List<String> villainActions;
   final List<String> tags;
@@ -12,6 +14,8 @@ class SpotSeedFormat {
     required this.player,
     required this.handGroup,
     required this.position,
+    this.opponentPosition,
+    this.heroStack,
     List<CardModel>? board,
     List<String>? villainActions,
     List<String>? tags,
@@ -23,10 +27,14 @@ class SpotSeedFormat {
     List<CardModel>? board,
     List<String>? villainActions,
     List<String>? tags,
+    double? heroStack,
+    String? opponentPosition,
   }) => SpotSeedFormat(
         player: player,
         handGroup: handGroup,
         position: position,
+        opponentPosition: opponentPosition ?? this.opponentPosition,
+        heroStack: heroStack ?? this.heroStack,
         board: board ?? this.board,
         villainActions: villainActions ?? this.villainActions,
         tags: tags ?? this.tags,

--- a/lib/services/spot_seed_filter_service.dart
+++ b/lib/services/spot_seed_filter_service.dart
@@ -46,10 +46,12 @@ class SpotSeedFilterService {
     if (spot.villainAction != null && spot.villainAction!.isNotEmpty) {
       actions.add(spot.villainAction!.split(' ').first);
     }
+    final stack = spot.hand.stacks['0'];
     return SpotSeedFormat(
       player: 'hero',
       handGroup: const [],
       position: heroPos,
+      heroStack: stack,
       board: board,
       villainActions: actions,
       tags: spot.tags,

--- a/lib/services/training_pack_template_set_expander.dart
+++ b/lib/services/training_pack_template_set_expander.dart
@@ -69,10 +69,12 @@ class TrainingPackTemplateSetExpander {
     if (spot.villainAction != null && spot.villainAction!.isNotEmpty) {
       actions.add(spot.villainAction!.split(' ').first);
     }
+    final stack = spot.hand.stacks['0'];
     return SpotSeedFormat(
       player: 'hero',
       handGroup: const [],
       position: heroPos,
+      heroStack: stack,
       board: board,
       villainActions: actions,
       tags: spot.tags,

--- a/lib/services/training_pack_template_set_generator.dart
+++ b/lib/services/training_pack_template_set_generator.dart
@@ -77,10 +77,12 @@ class TrainingPackTemplateSetGenerator {
     if (spot.villainAction != null && spot.villainAction!.isNotEmpty) {
       actions.add(spot.villainAction!.split(' ').first);
     }
+    final stack = spot.hand.stacks['0'];
     return SpotSeedFormat(
       player: 'hero',
       handGroup: const [],
       position: heroPos,
+      heroStack: stack,
       board: board,
       villainActions: actions,
       tags: spot.tags,

--- a/lib/utils/board_analyzer_utils.dart
+++ b/lib/utils/board_analyzer_utils.dart
@@ -1,0 +1,13 @@
+import '../models/card_model.dart';
+import '../services/dynamic_board_tagger_service.dart';
+
+/// Utility helpers for evaluating board textures.
+class BoardAnalyzerUtils {
+  BoardAnalyzerUtils._();
+
+  static final DynamicBoardTaggerService _tagger =
+      const DynamicBoardTaggerService();
+
+  /// Returns a set of tags describing the given [board].
+  static Set<String> tags(List<CardModel> board) => _tagger.tag(board);
+}

--- a/lib/utils/stack_utils.dart
+++ b/lib/utils/stack_utils.dart
@@ -1,0 +1,12 @@
+/// Utility helpers for evaluating stack-related constraints.
+class StackUtils {
+  StackUtils._();
+
+  /// Returns true if [stack] falls within the provided [min] and [max]
+  /// thresholds. Null bounds are treated as unbounded in that direction.
+  static bool inRange(double stack, {double? min, double? max}) {
+    if (min != null && stack < min) return false;
+    if (max != null && stack > max) return false;
+    return true;
+  }
+}

--- a/test/services/constraint_resolver_engine_v2_test.dart
+++ b/test/services/constraint_resolver_engine_v2_test.dart
@@ -101,4 +101,24 @@ void main() {
     final constraints = ConstraintSet(targetStreet: 'flop');
     expect(engine.isValid(candidate, constraints), isFalse);
   });
+
+  test('enforces required and excluded spot tags', () {
+    final candidate = buildCandidate().copyWith(tags: ['a', 'b']);
+    final ok = ConstraintSet(requiredTags: ['a'], excludedTags: ['c']);
+    final failReq = ConstraintSet(requiredTags: ['c']);
+    final failExcl = ConstraintSet(excludedTags: ['b']);
+    expect(engine.isValid(candidate, ok), isTrue);
+    expect(engine.isValid(candidate, failReq), isFalse);
+    expect(engine.isValid(candidate, failExcl), isFalse);
+  });
+
+  test('validates stack range when provided', () {
+    final candidate = buildCandidate().copyWith(heroStack: 20);
+    final ok = ConstraintSet(minStack: 10, maxStack: 25);
+    final low = ConstraintSet(minStack: 30);
+    final high = ConstraintSet(maxStack: 10);
+    expect(engine.isValid(candidate, ok), isTrue);
+    expect(engine.isValid(candidate, low), isFalse);
+    expect(engine.isValid(candidate, high), isFalse);
+  });
 }

--- a/test/services/training_pack_template_expander_service_test.dart
+++ b/test/services/training_pack_template_expander_service_test.dart
@@ -84,4 +84,27 @@ variations:
       expect(lowRanks.containsAll(s.board.take(3).map((c) => c[0])), isTrue);
     }
   });
+
+  test('filters out spots that fail constraint checks', () {
+    const yaml = '''
+baseSpot:
+  id: base
+  hand:
+    heroCards: Ah Kh
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+variations:
+  - positions: [co]
+    overrides:
+      heroStack: [20]
+    minStack: 25
+''';
+
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    final svc = TrainingPackTemplateExpanderService();
+    final spots = svc.expand(set);
+    expect(spots, isEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- add utilities for board texture tagging and stack range checks
- extend seed and constraint models for stack, position and tag rules
- filter generated spots with ConstraintResolverEngine and add tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891dab1e648832aadbe2da6f03fce6f