### PR TITLE
feat: add training pack audit log service

### DIFF
--- a/bin/training_pack_audit_cli.dart
+++ b/bin/training_pack_audit_cli.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/services/audit_log_storage_service.dart';
+
+void main(List<String> args) async {
+  final storage = AuditLogStorageService();
+  String? packId;
+  DateTime? from;
+  DateTime? to;
+  for (final arg in args) {
+    if (arg.startsWith('--pack=')) {
+      packId = arg.substring(7);
+    } else if (arg.startsWith('--from=')) {
+      from = DateTime.tryParse(arg.substring(7));
+    } else if (arg.startsWith('--to=')) {
+      to = DateTime.tryParse(arg.substring(5));
+    }
+  }
+  final logs = await storage.query(packId: packId, from: from, to: to);
+  if (logs.isEmpty) {
+    stdout.writeln('No logs found');
+    return;
+  }
+  for (final e in logs) {
+    stdout.writeln(
+        '${e.timestamp.toIso8601String()} [${e.packId}] ${e.userId}: ${e.changedFields.join(', ')}');
+  }
+}

--- a/lib/models/training_pack_audit_entry.dart
+++ b/lib/models/training_pack_audit_entry.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+class TrainingPackAuditEntry {
+  final String packId;
+  final DateTime timestamp;
+  final String userId;
+  final List<String> changedFields;
+  final Map<String, dynamic> diffSnapshot;
+
+  TrainingPackAuditEntry({
+    required this.packId,
+    required this.timestamp,
+    required this.userId,
+    required this.changedFields,
+    Map<String, dynamic>? diffSnapshot,
+  }) : diffSnapshot = diffSnapshot ?? const {};
+
+  Map<String, dynamic> toJson() => {
+        'packId': packId,
+        'timestamp': timestamp.toIso8601String(),
+        'userId': userId,
+        'changedFields': changedFields,
+        'diffSnapshot': diffSnapshot,
+      };
+
+  factory TrainingPackAuditEntry.fromJson(Map<String, dynamic> json) {
+    return TrainingPackAuditEntry(
+      packId: json['packId']?.toString() ?? '',
+      timestamp:
+          DateTime.tryParse(json['timestamp']?.toString() ?? '') ?? DateTime.now(),
+      userId: json['userId']?.toString() ?? '',
+      changedFields: (json['changedFields'] as List?)
+              ?.map((e) => e.toString())
+              .toList() ??
+          <String>[],
+      diffSnapshot: json['diffSnapshot'] is Map
+          ? Map<String, dynamic>.from(json['diffSnapshot'] as Map)
+          : <String, dynamic>{},
+    );
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/lib/models/training_pack_model.dart
+++ b/lib/models/training_pack_model.dart
@@ -5,11 +5,14 @@ class TrainingPackModel {
   final String title;
   final List<TrainingPackSpot> spots;
   final List<String> tags;
+  final Map<String, dynamic> metadata;
 
   TrainingPackModel({
     required this.id,
     required this.title,
     required this.spots,
     List<String>? tags,
-  }) : tags = tags ?? const [];
+    Map<String, dynamic>? metadata,
+  })  : tags = tags ?? const [],
+        metadata = metadata ?? const {};
 }

--- a/lib/services/audit_log_storage_service.dart
+++ b/lib/services/audit_log_storage_service.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../models/training_pack_audit_entry.dart';
+
+class AuditLogStorageService {
+  final File _file;
+
+  AuditLogStorageService({String? filePath})
+      : _file = File(filePath ?? 'training_pack_audit_log.json');
+
+  Future<List<TrainingPackAuditEntry>> _readAll() async {
+    if (!await _file.exists()) {
+      return [];
+    }
+    final content = await _file.readAsString();
+    if (content.trim().isEmpty) return [];
+    final list = jsonDecode(content) as List;
+    return list
+        .map((e) => TrainingPackAuditEntry.fromJson(
+            Map<String, dynamic>.from(e as Map)))
+        .toList();
+  }
+
+  Future<void> append(TrainingPackAuditEntry entry) async {
+    final logs = await _readAll();
+    logs.add(entry);
+    final encoded = jsonEncode(logs.map((e) => e.toJson()).toList());
+    await _file.writeAsString(encoded);
+  }
+
+  Future<List<TrainingPackAuditEntry>> query({
+    String? packId,
+    DateTime? from,
+    DateTime? to,
+  }) async {
+    final logs = await _readAll();
+    return logs.where((e) {
+      if (packId != null && e.packId != packId) return false;
+      if (from != null && e.timestamp.isBefore(from)) return false;
+      if (to != null && e.timestamp.isAfter(to)) return false;
+      return true;
+    }).toList();
+  }
+}

--- a/lib/services/training_pack_audit_log_service.dart
+++ b/lib/services/training_pack_audit_log_service.dart
@@ -1,0 +1,74 @@
+import 'package:collection/collection.dart';
+
+import '../models/training_pack_model.dart';
+import '../models/training_pack_audit_entry.dart';
+import 'audit_log_storage_service.dart';
+
+class TrainingPackAuditLogService {
+  final AuditLogStorageService _storage;
+
+  TrainingPackAuditLogService({AuditLogStorageService? storage})
+      : _storage = storage ?? AuditLogStorageService();
+
+  Future<void> recordChange(
+    TrainingPackModel oldPack,
+    TrainingPackModel newPack, {
+    String userId = 'unknown',
+    DateTime? timestamp,
+  }) async {
+    final changedFields = <String>[];
+    final diff = <String, dynamic>{};
+    if (oldPack.title != newPack.title) {
+      changedFields.add('title');
+      diff['title'] = {'old': oldPack.title, 'new': newPack.title};
+    }
+    if (!_listEquals(oldPack.tags, newPack.tags)) {
+      changedFields.add('tags');
+      diff['tags'] = {'old': oldPack.tags, 'new': newPack.tags};
+    }
+    if (!_spotsEquals(oldPack.spots, newPack.spots)) {
+      changedFields.add('spots');
+      diff['spots'] = {
+        'oldCount': oldPack.spots.length,
+        'newCount': newPack.spots.length,
+      };
+    }
+    if (!_mapEquals(oldPack.metadata, newPack.metadata)) {
+      changedFields.add('metadata');
+      diff['metadata'] = {
+        'old': oldPack.metadata,
+        'new': newPack.metadata,
+      };
+    }
+    if (changedFields.isEmpty) {
+      return;
+    }
+    final entry = TrainingPackAuditEntry(
+      packId: newPack.id,
+      timestamp: timestamp ?? DateTime.now(),
+      userId: userId,
+      changedFields: changedFields,
+      diffSnapshot: diff,
+    );
+    await _storage.append(entry);
+  }
+
+  Future<List<TrainingPackAuditEntry>> getLogs({
+    String? packId,
+    DateTime? from,
+    DateTime? to,
+  }) async {
+    return _storage.query(packId: packId, from: from, to: to);
+  }
+
+  bool _listEquals(List a, List b) => const DeepCollectionEquality().equals(a, b);
+
+  bool _mapEquals(Map a, Map b) => const DeepCollectionEquality().equals(a, b);
+
+  bool _spotsEquals(List a, List b) {
+    final convert = const DeepCollectionEquality().equals;
+    final oldYaml = a.map((s) => s.toYaml()).toList();
+    final newYaml = b.map((s) => s.toYaml()).toList();
+    return convert(oldYaml, newYaml);
+  }
+}

--- a/lib/services/training_pack_library_differ.dart
+++ b/lib/services/training_pack_library_differ.dart
@@ -69,6 +69,7 @@ class TrainingPackLibraryDiffer {
     'id': pack.id,
     'title': pack.title,
     if (pack.tags.isNotEmpty) 'tags': List.of(pack.tags),
+    if (pack.metadata.isNotEmpty) 'metadata': Map.of(pack.metadata),
     'spots': [for (final s in pack.spots) s.toYaml()],
   };
 }

--- a/lib/services/training_pack_library_exporter.dart
+++ b/lib/services/training_pack_library_exporter.dart
@@ -38,6 +38,7 @@ class TrainingPackLibraryExporter {
         'id': pack.id,
         'title': pack.title,
         if (pack.tags.isNotEmpty) 'tags': pack.tags,
+        if (pack.metadata.isNotEmpty) 'metadata': pack.metadata,
         'spots': [for (final s in pack.spots) s.toYaml()],
       };
 }

--- a/lib/services/training_pack_library_importer.dart
+++ b/lib/services/training_pack_library_importer.dart
@@ -61,8 +61,17 @@ class TrainingPackLibraryImporter {
         }
         final tags =
             (map['tags'] as List?)?.map((e) => e.toString()).toList() ?? [];
+        final meta = map['metadata'] is Map
+            ? Map<String, dynamic>.from(map['metadata'] as Map)
+            : <String, dynamic>{};
         packs.add(
-          TrainingPackModel(id: id, title: title, spots: spots, tags: tags),
+          TrainingPackModel(
+            id: id,
+            title: title,
+            spots: spots,
+            tags: tags,
+            metadata: meta,
+          ),
         );
       } catch (e) {
         errors.add('$name: $e');

--- a/test/services/training_pack_audit_log_service_test.dart
+++ b/test/services/training_pack_audit_log_service_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/services/audit_log_storage_service.dart';
+import 'package:poker_analyzer/services/training_pack_audit_log_service.dart';
+
+void main() {
+  test('records changes between packs', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    final storage = AuditLogStorageService(
+        filePath: '${dir.path}/audit.json');
+    final service = TrainingPackAuditLogService(storage: storage);
+
+    final oldPack = TrainingPackModel(
+      id: 'p1',
+      title: 'Old',
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      tags: ['a'],
+      metadata: {'level': 1},
+    );
+    final newPack = TrainingPackModel(
+      id: 'p1',
+      title: 'New',
+      spots: [
+        TrainingPackSpot(id: 's1', hand: HandData()),
+        TrainingPackSpot(id: 's2', hand: HandData()),
+      ],
+      tags: ['b'],
+      metadata: {'level': 2},
+    );
+
+    await service.recordChange(oldPack, newPack, userId: 'tester',
+        timestamp: DateTime.utc(2024, 1, 1));
+    final logs = await storage.query();
+    expect(logs.length, 1);
+    final entry = logs.first;
+    expect(entry.packId, 'p1');
+    expect(entry.userId, 'tester');
+    expect(entry.changedFields,
+        containsAll(['title', 'tags', 'spots', 'metadata']));
+    expect(entry.diffSnapshot['title']['old'], 'Old');
+    expect(entry.diffSnapshot['title']['new'], 'New');
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- track metadata in `TrainingPackModel`
- add `TrainingPackAuditLogService` to record changes and persistent storage
- provide CLI and tests for auditing

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689258a6d2b8832a811f611c68cc0608