### PR TITLE
feat: add ICM weight distributor

### DIFF
--- a/lib/services/icm_weight_distributor.dart
+++ b/lib/services/icm_weight_distributor.dart
@@ -1,0 +1,69 @@
+import '../models/v2/training_pack_spot.dart';
+
+/// Assigns a normalized weight to each [TrainingPackSpot].
+///
+/// Spots with rarer tags or types receive higher weights. An optional [icmMap]
+/// can override weights for specific spot IDs or tags. The resulting weights are
+/// stored in `spot.meta['weight']` and normalized so that the sum equals `1.0`.
+class ICMWeightDistributor {
+  /// Distributes weights across [spots].
+  void distribute(List<TrainingPackSpot> spots, {Map<String, double>? icmMap}) {
+    if (spots.isEmpty) return;
+
+    final Map<String, int> tagCounts = <String, int>{};
+    final Map<String, int> typeCounts = <String, int>{};
+
+    for (final spot in spots) {
+      typeCounts[spot.type] = (typeCounts[spot.type] ?? 0) + 1;
+      for (final String tag in spot.tags) {
+        tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
+      }
+    }
+
+    final Map<TrainingPackSpot, double> rawWeights =
+        <TrainingPackSpot, double>{};
+
+    for (final spot in spots) {
+      double weight = 0;
+
+      // Frequency-based component
+      if (spot.tags.isNotEmpty) {
+        for (final tag in spot.tags) {
+          final int count = tagCounts[tag] ?? 1;
+          weight += 1 / count;
+        }
+      }
+      final int typeCount = typeCounts[spot.type] ?? 1;
+      weight += 1 / typeCount;
+
+      // External ICM map overrides
+      if (icmMap != null) {
+        if (icmMap.containsKey(spot.id)) {
+          weight = icmMap[spot.id]!;
+        } else {
+          for (final tag in spot.tags) {
+            if (icmMap.containsKey(tag)) {
+              weight = icmMap[tag]!;
+              break;
+            }
+          }
+        }
+      }
+
+      rawWeights[spot] = weight;
+    }
+
+    double total = rawWeights.values.fold(0, (double a, double b) => a + b);
+    if (total == 0) {
+      final double equal = 1 / spots.length;
+      for (final spot in spots) {
+        spot.meta['weight'] = equal;
+      }
+      return;
+    }
+
+    rawWeights.forEach((spot, weight) {
+      spot.meta['weight'] = weight / total;
+    });
+  }
+}

--- a/test/icm_weight_distributor_test.dart
+++ b/test/icm_weight_distributor_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/icm_weight_distributor.dart';
+
+void main() {
+  group('ICMWeightDistributor', () {
+    test('distributes weights based on rarity', () {
+      final spots = [
+        TrainingPackSpot(id: '1', tags: ['x'], type: 'A'),
+        TrainingPackSpot(id: '2', tags: ['y'], type: 'A'),
+        TrainingPackSpot(id: '3', tags: ['x'], type: 'B'),
+      ];
+
+      ICMWeightDistributor().distribute(spots);
+
+      final w1 = spots[0].meta['weight'] as double;
+      final w2 = spots[1].meta['weight'] as double;
+      final w3 = spots[2].meta['weight'] as double;
+
+      expect(w1 + w2 + w3, closeTo(1.0, 1e-6));
+      expect(w2, closeTo(0.375, 1e-6));
+      expect(w3, closeTo(0.375, 1e-6));
+      expect(w1, closeTo(0.25, 1e-6));
+    });
+
+    test('icmMap overrides by spot id', () {
+      final spots = [
+        TrainingPackSpot(id: '1', tags: ['x'], type: 'A'),
+        TrainingPackSpot(id: '2', tags: ['y'], type: 'A'),
+      ];
+
+      ICMWeightDistributor().distribute(spots, icmMap: {'2': 5});
+
+      final w1 = spots[0].meta['weight'] as double;
+      final w2 = spots[1].meta['weight'] as double;
+
+      expect(w1 + w2, closeTo(1.0, 1e-6));
+      expect(w2, greaterThan(w1));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `ICMWeightDistributor` service for frequency- or map-based spot weights
- cover weight distribution and overrides with unit tests

## Testing
- `flutter test test/icm_weight_distributor_test.dart` *(fails: No tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6893dec24050832a8bfd84540098479c