### PR TITLE
Add serializer for theory lesson clusters

### DIFF
--- a/lib/models/theory_mini_lesson_node.dart
+++ b/lib/models/theory_mini_lesson_node.dart
@@ -98,4 +98,38 @@ class TheoryMiniLessonNode implements LearningPathNode {
       autoContent: yaml['autoContent'] as bool? ?? false,
     );
   }
+
+  factory TheoryMiniLessonNode.fromJson(Map<String, dynamic> json) {
+    final tags = <String>[for (final t in (json['tags'] as List? ?? [])) t.toString()];
+    final rawNext = json['nextIds'] ?? json['next'];
+    final nextIds = <String>[for (final v in (rawNext as List? ?? [])) v.toString()];
+    final linked = <String>[for (final v in (json['linkedPackIds'] as List? ?? [])) v.toString()];
+    return TheoryMiniLessonNode(
+      id: json['id']?.toString() ?? '',
+      refId: json['refId']?.toString(),
+      title: json['title']?.toString() ?? '',
+      content: json['content']?.toString() ?? '',
+      tags: tags,
+      targetStreet: json['targetStreet']?.toString(),
+      stage: json['stage']?.toString(),
+      nextIds: nextIds,
+      linkedPackIds: linked,
+      recoveredFromMistake: json['recoveredFromMistake'] as bool? ?? false,
+      autoContent: json['autoContent'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        if (refId != null) 'refId': refId,
+        'title': title,
+        'content': content,
+        if (tags.isNotEmpty) 'tags': tags,
+        if (targetStreet != null) 'targetStreet': targetStreet,
+        if (stage != null) 'stage': stage,
+        if (nextIds.isNotEmpty) 'nextIds': nextIds,
+        if (linkedPackIds.isNotEmpty) 'linkedPackIds': linkedPackIds,
+        if (recoveredFromMistake) 'recoveredFromMistake': recoveredFromMistake,
+        if (autoContent) 'autoContent': autoContent,
+      };
 }

--- a/lib/utils/theory_lesson_cluster_serializer.dart
+++ b/lib/utils/theory_lesson_cluster_serializer.dart
@@ -1,0 +1,48 @@
+import '../models/theory_lesson_cluster.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'theory_cluster_id_hasher.dart';
+
+/// Serializes and deserializes [TheoryLessonCluster] objects.
+class TheoryLessonClusterSerializer {
+  const TheoryLessonClusterSerializer();
+
+  /// Converts [cluster] into a JSON-friendly map.
+  Map<String, dynamic> toJson(TheoryLessonCluster cluster, {String? clusterId}) {
+    return {
+      'clusterId': clusterId ?? TheoryClusterIdHasher.hash(cluster),
+      'lessons': [for (final l in cluster.lessons) l.toJson()],
+      'sharedTags': cluster.sharedTags.toList(),
+      if (cluster.autoTags.isNotEmpty) 'autoTags': List<String>.from(cluster.autoTags),
+    };
+  }
+
+  /// Reconstructs a [TheoryLessonCluster] and its id from [json].
+  ({TheoryLessonCluster cluster, String clusterId}) fromJson(Map json) {
+    final lessonsJson = json['lessons'] as List? ?? [];
+    final lessons = <TheoryMiniLessonNode>[
+      for (final l in lessonsJson)
+        if (l is Map)
+          TheoryMiniLessonNode.fromJson(Map<String, dynamic>.from(l)),
+    ];
+
+    final rawTags = json['sharedTags'] ?? json['tags'];
+    final sharedTags = <String>{
+      for (final t in (rawTags as List? ?? [])) t.toString(),
+    };
+
+    final autoTags = <String>[
+      for (final t in (json['autoTags'] as List? ?? [])) t.toString(),
+    ];
+
+    final cluster = TheoryLessonCluster(
+      lessons: lessons,
+      tags: sharedTags,
+      autoTags: autoTags,
+    );
+
+    final clusterId =
+        json['clusterId']?.toString() ?? TheoryClusterIdHasher.hash(cluster);
+
+    return (cluster: cluster, clusterId: clusterId);
+  }
+}

--- a/test/utils/theory_lesson_cluster_serializer_test.dart
+++ b/test/utils/theory_lesson_cluster_serializer_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/utils/theory_cluster_id_hasher.dart';
+import 'package:poker_analyzer/utils/theory_lesson_cluster_serializer.dart';
+
+void main() {
+  test('serializes and deserializes cluster', () {
+    final l1 = TheoryMiniLessonNode(id: 'a', title: 'A', content: '', tags: ['t']);
+    final l2 = TheoryMiniLessonNode(id: 'b', title: 'B', content: '', tags: ['t']);
+    final cluster = TheoryLessonCluster(
+      lessons: [l1, l2],
+      tags: {'t'},
+      autoTags: ['x'],
+    );
+
+    final serializer = TheoryLessonClusterSerializer();
+    final json = serializer.toJson(cluster);
+    final (decoded, cid) = serializer.fromJson(json);
+
+    expect(decoded.lessons.length, 2);
+    expect(decoded.sharedTags, {'t'});
+    expect(decoded.autoTags, ['x']);
+    expect(cid, json['clusterId']);
+  });
+
+  test('computes clusterId when missing', () {
+    final lesson = TheoryMiniLessonNode(id: 'a', title: 'A', content: '');
+    final cluster = TheoryLessonCluster(lessons: [lesson], tags: {});
+    final serializer = TheoryLessonClusterSerializer();
+    final map = {
+      'lessons': [lesson.toJson()],
+      'sharedTags': [],
+    };
+    final (_, cid) = serializer.fromJson(map);
+    expect(cid, TheoryClusterIdHasher.hash(cluster));
+  });
+}


### PR DESCRIPTION
## Summary
- add JSON serialization helpers for mini lesson nodes
- implement TheoryLessonClusterSerializer with clusterId support
- test cluster serializer and id generation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart format lib/models/theory_mini_lesson_node.dart lib/utils/theory_lesson_cluster_serializer.dart test/utils/theory_lesson_cluster_serializer_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689328d52a10832a8f632641e0626d38