### PR TITLE
feat: show lesson progress in unlock notification

### DIFF
--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -4,6 +4,7 @@ import '../asset_manifest.dart';
 import '../core/training/generation/yaml_reader.dart';
 import '../models/theory_mini_lesson_node.dart';
 import 'theory_mini_lesson_factory_service.dart';
+import 'theory_lesson_completion_logger.dart';
 
 /// Loads and indexes mini lesson blocks stored as YAML files.
 class MiniLessonLibraryService {
@@ -76,4 +77,18 @@ class MiniLessonLibraryService {
   /// Returns lessons matching any of [tags]. Convenience for Set input.
   List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
       findByTags(tags.toList());
+}
+
+extension MiniLessonLibraryProgress on MiniLessonLibraryService {
+  Future<int> getTotalLessonCount() async {
+    await loadAll();
+    return all.length;
+  }
+
+  Future<int> getCompletedLessonCount() async {
+    await loadAll();
+    final completed =
+        await TheoryLessonCompletionLogger.instance.getCompletedLessons();
+    return completed.keys.where((id) => getById(id) != null).length;
+  }
 }

--- a/lib/services/theory_lesson_unlock_notification_service.dart
+++ b/lib/services/theory_lesson_unlock_notification_service.dart
@@ -31,13 +31,17 @@ class TheoryLessonUnlockNotificationService {
     }
 
     await _library.loadAll();
+    final total = await _library.getTotalLessonCount();
+    final completed = await _library.getCompletedLessonCount();
     for (final id in newIds) {
       if (!context.mounted) break;
       final lesson = _library.getById(id);
       final title = lesson?.title ?? id;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('New lesson unlocked: $title'),
+          content: Text(
+            'New lesson unlocked: $title\n($completed of $total lessons complete)',
+          ),
           action: SnackBarAction(
             label: 'View',
             onPressed: () {

--- a/test/services/theory_lesson_unlock_notification_service_test.dart
+++ b/test/services/theory_lesson_unlock_notification_service_test.dart
@@ -52,7 +52,10 @@ void main() {
     await service.checkAndNotify(['a', 'b'], ctx);
     await tester.pump();
     expect(find.byType(SnackBar), findsOneWidget);
-    expect(find.text('New lesson unlocked: B'), findsOneWidget);
+    expect(
+      find.text('New lesson unlocked: B\n(0 of 2 lessons complete)'),
+      findsOneWidget,
+    );
     expect(find.text('View'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- expose total and completed lesson counts in MiniLessonLibraryService
- include lesson progress in lesson unlock SnackBar
- adjust unit test for updated SnackBar message

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68929e72e4e4832abb8d2220f5b04e23