### PR TITLE
feat: track training session fingerprint

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -16,6 +16,8 @@ import 'services/service_registry.dart';
 import 'services/pack_library_loader_service.dart';
 import 'services/xp_goal_panel_booster_injector.dart';
 import 'services/training_session_fingerprint_service.dart';
+import 'services/training_session_context_service.dart';
+import 'services/training_session_context_service.dart';
 import 'helpers/training_pack_storage.dart';
 import 'core/error_logger.dart';
 import 'core/plugin_runtime.dart';
@@ -47,6 +49,8 @@ class AppBootstrap {
     registry.registerIfAbsent<EvaluationExecutor>(EvaluationExecutorService());
     registry.registerIfAbsent<TrainingSessionFingerprintService>(
         TrainingSessionFingerprintService());
+    registry.registerIfAbsent<TrainingSessionContextService>(
+        TrainingSessionContextService());
     XpGoalPanelBoosterInjector.instance.inject();
     _registry = registry;
     return registry;

--- a/lib/models/training_session_fingerprint.dart
+++ b/lib/models/training_session_fingerprint.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+class TrainingSessionFingerprint {
+  final String sessionId;
+  final DateTime startedAt;
+  final String packId;
+  final String trainingType;
+  final List<String> includedTags;
+  final List<String> involvedLines;
+  final String source;
+
+  TrainingSessionFingerprint({
+    required this.sessionId,
+    required this.startedAt,
+    required this.packId,
+    required this.trainingType,
+    List<String>? includedTags,
+    List<String>? involvedLines,
+    this.source = '',
+  })  : includedTags = includedTags ?? const [],
+        involvedLines = involvedLines ?? const [];
+
+  Map<String, dynamic> toJson() => {
+        'sessionId': sessionId,
+        'startedAt': startedAt.toIso8601String(),
+        'packId': packId,
+        'trainingType': trainingType,
+        'includedTags': includedTags,
+        'involvedLines': involvedLines,
+        'source': source,
+      };
+
+  @override
+  String toString() => jsonEncode(toJson());
+}
+

--- a/lib/services/training_session_context_service.dart
+++ b/lib/services/training_session_context_service.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:uuid/uuid.dart';
+
+import '../models/training_session_fingerprint.dart';
+import 'user_action_logger.dart';
+
+class TrainingSessionContextService {
+  TrainingSessionContextService({Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  final Uuid _uuid;
+  TrainingSessionFingerprint? _current;
+
+  TrainingSessionFingerprint start({
+    required String packId,
+    required String trainingType,
+    List<String> includedTags = const [],
+    List<String> involvedLines = const [],
+    String source = 'manual',
+  }) {
+    final fp = TrainingSessionFingerprint(
+      sessionId: _uuid.v4(),
+      startedAt: DateTime.now(),
+      packId: packId,
+      trainingType: trainingType,
+      includedTags: includedTags,
+      involvedLines: involvedLines,
+      source: source,
+    );
+    _current = fp;
+    unawaited(UserActionLogger.instance.logEvent({
+      'event': 'trainingSessionStart',
+      ...fp.toJson(),
+    }));
+    return fp;
+  }
+
+  TrainingSessionFingerprint? getCurrentSessionFingerprint() => _current;
+}
+

--- a/lib/services/training_session_service.dart
+++ b/lib/services/training_session_service.dart
@@ -44,6 +44,8 @@ import 'session_streak_tracker_service.dart';
 import 'smart_recap_banner_controller.dart';
 import 'training_progress_tracker_service.dart';
 import 'training_progress_logger.dart';
+import '../app_bootstrap.dart';
+import 'training_session_context_service.dart';
 
 class TrainingSessionService extends ChangeNotifier {
   Box<dynamic>? _box;
@@ -368,6 +370,15 @@ class TrainingSessionService extends ChangeNotifier {
     if (template.tags.contains('customPath')) {
       unawaited(LearningPathProgressService.instance.markCustomPathStarted());
     }
+    AppBootstrap.registry.get<TrainingSessionContextService>().start(
+      packId: template.id,
+      trainingType: 'standard',
+      includedTags: [
+        ...template.tags,
+        ...?sessionTags,
+      ],
+      source: 'manual',
+    );
     _template = template;
     _sessionTags
       ..clear()

--- a/test/services/training_session_context_service_test.dart
+++ b/test/services/training_session_context_service_test.dart
@@ -1,0 +1,17 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_session_context_service.dart';
+
+void main() {
+  test('start stores current fingerprint', () {
+    final service = TrainingSessionContextService();
+    final fp = service.start(
+      packId: 'pack1',
+      trainingType: 'manual',
+      includedTags: ['tagA'],
+      involvedLines: ['line1'],
+      source: 'historyReplay',
+    );
+    expect(fp.sessionId, isNotEmpty);
+    expect(service.getCurrentSessionFingerprint(), equals(fp));
+  });
+}


### PR DESCRIPTION
## Summary
- add new TrainingSessionFingerprint model for session metadata
- provide TrainingSessionContextService to manage fingerprints and log analytics
- integrate fingerprint tracking into TrainingSessionService and app bootstrap

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6891f02a1fe4832abc48ad030553285e