### PR TITLE
feat: add board cluster filters

### DIFF
--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -63,6 +63,14 @@ class TrainingPackTemplateSet {
   /// [BoardTexturePresetLibrary.matches], the postflop lines are skipped.
   final List<String> excludeBoardTexturePresets;
 
+  /// Board clusters that must be present on the base board for
+  /// `postflopLines` to expand.
+  final List<String> requiredBoardClusters;
+
+  /// Board clusters that must not be present on the base board for
+  /// `postflopLines` to expand.
+  final List<String> excludedBoardClusters;
+
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
@@ -73,6 +81,8 @@ class TrainingPackTemplateSet {
     List<PostflopLine>? postflopLines,
     this.boardTexturePreset,
     List<String>? excludeBoardTexturePresets,
+    List<String>? requiredBoardClusters,
+    List<String>? excludedBoardClusters,
     this.expandAllLines = false,
     this.postflopLineSeed,
   }) : variations = variations ?? const [],
@@ -80,7 +90,9 @@ class TrainingPackTemplateSet {
        stackDepthMods = stackDepthMods ?? const [],
        linePatterns = linePatterns ?? const [],
        postflopLines = postflopLines ?? const [],
-       excludeBoardTexturePresets = excludeBoardTexturePresets ?? const [];
+       excludeBoardTexturePresets = excludeBoardTexturePresets ?? const [],
+       requiredBoardClusters = requiredBoardClusters ?? const [],
+       excludedBoardClusters = excludedBoardClusters ?? const [];
 
   factory TrainingPackTemplateSet.fromJson(Map<String, dynamic> json) {
     final baseMap = Map<String, dynamic>.from(
@@ -119,6 +131,14 @@ class TrainingPackTemplateSet {
       for (final p in (json['excludeBoardTexturePresets'] as List? ?? []))
         p.toString(),
     ];
+    final requiredClusters = <String>[
+      for (final c in (json['requiredBoardClusters'] as List? ?? []))
+        c.toString(),
+    ];
+    final excludedClusters = <String>[
+      for (final c in (json['excludedBoardClusters'] as List? ?? []))
+        c.toString(),
+    ];
     final expandAll = json['expandAllLines'] == true;
     final seed = json['postflopLineSeed'];
     return TrainingPackTemplateSet(
@@ -131,6 +151,8 @@ class TrainingPackTemplateSet {
       postflopLines: postLines,
       boardTexturePreset: preset,
       excludeBoardTexturePresets: excluded,
+      requiredBoardClusters: requiredClusters,
+      excludedBoardClusters: excludedClusters,
       expandAllLines: expandAll,
       postflopLineSeed: seed is num ? seed.toInt() : null,
     );
@@ -161,6 +183,10 @@ class TrainingPackTemplateSet {
       'boardTexturePreset': boardTexturePreset,
     if (excludeBoardTexturePresets.isNotEmpty)
       'excludeBoardTexturePresets': excludeBoardTexturePresets,
+    if (requiredBoardClusters.isNotEmpty)
+      'requiredBoardClusters': requiredBoardClusters,
+    if (excludedBoardClusters.isNotEmpty)
+      'excludedBoardClusters': excludedBoardClusters,
     if (expandAllLines) 'expandAllLines': true,
     if (postflopLineSeed != null) 'postflopLineSeed': postflopLineSeed,
   };

--- a/lib/services/board_cluster_library.dart
+++ b/lib/services/board_cluster_library.dart
@@ -1,0 +1,26 @@
+import '../models/card_model.dart';
+import '../utils/board_analyzer_utils.dart';
+
+/// Maps raw boards into abstracted cluster labels used for filtering.
+class BoardClusterLibrary {
+  const BoardClusterLibrary._();
+
+  /// Returns a set of cluster names describing [board].
+  ///
+  /// Cluster names are derived from dynamic board tags with a few
+  /// additional composites for convenience (e.g. `static` for dry boards,
+  /// `trap` for paired/monotone boards, `broadway-heavy` for broadway
+  /// boards).
+  static Set<String> getClusters(List<CardModel> board) {
+    final tags = BoardAnalyzerUtils.tags(board).map((t) => t.toLowerCase()).toSet();
+    final clusters = <String>{...tags};
+
+    if (tags.contains('dry')) clusters.add('static');
+    if (tags.contains('broadway')) clusters.add('broadway-heavy');
+    if (tags.contains('paired') || tags.contains('monotone')) clusters.add('trap');
+    if (tags.contains('wet')) clusters.add('highinteraction');
+
+    return clusters;
+  }
+}
+

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -12,6 +12,7 @@ import 'full_board_generator_v2.dart';
 import 'line_graph_engine.dart';
 import 'inline_theory_node_linker.dart';
 import 'board_texture_preset_library.dart';
+import 'board_cluster_library.dart';
 import 'dart:math';
 
 /// Expands a [TrainingPackTemplateSet] into concrete [TrainingPackSpot]s using
@@ -201,6 +202,20 @@ class TrainingPackTemplateExpanderService {
 
     for (final ex in set.excludeBoardTexturePresets) {
       if (BoardTexturePresetLibrary.matches(board, ex)) {
+        return [];
+      }
+    }
+
+    final clusters = BoardClusterLibrary.getClusters(board)
+        .map((c) => c.toLowerCase())
+        .toSet();
+    for (final req in set.requiredBoardClusters) {
+      if (!clusters.contains(req.toLowerCase())) {
+        return [];
+      }
+    }
+    for (final ex in set.excludedBoardClusters) {
+      if (clusters.contains(ex.toLowerCase())) {
         return [];
       }
     }

--- a/test/services/training_pack_generator_postflop_line_test.dart
+++ b/test/services/training_pack_generator_postflop_line_test.dart
@@ -116,6 +116,78 @@ void main() {
     expect(spots.first.id, isNotEmpty);
   });
 
+  test('skips postflop line when required cluster mismatches', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', '9d', '4c'],
+        actions: {
+          0: [ActionEntry(0, 0, 'raise'), ActionEntry(0, 1, 'call')],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLines: [PostflopLine(line: 'cbet-check')],
+      requiredBoardClusters: ['wet'],
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    expect(spots, hasLength(1));
+  });
+
+  test('expands postflop line when required cluster matches', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', 'Kd', 'Qc'],
+        actions: {
+          0: [ActionEntry(0, 0, 'raise'), ActionEntry(0, 1, 'call')],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLines: [PostflopLine(line: 'cbet-check')],
+      requiredBoardClusters: ['wet'],
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    expect(spots, hasLength(3));
+  });
+
+  test('skips postflop line when board matches excluded cluster', () {
+    final base = TrainingPackSpot(
+      id: 'base',
+      hand: HandData(
+        heroCards: 'AhKh',
+        position: HeroPosition.btn,
+        board: ['As', 'Kd', 'Qc'],
+        actions: {
+          0: [ActionEntry(0, 0, 'raise'), ActionEntry(0, 1, 'call')],
+        },
+      ),
+    );
+    final set = TrainingPackTemplateSet(
+      baseSpot: base,
+      postflopLines: [PostflopLine(line: 'cbet-check')],
+      excludedBoardClusters: ['wet'],
+    );
+
+    final engine = TrainingPackGeneratorEngineV2();
+    final spots = engine.generate(set);
+
+    expect(spots, hasLength(1));
+  });
+
   test('expands multiple postflop lines into combined spots', () {
     final base = TrainingPackSpot(
       id: 'base',


### PR DESCRIPTION
## Summary
- support required and excluded board clusters in training pack templates
- derive cluster labels from board textures via new library
- filter postflop line expansion by cluster requirements and exclusions

## Testing
- `flutter test test/services/training_pack_generator_postflop_line_test.dart` *(fails: command not found)*
- `dart test test/services/training_pack_generator_postflop_line_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y dart-sdk` *(fails: Unable to locate package dart-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_6891f2be5ed0832a97f36dd2011945cb