### PR TITLE
feat: add targeted pack booster engine

### DIFF
--- a/lib/services/targeted_pack_booster_engine.dart
+++ b/lib/services/targeted_pack_booster_engine.dart
@@ -1,0 +1,66 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../utils/shared_prefs_keys.dart';
+
+/// Builds targeted booster packs for weak skill tags.
+class TargetedPackBoosterEngine {
+  final List<TrainingPackTemplateV2> Function() _packsProvider;
+  final Future<SharedPreferences> Function() _prefsProvider;
+  final Duration _cooldown;
+
+  TargetedPackBoosterEngine({
+    List<TrainingPackTemplateV2> Function()? packsProvider,
+    Future<SharedPreferences> Function()? prefsProvider,
+    Duration? cooldown,
+  })  : _packsProvider =
+            packsProvider ?? (() => TrainingPackLibraryV2.instance.packs),
+        _prefsProvider = prefsProvider ?? SharedPreferences.getInstance,
+        _cooldown = cooldown ?? const Duration(days: 1);
+
+  /// Generates booster packs for [weakTags].
+  ///
+  /// Each resulting pack includes only spots tagged with the respective
+  /// weakness and is titled "Booster — tag".
+  Future<List<TrainingPackModel>> generateBoostersFor(
+      List<String> weakTags) async {
+    if (weakTags.isEmpty) return [];
+    final prefs = await _prefsProvider();
+    final now = DateTime.now();
+    final packs = _packsProvider();
+    final result = <TrainingPackModel>[];
+
+    for (final rawTag in weakTags) {
+      final tag = rawTag.trim().toLowerCase();
+      if (tag.isEmpty) continue;
+      final last = prefs.getInt(SharedPrefsKeys.targetedBoosterLast(tag));
+      if (last != null &&
+          now.difference(DateTime.fromMillisecondsSinceEpoch(last)) <
+              _cooldown) {
+        continue;
+      }
+
+      final spots = <TrainingPackSpot>[];
+      for (final p in packs) {
+        spots.addAll(p.spots
+            .where((s) => s.tags.map((e) => e.toLowerCase()).contains(tag)));
+      }
+      if (spots.isEmpty) continue;
+
+      final model = TrainingPackModel(
+        id: 'booster_${tag}_${now.millisecondsSinceEpoch}',
+        title: 'Booster — $rawTag',
+        spots: spots,
+        tags: [tag, 'booster'],
+        metadata: const {'booster': true},
+      );
+      result.add(model);
+      await prefs.setInt(SharedPrefsKeys.targetedBoosterLast(tag),
+          now.millisecondsSinceEpoch);
+    }
+    return result;
+  }
+}

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -22,6 +22,9 @@ class SharedPrefsKeys {
   static String boosterDismissed(String tag) =>
       _boosterTagKey('dismissed', tag);
 
+  static String targetedBoosterLast(String tag) =>
+      _boosterTagKey('targeted_last', tag);
+
   // Training spot list keys
   static const String trainingPresetTags = 'training_preset_tags';
   static const String trainingPresetSearch = 'training_preset_search';

--- a/test/services/targeted_pack_booster_engine_test.dart
+++ b/test/services/targeted_pack_booster_engine_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/targeted_pack_booster_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 buildPack() {
+    final spot1 = TrainingPackSpot(id: 's1', tags: ['push']);
+    final spot2 = TrainingPackSpot(id: 's2', tags: ['fold']);
+    return TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Sample',
+      trainingType: TrainingType.custom,
+      spots: [spot1, spot2],
+      spotCount: 2,
+      tags: const ['push', 'fold'],
+      gameType: GameType.cash,
+    );
+  }
+
+  test('generates booster for weak tag', () async {
+    final engine = TargetedPackBoosterEngine(
+      packsProvider: () => [buildPack()],
+      cooldown: Duration.zero,
+    );
+    final boosters = await engine.generateBoostersFor(['push']);
+    expect(boosters.length, 1);
+    final b = boosters.first;
+    expect(b.title, 'Booster — push');
+    expect(b.tags, contains('push'));
+    expect(b.metadata['booster'], true);
+    expect(b.spots.length, 1);
+    expect(b.spots.first.id, 's1');
+  });
+
+  test('enforces cooldown per tag', () async {
+    final engine = TargetedPackBoosterEngine(
+      packsProvider: () => [buildPack()],
+    );
+    final first = await engine.generateBoostersFor(['fold']);
+    expect(first.length, 1);
+    final second = await engine.generateBoostersFor(['fold']);
+    expect(second, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add TargetedPackBoosterEngine to build tag-specific booster packs
- track last generated targeted boosters via SharedPrefs keys
- cover targeted booster engine with basic unit tests

## Testing
- `flutter test test/services/targeted_pack_booster_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68940ec6d914832aaf16525cca9f0416