### PR TITLE
feat: toast on daily lesson milestones

### DIFF
--- a/lib/services/lesson_completion_milestone_toast_service.dart
+++ b/lib/services/lesson_completion_milestone_toast_service.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Shows a short toast when daily lesson completion milestones are reached.
+class LessonCompletionMilestoneToastService {
+  LessonCompletionMilestoneToastService._();
+  static final LessonCompletionMilestoneToastService instance =
+      LessonCompletionMilestoneToastService._();
+
+  static const _prefsKeyPrefix = 'lesson_completion_milestone_';
+  static const Map<int, String> _messages = {
+    1: 'Nice start!',
+    3: 'Keep going!',
+    5: '🔥 Crushing it!',
+  };
+
+  Future<void> showIfMilestoneReached(
+      BuildContext context, int completionCount) async {
+    final message = _messages[completionCount];
+    if (message == null) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final today = DateTime.now();
+    final key = '$_prefsKeyPrefix$completionCount';
+    final todayStr = '${today.year}-${today.month}-${today.day}';
+    final lastShown = prefs.getString(key);
+    if (lastShown == todayStr) return;
+
+    await prefs.setString(key, todayStr);
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}
+

--- a/test/services/lesson_completion_milestone_toast_service_test.dart
+++ b/test/services/lesson_completion_milestone_toast_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/lesson_completion_milestone_toast_service.dart';
+
+void main() {
+  testWidgets('shows milestone toast only once per day', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: SizedBox())));
+    final context = tester.element(find.byType(SizedBox));
+
+    await LessonCompletionMilestoneToastService.instance
+        .showIfMilestoneReached(context, 1);
+    await tester.pump();
+    expect(find.text('Nice start!'), findsOneWidget);
+
+    await LessonCompletionMilestoneToastService.instance
+        .showIfMilestoneReached(context, 1);
+    await tester.pump();
+    expect(find.text('Nice start!'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add LessonCompletionMilestoneToastService to show SnackBar at daily milestones (1, 3, 5 completions)
- trigger milestone toast from TheoryLessonCompletionLogger after logging
- add test ensuring milestone toast only appears once per day

## Testing
- `dart format lib/services/lesson_completion_milestone_toast_service.dart lib/services/theory_lesson_completion_logger.dart test/services/lesson_completion_milestone_toast_service_test.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68931132fe80832ab621c6723a8c179c