### PR TITLE
feat: add theme filter for training packs

### DIFF
--- a/lib/core/training/library/training_pack_library_v2.dart
+++ b/lib/core/training/library/training_pack_library_v2.dart
@@ -66,15 +66,18 @@ class TrainingPackLibraryV2 {
     GameType? gameType,
     TrainingType? type,
     List<String>? tags,
+    List<String>? themes,
     TrainingPackLevel? level,
     String? goal,
   }) {
     final goalStr = goal?.trim().toLowerCase();
+    final themeSet = themes?.map((e) => e.trim().toLowerCase()).toSet();
     return [
       for (final p in _packs)
         if ((gameType == null || p.gameType == gameType) &&
             (type == null || p.trainingType == type) &&
             (tags == null || tags.every((t) => p.tags.contains(t))) &&
+            (themeSet == null || _themeMatches(p, themeSet)) &&
             (level == null || p.meta['level']?.toString() == level.name) &&
             (goalStr == null ||
                 ((p.goal.isNotEmpty
@@ -85,6 +88,20 @@ class TrainingPackLibraryV2 {
                     goalStr)))
           p
     ];
+  }
+
+  bool _themeMatches(TrainingPackTemplateV2 p, Set<String> themes) {
+    final raw = p.meta['theme'];
+    final set = <String>{};
+    if (raw is String) {
+      set.add(raw.trim().toLowerCase());
+    } else if (raw is List) {
+      for (final t in raw) {
+        set.add(t.toString().trim().toLowerCase());
+      }
+    }
+    if (set.isEmpty) return false;
+    return set.intersection(themes).isNotEmpty;
   }
 
   TrainingPackTemplateV2? getById(String id) => _index[id];

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -31,10 +31,12 @@ class _LibraryScreenState extends State<LibraryScreen> {
   bool _loading = true;
   List<TrainingPackTemplateV2> _packs = [];
   List<String> _tags = [];
+  List<String> _themes = [];
   List<String> _audiences = [];
   List<int> _difficulties = [];
   List<String> _goals = [];
   final Set<String> _selectedTags = {};
+  final Set<String> _selectedThemes = {};
   final Set<int> _selectedDifficulties = {};
   final Set<String> _selectedAudiences = {};
   String _selectedGoal = '';
@@ -109,13 +111,27 @@ class _LibraryScreenState extends State<LibraryScreen> {
     await TrainingPackAudienceService.instance.load(list);
     await TrainingPackDifficultyService.instance.load(list);
     final goalSet = <String>{};
+    final themeMap = <String, String>{};
     for (final p in list) {
       final g = _goalText(p);
       if (g.isNotEmpty) goalSet.add(g);
+      final th = p.meta['theme'];
+      if (th is String) {
+        final t = th.trim();
+        if (t.isNotEmpty) themeMap.putIfAbsent(t.toLowerCase(), () => t);
+      } else if (th is List) {
+        for (final e in th) {
+          final t = e.toString().trim();
+          if (t.isNotEmpty) {
+            themeMap.putIfAbsent(t.toLowerCase(), () => t);
+          }
+        }
+      }
     }
     setState(() {
       _packs = list;
       _tags = TrainingPackTagsService.instance.topTags;
+      _themes = themeMap.values.toList()..sort();
       _audiences = TrainingPackAudienceService.instance.topAudiences;
       _difficulties = TrainingPackDifficultyService.instance.topDifficulties;
       _goals = goalSet.toList()..sort();
@@ -145,6 +161,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
 
     final visible = const PackFilterService().filter(
       templates: baseTemplates,
+      themes: _selectedThemes.isEmpty ? null : _selectedThemes,
       tags: _selectedTags.isEmpty ? null : _selectedTags,
       types: _selectedTypes.isEmpty ? null : _selectedTypes,
       difficulties:
@@ -235,6 +252,40 @@ class _LibraryScreenState extends State<LibraryScreen> {
                     onChanged: (v) {
                       setState(() => _selectedGoal = v ?? '');
                     },
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                if (_themes.isNotEmpty) ...[
+                  const Text('🗂 Theme'),
+                  SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        for (final theme in _themes)
+                          Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 4),
+                            child: ChoiceChip(
+                              label: Text(theme),
+                              selected: _selectedThemes.contains(theme),
+                              selectedColor: AppColors.accent,
+                              backgroundColor: Colors.grey[700],
+                              visualDensity: VisualDensity.compact,
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              onSelected: (_) {
+                                setState(() {
+                                  if (_selectedThemes.contains(theme)) {
+                                    _selectedThemes.remove(theme);
+                                  } else {
+                                    _selectedThemes.add(theme);
+                                  }
+                                });
+                              },
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                   const SizedBox(height: 8),
                 ],
@@ -399,6 +450,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                     ),
                     const Spacer(),
                     if (_selectedTags.isNotEmpty ||
+                        _selectedThemes.isNotEmpty ||
                         _selectedDifficulties.isNotEmpty ||
                         _selectedAudiences.isNotEmpty ||
                         _selectedTypes.isNotEmpty ||
@@ -407,6 +459,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       TextButton(
                         onPressed: () => setState(() {
                           _selectedTags.clear();
+                          _selectedThemes.clear();
                           _selectedDifficulties.clear();
                           _selectedAudiences.clear();
                           _selectedTypes.clear();
@@ -416,6 +469,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                         child: const Text('Сбросить'),
                       ),
                     if (_selectedTags.isNotEmpty ||
+                        _selectedThemes.isNotEmpty ||
                         _selectedDifficulties.isNotEmpty ||
                         _selectedAudiences.isNotEmpty ||
                         _selectedTypes.isNotEmpty ||
@@ -436,6 +490,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       children: [
                         const Text('По текущему фильтру пакетов не найдено'),
                         if (_selectedTags.isNotEmpty ||
+                            _selectedThemes.isNotEmpty ||
                             _selectedDifficulties.isNotEmpty ||
                             _selectedAudiences.isNotEmpty ||
                             _selectedTypes.isNotEmpty ||
@@ -444,6 +499,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                           TextButton(
                             onPressed: () => setState(() {
                               _selectedTags.clear();
+                              _selectedThemes.clear();
                               _selectedDifficulties.clear();
                               _selectedAudiences.clear();
                               _selectedTypes.clear();

--- a/lib/services/pack_filter_service.dart
+++ b/lib/services/pack_filter_service.dart
@@ -7,6 +7,7 @@ class PackFilterService {
 
   List<TrainingPackTemplateV2> filter({
     required List<TrainingPackTemplateV2> templates,
+    Set<String>? themes,
     Set<String>? tags,
     Set<TrainingType>? types,
     Set<int>? difficulties,
@@ -14,6 +15,8 @@ class PackFilterService {
     TrainingPackLevel? level,
     String? goal,
   }) {
+    final themeSet =
+        themes?.map((e) => e.trim().toLowerCase()).toSet() ?? {};
     final tagSet = tags?.map((e) => e.trim().toLowerCase()).toSet() ?? {};
     final typeSet = types ?? {};
     final diffSet = difficulties ?? {};
@@ -22,12 +25,23 @@ class PackFilterService {
 
     return [
       for (final t in templates)
-        if (_matches(t, tagSet, typeSet, diffSet, audSet, level, goalStr)) t
+        if (_matches(
+          t,
+          themeSet,
+          tagSet,
+          typeSet,
+          diffSet,
+          audSet,
+          level,
+          goalStr,
+        ))
+          t
     ];
   }
 
   bool _matches(
     TrainingPackTemplateV2 tpl,
+    Set<String> themes,
     Set<String> tags,
     Set<TrainingType> types,
     Set<int> diffs,
@@ -36,6 +50,19 @@ class PackFilterService {
     String? goal,
   ) {
     if (types.isNotEmpty && !types.contains(tpl.trainingType)) return false;
+
+    if (themes.isNotEmpty) {
+      final tplThemes = <String>{};
+      final raw = tpl.meta['theme'];
+      if (raw is String) {
+        tplThemes.add(raw.trim().toLowerCase());
+      } else if (raw is List) {
+        for (final t in raw) {
+          tplThemes.add(t.toString().trim().toLowerCase());
+        }
+      }
+      if (tplThemes.intersection(themes).isEmpty) return false;
+    }
 
     if (tags.isNotEmpty) {
       final tplTags = {for (final t in tpl.tags) t.trim().toLowerCase()};

--- a/test/services/pack_filter_service_theme_test.dart
+++ b/test/services/pack_filter_service_theme_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/pack_filter_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  final pack1 = TrainingPackTemplateV2(
+    id: 'p1',
+    name: 'Pack 1',
+    trainingType: TrainingType.pushFold,
+    meta: {'theme': 'pushfold'},
+  );
+  final pack2 = TrainingPackTemplateV2(
+    id: 'p2',
+    name: 'Pack 2',
+    trainingType: TrainingType.pushFold,
+    meta: {
+      'theme': ['3bet', 'ICM']
+    },
+  );
+  final pack3 = TrainingPackTemplateV2(
+    id: 'p3',
+    name: 'Pack 3',
+    trainingType: TrainingType.pushFold,
+  );
+
+  test('filters by theme string case-insensitively', () {
+    final res = const PackFilterService().filter(
+      templates: [pack1, pack2, pack3],
+      themes: {'PushFold'},
+    );
+    expect(res.map((e) => e.id), ['p1']);
+  });
+
+  test('filters by theme list case-insensitively', () {
+    final res = const PackFilterService().filter(
+      templates: [pack1, pack2, pack3],
+      themes: {'icm'},
+    );
+    expect(res.map((e) => e.id), ['p2']);
+  });
+}

--- a/test/training_pack_library_theme_filter_test.dart
+++ b/test/training_pack_library_theme_filter_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  final lib = TrainingPackLibraryV2.instance;
+  setUp(() => lib.clear());
+  tearDown(() => lib.clear());
+
+  test('filterBy matches themes', () {
+    lib.addPack(
+      TrainingPackTemplateV2(
+        id: 'a',
+        name: 'A',
+        trainingType: TrainingType.pushFold,
+        meta: {'theme': 'pushfold'},
+      ),
+    );
+    lib.addPack(
+      TrainingPackTemplateV2(
+        id: 'b',
+        name: 'B',
+        trainingType: TrainingType.pushFold,
+        meta: {
+          'theme': ['3bet', 'icm']
+        },
+      ),
+    );
+    lib.addPack(
+      TrainingPackTemplateV2(
+        id: 'c',
+        name: 'C',
+        trainingType: TrainingType.pushFold,
+      ),
+    );
+
+    final res = lib.filterBy(themes: ['ICM']);
+    expect(res.map((e) => e.id).toList(), ['b']);
+  });
+}


### PR DESCRIPTION
## Summary
- support theme-based filtering in pack services and library
- add multiselect theme filter to library screen UI
- cover new filtering with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935649bdac832ab37ef2e24da51e49