### PR TITLE
feat: track skill tag coverage

### DIFF
--- a/lib/models/skill_tag_coverage_report.dart
+++ b/lib/models/skill_tag_coverage_report.dart
@@ -1,0 +1,21 @@
+class SkillTagCoverageReport {
+  final Map<String, int> tagCounts;
+  final int totalSpots;
+  final int minCount;
+  final int maxCount;
+
+  const SkillTagCoverageReport({
+    required this.tagCounts,
+    required this.totalSpots,
+    this.minCount = 0,
+    this.maxCount = 0,
+  });
+
+  double get minCoverage =>
+      totalSpots == 0 ? 0 : minCount / totalSpots;
+  double get maxCoverage =>
+      totalSpots == 0 ? 0 : maxCount / totalSpots;
+  double get imbalance => maxCount == 0
+      ? 0
+      : (maxCount - minCount) / maxCount;
+}

--- a/test/skill_tag_coverage_tracker_test.dart
+++ b/test/skill_tag_coverage_tracker_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/skill_tag_coverage_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('analyze computes tag coverage', () {
+    final spots = [
+      TrainingPackSpot(id: '1', tags: ['push', 'call']),
+      TrainingPackSpot(id: '2', tags: ['push']),
+    ];
+    final pack = TrainingPackModel(id: 'p1', title: 'Pack', spots: spots);
+    final tracker = SkillTagCoverageTracker();
+    final report = tracker.analyze(pack);
+    expect(report.totalSpots, 2);
+    expect(report.tagCounts['push'], 2);
+    expect(report.tagCounts['call'], 1);
+    final aggregate = tracker.aggregateReport;
+    expect(aggregate.totalSpots, 2);
+    expect(aggregate.tagCounts['push'], 2);
+    expect(aggregate.tagCounts['call'], 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillTagCoverageReport` model and `SkillTagCoverageTracker` service to analyze training pack tag distribution
- integrate coverage tracking with autogen pipeline and dashboard reporting
- add unit test for `SkillTagCoverageTracker`

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cc303944832abd37267a4b1feb25