### PR TITLE
feat: add theory lesson progress tracker service

### DIFF
--- a/lib/services/theory_lesson_progress_tracker_service.dart
+++ b/lib/services/theory_lesson_progress_tracker_service.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'mini_lesson_library_service.dart';
+import 'mini_lesson_progress_tracker.dart';
+
+/// Holds summary of theory lesson progress.
+class TheoryLessonProgressState {
+  final int completed;
+  final int total;
+  const TheoryLessonProgressState({required this.completed, required this.total});
+}
+
+/// Provides reactive updates for overall theory lesson progress.
+class TheoryLessonProgressTrackerService {
+  TheoryLessonProgressTrackerService._({
+    MiniLessonLibraryService? library,
+    MiniLessonProgressTracker? progress,
+  })  : _library = library ?? MiniLessonLibraryService.instance,
+        _progress = progress ?? MiniLessonProgressTracker.instance {
+    _progress.onLessonCompleted.listen((_) => refresh());
+    refresh();
+  }
+
+  static final TheoryLessonProgressTrackerService instance =
+      TheoryLessonProgressTrackerService._();
+
+  final MiniLessonLibraryService _library;
+  final MiniLessonProgressTracker _progress;
+  final _controller = StreamController<TheoryLessonProgressState>.broadcast();
+  TheoryLessonProgressState _state =
+      const TheoryLessonProgressState(completed: 0, total: 0);
+
+  /// Current progress state.
+  TheoryLessonProgressState get current => _state;
+
+  /// Stream of progress state updates.
+  Stream<TheoryLessonProgressState> get stream => _controller.stream;
+
+  /// Refreshes progress counts and emits a new state if changed.
+  Future<void> refresh() async {
+    final total = await _library.getTotalLessonCount();
+    final completed = await _library.getCompletedLessonCount();
+    final next = TheoryLessonProgressState(completed: completed, total: total);
+    if (next.completed != _state.completed || next.total != _state.total) {
+      _state = next;
+      _controller.add(_state);
+    }
+  }
+
+  /// Forces listeners to receive the current progress state.
+  Future<void> forceRefresh() async {
+    await refresh();
+    _controller.add(_state);
+  }
+}

--- a/lib/widgets/theory_lesson_progress_widget.dart
+++ b/lib/widgets/theory_lesson_progress_widget.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
-import '../services/mini_lesson_library_service.dart';
+import '../services/theory_lesson_progress_tracker_service.dart';
 
 class TheoryLessonProgressWidget extends StatefulWidget {
   const TheoryLessonProgressWidget({super.key});
@@ -12,38 +14,37 @@ class TheoryLessonProgressWidget extends StatefulWidget {
 
 class _TheoryLessonProgressWidgetState
     extends State<TheoryLessonProgressWidget> {
-  int _total = 0;
-  int _completed = 0;
-  bool _loading = true;
+  final _tracker = TheoryLessonProgressTrackerService.instance;
+  TheoryLessonProgressState? _state;
+  StreamSubscription<TheoryLessonProgressState>? _sub;
 
   @override
   void initState() {
     super.initState();
-    _load();
+    _sub = _tracker.stream.listen((s) {
+      if (!mounted) return;
+      setState(() => _state = s);
+    });
+    _tracker.refresh();
   }
 
-  Future<void> _load() async {
-    final total = await MiniLessonLibraryService.instance.getTotalLessonCount();
-    final completed = await MiniLessonLibraryService.instance
-        .getCompletedLessonCount();
-    if (!mounted) return;
-    setState(() {
-      _total = total;
-      _completed = completed;
-      _loading = false;
-    });
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_loading || _total == 0) return const SizedBox.shrink();
-    final progress = _total > 0 ? _completed / _total : 0.0;
+    final s = _state;
+    if (s == null || s.total == 0) return const SizedBox.shrink();
+    final progress = s.total > 0 ? s.completed / s.total : 0.0;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('$_completed of $_total lessons complete'),
+          Text('${s.completed} of ${s.total} lessons complete'),
           const SizedBox(height: 8),
           LinearProgressIndicator(value: progress),
         ],


### PR DESCRIPTION
## Summary
- implement `TheoryLessonProgressTrackerService` singleton with progress stream
- wire `TheoryLessonProgressWidget` to reactive progress updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b2245850832a9c8dcb182d0c4699