### PR TITLE
feat: auto inject theory links into spots

### DIFF
--- a/lib/models/inline_theory_entry.dart
+++ b/lib/models/inline_theory_entry.dart
@@ -2,8 +2,16 @@ class InlineTheoryEntry {
   final String tag;
   final String htmlSnippet;
 
+  /// Optional unique identifier of the theory entry.
+  final String? id;
+
+  /// Optional human readable title.
+  final String? title;
+
   const InlineTheoryEntry({
     required this.tag,
     required this.htmlSnippet,
+    this.id,
+    this.title,
   });
 }

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -88,7 +88,7 @@ class AutogenPipelineExecutor {
       if (generator.shouldAbort) break;
       if (spots.isEmpty) continue;
 
-      theoryInjector.injectAll(spots);
+      theoryInjector.injectAll(spots, theoryIndex);
       boardClassifier?.classifyAll(spots);
       skillLinker.linkAll(spots);
 

--- a/lib/services/theory_link_auto_injector.dart
+++ b/lib/services/theory_link_auto_injector.dart
@@ -1,16 +1,60 @@
+import '../models/inline_theory_entry.dart';
 import '../models/v2/training_pack_spot.dart';
-import 'auto_spot_theory_injector_service.dart';
 
-/// Wraps [AutoSpotTheoryInjectorService] for pipeline usage.
+/// Injects references to [InlineTheoryEntry] into [TrainingPackSpot] metadata
+/// based on matching tags.
 class TheoryLinkAutoInjector {
-  final AutoSpotTheoryInjectorService _injector;
+  const TheoryLinkAutoInjector();
 
-  TheoryLinkAutoInjector({AutoSpotTheoryInjectorService? injector})
-      : _injector = injector ?? AutoSpotTheoryInjectorService();
+  /// Inserts theory references into [spots] using [theoryIndex].
+  ///
+  /// [theoryIndex] should map theory tags to their corresponding
+  /// [InlineTheoryEntry]. For each spot, the first matching entry is inserted
+  /// into `spot.meta['theory']`. Duplicate theory ids across the provided
+  /// [spots] are avoided.
+  void injectAll(
+    List<TrainingPackSpot> spots,
+    Map<String, InlineTheoryEntry> theoryIndex,
+  ) {
+    final used = <String>{};
+    for (final spot in spots) {
+      for (final t in spot.tags) {
+        final entry = _findEntry(t, theoryIndex);
+        if (entry == null) continue;
+        final id = entry.id ?? entry.tag;
+        if (used.contains(id)) continue;
+        spot.meta['theory'] = {
+          'tag': entry.tag,
+          'id': id,
+          if (entry.title != null) 'title': entry.title,
+        };
+        used.add(id);
+        break;
+      }
+    }
+  }
 
-  /// Injects theory links into all [spots].
-  void injectAll(Iterable<TrainingPackSpot> spots) {
-    _injector.injectAll(spots);
+  InlineTheoryEntry? _findEntry(
+    String tag,
+    Map<String, InlineTheoryEntry> index,
+  ) {
+    // Exact match first
+    if (index.containsKey(tag)) return index[tag];
+
+    final tagLower = tag.toLowerCase();
+    for (final e in index.entries) {
+      final keyLower = e.key.toLowerCase();
+      if (tagLower == keyLower) return e.value;
+    }
+
+    // Fuzzy match: check if one tag contains the other.
+    for (final e in index.entries) {
+      final keyLower = e.key.toLowerCase();
+      if (tagLower.contains(keyLower) || keyLower.contains(tagLower)) {
+        return e.value;
+      }
+    }
+    return null;
   }
 }
 

--- a/test/services/theory_link_auto_injector_test.dart
+++ b/test/services/theory_link_auto_injector_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/hand_data.dart';
+import 'package:poker_analyzer/models/inline_theory_entry.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/theory_link_auto_injector.dart';
+
+void main() {
+  group('TheoryLinkAutoInjector', () {
+    test('injects matching theory metadata', () {
+      final spots = [
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['openSB']),
+      ];
+      final index = {
+        'openSB': const InlineTheoryEntry(
+          tag: 'openSB',
+          id: 'sb_vs_bb_open_range',
+          title: 'SB Opening Range vs BB',
+          htmlSnippet: '<p>SB open</p>',
+        ),
+      };
+      const injector = TheoryLinkAutoInjector();
+
+      injector.injectAll(spots, index);
+
+      final meta = spots.first.meta['theory'] as Map<String, dynamic>?;
+      expect(meta, isNotNull);
+      expect(meta!['id'], 'sb_vs_bb_open_range');
+      expect(meta['title'], 'SB Opening Range vs BB');
+      expect(meta['tag'], 'openSB');
+    });
+
+    test('falls back to fuzzy tag matches', () {
+      final spots = [
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['openSBWide']),
+      ];
+      final index = {
+        'openSB': const InlineTheoryEntry(
+          tag: 'openSB',
+          id: 'sb_vs_bb_open_range',
+          title: 'SB Opening Range',
+          htmlSnippet: '<p>SB open</p>',
+        ),
+      };
+      const injector = TheoryLinkAutoInjector();
+
+      injector.injectAll(spots, index);
+
+      final meta = spots.first.meta['theory'] as Map<String, dynamic>?;
+      expect(meta, isNotNull);
+      expect(meta!['tag'], 'openSB');
+    });
+
+    test('avoids duplicate theory ids across pack', () {
+      final spots = [
+        TrainingPackSpot(id: 's1', hand: HandData(), tags: ['openSB']),
+        TrainingPackSpot(id: 's2', hand: HandData(), tags: ['openSB']),
+      ];
+      final index = {
+        'openSB': const InlineTheoryEntry(
+          tag: 'openSB',
+          id: 'sb_vs_bb_open_range',
+          title: 'SB Opening Range',
+          htmlSnippet: '<p>SB open</p>',
+        ),
+      };
+      const injector = TheoryLinkAutoInjector();
+
+      injector.injectAll(spots, index);
+
+      final first = spots[0].meta['theory'] as Map<String, dynamic>?;
+      final second = spots[1].meta['theory'] as Map<String, dynamic>?;
+      expect(first, isNotNull);
+      expect(second, isNull);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add id and title fields to InlineTheoryEntry
- implement TheoryLinkAutoInjector to attach theory metadata to spots
- update pipeline to supply theory index
- cover TheoryLinkAutoInjector with tests

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf8ea2c0832a888c449d5bd3990a