### PR TITLE
feat: skip flutter SDK requirement

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,16 +1,14 @@
-pluginManagement {
-    val flutterSdkPath = run {
-        val properties = java.util.Properties()
-        val localProperties = File(rootDir, "local.properties")
-        if (localProperties.exists()) {
-            localProperties.inputStream().use { properties.load(it) }
-        }
-        val flutterSdkPath = properties.getProperty("flutter.sdk")
-        require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
-        flutterSdkPath
-    }
+val properties = java.util.Properties()
+val localProperties = File(rootDir, "local.properties")
+if (localProperties.exists()) {
+    localProperties.inputStream().use { properties.load(it) }
+}
+val flutterSdkPath = properties.getProperty("flutter.sdk")
 
-    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+pluginManagement {
+    if (flutterSdkPath != null) {
+        includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+    }
 
     repositories {
         google()
@@ -20,7 +18,9 @@ pluginManagement {
 }
 
 plugins {
-    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    if (flutterSdkPath != null) {
+        id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    }
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }


### PR DESCRIPTION
## Summary
- allow Gradle to skip Flutter integration when local.properties lacks `flutter.sdk`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933163f8ec832a853b17029c375ea0