### PR TITLE
feat: add auto deduplication for training spots

### DIFF
--- a/lib/services/auto_deduplication_engine.dart
+++ b/lib/services/auto_deduplication_engine.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import '../models/v2/training_pack_spot.dart';
+import 'spot_fingerprint_generator.dart';
+
+/// Keeps track of spot fingerprints to automatically skip duplicates.
+class AutoDeduplicationEngine {
+  final SpotFingerprintGenerator _fingerprint;
+  final Set<String> _seen = <String>{};
+  final IOSink _log;
+
+  AutoDeduplicationEngine({
+    SpotFingerprintGenerator? fingerprint,
+    IOSink? log,
+  })  : _fingerprint = fingerprint ?? const SpotFingerprintGenerator(),
+        _log = log ?? File('skipped_duplicates.log').openWrite(mode: FileMode.append);
+
+  /// Registers existing spots so future checks can detect duplicates.
+  void addExisting(Iterable<TrainingPackSpot> spots) {
+    for (final s in spots) {
+      _seen.add(_fingerprint.generate(s));
+    }
+  }
+
+  /// Returns `true` if [spot] is a duplicate and logs the skip.
+  bool isDuplicate(TrainingPackSpot spot, {String? source}) {
+    final fp = _fingerprint.generate(spot);
+    if (_seen.contains(fp)) {
+      _log.writeln('Skipped duplicate from ${source ?? 'unknown'}: ${spot.id}');
+      return true;
+    }
+    _seen.add(fp);
+    return false;
+  }
+
+  /// Closes the underlying log sink.
+  Future<void> dispose() => _log.close();
+}

--- a/lib/services/spot_fingerprint_generator.dart
+++ b/lib/services/spot_fingerprint_generator.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/action_entry.dart';
+
+/// Generates a stable fingerprint for a [TrainingPackSpot].
+///
+/// The fingerprint is based on key semantic features of the spot so that
+/// logically equivalent spots produce the same hash.
+class SpotFingerprintGenerator {
+  const SpotFingerprintGenerator();
+
+  /// Builds a SHA1 hash from the spot's hero/villain positions, action line,
+  /// board structure and spot type.
+  String generate(TrainingPackSpot spot) {
+    final buffer = StringBuffer()
+      ..write(spot.type)
+      ..write('|')
+      ..write(spot.hand.position.name)
+      ..write('|')
+      ..write(spot.board.join(','))
+      ..write('|');
+
+    final actions = spot.hand.actions;
+    final keys = actions.keys.toList()..sort();
+    for (final k in keys) {
+      buffer.write('$k:');
+      for (final ActionEntry a in actions[k]!) {
+        buffer.write('${a.playerIndex}${a.type}${a.amount ?? ''};');
+      }
+      buffer.write('|');
+    }
+
+    final bytes = utf8.encode(buffer.toString());
+    return sha1.convert(bytes).toString();
+  }
+}

--- a/lib/services/training_pack_auto_generator.dart
+++ b/lib/services/training_pack_auto_generator.dart
@@ -1,0 +1,33 @@
+import '../models/training_pack_template_set.dart';
+import '../models/inline_theory_entry.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'training_pack_generator_engine_v2.dart';
+import 'auto_deduplication_engine.dart';
+
+/// Wrapper around [TrainingPackGeneratorEngineV2] that skips duplicate spots.
+class TrainingPackAutoGenerator {
+  final TrainingPackGeneratorEngineV2 _engine;
+  final AutoDeduplicationEngine _dedup;
+
+  TrainingPackAutoGenerator({
+    TrainingPackGeneratorEngineV2? engine,
+    AutoDeduplicationEngine? dedup,
+  })  : _engine = engine ?? TrainingPackGeneratorEngineV2(),
+        _dedup = dedup ?? AutoDeduplicationEngine();
+
+  /// Generates spots from [set] while skipping duplicates based on fingerprints.
+  List<TrainingPackSpot> generate(
+    TrainingPackTemplateSet set, {
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+    Iterable<TrainingPackSpot> existingSpots = const [],
+  }) {
+    _dedup.addExisting(existingSpots);
+    final spots = _engine.generate(set, theoryIndex: theoryIndex);
+    final filtered = <TrainingPackSpot>[];
+    for (final spot in spots) {
+      if (_dedup.isDuplicate(spot, source: 'auto')) continue;
+      filtered.add(spot);
+    }
+    return filtered;
+  }
+}

--- a/lib/services/training_pack_template_importer.dart
+++ b/lib/services/training_pack_template_importer.dart
@@ -1,0 +1,27 @@
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'auto_deduplication_engine.dart';
+
+/// Imports template data while avoiding duplicate spots.
+class TrainingPackTemplateImporter {
+  final AutoDeduplicationEngine _dedup;
+
+  TrainingPackTemplateImporter({AutoDeduplicationEngine? dedup})
+      : _dedup = dedup ?? AutoDeduplicationEngine();
+
+  /// Merges [incoming] into [base], skipping any spots already present.
+  TrainingPackTemplateV2 merge(
+    TrainingPackTemplateV2 base,
+    TrainingPackTemplateV2 incoming,
+  ) {
+    _dedup.addExisting(base.spots);
+    final merged = <TrainingPackSpot>[];
+    for (final spot in incoming.spots) {
+      if (_dedup.isDuplicate(spot, source: incoming.id)) continue;
+      merged.add(spot);
+    }
+    base.spots.addAll(merged);
+    base.spotCount = base.spots.length;
+    return base;
+  }
+}


### PR DESCRIPTION
## Summary
- add SpotFingerprintGenerator to hash key spot features
- implement AutoDeduplicationEngine with skipped duplicate logging
- skip duplicate spots during template import and auto generation

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68938b569668832ab043c824ad9946e0