### PR TITLE
feat: fingerprint generator for training packs

### DIFF
--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -41,18 +41,20 @@ class AutogenPipelineExecutor {
     TrainingPackFingerprintGenerator? fingerprintGenerator,
     IOSink? fingerprintLog,
     AutogenStatusDashboardService? dashboard,
-  })  : dedup = dedup ?? AutoDeduplicationEngine(),
-        exporter = exporter ?? const YamlPackExporter(),
-        coverage = coverage ?? SkillTagCoverageTracker(),
-        theoryInjector = theoryInjector ?? TheoryLinkAutoInjector(),
-        boardClassifier = boardClassifier,
-        skillLinker = skillLinker ?? const SkillTreeAutoLinker(),
-        fingerprintGenerator =
-            fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
-        _fingerprintLog = fingerprintLog ??
-            File('generated_pack_fingerprints.log')
-                .openWrite(mode: FileMode.append),
-        dashboard = dashboard ?? AutogenStatusDashboardService() {
+  }) : dedup = dedup ?? AutoDeduplicationEngine(),
+       exporter = exporter ?? const YamlPackExporter(),
+       coverage = coverage ?? SkillTagCoverageTracker(),
+       theoryInjector = theoryInjector ?? TheoryLinkAutoInjector(),
+       boardClassifier = boardClassifier,
+       skillLinker = skillLinker ?? const SkillTreeAutoLinker(),
+       fingerprintGenerator =
+           fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
+       _fingerprintLog =
+           fingerprintLog ??
+           File(
+             'generated_pack_fingerprints.log',
+           ).openWrite(mode: FileMode.append),
+       dashboard = dashboard ?? AutogenStatusDashboardService() {
     this.generator = generator ?? TrainingPackAutoGenerator(dedup: this.dedup);
   }
 
@@ -81,10 +83,7 @@ class AutogenPipelineExecutor {
     final files = <File>[];
     for (final set in sets) {
       if (generator.shouldAbort) break;
-      final spots = generator.generate(
-        set,
-        theoryIndex: theoryIndex,
-      );
+      final spots = generator.generate(set, theoryIndex: theoryIndex);
       if (generator.shouldAbort) break;
       if (spots.isEmpty) continue;
 
@@ -121,8 +120,7 @@ class AutogenPipelineExecutor {
       files.add(file);
 
       dashboard.recordPack(spots.length);
-      final fp = fingerprintGenerator.generate(pack);
-      dashboard.recordFingerprint(fp);
+      final fp = fingerprintGenerator.generateFromTemplate(pack);
       _fingerprintLog.writeln(fp);
     }
 
@@ -131,8 +129,10 @@ class AutogenPipelineExecutor {
     await coverage.logSummary();
     await _fingerprintLog.flush();
     await _fingerprintLog.close();
-    await dashboard.logFinalStats(coverage.aggregateReport,
-        yamlFiles: files.length);
+    await dashboard.logFinalStats(
+      coverage.aggregateReport,
+      yamlFiles: files.length,
+    );
     return files;
   }
 }

--- a/lib/services/completed_training_pack_registry.dart
+++ b/lib/services/completed_training_pack_registry.dart
@@ -34,7 +34,7 @@ class CompletedTrainingPackRegistry {
     Duration? duration,
   }) async {
     final prefs = await _sp;
-    final fingerprint = _fingerprintGenerator.generate(pack);
+    final fingerprint = _fingerprintGenerator.generateFromTemplate(pack);
     final data = <String, dynamic>{
       'yaml': pack.toYamlString(),
       'timestamp': (completedAt ?? DateTime.now()).toIso8601String(),

--- a/lib/services/unique_pack_replay_blocker_service.dart
+++ b/lib/services/unique_pack_replay_blocker_service.dart
@@ -11,10 +11,10 @@ class UniquePackReplayBlockerService {
     SharedPreferences? prefs,
     TrainingPackFingerprintGenerator? fingerprintGenerator,
     TrainingSessionFingerprintRecorder? recorder,
-  })  : _prefs = prefs,
-        _fingerprintGenerator =
-            fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
-        _recorder = recorder ?? TrainingSessionFingerprintRecorder.instance;
+  }) : _prefs = prefs,
+       _fingerprintGenerator =
+           fingerprintGenerator ?? const TrainingPackFingerprintGenerator(),
+       _recorder = recorder ?? TrainingSessionFingerprintRecorder.instance;
 
   SharedPreferences? _prefs;
   final TrainingPackFingerprintGenerator _fingerprintGenerator;
@@ -39,8 +39,7 @@ class UniquePackReplayBlockerService {
   /// Returns `true` if replaying [pack] is blocked due to prior completion.
   Future<bool> isReplayBlocked(TrainingPackTemplateV2 pack) async {
     if (!await _isBlockingEnabled()) return false;
-    final fp = _fingerprintGenerator.generate(pack);
+    final fp = _fingerprintGenerator.generateFromTemplate(pack);
     return _recorder.isCompleted(fp);
   }
 }
-

--- a/test/services/completed_session_summary_service_test.dart
+++ b/test/services/completed_session_summary_service_test.dart
@@ -37,8 +37,12 @@ void main() {
     final summaries = await service.loadSummaries();
 
     expect(summaries, hasLength(2));
-    final fp1 = const TrainingPackFingerprintGenerator().generate(pack1);
-    final fp2 = const TrainingPackFingerprintGenerator().generate(pack2);
+    final fp1 = const TrainingPackFingerprintGenerator().generateFromTemplate(
+      pack1,
+    );
+    final fp2 = const TrainingPackFingerprintGenerator().generateFromTemplate(
+      pack2,
+    );
 
     expect(summaries[0].fingerprint, fp2);
     expect(summaries[0].timestamp, time2);

--- a/test/services/completed_training_pack_registry_test.dart
+++ b/test/services/completed_training_pack_registry_test.dart
@@ -33,7 +33,9 @@ void main() {
       duration: const Duration(seconds: 30),
     );
 
-    final fp = const TrainingPackFingerprintGenerator().generate(pack);
+    final fp = const TrainingPackFingerprintGenerator().generateFromTemplate(
+      pack,
+    );
     final data = await registry.getCompletedPackData(fp);
     expect(data, isNotNull);
     expect(data!['yaml'], equals(pack.toYamlString()));

--- a/test/services/unique_pack_replay_blocker_service_test.dart
+++ b/test/services/unique_pack_replay_blocker_service_test.dart
@@ -37,9 +37,8 @@ void main() {
 
   test('blocks replay when enabled and completed', () async {
     await blocker.setBlockingEnabled(true);
-    final fp = gen.generate(pack);
+    final fp = gen.generateFromTemplate(pack);
     await TrainingSessionFingerprintRecorder.instance.recordCompletion(fp);
     expect(await blocker.isReplayBlocked(pack), isTrue);
   });
 }
-

--- a/test/training_pack_fingerprint_generator_test.dart
+++ b/test/training_pack_fingerprint_generator_test.dart
@@ -3,6 +3,7 @@ import 'package:poker_analyzer/services/training_pack_fingerprint_generator.dart
 import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
 import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
 
 void main() {
@@ -24,12 +25,25 @@ void main() {
   test('fingerprint is deterministic regardless of ordering', () {
     final a = buildPack(['s1', 's2'], tags: ['b', 'a']);
     final b = buildPack(['s2', 's1'], tags: ['a', 'b']);
-    expect(gen.generate(a), gen.generate(b));
+    expect(gen.generateFromTemplate(a), gen.generateFromTemplate(b));
   });
 
   test('different packs produce different fingerprints', () {
     final a = buildPack(['s1', 's2']);
     final b = buildPack(['s1', 's3']);
-    expect(gen.generate(a), isNot(gen.generate(b)));
+    expect(gen.generateFromTemplate(a), isNot(gen.generateFromTemplate(b)));
+  });
+
+  test('generate stores fingerprint in model metadata', () {
+    final spot = TrainingPackSpot(id: 's1', hand: HandData());
+    final model = TrainingPackModel(
+      id: 'm1',
+      title: 'Model',
+      spots: [spot],
+      tags: ['x'],
+      metadata: {'trainingType': 'quiz', 'gameType': 'cash'},
+    );
+    final fp = gen.generate(model);
+    expect(model.metadata['fingerprint'], fp);
   });
 }

--- a/test/widgets/completed_session_detail_screen_test.dart
+++ b/test/widgets/completed_session_detail_screen_test.dart
@@ -34,7 +34,9 @@ void main() {
       completedAt: DateTime.utc(2024, 1, 1),
       accuracy: 0.8,
     );
-    final fp = const TrainingPackFingerprintGenerator().generate(pack);
+    final fp = const TrainingPackFingerprintGenerator().generateFromTemplate(
+      pack,
+    );
 
     await tester.pumpWidget(
       MaterialApp(home: CompletedSessionDetailScreen(fingerprint: fp)),
@@ -51,7 +53,8 @@ void main() {
   testWidgets('shows not found when missing', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-          home: CompletedSessionDetailScreen(fingerprint: 'missing')),
+        home: CompletedSessionDetailScreen(fingerprint: 'missing'),
+      ),
     );
     await tester.pumpAndSettle();
     expect(find.text('Session not found'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add TrainingPackFingerprintGenerator with model and template support
- log fingerprints and store them in pack metadata
- update services and tests to use new fingerprint API

## Testing
- `flutter test` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, but it does not provide an inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_6893d9443744832ab2913040874f24e4