### PR TITLE
feat: add river jam decision template after flop check-call

### DIFF
--- a/assets/packs/v2/postflop/templates/river_after_flop_cc_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/river_after_flop_cc_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: river_after_flop_cc_jam_decision_template
+name: River After Flop Check-Call Jam Decision
+trainingType: postflopJamDecision
+goal: riverDecision
+description: You check-call the flop out of position, check turn, and face a river jam — hold on with bluff-catchers or fold?
+theme: postflop
+tags: [river, jam, checkCall, fold, cappedRange]
+positions: [bb]
+spotCount: 0
+meta:
+  level: advanced
+  spotConstraints:
+    board: river
+    position: [bb]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add TrainingPackTemplateV2 for river jam after flop check-call line

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_68937f1adfb0832ab1d1ef3a3eb06548