### PR TITLE
feat: add board texture classifier

### DIFF
--- a/test/services/board_texture_classifier_test.dart
+++ b/test/services/board_texture_classifier_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:poker_analyzer/services/board_texture_classifier.dart';
 
 void main() {
@@ -11,6 +11,25 @@ void main() {
     expect(tags.contains('wet'), isTrue);
   });
 
+  test('detects two pairs on turn', () {
+    final tags = classifier.classify('AsAhKdKc');
+    expect(tags.contains('twoPaired'), isTrue);
+    expect(tags.contains('paired'), isTrue);
+    expect(tags.contains('trip'), isFalse);
+  });
+
+  test('detects trips', () {
+    final tags = classifier.classify('AsAhAc');
+    expect(tags.contains('trip'), isTrue);
+    expect(tags.contains('paired'), isTrue);
+  });
+
+  test('detects flush draw on turn', () {
+    final tags = classifier.classify('AsKsQd2s');
+    expect(tags.contains('flushDraw'), isTrue);
+    expect(tags.contains('wet'), isTrue);
+  });
+
   test('classifies monotone low connected board', () {
     final tags = classifier.classify('2c3c4c');
     expect(tags.containsAll({'low', 'monotone', 'connected', 'wet'}), isTrue);
@@ -20,14 +39,21 @@ void main() {
   test('classifies rainbow ace-high dry board', () {
     final tags = classifier.classify('AsKd7h');
     expect(
-        tags.containsAll({
-          'aceHigh',
-          'high',
-          'rainbow',
-          'disconnected',
-          'dry'
-        }),
+        tags.containsAll({'aceHigh', 'high', 'rainbow', 'disconnected', 'dry'}),
         isTrue);
     expect(tags.contains('wet'), isFalse);
+  });
+
+  test('detects straight draw', () {
+    final tags = classifier.classify('4c5d8h');
+    expect(tags.contains('straightDraw'), isTrue);
+    expect(tags.contains('wet'), isTrue);
+  });
+
+  test('detects broadway board', () {
+    final tags = classifier.classify('AsKsQh');
+    expect(tags.contains('broadway'), isTrue);
+    expect(tags.contains('high'), isTrue);
+    expect(tags.contains('aceHigh'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- classify board cards into texture tags like paired, flushDraw, straightDraw and more
- add unit tests for board texture classifier covering major board patterns

## Testing
- `dart test test/services/board_texture_classifier_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6893f87e2868832aa93023152e239389