### PR TITLE
feat: add line graph expansion

### DIFF
--- a/lib/models/spot_seed.dart
+++ b/lib/models/spot_seed.dart
@@ -1,0 +1,17 @@
+import 'card_model.dart';
+
+class SpotSeed {
+  final List<CardModel> board;
+  final List<CardModel> hand;
+  final String position;
+  final List<String> previousActions;
+  final String targetStreet;
+
+  SpotSeed({
+    required this.board,
+    required this.hand,
+    required this.position,
+    required this.previousActions,
+    required this.targetStreet,
+  });
+}

--- a/lib/services/board_splitter.dart
+++ b/lib/services/board_splitter.dart
@@ -1,0 +1,11 @@
+import '../models/board.dart';
+import '../models/card_model.dart';
+
+class BoardSplitter {
+  static Board split(List<CardModel> cards) {
+    final flop = cards.length >= 3 ? cards.sublist(0, 3) : <CardModel>[];
+    final turn = cards.length >= 4 ? cards[3] : null;
+    final river = cards.length >= 5 ? cards[4] : null;
+    return Board(flop: flop, turn: turn, river: river);
+  }
+}

--- a/lib/services/line_graph_engine.dart
+++ b/lib/services/line_graph_engine.dart
@@ -1,5 +1,9 @@
 import '../models/line_pattern.dart';
 import '../models/line_graph_result.dart';
+import '../models/spot_seed.dart';
+import '../models/board.dart';
+import '../models/card_model.dart';
+import 'board_splitter.dart';
 
 class LineGraphEngine {
   const LineGraphEngine();
@@ -36,4 +40,81 @@ class LineGraphEngine {
 
   String _capitalize(String value) =>
       value.isEmpty ? value : value[0].toUpperCase() + value.substring(1);
+
+  List<SpotSeed> expandLine({
+    required String preflopAction,
+    required String line,
+    required List<CardModel> board,
+    required List<CardModel> hand,
+    required String position,
+  }) {
+    final split = BoardSplitter.split(board);
+    final streets = <String>[];
+    if (split.flop.isNotEmpty) streets.add('flop');
+    if (split.turn != null) streets.add('turn');
+    if (split.river != null) streets.add('river');
+
+    final actions = line
+        .split('-')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+    final grouped = _groupActions(actions, streets.length);
+
+    final seeds = <SpotSeed>[];
+    final history = <String>[];
+    if (preflopAction.isNotEmpty) {
+      history.add(preflopAction);
+    }
+    for (var i = 0; i < streets.length; i++) {
+      seeds.add(
+        SpotSeed(
+          board: _boardUpTo(split, i),
+          hand: hand,
+          position: position,
+          previousActions: List<String>.from(history),
+          targetStreet: streets[i],
+        ),
+      );
+      history.addAll(grouped[i]);
+    }
+    return seeds;
+  }
+
+  List<List<String>> _groupActions(List<String> actions, int streetCount) {
+    final groups = <List<String>>[];
+    var index = 0;
+    var remaining = actions.length;
+    for (
+      var remainingStreets = streetCount;
+      remainingStreets > 0;
+      remainingStreets--
+    ) {
+      final minForRest = remainingStreets - 1;
+      var size = remaining - minForRest;
+      if (size < 0) size = 0;
+      final end = index + size;
+      groups.add(actions.sublist(index, end));
+      index = end;
+      remaining -= size;
+    }
+    return groups;
+  }
+
+  List<CardModel> _boardUpTo(Board board, int index) {
+    switch (index) {
+      case 0:
+        return List<CardModel>.from(board.flop);
+      case 1:
+        return [...board.flop, if (board.turn != null) board.turn!];
+      case 2:
+        return [
+          ...board.flop,
+          if (board.turn != null) board.turn!,
+          if (board.river != null) board.river!,
+        ];
+      default:
+        return [];
+    }
+  }
 }

--- a/test/line_graph_engine_test.dart
+++ b/test/line_graph_engine_test.dart
@@ -1,6 +1,7 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/services/line_graph_engine.dart';
 import 'package:poker_analyzer/models/line_pattern.dart';
+import 'package:poker_analyzer/models/card_model.dart';
 
 void main() {
   test('build creates multi-street hand line from pattern', () {
@@ -20,5 +21,35 @@ void main() {
     expect(result.streets.length, 3);
     expect(result.streets['flop']!.first.action, 'cbet');
     expect(result.tags, containsAll(['flopCbet', 'turnCheck', 'riverShove']));
+  });
+
+  test('expandLine generates spot seeds across streets', () {
+    final engine = const LineGraphEngine();
+    final board = [
+      CardModel(rank: 'A', suit: 's'),
+      CardModel(rank: 'K', suit: 'd'),
+      CardModel(rank: 'Q', suit: 'h'),
+      CardModel(rank: 'J', suit: 'c'),
+    ];
+    final hand = [
+      CardModel(rank: 'T', suit: 's'),
+      CardModel(rank: '9', suit: 's'),
+    ];
+
+    final seeds = engine.expandLine(
+      preflopAction: 'raise-call',
+      line: 'check-check-bet',
+      board: board,
+      hand: hand,
+      position: 'btn',
+    );
+
+    expect(seeds.length, 2);
+    expect(seeds[0].targetStreet, 'flop');
+    expect(seeds[0].board.length, 3);
+    expect(seeds[0].previousActions, ['raise-call']);
+    expect(seeds[1].targetStreet, 'turn');
+    expect(seeds[1].board.length, 4);
+    expect(seeds[1].previousActions, ['raise-call', 'check', 'check']);
   });
 }


### PR DESCRIPTION
## Summary
- add BoardSplitter and SpotSeed models
- expand LineGraphEngine to generate SpotSeeds from action lines
- test line graph expansion across streets

## Testing
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist)*
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6891dd434170832abdbb4d231d3e315f