### PR TITLE
feat: add mini lesson content templating

### DIFF
--- a/lib/services/theory_mini_lesson_content_template_service.dart
+++ b/lib/services/theory_mini_lesson_content_template_service.dart
@@ -1,0 +1,73 @@
+import '../models/theory_mini_lesson_node.dart';
+
+/// Generates placeholder content for [TheoryMiniLessonNode]s based on tags and
+/// metadata such as `stage` or `targetStreet`.
+class TheoryMiniLessonContentTemplateService {
+  /// Mapping from composite keys to content templates.
+  ///
+  /// Keys may combine tags and metadata separated by commas, e.g.
+  /// `'BTN vs BB, Flop CBet'`.
+  final Map<String, String> templateMap;
+
+  TheoryMiniLessonContentTemplateService({Map<String, String>? templateMap})
+      : templateMap = templateMap ?? _defaultTemplates;
+
+  /// Returns a new [TheoryMiniLessonNode] with its `content` field populated
+  /// using a matching template. If no template is found or [node.content] is
+  /// already non-empty, the original [node] is returned.
+  TheoryMiniLessonNode withGeneratedContent(TheoryMiniLessonNode node) {
+    if (node.content.isNotEmpty) return node;
+    final template = _matchTemplate(node);
+    if (template == null) return node;
+    return TheoryMiniLessonNode(
+      id: node.id,
+      refId: node.refId,
+      title: node.title,
+      content: template,
+      tags: List<String>.from(node.tags),
+      stage: node.stage,
+      targetStreet: node.targetStreet,
+      nextIds: List<String>.from(node.nextIds),
+      linkedPackIds: List<String>.from(node.linkedPackIds),
+      recoveredFromMistake: node.recoveredFromMistake,
+    );
+  }
+
+  /// Populates a list of lessons using [withGeneratedContent].
+  List<TheoryMiniLessonNode> withGeneratedContentForAll(
+    List<TheoryMiniLessonNode> nodes,
+  ) {
+    return [for (final n in nodes) withGeneratedContent(n)];
+  }
+
+  String? _matchTemplate(TheoryMiniLessonNode node) {
+    for (final key in _candidateKeys(node)) {
+      final template = templateMap[key];
+      if (template != null) return template;
+    }
+    return null;
+  }
+
+  Iterable<String> _candidateKeys(TheoryMiniLessonNode node) sync* {
+    final stage = node.stage;
+    final street = node.targetStreet;
+    final tagsKey = node.tags.join(', ');
+    if (tagsKey.isNotEmpty) {
+      if (stage != null && street != null) {
+        yield '$tagsKey, $stage, $street';
+      }
+      if (stage != null) yield '$tagsKey, $stage';
+      if (street != null) yield '$tagsKey, $street';
+      yield tagsKey;
+    }
+    if (stage != null && street != null) yield '$stage, $street';
+    if (stage != null) yield stage;
+    if (street != null) yield street;
+  }
+
+  static const Map<String, String> _defaultTemplates = {
+    'BTN vs BB, Flop CBet':
+        "In this spot, you're playing BTN against BB on the flop. Your goal is to decide whether to continuation bet...",
+  };
+}
+

--- a/test/services/theory_mini_lesson_content_template_service_test.dart
+++ b/test/services/theory_mini_lesson_content_template_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_mini_lesson_content_template_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('fills content for single node', () {
+    final service = TheoryMiniLessonContentTemplateService(templateMap: {
+      'BTN vs BB, Flop CBet': 'template text',
+    });
+    final node = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'T',
+      content: '',
+      tags: ['BTN vs BB', 'Flop CBet'],
+    );
+    final result = service.withGeneratedContent(node);
+    expect(result.content, 'template text');
+  });
+
+  test('fills content for list', () {
+    final service = TheoryMiniLessonContentTemplateService(templateMap: {
+      'BTN vs BB, Flop CBet': 'template text',
+    });
+    final lessons = [
+      TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'T1',
+        content: '',
+        tags: ['BTN vs BB', 'Flop CBet'],
+      ),
+      TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'T2',
+        content: '',
+        tags: ['BTN vs BB', 'Flop CBet'],
+      ),
+    ];
+    final result = service.withGeneratedContentForAll(lessons);
+    expect(result.every((l) => l.content == 'template text'), isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add TheoryMiniLessonContentTemplateService to generate mini-lesson content from tag/street metadata
- cover templating with unit tests

## Testing
- `flutter test test/services/theory_mini_lesson_content_template_service_test.dart` *(fails: command not found)*
- `apt-get install dart -y` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689277d5a52c832a99eaafd4abcbd912