### PR TITLE
Show lesson progress in resume card

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -40,7 +40,6 @@ import '../widgets/smart_recap_preview_widget.dart';
 import '../widgets/theory_inbox_banner.dart';
 import '../widgets/training_recommender_banner.dart';
 import '../widgets/leak_insight_banner.dart';
-import '../widgets/theory_lesson_progress_widget.dart';
 import '../widgets/daily_focus_recap_card.dart';
 import '../widgets/daily_focus_card.dart';
 import '../widgets/progress_summary_box.dart';
@@ -157,7 +156,6 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
           const TheoryInboxBanner(),
           const LeakInsightBanner(),
           const TrainingRecommenderBanner(),
-          TheoryLessonProgressWidget(),
           const TrackUnlockPreviewCard(),
           const RecommendedNextPackCard(),
           const AdaptiveTheoryReminderBanner(),

--- a/lib/widgets/resume_lesson_card.dart
+++ b/lib/widgets/resume_lesson_card.dart
@@ -4,6 +4,7 @@ import '../models/v3/lesson_step.dart';
 import '../services/lesson_resume_engine.dart';
 import '../screens/lesson_step_screen.dart';
 import '../screens/lesson_step_recap_screen.dart';
+import 'theory_lesson_progress_widget.dart';
 
 class ResumeLessonCard extends StatefulWidget {
   const ResumeLessonCard({super.key});
@@ -69,6 +70,7 @@ class _ResumeLessonCardState extends State<ResumeLessonCard> {
           const SizedBox(height: 4),
           Text(step.title, style: const TextStyle(color: Colors.white)),
           const SizedBox(height: 8),
+          const TheoryLessonProgressWidget(),
           Align(
             alignment: Alignment.centerRight,
             child: ElevatedButton(


### PR DESCRIPTION
## Summary
- embed lesson progress into ResumeLessonCard to show current theory lesson status
- remove standalone TheoryLessonProgressWidget from TrainingHomeScreen to avoid duplication

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab0cf198832a9edaa3c8a4981503