### PR TITLE
Add multi-set template multi-set expander service

### DIFF
--- a/lib/services/training_pack_template_multi_set_expander_service.dart
+++ b/lib/services/training_pack_template_multi_set_expander_service.dart
@@ -1,0 +1,33 @@
+import '../models/training_pack_template_set.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_template_set_expander_service.dart';
+
+/// Expands multiple [TrainingPackTemplateSet]s into a single list of
+/// [TrainingPackSpot]s.
+///
+/// Each set is processed via [TrainingPackTemplateSetExpanderService].
+/// Invalid sets are skipped, and the resulting spots preserve the order of the
+/// input sets.
+class TrainingPackTemplateMultiSetExpanderService {
+  final TrainingPackTemplateSetExpanderService _expander;
+
+  TrainingPackTemplateMultiSetExpanderService({
+    TrainingPackTemplateSetExpanderService? expander,
+  }) : _expander = expander ?? TrainingPackTemplateSetExpanderService();
+
+  /// Expands all [sets] and returns the aggregated list of spots.
+  ///
+  /// If any set fails to expand, it is silently skipped.
+  List<TrainingPackSpot> expandAll(List<TrainingPackTemplateSet> sets) {
+    final results = <TrainingPackSpot>[];
+    for (final set in sets) {
+      try {
+        results.addAll(_expander.expand(set));
+      } catch (_) {
+        // Ignore invalid sets
+      }
+    }
+    return results;
+  }
+}
+

--- a/test/services/training_pack_template_multi_set_expander_service_test.dart
+++ b/test/services/training_pack_template_multi_set_expander_service_test.dart
@@ -1,0 +1,81 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/services/training_pack_template_multi_set_expander_service.dart';
+
+TrainingPackSpot _base({required String id}) => TrainingPackSpot(
+      id: id,
+      hand: HandData(
+        heroCards: 'Ah Kh',
+        position: HeroPosition.btn,
+        heroIndex: 0,
+        playerCount: 2,
+        board: [],
+      ),
+      board: [],
+    );
+
+void main() {
+  test('returns empty list when no sets provided', () {
+    final svc = TrainingPackTemplateMultiSetExpanderService();
+    final spots = svc.expandAll([]);
+    expect(spots, isEmpty);
+  });
+
+  test('expands multiple sets and preserves order', () {
+    final set1 = TrainingPackTemplateSet(
+      baseSpot: _base(id: 's1'),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [
+            ['As', 'Kd', 'Qc'],
+          ],
+        }),
+      ],
+    );
+    final set2 = TrainingPackTemplateSet(
+      baseSpot: _base(id: 's2'),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [
+            ['2h', '3d', '4c'],
+          ],
+        }),
+      ],
+    );
+    final svc = TrainingPackTemplateMultiSetExpanderService();
+    final spots = svc.expandAll([set1, set2]);
+    expect(spots, hasLength(2));
+    expect(spots.first.templateSourceId, 's1');
+    expect(spots.last.templateSourceId, 's2');
+  });
+
+  test('skips invalid sets and continues processing', () {
+    final invalid = TrainingPackTemplateSet(
+      baseSpot: _base(id: 'bad'),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [123],
+        }),
+      ],
+    );
+    final valid = TrainingPackTemplateSet(
+      baseSpot: _base(id: 'good'),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [
+            ['5h', '6d', '7c'],
+          ],
+        }),
+      ],
+    );
+    final svc = TrainingPackTemplateMultiSetExpanderService();
+    final spots = svc.expandAll([invalid, valid]);
+    expect(spots, hasLength(1));
+    expect(spots.first.templateSourceId, 'good');
+  });
+}
+


### PR DESCRIPTION
## Summary
- support expanding multiple template sets into aggregated spots via `TrainingPackTemplateMultiSetExpanderService`
- cover multi-set expansion and error skipping with tests

## Testing
- `flutter test test/services/training_pack_template_multi_set_expander_service_test.dart` *(fails: missing files and unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_6892005979d4832aa0a5ef6db8f1e02c