### PR TITLE
feat: celebrate new lesson streak records

### DIFF
--- a/lib/providers/training_providers.dart
+++ b/lib/providers/training_providers.dart
@@ -119,6 +119,7 @@ import '../services/skill_loss_overlay_prompt_service.dart';
 import '../services/gift_drop_service.dart';
 import '../services/decay_badge_banner_controller.dart';
 import '../services/session_streak_overlay_prompt_service.dart';
+import '../services/lesson_streak_celebration_service.dart';
 import '../services/decay_streak_overlay_prompt_service.dart';
 import '../services/overlay_decay_booster_orchestrator.dart';
 import '../services/smart_recap_auto_injector.dart';
@@ -529,6 +530,7 @@ List<SingleChildWidget> buildTrainingProviders() {
     Provider(create: (_) => GiftDropService()),
     Provider(create: (_) => DecayBadgeBannerController()..start()),
     Provider(create: (_) => SessionStreakOverlayPromptService()),
+    Provider(create: (_) => LessonStreakCelebrationService()),
     Provider(create: (_) => DecayStreakOverlayPromptService()),
     Provider(create: (_) => OverlayDecayBoosterOrchestrator()),
     Provider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -14,6 +14,7 @@ import '../services/dynamic_pack_adjustment_service.dart';
 import 'training_session_screen.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../services/daily_spotlight_service.dart';
+import '../services/lesson_streak_celebration_service.dart';
 
 import '../widgets/booster_suggestion_block.dart';
 import '../widgets/theory_booster_suggestion_block.dart';
@@ -92,9 +93,10 @@ class _TrainingHomeScreenState extends State<TrainingHomeScreen> {
   void initState() {
     super.initState();
     context.read<SpotOfTheDayService>().ensureTodaySpot();
-    WidgetsBinding.instance.addPostFrameCallback(
-      (_) => widget.tutorial?.showCurrentStep(context),
-    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.tutorial?.showCurrentStep(context);
+      context.read<LessonStreakCelebrationService>().maybeCelebrate(context);
+    });
   }
 
   @override

--- a/lib/services/lesson_streak_celebration_service.dart
+++ b/lib/services/lesson_streak_celebration_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/lesson_streak_celebration_overlay.dart';
+import 'lesson_streak_tracker_service.dart';
+
+/// Triggers a celebration overlay when the user sets a new lesson streak record.
+class LessonStreakCelebrationService {
+  final LessonStreakTrackerService tracker;
+  bool _shown = false;
+
+  LessonStreakCelebrationService({LessonStreakTrackerService? tracker})
+      : tracker = tracker ?? LessonStreakTrackerService.instance;
+
+  /// Checks for a new streak record and shows [LessonStreakCelebrationOverlay]
+  /// once per app session.
+  Future<void> maybeCelebrate(BuildContext context) async {
+    if (_shown) return;
+
+    final previousBest = await tracker.getLongestStreak();
+    tracker.resetCache();
+    final current = await tracker.getCurrentStreak();
+    if (current <= previousBest) return;
+
+    final overlay = Overlay.of(context);
+    if (overlay == null) return;
+
+    _shown = true;
+    late OverlayEntry entry;
+    void close() => entry.remove();
+    entry = OverlayEntry(
+      builder: (_) => LessonStreakCelebrationOverlay(
+        streak: current,
+        onDismiss: close,
+      ),
+    );
+    overlay.insert(entry);
+  }
+}

--- a/lib/widgets/lesson_streak_celebration_overlay.dart
+++ b/lib/widgets/lesson_streak_celebration_overlay.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'confetti_overlay.dart';
+
+/// Full screen overlay celebrating a new lesson streak record.
+class LessonStreakCelebrationOverlay extends StatefulWidget {
+  final int streak;
+  final VoidCallback onDismiss;
+
+  const LessonStreakCelebrationOverlay({
+    super.key,
+    required this.streak,
+    required this.onDismiss,
+  });
+
+  @override
+  State<LessonStreakCelebrationOverlay> createState() =>
+      _LessonStreakCelebrationOverlayState();
+}
+
+class _LessonStreakCelebrationOverlayState
+    extends State<LessonStreakCelebrationOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showConfettiOverlay(context);
+    });
+    Future.delayed(const Duration(seconds: 4), _dismiss);
+  }
+
+  void _dismiss() {
+    if (!mounted) return;
+    widget.onDismiss();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final message = '🔥 New Record! ${widget.streak}-Day Streak!';
+    return GestureDetector(
+      onTap: _dismiss,
+      child: Scaffold(
+        backgroundColor: Colors.black87,
+        body: Center(
+          child: FadeTransition(
+            opacity: _controller,
+            child: ScaleTransition(
+              scale: CurvedAnimation(
+                parent: _controller,
+                curve: Curves.elasticOut,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('🔥', style: TextStyle(fontSize: 96)),
+                  const SizedBox(height: 16),
+                  Text(
+                    message,
+                    style: const TextStyle(color: Colors.white, fontSize: 24),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LessonStreakCelebrationOverlay` with confetti and flame animation
- trigger overlay once per session when a new streak record is detected
- wire celebration service into training home providers and screen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689308e94234832aafe5fc2cac7c0495