### PR TITLE
feat: add theory lesson completion logger

### DIFF
--- a/lib/models/lesson_completion_entry.dart
+++ b/lib/models/lesson_completion_entry.dart
@@ -1,0 +1,22 @@
+class LessonCompletionEntry {
+  final String lessonId;
+  final DateTime timestamp;
+
+  LessonCompletionEntry({
+    required this.lessonId,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'lessonId': lessonId,
+        'timestamp': timestamp.toUtc().toIso8601String(),
+      };
+
+  factory LessonCompletionEntry.fromJson(Map<String, dynamic> json) =>
+      LessonCompletionEntry(
+        lessonId: json['lessonId'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '')
+                ?.toUtc() ??
+            DateTime.now().toUtc(),
+      );
+}

--- a/test/services/theory_lesson_completion_logger_test.dart
+++ b/test/services/theory_lesson_completion_logger_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/theory_lesson_completion_logger.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('logCompletion adds unique entry per lesson per day', () async {
+    final logger = TheoryLessonCompletionLogger();
+    await logger.logCompletion('lessonA');
+    await logger.logCompletion('lessonA');
+    final entries = await logger.getCompletions();
+    expect(entries.length, 1);
+    expect(entries.first.lessonId, 'lessonA');
+  });
+
+  test('getCompletionsCountFor counts per day', () async {
+    final logger = TheoryLessonCompletionLogger();
+    await logger.logCompletion('lesson1');
+    await logger.logCompletion('lesson2');
+    final count = await logger.getCompletionsCountFor(DateTime.now());
+    expect(count, 2);
+  });
+
+  test('getCompletions filters by since', () async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_completion_log': jsonEncode([
+        {
+          'lessonId': 'old',
+          'timestamp': DateTime.utc(2021, 1, 1).toIso8601String(),
+        },
+        {
+          'lessonId': 'new',
+          'timestamp': DateTime.utc(2021, 1, 2).toIso8601String(),
+        }
+      ])
+    });
+    final logger = TheoryLessonCompletionLogger();
+    final entries =
+        await logger.getCompletions(since: DateTime.utc(2021, 1, 2));
+    expect(entries.length, 1);
+    expect(entries.first.lessonId, 'new');
+  });
+
+  test('logging same lesson on different days creates separate entries', () async {
+    final yesterday = DateTime.now().toUtc().subtract(const Duration(days: 1));
+    SharedPreferences.setMockInitialValues({
+      'lesson_completion_log': jsonEncode([
+        {
+          'lessonId': 'lessonX',
+          'timestamp': yesterday.toIso8601String(),
+        }
+      ])
+    });
+    final logger = TheoryLessonCompletionLogger();
+    await logger.logCompletion('lessonX');
+    final entries = await logger.getCompletions();
+    expect(entries.length, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LessonCompletionEntry` model for storing lesson ID and UTC timestamp
- implement `TheoryLessonCompletionLogger` to log and query completions in SharedPreferences with daily deduplication
- add tests covering logging, filtering, and per-day counts

## Testing
- `flutter test test/services/theory_lesson_completion_logger_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b46f4ffc832a9c08245102bd4f51