### PR TITLE
feat: add autogen pack generator service

### DIFF
--- a/lib/services/autogen_pack_generator_service.dart
+++ b/lib/services/autogen_pack_generator_service.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import '../models/training_pack_template_set.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/game_type.dart';
+import 'auto_deduplication_engine.dart';
+import 'training_pack_auto_generator.dart';
+import 'yaml_pack_exporter.dart';
+
+/// Generates training packs from template sets while automatically skipping
+/// duplicate spots and exporting the results to YAML.
+class AutogenPackGeneratorService {
+  late final TrainingPackAutoGenerator _generator;
+  final YamlPackExporter _exporter;
+  final AutoDeduplicationEngine _dedup;
+
+  AutogenPackGeneratorService({
+    TrainingPackAutoGenerator? generator,
+    YamlPackExporter? exporter,
+    AutoDeduplicationEngine? dedup,
+  })  : _dedup = dedup ?? AutoDeduplicationEngine(),
+        _exporter = exporter ?? const YamlPackExporter() {
+    _generator = generator ?? TrainingPackAutoGenerator(dedup: _dedup);
+  }
+
+  /// Generates packs from [sets].
+  ///
+  /// [existingYamlPath] points to a directory containing previously exported
+  /// YAML packs. These are loaded into memory so their spots can be registered
+  /// with the deduplication engine, ensuring only unique spots are exported.
+  Future<List<File>> generate(
+    List<TrainingPackTemplateSet> sets, {
+    String existingYamlPath = '',
+  }) async {
+    if (existingYamlPath.isNotEmpty) {
+      final dir = Directory(existingYamlPath);
+      if (await dir.exists()) {
+        await for (final entity in dir.list()) {
+          if (entity is File &&
+              (entity.path.endsWith('.yaml') || entity.path.endsWith('.yml'))) {
+            final yaml = await entity.readAsString();
+            final tpl = TrainingPackTemplateV2.fromYaml(yaml);
+            _dedup.addExisting(tpl.spots);
+          }
+        }
+      }
+    }
+
+    final files = <File>[];
+    for (final set in sets) {
+      final spots = _generator.generate(set);
+      if (spots.isEmpty) continue;
+      final base = set.baseSpot;
+      final pack = TrainingPackTemplateV2(
+        id: base.id,
+        name: base.title.isNotEmpty ? base.title : base.id,
+        trainingType: TrainingType.custom,
+        spots: spots,
+        spotCount: spots.length,
+        tags: List<String>.from(base.tags),
+        gameType: GameType.cash,
+        bb: base.hand.stacks['0']?.toInt() ?? 0,
+        positions: [base.hand.position.name],
+        meta: Map<String, dynamic>.from(base.meta),
+      );
+      pack.meta['uniqueSpotsOnly'] = true;
+      files.add(await _exporter.export(pack));
+    }
+
+    await _dedup.dispose();
+    return files;
+  }
+}

--- a/lib/services/yaml_pack_exporter.dart
+++ b/lib/services/yaml_pack_exporter.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import '../core/training/export/training_pack_exporter_v2.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Exports training packs to YAML files.
+class YamlPackExporter {
+  final TrainingPackExporterV2 _delegate;
+
+  const YamlPackExporter({TrainingPackExporterV2? delegate})
+      : _delegate = delegate ?? const TrainingPackExporterV2();
+
+  /// Writes [pack] to disk as a YAML file and returns the created [File].
+  Future<File> export(TrainingPackTemplateV2 pack) {
+    return _delegate.exportToFile(pack);
+  }
+
+  /// Converts [pack] to a YAML string.
+  String exportYaml(TrainingPackTemplateV2 pack) {
+    return _delegate.exportYaml(pack);
+  }
+}


### PR DESCRIPTION
## Summary
- add `YamlPackExporter` to write pack templates to YAML files
- add `AutogenPackGeneratorService` integrating `AutoDeduplicationEngine` for unique spot generation and export

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68938d49712c832a8b360b4708a21d44