### PR TITLE
feat: extract lesson meta tags

### DIFF
--- a/lib/models/theory_lesson_meta_data.dart
+++ b/lib/models/theory_lesson_meta_data.dart
@@ -1,0 +1,14 @@
+/// Metadata extracted from [TheoryMiniLessonNode] title and tags.
+class TheoryLessonMetaData {
+  final String? position;
+  final String? villainPosition;
+  final String? street;
+  final String? boardTexture;
+
+  const TheoryLessonMetaData({
+    this.position,
+    this.villainPosition,
+    this.street,
+    this.boardTexture,
+  });
+}

--- a/lib/services/theory_lesson_meta_tag_extractor_service.dart
+++ b/lib/services/theory_lesson_meta_tag_extractor_service.dart
@@ -1,0 +1,118 @@
+import '../models/theory_lesson_meta_data.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Extracts structured metadata such as positions and streets from
+/// [TheoryMiniLessonNode] titles and tags.
+class TheoryLessonMetaTagExtractorService {
+  const TheoryLessonMetaTagExtractorService();
+
+  static final RegExp _positionRegExp = RegExp(
+    r'^(utg(?:\+\d)?|lj|mp|hj|co|btn|sb|bb)$',
+    caseSensitive: false,
+  );
+
+  static final RegExp _villainRegExp = RegExp(
+    r'vs\s*(utg(?:\+\d)?|lj|mp|hj|co|btn|sb|bb)',
+    caseSensitive: false,
+  );
+
+  static final RegExp _streetRegExp = RegExp(
+    r'(flop|turn|river)',
+    caseSensitive: false,
+  );
+
+  static const List<String> _textures = [
+    'paired',
+    'wet',
+    'dry',
+    'acehigh',
+  ];
+
+  /// Parses [lesson] and returns extracted [TheoryLessonMetaData].
+  TheoryLessonMetaData extract(TheoryMiniLessonNode lesson) {
+    String? position;
+    for (final tag in lesson.tags) {
+      final match = _positionRegExp.firstMatch(tag.trim());
+      if (match != null) {
+        position = match.group(1)!.toUpperCase();
+        break;
+      }
+    }
+
+    String? villainPosition;
+    for (final tag in lesson.tags) {
+      final match = _villainRegExp.firstMatch(tag);
+      if (match != null) {
+        villainPosition = match.group(1)!.toUpperCase();
+        break;
+      }
+    }
+    if (villainPosition == null) {
+      final match = _villainRegExp.firstMatch(lesson.title);
+      if (match != null) {
+        villainPosition = match.group(1)!.toUpperCase();
+      }
+    }
+
+    String? street;
+    for (final tag in lesson.tags) {
+      final match = _streetRegExp.firstMatch(tag);
+      if (match != null) {
+        street = _capitalize(match.group(1)!);
+        break;
+      }
+    }
+    if (street == null) {
+      final match = _streetRegExp.firstMatch(lesson.title);
+      if (match != null) {
+        street = _capitalize(match.group(1)!);
+      }
+    }
+
+    String? boardTexture;
+    for (final tag in lesson.tags) {
+      final lower = tag.toLowerCase();
+      for (final tex in _textures) {
+        if (lower.contains(tex)) {
+          boardTexture = _formatTexture(tex);
+          break;
+        }
+      }
+      if (boardTexture != null) break;
+    }
+    if (boardTexture == null) {
+      final lower = lesson.title.toLowerCase();
+      for (final tex in _textures) {
+        if (lower.contains(tex)) {
+          boardTexture = _formatTexture(tex);
+          break;
+        }
+      }
+    }
+
+    return TheoryLessonMetaData(
+      position: position,
+      villainPosition: villainPosition,
+      street: street,
+      boardTexture: boardTexture,
+    );
+  }
+
+  String _capitalize(String input) =>
+      input[0].toUpperCase() + input.substring(1).toLowerCase();
+
+  String _formatTexture(String input) {
+    switch (input) {
+      case 'acehigh':
+        return 'AceHigh';
+      case 'paired':
+        return 'Paired';
+      case 'wet':
+        return 'Wet';
+      case 'dry':
+        return 'Dry';
+      default:
+        return _capitalize(input);
+    }
+  }
+}

--- a/test/services/theory_lesson_meta_tag_extractor_service_test.dart
+++ b/test/services/theory_lesson_meta_tag_extractor_service_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_meta_tag_extractor_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TheoryLessonMetaTagExtractorService', () {
+    const service = TheoryLessonMetaTagExtractorService();
+
+    test('extracts metadata from tags', () {
+      const lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'BTN vs BB, Flop CBet',
+        content: '',
+        tags: ['BTN', 'vs BB', 'Flop', 'Dry'],
+      );
+
+      final meta = service.extract(lesson);
+
+      expect(meta.position, 'BTN');
+      expect(meta.villainPosition, 'BB');
+      expect(meta.street, 'Flop');
+      expect(meta.boardTexture, 'Dry');
+    });
+
+    test('extracts metadata from title when tags missing', () {
+      const lesson = TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'SB vs BTN on Paired Turn',
+        content: '',
+        tags: [],
+      );
+
+      final meta = service.extract(lesson);
+
+      expect(meta.position, isNull);
+      expect(meta.villainPosition, 'BTN');
+      expect(meta.street, 'Turn');
+      expect(meta.boardTexture, 'Paired');
+    });
+
+    test('returns nulls when no matches found', () {
+      const lesson = TheoryMiniLessonNode(
+        id: 'l3',
+        title: 'Generic lesson',
+        content: '',
+        tags: ['misc'],
+      );
+
+      final meta = service.extract(lesson);
+
+      expect(meta.position, isNull);
+      expect(meta.villainPosition, isNull);
+      expect(meta.street, isNull);
+      expect(meta.boardTexture, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryLessonMetaData for structured lesson metadata
- implement TheoryLessonMetaTagExtractorService to parse titles and tags
- cover meta extraction with unit tests

## Testing
- `flutter test test/services/theory_lesson_meta_tag_extractor_service_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68927c47a914832aa9861f71decce9bf