### PR TITLE
feat: add training pack library exporter

### DIFF
--- a/lib/services/training_pack_library_exporter.dart
+++ b/lib/services/training_pack_library_exporter.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+import '../models/training_pack_model.dart';
+
+class TrainingPackLibraryExporter {
+  final YamlEncoder _encoder;
+
+  const TrainingPackLibraryExporter({YamlEncoder? encoder})
+      : _encoder = encoder ?? const YamlEncoder();
+
+  Future<List<String>> saveToDirectory(
+    List<TrainingPackModel> packs,
+    String path,
+  ) async {
+    final dir = Directory(path);
+    await dir.create(recursive: true);
+    final result = <String>[];
+    final map = exportToMap(packs);
+    for (final entry in map.entries) {
+      final file = File('${dir.path}/${entry.key}');
+      await file.writeAsString(entry.value);
+      result.add(file.path);
+    }
+    return result;
+  }
+
+  Map<String, String> exportToMap(List<TrainingPackModel> packs) {
+    final map = <String, String>{};
+    for (final p in packs) {
+      map['${p.id}.yaml'] = _encoder.convert(_packToMap(p));
+    }
+    return map;
+  }
+
+  Map<String, dynamic> _packToMap(TrainingPackModel pack) => {
+        'id': pack.id,
+        'title': pack.title,
+        if (pack.tags.isNotEmpty) 'tags': pack.tags,
+        'spots': [for (final s in pack.spots) s.toYaml()],
+      };
+}
+

--- a/test/services/training_pack_library_exporter_test.dart
+++ b/test/services/training_pack_library_exporter_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/services/training_pack_library_exporter.dart';
+
+void main() {
+  TrainingPackModel buildPack(String id, String title, {List<String>? tags}) {
+    return TrainingPackModel(
+      id: id,
+      title: title,
+      spots: [TrainingPackSpot(id: 's$id', hand: HandData())],
+      tags: tags,
+    );
+  }
+
+  test('exportToMap exports multiple packs', () {
+    final exporter = TrainingPackLibraryExporter();
+    final packs = [
+      buildPack('p1', 'Pack 1', tags: ['a']),
+      buildPack('p2', 'Pack 2'),
+    ];
+    final map = exporter.exportToMap(packs);
+    expect(map.length, 2);
+    expect(map.containsKey('p1.yaml'), true);
+    expect(map.containsKey('p2.yaml'), true);
+    final yaml = map['p1.yaml']!;
+    expect(yaml.contains('id: p1'), true);
+    expect(yaml.contains('title: Pack 1'), true);
+  });
+
+  test('exportToMap handles empty list', () {
+    final exporter = TrainingPackLibraryExporter();
+    final map = exporter.exportToMap([]);
+    expect(map, isEmpty);
+  });
+
+  test('saveToDirectory writes correct files and content', () async {
+    final exporter = TrainingPackLibraryExporter();
+    final dir = await Directory.systemTemp.createTemp();
+    final pack = buildPack('p1', 'Pack 1');
+    final paths = await exporter.saveToDirectory([pack], dir.path);
+    expect(paths.length, 1);
+    final file = File('${dir.path}/p1.yaml');
+    expect(await file.exists(), true);
+    final content = await file.readAsString();
+    expect(content.contains('id: p1'), true);
+    expect(content.contains('title: Pack 1'), true);
+    await dir.delete(recursive: true);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TrainingPackLibraryExporter to generate YAML for multiple TrainingPackModel instances
- cover exporter with unit tests for map export, empty lists, and directory saves

## Testing
- `flutter test test/services/training_pack_library_exporter_test.dart` *(fails: compilation errors across project)*


------
https://chatgpt.com/codex/tasks/task_e_6892171fec78832ab59eb5393c129f50