### PR TITLE
feat: link inline theory lessons in training spots

### DIFF
--- a/lib/models/training_spot.dart
+++ b/lib/models/training_spot.dart
@@ -2,10 +2,11 @@ import 'action_entry.dart';
 import 'card_model.dart';
 import 'player_model.dart';
 import 'saved_hand.dart';
+import 'spot_model.dart';
 
 enum SpotActionType { pushFold, callPush }
 
-class TrainingSpot {
+class TrainingSpot implements SpotModel {
   final List<List<CardModel>> playerCards;
   final List<CardModel> boardCards;
   final List<ActionEntry> actions;
@@ -31,6 +32,7 @@ class TrainingSpot {
   final int anteBb;
   final String? category;
   final List<String> tags;
+  final List<String> inlineLessons;
   final int difficulty;
   final int rating;
   final String? userAction;
@@ -79,8 +81,10 @@ class TrainingSpot {
     this.expectedValue,
     this.difficulty = 3,
     this.rating = 0,
+    List<String>? inlineLessons,
     DateTime? createdAt,
   })  : tags = tags ?? [],
+        inlineLessons = inlineLessons ?? [],
         createdAt = createdAt ?? DateTime.now();
 
   factory TrainingSpot.fromSavedHand(SavedHand hand) {
@@ -164,6 +168,7 @@ class TrainingSpot {
         'anteBb': anteBb,
         if (category != null) 'category': category,
         if (tags.isNotEmpty) 'tags': tags,
+        if (inlineLessons.isNotEmpty) 'inlineLessons': inlineLessons,
         if (strategyAdvice != null) 'strategyAdvice': strategyAdvice,
         'difficulty': difficulty,
         'rating': rating,
@@ -283,6 +288,9 @@ class TrainingSpot {
       anteBb: json['anteBb'] as int? ?? 0,
       category: json['category'] as String?,
       tags: [for (final t in (json['tags'] as List? ?? [])) t as String],
+      inlineLessons: [
+        for (final t in (json['inlineLessons'] as List? ?? [])) t as String
+      ],
       difficulty: (json['difficulty'] as num?)?.toInt() ?? 3,
       rating: (json['rating'] as num?)?.toInt() ?? 0,
       userAction: json['userAction'] as String?,
@@ -325,6 +333,7 @@ class TrainingSpot {
     List<List<double>>? rangeMatrix,
     DateTime? createdAt,
     int? anteBb,
+    List<String>? inlineLessons,
   }) {
     return TrainingSpot(
       playerCards: [for (final list in playerCards) List<CardModel>.from(list)],
@@ -346,6 +355,7 @@ class TrainingSpot {
       anteBb: anteBb ?? this.anteBb,
       category: category ?? this.category,
       tags: tags ?? List<String>.from(this.tags),
+      inlineLessons: inlineLessons ?? List<String>.from(this.inlineLessons),
       difficulty: difficulty ?? this.difficulty,
       rating: rating ?? this.rating,
       userAction: userAction ?? this.userAction,

--- a/lib/screens/training_spot_detail_screen.dart
+++ b/lib/screens/training_spot_detail_screen.dart
@@ -8,6 +8,7 @@ import '../services/training_session_controller.dart';
 import 'training_play_screen.dart';
 import '../widgets/sync_status_widget.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../services/theory_mini_lesson_navigator.dart';
 
 class TrainingSpotDetailScreen extends StatelessWidget {
   final TrainingSpot spot;
@@ -34,7 +35,15 @@ class TrainingSpotDetailScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(l.spotDetails),
         centerTitle: true,
-        actions: [SyncStatusIcon.of(context)],
+        actions: [
+          if (spot.inlineLessons.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.menu_book),
+              onPressed: () => TheoryMiniLessonNavigator.instance
+                  .openLessonById(spot.inlineLessons.first),
+            ),
+          SyncStatusIcon.of(context)
+        ],
       ),
       backgroundColor: Colors.black,
       body: ListView(

--- a/lib/services/theory_mini_lesson_navigator.dart
+++ b/lib/services/theory_mini_lesson_navigator.dart
@@ -39,5 +39,22 @@ class TheoryMiniLessonNavigator {
       MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
     );
   }
+
+  /// Opens a lesson directly by its [id].
+  Future<void> openLessonById(String id, [BuildContext? context]) async {
+    await _library.loadAll();
+    final lesson = _library.getById(id);
+    if (lesson == null) return;
+
+    BuildContext? ctx = context;
+    if (ctx == null || !(ctx.mounted)) {
+      ctx = _navigation.context;
+    }
+    if (ctx == null || !(ctx.mounted)) return;
+
+    await Navigator.of(ctx).push(
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
 }
 

--- a/test/services/inline_theory_linker_service_test.dart
+++ b/test/services/inline_theory_linker_service_test.dart
@@ -3,6 +3,10 @@ import 'package:poker_analyzer/models/theory_lesson_engagement_stats.dart';
 import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/training_spot.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
 import 'package:poker_analyzer/services/inline_theory_linker_service.dart';
 import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
 import 'package:poker_analyzer/services/theory_engagement_analytics_service.dart';
@@ -158,5 +162,56 @@ void main() {
     expect(spots[0].inlineLessonId, 'l1');
     expect(spots[1].inlineLessonId, 'l2');
     expect(spots[2].inlineLessonId, 'l3');
+  });
+
+  test('attachInlineLessonsToSpot filters by street and stage', () async {
+    final lessons = [
+      const TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'Flop CBet',
+        content: '',
+        tags: ['cbet'],
+        targetStreet: 'flop',
+        stage: 'basic',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'Turn CBet',
+        content: '',
+        tags: ['cbet', 'turn'],
+        targetStreet: 'turn',
+        stage: 'basic',
+      ),
+      const TheoryMiniLessonNode(
+        id: 'l3',
+        title: 'Flop Probe',
+        content: '',
+        tags: ['probe'],
+        targetStreet: 'flop',
+        stage: 'basic',
+      ),
+    ];
+    final service = InlineTheoryLinkerService(library: _FakeLibrary(lessons));
+    final spot = TrainingSpot(
+      playerCards: [<CardModel>[], <CardModel>[]],
+      boardCards: [
+        CardModel(rank: 'A', suit: 'h'),
+        CardModel(rank: 'K', suit: 'd'),
+        CardModel(rank: 'Q', suit: 'c'),
+      ],
+      actions: <ActionEntry>[],
+      heroIndex: 0,
+      numberOfPlayers: 2,
+      playerTypes: const [PlayerType.unknown, PlayerType.unknown],
+      positions: const ['UTG', 'BB'],
+      stacks: const [100, 100],
+      tags: ['cbet'],
+      category: 'basic',
+      anteBb: 0,
+      createdAt: DateTime(2024),
+    );
+
+    await service.attachInlineLessonsToSpot(spot);
+    expect(spot.inlineLessons, ['l1']);
   });
 }


### PR DESCRIPTION
## Summary
- add inlineLessons field to TrainingSpot and support serialization
- attach related theory mini-lessons to spots via InlineTheoryLinkerService
- expose inline lesson icon in TrainingSpotDetailScreen

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892826fbf48832aab54685e74d68200