### PR TITLE
feat: show linked content for line graph nodes

### DIFF
--- a/lib/services/line_graph_engine.dart
+++ b/lib/services/line_graph_engine.dart
@@ -104,6 +104,10 @@ class LineGraphEngine {
   List<TheoryMiniLessonNode> findLinkedLessons(LineGraphNode node) =>
       List.unmodifiable(_lessonLinks[node] ?? const []);
 
+  /// Returns training spots linked to [node].
+  List<TrainingPackSpot> findLinkedPacks(LineGraphNode node) =>
+      List.unmodifiable(_spotLinks[node] ?? const []);
+
   /// Returns next possible nodes reachable from [node].
   List<LineGraphNode> findNextOptions(LineGraphNode node) => [
         for (final e in _edges)

--- a/lib/widgets/line_graph_node_detail_widget.dart
+++ b/lib/widgets/line_graph_node_detail_widget.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../models/line_graph_node.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../screens/mini_lesson_screen.dart';
+import '../services/line_graph_engine.dart';
+import '../services/pack_library_service.dart';
+import '../services/training_session_launcher.dart';
+
+/// Displays lessons and training packs linked to a [LineGraphNode].
+class LineGraphNodeDetailWidget extends StatelessWidget {
+  final LineGraphNode node;
+  final LineGraphEngine engine;
+
+  const LineGraphNodeDetailWidget({
+    super.key,
+    required this.node,
+    required this.engine,
+  });
+
+  String _title(LineGraphNode n) {
+    String cap(String v) =>
+        v.isEmpty ? v : v[0].toUpperCase() + v.substring(1);
+    return '${cap(n.street)} ${cap(n.action)} — ${n.position}';
+  }
+
+  Future<void> _openLesson(
+    BuildContext context,
+    TheoryMiniLessonNode lesson,
+  ) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => MiniLessonScreen(lesson: lesson)),
+    );
+  }
+
+  Future<void> _startPack(BuildContext context, TrainingPackSpot spot) async {
+    final packId = spot.meta['packId']?.toString();
+    if (packId == null) return;
+    final tpl = await PackLibraryService.instance.getById(packId);
+    if (tpl == null) return;
+    await const TrainingSessionLauncher().launch(tpl);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lessons = engine.findLinkedLessons(node);
+    final packs = engine.findLinkedPacks(node);
+    final title = _title(node);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        if (lessons.isEmpty && packs.isEmpty) ...[
+          const Text('Нет связанных уроков или тренировок'),
+        ] else ...[
+          if (lessons.isNotEmpty) ...[
+            for (final l in lessons)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Row(
+                  children: [
+                    Expanded(child: Text(l.resolvedTitle)),
+                    ElevatedButton(
+                      onPressed: () => _openLesson(context, l),
+                      child: const Text('Открыть'),
+                    ),
+                  ],
+                ),
+              ),
+            if (packs.isNotEmpty) const SizedBox(height: 16),
+          ],
+          if (packs.isNotEmpty) ...[
+            for (final p in packs)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Row(
+                  children: [
+                    Expanded(child: Text(p.title)),
+                    ElevatedButton(
+                      onPressed: () => _startPack(context, p),
+                      child: const Text('Начать'),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ],
+      ],
+    );
+  }
+}

--- a/test/line_graph_builder_service_test.dart
+++ b/test/line_graph_builder_service_test.dart
@@ -31,6 +31,7 @@ void main() {
     expect(line.length, 2);
     final start = line.first;
     expect(engine.findLinkedLessons(start).map((l) => l.id), contains('l1'));
+    expect(engine.findLinkedPacks(start).map((s) => s.id), contains('s1'));
     final next = engine.findNextOptions(start);
     expect(next.length, 1);
     expect(engine.findLinkedLessons(next.first).map((l) => l.id), contains('l2'));


### PR DESCRIPTION
## Summary
- expose `findLinkedPacks` in `LineGraphEngine` to surface training spots attached to a node
- add `LineGraphNodeDetailWidget` to display linked lessons and drills with quick actions
- verify pack linking in `LineGraphBuilderService` test

## Testing
- `dart test test/line_graph_builder_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892868157a8832a82e0836263ef3032