### PR TITLE
feat: add view action to lesson unlock snackbar

### DIFF
--- a/lib/services/theory_lesson_unlock_notification_service.dart
+++ b/lib/services/theory_lesson_unlock_notification_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'mini_lesson_library_service.dart';
+import '../screens/theory_lesson_viewer_screen.dart';
 
 /// Shows a notification when new theory lessons become unlocked.
 class TheoryLessonUnlockNotificationService {
@@ -32,9 +33,28 @@ class TheoryLessonUnlockNotificationService {
     await _library.loadAll();
     for (final id in newIds) {
       if (!context.mounted) break;
-      final title = _library.getById(id)?.title ?? id;
+      final lesson = _library.getById(id);
+      final title = lesson?.title ?? id;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('New lesson unlocked: $title')),
+        SnackBar(
+          content: Text('New lesson unlocked: $title'),
+          action: SnackBarAction(
+            label: 'View',
+            onPressed: () {
+              if (!context.mounted || lesson == null) return;
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TheoryLessonViewerScreen(
+                    lesson: lesson,
+                    currentIndex: 1,
+                    totalCount: 1,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
       );
     }
 

--- a/test/services/theory_lesson_unlock_notification_service_test.dart
+++ b/test/services/theory_lesson_unlock_notification_service_test.dart
@@ -53,6 +53,7 @@ void main() {
     await tester.pump();
     expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('New lesson unlocked: B'), findsOneWidget);
+    expect(find.text('View'), findsOneWidget);
   });
 
   testWidgets('does nothing when no new lessons', (tester) async {


### PR DESCRIPTION
## Summary
- show "View" button in theory lesson unlock snackbar to jump directly to the lesson
- cover unlock notification with updated test for the action button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929bc96750832a99b197e7699375d2