### PR TITLE
chore(android): specify plugin versions

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
+    id("com.android.application") version "8.1.1"
+    kotlin("android") version "1.9.10"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,6 +1,14 @@
 import java.io.FileInputStream
 import java.util.Properties
 
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 val localProperties = Properties()
 val localPropertiesFile = File(rootDir, "local.properties")
 if (localPropertiesFile.exists()) {


### PR DESCRIPTION
## Summary
- specify Android and Kotlin plugin versions in app Gradle build file
- declare pluginManagement repositories for standalone Gradle builds

## Testing
- `gradle help` *(fails: Plugin [id: 'dev.flutter.flutter-gradle-plugin'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933a91ccb8832a83fc0ac82cc6d447