### PR TITLE
feat: add goal-based pack filtering

### DIFF
--- a/lib/core/training/library/training_pack_library_v2.dart
+++ b/lib/core/training/library/training_pack_library_v2.dart
@@ -67,13 +67,22 @@ class TrainingPackLibraryV2 {
     TrainingType? type,
     List<String>? tags,
     TrainingPackLevel? level,
+    String? goal,
   }) {
+    final goalStr = goal?.trim().toLowerCase();
     return [
       for (final p in _packs)
         if ((gameType == null || p.gameType == gameType) &&
             (type == null || p.trainingType == type) &&
             (tags == null || tags.every((t) => p.tags.contains(t))) &&
-            (level == null || p.meta['level']?.toString() == level.name))
+            (level == null || p.meta['level']?.toString() == level.name) &&
+            (goalStr == null ||
+                ((p.goal.isNotEmpty
+                        ? p.goal
+                        : p.meta['goal']?.toString() ?? '')
+                    .trim()
+                    .toLowerCase() ==
+                    goalStr)))
           p
     ];
   }

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -33,9 +33,11 @@ class _LibraryScreenState extends State<LibraryScreen> {
   List<String> _tags = [];
   List<String> _audiences = [];
   List<int> _difficulties = [];
+  List<String> _goals = [];
   final Set<String> _selectedTags = {};
   final Set<int> _selectedDifficulties = {};
   final Set<String> _selectedAudiences = {};
+  String _selectedGoal = '';
   TrainingPackLevel? _levelFilter;
   final List<TrainingType> _types = TrainingType.values;
   final Set<TrainingType> _selectedTypes = {};
@@ -106,11 +108,17 @@ class _LibraryScreenState extends State<LibraryScreen> {
     await TrainingPackTagsService.instance.load(list);
     await TrainingPackAudienceService.instance.load(list);
     await TrainingPackDifficultyService.instance.load(list);
+    final goalSet = <String>{};
+    for (final p in list) {
+      final g = _goalText(p);
+      if (g.isNotEmpty) goalSet.add(g);
+    }
     setState(() {
       _packs = list;
       _tags = TrainingPackTagsService.instance.topTags;
       _audiences = TrainingPackAudienceService.instance.topAudiences;
       _difficulties = TrainingPackDifficultyService.instance.topDifficulties;
+      _goals = goalSet.toList()..sort();
       _ratings = ratingMap;
       _loading = false;
     });
@@ -143,6 +151,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
           _selectedDifficulties.isEmpty ? null : _selectedDifficulties,
       audiences: _selectedAudiences.isEmpty ? null : _selectedAudiences,
       level: _levelFilter,
+      goal: _selectedGoal.isEmpty ? null : _selectedGoal,
     );
 
     DateTime createdAt(TrainingPackTemplateV2 p) {
@@ -210,6 +219,25 @@ class _LibraryScreenState extends State<LibraryScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (_goals.isNotEmpty) ...[
+                  const Text('🎯 Goal'),
+                  DropdownButton<String>(
+                    value: _selectedGoal,
+                    isExpanded: true,
+                    items: [
+                      const DropdownMenuItem(
+                        value: '',
+                        child: Text('All goals'),
+                      ),
+                      for (final g in _goals)
+                        DropdownMenuItem(value: g, child: Text(g)),
+                    ],
+                    onChanged: (v) {
+                      setState(() => _selectedGoal = v ?? '');
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 if (_tags.isNotEmpty)
                   SingleChildScrollView(
                     scrollDirection: Axis.horizontal,
@@ -374,7 +402,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
                         _selectedDifficulties.isNotEmpty ||
                         _selectedAudiences.isNotEmpty ||
                         _selectedTypes.isNotEmpty ||
-                        _levelFilter != null)
+                        _levelFilter != null ||
+                        _selectedGoal.isNotEmpty)
                       TextButton(
                         onPressed: () => setState(() {
                           _selectedTags.clear();
@@ -382,6 +411,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                           _selectedAudiences.clear();
                           _selectedTypes.clear();
                           _levelFilter = null;
+                          _selectedGoal = '';
                         }),
                         child: const Text('Сбросить'),
                       ),
@@ -389,7 +419,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
                         _selectedDifficulties.isNotEmpty ||
                         _selectedAudiences.isNotEmpty ||
                         _selectedTypes.isNotEmpty ||
-                        _levelFilter != null)
+                        _levelFilter != null ||
+                        _selectedGoal.isNotEmpty)
                       const SizedBox(width: 12),
                     Text('Найдено: ${visible.length}')
                   ],
@@ -408,7 +439,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
                             _selectedDifficulties.isNotEmpty ||
                             _selectedAudiences.isNotEmpty ||
                             _selectedTypes.isNotEmpty ||
-                            _levelFilter != null)
+                            _levelFilter != null ||
+                            _selectedGoal.isNotEmpty)
                           TextButton(
                             onPressed: () => setState(() {
                               _selectedTags.clear();
@@ -416,6 +448,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                               _selectedAudiences.clear();
                               _selectedTypes.clear();
                               _levelFilter = null;
+                              _selectedGoal = '';
                             }),
                             child: const Text('Сбросить'),
                           ),

--- a/lib/services/pack_filter_service.dart
+++ b/lib/services/pack_filter_service.dart
@@ -12,15 +12,17 @@ class PackFilterService {
     Set<int>? difficulties,
     Set<String>? audiences,
     TrainingPackLevel? level,
+    String? goal,
   }) {
     final tagSet = tags?.map((e) => e.trim().toLowerCase()).toSet() ?? {};
     final typeSet = types ?? {};
     final diffSet = difficulties ?? {};
     final audSet = audiences?.map((e) => e.trim().toLowerCase()).toSet() ?? {};
+    final goalStr = goal?.trim().toLowerCase();
 
     return [
       for (final t in templates)
-        if (_matches(t, tagSet, typeSet, diffSet, audSet, level)) t
+        if (_matches(t, tagSet, typeSet, diffSet, audSet, level, goalStr)) t
     ];
   }
 
@@ -31,6 +33,7 @@ class PackFilterService {
     Set<int> diffs,
     Set<String> audiences,
     TrainingPackLevel? level,
+    String? goal,
   ) {
     if (types.isNotEmpty && !types.contains(tpl.trainingType)) return false;
 
@@ -54,6 +57,15 @@ class PackFilterService {
     if (level != null) {
       final lvl = tpl.meta['level']?.toString();
       if (lvl != level.name) return false;
+    }
+
+    if (goal != null && goal.isNotEmpty) {
+      final g = (tpl.goal.isNotEmpty
+              ? tpl.goal
+              : tpl.meta['goal']?.toString() ?? '')
+          .trim()
+          .toLowerCase();
+      if (g != goal) return false;
     }
     return true;
   }

--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -393,6 +393,9 @@ class _PackCardState extends State<PackCard>
           break;
       }
     }
+    final goalText = widget.template.goal.isNotEmpty
+        ? widget.template.goal
+        : (widget.template.meta['goal']?.toString() ?? '').trim();
     return GestureDetector(
       onTap: () async {
         if (_locked) {
@@ -467,6 +470,19 @@ class _PackCardState extends State<PackCard>
                     style: const TextStyle(color: Colors.white70),
                   ),
                 ),
+                if (goalText.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      goalText,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
                 if (!_locked &&
                     ((_requiredAccuracy ?? 0) > 0 || (_minHands ?? 0) > 0))
                   PackProgressSummaryWidget(


### PR DESCRIPTION
## Summary
- support filtering training packs by goal metadata
- allow selecting goals in library screen and show goal on pack cards

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689354460d30832aa9c7ea4f7e206e40