### PR TITLE
feat: auto-link theory lessons

### DIFF
--- a/lib/services/theory_link_auto_injector_service.dart
+++ b/lib/services/theory_link_auto_injector_service.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/v2/training_pack_spot.dart';
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Automatically links training spots with relevant theory mini lessons based
+/// on shared tags.
+class TheoryLinkAutoInjectorService {
+  final MiniLessonLibraryService library;
+
+  TheoryLinkAutoInjectorService({MiniLessonLibraryService? library})
+    : library = library ?? MiniLessonLibraryService.instance;
+
+  /// Enriches [spots] with a `linkedTheoryLessonId` meta field when a matching
+  /// [TheoryMiniLessonNode] exists.
+  ///
+  /// Returns the number of spots that received links.
+  Future<int> injectLinks(
+    List<TrainingPackSpot> spots, {
+    List<TheoryMiniLessonNode>? lessons,
+  }) async {
+    final lessonList = lessons ?? await _loadLessons();
+    int injected = 0;
+    for (final spot in spots) {
+      if (spot.meta.containsKey('linkedTheoryLessonId')) continue;
+      final lesson = _findBestMatch(spot, lessonList);
+      if (lesson == null) continue;
+      spot.meta['linkedTheoryLessonId'] = lesson.id;
+      injected++;
+    }
+    debugPrint('TheoryLinkAutoInjectorService: injected $injected links');
+    return injected;
+  }
+
+  Future<List<TheoryMiniLessonNode>> _loadLessons() async {
+    await library.loadAll();
+    return library.all;
+  }
+
+  TheoryMiniLessonNode? _findBestMatch(
+    TrainingPackSpot spot,
+    List<TheoryMiniLessonNode> lessons,
+  ) {
+    TheoryMiniLessonNode? best;
+    int bestOverlap = 0;
+    final spotTags = spot.tags.toSet();
+    for (final lesson in lessons) {
+      final overlap = spotTags.intersection(lesson.tags.toSet()).length;
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap;
+        best = lesson;
+      }
+    }
+    return best;
+  }
+}

--- a/test/services/theory_link_auto_injector_service_test.dart
+++ b/test/services/theory_link_auto_injector_service_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/theory_link_auto_injector_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TheoryLinkAutoInjectorService', () {
+    test('injects linkedTheoryLessonId when tags match', () async {
+      final spots = [
+        TrainingPackSpot(id: 's1', tags: ['push']),
+      ];
+      final lessons = [
+        const TheoryMiniLessonNode(
+          id: 'l1',
+          title: 'Push basics',
+          content: '...',
+          tags: ['push'],
+        ),
+      ];
+      final service = TheoryLinkAutoInjectorService();
+      final count = await service.injectLinks(spots, lessons: lessons);
+      expect(count, 1);
+      expect(spots.first.meta['linkedTheoryLessonId'], 'l1');
+    });
+
+    test('skips spots without matching lessons', () async {
+      final spots = [
+        TrainingPackSpot(id: 's2', tags: ['push']),
+      ];
+      final lessons = [
+        const TheoryMiniLessonNode(
+          id: 'l1',
+          title: 'Fold basics',
+          content: '...',
+          tags: ['fold'],
+        ),
+      ];
+      final service = TheoryLinkAutoInjectorService();
+      final count = await service.injectLinks(spots, lessons: lessons);
+      expect(count, 0);
+      expect(spots.first.meta.containsKey('linkedTheoryLessonId'), false);
+    });
+
+    test('prefers lesson with more overlapping tags', () async {
+      final spots = [
+        TrainingPackSpot(id: 's3', tags: ['push', 'call']),
+      ];
+      final lessons = [
+        const TheoryMiniLessonNode(
+          id: 'l1',
+          title: 'Push',
+          content: '...',
+          tags: ['push'],
+        ),
+        const TheoryMiniLessonNode(
+          id: 'l2',
+          title: 'Push and call',
+          content: '...',
+          tags: ['push', 'call'],
+        ),
+      ];
+      final service = TheoryLinkAutoInjectorService();
+      final count = await service.injectLinks(spots, lessons: lessons);
+      expect(count, 1);
+      expect(spots.first.meta['linkedTheoryLessonId'], 'l2');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `TheoryLinkAutoInjectorService` to link training spots with matching mini lessons
- cover new injector with unit tests

## Testing
- `flutter test test/services/theory_link_auto_injector_service_test.dart` *(fails: missing file references)*

------
https://chatgpt.com/codex/tasks/task_e_6893fc2db300832a804ba8c3fc1aff73