### PR TITLE
feat: add daily training recap card

### DIFF
--- a/lib/screens/lesson_step_recap_screen.dart
+++ b/lib/screens/lesson_step_recap_screen.dart
@@ -12,6 +12,7 @@ import '../services/smart_review_service.dart';
 import '../services/training_pack_template_storage_service.dart';
 import '../widgets/streak_banner_widget.dart';
 import '../services/lesson_streak_engine.dart';
+import '../widgets/daily_training_recap_card.dart';
 import 'lesson_step_screen.dart';
 import 'track_recap_screen.dart';
 
@@ -164,6 +165,8 @@ class _LessonStepRecapScreenState extends State<LessonStepRecapScreen> {
                     return const StreakBannerWidget();
                   },
                 ),
+                const SizedBox(height: 12),
+                const DailyTrainingRecapCard(),
                 const Spacer(),
                 if (!done)
                   const Center(child: CircularProgressIndicator())

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -29,6 +29,18 @@ class MiniLessonLibraryService {
     List<String> linkedPacksFor(String lessonId) =>
         _byId[lessonId]?.linkedPackIds ?? const [];
 
+  /// Suggests the next lesson that has not been completed yet.
+  Future<TheoryMiniLessonNode?> getNextLesson() async {
+    await loadAll();
+    final completions =
+        await TheoryLessonCompletionLogger.instance.getCompletions();
+    final completedIds = completions.map((e) => e.lessonId).toSet();
+    for (final lesson in _lessons) {
+      if (!completedIds.contains(lesson.id)) return lesson;
+    }
+    return null;
+  }
+
   Future<void> loadAll() async {
     if (_lessons.isNotEmpty) return;
     await reload();

--- a/lib/widgets/daily_training_recap_card.dart
+++ b/lib/widgets/daily_training_recap_card.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../services/lesson_streak_tracker_service.dart';
+import '../services/theory_lesson_completion_logger.dart';
+import '../services/mini_lesson_library_service.dart';
+import '../models/theory_mini_lesson_node.dart';
+import '../screens/mini_lesson_screen.dart';
+
+class DailyTrainingRecapCard extends StatefulWidget {
+  const DailyTrainingRecapCard({super.key});
+
+  @override
+  State<DailyTrainingRecapCard> createState() => _DailyTrainingRecapCardState();
+}
+
+class _RecapData {
+  final int streak;
+  final int completedToday;
+  final TheoryMiniLessonNode? next;
+  const _RecapData({required this.streak, required this.completedToday, this.next});
+}
+
+class _DailyTrainingRecapCardState extends State<DailyTrainingRecapCard> {
+  late Future<_RecapData> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<_RecapData> _load() async {
+    final streak = await LessonStreakTrackerService.instance.getCurrentStreak();
+    final completed = await TheoryLessonCompletionLogger.instance
+        .getCompletionsCountFor(DateTime.now());
+    final next = await MiniLessonLibraryService.instance.getNextLesson();
+    return _RecapData(streak: streak, completedToday: completed, next: next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_RecapData>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return const SizedBox.shrink();
+        final data = snapshot.data!;
+        return Container(
+          margin: const EdgeInsets.symmetric(vertical: 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey[850],
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Текущий стрик: ${data.streak}',
+                  style: const TextStyle(color: Colors.white)),
+              const SizedBox(height: 4),
+              Text('Уроков сегодня: ${data.completedToday}',
+                  style: const TextStyle(color: Colors.white)),
+              if (data.next != null) ...[
+                const SizedBox(height: 8),
+                Text('Следующий урок: ${data.next!.resolvedTitle}',
+                    style: const TextStyle(color: Colors.white)),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MiniLessonScreen(lesson: data.next!),
+                        ),
+                      );
+                    },
+                    child: const Text('Начать следующий урок'),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `getNextLesson` to `MiniLessonLibraryService` to surface uncompleted lessons
- introduce `DailyTrainingRecapCard` showing streak, today’s completions, and next lesson CTA
- display the recap card after lesson completion on `LessonStepRecapScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68930f35da8c832a8d8f55d10225213b