### PR TITLE
feat: notify on new theory lesson unlock

### DIFF
--- a/lib/services/theory_lesson_unlock_notification_service.dart
+++ b/lib/services/theory_lesson_unlock_notification_service.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'mini_lesson_library_service.dart';
+
+/// Shows a notification when new theory lessons become unlocked.
+class TheoryLessonUnlockNotificationService {
+  TheoryLessonUnlockNotificationService({MiniLessonLibraryService? library})
+      : _library = library ?? MiniLessonLibraryService.instance;
+
+  final MiniLessonLibraryService _library;
+
+  /// Key used to store unlocked lesson ids in [SharedPreferences].
+  static const storageKey = 'unlocked_theory_lessons';
+
+  /// Compares [currentUnlockedLessonIds] with previously stored ids and shows
+  /// notifications for newly unlocked lessons.
+  Future<void> checkAndNotify(
+    List<String> currentUnlockedLessonIds,
+    BuildContext context,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final previous = prefs.getStringList(storageKey)?.toSet() ?? <String>{};
+    final current = currentUnlockedLessonIds.toSet();
+    final newIds = current.difference(previous);
+
+    if (newIds.isEmpty) {
+      await prefs.setStringList(storageKey, currentUnlockedLessonIds);
+      return;
+    }
+
+    await _library.loadAll();
+    for (final id in newIds) {
+      if (!context.mounted) break;
+      final title = _library.getById(id)?.title ?? id;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('New lesson unlocked: $title')),
+      );
+    }
+
+    await prefs.setStringList(storageKey, currentUnlockedLessonIds);
+  }
+}
+

--- a/test/services/theory_lesson_unlock_notification_service_test.dart
+++ b/test/services/theory_lesson_unlock_notification_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/theory_lesson_unlock_notification_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final Map<String, TheoryMiniLessonNode> items;
+  _FakeLibrary(this.items);
+
+  @override
+  List<TheoryMiniLessonNode> get all => items.values.toList();
+
+  @override
+  TheoryMiniLessonNode? getById(String id) => items[id];
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => const [];
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('shows snackbar for newly unlocked lessons', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      TheoryLessonUnlockNotificationService.storageKey: ['a'],
+    });
+    final library = _FakeLibrary({
+      'a': const TheoryMiniLessonNode(id: 'a', title: 'A', content: ''),
+      'b': const TheoryMiniLessonNode(id: 'b', title: 'B', content: ''),
+    });
+    final service = TheoryLessonUnlockNotificationService(library: library);
+    final key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: Container(key: key))),
+    );
+    final ctx = key.currentContext!;
+    await service.checkAndNotify(['a', 'b'], ctx);
+    await tester.pump();
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('New lesson unlocked: B'), findsOneWidget);
+  });
+
+  testWidgets('does nothing when no new lessons', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      TheoryLessonUnlockNotificationService.storageKey: ['a'],
+    });
+    final library = _FakeLibrary({
+      'a': const TheoryMiniLessonNode(id: 'a', title: 'A', content: ''),
+    });
+    final service = TheoryLessonUnlockNotificationService(library: library);
+    final key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: Container(key: key))),
+    );
+    final ctx = key.currentContext!;
+    await service.checkAndNotify(['a'], ctx);
+    await tester.pump();
+    expect(find.byType(SnackBar), findsNothing);
+  });
+}
+


### PR DESCRIPTION
## Summary
- show SnackBar when new theory lessons unlock
- track unlocked lesson ids in SharedPreferences
- add tests for notification behavior

## Testing
- `flutter test test/services/theory_lesson_unlock_notification_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892982dad40832abd45ea4515d10529