### PR TITLE
feat: auto-inject theory links into training spots

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -47,6 +47,11 @@ class TrainingPackSpot
   /// links the spot to a [TheoryMiniLessonNode].
   String? inlineLessonId;
 
+  /// Ephemeral reference to a full theory lesson matched by tags.
+  ///
+  /// Populated at runtime by [TheoryLinkAutoInjector] and never serialized.
+  String? theoryId;
+
   /// Ephemeral reference to inline theory content matched by tags.
   ///
   /// Populated at runtime by [InlineTheoryLinkAutoInjector] and never serialized.
@@ -86,6 +91,7 @@ class TrainingPackSpot
     DateTime? createdAt,
     this.templateSourceId,
     this.inlineLessonId,
+    this.theoryId,
     List<String>? theoryRefs,
   }) : hand = hand ?? HandData(),
        tags = tags != null ? List<String>.from(tags) : <String>[],

--- a/lib/services/mini_lesson_library_service.dart
+++ b/lib/services/mini_lesson_library_service.dart
@@ -95,6 +95,19 @@ class MiniLessonLibraryService {
   /// Returns lessons matching any of [tags]. Convenience for Set input.
   List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
       findByTags(tags.toList());
+
+  /// Returns the first lesson matching [tag], or `null` if none found.
+  TheoryMiniLessonNode? findLessonByTag(String tag) {
+    final direct = _byTag[tag];
+    if (direct != null && direct.isNotEmpty) return direct.first;
+    final lower = tag.toLowerCase();
+    for (final entry in _byTag.entries) {
+      if (entry.key.toLowerCase() == lower && entry.value.isNotEmpty) {
+        return entry.value.first;
+      }
+    }
+    return null;
+  }
 }
 
 extension MiniLessonLibraryFetch on MiniLessonLibraryService {


### PR DESCRIPTION
## Summary
- add TheoryLinkAutoInjector to attach theory lessons to spots based on tags
- allow TrainingPackSpot to store a theoryId populated by the injector
- expose MiniLessonLibraryService.findLessonByTag and add tests

## Testing
- `flutter test test/services/theory_link_auto_injector_test.dart` *(fails: command not found)*
- `dart test test/services/theory_link_auto_injector_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_6893f6da0d18832aa7217c4ec0ac097d