### PR TITLE
feat: cluster theory lessons via shared engagement

### DIFF
--- a/lib/models/theory_lesson_cluster.dart
+++ b/lib/models/theory_lesson_cluster.dart
@@ -2,10 +2,13 @@ import 'theory_mini_lesson_node.dart';
 
 class TheoryLessonCluster {
   final List<TheoryMiniLessonNode> lessons;
-  final Set<String> tags;
+  final Set<String> sharedTags;
 
   const TheoryLessonCluster({
     required this.lessons,
-    required this.tags,
-  });
+    required Set<String> tags,
+  }) : sharedTags = tags;
+
+  @Deprecated('Use sharedTags')
+  Set<String> get tags => sharedTags;
 }

--- a/lib/services/theory_lesson_cluster_linker_service.dart
+++ b/lib/services/theory_lesson_cluster_linker_service.dart
@@ -1,0 +1,138 @@
+import '../models/theory_lesson_cluster.dart';
+import 'mini_lesson_library_service.dart';
+import 'theory_suggestion_engagement_tracker_service.dart';
+
+/// Links theory lessons into clusters based on shared tags, linked packs,
+/// and co-suggestion history.
+class TheoryLessonClusterLinkerService {
+  final MiniLessonLibraryService library;
+  final TheorySuggestionEngagementTrackerService tracker;
+
+  TheoryLessonClusterLinkerService({
+    MiniLessonLibraryService? library,
+    TheorySuggestionEngagementTrackerService? tracker,
+  })  : library = library ?? MiniLessonLibraryService.instance,
+        tracker = tracker ?? TheorySuggestionEngagementTrackerService.instance;
+
+  List<TheoryLessonCluster>? _cache;
+
+  /// Returns all computed clusters, building them on first use.
+  Future<List<TheoryLessonCluster>> clusters() async {
+    if (_cache != null) return _cache!;
+    _cache = await _build();
+    return _cache!;
+  }
+
+  /// Returns the cluster containing [lessonId], if any.
+  Future<TheoryLessonCluster?> getCluster(String lessonId) async {
+    final clusters = await clusters();
+    for (final c in clusters) {
+      for (final l in c.lessons) {
+        if (l.id == lessonId) return c;
+      }
+    }
+    return null;
+  }
+
+  Future<List<TheoryLessonCluster>> _build() async {
+    await library.loadAll();
+    final lessons = library.all;
+    final byId = {for (final l in lessons) l.id: l};
+    final adj = <String, Set<String>>{for (final l in lessons) l.id: <String>{}};
+
+    // Shared tags.
+    final tagIndex = <String, List<String>>{};
+    for (final l in lessons) {
+      for (final t in l.tags) {
+        final key = t.trim().toLowerCase();
+        if (key.isEmpty) continue;
+        tagIndex.putIfAbsent(key, () => []).add(l.id);
+      }
+    }
+    for (final ids in tagIndex.values) {
+      for (var i = 0; i < ids.length; i++) {
+        for (var j = i + 1; j < ids.length; j++) {
+          adj[ids[i]]!.add(ids[j]);
+          adj[ids[j]]!.add(ids[i]);
+        }
+      }
+    }
+
+    // Shared linked packs.
+    final packIndex = <String, List<String>>{};
+    for (final l in lessons) {
+      for (final p in l.linkedPackIds) {
+        final key = p.trim();
+        if (key.isEmpty) continue;
+        packIndex.putIfAbsent(key, () => []).add(l.id);
+      }
+    }
+    for (final ids in packIndex.values) {
+      for (var i = 0; i < ids.length; i++) {
+        for (var j = i + 1; j < ids.length; j++) {
+          adj[ids[i]]!.add(ids[j]);
+          adj[ids[j]]!.add(ids[i]);
+        }
+      }
+    }
+
+    // Co-suggestions from engagement history.
+    final events = await tracker.eventsByAction('suggested');
+    final byTime = <int, List<String>>{};
+    for (final e in events) {
+      final t = e.timestamp.millisecondsSinceEpoch;
+      byTime.putIfAbsent(t, () => []).add(e.lessonId);
+    }
+    final pairCounts = <String, int>{};
+    for (final ids in byTime.values) {
+      for (var i = 0; i < ids.length; i++) {
+        for (var j = i + 1; j < ids.length; j++) {
+          final a = ids[i];
+          final b = ids[j];
+          final key = a.compareTo(b) < 0 ? '$a|$b' : '$b|$a';
+          pairCounts[key] = (pairCounts[key] ?? 0) + 1;
+        }
+      }
+    }
+    pairCounts.forEach((key, count) {
+      if (count >= 3) {
+        final parts = key.split('|');
+        final a = parts[0];
+        final b = parts[1];
+        adj[a]!.add(b);
+        adj[b]!.add(a);
+      }
+    });
+
+    // Connected components.
+    final visited = <String>{};
+    final clusters = <TheoryLessonCluster>[];
+    for (final id in byId.keys) {
+      if (!visited.add(id)) continue;
+      final stack = <String>[id];
+      final ids = <String>[];
+      final tags = <String>{};
+      while (stack.isNotEmpty) {
+        final cur = stack.removeLast();
+        ids.add(cur);
+        final node = byId[cur];
+        if (node == null) continue;
+        for (final t in node.tags) {
+          final tr = t.trim();
+          if (tr.isNotEmpty) tags.add(tr);
+        }
+        for (final n in adj[cur] ?? {}) {
+          if (visited.add(n)) stack.add(n);
+        }
+      }
+      clusters.add(TheoryLessonCluster(
+        lessons: [for (final cid in ids) byId[cid]!],
+        tags: tags,
+      ));
+    }
+
+    clusters.sort((a, b) => b.lessons.length.compareTo(a.lessons.length));
+    return clusters;
+  }
+}
+

--- a/lib/services/theory_suggestion_engagement_tracker_service.dart
+++ b/lib/services/theory_suggestion_engagement_tracker_service.dart
@@ -64,4 +64,11 @@ class TheorySuggestionEngagementTrackerService {
     }
     return counts;
   }
+
+  /// Returns all events matching [action].
+  Future<List<TheorySuggestionEngagementEvent>> eventsByAction(
+      String action) async {
+    await _load();
+    return _events.where((e) => e.action == action).toList(growable: false);
+  }
 }

--- a/test/services/theory_lesson_cluster_linker_service_test.dart
+++ b/test/services/theory_lesson_cluster_linker_service_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/theory_suggestion_engagement_event.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_lesson_cluster_linker_service.dart';
+import 'package:poker_analyzer/services/theory_suggestion_engagement_tracker_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) =>
+      [for (final t in tags) ...lessons.where((l) => l.tags.contains(t))];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => findByTags(tags.toList());
+
+  @override
+  List<String> linkedPacksFor(String lessonId) =>
+      getById(lessonId)?.linkedPackIds ?? const [];
+}
+
+class _FakeTracker implements TheorySuggestionEngagementTrackerService {
+  final List<TheorySuggestionEngagementEvent> events;
+  _FakeTracker(this.events);
+
+  @override
+  Future<void> lessonSuggested(String lessonId) async {}
+
+  @override
+  Future<void> lessonExpanded(String lessonId) async {}
+
+  @override
+  Future<void> lessonOpened(String lessonId) async {}
+
+  @override
+  Future<Map<String, int>> countByAction(String action) async => const {};
+
+  @override
+  Future<List<TheorySuggestionEngagementEvent>> eventsByAction(String action) async =>
+      events.where((e) => e.action == action).toList();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('clusters lessons by tags, packs and co-suggestions', () async {
+    final lessons = [
+      TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: '',
+        tags: const ['x'],
+        linkedPackIds: const ['p1'],
+      ),
+      TheoryMiniLessonNode(
+        id: 'l2',
+        title: 'L2',
+        content: '',
+        tags: const ['x'],
+      ),
+      TheoryMiniLessonNode(
+        id: 'l3',
+        title: 'L3',
+        content: '',
+        tags: const ['y'],
+        linkedPackIds: const ['p1'],
+      ),
+      TheoryMiniLessonNode(
+        id: 'l4',
+        title: 'L4',
+        content: '',
+        tags: const ['z'],
+      ),
+      TheoryMiniLessonNode(
+        id: 'l5',
+        title: 'L5',
+        content: '',
+        tags: const ['w'],
+      ),
+    ];
+
+    final now = DateTime(2023, 1, 1);
+    final events = <TheorySuggestionEngagementEvent>[];
+    for (var i = 0; i < 3; i++) {
+      final t = now.add(Duration(minutes: i));
+      events.add(TheorySuggestionEngagementEvent(
+          lessonId: 'l4', action: 'suggested', timestamp: t));
+      events.add(TheorySuggestionEngagementEvent(
+          lessonId: 'l5', action: 'suggested', timestamp: t));
+    }
+
+    final library = _FakeLibrary(lessons);
+    final tracker = _FakeTracker(events);
+    final service = TheoryLessonClusterLinkerService(
+      library: library,
+      tracker: tracker,
+    );
+
+    final clusters = await service.clusters();
+    expect(clusters.length, 2);
+
+    final idsCluster1 = clusters[0].lessons.map((e) => e.id).toSet();
+    final idsCluster2 = clusters[1].lessons.map((e) => e.id).toSet();
+
+    expect(idsCluster1, containsAll(['l1', 'l2', 'l3']));
+    expect(idsCluster2, containsAll(['l4', 'l5']));
+
+    final cluster = await service.getCluster('l5');
+    expect(cluster, isNotNull);
+    expect(cluster!.lessons.map((e) => e.id).toSet(), {'l4', 'l5'});
+  });
+}


### PR DESCRIPTION
## Summary
- expose sharedTags on TheoryLessonCluster with backward-compatible getter
- allow accessing engagement events by action for co-suggestion analysis
- add TheoryLessonClusterLinkerService to cluster lessons via tags, linked packs and co-suggestions

## Testing
- `flutter test test/services/theory_lesson_cluster_linker_service_test.dart` *(fails: command not found)*
- `dart test test/services/theory_lesson_cluster_linker_service_test.dart` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689291b95820832ab77f97d8a705a3e4