### PR TITLE
feat: add skill tag coverage tracker

### DIFF
--- a/test/services/skill_tag_coverage_tracker_test.dart
+++ b/test/services/skill_tag_coverage_tracker_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/skill_tag_coverage_tracker.dart';
+
+void main() {
+  group('SkillTagCoverageTracker', () {
+    test('normalizes and counts tags', () {
+      final tracker = SkillTagCoverageTracker();
+      final spots = [
+        TrainingPackSpot(id: '1', tags: ['OpenSB', 'PairedBoards']),
+        TrainingPackSpot(id: '2', tags: ['opensb', 'Vs3betIP']),
+      ];
+      final coverage = tracker.getSkillTagCoverage(spots);
+      expect(coverage['opensb'], 2);
+      expect(coverage['pairedboards'], 1);
+      expect(coverage['vs3betip'], 1);
+    });
+
+    test('applies min count filter', () {
+      final tracker = SkillTagCoverageTracker();
+      final spots = [
+        TrainingPackSpot(id: '1', tags: ['a']),
+        TrainingPackSpot(id: '2', tags: ['b']),
+        TrainingPackSpot(id: '3', tags: ['a']),
+      ];
+      final coverage = tracker.getSkillTagCoverage(spots, minCount: 2);
+      expect(coverage, {'a': 2});
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- track normalized skill tag frequencies across generated spots
- expose coverage maps and per-pack grouping with optional filtering
- log coverage summary and add unit tests

## Testing
- `dart format lib/services/skill_tag_coverage_tracker.dart test/services/skill_tag_coverage_tracker_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893f5396988832ab347f99ba27af1fe