### PR TITLE
feat: filter postflop lines by board preset

### DIFF
--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -39,6 +39,12 @@ class TrainingPackTemplateSet {
   /// to generate multiple street-specific training spots.
   final String? postflopLine;
 
+  /// Optional board texture preset used to filter `postflopLine` expansions.
+  ///
+  /// When set, the `postflopLine` is only expanded if the base spot's board
+  /// matches the named preset via [BoardTexturePresetLibrary.matches].
+  final String? boardTexturePreset;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
@@ -47,6 +53,7 @@ class TrainingPackTemplateSet {
     List<int>? stackDepthMods,
     List<LinePattern>? linePatterns,
     this.postflopLine,
+    this.boardTexturePreset,
   }) : variations = variations ?? const [],
        playerTypeVariations = playerTypeVariations ?? const [],
        stackDepthMods = stackDepthMods ?? const [],
@@ -75,6 +82,7 @@ class TrainingPackTemplateSet {
         LinePattern.fromJson(Map<String, dynamic>.from(p as Map)),
     ];
     final postLine = json['postflopLine']?.toString();
+    final preset = json['boardTexturePreset']?.toString();
     return TrainingPackTemplateSet(
       baseSpot: base,
       variations: vars,
@@ -83,6 +91,7 @@ class TrainingPackTemplateSet {
       stackDepthMods: depthMods,
       linePatterns: patterns,
       postflopLine: postLine,
+      boardTexturePreset: preset,
     );
   }
 
@@ -103,5 +112,7 @@ class TrainingPackTemplateSet {
       'linePatterns': [for (final p in linePatterns) p.toJson()],
     if (postflopLine != null && postflopLine!.isNotEmpty)
       'postflopLine': postflopLine,
+    if (boardTexturePreset != null && boardTexturePreset!.isNotEmpty)
+      'boardTexturePreset': boardTexturePreset,
   };
 }

--- a/lib/services/board_texture_preset_library.dart
+++ b/lib/services/board_texture_preset_library.dart
@@ -1,4 +1,9 @@
 import '../models/constraint_set.dart';
+import '../models/board_stages.dart';
+import '../models/card_model.dart';
+import '../helpers/board_filtering_params_builder.dart';
+import 'board_texture_filter_service.dart';
+import 'board_filtering_service_v2.dart';
 
 /// Provides predefined board texture presets that expand to board constraint
 /// parameter maps suitable for [ConstraintSet.boardConstraints].
@@ -31,4 +36,53 @@ class BoardTexturePresetLibrary {
     // Return a copy to prevent external mutation.
     return Map<String, dynamic>.from(preset);
   }
+
+  /// Checks whether [board] satisfies the texture constraints of [presetName].
+  ///
+  /// The board must satisfy all `requiredTextures` and `requiredTags` while
+  /// avoiding any `excludedTags` defined by the preset. Returns `true` if the
+  /// board matches the preset, otherwise `false`.
+  static bool matches(List<CardModel> board, String presetName) {
+    if (board.isEmpty) return false;
+    final preset = get(presetName);
+
+    final textures = <String>[
+      for (final t in (preset['requiredTextures'] as List? ?? []))
+        t.toString(),
+    ];
+    final filter = BoardFilteringParamsBuilder.build(textures);
+    if (!_textureFilter.isMatch(board, filter)) {
+      return false;
+    }
+
+    final requiredTags = <String>{
+      for (final t in (filter['boardTexture'] as List? ?? []))
+        t == 'broadway' ? 'broadwayHeavy' : t.toString(),
+      for (final t in (preset['requiredTags'] as List? ?? []))
+        t.toString(),
+    };
+    final excludedTags = <String>{
+      for (final t in (preset['excludedTags'] as List? ?? []))
+        t.toString(),
+    };
+
+    final stages = _toBoardStages(board);
+    return _boardFilter.isMatch(stages, requiredTags,
+        excludedTags: excludedTags);
+  }
+
+  static BoardStages _toBoardStages(List<CardModel> board) {
+    final flop = <String>[];
+    for (var i = 0; i < 3; i++) {
+      flop.add(i < board.length ? board[i].toString() : '2c');
+    }
+    final turn = board.length > 3 ? board[3].toString() : '2d';
+    final river = board.length > 4 ? board[4].toString() : '3c';
+    return BoardStages(flop: flop, turn: turn, river: river);
+  }
+
+  static final BoardTextureFilterService _textureFilter =
+      const BoardTextureFilterService();
+  static final BoardFilteringServiceV2 _boardFilter =
+      const BoardFilteringServiceV2();
 }

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -193,6 +193,13 @@ class TrainingPackTemplateExpanderService {
         CardModel(rank: c[0], suit: c.length > 1 ? c[1] : ''),
     ];
 
+    final preset = set.boardTexturePreset;
+    if (preset != null && preset.isNotEmpty) {
+      if (!BoardTexturePresetLibrary.matches(board, preset)) {
+        return [];
+      }
+    }
+
     final preActions = set.baseSpot.hand.actions[0] ?? [];
     final preflopAction = preActions.map((a) => a.action).join('-');
 

--- a/test/services/board_texture_preset_library_test.dart
+++ b/test/services/board_texture_preset_library_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/services/board_texture_preset_library.dart';
+import 'package:poker_analyzer/models/card_model.dart';
 
 void main() {
   test('returns preset map for lowPaired', () {
@@ -9,5 +10,23 @@ void main() {
 
   test('throws on unknown preset', () {
     expect(() => BoardTexturePresetLibrary.get('unknown'), throwsArgumentError);
+  });
+
+  test('matches returns true for compatible board', () {
+    final board = [
+      CardModel(rank: 'A', suit: 's'),
+      CardModel(rank: '9', suit: 'd'),
+      CardModel(rank: '4', suit: 'c'),
+    ];
+    expect(BoardTexturePresetLibrary.matches(board, 'dryAceHigh'), isTrue);
+  });
+
+  test('matches returns false for incompatible board', () {
+    final board = [
+      CardModel(rank: '7', suit: 'h'),
+      CardModel(rank: '7', suit: 'd'),
+      CardModel(rank: '2', suit: 'c'),
+    ];
+    expect(BoardTexturePresetLibrary.matches(board, 'dryAceHigh'), isFalse);
   });
 }

--- a/test/services/training_pack_generator_postflop_line_test.dart
+++ b/test/services/training_pack_generator_postflop_line_test.dart
@@ -40,4 +40,61 @@ void main() {
     expect(turn.tags, containsAll(['flopCbet', 'turnCheck']));
     expect(turn.meta['previousActions'], ['raise-call', 'cbet']);
   });
+
+  test('skips postflop line when board preset mismatches', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', 'Kd', 'Qc'],
+        actions: {
+          0: [
+            ActionEntry(0, 0, 'raise'),
+            ActionEntry(0, 1, 'call'),
+          ],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLine: 'cbet-check',
+      boardTexturePreset: 'lowPaired',
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    // Only the base spot should remain; line expansion is filtered out.
+    expect(spots, hasLength(1));
+    expect(spots.first.id, isNotEmpty);
+  });
+
+  test('expands postflop line when board preset matches', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', '9d', '4c'],
+        actions: {
+          0: [
+            ActionEntry(0, 0, 'raise'),
+            ActionEntry(0, 1, 'call'),
+          ],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLine: 'cbet-check',
+      boardTexturePreset: 'dryAceHigh',
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    // Base + two street expansions (flop & turn)
+    expect(spots, hasLength(3));
+  });
 }


### PR DESCRIPTION
## Summary
- extend training pack templates with optional `boardTexturePreset`
- allow filtering postflop line expansions by matching the board against preset textures
- add reusable preset matcher and tests covering board presets and generator behavior

## Testing
- `dart test test/services/board_texture_preset_library_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891e1669fa0832a8f0e494ef357dc9b