### PR TITLE
feat: link training spots to skill tree

### DIFF
--- a/lib/services/skill_tag_skill_node_map_service.dart
+++ b/lib/services/skill_tag_skill_node_map_service.dart
@@ -1,0 +1,10 @@
+/// Provides mapping from skill tags to skill tree node IDs.
+class SkillTagSkillNodeMapService {
+  final Map<String, String> _map;
+
+  const SkillTagSkillNodeMapService({Map<String, String>? map})
+    : _map = map ?? const {};
+
+  /// Returns the skill tree node ID for [tag], or null if not mapped.
+  String? nodeIdForTag(String tag) => _map[tag.trim().toLowerCase()];
+}

--- a/lib/services/skill_tree_auto_linker.dart
+++ b/lib/services/skill_tree_auto_linker.dart
@@ -1,16 +1,24 @@
 import '../models/v2/training_pack_spot.dart';
+import 'skill_tag_skill_node_map_service.dart';
 
-/// Naively links spots to skill tags for later processing.
+/// Links spots to skill tree nodes based on their tags.
 class SkillTreeAutoLinker {
-  const SkillTreeAutoLinker();
+  final SkillTagSkillNodeMapService map;
 
-  /// Writes the spot's tags into `skillTags` meta field.
-  void linkAll(Iterable<TrainingPackSpot> spots) {
+  const SkillTreeAutoLinker({SkillTagSkillNodeMapService? map})
+    : map = map ?? const SkillTagSkillNodeMapService();
+
+  /// Assigns `skillNode` meta fields for all [spots].
+  void linkAll(List<TrainingPackSpot> spots) {
+    final used = <String>{};
     for (final s in spots) {
-      if (s.tags.isNotEmpty) {
-        s.meta['skillTags'] = List<String>.from(s.tags);
+      for (final tag in s.tags) {
+        final node = map.nodeIdForTag(tag);
+        if (node != null && used.add(node)) {
+          s.meta['skillNode'] = node;
+          break;
+        }
       }
     }
   }
 }
-

--- a/test/services/skill_tree_auto_linker_test.dart
+++ b/test/services/skill_tree_auto_linker_test.dart
@@ -1,0 +1,39 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/skill_tree_auto_linker.dart';
+import 'package:poker_analyzer/services/skill_tag_skill_node_map_service.dart';
+
+void main() {
+  test('links spots to unique skill nodes based on tags', () {
+    final spots = [
+      TrainingPackSpot(id: 's1', tags: ['push']),
+      TrainingPackSpot(id: 's2', tags: ['push', 'call']),
+      TrainingPackSpot(id: 's3', tags: ['call']),
+    ];
+
+    final map = SkillTagSkillNodeMapService(
+      map: {'push': 'node_a', 'call': 'node_b'},
+    );
+
+    final linker = SkillTreeAutoLinker(map: map);
+    linker.linkAll(spots);
+
+    expect(spots[0].meta['skillNode'], 'node_a');
+    expect(spots[1].meta['skillNode'], 'node_b');
+    expect(spots[2].meta.containsKey('skillNode'), isFalse);
+  });
+
+  test('uses the first matching tag', () {
+    final spots = [
+      TrainingPackSpot(id: 's1', tags: ['unknown', 'call', 'push']),
+    ];
+
+    final map = SkillTagSkillNodeMapService(
+      map: {'push': 'node_a', 'call': 'node_b'},
+    );
+
+    SkillTreeAutoLinker(map: map).linkAll(spots);
+
+    expect(spots[0].meta['skillNode'], 'node_b');
+  });
+}


### PR DESCRIPTION
## Summary
- map training spot tags to skill tree nodes
- assign skill node meta via SkillTreeAutoLinker
- add unit tests for automatic linking

## Testing
- `dart test test/services/skill_tree_auto_linker_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed. Flutter users should use `flutter pub` instead of `dart pub`.)*


------
https://chatgpt.com/codex/tasks/task_e_6893d121a95c832ab5881832339fd871