### PR TITLE
feat: add skill tag coverage tracker

### DIFF
--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -45,4 +45,7 @@ class SharedPrefsKeys {
   static const String trainingSearchHistory = 'training_search_history';
   static const String trainingSpotListSort = 'training_spot_list_sort';
   static const String trainingQuickSortOption = 'training_quick_sort_option';
+
+  // Skill tag coverage report
+  static const String skillTagCoverageReport = 'skill_tag_coverage_report';
 }

--- a/test/skill_tag_coverage_tracker_test.dart
+++ b/test/skill_tag_coverage_tracker_test.dart
@@ -28,4 +28,27 @@ void main() {
     expect(aggregate.tagCounts['push'], 2);
     expect(aggregate.tagCounts['call'], 1);
   });
+
+  test('computeTagCounts and findUnusedTags work across packs', () {
+    final packs = [
+      TrainingPackModel(
+        id: 'p1',
+        title: 'P1',
+        spots: const <TrainingPackSpot>[],
+        tags: ['a', 'b'],
+      ),
+      TrainingPackModel(
+        id: 'p2',
+        title: 'P2',
+        spots: const <TrainingPackSpot>[],
+        tags: ['a'],
+      ),
+    ];
+    final tracker = SkillTagCoverageTracker();
+    final counts = tracker.computeTagCounts(packs);
+    expect(counts['a'], 2);
+    expect(counts['b'], 1);
+    final unused = tracker.findUnusedTags(packs, {'a', 'b', 'c'});
+    expect(unused, ['c']);
+  });
 }


### PR DESCRIPTION
## Summary
- track tag usage across packs and report unused tags
- persist coverage reports to SharedPreferences or YAML
- test coverage counting and unused tag detection

## Testing
- `flutter test test/skill_tag_coverage_tracker_test.dart` *(fails: command not found: flutter)*
- `dart format lib/services/skill_tag_coverage_tracker.dart lib/utils/shared_prefs_keys.dart test/skill_tag_coverage_tracker_test.dart` *(fails: command not found: dart)*


------
https://chatgpt.com/codex/tasks/task_e_6893eb6876a0832a89d743cc5d801ddf