### PR TITLE
feat: add board texture classifier

### DIFF
--- a/lib/models/board_texture_tag.dart
+++ b/lib/models/board_texture_tag.dart
@@ -1,0 +1,15 @@
+enum BoardTextureTag {
+  low,
+  high,
+  paired,
+  trip,
+  aceHigh,
+  kingHigh,
+  monotone,
+  rainbow,
+  twoTone,
+  straighty,
+  disconnected,
+  wet,
+  dry,
+}

--- a/lib/services/board_texture_classifier.dart
+++ b/lib/services/board_texture_classifier.dart
@@ -1,27 +1,115 @@
+import '../models/card_model.dart';
+import '../models/board_texture_tag.dart';
 import '../models/v2/training_pack_spot.dart';
 
-/// Simple board texture classifier used during auto-generation.
+/// Classifies board textures for generated training spots.
 class BoardTextureClassifier {
   const BoardTextureClassifier();
 
-  /// Returns a rough classification for [spot]'s board.
-  String classify(TrainingPackSpot spot) {
-    final board = spot.board;
-    if (board.length >= 3) {
-      final ranks = board.map((c) => c[0]).toList();
-      final unique = ranks.toSet();
-      if (unique.length < ranks.length) {
-        return 'paired';
-      }
+  /// Returns a set of tags describing [board]'s texture.
+  Set<BoardTextureTag> classify(List<CardModel> board) {
+    final tags = <BoardTextureTag>{};
+    if (board.isEmpty) return tags;
+
+    final ranks = board.map((c) => _rankValue(c.rank)).toList()..sort();
+    final suits = board.map((c) => c.suit).toList();
+
+    // Duplication checks
+    final rankCounts = <int, int>{};
+    for (final r in ranks) {
+      rankCounts[r] = (rankCounts[r] ?? 0) + 1;
     }
-    return 'unpaired';
+    if (rankCounts.values.contains(3)) {
+      tags.add(BoardTextureTag.trip);
+    }
+    if (rankCounts.values.any((c) => c >= 2)) {
+      tags.add(BoardTextureTag.paired);
+    }
+
+    // Highest rank
+    final maxRank = ranks.last;
+    if (maxRank == 14) {
+      tags.add(BoardTextureTag.aceHigh);
+      tags.add(BoardTextureTag.high);
+    } else if (maxRank == 13) {
+      tags.add(BoardTextureTag.kingHigh);
+      tags.add(BoardTextureTag.high);
+    } else if (maxRank >= 10) {
+      tags.add(BoardTextureTag.high);
+    } else {
+      tags.add(BoardTextureTag.low);
+    }
+
+    // Suit distribution
+    final uniqueSuits = suits.toSet().length;
+    if (uniqueSuits == 1) {
+      tags.add(BoardTextureTag.monotone);
+    } else if (uniqueSuits == 2) {
+      tags.add(BoardTextureTag.twoTone);
+    } else {
+      tags.add(BoardTextureTag.rainbow);
+    }
+
+    // Connectedness
+    if (ranks.last - ranks.first <= 4) {
+      tags.add(BoardTextureTag.straighty);
+    } else {
+      tags.add(BoardTextureTag.disconnected);
+    }
+
+    // Wet vs dry
+    final hasFlushDraw = uniqueSuits <= 2;
+    final hasStraightDraw = ranks.last - ranks.first <= 4;
+    if (hasFlushDraw || hasStraightDraw || tags.contains(BoardTextureTag.paired)) {
+      tags.add(BoardTextureTag.wet);
+    } else {
+      tags.add(BoardTextureTag.dry);
+    }
+
+    return tags;
   }
 
-  /// Annotates each spot with a `boardTexture` meta field.
+  /// Annotates each [TrainingPackSpot] with `boardTextureTags` in its meta map.
   void classifyAll(Iterable<TrainingPackSpot> spots) {
     for (final s in spots) {
-      s.meta['boardTexture'] = classify(s);
+      final board = [
+        for (final c in s.board) CardModel(rank: c[0], suit: c[1])
+      ];
+      final tags = classify(board).map((e) => e.name).toList();
+      s.meta['boardTextureTags'] = tags;
+    }
+  }
+
+  int _rankValue(String r) {
+    switch (r.toUpperCase()) {
+      case 'A':
+        return 14;
+      case 'K':
+        return 13;
+      case 'Q':
+        return 12;
+      case 'J':
+        return 11;
+      case 'T':
+        return 10;
+      case '9':
+        return 9;
+      case '8':
+        return 8;
+      case '7':
+        return 7;
+      case '6':
+        return 6;
+      case '5':
+        return 5;
+      case '4':
+        return 4;
+      case '3':
+        return 3;
+      case '2':
+        return 2;
+      default:
+        return 0;
     }
   }
 }
-

--- a/test/services/board_texture_classifier_test.dart
+++ b/test/services/board_texture_classifier_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/board_texture_tag.dart';
+import 'package:poker_analyzer/services/board_texture_classifier.dart';
+
+void main() {
+  final classifier = BoardTextureClassifier();
+
+  test('classifies paired ace-high board as wet', () {
+    final board = [
+      CardModel(rank: 'A', suit: 's'),
+      CardModel(rank: 'A', suit: 'h'),
+      CardModel(rank: 'T', suit: 'd'),
+    ];
+    final tags = classifier.classify(board);
+    expect(tags.contains(BoardTextureTag.paired), isTrue);
+    expect(tags.contains(BoardTextureTag.aceHigh), isTrue);
+    expect(tags.contains(BoardTextureTag.wet), isTrue);
+  });
+
+  test('classifies monotone low straighty board', () {
+    final board = [
+      CardModel(rank: '2', suit: 'c'),
+      CardModel(rank: '3', suit: 'c'),
+      CardModel(rank: '4', suit: 'c'),
+    ];
+    final tags = classifier.classify(board);
+    expect(tags.containsAll({
+      BoardTextureTag.low,
+      BoardTextureTag.monotone,
+      BoardTextureTag.straighty,
+      BoardTextureTag.wet,
+    }), isTrue);
+    expect(tags.contains(BoardTextureTag.dry), isFalse);
+  });
+
+  test('classifies rainbow ace-high dry board', () {
+    final board = [
+      CardModel(rank: 'A', suit: 's'),
+      CardModel(rank: 'K', suit: 'd'),
+      CardModel(rank: '7', suit: 'h'),
+    ];
+    final tags = classifier.classify(board);
+    expect(tags.containsAll({
+      BoardTextureTag.aceHigh,
+      BoardTextureTag.high,
+      BoardTextureTag.rainbow,
+      BoardTextureTag.disconnected,
+      BoardTextureTag.dry,
+    }), isTrue);
+    expect(tags.contains(BoardTextureTag.wet), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoardTextureTag` enum for board characteristics
- implement `BoardTextureClassifier` to tag boards and annotate spots
- cover classifier behavior with tests

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c2abe594832a988ccb4355ba62cb