### PR TITLE
feat: inject theory lessons for template sets

### DIFF
--- a/lib/services/theory_injector_from_template_set_service.dart
+++ b/lib/services/theory_injector_from_template_set_service.dart
@@ -1,0 +1,59 @@
+import '../models/theory_mini_lesson_node.dart';
+import '../models/training_pack_template_set.dart';
+import '../models/training_pack_model.dart';
+import 'training_pack_template_instance_expander_service.dart';
+
+/// Generates [TheoryMiniLessonNode]s for packs produced from a
+/// [TrainingPackTemplateSet].
+///
+/// Each generated lesson is linked to a single training pack and mirrors its
+/// tags and relevant metadata such as `stage` or `targetStreet`.
+class TheoryInjectorFromTemplateSetService {
+  final TrainingPackTemplateInstanceExpanderService _expander;
+
+  TheoryInjectorFromTemplateSetService({
+    TrainingPackTemplateInstanceExpanderService? expander,
+  }) : _expander = expander ?? TrainingPackTemplateInstanceExpanderService();
+
+  /// Creates theory lessons corresponding to packs expanded from [set].
+  ///
+  /// [titlePrefix] is prepended to each lesson title. Additional parameters are
+  /// forwarded to [TrainingPackTemplateInstanceExpanderService.expand] to ensure
+  /// consistency with generated packs.
+  List<TheoryMiniLessonNode> inject(
+    TrainingPackTemplateSet set, {
+    String titlePrefix = '',
+    String? packIdPrefix,
+    String? packTitle,
+    List<String> tags = const [],
+    Map<String, dynamic> metadata = const {},
+  }) {
+    final List<TrainingPackModel> packs = _expander.expand(
+      set,
+      packIdPrefix: packIdPrefix,
+      title: packTitle,
+      tags: tags,
+      metadata: metadata,
+    );
+
+    final lessons = <TheoryMiniLessonNode>[];
+    for (final pack in packs) {
+      final stage = pack.metadata['stage']?.toString();
+      final street = pack.metadata['targetStreet']?.toString() ??
+          pack.metadata['street']?.toString();
+      lessons.add(
+        TheoryMiniLessonNode(
+          id: 'theory_${pack.id}',
+          title: '$titlePrefix${pack.title}',
+          content: '',
+          tags: List<String>.from(pack.tags),
+          stage: stage,
+          targetStreet: street,
+          linkedPackIds: [pack.id],
+        ),
+      );
+    }
+    return lessons;
+  }
+}
+

--- a/test/services/theory_injector_from_template_set_service_test.dart
+++ b/test/services/theory_injector_from_template_set_service_test.dart
@@ -1,0 +1,70 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/constraint_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/hero_position.dart';
+import 'package:poker_analyzer/services/training_pack_template_instance_expander_service.dart';
+import 'package:poker_analyzer/services/theory_injector_from_template_set_service.dart';
+
+void main() {
+  TrainingPackSpot _baseSpot() => TrainingPackSpot(
+        id: 'base',
+        title: 'Base',
+        tags: ['init'],
+        hand: HandData(
+          heroCards: 'Ah Kh',
+          position: HeroPosition.btn,
+          heroIndex: 0,
+          playerCount: 2,
+          board: [],
+        ),
+        board: [],
+        meta: {'foo': 'bar'},
+      );
+
+  test('creates mini lessons for each generated pack', () {
+    final set = TrainingPackTemplateSet(
+      baseSpot: _baseSpot(),
+      variations: [
+        ConstraintSet(overrides: {
+          'board': [
+            ['As', 'Kd', 'Qc'],
+            ['2h', '3d', '4c'],
+          ],
+        }),
+      ],
+    );
+
+    final expander = TrainingPackTemplateInstanceExpanderService();
+    final packs = expander.expand(
+      set,
+      packIdPrefix: 'pack',
+      title: 'Drill',
+      tags: ['global'],
+      metadata: {'stage': 'level1'},
+    );
+
+    final injector = TheoryInjectorFromTemplateSetService(expander: expander);
+    final lessons = injector.inject(
+      set,
+      titlePrefix: 'Lesson: ',
+      packIdPrefix: 'pack',
+      packTitle: 'Drill',
+      tags: ['global'],
+      metadata: {'stage': 'level1'},
+    );
+
+    expect(lessons, hasLength(packs.length));
+
+    final firstPack = packs.first;
+    final firstLesson = lessons.first;
+    expect(firstLesson.id, 'theory_${firstPack.id}');
+    expect(firstLesson.title, 'Lesson: ${firstPack.title}');
+    expect(firstLesson.tags, containsAll(['global', 'init']));
+    expect(firstLesson.stage, 'level1');
+    expect(firstLesson.linkedPackIds, [firstPack.id]);
+    expect(firstLesson.content, isEmpty);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TheoryInjectorFromTemplateSetService to create theory mini lessons linked to generated packs
- cover service with tests ensuring IDs, titles, tags, and metadata are synced

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926bfedef0832aaebc4e6b8a9e9c85