### PR TITLE
feat: auto inject inline theory links

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -8,6 +8,7 @@ import 'hero_position.dart';
 import '../card_model.dart';
 import 'package:uuid/uuid.dart';
 import '../../services/inline_theory_linker.dart';
+import '../inline_theory_entry.dart';
 
 class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> implements SpotModel {
   final String id;
@@ -43,6 +44,11 @@ class TrainingPackSpot with CopyWithMixin<TrainingPackSpot> implements SpotModel
   /// When present, this value is serialized to `inlineLessonId` in YAML and
   /// links the spot to a [TheoryMiniLessonNode].
   String? inlineLessonId;
+
+  /// Ephemeral reference to inline theory content matched by tags.
+  ///
+  /// Populated at runtime by [TheoryLinkAutoInjector] and never serialized.
+  InlineTheoryEntry? inlineTheory;
 
   /// Ephemeral link to a related theory lesson.
   ///

--- a/lib/services/theory_link_auto_injector.dart
+++ b/lib/services/theory_link_auto_injector.dart
@@ -1,37 +1,67 @@
 import '../models/inline_theory_entry.dart';
 import '../models/v2/training_pack_spot.dart';
+import '../models/training_pack_model.dart';
 
-/// Injects references to [InlineTheoryEntry] into [TrainingPackSpot] metadata
-/// based on matching tags.
+/// Injects references to [InlineTheoryEntry] into [TrainingPackSpot]s based on
+/// matching tags.
 class TheoryLinkAutoInjector {
   const TheoryLinkAutoInjector();
 
-  /// Inserts theory references into [spots] using [theoryIndex].
+  /// Attaches theory links to all spots within [model] using [theoryIndex].
   ///
-  /// [theoryIndex] should map theory tags to their corresponding
-  /// [InlineTheoryEntry]. For each spot, the first matching entry is inserted
-  /// into `spot.meta['theory']`. Duplicate theory ids across the provided
-  /// [spots] are avoided.
+  /// Returns the mutated [model] for convenience and logs the number of
+  /// injected links.
+  TrainingPackModel injectLinks(
+    TrainingPackModel model,
+    Map<String, InlineTheoryEntry> theoryIndex,
+  ) {
+    final count = _injectAll(model.spots, theoryIndex);
+    if (count > 0) {
+      print('TheoryLinkAutoInjector: injected $count links');
+    }
+    return model;
+  }
+
+  /// Convenience method to inject links into a list of [spots].
   void injectAll(
     List<TrainingPackSpot> spots,
     Map<String, InlineTheoryEntry> theoryIndex,
   ) {
+    final count = _injectAll(spots, theoryIndex);
+    if (count > 0) {
+      print('TheoryLinkAutoInjector: injected $count links');
+    }
+  }
+
+  int _injectAll(
+    List<TrainingPackSpot> spots,
+    Map<String, InlineTheoryEntry> theoryIndex,
+  ) {
     final used = <String>{};
+    var injected = 0;
     for (final spot in spots) {
+      if (spot.inlineTheory != null) {
+        final id = spot.inlineTheory!.id ?? spot.inlineTheory!.tag;
+        used.add(id);
+        continue;
+      }
       for (final t in spot.tags) {
         final entry = _findEntry(t, theoryIndex);
         if (entry == null) continue;
         final id = entry.id ?? entry.tag;
         if (used.contains(id)) continue;
+        spot.inlineTheory = entry;
         spot.meta['theory'] = {
           'tag': entry.tag,
           'id': id,
           if (entry.title != null) 'title': entry.title,
         };
         used.add(id);
+        injected++;
         break;
       }
     }
+    return injected;
   }
 
   InlineTheoryEntry? _findEntry(


### PR DESCRIPTION
## Summary
- attach inline theory entries to training pack spots based on tags
- add injector service with `injectLinks` to process entire packs
- cover cases with fuzzy matches and duplicate avoidance

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e98bdde4832ab89820791648a916