### PR TITLE
Add river block-bet jam decision template

### DIFF
--- a/assets/packs/v2/postflop/templates/river_blockbet_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/river_blockbet_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: river_blockbet_jam_decision_template
+name: River Block-Bet Jam Decision
+trainingType: postflopJamDecision
+goal: riverDecision
+description: Hero block-bets river in position and faces a jam — can you find the thin value call or disciplined fold?
+theme: postflop
+tags: [river, blockbet, jam, fold, thinValue]
+positions: [btn]
+spotCount: 0
+meta:
+  level: advanced
+  spotConstraints:
+    board: river
+    position: [btn]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add advanced river block-bet jam decision template for postflop jam training

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68937acc3cdc832aba9173cc71a063e3