### PR TITLE
feat: add skill tag coverage tracker

### DIFF
--- a/lib/services/skill_tag_session_coverage_tracker_service.dart
+++ b/lib/services/skill_tag_session_coverage_tracker_service.dart
@@ -1,0 +1,37 @@
+import 'training_session_fingerprint_logger_service.dart';
+
+/// Tracks how often skill tags appear across training sessions.
+class SkillTagSessionCoverageTrackerService {
+  final TrainingSessionFingerprintLoggerService logger;
+
+  SkillTagSessionCoverageTrackerService({
+    TrainingSessionFingerprintLoggerService? logger,
+  }) : logger = logger ?? TrainingSessionFingerprintLoggerService();
+
+  /// Computes how frequently each tag appears in [sessions].
+  ///
+  /// If [sessions] is omitted, all logged sessions will be used.
+  Future<Map<String, int>> computeCoverage([
+    List<TrainingSessionFingerprint>? sessions,
+  ]) async {
+    final list = sessions ?? await logger.getAll();
+    final freq = <String, int>{};
+    for (final s in list) {
+      for (final tag in s.tags) {
+        freq.update(tag, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    return freq;
+  }
+
+  /// Returns tags occurring less than [threshold] times.
+  Future<List<String>> lowFrequencyTags(int threshold, [
+    List<TrainingSessionFingerprint>? sessions,
+  ]) async {
+    final coverage = await computeCoverage(sessions);
+    return [
+      for (final entry in coverage.entries)
+        if (entry.value < threshold) entry.key
+    ];
+  }
+}

--- a/test/services/skill_tag_session_coverage_tracker_service_test.dart
+++ b/test/services/skill_tag_session_coverage_tracker_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/skill_tag_session_coverage_tracker_service.dart';
+import 'package:poker_analyzer/services/training_session_fingerprint_logger_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('computeCoverage counts tags correctly', () async {
+    final logger = TrainingSessionFingerprintLoggerService();
+    await logger.logSession(
+      TrainingSessionFingerprint(packId: '1', tags: const ['a', 'b']),
+    );
+    await logger.logSession(
+      TrainingSessionFingerprint(packId: '2', tags: const ['b']),
+    );
+    final tracker = SkillTagSessionCoverageTrackerService(logger: logger);
+    final coverage = await tracker.computeCoverage();
+    expect(coverage['a'], 1);
+    expect(coverage['b'], 2);
+    expect(coverage.containsKey('c'), isFalse);
+  });
+
+  test('lowFrequencyTags returns tags under threshold', () async {
+    final logger = TrainingSessionFingerprintLoggerService();
+    await logger.logSession(
+      TrainingSessionFingerprint(packId: '1', tags: const ['x']),
+    );
+    await logger.logSession(
+      TrainingSessionFingerprint(packId: '2', tags: const ['x', 'y']),
+    );
+    await logger.logSession(
+      TrainingSessionFingerprint(packId: '3', tags: const ['y', 'z']),
+    );
+    final tracker = SkillTagSessionCoverageTrackerService(logger: logger);
+    final low = await tracker.lowFrequencyTags(2);
+    expect(low, contains('z'));
+    expect(low, isNot(contains('x')));
+    expect(low, isNot(contains('y')));
+  });
+}


### PR DESCRIPTION
## Summary
- track how often skill tags appear across training sessions
- expose helper to list low-frequency tags
- cover service with unit tests

## Testing
- `flutter format lib/services/skill_tag_session_coverage_tracker_service.dart test/services/skill_tag_session_coverage_tracker_service_test.dart` (fails: command not found)
- `flutter test` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68940364a4c8832ab050751bd81b4ca1