### PR TITLE
feat: add lesson streak tracker service

### DIFF
--- a/lib/services/lesson_streak_tracker_service.dart
+++ b/lib/services/lesson_streak_tracker_service.dart
@@ -1,0 +1,79 @@
+import 'theory_lesson_completion_logger.dart';
+
+/// Computes current and longest streaks of consecutive days with lesson completions.
+class LessonStreakTrackerService {
+  LessonStreakTrackerService._();
+  static final LessonStreakTrackerService instance =
+      LessonStreakTrackerService._();
+
+  final _logger = TheoryLessonCompletionLogger();
+
+  int? _current;
+  int? _longest;
+
+  /// Clears cached values.
+  void resetCache() {
+    _current = null;
+    _longest = null;
+  }
+
+  /// Returns the current streak, ending today or yesterday.
+  Future<int> getCurrentStreak() async {
+    if (_current == null) await _compute();
+    return _current!;
+  }
+
+  /// Returns the longest streak recorded.
+  Future<int> getLongestStreak() async {
+    if (_longest == null) await _compute();
+    return _longest!;
+  }
+
+  Future<void> _compute() async {
+    final entries = await _logger.getCompletions();
+    final days = <DateTime>{};
+    for (final e in entries) {
+      final t = e.timestamp.toUtc();
+      days.add(DateTime.utc(t.year, t.month, t.day));
+    }
+
+    final ordered = days.toList()..sort();
+    _current = 0;
+    _longest = 0;
+    if (ordered.isEmpty) return;
+
+    // Compute longest streak.
+    var best = 1;
+    var streak = 1;
+    for (var i = 1; i < ordered.length; i++) {
+      final diff = ordered[i].difference(ordered[i - 1]).inDays;
+      if (diff == 1) {
+        streak += 1;
+      } else if (diff > 1) {
+        if (streak > best) best = streak;
+        streak = 1;
+      }
+    }
+    if (streak > best) best = streak;
+    _longest = best;
+
+    // Compute current streak.
+    final now = DateTime.now().toUtc();
+    final today = DateTime.utc(now.year, now.month, now.day);
+    final last = ordered.last;
+    if (today.difference(last).inDays > 1) {
+      _current = 0;
+      return;
+    }
+    streak = 1;
+    for (var i = ordered.length - 2; i >= 0; i--) {
+      final diff = ordered[i + 1].difference(ordered[i]).inDays;
+      if (diff == 1) {
+        streak += 1;
+      } else if (diff > 1) {
+        break;
+      }
+    }
+    _current = streak;
+  }
+}

--- a/test/services/lesson_streak_tracker_service_test.dart
+++ b/test/services/lesson_streak_tracker_service_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/lesson_streak_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    LessonStreakTrackerService.instance.resetCache();
+  });
+
+  test('computes current and longest lesson streaks', () async {
+    final now = DateTime.now().toUtc();
+    SharedPreferences.setMockInitialValues({
+      'lesson_completion_log': jsonEncode([
+        {
+          'lessonId': 'a',
+          'timestamp': now.subtract(const Duration(days: 10)).toIso8601String(),
+        },
+        {
+          'lessonId': 'b',
+          'timestamp': now.subtract(const Duration(days: 9)).toIso8601String(),
+        },
+        {
+          'lessonId': 'c',
+          'timestamp': now.subtract(const Duration(days: 8)).toIso8601String(),
+        },
+        {
+          'lessonId': 'd',
+          'timestamp': now.subtract(const Duration(days: 1)).toIso8601String(),
+        },
+        {
+          'lessonId': 'e',
+          'timestamp': now.toIso8601String(),
+        }
+      ])
+    });
+
+    final current = await LessonStreakTrackerService.instance.getCurrentStreak();
+    final longest = await LessonStreakTrackerService.instance.getLongestStreak();
+    expect(current, 2);
+    expect(longest, 3);
+  });
+
+  test('streak resets if gap exceeds one day', () async {
+    final now = DateTime.now().toUtc();
+    SharedPreferences.setMockInitialValues({
+      'lesson_completion_log': jsonEncode([
+        {
+          'lessonId': 'x',
+          'timestamp': now.subtract(const Duration(days: 2)).toIso8601String(),
+        }
+      ])
+    });
+
+    final current = await LessonStreakTrackerService.instance.getCurrentStreak();
+    final longest = await LessonStreakTrackerService.instance.getLongestStreak();
+    expect(current, 0);
+    expect(longest, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LessonStreakTrackerService` to compute lesson streak stats
- cover streak computations with unit tests

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892b5dc067c832a8802e380d373d699