### PR TITLE
feat: add continue lesson button

### DIFF
--- a/lib/screens/theory_pack_preview_screen.dart
+++ b/lib/screens/theory_pack_preview_screen.dart
@@ -64,6 +64,16 @@ class _TheoryPackPreviewScreenState extends State<TheoryPackPreviewScreen> {
     return done;
   }
 
+  Future<TheoryMiniLessonNode?> _firstIncompleteLesson(
+      TheoryLessonCluster cluster) async {
+    for (final l in cluster.lessons) {
+      if (!await MiniLessonLibraryService.instance.isLessonCompleted(l.id)) {
+        return l;
+      }
+    }
+    return null;
+  }
+
   Widget _clusterPreview() {
     return FutureBuilder<TheoryLessonCluster?>(
       future: _clusterFuture,
@@ -82,6 +92,23 @@ class _TheoryPackPreviewScreenState extends State<TheoryPackPreviewScreen> {
                   ),
                 ]
               : [
+                  FutureBuilder<TheoryMiniLessonNode?>(
+                    future: _firstIncompleteLesson(cluster),
+                    builder: (context, lessonSnap) {
+                      final firstIncomplete = lessonSnap.data;
+                      if (firstIncomplete == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        child: ElevatedButton(
+                          onPressed: () => _openLesson(firstIncomplete),
+                          child: const Text('Continue lesson'),
+                        ),
+                      );
+                    },
+                  ),
                   FutureBuilder<int>(
                     future: _completedLessonCount(cluster),
                     builder: (context, countSnap) {


### PR DESCRIPTION
## Summary
- add helper to find first incomplete theory lesson
- show 'Continue lesson' button to resume unfinished theory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689335010e80832a8b0d54ffd846c6f4