### PR TITLE
feat: centralize board cluster filtering

### DIFF
--- a/lib/services/board_cluster_constraint_engine.dart
+++ b/lib/services/board_cluster_constraint_engine.dart
@@ -1,0 +1,30 @@
+import "../models/card_model.dart";
+import "board_cluster_library.dart";
+
+class BoardClusterConstraintEngine {
+  const BoardClusterConstraintEngine._();
+
+  static bool matches({
+    required List<CardModel> board,
+    List<String>? requiredClusters,
+    List<String>? excludedClusters,
+  }) {
+    final req = [
+      for (final c in requiredClusters ?? const []) c.toLowerCase(),
+    ];
+    final excl = [
+      for (final c in excludedClusters ?? const []) c.toLowerCase(),
+    ];
+    if (req.isEmpty && excl.isEmpty) return true;
+    final clusters = BoardClusterLibrary.getClusters(board)
+        .map((c) => c.toLowerCase())
+        .toSet();
+    for (final r in req) {
+      if (!clusters.contains(r)) return false;
+    }
+    for (final e in excl) {
+      if (clusters.contains(e)) return false;
+    }
+    return true;
+  }
+}

--- a/test/services/board_cluster_constraint_engine_test.dart
+++ b/test/services/board_cluster_constraint_engine_test.dart
@@ -1,0 +1,61 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/services/board_cluster_constraint_engine.dart';
+
+void main() {
+  group('BoardClusterConstraintEngine.matches', () {
+    final board = [
+      CardModel(rank: 'A', suit: 's'),
+      CardModel(rank: 'K', suit: 'd'),
+      CardModel(rank: 'Q', suit: 'c'),
+    ];
+
+    test('returns true when constraints satisfied', () {
+      expect(
+        BoardClusterConstraintEngine.matches(
+          board: board,
+          requiredClusters: ['broadway-heavy'],
+        ),
+        isTrue,
+      );
+    });
+
+    test('fails when required cluster missing', () {
+      expect(
+        BoardClusterConstraintEngine.matches(
+          board: board,
+          requiredClusters: ['trap'],
+        ),
+        isFalse,
+      );
+    });
+
+    test('fails when excluded cluster present', () {
+      expect(
+        BoardClusterConstraintEngine.matches(
+          board: board,
+          excludedClusters: ['broadway-heavy'],
+        ),
+        isFalse,
+      );
+    });
+
+    test('is case insensitive', () {
+      expect(
+        BoardClusterConstraintEngine.matches(
+          board: board,
+          requiredClusters: ['BROADWAY-HEAVY'],
+        ),
+        isTrue,
+      );
+    });
+
+    test('handles empty requirements', () {
+      expect(
+        BoardClusterConstraintEngine.matches(board: board),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add BoardClusterConstraintEngine to evaluate board cluster constraints
- use BoardClusterConstraintEngine in TrainingPackTemplateExpanderService
- cover BoardClusterConstraintEngine with unit tests

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891f9fa822c832ab7da2ae417b23974