### PR TITLE
feat: add pack library round-trip validator

### DIFF
--- a/lib/services/pack_library_round_trip_validator_service.dart
+++ b/lib/services/pack_library_round_trip_validator_service.dart
@@ -1,0 +1,67 @@
+import 'package:collection/collection.dart';
+
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_library_exporter.dart';
+import 'training_pack_library_importer.dart';
+
+class RoundTripResult {
+  final bool success;
+  final List<String> errors;
+
+  RoundTripResult({required this.success, required this.errors});
+}
+
+class PackLibraryRoundTripValidatorService {
+  final TrainingPackLibraryExporter exporter;
+  final TrainingPackLibraryImporter importer;
+
+  PackLibraryRoundTripValidatorService({
+    TrainingPackLibraryExporter? exporter,
+    TrainingPackLibraryImporter? importer,
+  }) : exporter = exporter ?? const TrainingPackLibraryExporter(),
+       importer = importer ?? TrainingPackLibraryImporter();
+
+  RoundTripResult validate(List<TrainingPackModel> packs) {
+    final files = exporter.exportToMap(packs);
+    final imported = importer.importFromMap(files);
+    final errors = <String>[...importer.errors];
+
+    final importedMap = {for (final p in imported) p.id: p};
+
+    for (final original in packs) {
+      final roundTripped = importedMap[original.id];
+      if (roundTripped == null) {
+        errors.add('Pack ${original.id} missing after import');
+        continue;
+      }
+      if (original.title != roundTripped.title) {
+        errors.add('Pack ${original.id}: title mismatch');
+      }
+      if (!const UnorderedIterableEquality<String>().equals(
+        original.tags,
+        roundTripped.tags,
+      )) {
+        errors.add('Pack ${original.id}: tags mismatch');
+      }
+      if (original.spots.length != roundTripped.spots.length) {
+        errors.add('Pack ${original.id}: spot count mismatch');
+      }
+      final roundTrippedSpotMap = {for (final s in roundTripped.spots) s.id: s};
+      for (final spot in original.spots) {
+        final rtSpot = roundTrippedSpotMap[spot.id];
+        if (rtSpot == null) {
+          errors.add('Pack ${original.id}: spot ${spot.id} missing');
+          continue;
+        }
+        final origMap = spot.toYaml();
+        final rtMap = rtSpot.toYaml();
+        if (!const DeepCollectionEquality().equals(origMap, rtMap)) {
+          errors.add('Pack ${original.id}: spot ${spot.id} mismatch');
+        }
+      }
+    }
+
+    return RoundTripResult(success: errors.isEmpty, errors: errors);
+  }
+}

--- a/test/services/pack_library_round_trip_validator_service_test.dart
+++ b/test/services/pack_library_round_trip_validator_service_test.dart
@@ -1,0 +1,78 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/pack_library_round_trip_validator_service.dart';
+import 'package:poker_analyzer/services/training_pack_library_exporter.dart';
+import 'package:poker_analyzer/services/training_pack_library_importer.dart';
+
+TrainingPackModel buildPack() {
+  final spot = TrainingPackSpot(
+    id: 's1',
+    hand: HandData(heroCards: 'AhAd', position: HeroPosition.btn),
+    board: ['As', 'Kd', 'Qh'],
+  );
+  return TrainingPackModel(
+    id: 'p1',
+    title: 'Pack 1',
+    spots: [spot],
+    tags: ['tag1'],
+  );
+}
+
+class TagTamperingImporter extends TrainingPackLibraryImporter {
+  @override
+  List<TrainingPackModel> importFromMap(Map<String, String> files) {
+    final packs = super.importFromMap(files);
+    if (packs.isNotEmpty) {
+      packs.first.tags.add('extra');
+    }
+    return packs;
+  }
+}
+
+class BrokenExporter extends TrainingPackLibraryExporter {
+  @override
+  Map<String, String> exportToMap(List<TrainingPackModel> packs) {
+    final map = <String, String>{};
+    for (final p in packs) {
+      map['${p.id}.yaml'] =
+          'id: ${p.id}\n'
+          'title: ${p.title}\n'
+          'spots:\n'
+          '  - 123\n';
+    }
+    return map;
+  }
+}
+
+void main() {
+  test('returns success when round trip matches', () {
+    final service = PackLibraryRoundTripValidatorService();
+    final pack = buildPack();
+    final result = service.validate([pack]);
+    expect(result.success, isTrue);
+    expect(result.errors, isEmpty);
+  });
+
+  test('detects tag mismatches', () {
+    final service = PackLibraryRoundTripValidatorService(
+      importer: TagTamperingImporter(),
+    );
+    final pack = buildPack();
+    final result = service.validate([pack]);
+    expect(result.success, isFalse);
+    expect(result.errors, contains('Pack p1: tags mismatch'));
+  });
+
+  test('reports structural issues in spot serialization', () {
+    final service = PackLibraryRoundTripValidatorService(
+      exporter: BrokenExporter(),
+    );
+    final pack = buildPack();
+    final result = service.validate([pack]);
+    expect(result.success, isFalse);
+    expect(result.errors.any((e) => e.contains('spot is not a map')), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `PackLibraryRoundTripValidatorService` to ensure YAML export/import fidelity
- cover full match, tag mismatch, and structural issues in round-trip tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart pub get` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689243465650832a85fd061d6f14d6b7