### PR TITLE
feat: enrich training pack metadata

### DIFF
--- a/lib/services/training_pack_metadata_enricher_service.dart
+++ b/lib/services/training_pack_metadata_enricher_service.dart
@@ -1,0 +1,141 @@
+import 'package:collection/collection.dart';
+
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/action_entry.dart';
+import 'training_pack_audit_log_service.dart';
+
+/// Analyzes [TrainingPackModel]s and enriches their metadata with
+/// computed characteristics such as difficulty, street coverage and stack
+/// distribution.
+class TrainingPackMetadataEnricherService {
+  final TrainingPackAuditLogService _audit;
+
+  TrainingPackMetadataEnricherService({TrainingPackAuditLogService? audit})
+      : _audit = audit ?? TrainingPackAuditLogService();
+
+  /// Returns a new [TrainingPackModel] with the metadata field populated
+  /// with derived attributes. If the metadata changes, an audit entry is
+  /// recorded via [_audit].
+  Future<TrainingPackModel> enrich(
+    TrainingPackModel pack, {
+    String userId = 'system',
+  }) async {
+    final newMeta = Map<String, dynamic>.from(pack.metadata);
+
+    final analysis = _analyze(pack.spots);
+    newMeta
+      ..addAll(analysis)
+      ..['numSpots'] = pack.spots.length;
+
+    final newPack = TrainingPackModel(
+      id: pack.id,
+      title: pack.title,
+      spots: pack.spots,
+      tags: pack.tags,
+      metadata: newMeta,
+    );
+
+    if (!const DeepCollectionEquality().equals(pack.metadata, newMeta)) {
+      await _audit.recordChange(pack, newPack, userId: userId);
+    }
+
+    return newPack;
+  }
+
+  Map<String, dynamic> _analyze(List<TrainingPackSpot> spots) {
+    var maxStreet = 0;
+    var hasLimp = false;
+    var complexActions = false;
+    double? minStack;
+    double? maxStack;
+    var stackTotal = 0.0;
+    var stackCount = 0;
+
+    for (final s in spots) {
+      // track street coverage using spot.street and board length
+      maxStreet = _maxStreet(maxStreet, s);
+
+      // check for limped pots
+      final preflop = s.hand.actions[0] ?? [];
+      if (preflop.any((a) => a.action == 'limp')) {
+        hasLimp = true;
+      } else {
+        final hasRaise = preflop.any((a) => a.action == 'raise' || a.action == 'bet');
+        final hasCall = preflop.any((a) => a.action == 'call');
+        if (!hasRaise && hasCall) hasLimp = true;
+      }
+
+      // inspect actions for complexity
+      if (!complexActions) {
+        for (final list in s.hand.actions.values) {
+          if (list.any(_isComplexAction)) {
+            complexActions = true;
+            break;
+          }
+        }
+      }
+
+      // stack spread using hero stack
+      final heroKey = s.hand.heroIndex.toString();
+      final stack = s.hand.stacks[heroKey] ?? 0;
+      minStack = (minStack == null) ? stack : (stack < minStack! ? stack : minStack);
+      maxStack = (maxStack == null) ? stack : (stack > maxStack! ? stack : maxStack);
+      stackTotal += stack;
+      stackCount++;
+    }
+
+    final avgStack = stackCount > 0 ? stackTotal / stackCount : 0.0;
+    final difficultyScore = (avgStack > 40 ? 1 : 0) +
+        (maxStreet >= 2 ? 1 : 0) +
+        (complexActions ? 1 : 0);
+
+    final difficulty = difficultyScore >= 3
+        ? 'hard'
+        : difficultyScore >= 1
+            ? 'medium'
+            : 'easy';
+
+    final streets = maxStreet >= 3
+        ? 'river'
+        : maxStreet >= 1
+            ? 'flop+turn'
+            : 'preflop';
+
+    return {
+      'difficulty': difficulty,
+      'streets': streets,
+      'stackSpread': {
+        'min': minStack ?? 0,
+        'max': maxStack ?? 0,
+      },
+      'hasLimpedPots': hasLimp,
+    };
+  }
+
+  int _maxStreet(int currentMax, TrainingPackSpot s) {
+    var street = s.street;
+    if (s.board.length >= 5) {
+      street = street < 3 ? 3 : street;
+    } else if (s.board.length >= 4) {
+      street = street < 2 ? 2 : street;
+    } else if (s.board.length >= 3) {
+      street = street < 1 ? 1 : street;
+    }
+    return street > currentMax ? street : currentMax;
+  }
+
+  bool _isComplexAction(ActionEntry a) {
+    const advanced = {
+      'raise',
+      'bet',
+      'check-raise',
+      '3bet',
+      '4bet',
+      'push',
+      'allin',
+    };
+    return advanced.contains(a.action.toLowerCase());
+  }
+}
+

--- a/test/services/training_pack_metadata_enricher_service_test.dart
+++ b/test/services/training_pack_metadata_enricher_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/services/training_pack_metadata_enricher_service.dart';
+import 'package:poker_analyzer/services/training_pack_audit_log_service.dart';
+
+class _FakeAuditService extends TrainingPackAuditLogService {
+  int calls = 0;
+  @override
+  Future<void> recordChange(TrainingPackModel oldPack, TrainingPackModel newPack,
+      {String userId = 'unknown', DateTime? timestamp}) async {
+    calls++;
+  }
+}
+
+void main() {
+  test('enriches metadata and records audit when changed', () async {
+    final spot1 = TrainingPackSpot(
+      id: 's1',
+      street: 0,
+      hand: HandData(
+        heroIndex: 0,
+        stacks: {'0': 30, '1': 30},
+        actions: {
+          0: [
+            ActionEntry(0, 1, 'limp'),
+            ActionEntry(0, 0, 'raise', amount: 3),
+          ],
+        },
+      ),
+    );
+    final spot2 = TrainingPackSpot(
+      id: 's2',
+      street: 2,
+      board: ['As', 'Ks', 'Qh', 'Jd'],
+      hand: HandData(
+        heroIndex: 0,
+        stacks: {'0': 70, '1': 70},
+        actions: {
+          0: [
+            ActionEntry(0, 0, 'raise', amount: 2),
+            ActionEntry(0, 1, 'call'),
+          ],
+          1: [
+            ActionEntry(1, 0, 'bet', amount: 3),
+            ActionEntry(1, 1, 'call'),
+          ],
+        },
+      ),
+    );
+    final pack = TrainingPackModel(
+      id: 'p1',
+      title: 'Test',
+      spots: [spot1, spot2],
+      metadata: const {},
+    );
+
+    final audit = _FakeAuditService();
+    final service = TrainingPackMetadataEnricherService(audit: audit);
+
+    final enriched = await service.enrich(pack);
+    expect(enriched.metadata['numSpots'], 2);
+    expect(enriched.metadata['hasLimpedPots'], isTrue);
+    expect(enriched.metadata['streets'], 'flop+turn');
+    expect(enriched.metadata['difficulty'], 'hard');
+    expect(enriched.metadata['stackSpread'], {'min': 30.0, 'max': 70.0});
+    expect(audit.calls, 1);
+
+    // running again should not trigger another audit as metadata stays same
+    await service.enrich(enriched);
+    expect(audit.calls, 1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TrainingPackMetadataEnricherService for automatic pack metadata
- cover service with tests including audit log integration

## Testing
- `flutter test test/services/training_pack_metadata_enricher_service_test.dart` *(fails: command not found)*
- `dart test test/services/training_pack_metadata_enricher_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68925df1762c832aa1e05906233ba6a5