### PR TITLE
feat: add training run AB comparator

### DIFF
--- a/lib/repositories/training_session_log_repository.dart
+++ b/lib/repositories/training_session_log_repository.dart
@@ -1,0 +1,19 @@
+import '../models/session_log.dart';
+import '../services/session_log_service.dart';
+
+/// Repository for accessing training session logs.
+class TrainingSessionLogRepository {
+  final SessionLogService logs;
+  TrainingSessionLogRepository({required this.logs});
+
+  /// Returns logs filtered by [packId] and optional [variant] tag.
+  List<SessionLog> getLogs({required String packId, String? variant}) {
+    return logs.logs.where((log) {
+      if (log.templateId != packId) return false;
+      if (variant != null && variant.isNotEmpty && !log.tags.contains(variant)) {
+        return false;
+      }
+      return true;
+    }).toList();
+  }
+}

--- a/lib/services/training_run_ab_comparator_service.dart
+++ b/lib/services/training_run_ab_comparator_service.dart
@@ -1,0 +1,106 @@
+import '../models/session_log.dart';
+import '../repositories/training_session_log_repository.dart';
+
+class ABComparisonResult {
+  final double accuracyA;
+  final double accuracyB;
+  final double timeA;
+  final double timeB;
+  final double retentionA;
+  final double retentionB;
+  final int sampleSizeA;
+  final int sampleSizeB;
+  final int earlyDropA;
+  final int earlyDropB;
+
+  const ABComparisonResult({
+    required this.accuracyA,
+    required this.accuracyB,
+    required this.timeA,
+    required this.timeB,
+    required this.retentionA,
+    required this.retentionB,
+    required this.sampleSizeA,
+    required this.sampleSizeB,
+    required this.earlyDropA,
+    required this.earlyDropB,
+  });
+}
+
+/// Compares metrics between two training run variants.
+class TrainingRunABComparatorService {
+  final TrainingSessionLogRepository repository;
+  TrainingRunABComparatorService({required this.repository});
+
+  /// Compares metrics for [packIdA]/[variantA] vs [packIdB]/[variantB].
+  ABComparisonResult compare({
+    required String packIdA,
+    required String packIdB,
+    String? variantA,
+    String? variantB,
+  }) {
+    final listA =
+        repository.getLogs(packId: packIdA, variant: variantA);
+    final listB =
+        repository.getLogs(packId: packIdB, variant: variantB);
+    return compareLogs(listA, listB);
+  }
+
+  /// Compares two lists of logs and computes aggregate metrics.
+  ABComparisonResult compareLogs(
+      List<SessionLog> listA, List<SessionLog> listB) {
+    final maxSpots = _maxSpots([...listA, ...listB]);
+    return ABComparisonResult(
+      accuracyA: _averageAccuracy(listA),
+      accuracyB: _averageAccuracy(listB),
+      timeA: _averageTime(listA),
+      timeB: _averageTime(listB),
+      retentionA: _retention(listA),
+      retentionB: _retention(listB),
+      sampleSizeA: listA.length,
+      sampleSizeB: listB.length,
+      earlyDropA: _earlyDrops(listA, maxSpots),
+      earlyDropB: _earlyDrops(listB, maxSpots),
+    );
+  }
+
+  double _averageAccuracy(List<SessionLog> logs) {
+    var correct = 0;
+    var total = 0;
+    for (final l in logs) {
+      correct += l.correctCount;
+      total += l.correctCount + l.mistakeCount;
+    }
+    return total == 0 ? 0.0 : correct / total;
+  }
+
+  double _averageTime(List<SessionLog> logs) {
+    if (logs.isEmpty) return 0.0;
+    final sum = logs
+        .map((l) => l.completedAt.difference(l.startedAt).inSeconds)
+        .fold<int>(0, (a, b) => a + b);
+    return sum / logs.length;
+  }
+
+  double _retention(List<SessionLog> logs) {
+    if (logs.length <= 1) return 0.0;
+    return (logs.length - 1) / logs.length;
+  }
+
+  int _earlyDrops(List<SessionLog> logs, int maxSpots) {
+    if (maxSpots == 0) return 0;
+    final threshold = maxSpots / 2;
+    return logs
+        .where((l) => l.correctCount + l.mistakeCount < threshold)
+        .length;
+  }
+
+  int _maxSpots(List<SessionLog> logs) {
+    var max = 0;
+    for (final l in logs) {
+      final played = l.correctCount + l.mistakeCount;
+      if (played > max) max = played;
+    }
+    return max;
+  }
+}

--- a/test/services/training_run_ab_comparator_service_test.dart
+++ b/test/services/training_run_ab_comparator_service_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/repositories/training_session_log_repository.dart';
+import 'package:poker_analyzer/services/training_run_ab_comparator_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeLogRepository extends TrainingSessionLogRepository {
+  final List<SessionLog> entries;
+  _FakeLogRepository(this.entries)
+      : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  List<SessionLog> getLogs({required String packId, String? variant}) {
+    return entries.where((l) {
+      if (l.templateId != packId) return false;
+      if (variant != null && !l.tags.contains(variant)) return false;
+      return true;
+    }).toList();
+  }
+}
+
+void main() {
+  group('TrainingRunABComparatorService', () {
+    test('computes metrics for two variants', () {
+      final logs = <SessionLog>[
+        SessionLog(
+          sessionId: 'a1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 1, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 1, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'a2',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 2, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 2, 0, 1, 30),
+          correctCount: 7,
+          mistakeCount: 3,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'b1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 3, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 3, 0, 2, 0),
+          correctCount: 5,
+          mistakeCount: 5,
+          tags: const ['vB'],
+        ),
+      ];
+
+      final repo = _FakeLogRepository(logs);
+      final service = TrainingRunABComparatorService(repository: repo);
+
+      final result = service.compare(
+        packIdA: 'p',
+        packIdB: 'p',
+        variantA: 'vA',
+        variantB: 'vB',
+      );
+
+      expect(result.sampleSizeA, 2);
+      expect(result.sampleSizeB, 1);
+      expect(result.accuracyA, closeTo(0.75, 1e-9));
+      expect(result.accuracyB, closeTo(0.5, 1e-9));
+      expect(result.timeA, closeTo(75.0, 1e-9));
+      expect(result.timeB, closeTo(120.0, 1e-9));
+      expect(result.retentionA, closeTo(0.5, 1e-9));
+      expect(result.retentionB, closeTo(0.0, 1e-9));
+      expect(result.earlyDropA, 0);
+      expect(result.earlyDropB, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add TrainingSessionLogRepository for filtered log access
- introduce TrainingRunABComparatorService with accuracy, time, retention and early drop metrics
- test comparator logic for A/B variants

## Testing
- `flutter test test/services/training_run_ab_comparator_service_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689417d32a58832aa9e15ee859f5b6da