### PR TITLE
feat: improve deduplication logging

### DIFF
--- a/test/services/auto_deduplication_engine_test.dart
+++ b/test/services/auto_deduplication_engine_test.dart
@@ -51,5 +51,22 @@ void main() {
     expect(result.length, 1);
     expect(result.first.id, 'b');
   });
-}
 
+  test('tracks number of skipped duplicates', () {
+    final spot1 = TrainingPackSpot(
+      id: 'a',
+      hand: HandData(heroCards: 'Ah As', position: HeroPosition.sb),
+      villainAction: 'fold',
+    );
+    final spot2 = TrainingPackSpot(
+      id: 'b',
+      hand: HandData(heroCards: 'As Ah', position: HeroPosition.sb),
+      villainAction: 'fold',
+    );
+
+    final engine = AutoDeduplicationEngine();
+    engine.deduplicate([spot1, spot2]);
+
+    expect(engine.skippedCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- log removed spot count and optional id lists in AutoDeduplicationEngine
- test AutoDeduplicationEngine duplicate tracking

## Testing
- `flutter test test/services/auto_deduplication_engine_test.dart` *(fails: Error reading lib/core/models/v2/training_pack_template_v2.dart)*

------
https://chatgpt.com/codex/tasks/task_e_6893ed229d80832aac73dd87d5fbecab