### PR TITLE
Add river jam decision template after flop check-raise

### DIFF
--- a/assets/packs/v2/postflop/templates/river_after_flop_xr_check_jam_decision_template.yaml
+++ b/assets/packs/v2/postflop/templates/river_after_flop_xr_check_jam_decision_template.yaml
@@ -1,0 +1,16 @@
+id: river_after_flop_xr_check_jam_decision_template
+name: River After Flop Check-Raise Check Jam Decision
+trainingType: postflopJamDecision
+goal: riverDecision
+description: BB check-raises the flop, checks turn, BTN checks back or bets small, you check river and face a jam — sniff out overbluffs or release?
+theme: postflop
+tags: [river, jam, checkRaise, fold, rangeCap]
+positions: [bb]
+spotCount: 0
+meta:
+  level: advanced
+  spotConstraints:
+    board: river
+    position: [bb]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add advanced river jam decision template for XR-flop, turn-check line

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(package not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893832d3c6c832a92ee53363e779900