### PR TITLE
feat: add training pack metadata search index

### DIFF
--- a/lib/services/training_pack_search_index_builder.dart
+++ b/lib/services/training_pack_search_index_builder.dart
@@ -1,0 +1,87 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/pack_ux_metadata.dart';
+
+class TrainingPackSearchIndexBuilder {
+  final Map<String, List<TrainingPackTemplateV2>> byLevel = {};
+  final Map<String, List<TrainingPackTemplateV2>> byTopic = {};
+  final Map<String, List<TrainingPackTemplateV2>> byTag = {};
+  final Map<String, List<TrainingPackTemplateV2>> byFormat = {};
+  final Map<String, List<TrainingPackTemplateV2>> byComplexity = {};
+
+  List<TrainingPackTemplateV2> _all = [];
+
+  void build(List<TrainingPackTemplateV2> packs) {
+    _all = packs;
+    byLevel.clear();
+    byTopic.clear();
+    byTag.clear();
+    byFormat.clear();
+    byComplexity.clear();
+
+    for (final p in packs) {
+      final level = p.meta['level']?.toString();
+      final topic = p.meta['topic']?.toString();
+      final format = p.meta['format']?.toString();
+      final complexity = p.meta['complexity']?.toString();
+
+      if (level != null) {
+        byLevel.putIfAbsent(level, () => <TrainingPackTemplateV2>[]).add(p);
+      }
+      if (topic != null) {
+        byTopic.putIfAbsent(topic, () => <TrainingPackTemplateV2>[]).add(p);
+      }
+      if (format != null) {
+        byFormat.putIfAbsent(format, () => <TrainingPackTemplateV2>[]).add(p);
+      }
+      if (complexity != null) {
+        byComplexity
+            .putIfAbsent(complexity, () => <TrainingPackTemplateV2>[])
+            .add(p);
+      }
+      for (final tag in p.tags) {
+        final key = tag.toLowerCase();
+        byTag.putIfAbsent(key, () => <TrainingPackTemplateV2>[]).add(p);
+      }
+    }
+  }
+
+  List<TrainingPackTemplateV2> query({
+    TrainingPackLevel? level,
+    TrainingPackTopic? topic,
+    List<String>? tags,
+    TrainingPackFormat? format,
+    TrainingPackComplexity? complexity,
+  }) {
+    Set<TrainingPackTemplateV2>? results;
+
+    void intersect(List<TrainingPackTemplateV2>? list) {
+      if (results != null && results!.isEmpty) return;
+      if (list == null) {
+        results = <TrainingPackTemplateV2>{};
+        return;
+      }
+      final set = list.toSet();
+      results = results == null ? set : results!.intersection(set);
+    }
+
+    if (level != null) {
+      intersect(byLevel[level.name]);
+    }
+    if (topic != null) {
+      intersect(byTopic[topic.name]);
+    }
+    if (format != null) {
+      intersect(byFormat[format.name]);
+    }
+    if (complexity != null) {
+      intersect(byComplexity[complexity.name]);
+    }
+    if (tags != null && tags.isNotEmpty) {
+      for (final t in tags) {
+        intersect(byTag[t.toLowerCase()]);
+      }
+    }
+
+    return results?.toList() ?? List<TrainingPackTemplateV2>.from(_all);
+  }
+}

--- a/test/services/training_pack_search_index_builder_test.dart
+++ b/test/services/training_pack_search_index_builder_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/v2/pack_ux_metadata.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_pack_search_index_builder.dart';
+
+void main() {
+  test('filters by multiple metadata fields and tags', () {
+    final p1 = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Beginner Postflop',
+      trainingType: TrainingType.postflop,
+      tags: ['postflop'],
+      meta: {
+        'level': TrainingPackLevel.beginner.name,
+        'topic': TrainingPackTopic.postflop.name,
+        'format': TrainingPackFormat.tournament.name,
+        'complexity': TrainingPackComplexity.simple.name,
+      },
+    );
+    final p2 = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Beginner 3bet',
+      trainingType: TrainingType.postflop,
+      tags: ['3bet'],
+      meta: {
+        'level': TrainingPackLevel.beginner.name,
+        'topic': TrainingPackTopic.threeBet.name,
+        'format': TrainingPackFormat.tournament.name,
+        'complexity': TrainingPackComplexity.multiStreet.name,
+      },
+    );
+    final p3 = TrainingPackTemplateV2(
+      id: 'p3',
+      name: 'Intermediate 3bet',
+      trainingType: TrainingType.postflop,
+      tags: ['3bet', 'extra'],
+      meta: {
+        'level': TrainingPackLevel.intermediate.name,
+        'topic': TrainingPackTopic.threeBet.name,
+        'format': TrainingPackFormat.tournament.name,
+        'complexity': TrainingPackComplexity.multiStreet.name,
+      },
+    );
+    final p4 = TrainingPackTemplateV2(
+      id: 'p4',
+      name: 'Intermediate 3bet Cash',
+      trainingType: TrainingType.postflop,
+      tags: ['3bet'],
+      meta: {
+        'level': TrainingPackLevel.intermediate.name,
+        'topic': TrainingPackTopic.threeBet.name,
+        'format': TrainingPackFormat.cash.name,
+        'complexity': TrainingPackComplexity.multiStreet.name,
+      },
+    );
+
+    final builder = TrainingPackSearchIndexBuilder();
+    builder.build([p1, p2, p3, p4]);
+
+    final res = builder.query(
+      level: TrainingPackLevel.intermediate,
+      topic: TrainingPackTopic.threeBet,
+      format: TrainingPackFormat.tournament,
+      complexity: TrainingPackComplexity.multiStreet,
+      tags: ['3bet', 'extra'],
+    );
+
+    expect(res, [p3]);
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingPackSearchIndexBuilder to index packs by level, topic, format, complexity, and tags
- allow querying packs with multiple filter parameters
- cover multi-parameter filtering with unit test

## Testing
- `flutter test test/services/training_pack_search_index_builder_test.dart` *(fails: The current Dart SDK version is 3.5.0 but >=3.6.0 <4.0.0 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68933c57f400832abf4edb679c593ecb