### PR TITLE
feat: add turn after flop check-call jam decision template

### DIFF
--- a/assets/packs/v2/postflop/templates/turn_after_flop_cc_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/turn_after_flop_cc_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: turn_after_flop_cc_jam_decision_template
+name: Turn After Flop Check-Call Jam Decision
+trainingType: postflopJamDecision
+goal: turnDecision
+description: You check-call the flop out of position and face a turn jam — cling to thin equity or find the fold?
+theme: postflop
+tags: [turn, jam, checkCall, fold, equityRealization]
+positions: [bb]
+spotCount: 0
+meta:
+  level: [intermediate, advanced]
+  spotConstraints:
+    board: turn
+    position: [bb]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add postflop jam decision template for turn jams after flop check-call

## Testing
- `dart run tool/validate_packs.dart assets/packs/v2` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68937cb1d754832aa7dedf0670046508