### PR TITLE
Add lesson streak milestone summary card

### DIFF
--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -65,6 +65,7 @@ import '../widgets/daily_spotlight_card.dart';
 import '../widgets/streak_banner_widget.dart';
 import '../widgets/streak_analytics_card.dart';
 import '../widgets/decay_memory_health_banner.dart';
+import '../widgets/lesson_streak_summary_card.dart';
 import 'booster_library_screen.dart';
 import 'booster_archive_screen.dart';
 import 'training_progress_analytics_screen.dart';
@@ -151,6 +152,7 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
       body: ListView(
         children: [
           const StarterPathCard(),
+          const LessonStreakSummaryCard(),
           const NextUpBanner(),
           const SmartRecapPreviewWidget(),
           const TheoryInboxBanner(),

--- a/lib/widgets/lesson_streak_summary_card.dart
+++ b/lib/widgets/lesson_streak_summary_card.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/lesson_streak_engine.dart';
+
+class LessonStreakSummaryCard extends StatefulWidget {
+  const LessonStreakSummaryCard({super.key});
+
+  @override
+  State<LessonStreakSummaryCard> createState() => _LessonStreakSummaryCardState();
+}
+
+class _LessonStreakSummaryCardState extends State<LessonStreakSummaryCard> {
+  static const _prefsKey = 'lesson_streak_summary_shown';
+  static const _milestones = [3, 5, 7, 10, 14, 21, 30, 50, 100];
+
+  bool _visible = false;
+  int _streak = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _check();
+  }
+
+  Future<void> _check() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = await LessonStreakEngine.instance.getCurrentStreak();
+    final shown = prefs.getStringList(_prefsKey) ?? [];
+    if (_milestones.contains(current) && !shown.contains('$current')) {
+      shown.add('$current');
+      await prefs.setStringList(_prefsKey, shown);
+      if (!mounted) return;
+      setState(() {
+        _visible = true;
+        _streak = current;
+      });
+    }
+  }
+
+  void _dismiss() {
+    setState(() => _visible = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [Colors.deepOrange, Colors.orangeAccent],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Align(
+            alignment: Alignment.topRight,
+            child: IconButton(
+              icon: const Icon(Icons.close, color: Colors.white),
+              onPressed: _dismiss,
+            ),
+          ),
+          Text(
+            "🔥 You're on a $_streak-day learning streak!",
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Keep it up!',
+            style: TextStyle(color: Colors.white),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/test/widgets/lesson_streak_summary_card_test.dart
+++ b/test/widgets/lesson_streak_summary_card_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/widgets/lesson_streak_summary_card.dart';
+
+void main() {
+  testWidgets('shows when hitting new milestone', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_streak_count': 3,
+      'lesson_streak_last_day': DateTime.now().toIso8601String().split('T').first,
+    });
+    await tester.pumpWidget(const MaterialApp(home: LessonStreakSummaryCard()));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('3-day learning streak'), findsOneWidget);
+  });
+
+  testWidgets('does not show when milestone already shown', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'lesson_streak_count': 3,
+      'lesson_streak_last_day': DateTime.now().toIso8601String().split('T').first,
+      'lesson_streak_summary_shown': ['3'],
+    });
+    await tester.pumpWidget(const MaterialApp(home: LessonStreakSummaryCard()));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('3-day learning streak'), findsNothing);
+  });
+}
+


### PR DESCRIPTION
## Summary
- celebrate streak milestones with new `LessonStreakSummaryCard`
- show milestone card on TrainingHomeScreen near the top
- cover milestone display logic with widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b860a12c832a9b93ea6df241ff48