### PR TITLE
Add auto tagger for theory lesson clusters

### DIFF
--- a/lib/models/theory_lesson_cluster.dart
+++ b/lib/models/theory_lesson_cluster.dart
@@ -4,10 +4,17 @@ class TheoryLessonCluster {
   final List<TheoryMiniLessonNode> lessons;
   final Set<String> sharedTags;
 
-  const TheoryLessonCluster({
+  /// Tags automatically inferred from the lessons within this cluster.
+  ///
+  /// Populated by [TheoryLessonClusterAutoTagger].
+  List<String> autoTags;
+
+  TheoryLessonCluster({
     required this.lessons,
     required Set<String> tags,
-  }) : sharedTags = tags;
+    List<String>? autoTags,
+  })  : sharedTags = tags,
+        autoTags = autoTags ?? [];
 
   @Deprecated('Use sharedTags')
   Set<String> get tags => sharedTags;

--- a/lib/services/theory_lesson_cluster_auto_tagger.dart
+++ b/lib/services/theory_lesson_cluster_auto_tagger.dart
@@ -1,0 +1,29 @@
+import '../models/theory_lesson_cluster.dart';
+
+/// Suggests representative tags for [TheoryLessonCluster]s based on the
+/// frequency of tags across all lessons in each cluster.
+class TheoryLessonClusterAutoTagger {
+  /// Assigns the top [count] most common tags from each cluster's lessons to
+  /// [TheoryLessonCluster.autoTags].
+  void tagClusters(List<TheoryLessonCluster> clusters, {int count = 3}) {
+    for (final cluster in clusters) {
+      cluster.autoTags = _topTags(cluster, count);
+    }
+  }
+
+  /// Returns the top [count] tags for a single [cluster].
+  List<String> _topTags(TheoryLessonCluster cluster, int count) {
+    final frequencies = <String, int>{};
+    for (final lesson in cluster.lessons) {
+      for (final tag in lesson.tags) {
+        final trimmed = tag.trim();
+        if (trimmed.isEmpty) continue;
+        frequencies[trimmed] = (frequencies[trimmed] ?? 0) + 1;
+      }
+    }
+
+    final sorted = frequencies.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return [for (final e in sorted.take(count)) e.key];
+  }
+}

--- a/test/services/smart_theory_booster_linker_test.dart
+++ b/test/services/smart_theory_booster_linker_test.dart
@@ -18,10 +18,10 @@ void main() {
   test('linkForLesson returns deep link to containing cluster', () async {
     const l1 = TheoryMiniLessonNode(id: 'a', title: 'A', content: '', nextIds: ['b']);
     const l2 = TheoryMiniLessonNode(id: 'b', title: 'B', content: '');
-    const cluster = TheoryLessonCluster(lessons: [l1, l2], tags: {'preflop'});
+    final cluster = TheoryLessonCluster(lessons: [l1, l2], tags: {'preflop'});
 
     final linker = SmartTheoryBoosterLinker(
-      clusterer: _StubClusterer(const [cluster]),
+      clusterer: _StubClusterer([cluster]),
       summaryService: TheoryClusterSummaryService(),
     );
 
@@ -30,17 +30,17 @@ void main() {
   });
 
   test('linkForTags picks cluster with overlapping tags', () async {
-    const c1 = TheoryLessonCluster(
+    final c1 = TheoryLessonCluster(
       lessons: [TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '')],
       tags: {'push'},
     );
-    const c2 = TheoryLessonCluster(
+    final c2 = TheoryLessonCluster(
       lessons: [TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '')],
       tags: {'call'},
     );
 
     final linker = SmartTheoryBoosterLinker(
-      clusterer: _StubClusterer(const [c1, c2]),
+      clusterer: _StubClusterer([c1, c2]),
       summaryService: TheoryClusterSummaryService(),
     );
 

--- a/test/services/theory_lesson_cluster_auto_tagger_test.dart
+++ b/test/services/theory_lesson_cluster_auto_tagger_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/theory_lesson_cluster_auto_tagger.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('tagClusters assigns top tags to clusters', () {
+    final a = TheoryMiniLessonNode(
+      id: 'a',
+      title: 'A',
+      content: '',
+      tags: const ['push', 'preflop'],
+    );
+    final b = TheoryMiniLessonNode(
+      id: 'b',
+      title: 'B',
+      content: '',
+      tags: const ['push', 'call'],
+    );
+    final c = TheoryMiniLessonNode(
+      id: 'c',
+      title: 'C',
+      content: '',
+      tags: const ['push', 'call'],
+    );
+
+    final cluster = TheoryLessonCluster(
+      lessons: [a, b, c],
+      tags: const {'push', 'call', 'preflop'},
+    );
+
+    TheoryLessonClusterAutoTagger().tagClusters([cluster]);
+
+    expect(cluster.autoTags, ['push', 'call', 'preflop']);
+  });
+}


### PR DESCRIPTION
## Summary
- extend TheoryLessonCluster with `autoTags`
- implement TheoryLessonClusterAutoTagger to assign top tags based on lesson frequency
- add unit test for auto tagger and adjust existing tests

## Testing
- `flutter test` *(fails: command not found: flutter; attempted install but download corrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689325a83844832a994608b835193212