### PR TITLE
feat: add board texture exclusion presets

### DIFF
--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -57,6 +57,12 @@ class TrainingPackTemplateSet {
   /// matches the named preset via [BoardTexturePresetLibrary.matches].
   final String? boardTexturePreset;
 
+  /// Optional board texture presets that exclude `postflopLines` expansions.
+  ///
+  /// If any preset in this list matches the base spot's board via
+  /// [BoardTexturePresetLibrary.matches], the postflop lines are skipped.
+  final List<String> excludeBoardTexturePresets;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
@@ -66,13 +72,15 @@ class TrainingPackTemplateSet {
     List<LinePattern>? linePatterns,
     List<PostflopLine>? postflopLines,
     this.boardTexturePreset,
+    List<String>? excludeBoardTexturePresets,
     this.expandAllLines = false,
     this.postflopLineSeed,
   }) : variations = variations ?? const [],
        playerTypeVariations = playerTypeVariations ?? const [],
        stackDepthMods = stackDepthMods ?? const [],
        linePatterns = linePatterns ?? const [],
-       postflopLines = postflopLines ?? const [];
+       postflopLines = postflopLines ?? const [],
+       excludeBoardTexturePresets = excludeBoardTexturePresets ?? const [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     final baseMap = Map<String, dynamic>.from(
@@ -107,6 +115,10 @@ class TrainingPackTemplateSet {
     }
 
     final preset = json['boardTexturePreset']?.toString();
+    final excluded = <String>[
+      for (final p in (json['excludeBoardTexturePresets'] as List? ?? []))
+        p.toString(),
+    ];
     final expandAll = json['expandAllLines'] == true;
     final seed = json['postflopLineSeed'];
     return TrainingPackTemplateSet(
@@ -118,6 +130,7 @@ class TrainingPackTemplateSet {
       linePatterns: patterns,
       postflopLines: postLines,
       boardTexturePreset: preset,
+      excludeBoardTexturePresets: excluded,
       expandAllLines: expandAll,
       postflopLineSeed: seed is num ? seed.toInt() : null,
     );
@@ -146,6 +159,8 @@ class TrainingPackTemplateSet {
       ],
     if (boardTexturePreset != null && boardTexturePreset!.isNotEmpty)
       'boardTexturePreset': boardTexturePreset,
+    if (excludeBoardTexturePresets.isNotEmpty)
+      'excludeBoardTexturePresets': excludeBoardTexturePresets,
     if (expandAllLines) 'expandAllLines': true,
     if (postflopLineSeed != null) 'postflopLineSeed': postflopLineSeed,
   };

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -199,6 +199,12 @@ class TrainingPackTemplateExpanderService {
       }
     }
 
+    for (final ex in set.excludeBoardTexturePresets) {
+      if (BoardTexturePresetLibrary.matches(board, ex)) {
+        return [];
+      }
+    }
+
     final preActions = set.baseSpot.hand.actions[0] ?? [];
     final preflopAction = preActions.map((a) => a.action).join('-');
 

--- a/test/services/training_pack_generator_postflop_line_test.dart
+++ b/test/services/training_pack_generator_postflop_line_test.dart
@@ -90,6 +90,32 @@ void main() {
     expect(spots, hasLength(3));
   });
 
+  test('skips postflop line when board matches excluded preset', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', '9d', '4c'],
+        actions: {
+          0: [ActionEntry(0, 0, 'raise'), ActionEntry(0, 1, 'call')],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLines: [PostflopLine(line: 'cbet-check')],
+      excludeBoardTexturePresets: ['aceHigh'],
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    // Only the base spot should remain; line expansion is filtered out.
+    expect(spots, hasLength(1));
+    expect(spots.first.id, isNotEmpty);
+  });
+
   test('expands multiple postflop lines into combined spots', () {
     final base = TrainingPackSpot(
       id: 'base',


### PR DESCRIPTION
## Summary
- allow `TrainingPackTemplateSet` to list `excludeBoardTexturePresets`
- skip postflop line expansion when board hits an excluded preset
- cover board texture exclusion with unit test

## Testing
- `dart analyze`
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*

------
https://chatgpt.com/codex/tasks/task_e_6891ee3d303c832a93eb7808d30cce38