### PR TITLE
feat: display skill level chip

### DIFF
--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -463,21 +463,20 @@ class _PackCardState extends State<PackCard>
                       ),
                     ),
                     if (levelLabel != null)
-                      Container(
-                        margin: const EdgeInsets.only(left: 4),
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 6, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: levelColor,
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: Text(
-                          levelLabel!,
-                          style: const TextStyle(
+                      Padding(
+                        padding: const EdgeInsets.only(left: 4),
+                        child: Chip(
+                          label: Text(levelLabel!),
+                          backgroundColor: levelColor,
+                          labelStyle: const TextStyle(
                             color: Colors.black,
                             fontSize: 10,
                             fontWeight: FontWeight.bold,
                           ),
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: const VisualDensity(
+                              horizontal: -4, vertical: -4),
                         ),
                       ),
                   ],


### PR DESCRIPTION
## Summary
- show color-coded skill level chip on PackCard

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935a09b9d0832aa8ae36859f602ed1