### PR TITLE
feat: centralize theory lesson templates

### DIFF
--- a/lib/constants/theory_lesson_template_map.dart
+++ b/lib/constants/theory_lesson_template_map.dart
@@ -1,0 +1,26 @@
+const Map<String, String> theoryLessonTemplateMap = {
+  'BTN vs BB, Flop CBet':
+      "As the aggressor on the button, continuation betting on the flop pressures the big blind's wide range. Focus on board texture and size accordingly.",
+  'SB vs BB, Flop Probe':
+      "When the preflop aggressor checks back, the small blind can probe to deny equity and pick up the pot on favorable boards.",
+  'CO vs BTN, Turn Check-Raise':
+      "After calling the button's flop bet, mix in turn check-raises on cards that strengthen your range and weaken theirs.",
+  'UTG vs MP, Flop 3-Bet':
+      "Facing a middle-position raise, 3-betting from under the gun represents a narrow, strong range aimed at denying equity and building the pot.",
+  'MP vs CO, River Overbet':
+      "Overbetting the river can apply maximum pressure on capped ranges; choose polarized hands when deciding to use this line.",
+  'BB Defense vs SB, Turn Float':
+      "Defending the big blind versus a small blind stab often requires floating the turn with hands that can bluff rivers or improve.",
+  'BTN vs SB, Flop Bet-3-Bet':
+      "Against a check-raise from the small blind, the button can respond with a bet-3-bet on flops that heavily favor their range.",
+  'CO vs BB, Turn Double Barrel':
+      "Firing the second barrel from the cutoff keeps pressure on the big blind's marginal holdings and sets up profitable river shoves.",
+  'SB vs BTN, Flop Check-Raise':
+      "Check-raising from the small blind targets the button's wide c-betting range; select strong value hands and balanced bluffs.",
+  'BB vs BTN, River Bluff-Catch':
+      "On the river, the big blind must defend with enough bluff-catchers to prevent the button from profitably over-bluffing.",
+  'HJ vs CO, Flop Donk Bet':
+      "Donk betting from the hijack can exploit boards that miss the cutoff's range while interacting well with your own.",
+  'UTG vs BB, Turn Probe':
+      "After the flop checks through, the big blind can probe the turn to realize equity and pressure the under-the-gun player's range.",
+};

--- a/lib/services/theory_mini_lesson_content_template_service.dart
+++ b/lib/services/theory_mini_lesson_content_template_service.dart
@@ -1,4 +1,5 @@
 import '../models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/constants/theory_lesson_template_map.dart';
 
 /// Generates placeholder content for [TheoryMiniLessonNode]s based on tags and
 /// metadata such as `stage` or `targetStreet`.
@@ -10,7 +11,7 @@ class TheoryMiniLessonContentTemplateService {
   final Map<String, String> templateMap;
 
   TheoryMiniLessonContentTemplateService({Map<String, String>? templateMap})
-      : templateMap = templateMap ?? _defaultTemplates;
+      : templateMap = templateMap ?? theoryLessonTemplateMap;
 
   /// Returns a new [TheoryMiniLessonNode] with its `content` field populated
   /// using a matching template. If no template is found or [node.content] is
@@ -65,9 +66,5 @@ class TheoryMiniLessonContentTemplateService {
     if (street != null) yield street;
   }
 
-  static const Map<String, String> _defaultTemplates = {
-    'BTN vs BB, Flop CBet':
-        "In this spot, you're playing BTN against BB on the flop. Your goal is to decide whether to continuation bet...",
-  };
 }
 

--- a/test/services/theory_mini_lesson_content_template_service_test.dart
+++ b/test/services/theory_mini_lesson_content_template_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
 import 'package:poker_analyzer/services/theory_mini_lesson_content_template_service.dart';
+import 'package:poker_analyzer/constants/theory_lesson_template_map.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -39,6 +40,18 @@ void main() {
     ];
     final result = service.withGeneratedContentForAll(lessons);
     expect(result.every((l) => l.content == 'template text'), isTrue);
+  });
+
+  test('uses centralized template map by default', () {
+    final service = TheoryMiniLessonContentTemplateService();
+    final node = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'T',
+      content: '',
+      tags: ['BTN vs BB', 'Flop CBet'],
+    );
+    final result = service.withGeneratedContent(node);
+    expect(result.content, theoryLessonTemplateMap['BTN vs BB, Flop CBet']);
   });
 }
 


### PR DESCRIPTION
## Summary
- add shared theory lesson template map with expanded coverage
- use centralized template map in TheoryMiniLessonContentTemplateService
- verify default template mapping in tests

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6892798df9ec832a953b39a8ddbff549