### PR TITLE
feat: dedupe tags in targeted booster engine

### DIFF
--- a/lib/services/targeted_pack_booster_engine.dart
+++ b/lib/services/targeted_pack_booster_engine.dart
@@ -32,10 +32,12 @@ class TargetedPackBoosterEngine {
     final now = DateTime.now();
     final packs = _packsProvider();
     final result = <TrainingPackModel>[];
+    final seen = <String>{};
 
     for (final rawTag in weakTags) {
-      final tag = rawTag.trim().toLowerCase();
-      if (tag.isEmpty) continue;
+      final displayTag = rawTag.trim();
+      final tag = displayTag.toLowerCase();
+      if (tag.isEmpty || !seen.add(tag)) continue;
       final last = prefs.getInt(SharedPrefsKeys.targetedBoosterLast(tag));
       if (last != null &&
           now.difference(DateTime.fromMillisecondsSinceEpoch(last)) <
@@ -52,7 +54,7 @@ class TargetedPackBoosterEngine {
 
       final model = TrainingPackModel(
         id: 'booster_${tag}_${now.millisecondsSinceEpoch}',
-        title: 'Booster — $rawTag',
+        title: 'Booster — $displayTag',
         spots: spots,
         tags: [tag, 'booster'],
         metadata: const {'booster': true},

--- a/test/services/targeted_pack_booster_engine_test.dart
+++ b/test/services/targeted_pack_booster_engine_test.dart
@@ -52,4 +52,14 @@ void main() {
     final second = await engine.generateBoostersFor(['fold']);
     expect(second, isEmpty);
   });
+
+  test('deduplicates repeated tags', () async {
+    final engine = TargetedPackBoosterEngine(
+      packsProvider: () => [buildPack()],
+      cooldown: Duration.zero,
+    );
+    final boosters =
+        await engine.generateBoostersFor(['push', 'Push', ' push ']);
+    expect(boosters.length, 1);
+  });
 }


### PR DESCRIPTION
## Summary
- avoid generating multiple boosters for the same skill tag
- test that booster generation ignores duplicate tags

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68941030d73c832aac067868e0fd906a