### PR TITLE
feat: add delayed turn jam decision template

### DIFF
--- a/assets/packs/v2/postflop/templates/delayed_turn_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/delayed_turn_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: delayed_turn_jam_decision_template
+name: Delayed Turn Jam Decision
+trainingType: postflopJamDecision
+goal: turnDecision
+description: You delay cbet turn and get jammed on — what now?
+theme: postflop
+tags: [turn, jam, delayCbet, call, fold]
+positions: [sb, bb]
+spotCount: 0
+meta:
+  level: [intermediate, advanced]
+  spotConstraints:
+    board: turn
+    position: [sb, bb]
+    actionFacing: jam
+  schemaVersion: 2.0.0

--- a/test/services/postflop_jam_decision_template_generator_service_test.dart
+++ b/test/services/postflop_jam_decision_template_generator_service_test.dart
@@ -32,4 +32,28 @@ void main() {
       ),
     );
   });
+
+  test('generates delayed turn jam decision templates with metadata', () {
+    final service =
+        PostflopJamDecisionTemplateGeneratorService(random: Random(2));
+    final templates = service.generate(
+      boardTexture: 'wet',
+      heroHandGroup: 'broadways',
+      villainLine: 'check bet jam',
+      effectiveStack: 40,
+      potSize: 20,
+      delayedTurn: true,
+    );
+    expect(templates.length, inInclusiveRange(5, 10));
+    final tpl = templates.first;
+    expect(tpl.tags,
+        containsAll(['turn', 'jam', 'delayCbet', 'call', 'fold']));
+    expect(tpl.meta['goal'], 'turnDecision');
+    final spot = tpl.spots.first;
+    expect(spot.hand.board.length, 4);
+    expect(spot.heroOptions, equals(['call', 'fold']));
+    final actions = spot.hand.actions[2]!;
+    expect(actions.first.action, 'bet');
+    expect(actions[1].action, 'push');
+  });
 }


### PR DESCRIPTION
## Summary
- add template for delayed turn jam decision
- support delayed turn jam generation and tests

## Testing
- `dart format lib/services/postflop_jam_decision_template_generator_service.dart test/services/postflop_jam_decision_template_generator_service_test.dart` *(failed: command not found)*
- `flutter format lib/services/postflop_jam_decision_template_generator_service.dart test/services/postflop_jam_decision_template_generator_service_test.dart` *(failed: command not found)*
- `dart test test/services/postflop_jam_decision_template_generator_service_test.dart` *(failed: command not found)*
- `apt-get install -y dart` *(failed: Unable to locate package)*
- `apt-get install -y dart-sdk` *(failed: Unable to locate package)*
- `apt-get install -y flutter` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68936495b684832aa28626de27cb5608