### PR TITLE
feat: add training pack library importer

### DIFF
--- a/lib/services/training_pack_library_importer.dart
+++ b/lib/services/training_pack_library_importer.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+
+class TrainingPackLibraryImporter {
+  final List<String> errors = [];
+
+  Future<List<TrainingPackModel>> loadFromDirectory(String path) async {
+    final dir = Directory(path);
+    if (!await dir.exists()) return [];
+    final files = <String, String>{};
+    await for (final entity in dir.list()) {
+      if (entity is File &&
+          (entity.path.endsWith('.yaml') || entity.path.endsWith('.yml'))) {
+        files[entity.uri.pathSegments.last] = await entity.readAsString();
+      }
+    }
+    return importFromMap(files);
+  }
+
+  List<TrainingPackModel> importFromMap(Map<String, String> files) {
+    errors.clear();
+    final packs = <TrainingPackModel>[];
+    files.forEach((name, content) {
+      try {
+        final yaml = loadYaml(content);
+        if (yaml is! Map) {
+          errors.add('$name: YAML is not a map');
+          return;
+        }
+        final map = Map<String, dynamic>.from(yaml);
+        final id = map['id']?.toString();
+        final title = map['title']?.toString();
+        final spotsYaml = map['spots'];
+        if (id == null || id.isEmpty || title == null || title.isEmpty) {
+          errors.add('$name: missing id or title');
+          return;
+        }
+        if (spotsYaml is! List || spotsYaml.isEmpty) {
+          errors.add('$name: spots missing or empty');
+          return;
+        }
+        final spots = <TrainingPackSpot>[];
+        for (final s in spotsYaml) {
+          if (s is Map) {
+            try {
+              spots.add(
+                TrainingPackSpot.fromYaml(Map<String, dynamic>.from(s)),
+              );
+            } catch (e) {
+              errors.add('$name: invalid spot - $e');
+              return;
+            }
+          } else {
+            errors.add('$name: spot is not a map');
+            return;
+          }
+        }
+        final tags =
+            (map['tags'] as List?)?.map((e) => e.toString()).toList() ?? [];
+        packs.add(
+          TrainingPackModel(id: id, title: title, spots: spots, tags: tags),
+        );
+      } catch (e) {
+        errors.add('$name: $e');
+      }
+    });
+    return packs;
+  }
+}
+

--- a/test/services/training_pack_library_importer_test.dart
+++ b/test/services/training_pack_library_importer_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_library_importer.dart';
+
+void main() {
+  const validPack1 = '''
+id: p1
+title: Pack 1
+tags:
+  - a
+spots:
+  - id: s1
+    hand: {}
+''';
+  const validPack2 = '''
+id: p2
+title: Pack 2
+spots:
+  - id: s2
+    hand: {}
+''';
+
+  test('importFromMap imports multiple valid packs', () {
+    final importer = TrainingPackLibraryImporter();
+    final packs = importer.importFromMap({
+      'p1.yaml': validPack1,
+      'p2.yaml': validPack2,
+    });
+    expect(importer.errors, isEmpty);
+    expect(packs.length, 2);
+    expect(packs.first.id, 'p1');
+    expect(packs[1].title, 'Pack 2');
+  });
+
+  test('importFromMap handles malformed YAML', () {
+    final importer = TrainingPackLibraryImporter();
+    final packs = importer.importFromMap({'bad.yaml': 'id: 1\ntitle Pack'});
+    expect(packs, isEmpty);
+    expect(importer.errors, isNotEmpty);
+  });
+
+  test('importFromMap skips packs with missing fields', () {
+    final importer = TrainingPackLibraryImporter();
+    final packs = importer.importFromMap({
+      'missing_title.yaml': 'id: x\nspots: []',
+      'missing_spots.yaml': 'id: y\ntitle: T',
+    });
+    expect(packs, isEmpty);
+    expect(importer.errors.length, 2);
+  });
+
+  test('loadFromDirectory reads packs from disk', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    await File('${dir.path}/p1.yaml').writeAsString(validPack1);
+    final importer = TrainingPackLibraryImporter();
+    final packs = await importer.loadFromDirectory(dir.path);
+    expect(importer.errors, isEmpty);
+    expect(packs.length, 1);
+    expect(packs.first.title, 'Pack 1');
+    await dir.delete(recursive: true);
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement TrainingPackLibraryImporter for importing YAML packs from directory or map
- add tests covering valid imports, malformed YAML, missing fields

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68921b3056cc832a9ce58007e7a5cf6e