### PR TITLE
Add metadata section to training pack preview

### DIFF
--- a/lib/screens/training_pack_preview_screen.dart
+++ b/lib/screens/training_pack_preview_screen.dart
@@ -8,6 +8,7 @@ import '../services/mini_lesson_library_service.dart';
 import '../services/inline_theory_linker_service.dart';
 import '../widgets/pack_insights_banner.dart';
 import '../widgets/pack_recommendation_section.dart';
+import '../widgets/pack_preview_screen_metadata_section.dart';
 import 'mini_lesson_screen.dart';
 import '../models/theory_mini_lesson_node.dart';
 import 'training_session_screen.dart';
@@ -40,8 +41,12 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
   }
 
   Future<void> _loadRating() async {
-    final r = await PackRatingService.instance.getUserRating(widget.template.id);
-    final avg = await PackRatingService.instance.getAverageRating(widget.template.id);
+    final r = await PackRatingService.instance.getUserRating(
+      widget.template.id,
+    );
+    final avg = await PackRatingService.instance.getAverageRating(
+      widget.template.id,
+    );
     if (mounted) {
       setState(() {
         _userRating = r;
@@ -51,8 +56,9 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
   }
 
   Future<void> _loadComment() async {
-    final c = await TrainingPackCommentsService.instance
-        .getComment(widget.template.id);
+    final c = await TrainingPackCommentsService.instance.getComment(
+      widget.template.id,
+    );
     if (mounted) setState(() => _comment = c);
   }
 
@@ -63,7 +69,9 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
 
   Future<void> _setRating(int r) async {
     await PackRatingService.instance.rate(widget.template.id, r);
-    final avg = await PackRatingService.instance.getAverageRating(widget.template.id);
+    final avg = await PackRatingService.instance.getAverageRating(
+      widget.template.id,
+    );
     if (mounted) {
       setState(() {
         _userRating = r;
@@ -96,8 +104,10 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
       ),
     );
     if (result != null) {
-      await TrainingPackCommentsService.instance
-          .saveComment(widget.template.id, result);
+      await TrainingPackCommentsService.instance.saveComment(
+        widget.template.id,
+        result,
+      );
       if (mounted) setState(() => _comment = result);
     }
   }
@@ -123,35 +133,30 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
             color: _favorite ? Colors.amber : Colors.white,
             onPressed: _toggleFavorite,
           ),
-          IconButton(
-            onPressed: () {},
-            icon: const Icon(Icons.share),
-          ),
+          IconButton(onPressed: () {}, icon: const Icon(Icons.share)),
         ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          Text(widget.template.name,
-              style:
-                  const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          Text(
+            widget.template.name,
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
           const SizedBox(height: 4),
           _buildRatingRow(),
           const SizedBox(height: 8),
+          PackPreviewScreenMetadataSection(template: widget.template),
+          const SizedBox(height: 8),
           _buildCommentSection(),
           const SizedBox(height: 8),
-          Text('Type: ${widget.template.trainingType.name}',
-              style: const TextStyle(color: Colors.white70)),
-          if (widget.template.tags.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text('Tags: ${widget.template.tags.join(', ')}',
-                style: const TextStyle(color: Colors.white70)),
-          ],
           if (widget.template.audience != null &&
               widget.template.audience!.isNotEmpty) ...[
             const SizedBox(height: 4),
-            Text('Audience: ${widget.template.audience!}',
-                style: const TextStyle(color: Colors.white70)),
+            Text(
+              'Audience: ${widget.template.audience!}',
+              style: const TextStyle(color: Colors.white70),
+            ),
           ],
           if (widget.template.description.isNotEmpty) ...[
             const SizedBox(height: 8),
@@ -177,35 +182,38 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
               );
             },
             icon: const Icon(Icons.menu_book, color: Colors.lightBlueAccent),
-            label: const Text('Теория пака',
-                style: TextStyle(color: Colors.lightBlueAccent)),
+            label: const Text(
+              'Теория пака',
+              style: TextStyle(color: Colors.lightBlueAccent),
+            ),
           ),
           if (widget.template.goal.isNotEmpty) ...[
             const SizedBox(height: 8),
-            Text('Goal: ${widget.template.goal}',
-                style: const TextStyle(color: Colors.white70)),
+            Text(
+              'Goal: ${widget.template.goal}',
+              style: const TextStyle(color: Colors.white70),
+            ),
           ],
           if (widget.template.positions.isNotEmpty) ...[
             const SizedBox(height: 8),
-            Text('Positions: ${widget.template.positions.join(', ')}',
-                style: const TextStyle(color: Colors.white70)),
-          ],
-          if (widget.template.meta.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            const Text('Meta:', style: TextStyle(fontWeight: FontWeight.bold)),
-            for (final e in widget.template.meta.entries)
-              Text('${e.key}: ${e.value}',
-                  style: const TextStyle(color: Colors.white70)),
+            Text(
+              'Positions: ${widget.template.positions.join(', ')}',
+              style: const TextStyle(color: Colors.white70),
+            ),
           ],
           if (widget.template.spotCount > 0) ...[
             const SizedBox(height: 8),
-            Text('Spots: ${widget.template.spotCount}',
-                style: const TextStyle(color: Colors.white70)),
+            Text(
+              'Spots: ${widget.template.spotCount}',
+              style: const TextStyle(color: Colors.white70),
+            ),
           ],
           if (widget.template.spots.isNotEmpty) ...[
             const SizedBox(height: 16),
-            const Text('Примеры:',
-                style: TextStyle(fontWeight: FontWeight.bold)),
+            const Text(
+              'Примеры:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
             for (final s in widget.template.spots.take(3))
               ListTile(
@@ -233,7 +241,9 @@ class _TrainingPackPreviewScreenState extends State<TrainingPackPreviewScreen> {
           ElevatedButton(
             onPressed: () {
               final pack = TrainingPackV2.fromTemplate(
-                  widget.template, widget.template.id);
+                widget.template,
+                widget.template.id,
+              );
               Navigator.pushReplacement(
                 context,
                 MaterialPageRoute(

--- a/lib/widgets/pack_preview_screen_metadata_section.dart
+++ b/lib/widgets/pack_preview_screen_metadata_section.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../models/v2/pack_ux_metadata.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class PackPreviewScreenMetadataSection extends StatelessWidget {
+  final TrainingPackTemplateV2 template;
+  const PackPreviewScreenMetadataSection({super.key, required this.template});
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = template.meta;
+
+    TrainingPackLevel? level;
+    TrainingPackTopic? topic;
+    TrainingPackFormat? format;
+    TrainingPackComplexity? complexity;
+
+    try {
+      final v = meta['level'];
+      if (v is String) level = TrainingPackLevel.values.byName(v);
+    } catch (_) {}
+    try {
+      final v = meta['topic'];
+      if (v is String) topic = TrainingPackTopic.values.byName(v);
+    } catch (_) {}
+    try {
+      final v = meta['format'];
+      if (v is String) format = TrainingPackFormat.values.byName(v);
+    } catch (_) {}
+    try {
+      final v = meta['complexity'];
+      if (v is String) {
+        complexity = TrainingPackComplexity.values.byName(v);
+      }
+    } catch (_) {}
+
+    final items = <Widget>[];
+    if (level != null) {
+      items.add(_MetaItem(icon: Icons.school, label: _levelLabel(level!)));
+    }
+    if (topic != null) {
+      items.add(_MetaItem(icon: Icons.topic, label: _topicLabel(topic!)));
+    }
+    if (format != null) {
+      final icon = format == TrainingPackFormat.cash
+          ? Icons.attach_money
+          : Icons.emoji_events;
+      items.add(_MetaItem(icon: icon, label: _formatLabel(format!)));
+    }
+    if (complexity != null) {
+      items.add(
+        _MetaItem(icon: Icons.tune, label: _complexityLabel(complexity!)),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (items.isNotEmpty) Wrap(spacing: 8, runSpacing: 4, children: items),
+        if (template.tags.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: SizedBox(
+              height: 32,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: template.tags.length,
+                separatorBuilder: (_, __) => const SizedBox(width: 4),
+                itemBuilder: (_, i) => Chip(label: Text(template.tags[i])),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _levelLabel(TrainingPackLevel l) {
+    switch (l) {
+      case TrainingPackLevel.beginner:
+        return 'Beginner';
+      case TrainingPackLevel.intermediate:
+        return 'Intermediate';
+      case TrainingPackLevel.advanced:
+        return 'Advanced';
+    }
+  }
+
+  String _topicLabel(TrainingPackTopic t) {
+    switch (t) {
+      case TrainingPackTopic.pushFold:
+        return 'Push/Fold';
+      case TrainingPackTopic.openFold:
+        return 'Open/Fold';
+      case TrainingPackTopic.threeBet:
+        return '3-Bet';
+      case TrainingPackTopic.postflop:
+        return 'Postflop';
+    }
+  }
+
+  String _formatLabel(TrainingPackFormat f) {
+    switch (f) {
+      case TrainingPackFormat.cash:
+        return 'Cash';
+      case TrainingPackFormat.tournament:
+        return 'Tournament';
+    }
+  }
+
+  String _complexityLabel(TrainingPackComplexity c) {
+    switch (c) {
+      case TrainingPackComplexity.simple:
+        return 'Simple';
+      case TrainingPackComplexity.multiStreet:
+        return 'Multi-Street';
+      case TrainingPackComplexity.icm:
+        return 'ICM';
+    }
+  }
+}
+
+class _MetaItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _MetaItem({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: Colors.white70),
+        const SizedBox(width: 4),
+        Text(label, style: const TextStyle(color: Colors.white70)),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show pack level, topic, format, complexity, and tags via new `PackPreviewScreenMetadataSection`
- display metadata section under the title in training pack preview screen

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: command interrupted)*
- `flutter test` *(fails: multiple compilation errors, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6893422528cc832abbea7bbd5da85c02