### PR TITLE
feat: add training pack tooltip widget

### DIFF
--- a/lib/screens/pack_library_search_screen.dart
+++ b/lib/screens/pack_library_search_screen.dart
@@ -3,6 +3,7 @@ import '../core/training/library/training_pack_library_v2.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
 import '../widgets/pack_card.dart';
+import '../widgets/training_pack_template_tooltip_widget.dart';
 import '../widgets/training_pack_library_metadata_filter_bar.dart';
 import '../widgets/training_pack_library_sort_bar.dart';
 import '../models/v2/pack_ux_metadata.dart';
@@ -145,9 +146,12 @@ class _PackLibrarySearchScreenState extends State<PackLibrarySearchScreen> {
               separatorBuilder: (_, __) => const SizedBox(height: 8),
               itemBuilder: (context, index) {
                 final tpl = _results[index];
-                return PackCard(
+                return TrainingPackTemplateTooltipWidget(
                   template: tpl,
-                  onTap: () => _open(tpl),
+                  child: PackCard(
+                    template: tpl,
+                    onTap: () => _open(tpl),
+                  ),
                 );
               },
             ),

--- a/lib/widgets/training_pack_template_tooltip_widget.dart
+++ b/lib/widgets/training_pack_template_tooltip_widget.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../models/v2/pack_ux_metadata.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Displays a tooltip with basic metadata for a [TrainingPackTemplateV2].
+///
+/// The tooltip is shown on long press (mobile) or hover (desktop/web)
+/// and contains the template's title, level, topic and format if
+/// available. Missing or malformed metadata fields are ignored.
+class TrainingPackTemplateTooltipWidget extends StatelessWidget {
+  final TrainingPackTemplateV2 template;
+  final Widget child;
+  const TrainingPackTemplateTooltipWidget({
+    super.key,
+    required this.template,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final buffer = StringBuffer(template.name);
+    final meta = template.meta;
+
+    final level =
+        _tryParse<TrainingPackLevel>(meta['level'], (v) => TrainingPackLevel.values.byName(v));
+    final topic =
+        _tryParse<TrainingPackTopic>(meta['topic'], (v) => TrainingPackTopic.values.byName(v));
+    final format = _tryParse<TrainingPackFormat>(meta['format'], (v) =>
+        TrainingPackFormat.values.byName(v));
+
+    if (level != null || topic != null || format != null) {
+      buffer.writeln();
+    }
+    if (level != null) buffer.writeln('Level: ${_levelLabel(level)}');
+    if (topic != null) buffer.writeln('Topic: ${_topicLabel(topic)}');
+    if (format != null) buffer.writeln('Format: ${_formatLabel(format)}');
+
+    final message = buffer.toString().trim();
+
+    return Tooltip(message: message, child: child);
+  }
+
+  T? _tryParse<T>(dynamic value, T Function(String) parser) {
+    if (value is String) {
+      try {
+        return parser(value);
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  String _levelLabel(TrainingPackLevel l) {
+    switch (l) {
+      case TrainingPackLevel.beginner:
+        return 'Beginner';
+      case TrainingPackLevel.intermediate:
+        return 'Intermediate';
+      case TrainingPackLevel.advanced:
+        return 'Advanced';
+    }
+  }
+
+  String _topicLabel(TrainingPackTopic t) {
+    switch (t) {
+      case TrainingPackTopic.pushFold:
+        return 'Push/Fold Spots';
+      case TrainingPackTopic.openFold:
+        return 'Open/Fold Spots';
+      case TrainingPackTopic.threeBet:
+        return '3-Bet Spots';
+      case TrainingPackTopic.postflop:
+        return 'Postflop Spots';
+    }
+  }
+
+  String _formatLabel(TrainingPackFormat f) {
+    switch (f) {
+      case TrainingPackFormat.cash:
+        return 'Cash';
+      case TrainingPackFormat.tournament:
+        return 'Tournament';
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable tooltip widget for training pack templates
- show pack metadata tooltip on search results

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6893498a3d8c832aaca0f73abaf3ddab