### PR TITLE
feat: show pack completion stats in tooltip

### DIFF
--- a/lib/services/training_pack_progress_service.dart
+++ b/lib/services/training_pack_progress_service.dart
@@ -1,0 +1,38 @@
+import 'training_pack_template_service.dart';
+import 'training_progress_tracker_service.dart';
+
+class TrainingPackProgressStats {
+  final int completedCount;
+  final int totalCount;
+  const TrainingPackProgressStats({required this.completedCount, required this.totalCount});
+}
+
+/// Provides per-pack completion stats.
+class TrainingPackProgressService {
+  TrainingPackProgressService._();
+  static final instance = TrainingPackProgressService._();
+
+  final Map<String, TrainingPackProgressStats?> _cache = {};
+
+  Future<TrainingPackProgressStats?> getStatsForPack(String packId) async {
+    if (_cache.containsKey(packId)) return _cache[packId];
+    final template = TrainingPackTemplateService.getById(packId);
+    if (template == null) {
+      _cache[packId] = null;
+      return null;
+    }
+    final total = template.spots.isNotEmpty ? template.spots.length : template.spotCount;
+    if (total <= 0) {
+      _cache[packId] = null;
+      return null;
+    }
+    final completed =
+        (await TrainingProgressTrackerService.instance.getCompletedSpotIds(packId)).length;
+    final stats = TrainingPackProgressStats(completedCount: completed, totalCount: total);
+    _cache[packId] = stats;
+    return stats;
+  }
+
+  void invalidate(String packId) => _cache.remove(packId);
+}
+

--- a/lib/services/training_progress_tracker_service.dart
+++ b/lib/services/training_progress_tracker_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'training_pack_stats_service.dart';
+import 'training_pack_progress_service.dart';
 import 'training_progress_notifier.dart';
 import 'training_progress_storage_service.dart';
 
@@ -23,6 +24,7 @@ class TrainingProgressTrackerService {
     if (ids.add(spotId)) {
       await _storage.saveCompletedSpotIds(packId, ids);
       notifier.notifyProgressChanged();
+      TrainingPackProgressService.instance.invalidate(packId);
     }
   }
 

--- a/lib/widgets/training_pack_template_tooltip_widget.dart
+++ b/lib/widgets/training_pack_template_tooltip_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/v2/pack_ux_metadata.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import '../services/training_pack_progress_service.dart';
 
 /// Displays a tooltip with basic metadata for a [TrainingPackTemplateV2].
 ///
@@ -36,9 +37,19 @@ class TrainingPackTemplateTooltipWidget extends StatelessWidget {
     if (topic != null) buffer.writeln('Topic: ${_topicLabel(topic)}');
     if (format != null) buffer.writeln('Format: ${_formatLabel(format)}');
 
-    final message = buffer.toString().trim();
+    final baseMessage = buffer.toString().trim();
 
-    return Tooltip(message: message, child: child);
+    return FutureBuilder<TrainingPackProgressStats?>(
+      future: TrainingPackProgressService.instance.getStatsForPack(template.id),
+      builder: (context, snapshot) {
+        var msg = baseMessage;
+        final stats = snapshot.data;
+        if (stats != null) {
+          msg += '\nCompleted: ${stats.completedCount} / ${stats.totalCount}';
+        }
+        return Tooltip(message: msg, child: child);
+      },
+    );
   }
 
   T? _tryParse<T>(dynamic value, T Function(String) parser) {


### PR DESCRIPTION
## Summary
- display user completion counts in `TrainingPackTemplateTooltipWidget`
- add `TrainingPackProgressService` with caching to provide completion stats
- invalidate progress cache when a spot completion is recorded

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68934b910cf8832ab82fb8da3d6ee282