### PR TITLE
feat: add batch training pack metadata enricher

### DIFF
--- a/lib/services/training_pack_auto_enricher_batch_service.dart
+++ b/lib/services/training_pack_auto_enricher_batch_service.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+
+import '../models/training_pack_model.dart';
+import 'training_pack_library_importer.dart';
+import 'training_pack_library_exporter.dart';
+import 'training_pack_metadata_enricher_service.dart';
+
+class TrainingPackEnrichmentReport {
+  final int enrichedCount;
+  final int changedCount;
+  final int skippedCount;
+
+  TrainingPackEnrichmentReport({
+    required this.enrichedCount,
+    required this.changedCount,
+    required this.skippedCount,
+  });
+}
+
+class TrainingPackAutoEnricherBatchService {
+  final TrainingPackLibraryImporter importer;
+  final TrainingPackMetadataEnricherService enricher;
+  final TrainingPackLibraryExporter exporter;
+
+  TrainingPackAutoEnricherBatchService({
+    TrainingPackLibraryImporter? importer,
+    TrainingPackMetadataEnricherService? enricher,
+    TrainingPackLibraryExporter? exporter,
+  }) : importer = importer ?? TrainingPackLibraryImporter(),
+       enricher = enricher ?? TrainingPackMetadataEnricherService(),
+       exporter = exporter ?? const TrainingPackLibraryExporter();
+
+  Future<TrainingPackEnrichmentReport> enrichDirectory(
+    String path, {
+    bool saveChanges = false,
+  }) async {
+    final dir = Directory(path);
+    if (!await dir.exists()) {
+      return TrainingPackEnrichmentReport(
+        enrichedCount: 0,
+        changedCount: 0,
+        skippedCount: 0,
+      );
+    }
+
+    var enriched = 0;
+    var changed = 0;
+    var skipped = 0;
+
+    await for (final entity in dir.list()) {
+      if (entity is! File ||
+          !(entity.path.endsWith('.yaml') || entity.path.endsWith('.yml'))) {
+        continue;
+      }
+
+      final name = entity.uri.pathSegments.last;
+      final content = await entity.readAsString();
+      final packs = importer.importFromMap({name: content});
+      if (packs.isEmpty) {
+        skipped++;
+        continue;
+      }
+      final original = packs.first;
+      final enrichedPack = await enricher.enrich(original);
+      enriched++;
+      final isSame = const DeepCollectionEquality().equals(
+        original.metadata,
+        enrichedPack.metadata,
+      );
+      if (!isSame) {
+        changed++;
+        if (saveChanges) {
+          final yaml = exporter.exportToMap([enrichedPack]).values.first;
+          await entity.writeAsString(yaml);
+        }
+      }
+    }
+
+    return TrainingPackEnrichmentReport(
+      enrichedCount: enriched,
+      changedCount: changed,
+      skippedCount: skipped,
+    );
+  }
+}

--- a/test/services/training_pack_auto_enricher_batch_service_test.dart
+++ b/test/services/training_pack_auto_enricher_batch_service_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_auto_enricher_batch_service.dart';
+
+void main() {
+  test('enriches directory and saves updates', () async {
+    final dir = await Directory.systemTemp.createTemp();
+
+    const pack1 = '''
+id: p1
+title: Pack 1
+spots:
+  - id: s1
+    hand: {}
+''';
+
+    const pack2 = '''
+id: p2
+title: Pack 2
+metadata:
+  difficulty: easy
+  streets: preflop
+  stackSpread:
+    min: 0
+    max: 0
+  hasLimpedPots: false
+  numSpots: 1
+spots:
+  - id: s2
+    hand: {}
+''';
+
+    const invalid = 'id: x\nspots: []';
+
+    await File('${dir.path}/p1.yaml').writeAsString(pack1);
+    await File('${dir.path}/p2.yaml').writeAsString(pack2);
+    await File('${dir.path}/bad.yaml').writeAsString(invalid);
+
+    final service = TrainingPackAutoEnricherBatchService();
+    final report = await service.enrichDirectory(dir.path, saveChanges: true);
+
+    expect(report.enrichedCount, 2);
+    expect(report.changedCount, 1);
+    expect(report.skippedCount, 1);
+
+    final updated = await File('${dir.path}/p1.yaml').readAsString();
+    expect(updated.contains('numSpots: 1'), isTrue);
+
+    final unchanged = await File('${dir.path}/p2.yaml').readAsString();
+    expect(unchanged, pack2);
+
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingPackAutoEnricherBatchService to bulk enrich YAML training packs and save updates
- cover enrichment flow with unit test

## Testing
- `dart test test/services/training_pack_auto_enricher_batch_service_test.dart` *(fails: Flutter SDK is not available)*


------
https://chatgpt.com/codex/tasks/task_e_68925fed6348832a8a03819a58ac2d05