### PR TITLE
feat: add weighted postflop line expansion

### DIFF
--- a/lib/models/postflop_line.dart
+++ b/lib/models/postflop_line.dart
@@ -1,0 +1,24 @@
+class PostflopLine {
+  final String line;
+  final int weight;
+
+  const PostflopLine({required this.line, this.weight = 1});
+
+  factory PostflopLine.fromJson(dynamic json) {
+    if (json is String) {
+      return PostflopLine(line: json);
+    }
+    if (json is Map) {
+      final map = Map<String, dynamic>.from(json as Map);
+      final line = map['line']?.toString() ?? '';
+      final weight = (map['weight'] as num?)?.toInt() ?? 1;
+      return PostflopLine(line: line, weight: weight);
+    }
+    return const PostflopLine(line: '');
+  }
+
+  Map<String, dynamic> toJson() => {
+    'line': line,
+    if (weight != 1) 'weight': weight,
+  };
+}

--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -4,6 +4,7 @@ import '../utils/yaml_utils.dart';
 import 'constraint_set.dart';
 import 'v2/training_pack_spot.dart';
 import 'line_pattern.dart';
+import 'postflop_line.dart';
 
 /// Defines a base spot and a list of variation rules that can be expanded
 /// into multiple [TrainingPackSpot]s.
@@ -35,9 +36,20 @@ class TrainingPackTemplateSet {
 
   /// Optional shorthand postflop action lines applied to the base spot.
   ///
-  /// When provided, each string is expanded via [LineGraphEngine.expandLine]
-  /// to generate multiple street-specific training spots.
-  final List<String> postflopLines;
+  /// Each entry may include an optional [PostflopLine.weight] controlling
+  /// its selection frequency during expansion. When provided, a single line is
+  /// chosen based on weighted probability unless [expandAllLines] is `true`.
+  /// Each selected line is expanded via [LineGraphEngine.expandLine] to
+  /// generate street-specific training spots.
+  final List<PostflopLine> postflopLines;
+
+  /// When `true`, all [postflopLines] are expanded regardless of their
+  /// [PostflopLine.weight].
+  final bool expandAllLines;
+
+  /// Optional deterministic seed used when randomly selecting among
+  /// [postflopLines].
+  final int? postflopLineSeed;
 
   /// Optional board texture preset used to filter `postflopLines` expansions.
   ///
@@ -52,8 +64,10 @@ class TrainingPackTemplateSet {
     this.suitAlternation = false,
     List<int>? stackDepthMods,
     List<LinePattern>? linePatterns,
-    List<String>? postflopLines,
+    List<PostflopLine>? postflopLines,
     this.boardTexturePreset,
+    this.expandAllLines = false,
+    this.postflopLineSeed,
   }) : variations = variations ?? const [],
        playerTypeVariations = playerTypeVariations ?? const [],
        stackDepthMods = stackDepthMods ?? const [],
@@ -83,15 +97,18 @@ class TrainingPackTemplateSet {
         LinePattern.fromJson(Map<String, dynamic>.from(p as Map)),
     ];
 
-    final postLines = <String>[
-      for (final l in (json['postflopLines'] as List? ?? [])) l.toString(),
+    final postLines = <PostflopLine>[
+      for (final l in (json['postflopLines'] as List? ?? []))
+        PostflopLine.fromJson(l),
     ];
-    final postLine = json['postflopLine']?.toString();
-    if (postLine != null && postLine.isNotEmpty) {
-      postLines.add(postLine);
+    final postLine = json['postflopLine'];
+    if (postLine != null && postLine.toString().isNotEmpty) {
+      postLines.add(PostflopLine.fromJson(postLine));
     }
 
     final preset = json['boardTexturePreset']?.toString();
+    final expandAll = json['expandAllLines'] == true;
+    final seed = json['postflopLineSeed'];
     return TrainingPackTemplateSet(
       baseSpot: base,
       variations: vars,
@@ -101,6 +118,8 @@ class TrainingPackTemplateSet {
       linePatterns: patterns,
       postflopLines: postLines,
       boardTexturePreset: preset,
+      expandAllLines: expandAll,
+      postflopLineSeed: seed is num ? seed.toInt() : null,
     );
   }
 
@@ -119,11 +138,15 @@ class TrainingPackTemplateSet {
     if (stackDepthMods.isNotEmpty) 'stackDepthMods': stackDepthMods,
     if (linePatterns.isNotEmpty)
       'linePatterns': [for (final p in linePatterns) p.toJson()],
-    if (postflopLines.length == 1)
-      'postflopLine': postflopLines.first
-    else if (postflopLines.length > 1)
-      'postflopLines': postflopLines,
+    if (postflopLines.length == 1 && postflopLines.first.weight == 1)
+      'postflopLine': postflopLines.first.line
+    else if (postflopLines.isNotEmpty)
+      'postflopLines': [
+        for (final l in postflopLines) l.weight == 1 ? l.line : l.toJson(),
+      ],
     if (boardTexturePreset != null && boardTexturePreset!.isNotEmpty)
       'boardTexturePreset': boardTexturePreset,
+    if (expandAllLines) 'expandAllLines': true,
+    if (postflopLineSeed != null) 'postflopLineSeed': postflopLineSeed,
   };
 }

--- a/test/services/training_pack_generator_postflop_line_test.dart
+++ b/test/services/training_pack_generator_postflop_line_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/postflop_line.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
@@ -21,7 +22,7 @@ void main() {
     );
     final set = TrainingPackTemplateSet(
       baseSpot: base,
-      postflopLines: ['cbet-check'],
+      postflopLines: [PostflopLine(line: 'cbet-check')],
     );
 
     final engine = TrainingPackGeneratorEngineV2();
@@ -52,7 +53,7 @@ void main() {
     );
     final set = TrainingPackTemplateSet(
       baseSpot: base,
-      postflopLines: ['cbet-check'],
+      postflopLines: [PostflopLine(line: 'cbet-check')],
       boardTexturePreset: 'lowPaired',
     );
 
@@ -78,7 +79,7 @@ void main() {
     );
     final set = TrainingPackTemplateSet(
       baseSpot: base,
-      postflopLines: ['cbet-check'],
+      postflopLines: [PostflopLine(line: 'cbet-check')],
       boardTexturePreset: 'dryAceHigh',
     );
 
@@ -103,7 +104,11 @@ void main() {
     );
     final set = TrainingPackTemplateSet(
       baseSpot: base,
-      postflopLines: ['cbet-check', 'check'],
+      postflopLines: [
+        PostflopLine(line: 'cbet-check'),
+        PostflopLine(line: 'check'),
+      ],
+      expandAllLines: true,
     );
 
     final engine = TrainingPackGeneratorEngineV2();
@@ -116,5 +121,36 @@ void main() {
       (s) => s.street == 1 && s.tags.contains('flopCheck'),
     );
     expect(altFlop.length, 1);
+  });
+
+  test('selects weighted postflop line deterministically', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', 'Kd', 'Qc', '2h'],
+        actions: {
+          0: [ActionEntry(0, 0, 'raise'), ActionEntry(0, 1, 'call')],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLines: [
+        PostflopLine(line: 'cbet-check', weight: 2),
+        PostflopLine(line: 'check', weight: 1),
+      ],
+      postflopLineSeed: 1,
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    // Only one of the lines should be expanded.
+    expect(spots.length, 3);
+    final hasCbet = spots.any((s) => s.tags.contains('flopCbet'));
+    final hasCheck = spots.any((s) => s.tags.contains('flopCheck'));
+    expect(hasCbet ^ hasCheck, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- support weighted postflop line definitions with optional global expansion override
- add deterministic seed and weight-aware selection when expanding lines
- cover weighted line behavior with new tests

## Testing
- `dart format lib/models/postflop_line.dart lib/models/training_pack_template_set.dart lib/services/training_pack_template_expander_service.dart test/services/training_pack_generator_postflop_line_test.dart`
- `dart pub get` *(fails: Flutter SDK is not available)*
- `snap install flutter --classic` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ebffa41c832a89c883b1aba5ad73