### PR TITLE
feat: add autogen status dashboard

### DIFF
--- a/lib/services/auto_deduplication_engine.dart
+++ b/lib/services/auto_deduplication_engine.dart
@@ -7,6 +7,7 @@ class AutoDeduplicationEngine {
   final SpotFingerprintGenerator _fingerprint;
   final Set<String> _seen = <String>{};
   final IOSink _log;
+  int _skipped = 0;
 
   AutoDeduplicationEngine({
     SpotFingerprintGenerator? fingerprint,
@@ -25,12 +26,15 @@ class AutoDeduplicationEngine {
   bool isDuplicate(TrainingPackSpot spot, {String? source}) {
     final fp = _fingerprint.generate(spot);
     if (_seen.contains(fp)) {
+      _skipped++;
       _log.writeln('Skipped duplicate from ${source ?? 'unknown'}: ${spot.id}');
       return true;
     }
     _seen.add(fp);
     return false;
   }
+
+  int get skippedCount => _skipped;
 
   /// Closes the underlying log sink.
   Future<void> dispose() => _log.close();

--- a/lib/services/autogen_status_dashboard_service.dart
+++ b/lib/services/autogen_status_dashboard_service.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'skill_tag_coverage_tracker.dart';
+
+/// Centralized logger aggregating key metrics during hyperscale autogeneration.
+class AutogenStatusDashboardService {
+  AutogenStatusDashboardService({String logPath = 'autogen_report.log'})
+      : _logFile = File(logPath);
+
+  final File _logFile;
+  DateTime? _start;
+  int _totalPacks = 0;
+  int _totalSpots = 0;
+  int _skippedSpots = 0;
+  int _fingerprintCount = 0;
+  int _yamlFiles = 0;
+
+  /// Marks the beginning of tracking.
+  void start() => _start = DateTime.now();
+
+  /// Records a generated pack and its [spotCount].
+  void recordPack(int spotCount) {
+    _totalPacks++;
+    _yamlFiles++;
+    _totalSpots += spotCount;
+  }
+
+  /// Records the number of skipped duplicate spots.
+  void recordSkipped(int count) => _skippedSpots = count;
+
+  /// Records that a fingerprint was generated.
+  void recordFingerprint(String _) => _fingerprintCount++;
+
+  /// Logs final aggregated statistics to console and to a log file.
+  Future<void> logFinalStats(
+    SkillTagCoverageTracker coverage, {
+    int? yamlFiles,
+  }) async {
+    final end = DateTime.now();
+    final start = _start ?? end;
+    final buffer = StringBuffer()
+      ..writeln('=== Autogen Status Report ===')
+      ..writeln('Start: $start')
+      ..writeln('End:   $end')
+      ..writeln('Duration: ${end.difference(start)}')
+      ..writeln('Packs generated: $_totalPacks')
+      ..writeln('Unique spots: $_totalSpots')
+      ..writeln('Duplicates skipped: $_skippedSpots')
+      ..writeln('YAML files: ${yamlFiles ?? _yamlFiles}')
+      ..writeln('Top 10 tags:');
+
+    final sorted = coverage.counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    for (final entry in sorted.take(10)) {
+      buffer.writeln('  ${entry.key}: ${entry.value}');
+    }
+
+    final report = buffer.toString();
+    // Output to console for immediate visibility.
+    print(report);
+    // Persist to log file.
+    await _logFile.writeAsString(report);
+  }
+}


### PR DESCRIPTION
## Summary
- add AutogenStatusDashboardService to centralize metrics for hyperscale generation
- track skipped duplicates in AutoDeduplicationEngine
- integrate dashboard into AutogenPipelineExecutor and log final run stats

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68939ead04d0832ab97f6f86889e3719