### PR TITLE
feat: add autogen controls

### DIFF
--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -4,10 +4,51 @@ import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
 import '../widgets/autogen_realtime_stats_panel.dart';
 import '../widgets/inline_report_viewer_widget.dart';
+import '../services/autogen_status_dashboard_service.dart';
+import '../services/autogen_pipeline_executor.dart';
+import '../services/training_pack_auto_generator.dart';
 
-/// Debug screen that monitors autogeneration progress.
-class AutogenDebugScreen extends StatelessWidget {
+enum _AutogenStatus { idle, running, completed, stopped }
+
+/// Debug screen that monitors autogeneration progress and controls the pipeline.
+class AutogenDebugScreen extends StatefulWidget {
   const AutogenDebugScreen({super.key});
+
+  @override
+  State<AutogenDebugScreen> createState() => _AutogenDebugScreenState();
+}
+
+class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
+  _AutogenStatus _status = _AutogenStatus.idle;
+  TrainingPackAutoGenerator? _generator;
+
+  void _startAutogen() {
+    if (_status == _AutogenStatus.running) return;
+    final dashboard = AutogenStatusDashboardService.instance;
+    dashboard.start();
+    final generator = TrainingPackAutoGenerator();
+    _generator = generator;
+    final executor = AutogenPipelineExecutor(
+      generator: generator,
+      dashboard: dashboard,
+    );
+    setState(() {
+      _status = _AutogenStatus.running;
+    });
+    Future(() async {
+      await executor.execute(const []);
+      if (mounted && _status == _AutogenStatus.running) {
+        setState(() => _status = _AutogenStatus.completed);
+      }
+    });
+  }
+
+  void _stopAutogen() {
+    _generator?.abort();
+    if (mounted) {
+      setState(() => _status = _AutogenStatus.stopped);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -16,10 +57,32 @@ class AutogenDebugScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Autogen Debug')),
       backgroundColor: AppColors.background,
       body: Column(
-        children: const [
-          Expanded(child: Center(child: Text('Autogen controls placeholder'))),
-          AutogenRealtimeStatsPanel(),
-          SizedBox(height: 200, child: InlineReportViewerWidget()),
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed:
+                      _status == _AutogenStatus.running ? null : _startAutogen,
+                  child: const Text('Start Autogen'),
+                ),
+                OutlinedButton(
+                  onPressed:
+                      _status == _AutogenStatus.running ? _stopAutogen : null,
+                  child: const Text('Stop'),
+                ),
+                Text('Status: ${_status.name}'),
+              ],
+            ),
+          ),
+          Expanded(child: Container()),
+          const AutogenRealtimeStatsPanel(),
+          const SizedBox(
+            height: 200,
+            child: InlineReportViewerWidget(),
+          ),
         ],
       ),
     );

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -79,10 +79,12 @@ class AutogenPipelineExecutor {
 
     final files = <File>[];
     for (final set in sets) {
+      if (generator.shouldAbort) break;
       final spots = generator.generate(
         set,
         theoryIndex: theoryIndex,
       );
+      if (generator.shouldAbort) break;
       if (spots.isEmpty) continue;
 
       theoryInjector.injectAll(spots);

--- a/lib/services/training_pack_auto_generator.dart
+++ b/lib/services/training_pack_auto_generator.dart
@@ -8,6 +8,7 @@ import 'auto_deduplication_engine.dart';
 class TrainingPackAutoGenerator {
   final TrainingPackGeneratorEngineV2 _engine;
   final AutoDeduplicationEngine _dedup;
+  bool _shouldAbort = false;
 
   TrainingPackAutoGenerator({
     TrainingPackGeneratorEngineV2? engine,
@@ -21,13 +22,23 @@ class TrainingPackAutoGenerator {
     Map<String, InlineTheoryEntry> theoryIndex = const {},
     Iterable<TrainingPackSpot> existingSpots = const [],
   }) {
+    if (_shouldAbort) return [];
     _dedup.addExisting(existingSpots);
     final spots = _engine.generate(set, theoryIndex: theoryIndex);
     final filtered = <TrainingPackSpot>[];
     for (final spot in spots) {
+      if (_shouldAbort) break;
       if (_dedup.isDuplicate(spot, source: 'auto')) continue;
       filtered.add(spot);
     }
     return filtered;
   }
+
+  /// Requests the generator to stop processing.
+  void abort() {
+    _shouldAbort = true;
+  }
+
+  /// Whether an abort has been requested.
+  bool get shouldAbort => _shouldAbort;
 }


### PR DESCRIPTION
## Summary
- enable start/stop controls for autogen debug screen
- allow TrainingPackAutoGenerator to abort generation
- respect abort flag in AutogenPipelineExecutor

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893b6399204832ab2de29313582bf2f