### PR TITLE
feat: support placeholders in mini lesson templates

### DIFF
--- a/lib/services/theory_mini_lesson_content_template_service.dart
+++ b/lib/services/theory_mini_lesson_content_template_service.dart
@@ -20,11 +20,12 @@ class TheoryMiniLessonContentTemplateService {
     if (node.content.isNotEmpty) return node;
     final template = _matchTemplate(node);
     if (template == null) return node;
+    final filled = _fillPlaceholders(template, node);
     return TheoryMiniLessonNode(
       id: node.id,
       refId: node.refId,
       title: node.title,
-      content: template,
+      content: filled,
       tags: List<String>.from(node.tags),
       stage: node.stage,
       targetStreet: node.targetStreet,
@@ -66,5 +67,42 @@ class TheoryMiniLessonContentTemplateService {
     if (street != null) yield street;
   }
 
-}
+  String _fillPlaceholders(String template, TheoryMiniLessonNode node) {
+    var result = template;
 
+    final posTag =
+        node.tags.firstWhere((t) => t.contains(' vs '), orElse: () => '');
+    if (posTag.isNotEmpty) {
+      final parts = posTag.split(' vs ');
+      final hero = parts.first;
+      final villain = parts.length > 1 ? parts[1] : '';
+      result = result.replaceAll('{position}', hero);
+      result = result.replaceAll('{villainPosition}', villain);
+    } else {
+      result = result.replaceAll('{position}', '');
+      result = result.replaceAll('{villainPosition}', '');
+    }
+
+    final boardTexture = _extractBoardTexture(node.tags);
+    result = result.replaceAll('{boardTexture}', boardTexture);
+
+    result = result.replaceAll('{stage}', node.stage ?? '');
+    result = result.replaceAll('{targetStreet}', node.targetStreet ?? '');
+
+    return result;
+  }
+
+  String _extractBoardTexture(List<String> tags) {
+    const textures = {
+      'Wet Board',
+      'Dry Board',
+      'Paired',
+      'Monotone',
+      'Rainbow',
+    };
+    for (final t in tags) {
+      if (textures.contains(t)) return t;
+    }
+    return '';
+  }
+}

--- a/test/services/theory_mini_lesson_content_template_service_test.dart
+++ b/test/services/theory_mini_lesson_content_template_service_test.dart
@@ -53,5 +53,25 @@ void main() {
     final result = service.withGeneratedContent(node);
     expect(result.content, theoryLessonTemplateMap['BTN vs BB, Flop CBet']);
   });
+
+  test('replaces placeholders with metadata', () {
+    final service = TheoryMiniLessonContentTemplateService(templateMap: {
+      'BTN vs BB, Flop CBet':
+          '{position} vs {villainPosition} on {targetStreet} {stage} {boardTexture}',
+    });
+    final node = TheoryMiniLessonNode(
+      id: 'n1',
+      title: 'T',
+      content: '',
+      tags: ['BTN vs BB', 'Flop CBet', 'Wet Board'],
+      stage: 'Level1',
+      targetStreet: 'Flop',
+    );
+    final result = service.withGeneratedContent(node);
+    expect(
+      result.content,
+      'BTN vs BB on Flop Level1 Wet Board',
+    );
+  });
 }
 


### PR DESCRIPTION
## Summary
- generate mini lesson content with metadata-driven placeholder substitution
- cover placeholder replacements with dedicated test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927aa334f4832abc9b52b646f54708