### PR TITLE
feat: expand template sets into standalone packs

### DIFF
--- a/lib/services/training_pack_template_instance_expander_service.dart
+++ b/lib/services/training_pack_template_instance_expander_service.dart
@@ -1,0 +1,54 @@
+import '../models/training_pack_model.dart';
+import '../models/training_pack_template_set.dart';
+import 'training_pack_template_set_expander_service.dart';
+
+/// Expands a [TrainingPackTemplateSet] into standalone [TrainingPackModel]s.
+///
+/// Each generated pack contains a single spot produced by
+/// [TrainingPackTemplateSetExpanderService]. Shared metadata and tags are
+/// merged with per-spot data, and unique ids/titles are assigned based on the
+/// provided prefixes.
+class TrainingPackTemplateInstanceExpanderService {
+  final TrainingPackTemplateSetExpanderService _expander;
+
+  TrainingPackTemplateInstanceExpanderService({
+    TrainingPackTemplateSetExpanderService? expander,
+  }) : _expander = expander ?? TrainingPackTemplateSetExpanderService();
+
+  /// Generates packs from [set].
+  ///
+  /// [packIdPrefix] and [title] provide base values for the resulting packs.
+  /// Tags and metadata are merged with each spot's own fields.
+  List<TrainingPackModel> expand(
+    TrainingPackTemplateSet set, {
+    String? packIdPrefix,
+    String? title,
+    List<String> tags = const [],
+    Map<String, dynamic> metadata = const {},
+  }) {
+    final spots = _expander.expand(set);
+    final baseTitle = title ?? set.baseSpot.title;
+    final idPrefix = packIdPrefix ?? set.baseSpot.id;
+    final packs = <TrainingPackModel>[];
+    for (var i = 0; i < spots.length; i++) {
+      final spot = spots[i];
+      final id = '${idPrefix}_${i + 1}';
+      final boardSuffix =
+          spot.board.isNotEmpty ? ' - ${spot.board.join(' ')}' : '';
+      final packTitle = '$baseTitle$boardSuffix';
+      final mergedTags = {...tags, ...spot.tags}.toList()..sort();
+      final mergedMeta = {...metadata, ...spot.meta};
+      packs.add(
+        TrainingPackModel(
+          id: id,
+          title: packTitle,
+          spots: [spot],
+          tags: mergedTags,
+          metadata: mergedMeta,
+        ),
+      );
+    }
+    return packs;
+  }
+}
+

--- a/test/services/training_pack_template_instance_expander_service_test.dart
+++ b/test/services/training_pack_template_instance_expander_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/services/training_pack_template_instance_expander_service.dart';
+
+void main() {
+  TrainingPackSpot _baseSpot() => TrainingPackSpot(
+        id: 'base',
+        title: 'Base',
+        tags: ['init'],
+        hand: HandData(
+          heroCards: 'Ah Kh',
+          position: HeroPosition.btn,
+          heroIndex: 0,
+          playerCount: 2,
+          board: [],
+        ),
+        board: [],
+        meta: {'foo': 'bar'},
+      );
+
+  test('expands set into one-pack-per-spot', () {
+    final set = TrainingPackTemplateSet(
+      baseSpot: _baseSpot(),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [
+            ['As', 'Kd', 'Qc'],
+            ['2h', '3d', '4c'],
+          ],
+        }),
+      ],
+    );
+    final svc = TrainingPackTemplateInstanceExpanderService();
+    final packs = svc.expand(
+      set,
+      packIdPrefix: 'pack',
+      title: 'Drill',
+      tags: ['global'],
+      metadata: {'shared': 1},
+    );
+    expect(packs, hasLength(2));
+    final first = packs.first;
+    expect(first.id, 'pack_1');
+    expect(first.title, 'Drill - As Kd Qc');
+    expect(first.tags, containsAll(['global', 'init']));
+    expect(first.metadata['shared'], 1);
+    expect(first.metadata['foo'], 'bar');
+    expect(first.spots, hasLength(1));
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `TrainingPackTemplateInstanceExpanderService` to turn template sets into individual packs with merged tags and metadata
- cover expansion logic with unit test

## Testing
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68926719f7c8832aa7ea68adfa16c64f