### PR TITLE
feat: add training pack library differ

### DIFF
--- a/lib/services/training_pack_library_differ.dart
+++ b/lib/services/training_pack_library_differ.dart
@@ -1,0 +1,74 @@
+import 'package:collection/collection.dart';
+
+import '../models/training_pack_model.dart';
+import 'training_pack_library_importer.dart';
+
+class PackLibraryDiffResult {
+  final List<String> added;
+  final List<String> removed;
+  final List<String> changed;
+
+  PackLibraryDiffResult({
+    required this.added,
+    required this.removed,
+    required this.changed,
+  });
+}
+
+class TrainingPackLibraryDiffer {
+  final TrainingPackLibraryImporter importer;
+
+  TrainingPackLibraryDiffer({TrainingPackLibraryImporter? importer})
+    : importer = importer ?? TrainingPackLibraryImporter();
+
+  Future<PackLibraryDiffResult> diff(String oldDir, String newDir) async {
+    final oldPacks = await importer.loadFromDirectory(oldDir);
+    final newPacks = await importer.loadFromDirectory(newDir);
+
+    final oldMap = {for (final p in oldPacks) p.id: p};
+    final newMap = {for (final p in newPacks) p.id: p};
+
+    final added = <String>[];
+    final removed = <String>[];
+    final changed = <String>[];
+
+    final equality = const DeepCollectionEquality();
+
+    for (final id in oldMap.keys) {
+      final oldPack = oldMap[id]!;
+      final newPack = newMap[id];
+      if (newPack == null) {
+        removed.add(id);
+        continue;
+      }
+      final oldData = _packToMap(oldPack);
+      final newData = _packToMap(newPack);
+      if (!equality.equals(oldData, newData)) {
+        changed.add(id);
+      }
+    }
+
+    for (final id in newMap.keys) {
+      if (!oldMap.containsKey(id)) {
+        added.add(id);
+      }
+    }
+
+    added.sort();
+    removed.sort();
+    changed.sort();
+
+    return PackLibraryDiffResult(
+      added: added,
+      removed: removed,
+      changed: changed,
+    );
+  }
+
+  Map<String, dynamic> _packToMap(TrainingPackModel pack) => {
+    'id': pack.id,
+    'title': pack.title,
+    if (pack.tags.isNotEmpty) 'tags': List.of(pack.tags),
+    'spots': [for (final s in pack.spots) s.toYaml()],
+  };
+}

--- a/test/services/training_pack_library_differ_test.dart
+++ b/test/services/training_pack_library_differ_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_library_differ.dart';
+
+void main() {
+  const packA = '''
+id: a
+title: Pack A
+spots:
+  - id: s1
+    hand: {}
+''';
+
+  const packA2 = '''
+id: a
+title: Pack A2
+spots:
+  - id: s1
+    hand: {}
+''';
+
+  const packB = '''
+id: b
+title: Pack B
+spots:
+  - id: s2
+    hand: {}
+''';
+
+  const packC = '''
+id: c
+title: Pack C
+spots:
+  - id: s3
+    hand: {}
+''';
+
+  test('detects added, removed, and changed packs', () async {
+    final oldDir = await Directory.systemTemp.createTemp();
+    final newDir = await Directory.systemTemp.createTemp();
+    try {
+      await File('${oldDir.path}/a.yaml').writeAsString(packA);
+      await File('${oldDir.path}/b.yaml').writeAsString(packB);
+
+      await File('${newDir.path}/a.yaml').writeAsString(packA2);
+      await File('${newDir.path}/c.yaml').writeAsString(packC);
+
+      final differ = TrainingPackLibraryDiffer();
+      final result = await differ.diff(oldDir.path, newDir.path);
+
+      expect(result.added, ['c']);
+      expect(result.removed, ['b']);
+      expect(result.changed, ['a']);
+    } finally {
+      await oldDir.delete(recursive: true);
+      await newDir.delete(recursive: true);
+    }
+  });
+}

--- a/tool/pack_library_diff.dart
+++ b/tool/pack_library_diff.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/services/training_pack_library_differ.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.length != 2) {
+    stderr.writeln(
+      'Usage: dart run tool/pack_library_diff.dart <oldDir> <newDir>',
+    );
+    exit(64);
+  }
+
+  final differ = TrainingPackLibraryDiffer();
+  final result = await differ.diff(args[0], args[1]);
+
+  stdout.writeln(
+    'Comparing ${p.normalize(args[0])} to ${p.normalize(args[1])}:',
+  );
+  stdout.writeln('Added:   ${result.added}');
+  stdout.writeln('Removed: ${result.removed}');
+  stdout.writeln('Changed: ${result.changed}');
+}


### PR DESCRIPTION
## Summary
- add TrainingPackLibraryDiffer service to compare YAML pack directories
- provide command-line utility `tool/pack_library_diff.dart`
- cover differ with a unit test

## Testing
- `/tmp/dart-sdk/bin/dart format lib/services/training_pack_library_differ.dart tool/pack_library_diff.dart test/services/training_pack_library_differ_test.dart`
- `/tmp/dart-sdk/bin/dart test` *(fails: Flutter SDK is not available)*
- `/tmp/dart-sdk/bin/dart analyze` *(fails: numerous missing Flutter symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68924f1481ac832abf8da1d65aab17f5