### PR TITLE
Add delayed c-bet turn jam decision template

### DIFF
--- a/assets/packs/v2/postflop/templates/delayed_cbet_turn_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/delayed_cbet_turn_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: delayed_cbet_turn_jam_decision_template
+name: Delayed C-Bet Turn Jam Decision
+trainingType: postflopJamDecision
+goal: turnDecision
+description: Hero checks the flop in position, bets the turn, and faces a jam — manage thin barreling under pressure.
+theme: postflop
+tags: [turn, jam, delayedCbet, fold, initiative]
+positions: [btn]
+spotCount: 0
+meta:
+  level: [intermediate, advanced]
+  spotConstraints:
+    board: turn
+    position: [btn]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add postflop jam decision template for delayed c-bet facing turn jam

## Testing
- `dart run tools/validate_packs.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893817bd434832ab0c9025c9ab68be6