### PR TITLE
Add postflop jam decision training template

### DIFF
--- a/assets/packs/v2/postflop/templates/river_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/river_jam_decision_template.yaml
@@ -1,0 +1,17 @@
+id: river_jam_decision_template
+name: River Jam Decision
+trainingType: postflopJamDecision
+goal: riverDecision
+description: River decision after missed draw vs jam — call or fold?
+theme: postflop
+tags: [river, jam, call, potOdds]
+positions: [sb, bb]
+spotCount: 0
+meta:
+  level: [intermediate, advanced]
+  spotConstraints:
+    board: full
+    position: [sb, bb]
+    actionFacing: [bet, jam]
+    effectiveStack: 20-40bb
+  schemaVersion: 2.0.0

--- a/lib/core/training/engine/training_type_engine.dart
+++ b/lib/core/training/engine/training_type_engine.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 enum TrainingType {
   pushFold,
   postflop,
+  postflopJamDecision,
   icm,
   bounty,
   custom,
@@ -77,6 +78,9 @@ class TrainingTypeEngine {
     if (tags.contains('quiz')) return TrainingType.quiz;
     if (tags.contains('bounty')) return TrainingType.bounty;
     if (tags.contains('icm')) return TrainingType.icm;
+    if (tags.contains('jam') || tags.contains('jamdecision')) {
+      return TrainingType.postflopJamDecision;
+    }
     final hasPostflop = pack.spots.any((s) {
       if (s.hand.board.isNotEmpty) return true;
       return s.hand.actions.entries.any((e) => e.key > 0 && e.value.isNotEmpty);
@@ -102,6 +106,8 @@ extension TrainingTypeInfo on TrainingType {
         return 'Push/Fold';
       case TrainingType.postflop:
         return 'Postflop';
+      case TrainingType.postflopJamDecision:
+        return 'Postflop Jam';
       case TrainingType.icm:
         return 'ICM';
       case TrainingType.bounty:
@@ -125,6 +131,8 @@ extension TrainingTypeInfo on TrainingType {
       case TrainingType.pushFold:
         return Icons.swap_vert;
       case TrainingType.postflop:
+        return Icons.timeline;
+      case TrainingType.postflopJamDecision:
         return Icons.timeline;
       case TrainingType.icm:
         return Icons.pie_chart;

--- a/lib/services/postflop_jam_decision_template_generator_service.dart
+++ b/lib/services/postflop_jam_decision_template_generator_service.dart
@@ -70,16 +70,17 @@ class PostflopJamDecisionTemplateGeneratorService {
         name: 'River Jam Decision ${i + 1}',
         description:
             '${heroPos == HeroPosition.btn ? 'IP' : 'OOP'} decision with ${selected[i]}',
-        trainingType: TrainingType.postflop,
+        trainingType: TrainingType.postflopJamDecision,
         spots: [spot],
         spotCount: 1,
         gameType: GameType.tournament,
         bb: effectiveStack,
         positions: [heroPos.name],
-        tags: const ['postflop', 'river', 'jamDecision', 'LevelIII'],
+        tags: const ['river', 'jam', 'call', 'potOdds'],
         meta: const {
-          'level': 3,
-          'topic': 'river jam',
+          'level': 'intermediate/advanced',
+          'goal': 'riverDecision',
+          'theme': 'postflop',
         },
       );
       templates.add(tpl);
@@ -136,7 +137,7 @@ class PostflopJamDecisionTemplateGeneratorService {
       heroOptions: facingJam
           ? const ['call', 'fold']
           : const ['shove', 'fold'],
-      tags: const ['postflop', 'river', 'jamDecision', 'LevelIII'],
+      tags: const ['river', 'jam', 'call', 'potOdds'],
       meta: {
         'villainLine': villainLine,
         'potSize': potSize,

--- a/test/services/postflop_jam_decision_template_generator_service_test.dart
+++ b/test/services/postflop_jam_decision_template_generator_service_test.dart
@@ -16,11 +16,12 @@ void main() {
     );
     expect(templates.length, inInclusiveRange(5, 10));
     final tpl = templates.first;
-    expect(tpl.tags, containsAll(['postflop', 'river', 'jamDecision', 'LevelIII']));
-    expect(tpl.meta['level'], 3);
-    expect(tpl.meta['topic'], 'river jam');
+    expect(tpl.tags, containsAll(['river', 'jam', 'call', 'potOdds']));
+    expect(tpl.meta['level'], 'intermediate/advanced');
+    expect(tpl.meta['goal'], 'riverDecision');
+    expect(tpl.meta['theme'], 'postflop');
     final spot = tpl.spots.first;
-    expect(spot.tags, contains('jamDecision'));
+    expect(spot.tags, contains('jam'));
     expect(spot.hand.stacks['0'], 40);
     expect(spot.hand.board.length, 5);
     expect(


### PR DESCRIPTION
## Summary
- introduce `postflopJamDecision` training type with detection and UI mappings
- extend jam decision template generator with new metadata
- add river jam decision YAML template for Level III postflop curriculum

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936045c70c832a83266b0b0311ecd7