### PR TITLE
feat: show goal label on pack card

### DIFF
--- a/lib/widgets/pack_card.dart
+++ b/lib/widgets/pack_card.dart
@@ -341,6 +341,28 @@ class _PackCardState extends State<PackCard>
     await const TrainingSessionLauncher().launch(widget.template);
   }
 
+  String? _goalLabel() {
+    final raw = widget.template.meta['goal'];
+    if (raw is! String || raw.trim().isEmpty) return null;
+    return _humanizeGoal(raw.trim());
+  }
+
+  String _humanizeGoal(String raw) {
+    final words = raw
+        .replaceAllMapped(RegExp(r'(?<=[a-z])(?=[A-Z])'), (m) => ' ')
+        .split(RegExp(r'[\s_]+'));
+    const uppers = {'btn', 'bb', 'sb', 'utg', 'mp', 'co', 'hj'};
+    return words
+        .where((w) => w.isNotEmpty)
+        .map((w) {
+          final lower = w.toLowerCase();
+          if (lower == 'vs') return 'vs';
+          if (uppers.contains(lower)) return lower.toUpperCase();
+          return lower[0].toUpperCase() + lower.substring(1);
+        })
+        .join(' ');
+  }
+
   @override
   Widget build(BuildContext context) {
     unawaited(_logLockedViewEventIfNeeded());
@@ -412,9 +434,7 @@ class _PackCardState extends State<PackCard>
           break;
       }
     }
-    final goalText = widget.template.goal.isNotEmpty
-        ? widget.template.goal
-        : (widget.template.meta['goal']?.toString() ?? '').trim();
+    final goalLabel = _goalLabel();
     return GestureDetector(
       onTap: () async {
         if (_locked) {
@@ -488,16 +508,16 @@ class _PackCardState extends State<PackCard>
                     style: const TextStyle(color: Colors.white70),
                   ),
                 ),
-                if (goalText.isNotEmpty)
+                if (goalLabel != null)
                   Padding(
                     padding: const EdgeInsets.only(top: 4),
                     child: Text(
-                      goalText,
+                      goalLabel,
                       style: const TextStyle(
                         color: Colors.white70,
                         fontSize: 12,
                       ),
-                      maxLines: 2,
+                      maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),

--- a/test/widgets/pack_card_goal_label_test.dart
+++ b/test/widgets/pack_card_goal_label_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/training_type.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/widgets/pack_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows humanized goal label when metadata provided',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final tpl = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      spotCount: 1,
+      meta: {'goal': 'btnOpen'},
+    );
+    await tester.pumpWidget(
+      MaterialApp(home: PackCard(template: tpl, onTap: () {})),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('BTN Open'), findsOneWidget);
+  });
+
+  testWidgets('hides goal label when metadata missing', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final tpl = TrainingPackTemplateV2(
+      id: 'p2',
+      name: 'Pack2',
+      trainingType: TrainingType.pushFold,
+      spotCount: 1,
+    );
+    await tester.pumpWidget(
+      MaterialApp(home: PackCard(template: tpl, onTap: () {})),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('BTN Open'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- display humanized goal labels beneath pack titles using metadata
- helper converts camelCase goals like `btnOpen` to friendly text
- widget tests cover goal label rendering

## Testing
- `dart format lib/widgets/pack_card.dart test/widgets/pack_card_goal_label_test.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935c5678b4832aba29aeaa026bc971