### PR TITLE
Add flop c-bet jam decision template

### DIFF
--- a/assets/packs/v2/postflop/templates/flop_cbet_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/flop_cbet_jam_decision_template.yaml
@@ -1,0 +1,18 @@
+id: flop_cbet_jam_decision_template
+name: Flop C-Bet Jam Decision
+trainingType: postflopJamDecision
+goal: flopDecision
+description: You c-bet the flop in position and face a jam — pot-committed or fold?
+theme: postflop
+tags: [flop, jam, cbet, fold, potOdds]
+positions: [btn]
+spotCount: 0
+meta:
+  level: [intermediate, advanced]
+  spotConstraints:
+    board: flop
+    position: [btn]
+    actionFacing: jam
+    effectiveStack: 25-40bb
+    cbetSize: 33-66% pot
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add TrainingPackTemplateV2 for flop c-bet jam decisions

## Testing
- `dart run tools/validate_packs.dart` *(fails: command not found: dart)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689371e26adc832a8c1d0c8d7ca1b59a