### PR TITLE
feat: link river jam spots to theory

### DIFF
--- a/lib/services/inline_theory_linking/postflop_jam_decision_theory_linker.dart
+++ b/lib/services/inline_theory_linking/postflop_jam_decision_theory_linker.dart
@@ -1,0 +1,45 @@
+import '../../models/theory_mini_lesson_node.dart';
+import '../../models/v2/training_pack_template_v2.dart';
+import '../../services/mini_lesson_library_service.dart';
+
+/// Links river jam decision spots to relevant theory mini lessons.
+class PostflopJamDecisionTheoryLinker {
+  PostflopJamDecisionTheoryLinker({MiniLessonLibraryService? library})
+      : _library = library ?? MiniLessonLibraryService.instance;
+
+  final MiniLessonLibraryService _library;
+
+  /// Injects `theoryRef` links into qualifying packs.
+  ///
+  /// Packs are considered when their `meta.topic` equals `river jam` or
+  /// contain the tag `jamDecision`. For the first [TheoryMiniLessonNode]
+  /// that has all tags `river`, `jam` and `decision`, each spot's `meta`
+  /// map receives a `theoryRef` entry with the lesson's id and title.
+  Future<void> link(List<TrainingPackTemplateV2> packs) async {
+    if (packs.isEmpty) return;
+    await _library.loadAll();
+
+    const required = ['river', 'jam', 'decision'];
+    final candidates = _library.findByTags(required);
+    final lesson = candidates.firstWhere(
+      (l) => required.every((t) => l.tags.contains(t)),
+      orElse: () => null,
+    );
+    if (lesson == null) return;
+
+    for (final pack in packs) {
+      final topic = pack.meta['topic']?.toString().toLowerCase();
+      final hasTag = pack.tags.map((t) => t.toLowerCase()).contains('jamdecision');
+      if (topic != 'river jam' && !hasTag) continue;
+
+      for (final spot in pack.spots) {
+        if (spot.meta.containsKey('theoryRef')) continue;
+        spot.meta['theoryRef'] = {
+          'lessonId': lesson.id,
+          'title': lesson.title,
+        };
+      }
+    }
+  }
+}
+

--- a/test/services/postflop_jam_decision_theory_linker_test.dart
+++ b/test/services/postflop_jam_decision_theory_linker_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/hand_data.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/inline_theory_linking/postflop_jam_decision_theory_linker.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((e) => e.id == id, orElse: () => null);
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) => lessons;
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) => lessons;
+}
+
+void main() {
+  test('links jam decision packs', () async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'River Jam Decisions',
+      content: '',
+      tags: ['river', 'jam', 'decision'],
+    );
+    final library = _FakeLibrary([lesson]);
+    final linker =
+        PostflopJamDecisionTheoryLinker(library: library);
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack',
+      trainingType: TrainingType.postflop,
+      tags: ['jamDecision'],
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+      meta: {},
+    );
+
+    await linker.link([pack]);
+
+    expect(pack.spots.first.meta['theoryRef'], {
+      'lessonId': 'l1',
+      'title': 'River Jam Decisions',
+    });
+  });
+
+  test('ignores packs without jam tag', () async {
+    const lesson = TheoryMiniLessonNode(
+      id: 'l1',
+      title: 'River Jam Decisions',
+      content: '',
+      tags: ['river', 'jam', 'decision'],
+    );
+    final library = _FakeLibrary([lesson]);
+    final linker =
+        PostflopJamDecisionTheoryLinker(library: library);
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack',
+      trainingType: TrainingType.postflop,
+      tags: [],
+      spots: [TrainingPackSpot(id: 's1', hand: HandData())],
+      spotCount: 1,
+      meta: {},
+    );
+
+    await linker.link([pack]);
+
+    expect(pack.spots.first.meta.containsKey('theoryRef'), false);
+  });
+}


### PR DESCRIPTION
## Summary
- add `PostflopJamDecisionTheoryLinker` service that injects `theoryRef` metadata for river jam decision packs
- cover jam decision linking logic with unit tests

## Testing
- `flutter test test/services/postflop_jam_decision_theory_linker_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931a9becc0832aa2f55624321aa2ac