### PR TITLE
feat: add training session fingerprint logger

### DIFF
--- a/lib/services/training_session_fingerprint_logger_service.dart
+++ b/lib/services/training_session_fingerprint_logger_service.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../core/training/engine/training_type_engine.dart';
+
+class TrainingSessionFingerprint {
+  final String fingerprint;
+  final String packId;
+  final TrainingType trainingType;
+  final int spotCount;
+  final double accuracy;
+  final DateTime completedAt;
+
+  TrainingSessionFingerprint({
+    required this.fingerprint,
+    required this.packId,
+    required this.trainingType,
+    required this.spotCount,
+    required this.accuracy,
+    DateTime? completedAt,
+  }) : completedAt = completedAt ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'fingerprint': fingerprint,
+        'packId': packId,
+        'trainingType': trainingType.name,
+        'spotCount': spotCount,
+        'accuracy': accuracy,
+        'completedAt': completedAt.toIso8601String(),
+      };
+
+  factory TrainingSessionFingerprint.fromJson(Map<String, dynamic> json) {
+    return TrainingSessionFingerprint(
+      fingerprint: json['fingerprint'] as String,
+      packId: json['packId'] as String,
+      trainingType: TrainingType.values.firstWhere(
+        (e) => e.name == json['trainingType'],
+        orElse: () => TrainingType.custom,
+      ),
+      spotCount: json['spotCount'] as int? ?? 0,
+      accuracy: (json['accuracy'] as num?)?.toDouble() ?? 0.0,
+      completedAt:
+          DateTime.tryParse(json['completedAt'] ?? '') ?? DateTime.now(),
+    );
+  }
+}
+
+class TrainingSessionFingerprintLoggerService {
+  TrainingSessionFingerprintLoggerService({SharedPreferences? prefs})
+      : _prefs = prefs;
+
+  SharedPreferences? _prefs;
+  static const _prefix = 'session_fingerprint_';
+
+  Future<SharedPreferences> get _sp async =>
+      _prefs ??= await SharedPreferences.getInstance();
+
+  Future<void> logSession(TrainingSessionFingerprint session) async {
+    final prefs = await _sp;
+    await prefs.setString(
+      '$_prefix${session.fingerprint}',
+      jsonEncode(session.toJson()),
+    );
+  }
+
+  Future<List<TrainingSessionFingerprint>> getAll() async {
+    final prefs = await _sp;
+    final list = <TrainingSessionFingerprint>[];
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(_prefix)) {
+        final raw = prefs.getString(key);
+        if (raw == null) continue;
+        try {
+          final data = jsonDecode(raw);
+          if (data is Map<String, dynamic>) {
+            list.add(
+              TrainingSessionFingerprint.fromJson(
+                Map<String, dynamic>.from(data),
+              ),
+            );
+          }
+        } catch (_) {}
+      }
+    }
+    return list;
+  }
+}

--- a/test/services/training_session_fingerprint_logger_service_test.dart
+++ b/test/services/training_session_fingerprint_logger_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/training_session_fingerprint_logger_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('logs and retrieves sessions', () async {
+    final service = TrainingSessionFingerprintLoggerService();
+    final session = TrainingSessionFingerprint(
+      fingerprint: 'abc',
+      packId: 'pack1',
+      trainingType: TrainingType.pushFold,
+      spotCount: 5,
+      accuracy: 0.8,
+      completedAt: DateTime(2023, 1, 1),
+    );
+    await service.logSession(session);
+
+    final all = await service.getAll();
+    expect(all, hasLength(1));
+    expect(all.first.fingerprint, 'abc');
+    expect(all.first.packId, 'pack1');
+    expect(all.first.trainingType, TrainingType.pushFold);
+    expect(all.first.spotCount, 5);
+    expect(all.first.accuracy, closeTo(0.8, 0.0001));
+    expect(all.first.completedAt, DateTime(2023, 1, 1));
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingSessionFingerprintLoggerService for storing completed session metadata
- include TrainingSessionFingerprint model for metadata encapsulation
- cover logging and retrieval with unit test

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(package not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e0ef4eb0832aadb3a1045481b1d9