### PR TITLE
feat: add theory library sync CLI

### DIFF
--- a/bin/theory_library_sync.dart
+++ b/bin/theory_library_sync.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:poker_analyzer/services/theory_pack_exporter_service.dart';
+import 'package:poker_analyzer/services/theory_pack_importer_service.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_library_service.dart';
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()..addFlag('help', abbr: 'h', negatable: false);
+  final result = parser.parse(args);
+  if (result['help'] as bool || result.rest.length < 2) {
+    stdout.writeln('Usage: dart theory_library_sync.dart <export|import> <dir>');
+    return;
+  }
+
+  final command = result.rest[0];
+  final dir = result.rest[1];
+
+  switch (command) {
+    case 'export':
+      await TheoryMiniLessonLibraryService.instance.loadFromDirs(const [
+        'assets/mini_lessons',
+        'assets/theory_mini_lessons',
+        'assets/theory_lessons/level1',
+        'assets/theory_lessons/level2',
+        'assets/theory_lessons/level3',
+      ]);
+      final lessons = TheoryMiniLessonLibraryService.instance.lessons;
+      final exporter = const TheoryPackExporterService();
+      final files = await exporter.export(lessons, dir);
+      stdout.writeln('Exported ${lessons.length} lessons into ${files.length} files.');
+      break;
+    case 'import':
+      final importer = const TheoryPackImporterService();
+      final lessons = await importer.importLessons(dir);
+      TheoryMiniLessonLibraryService.instance.register(lessons);
+      stdout.writeln('Imported ${lessons.length} lessons.');
+      break;
+    default:
+      stdout.writeln('Unknown command: $command');
+  }
+}
+

--- a/lib/services/theory_mini_lesson_library_service.dart
+++ b/lib/services/theory_mini_lesson_library_service.dart
@@ -1,0 +1,32 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'theory_pack_importer_service.dart';
+
+/// Simple in-memory library for [TheoryMiniLessonNode] used by CLI tools.
+class TheoryMiniLessonLibraryService {
+  TheoryMiniLessonLibraryService._();
+
+  /// Singleton instance.
+  static final TheoryMiniLessonLibraryService instance =
+      TheoryMiniLessonLibraryService._();
+
+  final List<TheoryMiniLessonNode> _lessons = [];
+
+  /// Unmodifiable list of loaded lessons.
+  List<TheoryMiniLessonNode> get lessons => List.unmodifiable(_lessons);
+
+  /// Loads lessons from [dirs] using [TheoryPackImporterService].
+  Future<void> loadFromDirs(List<String> dirs) async {
+    _lessons.clear();
+    final importer = const TheoryPackImporterService();
+    for (final dir in dirs) {
+      final list = await importer.importLessons(dir);
+      _lessons.addAll(list);
+    }
+  }
+
+  /// Adds [lessons] to the library.
+  void register(List<TheoryMiniLessonNode> lessons) {
+    _lessons.addAll(lessons);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add theory library sync CLI with export/import commands
- add simple TheoryMiniLessonLibraryService for CLI usage

## Testing
- `dart format bin/theory_library_sync.dart lib/services/theory_mini_lesson_library_service.dart` *(fails: command not found)*
- `dart test test/services/theory_pack_exporter_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927612eda0832a9b8f13b0dedd48c4