### PR TITLE
feat: add autogen pipeline executor

### DIFF
--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import '../models/training_pack_template_set.dart';
+import '../models/inline_theory_entry.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/game_type.dart';
+
+import 'auto_deduplication_engine.dart';
+import 'training_pack_auto_generator.dart';
+import 'yaml_pack_exporter.dart';
+import 'skill_tag_coverage_tracker.dart';
+import 'theory_link_auto_injector.dart';
+import 'board_texture_classifier.dart';
+import 'skill_tree_auto_linker.dart';
+import 'training_pack_fingerprint_generator.dart';
+
+/// Centralized orchestrator running the full auto-generation pipeline.
+class AutogenPipelineExecutor {
+  late final TrainingPackAutoGenerator generator;
+  final AutoDeduplicationEngine dedup;
+  final YamlPackExporter exporter;
+  final SkillTagCoverageTracker coverage;
+  final TheoryLinkAutoInjector theoryInjector;
+  final BoardTextureClassifier? boardClassifier;
+  final SkillTreeAutoLinker skillLinker;
+  final TrainingPackFingerprintGenerator fingerprintGenerator;
+  final IOSink _fingerprintLog;
+
+  AutogenPipelineExecutor({
+    TrainingPackAutoGenerator? generator,
+    AutoDeduplicationEngine? dedup,
+    YamlPackExporter? exporter,
+    SkillTagCoverageTracker? coverage,
+    TheoryLinkAutoInjector? theoryInjector,
+    BoardTextureClassifier? boardClassifier,
+    SkillTreeAutoLinker? skillLinker,
+    TrainingPackFingerprintGenerator? fingerprintGenerator,
+    IOSink? fingerprintLog,
+  })  : dedup = dedup ?? AutoDeduplicationEngine(),
+        exporter = exporter ?? const YamlPackExporter(),
+        coverage = coverage ?? SkillTagCoverageTracker(),
+        theoryInjector = theoryInjector ?? TheoryLinkAutoInjector(),
+        boardClassifier = boardClassifier,
+        skillLinker = skillLinker ?? const SkillTreeAutoLinker(),
+        fingerprintGenerator =
+            fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
+        _fingerprintLog = fingerprintLog ??
+            File('generated_pack_fingerprints.log')
+                .openWrite(mode: FileMode.append) {
+    this.generator = generator ?? TrainingPackAutoGenerator(dedup: this.dedup);
+  }
+
+  /// Runs the pipeline on [sets].
+  Future<List<File>> execute(
+    List<TrainingPackTemplateSet> sets, {
+    String existingYamlPath = '',
+    Map<String, InlineTheoryEntry> theoryIndex = const {},
+  }) async {
+    // Load existing YAMLs to prime deduplication engine.
+    if (existingYamlPath.isNotEmpty) {
+      final dir = Directory(existingYamlPath);
+      if (await dir.exists()) {
+        await for (final entity in dir.list()) {
+          if (entity is File &&
+              (entity.path.endsWith('.yaml') || entity.path.endsWith('.yml'))) {
+            final yaml = await entity.readAsString();
+            final tpl = TrainingPackTemplateV2.fromYaml(yaml);
+            dedup.addExisting(tpl.spots);
+          }
+        }
+      }
+    }
+
+    final files = <File>[];
+    for (final set in sets) {
+      final spots = generator.generate(
+        set,
+        theoryIndex: theoryIndex,
+      );
+      if (spots.isEmpty) continue;
+
+      theoryInjector.injectAll(spots);
+      boardClassifier?.classifyAll(spots);
+      skillLinker.linkAll(spots);
+      coverage.trackAll(spots);
+
+      final base = set.baseSpot;
+      final pack = TrainingPackTemplateV2(
+        id: base.id,
+        name: base.title.isNotEmpty ? base.title : base.id,
+        trainingType: TrainingType.custom,
+        spots: spots,
+        spotCount: spots.length,
+        tags: List<String>.from(base.tags),
+        gameType: GameType.cash,
+        bb: base.hand.stacks['0']?.toInt() ?? 0,
+        positions: [base.hand.position.name],
+        meta: Map<String, dynamic>.from(base.meta),
+      );
+      pack.meta['uniqueSpotsOnly'] = true;
+
+      final file = await exporter.export(pack);
+      files.add(file);
+
+      final fp = fingerprintGenerator.generate(pack);
+      _fingerprintLog.writeln(fp);
+    }
+
+    await dedup.dispose();
+    await coverage.logSummary();
+    await _fingerprintLog.flush();
+    await _fingerprintLog.close();
+    return files;
+  }
+}
+

--- a/lib/services/board_texture_classifier.dart
+++ b/lib/services/board_texture_classifier.dart
@@ -1,0 +1,27 @@
+import '../models/v2/training_pack_spot.dart';
+
+/// Simple board texture classifier used during auto-generation.
+class BoardTextureClassifier {
+  const BoardTextureClassifier();
+
+  /// Returns a rough classification for [spot]'s board.
+  String classify(TrainingPackSpot spot) {
+    final board = spot.board;
+    if (board.length >= 3) {
+      final ranks = board.map((c) => c[0]).toList();
+      final unique = ranks.toSet();
+      if (unique.length < ranks.length) {
+        return 'paired';
+      }
+    }
+    return 'unpaired';
+  }
+
+  /// Annotates each spot with a `boardTexture` meta field.
+  void classifyAll(Iterable<TrainingPackSpot> spots) {
+    for (final s in spots) {
+      s.meta['boardTexture'] = classify(s);
+    }
+  }
+}
+

--- a/lib/services/skill_tag_coverage_tracker.dart
+++ b/lib/services/skill_tag_coverage_tracker.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import '../models/v2/training_pack_spot.dart';
+
+/// Tracks how often skill tags appear across generated spots.
+class SkillTagCoverageTracker {
+  final Map<String, int> _counts = <String, int>{};
+
+  /// Records tags from a single [spot].
+  void track(TrainingPackSpot spot) {
+    for (final tag in spot.tags) {
+      _counts[tag] = (_counts[tag] ?? 0) + 1;
+    }
+  }
+
+  /// Convenience method to record tags from multiple [spots].
+  void trackAll(Iterable<TrainingPackSpot> spots) {
+    for (final s in spots) {
+      track(s);
+    }
+  }
+
+  /// Returns the current tag coverage counts.
+  Map<String, int> get counts => _counts;
+
+  /// Logs the coverage summary to [sink] or a default file.
+  Future<void> logSummary([IOSink? sink]) async {
+    final out = sink ??
+        File('skill_tag_coverage.log').openWrite(mode: FileMode.append);
+    for (final entry in _counts.entries) {
+      out.writeln('${entry.key}: ${entry.value}');
+    }
+    await out.flush();
+    if (sink == null) {
+      await out.close();
+    }
+  }
+}
+

--- a/lib/services/skill_tree_auto_linker.dart
+++ b/lib/services/skill_tree_auto_linker.dart
@@ -1,0 +1,16 @@
+import '../models/v2/training_pack_spot.dart';
+
+/// Naively links spots to skill tags for later processing.
+class SkillTreeAutoLinker {
+  const SkillTreeAutoLinker();
+
+  /// Writes the spot's tags into `skillTags` meta field.
+  void linkAll(Iterable<TrainingPackSpot> spots) {
+    for (final s in spots) {
+      if (s.tags.isNotEmpty) {
+        s.meta['skillTags'] = List<String>.from(s.tags);
+      }
+    }
+  }
+}
+

--- a/lib/services/theory_link_auto_injector.dart
+++ b/lib/services/theory_link_auto_injector.dart
@@ -1,0 +1,16 @@
+import '../models/v2/training_pack_spot.dart';
+import 'auto_spot_theory_injector_service.dart';
+
+/// Wraps [AutoSpotTheoryInjectorService] for pipeline usage.
+class TheoryLinkAutoInjector {
+  final AutoSpotTheoryInjectorService _injector;
+
+  TheoryLinkAutoInjector({AutoSpotTheoryInjectorService? injector})
+      : _injector = injector ?? AutoSpotTheoryInjectorService();
+
+  /// Injects theory links into all [spots].
+  void injectAll(Iterable<TrainingPackSpot> spots) {
+    _injector.injectAll(spots);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `AutogenPipelineExecutor` to orchestrate full spot generation pipeline
- track skill tag coverage and log fingerprints during generation
- include helpers for theory link injection, board texture classification, and skill tree auto linking

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689399f035c4832a8f41d8364ed0de3c