### PR TITLE
feat: cluster pack spots with inline theory notes

### DIFF
--- a/lib/models/theory_note_entry.dart
+++ b/lib/models/theory_note_entry.dart
@@ -1,0 +1,6 @@
+class TheoryNoteEntry {
+  final String tag;
+  final String text;
+
+  const TheoryNoteEntry({required this.tag, required this.text});
+}

--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -9,6 +9,7 @@ import '../card_model.dart';
 import 'package:uuid/uuid.dart';
 import '../../services/inline_theory_linker.dart';
 import '../inline_theory_entry.dart';
+import '../theory_note_entry.dart';
 
 class TrainingPackSpot
     with CopyWithMixin<TrainingPackSpot>
@@ -63,6 +64,13 @@ class TrainingPackSpot
   /// and is never serialized.
   InlineTheoryLink? theoryLink;
 
+  /// Marks this spot as a lightweight theory note inserted by clustering.
+  /// Never serialized to persistent storage.
+  bool isTheoryNote;
+
+  /// Optional note metadata for inline theory clusters.
+  TheoryNoteEntry? theoryNote;
+
   /// Ephemeral list of IDs for theory mini-lessons relevant to this spot.
   ///
   /// Populated at runtime by [TheoryLinkAutoInjector] and never serialized.
@@ -93,6 +101,8 @@ class TrainingPackSpot
     this.inlineLessonId,
     this.theoryId,
     List<String>? theoryRefs,
+    this.isTheoryNote = false,
+    this.theoryNote,
   }) : hand = hand ?? HandData(),
        tags = tags != null ? List<String>.from(tags) : <String>[],
        categories = categories != null
@@ -138,6 +148,13 @@ class TrainingPackSpot
     templateSourceId: j['templateSourceId']?.toString(),
     inlineLessonId:
         j['inlineLessonId']?.toString() ?? j['inlineTheoryId']?.toString(),
+    isTheoryNote: j['isTheoryNote'] == true,
+    theoryNote: j['theoryNote'] is Map
+        ? TheoryNoteEntry(
+            tag: j['theoryNote']['tag']?.toString() ?? '',
+            text: j['theoryNote']['text']?.toString() ?? '',
+          )
+        : null,
   );
 
   factory TrainingPackSpot.fromTrainingSpot(

--- a/lib/services/inline_pack_theory_clusterer.dart
+++ b/lib/services/inline_pack_theory_clusterer.dart
@@ -1,0 +1,58 @@
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import '../models/theory_note_entry.dart';
+
+/// Groups spots within a training pack by tag and inserts lightweight theory
+/// notes before each cluster.
+class InlinePackTheoryClusterer {
+  const InlinePackTheoryClusterer();
+
+  /// Returns a new [TrainingPackModel] where spots are grouped by tag and a
+  /// [TheoryNoteEntry] is inserted before each cluster.
+  TrainingPackModel clusterWithTheory(TrainingPackModel input) {
+    if (input.spots.isEmpty) return input;
+
+    final clusters = <String, List<TrainingPackSpot>>{};
+    final order = <String>[];
+
+    for (final spot in input.spots) {
+      final key = _clusterKey(spot);
+      clusters.putIfAbsent(key, () {
+        order.add(key);
+        return [];
+      }).add(spot);
+    }
+
+    final result = <TrainingPackSpot>[];
+    var noteId = 0;
+    for (final tag in order) {
+      final text = 'In this section, we cover [$tag] situations...';
+      final note = TheoryNoteEntry(tag: tag, text: text);
+      final noteSpot = TrainingPackSpot(
+        id: 'theory_note_${noteId++}',
+        tags: [tag],
+        note: text,
+        type: 'theoryNote',
+        isTheoryNote: true,
+        theoryNote: note,
+      );
+      result.add(noteSpot);
+      result.addAll(clusters[tag]!);
+    }
+
+    return TrainingPackModel(
+      id: input.id,
+      title: input.title,
+      spots: result,
+      tags: input.tags,
+      metadata: input.metadata,
+    );
+  }
+
+  String _clusterKey(TrainingPackSpot spot) {
+    if (spot.tags.isNotEmpty) return spot.tags.first;
+    final skill = spot.meta['skill'];
+    if (skill is String && skill.isNotEmpty) return skill;
+    return 'misc';
+  }
+}

--- a/test/services/inline_pack_theory_clusterer_test.dart
+++ b/test/services/inline_pack_theory_clusterer_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/inline_pack_theory_clusterer.dart';
+
+void main() {
+  group('InlinePackTheoryClusterer', () {
+    test('clusters spots and injects theory notes', () {
+      final spots = [
+        TrainingPackSpot(id: 's1', tags: ['sb']),
+        TrainingPackSpot(id: 's2', tags: ['sb']),
+        TrainingPackSpot(id: 's3', tags: ['bb']),
+      ];
+      final model = TrainingPackModel(id: 'p1', title: 'Pack', spots: spots);
+      final clusterer = InlinePackTheoryClusterer();
+
+      final output = clusterer.clusterWithTheory(model);
+
+      expect(output.spots.length, 5);
+      expect(output.spots[0].isTheoryNote, isTrue);
+      expect(output.spots[0].note, 'In this section, we cover [sb] situations...');
+      expect(output.spots[1].id, 's1');
+      expect(output.spots[2].id, 's2');
+      expect(output.spots[3].isTheoryNote, isTrue);
+      expect(output.spots[3].note, 'In this section, we cover [bb] situations...');
+      expect(output.spots[4].id, 's3');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- group training pack spots by tag and insert inline theory notes
- mark note entries with `isTheoryNote` and `TheoryNoteEntry`
- test inline clustering behavior

## Testing
- `flutter test test/services/inline_pack_theory_clusterer_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689412aa8660832aa70fd11ddf63387f