### PR TITLE
feat: add pack format selection service

### DIFF
--- a/lib/services/pack_format_selection_service.dart
+++ b/lib/services/pack_format_selection_service.dart
@@ -1,0 +1,74 @@
+import 'dart:math';
+
+import 'training_run_ab_comparator_service.dart';
+
+/// Selects the best performing variant for a pack using A/B comparison
+/// metrics.
+class PackFormatSelectionService {
+  final TrainingRunABComparatorService comparator;
+
+  PackFormatSelectionService({required this.comparator});
+
+  /// Returns the identifier of the best variant for [packId] from
+  /// [variantIds] based on metrics priority: accuracy, retention, and
+  /// earlyDrop (lower is better).
+  ///
+  /// If all variants have fewer than 3 samples, returns `null`.
+  String? selectBestVariant({
+    required String packId,
+    required List<String> variantIds,
+  }) {
+    if (variantIds.isEmpty) return null;
+
+    // Determine sample sizes for each variant.
+    final repo = comparator.repository;
+    final sampleSizes = <String, int>{
+      for (final v in variantIds)
+        v: repo.getLogs(packId: packId, variant: v).length,
+    };
+
+    // Fallback: if no variant has at least 3 samples, do not select.
+    if (sampleSizes.values.every((s) => s < 3)) {
+      return null;
+    }
+
+    // Pairwise comparisons to accumulate wins for each variant.
+    final scores = {for (final v in variantIds) v: 0};
+    for (var i = 0; i < variantIds.length; i++) {
+      for (var j = i + 1; j < variantIds.length; j++) {
+        final a = variantIds[i];
+        final b = variantIds[j];
+        final result = comparator.compare(
+          packIdA: packId,
+          packIdB: packId,
+          variantA: a,
+          variantB: b,
+        );
+        final winner = _winner(result, a, b);
+        if (winner != null) {
+          scores[winner] = scores[winner]! + 1;
+        }
+      }
+    }
+
+    final maxScore = scores.values.reduce(max);
+    final best = scores.entries
+        .where((e) => e.value == maxScore)
+        .map((e) => e.key)
+        .toList();
+    return best.length == 1 ? best.first : null;
+  }
+
+  String? _winner(ABComparisonResult r, String a, String b) {
+    if (r.accuracyA != r.accuracyB) {
+      return r.accuracyA > r.accuracyB ? a : b;
+    }
+    if (r.retentionA != r.retentionB) {
+      return r.retentionA > r.retentionB ? a : b;
+    }
+    if (r.earlyDropA != r.earlyDropB) {
+      return r.earlyDropA < r.earlyDropB ? a : b;
+    }
+    return null;
+  }
+}

--- a/test/services/pack_format_selection_service_test.dart
+++ b/test/services/pack_format_selection_service_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+import 'package:poker_analyzer/repositories/training_session_log_repository.dart';
+import 'package:poker_analyzer/services/pack_format_selection_service.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/training_run_ab_comparator_service.dart';
+import 'package:poker_analyzer/services/training_session_service.dart';
+
+class _FakeLogRepository extends TrainingSessionLogRepository {
+  final List<SessionLog> entries;
+  _FakeLogRepository(this.entries)
+    : super(logs: SessionLogService(sessions: TrainingSessionService()));
+
+  @override
+  List<SessionLog> getLogs({required String packId, String? variant}) {
+    return entries.where((l) {
+      if (l.templateId != packId) return false;
+      if (variant != null && !l.tags.contains(variant)) return false;
+      return true;
+    }).toList();
+  }
+}
+
+void main() {
+  group('PackFormatSelectionService', () {
+    test('selects variant with best metrics', () {
+      final logs = <SessionLog>[
+        // Variant A
+        SessionLog(
+          sessionId: 'a1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 1, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 1, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'a2',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 2, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 2, 0, 1, 30),
+          correctCount: 7,
+          mistakeCount: 3,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'a3',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 3, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 3, 0, 1, 0),
+          correctCount: 9,
+          mistakeCount: 1,
+          tags: const ['vA'],
+        ),
+        // Variant B
+        SessionLog(
+          sessionId: 'b1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 4, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 4, 0, 1, 0),
+          correctCount: 5,
+          mistakeCount: 5,
+          tags: const ['vB'],
+        ),
+        SessionLog(
+          sessionId: 'b2',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 5, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 5, 0, 1, 0),
+          correctCount: 6,
+          mistakeCount: 4,
+          tags: const ['vB'],
+        ),
+        SessionLog(
+          sessionId: 'b3',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 6, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 6, 0, 1, 0),
+          correctCount: 5,
+          mistakeCount: 5,
+          tags: const ['vB'],
+        ),
+      ];
+
+      final repo = _FakeLogRepository(logs);
+      final comparator = TrainingRunABComparatorService(repository: repo);
+      final service = PackFormatSelectionService(comparator: comparator);
+
+      final id = service.selectBestVariant(
+        packId: 'p',
+        variantIds: const ['vA', 'vB'],
+      );
+      expect(id, 'vA');
+    });
+
+    test('returns null when sample sizes are insufficient', () {
+      final logs = <SessionLog>[
+        SessionLog(
+          sessionId: 'a1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 1, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 1, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'b1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 2, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 2, 0, 1, 0),
+          correctCount: 5,
+          mistakeCount: 5,
+          tags: const ['vB'],
+        ),
+      ];
+
+      final repo = _FakeLogRepository(logs);
+      final comparator = TrainingRunABComparatorService(repository: repo);
+      final service = PackFormatSelectionService(comparator: comparator);
+
+      final id = service.selectBestVariant(
+        packId: 'p',
+        variantIds: const ['vA', 'vB'],
+      );
+      expect(id, isNull);
+    });
+
+    test('uses retention then earlyDrop for tie-breaking', () {
+      final logs = <SessionLog>[
+        // Variant A: same accuracy as B but lower retention
+        SessionLog(
+          sessionId: 'a1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 1, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 1, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'a2',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 2, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 2, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        SessionLog(
+          sessionId: 'a3',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 3, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 3, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vA'],
+        ),
+        // Variant B with higher retention and fewer early drops
+        SessionLog(
+          sessionId: 'b1',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 4, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 4, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vB'],
+        ),
+        SessionLog(
+          sessionId: 'b2',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 5, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 5, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vB'],
+        ),
+        SessionLog(
+          sessionId: 'b3',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 6, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 6, 0, 1, 0),
+          correctCount: 8,
+          mistakeCount: 2,
+          tags: const ['vB'],
+        ),
+        SessionLog(
+          sessionId: 'b4',
+          templateId: 'p',
+          startedAt: DateTime(2023, 1, 7, 0, 0, 0),
+          completedAt: DateTime(2023, 1, 7, 0, 0, 10),
+          correctCount: 1,
+          mistakeCount: 0,
+          tags: const ['vB'],
+        ),
+      ];
+
+      final repo = _FakeLogRepository(logs);
+      final comparator = TrainingRunABComparatorService(repository: repo);
+      final service = PackFormatSelectionService(comparator: comparator);
+
+      final id = service.selectBestVariant(
+        packId: 'p',
+        variantIds: const ['vA', 'vB'],
+      );
+      expect(id, 'vB');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `PackFormatSelectionService` to choose the best-performing variant via A/B comparison metrics
- cover variant selection logic with unit tests and insufficient-sample fallback

## Testing
- `flutter pub get`
- `flutter test test/services/pack_format_selection_service_test.dart` *(fails: Couldn't resolve the package 'flutter_gen', plus numerous compilation errors)*


------
https://chatgpt.com/codex/tasks/task_e_68941997a4d4832a88fa27b167b621e8