### PR TITLE
feat: expand line patterns into tagged seeds

### DIFF
--- a/lib/models/spot_seed.dart
+++ b/lib/models/spot_seed.dart
@@ -6,6 +6,7 @@ class SpotSeed {
   final String position;
   final List<String> previousActions;
   final String targetStreet;
+  final List<String> tags;
 
   SpotSeed({
     required this.board,
@@ -13,5 +14,6 @@ class SpotSeed {
     required this.position,
     required this.previousActions,
     required this.targetStreet,
-  });
+    List<String>? tags,
+  }) : tags = tags ?? [];
 }

--- a/lib/services/line_graph_engine.dart
+++ b/lib/services/line_graph_engine.dart
@@ -63,17 +63,24 @@ class LineGraphEngine {
 
     final seeds = <SpotSeed>[];
     final history = <String>[];
+    final accumulatedTags = <String>[];
     if (preflopAction.isNotEmpty) {
       history.add(preflopAction);
     }
     for (var i = 0; i < streets.length; i++) {
+      final street = streets[i];
+      final tags = grouped[i]
+          .map((act) => '${street}${_capitalize(act)}')
+          .toList();
+      accumulatedTags.addAll(tags);
       seeds.add(
         SpotSeed(
           board: _boardUpTo(split, i),
           hand: hand,
           position: position,
           previousActions: List<String>.from(history),
-          targetStreet: streets[i],
+          targetStreet: street,
+          tags: List<String>.from(accumulatedTags),
         ),
       );
       history.addAll(grouped[i]);

--- a/lib/services/training_pack_generator_engine_v2.dart
+++ b/lib/services/training_pack_generator_engine_v2.dart
@@ -78,15 +78,7 @@ class TrainingPackGeneratorEngineV2 {
     // Postflop shorthand line expansion.
     if (set.postflopLine != null && set.postflopLine!.isNotEmpty) {
       final lineSeeds = _expander.expandPostflopLine(set);
-      final actions = set.postflopLine!
-          .split('-')
-          .map((e) => e.trim())
-          .where((e) => e.isNotEmpty)
-          .toList();
-      final groups = _groupActions(actions, lineSeeds.length);
-      final accumulated = <String>[];
-      for (var i = 0; i < lineSeeds.length; i++) {
-        final seed = lineSeeds[i];
+      for (final seed in lineSeeds) {
         final copy = _cloneBase(baseSpot);
 
         copy.hand.position = parseHeroPosition(seed.position);
@@ -96,12 +88,9 @@ class TrainingPackGeneratorEngineV2 {
         copy.street = _streetFromBoard(board.length);
         copy.meta['previousActions'] = List<String>.from(seed.previousActions);
 
-        for (final act in groups[i]) {
-          accumulated.add('${seed.targetStreet}${_capitalize(act)}');
-        }
         final tags = {
           ...baseSpot.tags,
-          ...accumulated,
+          ...seed.tags,
           ..._autoTags(copy),
         };
         copy.tags = tags.toList()..sort();
@@ -161,22 +150,4 @@ class TrainingPackGeneratorEngineV2 {
     return list;
   }
 
-  List<List<String>> _groupActions(List<String> actions, int streetCount) {
-    final groups = <List<String>>[];
-    var index = 0;
-    var remaining = actions.length;
-    for (var remainingStreets = streetCount; remainingStreets > 0; remainingStreets--) {
-      final minForRest = remainingStreets - 1;
-      var size = remaining - minForRest;
-      if (size < 0) size = 0;
-      final end = index + size;
-      groups.add(actions.sublist(index, end));
-      index = end;
-      remaining -= size;
-    }
-    return groups;
-  }
-
-  String _capitalize(String value) =>
-      value.isEmpty ? value : value[0].toUpperCase() + value.substring(1);
 }

--- a/test/line_graph_engine_test.dart
+++ b/test/line_graph_engine_test.dart
@@ -23,13 +23,14 @@ void main() {
     expect(result.tags, containsAll(['flopCbet', 'turnCheck', 'riverShove']));
   });
 
-  test('expandLine generates spot seeds across streets', () {
+  test('expandLine generates tagged spot seeds across streets', () {
     final engine = const LineGraphEngine();
     final board = [
       CardModel(rank: 'A', suit: 's'),
       CardModel(rank: 'K', suit: 'd'),
       CardModel(rank: 'Q', suit: 'h'),
       CardModel(rank: 'J', suit: 'c'),
+      CardModel(rank: 'T', suit: 'd'),
     ];
     final hand = [
       CardModel(rank: 'T', suit: 's'),
@@ -38,18 +39,27 @@ void main() {
 
     final seeds = engine.expandLine(
       preflopAction: 'raise-call',
-      line: 'check-check-bet',
+      line: 'cbet-check-shove',
       board: board,
       hand: hand,
       position: 'btn',
     );
 
-    expect(seeds.length, 2);
+    expect(seeds.length, 3);
     expect(seeds[0].targetStreet, 'flop');
     expect(seeds[0].board.length, 3);
     expect(seeds[0].previousActions, ['raise-call']);
+    expect(seeds[0].tags, contains('flopCbet'));
+
     expect(seeds[1].targetStreet, 'turn');
     expect(seeds[1].board.length, 4);
-    expect(seeds[1].previousActions, ['raise-call', 'check', 'check']);
+    expect(seeds[1].previousActions, ['raise-call', 'cbet']);
+    expect(seeds[1].tags, containsAll(['flopCbet', 'turnCheck']));
+
+    expect(seeds[2].targetStreet, 'river');
+    expect(seeds[2].board.length, 5);
+    expect(seeds[2].previousActions, ['raise-call', 'cbet', 'check']);
+    expect(
+        seeds[2].tags, containsAll(['flopCbet', 'turnCheck', 'riverShove']));
   });
 }


### PR DESCRIPTION
## Summary
- add tags to `SpotSeed` to track action chain progress
- teach `LineGraphEngine.expandLine` to emit tagged seeds for each street
- simplify training pack generation to leverage seed tags

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e300098c832ab2475e9a6d468218