### PR TITLE
Add lesson streak badge widget

### DIFF
--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -16,7 +16,7 @@ import '../services/daily_target_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
-import '../widgets/theory_streak_badge.dart';
+import '../widgets/lesson_streak_badge_widget.dart';
 import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
 import '../utils/responsive.dart';
@@ -148,7 +148,7 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
         actions: [
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 8),
-            child: StreakBadge(),
+            child: LessonStreakBadgeWidget(dense: true),
           ),
           IconButton(onPressed: _share, icon: const Icon(Icons.share)),
           IconButton(onPressed: _exportCsv, icon: const Icon(Icons.download)),

--- a/lib/widgets/lesson_streak_badge_widget.dart
+++ b/lib/widgets/lesson_streak_badge_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../services/lesson_streak_tracker_service.dart';
+
+/// Displays the current lesson streak as a small badge.
+class LessonStreakBadgeWidget extends StatelessWidget {
+  final bool dense;
+
+  const LessonStreakBadgeWidget({super.key, this.dense = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<int>(
+      future: LessonStreakTrackerService.instance.getCurrentStreak(),
+      builder: (context, snapshot) {
+        final streak = snapshot.data ?? 0;
+        if (streak <= 0) return const SizedBox.shrink();
+        final iconSize = dense ? 16.0 : 20.0;
+        final fontSize = dense ? 12.0 : 14.0;
+        final spacing = dense ? 4.0 : 6.0;
+        final label = dense ? '$streak' : '$streak-day streak';
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.local_fire_department,
+              size: iconSize,
+              color: Colors.deepOrange,
+            ),
+            SizedBox(width: spacing),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: fontSize,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `LessonStreakBadgeWidget` to show lesson streak with fire icon and optional dense mode
- integrate lesson streak badge into progress dashboard app bar

## Testing
- `flutter format lib/widgets/lesson_streak_badge_widget.dart lib/screens/progress_dashboard_screen.dart` *(command not found)*
- `apt-get install -y dart` *(package not found)*
- `apt-get install -y flutter` *(package not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b709efbc832a882e8124f6f381da