### PR TITLE
feat: enrich training pack library metadata

### DIFF
--- a/lib/models/v2/pack_ux_metadata.dart
+++ b/lib/models/v2/pack_ux_metadata.dart
@@ -1,0 +1,7 @@
+enum TrainingPackLevel { beginner, intermediate, advanced }
+
+enum TrainingPackTopic { pushFold, openFold, threeBet, postflop }
+
+enum TrainingPackFormat { cash, tournament }
+
+enum TrainingPackComplexity { simple, multiStreet, icm }

--- a/lib/services/training_pack_library_metadata_enricher.dart
+++ b/lib/services/training_pack_library_metadata_enricher.dart
@@ -1,0 +1,78 @@
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/pack_ux_metadata.dart';
+import '../models/game_type.dart';
+import '../core/training/engine/training_type_engine.dart';
+
+class TrainingPackLibraryMetadataEnricher {
+  final TrainingPackLibraryV2 library;
+
+  TrainingPackLibraryMetadataEnricher({TrainingPackLibraryV2? library})
+      : library = library ?? TrainingPackLibraryV2.instance;
+
+  /// Iterates over all packs and enriches each with UX metadata.
+  void enrichAll() {
+    for (final pack in library.packs) {
+      pack.meta['level'] = _inferLevel(pack).name;
+      pack.meta['topic'] = _inferTopic(pack).name;
+      pack.meta['format'] = _inferFormat(pack).name;
+      pack.meta['complexity'] = _inferComplexity(pack).name;
+    }
+  }
+
+  TrainingPackLevel _inferLevel(TrainingPackTemplateV2 p) {
+    final skill = p.meta['skillLevel']?.toString().toLowerCase();
+    if (skill == 'beginner') return TrainingPackLevel.beginner;
+    if (skill == 'advanced') return TrainingPackLevel.advanced;
+    if (skill == 'intermediate') return TrainingPackLevel.intermediate;
+    final tags = p.tags.map((t) => t.toLowerCase());
+    if (tags.contains('starter') || tags.contains('beginner')) {
+      return TrainingPackLevel.beginner;
+    }
+    if (tags.contains('advanced')) return TrainingPackLevel.advanced;
+    return TrainingPackLevel.intermediate;
+  }
+
+  TrainingPackTopic _inferTopic(TrainingPackTemplateV2 p) {
+    final tags = p.tags.map((t) => t.toLowerCase()).toList();
+    if (tags.any((t) => t.contains('3bet'))) {
+      return TrainingPackTopic.threeBet;
+    }
+    if (tags.any((t) => t.contains('open'))) {
+      return TrainingPackTopic.openFold;
+    }
+    if (tags.any((t) => t.contains('push'))) {
+      return TrainingPackTopic.pushFold;
+    }
+    if (tags.any((t) =>
+        t.contains('flop') ||
+        t.contains('turn') ||
+        t.contains('river') ||
+        t.contains('postflop'))) {
+      return TrainingPackTopic.postflop;
+    }
+    if (p.trainingType == TrainingType.postflop) {
+      return TrainingPackTopic.postflop;
+    }
+    return TrainingPackTopic.pushFold;
+  }
+
+  TrainingPackFormat _inferFormat(TrainingPackTemplateV2 p) {
+    return p.gameType == GameType.cash
+        ? TrainingPackFormat.cash
+        : TrainingPackFormat.tournament;
+  }
+
+  TrainingPackComplexity _inferComplexity(TrainingPackTemplateV2 p) {
+    final tags = p.tags.map((t) => t.toLowerCase());
+    if (tags.contains('icm') || p.meta['icm'] == true) {
+      return TrainingPackComplexity.icm;
+    }
+    if ((p.targetStreet != null &&
+            p.targetStreet!.toLowerCase() != 'preflop') ||
+        p.spotCount > 20) {
+      return TrainingPackComplexity.multiStreet;
+    }
+    return TrainingPackComplexity.simple;
+  }
+}

--- a/test/services/training_pack_library_metadata_enricher_test.dart
+++ b/test/services/training_pack_library_metadata_enricher_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_pack_library_metadata_enricher.dart';
+
+void main() {
+  test('enrichAll populates UX metadata for all packs', () {
+    final lib = TrainingPackLibraryV2.instance;
+    lib.clear();
+
+    final p1 = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack1',
+      tags: ['river', 'icm'],
+      trainingType: TrainingType.postflop,
+      spots: [],
+      spotCount: 5,
+      gameType: GameType.tournament,
+      targetStreet: 'river',
+      meta: {'skillLevel': 'advanced'},
+    );
+
+    final p2 = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Pack2',
+      tags: ['starter', 'flop'],
+      trainingType: TrainingType.postflop,
+      spots: [],
+      spotCount: 30,
+      gameType: GameType.cash,
+      targetStreet: 'flop',
+    );
+
+    lib.addPack(p1);
+    lib.addPack(p2);
+
+    final enricher = TrainingPackLibraryMetadataEnricher(library: lib);
+    enricher.enrichAll();
+
+    expect(p1.meta['level'], 'advanced');
+    expect(p1.meta['topic'], 'postflop');
+    expect(p1.meta['format'], 'tournament');
+    expect(p1.meta['complexity'], 'icm');
+
+    expect(p2.meta['level'], 'beginner');
+    expect(p2.meta['topic'], 'postflop');
+    expect(p2.meta['format'], 'cash');
+    expect(p2.meta['complexity'], 'multiStreet');
+  });
+}


### PR DESCRIPTION
## Summary
- add enums for level, topic, format and complexity metadata
- implement TrainingPackLibraryMetadataEnricher to populate UX metadata on all packs
- cover enrichment logic with unit test

## Testing
- `dart test test/services/training_pack_library_metadata_enricher_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933a6adce8832aa8d3a2815feacadf