### PR TITLE
Show longest lesson streak via tooltip

### DIFF
--- a/lib/screens/progress_dashboard_screen.dart
+++ b/lib/screens/progress_dashboard_screen.dart
@@ -16,7 +16,7 @@ import '../services/daily_target_service.dart';
 import '../services/saved_hand_manager_service.dart';
 import '../theme/app_colors.dart';
 import '../widgets/sync_status_widget.dart';
-import '../widgets/lesson_streak_badge_widget.dart';
+import '../widgets/lesson_streak_badge_tooltip_widget.dart';
 import '../services/png_exporter.dart';
 import '../helpers/date_utils.dart';
 import '../utils/responsive.dart';
@@ -148,7 +148,7 @@ class _ProgressDashboardScreenState extends State<ProgressDashboardScreen> {
         actions: [
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 8),
-            child: LessonStreakBadgeWidget(dense: true),
+            child: LessonStreakBadgeTooltipWidget(dense: true),
           ),
           IconButton(onPressed: _share, icon: const Icon(Icons.share)),
           IconButton(onPressed: _exportCsv, icon: const Icon(Icons.download)),

--- a/lib/widgets/lesson_streak_badge_tooltip_widget.dart
+++ b/lib/widgets/lesson_streak_badge_tooltip_widget.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../services/lesson_streak_tracker_service.dart';
+import 'lesson_streak_badge_widget.dart';
+
+/// Displays the current lesson streak badge with a tooltip revealing
+/// the user's longest recorded streak when hovered or long-pressed.
+class LessonStreakBadgeTooltipWidget extends StatelessWidget {
+  final bool dense;
+
+  const LessonStreakBadgeTooltipWidget({super.key, this.dense = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<int>(
+      future: LessonStreakTrackerService.instance.getLongestStreak(),
+      builder: (context, snapshot) {
+        final longest = snapshot.data ?? 0;
+        final message = 'Your longest streak: $longest days';
+        return Tooltip(
+          message: message,
+          child: LessonStreakBadgeWidget(dense: dense),
+        );
+      },
+    );
+  }
+}
+

--- a/test/widgets/lesson_streak_badge_tooltip_widget_test.dart
+++ b/test/widgets/lesson_streak_badge_tooltip_widget_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/widgets/lesson_streak_badge_tooltip_widget.dart';
+import 'package:poker_analyzer/services/lesson_streak_tracker_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    LessonStreakTrackerService.instance.resetCache();
+  });
+
+  testWidgets('shows longest streak in tooltip', (tester) async {
+    final now = DateTime.now().toUtc();
+    SharedPreferences.setMockInitialValues({
+      'lesson_completion_log': jsonEncode([
+        {
+          'lessonId': 'a',
+          'timestamp':
+              now.subtract(const Duration(days: 10)).toIso8601String(),
+        },
+        {
+          'lessonId': 'b',
+          'timestamp':
+              now.subtract(const Duration(days: 9)).toIso8601String(),
+        },
+        {
+          'lessonId': 'c',
+          'timestamp':
+              now.subtract(const Duration(days: 8)).toIso8601String(),
+        },
+        {
+          'lessonId': 'd',
+          'timestamp':
+              now.subtract(const Duration(days: 1)).toIso8601String(),
+        },
+        {
+          'lessonId': 'e',
+          'timestamp': now.toIso8601String(),
+        }
+      ])
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: LessonStreakBadgeTooltipWidget(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.longPress(find.byType(LessonStreakBadgeTooltipWidget));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Your longest streak: 3 days'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `LessonStreakBadgeTooltipWidget` to expose longest streak via hover/long press
- display tooltip-equipped badge in progress dashboard
- cover streak tooltip behavior with widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b9a6b028832aa1e865538c22851f