### PR TITLE
feat: add river thin value bet face jam training template

### DIFF
--- a/assets/packs/v2/postflop/templates/river_thin_value_bet_face_jam_template.yaml
+++ b/assets/packs/v2/postflop/templates/river_thin_value_bet_face_jam_template.yaml
@@ -1,0 +1,16 @@
+id: river_thin_value_bet_face_jam_template
+name: River Thin Value Bet Face Jam
+trainingType: postflopJamDecision
+goal: riverDecision
+description: Flop and turn check through. BTN thin value-bets river and faces a BB jam — is it thin value or a trap?
+theme: postflop
+tags: [river, thinValue, jam, trap, valueBet]
+positions: [btn]
+spotCount: 0
+meta:
+  level: advanced
+  spotConstraints:
+    board: river
+    position: [btn]
+    actionFacing: jam
+  schemaVersion: 2.0.0


### PR DESCRIPTION
## Summary
- add river thin value bet face jam training template for BTN vs jam after passive streets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68938373b8a8832abd743e60a89b1a30