### PR TITLE
feat: schedule lesson streak reminders

### DIFF
--- a/lib/providers/training_providers.dart
+++ b/lib/providers/training_providers.dart
@@ -68,6 +68,7 @@ import '../services/personal_recommendation_service.dart';
 import '../services/reminder_service.dart';
 import '../services/daily_reminder_service.dart';
 import '../services/streak_reminder_service.dart';
+import '../services/streak_reminder_scheduler_service.dart';
 import '../services/next_step_engine.dart';
 import '../services/drill_suggestion_engine.dart';
 import '../services/weak_spot_recommendation_service.dart';
@@ -332,6 +333,9 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => StreakReminderService(
         logs: context.read<SessionLogService>(),
       )..init(),
+    ),
+    Provider(
+      create: (_) => StreakReminderSchedulerService()..init(),
     ),
     ChangeNotifierProvider(
       create: (context) => NextStepEngine(

--- a/lib/services/streak_reminder_scheduler_service.dart
+++ b/lib/services/streak_reminder_scheduler_service.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'lesson_streak_tracker_service.dart';
+import 'theory_lesson_completion_logger.dart';
+import 'notification_service.dart';
+
+/// Schedules reminders when the lesson streak is at risk.
+class StreakReminderSchedulerService {
+  StreakReminderSchedulerService({
+    this.logger = TheoryLessonCompletionLogger(),
+    this.streak = LessonStreakTrackerService.instance,
+  });
+
+  /// Logs lesson completions.
+  final TheoryLessonCompletionLogger logger;
+
+  /// Tracks current lesson streak.
+  final LessonStreakTrackerService streak;
+
+  static const String _hourKey = 'streak_reminder_hour';
+  static const String _muteKey = 'streak_reminder_muted';
+  static const String _lastKey = 'streak_reminder_last';
+
+  int _hour = 20;
+  bool _muted = false;
+  Timer? _timer;
+
+  /// Initializes the scheduler and begins daily checks.
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    _hour = prefs.getInt(_hourKey) ?? 20;
+    _muted = prefs.getBool(_muteKey) ?? false;
+    _schedule();
+  }
+
+  /// Updates the daily reminder hour.
+  Future<void> setHour(int hour) async {
+    final prefs = await SharedPreferences.getInstance();
+    _hour = hour;
+    await prefs.setInt(_hourKey, hour);
+    _schedule();
+  }
+
+  /// Enables or disables notifications.
+  Future<void> setMuted(bool muted) async {
+    final prefs = await SharedPreferences.getInstance();
+    _muted = muted;
+    await prefs.setBool(_muteKey, muted);
+    if (muted) {
+      _timer?.cancel();
+    } else {
+      _schedule();
+    }
+  }
+
+  void dispose() {
+    _timer?.cancel();
+  }
+
+  void _schedule() {
+    _timer?.cancel();
+    if (_muted) return;
+    final now = DateTime.now();
+    var next = DateTime(now.year, now.month, now.day, _hour);
+    if (next.isBefore(now)) next = next.add(const Duration(days: 1));
+    _timer = Timer(next.difference(now), () async {
+      await _evaluate();
+      _schedule();
+    });
+  }
+
+  Future<void> _evaluate() async {
+    if (_muted) return;
+    if (!await shouldNotifyToday()) return;
+    final today = DateTime.now();
+    final count = await logger.getCompletionsCountFor(today);
+    if (count > 0) return;
+    final current = await streak.getCurrentStreak();
+    if (current < 3) return;
+    await NotificationService.schedule(
+      id: 331,
+      when: DateTime.now().add(const Duration(seconds: 1)),
+      body: 'Your streak is in danger! Complete a lesson today.',
+    );
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastKey, DateTime.now().toIso8601String());
+  }
+
+  /// Returns true if the user hasn't been notified today.
+  Future<bool> shouldNotifyToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastStr = prefs.getString(_lastKey);
+    if (lastStr == null) return true;
+    final last = DateTime.tryParse(lastStr);
+    if (last == null) return true;
+    final now = DateTime.now();
+    return !(last.year == now.year &&
+        last.month == now.month &&
+        last.day == now.day);
+  }
+}
+

--- a/test/services/streak_reminder_scheduler_service_test.dart
+++ b/test/services/streak_reminder_scheduler_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/streak_reminder_scheduler_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('shouldNotifyToday prevents duplicate reminders', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = StreakReminderSchedulerService();
+    await service.init();
+    expect(await service.shouldNotifyToday(), isTrue);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('streak_reminder_last', DateTime.now().toIso8601String());
+    expect(await service.shouldNotifyToday(), isFalse);
+    service.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add StreakReminderSchedulerService to nudge users when lesson streak at risk
- wire scheduler into training providers
- test duplicate reminder suppression

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68930b16c8f0832a99f466733355b78b