### PR TITLE
feat: implement level tag auto assigner

### DIFF
--- a/lib/services/level_tag_auto_assigner.dart
+++ b/lib/services/level_tag_auto_assigner.dart
@@ -1,0 +1,30 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+/// Assigns a level to training packs based on their tags or training type.
+class LevelTagAutoAssigner {
+  const LevelTagAutoAssigner();
+
+  /// Updates `meta['level']` for each [templates] item and returns the list.
+  List<TrainingPackTemplateV2> assign(List<TrainingPackTemplateV2> templates) {
+    for (final tpl in templates) {
+      tpl.meta['level'] = _detectLevel(tpl);
+    }
+    return templates;
+  }
+
+  int _detectLevel(TrainingPackTemplateV2 tpl) {
+    final tags = {for (final t in tpl.tags) t.toLowerCase()};
+    if (tags.contains('pushfold') || tpl.trainingType == TrainingType.pushFold) {
+      return 1;
+    }
+    if (tags.contains('open') || tags.contains('3betpush')) {
+      return 2;
+    }
+    if (tags.contains('jamdecision') || tpl.trainingType == TrainingType.postflop) {
+      return 3;
+    }
+    return 0;
+  }
+}
+

--- a/test/level_tag_auto_assigner_test.dart
+++ b/test/level_tag_auto_assigner_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/level_tag_auto_assigner.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+
+void main() {
+  const assigner = LevelTagAutoAssigner();
+
+  TrainingPackTemplateV2 _tpl({
+    List<String>? tags,
+    TrainingType trainingType = TrainingType.custom,
+  }) {
+    return TrainingPackTemplateV2(
+      id: 'id',
+      name: 'name',
+      tags: tags,
+      trainingType: trainingType,
+    );
+  }
+
+  test('assigns level 1 for pushFold training type', () {
+    final tpl = _tpl(trainingType: TrainingType.pushFold);
+    assigner.assign([tpl]);
+    expect(tpl.meta['level'], 1);
+  });
+
+  test('assigns level 2 for open tag', () {
+    final tpl = _tpl(tags: ['open']);
+    assigner.assign([tpl]);
+    expect(tpl.meta['level'], 2);
+  });
+
+  test('assigns level 3 for jamDecision tag', () {
+    final tpl = _tpl(tags: ['jamDecision']);
+    assigner.assign([tpl]);
+    expect(tpl.meta['level'], 3);
+  });
+
+  test('defaults to level 0 when no rules match', () {
+    final tpl = _tpl(tags: ['random']);
+    assigner.assign([tpl]);
+    expect(tpl.meta['level'], 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add LevelTagAutoAssigner to assign meta['level'] based on tags and training type
- add tests covering pushFold, open, jamDecision and default cases

## Testing
- `flutter test test/level_tag_auto_assigner_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68931f2534f0832aa421ae299f6ddd91