### PR TITLE
chore(ci): ignore local properties

### DIFF
--- a/.ci-ignore
+++ b/.ci-ignore
@@ -1,0 +1,2 @@
+# Ignore generated local configuration files
+android/local.properties


### PR DESCRIPTION
## Summary
- ignore generated `local.properties` in CI to avoid flutter SDK dependency

## Testing
- `gradle -p android help` *(fails: Plugin [id: 'com.android.application'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689338c9e04c832a8ed1a2277b2102b5