### PR TITLE
feat: configurable autogen via UI selection

### DIFF
--- a/lib/services/training_pack_template_set_library_service.dart
+++ b/lib/services/training_pack_template_set_library_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../asset_manifest.dart';
+import '../models/training_pack_template_set.dart';
+
+/// Loads training pack template sets from asset YAML files.
+class TrainingPackTemplateSetLibraryService {
+  TrainingPackTemplateSetLibraryService._();
+  static final TrainingPackTemplateSetLibraryService instance =
+      TrainingPackTemplateSetLibraryService._();
+
+  static const List<String> _dirs = [
+    'assets/templates/postflop_sets/',
+  ];
+
+  final List<TrainingPackTemplateSet> _sets = [];
+
+  List<TrainingPackTemplateSet> get all => List.unmodifiable(_sets);
+
+  Future<void> loadAll() async {
+    if (_sets.isNotEmpty) return;
+    await reload();
+  }
+
+  Future<void> reload() async {
+    _sets.clear();
+    final manifest = await AssetManifest.instance;
+    final paths = manifest.keys
+        .where((p) => _dirs.any((d) => p.startsWith(d)) && p.endsWith('.yaml'))
+        .toList();
+    for (final path in paths) {
+      try {
+        final raw = await rootBundle.loadString(path);
+        _sets.add(TrainingPackTemplateSet.fromYaml(raw));
+      } catch (_) {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow choosing a template set and output directory before running autogen
- load template sets from assets via TrainingPackTemplateSetLibraryService

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc7e4938832a8d58cbed7d3faf88