### PR TITLE
feat: track theory suggestion engagement

### DIFF
--- a/lib/models/theory_suggestion_engagement_event.dart
+++ b/lib/models/theory_suggestion_engagement_event.dart
@@ -1,0 +1,27 @@
+class TheorySuggestionEngagementEvent {
+  final String lessonId;
+  final String action; // 'suggested' | 'expanded' | 'opened'
+  final DateTime timestamp;
+
+  const TheorySuggestionEngagementEvent({
+    required this.lessonId,
+    required this.action,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'action': action,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory TheorySuggestionEngagementEvent.fromJson(
+      Map<String, dynamic> json) {
+    return TheorySuggestionEngagementEvent(
+      lessonId: json['lessonId'] as String? ?? '',
+      action: json['action'] as String? ?? '',
+      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
+}

--- a/lib/services/theory_suggestion_engagement_tracker_service.dart
+++ b/lib/services/theory_suggestion_engagement_tracker_service.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_suggestion_engagement_event.dart';
+
+/// Tracks user engagement with automatically suggested theory lessons.
+class TheorySuggestionEngagementTrackerService {
+  TheorySuggestionEngagementTrackerService._();
+
+  /// Singleton instance.
+  static final TheorySuggestionEngagementTrackerService instance =
+      TheorySuggestionEngagementTrackerService._();
+
+  static const String _prefsKey = 'theory_suggestion_engagement_events';
+
+  final List<TheorySuggestionEngagementEvent> _events = [];
+  bool _loaded = false;
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_prefsKey) ?? [];
+    _events
+      ..clear()
+      ..addAll(raw.map((e) => TheorySuggestionEngagementEvent.fromJson(
+          jsonDecode(e) as Map<String, dynamic>)));
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      [for (final e in _events) jsonEncode(e.toJson())],
+    );
+  }
+
+  Future<void> _log(String lessonId, String action) async {
+    await _load();
+    _events.add(TheorySuggestionEngagementEvent(
+      lessonId: lessonId,
+      action: action,
+      timestamp: DateTime.now(),
+    ));
+    await _save();
+  }
+
+  /// Records that a lesson suggestion was shown to the user.
+  Future<void> lessonSuggested(String lessonId) => _log(lessonId, 'suggested');
+
+  /// Records that the suggested lesson was expanded by the user.
+  Future<void> lessonExpanded(String lessonId) => _log(lessonId, 'expanded');
+
+  /// Records that the full lesson was opened by the user.
+  Future<void> lessonOpened(String lessonId) => _log(lessonId, 'opened');
+
+  /// Returns a map of lesson ids and their count for the given [action].
+  Future<Map<String, int>> countByAction(String action) async {
+    await _load();
+    final counts = <String, int>{};
+    for (final e in _events.where((e) => e.action == action)) {
+      counts[e.lessonId] = (counts[e.lessonId] ?? 0) + 1;
+    }
+    return counts;
+  }
+}

--- a/test/services/theory_suggestion_engagement_tracker_service_test.dart
+++ b/test/services/theory_suggestion_engagement_tracker_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_suggestion_engagement_tracker_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('tracks lesson suggestion interactions', () async {
+    final service = TheorySuggestionEngagementTrackerService.instance;
+
+    await service.lessonSuggested('l1');
+    await service.lessonExpanded('l1');
+    await service.lessonOpened('l1');
+    await service.lessonSuggested('l2');
+
+    final suggested = await service.countByAction('suggested');
+    final expanded = await service.countByAction('expanded');
+    final opened = await service.countByAction('opened');
+
+    expect(suggested['l1'], 1);
+    expect(suggested['l2'], 1);
+    expect(expanded['l1'], 1);
+    expect(expanded['l2'], isNull);
+    expect(opened['l1'], 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheorySuggestionEngagementEvent` model to serialize lesson engagement actions
- log suggested, expanded, opened mini-lessons with `TheorySuggestionEngagementTrackerService`
- cover engagement tracking flow with a unit test

## Testing
- `flutter test test/services/theory_suggestion_engagement_tracker_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68928cc1c2f0832ab7d5f848e5d2c2e1