### PR TITLE
feat: add autogen status dashboard service

### DIFF
--- a/lib/models/autogen_status.dart
+++ b/lib/models/autogen_status.dart
@@ -1,0 +1,33 @@
+enum AutogenPipelineStatus { idle, running, completed, failed }
+
+class AutogenStatus {
+  final AutogenPipelineStatus status;
+  final String? lastTemplateSet;
+  final DateTime? lastRun;
+  final String? error;
+  final String? activeStage;
+
+  const AutogenStatus({
+    this.status = AutogenPipelineStatus.idle,
+    this.lastTemplateSet,
+    this.lastRun,
+    this.error,
+    this.activeStage,
+  });
+
+  AutogenStatus copyWith({
+    AutogenPipelineStatus? status,
+    String? lastTemplateSet,
+    DateTime? lastRun,
+    String? error,
+    String? activeStage,
+  }) {
+    return AutogenStatus(
+      status: status ?? this.status,
+      lastTemplateSet: lastTemplateSet ?? this.lastTemplateSet,
+      lastRun: lastRun ?? this.lastRun,
+      error: error ?? this.error,
+      activeStage: activeStage ?? this.activeStage,
+    );
+  }
+}

--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
 import '../widgets/autogen_realtime_stats_panel.dart';
 import '../widgets/inline_report_viewer_widget.dart';
+import '../services/autogen_stats_dashboard_service.dart';
 import '../services/autogen_status_dashboard_service.dart';
 import '../services/autogen_pipeline_executor.dart';
 import '../services/training_pack_auto_generator.dart';
@@ -68,8 +69,9 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
 
   void _startAutogen() {
     if (_status == _AutogenStatus.running) return;
-    final dashboard = AutogenStatusDashboardService.instance;
+    final dashboard = AutogenStatsDashboardService.instance;
     dashboard.start();
+    final status = AutogenStatusDashboardService.instance;
     final generator = TrainingPackAutoGenerator();
     _generator = generator;
     final exporter = YamlPackExporter(
@@ -78,6 +80,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     final executor = AutogenPipelineExecutor(
       generator: generator,
       dashboard: dashboard,
+      status: status,
       exporter: exporter,
     );
     setState(() {

--- a/lib/services/autogen_stats_dashboard_service.dart
+++ b/lib/services/autogen_stats_dashboard_service.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/autogen_stats_model.dart';
+import '../models/skill_tag_coverage_report.dart';
+
+/// Centralized logger aggregating key metrics during hyperscale autogeneration.
+class AutogenStatsDashboardService extends ChangeNotifier {
+  AutogenStatsDashboardService._({String logPath = 'autogen_report.log'})
+      : _logFile = File(logPath);
+
+  static final AutogenStatsDashboardService _instance =
+      AutogenStatsDashboardService._();
+
+  factory AutogenStatsDashboardService() => _instance;
+  static AutogenStatsDashboardService get instance => _instance;
+
+  final File _logFile;
+  final AutogenStatsModel stats = AutogenStatsModel();
+  SkillTagCoverageReport coverage =
+      const SkillTagCoverageReport(tagCounts: {}, totalSpots: 0);
+  DateTime? _start;
+  int _yamlFiles = 0;
+
+  /// Marks the beginning of tracking.
+  void start() {
+    _start = DateTime.now();
+    stats
+      ..totalPacks = 0
+      ..totalSpots = 0
+      ..skippedSpots = 0
+      ..fingerprintCount = 0;
+    coverage = const SkillTagCoverageReport(tagCounts: {}, totalSpots: 0);
+    _yamlFiles = 0;
+    notifyListeners();
+  }
+
+  /// Records a generated pack and its [spotCount].
+  void recordPack(int spotCount) {
+    stats.totalPacks++;
+    _yamlFiles++;
+    stats.totalSpots += spotCount;
+    notifyListeners();
+  }
+
+  /// Records the number of skipped duplicate spots.
+  void recordSkipped(int count) {
+    stats.skippedSpots = count;
+    notifyListeners();
+  }
+
+  /// Records that a fingerprint was generated.
+  void recordFingerprint(String _) {
+    stats.fingerprintCount++;
+    notifyListeners();
+  }
+
+  /// Updates coverage statistics for dashboard preview.
+  void recordCoverage(SkillTagCoverageReport report) {
+    coverage = report;
+    notifyListeners();
+  }
+
+  /// Logs final aggregated statistics to console and to a log file.
+  Future<void> logFinalStats(
+    SkillTagCoverageReport coverage, {
+    int? yamlFiles,
+  }) async {
+    final end = DateTime.now();
+    final start = _start ?? end;
+    final buffer = StringBuffer()
+      ..writeln('=== Autogen Stats Report ===')
+      ..writeln('Start: $start')
+      ..writeln('End:   $end')
+      ..writeln('Duration: ${end.difference(start)}')
+      ..writeln('Packs generated: ${stats.totalPacks}')
+      ..writeln('Unique spots: ${stats.totalSpots}')
+      ..writeln('Duplicates skipped: ${stats.skippedSpots}')
+      ..writeln('YAML files: ${yamlFiles ?? _yamlFiles}')
+      ..writeln('Top 10 tags:');
+
+    final sorted = coverage.tagCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    for (final entry in sorted.take(10)) {
+      buffer.writeln('  ${entry.key}: ${entry.value}');
+    }
+
+    final report = buffer.toString();
+    // Output to console for immediate visibility.
+    print(report);
+    // Persist to log file.
+    await _logFile.writeAsString(report);
+  }
+}

--- a/lib/services/training_pack_fingerprint_generator.dart
+++ b/lib/services/training_pack_fingerprint_generator.dart
@@ -6,7 +6,7 @@ import 'package:crypto/crypto.dart';
 import '../models/training_pack_model.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import 'spot_fingerprint_generator.dart';
-import 'autogen_status_dashboard_service.dart';
+import 'autogen_stats_dashboard_service.dart';
 
 /// Generates a deterministic fingerprint for training packs.
 ///
@@ -17,12 +17,12 @@ import 'autogen_status_dashboard_service.dart';
 class TrainingPackFingerprintGenerator {
   const TrainingPackFingerprintGenerator({
     SpotFingerprintGenerator? spotFingerprint,
-    AutogenStatusDashboardService? dashboard,
+    AutogenStatsDashboardService? dashboard,
   }) : _spotFingerprint = spotFingerprint ?? const SpotFingerprintGenerator(),
-       _dashboard = dashboard ?? AutogenStatusDashboardService();
+       _dashboard = dashboard ?? AutogenStatsDashboardService();
 
   final SpotFingerprintGenerator _spotFingerprint;
-  final AutogenStatusDashboardService _dashboard;
+  final AutogenStatsDashboardService _dashboard;
 
   /// Returns a SHA256 hash uniquely representing [model]. The fingerprint is
   /// stored in `model.metadata['fingerprint']` and recorded via the autogen

--- a/lib/widgets/autogen_realtime_stats_panel.dart
+++ b/lib/widgets/autogen_realtime_stats_panel.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../services/autogen_status_dashboard_service.dart';
+import '../services/autogen_stats_dashboard_service.dart';
 
 /// Compact real-time display of autogeneration statistics.
 class AutogenRealtimeStatsPanel extends StatelessWidget {
@@ -9,10 +9,10 @@ class AutogenRealtimeStatsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final service = AutogenStatusDashboardService.instance;
+    final service = AutogenStatsDashboardService.instance;
     return ChangeNotifierProvider.value(
       value: service,
-      child: Consumer<AutogenStatusDashboardService>(
+      child: Consumer<AutogenStatsDashboardService>(
         builder: (context, dashboard, _) {
           final stats = dashboard.stats;
           return Container(


### PR DESCRIPTION
## Summary
- add AutogenStatusDashboardService with pipeline status tracking
- rename metrics service to AutogenStatsDashboardService
- update pipeline executor to broadcast pipeline stage updates and persist last run

## Testing
- `flutter format lib/services/autogen_stats_dashboard_service.dart lib/models/autogen_status.dart lib/services/autogen_status_dashboard_service.dart lib/services/autogen_pipeline_executor.dart lib/widgets/autogen_realtime_stats_panel.dart lib/screens/autogen_debug_screen.dart lib/services/training_pack_fingerprint_generator.dart` *(command not found)*
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e2c1da70832aae91f3cc91741011