### PR TITLE
chore(android): safely load local properties

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,7 +1,10 @@
 pluginManagement {
     val flutterSdkPath = run {
         val properties = java.util.Properties()
-        file("local.properties").inputStream().use { properties.load(it) }
+        val localProperties = File(rootDir, "local.properties")
+        if (localProperties.exists()) {
+            localProperties.inputStream().use { properties.load(it) }
+        }
         val flutterSdkPath = properties.getProperty("flutter.sdk")
         require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
         flutterSdkPath


### PR DESCRIPTION
## Summary
- safely read `local.properties` in `settings.gradle.kts` to avoid crashes when file is absent

## Testing
- `gradle -p android help` *(fails: flutter.sdk not set in local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6892b30c83dc832abaa8f705044aa9db