### PR TITLE
feat: add lazy loader and streaming widgets

### DIFF
--- a/lib/screens/pack_library_search_screen.dart
+++ b/lib/screens/pack_library_search_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../core/training/library/training_pack_library_v2.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import '../theme/app_colors.dart';
 import '../widgets/pack_card.dart';
@@ -8,6 +7,7 @@ import '../widgets/training_pack_library_metadata_filter_bar.dart';
 import '../widgets/training_pack_library_sort_bar.dart';
 import '../models/v2/pack_ux_metadata.dart';
 import 'training_pack_preview_screen.dart';
+import '../services/lazy_pack_loader_service.dart';
 
 class PackLibrarySearchScreen extends StatefulWidget {
   const PackLibrarySearchScreen({super.key});
@@ -33,8 +33,8 @@ class _PackLibrarySearchScreenState extends State<PackLibrarySearchScreen> {
   }
 
   Future<void> _load() async {
-    await TrainingPackLibraryV2.instance.loadFromFolder();
-    _all = TrainingPackLibraryV2.instance.packs;
+    await LazyPackLoaderService.instance.preloadMetadata();
+    _all = LazyPackLoaderService.instance.templates;
     _topics = _availableTopics();
     _applyFilters();
     setState(() {
@@ -106,10 +106,12 @@ class _PackLibrarySearchScreenState extends State<PackLibrarySearchScreen> {
   }
 
   Future<void> _open(TrainingPackTemplateV2 tpl) async {
+    final loader = LazyPackLoaderService.instance;
+    final full = await loader.loadFullPack(tpl.id) ?? tpl;
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => TrainingPackPreviewScreen(template: tpl),
+        builder: (_) => TrainingPackPreviewScreen(template: full),
       ),
     );
   }

--- a/lib/services/lazy_pack_loader_service.dart
+++ b/lib/services/lazy_pack_loader_service.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/services.dart' show rootBundle;
+import '../core/training/generation/yaml_reader.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../asset_manifest.dart';
+
+/// Loads training pack templates lazily by parsing only metadata initially.
+///
+/// The full YAML for a pack is fetched and parsed only when explicitly
+/// requested via [loadFullPack]. This keeps memory usage low when dealing with
+/// large libraries containing thousands of spots.
+class LazyPackLoaderService {
+  LazyPackLoaderService._();
+
+  static final instance = LazyPackLoaderService._();
+
+  final List<TrainingPackTemplateV2> _metadata = [];
+  final Map<String, String> _paths = {};
+  final Map<String, TrainingPackTemplateV2> _cache = {};
+
+  /// Loads basic information (id, name, tags, meta) for all packs found in the
+  /// asset manifest. Spot details are discarded to avoid large allocations.
+  Future<void> preloadMetadata({String path = TrainingPackLibraryV2.packsDir}) async {
+    if (_metadata.isNotEmpty) return;
+    final manifest = await AssetManifest.instance;
+    final reader = const YamlReader();
+    Iterable<String> paths = manifest.keys.where(
+      (p) => p.startsWith(path) && p.endsWith('.yaml'),
+    );
+    for (final p in paths) {
+      try {
+        final yaml = await rootBundle.loadString(p);
+        final map = reader.read(yaml);
+        final json = Map<String, dynamic>.from(map);
+        json.remove('spots');
+        json.remove('dynamicSpots');
+        final tpl = TrainingPackTemplateV2.fromJson(json);
+        _metadata.add(tpl);
+        _paths[tpl.id] = p;
+      } catch (_) {}
+    }
+    _metadata.sort((a, b) => a.name.compareTo(b.name));
+  }
+
+  /// Returns all loaded template metadata. Ensure [preloadMetadata] has been
+  /// invoked prior to calling this getter.
+  List<TrainingPackTemplateV2> get templates => List.unmodifiable(_metadata);
+
+  /// Loads the full template (including spot data) for the given [id].
+  /// Results are cached for subsequent calls.
+  Future<TrainingPackTemplateV2?> loadFullPack(String id) async {
+    if (_cache.containsKey(id)) return _cache[id];
+    final path = _paths[id];
+    if (path == null) return null;
+    try {
+      final tpl = await const YamlReader().loadTemplate(path);
+      _cache[id] = tpl;
+      return tpl;
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// Simple engine that streams spots from a loaded [TrainingPackTemplateV2].
+/// It keeps a sliding window cache of upcoming spots to minimize pauses during
+/// training drills.
+class SpotStreamingEngine {
+  SpotStreamingEngine(this._template, {this.prefetch = 5})
+      : _index = 0,
+        _cache = [];
+
+  final TrainingPackTemplateV2 _template;
+  final int prefetch;
+  final List<TrainingPackSpot> _cache;
+  int _index;
+
+  /// Pre-loads the initial set of spots.
+  Future<void> initialize() async {
+    _cache.addAll(_template.spots.take(prefetch));
+  }
+
+  /// Returns the next spot in the sequence and triggers prefetching of
+  /// subsequent spots.
+  TrainingPackSpot? next() {
+    if (_index >= _template.spots.length) return null;
+    if (_cache.length < prefetch && _cache.length + _index < _template.spots.length) {
+      final remaining = _template.spots.skip(_index + _cache.length).take(prefetch - _cache.length);
+      _cache.addAll(remaining);
+    }
+    final spot = _cache.removeAt(0);
+    _index++;
+    return spot;
+  }
+}

--- a/lib/widgets/training_drill_widget.dart
+++ b/lib/widgets/training_drill_widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import '../services/lazy_pack_loader_service.dart';
+import '../models/v2/training_pack_spot.dart';
+
+/// Widget that consumes a [SpotStreamingEngine] to provide a smooth training
+/// experience for packs with a large number of spots.
+class TrainingDrillWidget extends StatefulWidget {
+  const TrainingDrillWidget({super.key, required this.engine});
+
+  final SpotStreamingEngine engine;
+
+  @override
+  State<TrainingDrillWidget> createState() => _TrainingDrillWidgetState();
+}
+
+class _TrainingDrillWidgetState extends State<TrainingDrillWidget> {
+  TrainingPackSpot? _current;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.engine.initialize().then((_) {
+      setState(() {
+        _current = widget.engine.next();
+      });
+    });
+  }
+
+  void _advance() {
+    final next = widget.engine.next();
+    if (next != null) {
+      setState(() => _current = next);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_current == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Column(
+      children: [
+        Expanded(child: Text('Spot: ${_current!.id}')),
+        ElevatedButton(onPressed: _advance, child: const Text('Next')),
+      ],
+    );
+  }
+}

--- a/lib/widgets/training_pack_list_widget.dart
+++ b/lib/widgets/training_pack_list_widget.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../services/lazy_pack_loader_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_card.dart';
+import 'training_pack_template_tooltip_widget.dart';
+
+/// Paginated list that only renders a subset of packs at a time.
+/// Uses [LazyPackLoaderService] to avoid loading full pack data until needed.
+class TrainingPackListWidget extends StatefulWidget {
+  const TrainingPackListWidget({super.key, required this.loader, this.pageSize = 50, this.onOpen});
+
+  final LazyPackLoaderService loader;
+  final int pageSize;
+  final void Function(TrainingPackTemplateV2)? onOpen;
+
+  @override
+  State<TrainingPackListWidget> createState() => _TrainingPackListWidgetState();
+}
+
+class _TrainingPackListWidgetState extends State<TrainingPackListWidget> {
+  final ScrollController _controller = ScrollController();
+  final List<TrainingPackTemplateV2> _visible = [];
+  int _offset = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMore();
+    _controller.addListener(() {
+      if (_controller.position.pixels >= _controller.position.maxScrollExtent - 200) {
+        _loadMore();
+      }
+    });
+  }
+
+  void _loadMore() {
+    final all = widget.loader.templates;
+    if (_offset >= all.length) return;
+    setState(() {
+      _visible.addAll(all.skip(_offset).take(widget.pageSize));
+      _offset = _visible.length;
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _open(TrainingPackTemplateV2 tpl) async {
+    if (widget.onOpen != null) {
+      await widget.onOpen!(tpl);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      controller: _controller,
+      itemCount: _visible.length,
+      itemBuilder: (context, index) {
+        final tpl = _visible[index];
+        return TrainingPackTemplateTooltipWidget(
+          template: tpl,
+          child: PackCard(
+            template: tpl,
+            onTap: () => _open(tpl),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `LazyPackLoaderService` to load pack metadata without spots and `SpotStreamingEngine` to stream spot data
- introduce `TrainingPackListWidget` with simple pagination and `TrainingDrillWidget` consuming the streaming engine
- update `PackLibrarySearchScreen` to preload metadata lazily and fetch full packs on demand

## Testing
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68938a44a804832aa0a01f4a93b88d88