### PR TITLE
feat: add pack fingerprint comparer

### DIFF
--- a/lib/services/pack_fingerprint_comparer_service.dart
+++ b/lib/services/pack_fingerprint_comparer_service.dart
@@ -1,124 +1,127 @@
-import '../models/training_pack_model.dart';
-import '../models/action_entry.dart';
-import 'board_texture_classifier.dart';
 import 'dart:math';
 
-/// Data class representing a training pack fingerprint.
-class PackFingerprint {
-  final Set<String> tags;
-  final Set<String> boardTextures;
-  final List<String> actionLines;
-  final int spotCount;
+import '../models/action_entry.dart';
+import '../models/training_pack_model.dart';
 
-  const PackFingerprint({
+/// Represents another pack that is similar to the target.
+class SimilarPackMatch {
+  final TrainingPackModel pack;
+  final double similarity;
+
+  const SimilarPackMatch(this.pack, this.similarity);
+}
+
+/// Internal fingerprint representation used for similarity comparisons.
+class _PackFingerprint {
+  final Set<String> tags;
+  final Set<String> boards;
+  final Set<String> actions;
+  final Map<int, int> streetCounts;
+
+  const _PackFingerprint({
     required this.tags,
-    required this.boardTextures,
-    required this.actionLines,
-    required this.spotCount,
+    required this.boards,
+    required this.actions,
+    required this.streetCounts,
   });
 }
 
-/// Result describing similarity between two packs.
-class PackSimilarityResult {
-  final TrainingPackModel a;
-  final TrainingPackModel b;
-  final double similarity;
-
-  const PackSimilarityResult(this.a, this.b, this.similarity);
-}
-
-/// Computes and compares fingerprints of training packs to detect duplicates.
+/// Compares training packs based on tags, board coverage, action sequences and
+/// high level structure.
 class PackFingerprintComparerService {
-  final BoardTextureClassifier _classifier;
+  const PackFingerprintComparerService();
 
-  const PackFingerprintComparerService({BoardTextureClassifier? classifier})
-      : _classifier = classifier ?? const BoardTextureClassifier();
+  /// Returns a similarity score between [a] and [b] from 0.0 (no overlap) to
+  /// 1.0 (identical) based on weighted metrics.
+  double computeSimilarity(TrainingPackModel a, TrainingPackModel b) {
+    final fa = _fingerprint(a);
+    final fb = _fingerprint(b);
 
-  /// Generates a fingerprint capturing high-level structure of [pack].
-  PackFingerprint generatePackFingerprint(TrainingPackModel pack) {
+    final tagScore = _jaccard(fa.tags, fb.tags);
+    final boardScore = _jaccard(fa.boards, fb.boards);
+    final actionScore = _jaccard(fa.actions, fb.actions);
+    final structureScore = _structureScore(fa.streetCounts, fb.streetCounts);
+
+    return tagScore * 0.3 +
+        boardScore * 0.3 +
+        actionScore * 0.3 +
+        structureScore * 0.1;
+  }
+
+  /// Finds packs from [all] that are similar to [target] above [threshold].
+  List<SimilarPackMatch> findSimilarPacks(
+    TrainingPackModel target,
+    List<TrainingPackModel> all, {
+    double threshold = 0.8,
+  }) {
+    final matches = <SimilarPackMatch>[];
+    for (final p in all) {
+      if (identical(p, target) || p.id == target.id) continue;
+      final sim = computeSimilarity(target, p);
+      if (sim >= threshold) {
+        matches.add(SimilarPackMatch(p, sim));
+      }
+    }
+    matches.sort((a, b) => b.similarity.compareTo(a.similarity));
+    return matches;
+  }
+
+  _PackFingerprint _fingerprint(TrainingPackModel pack) {
     final tags = <String>{
       for (final t in pack.tags) t.trim().toLowerCase(),
     };
-    final boardTextures = <String>{};
-    final actionLines = <String>[];
+    final boards = <String>{};
+    final actions = <String>{};
+    final streetCounts = <int, int>{};
 
     for (final spot in pack.spots) {
       tags.addAll(spot.tags.map((t) => t.trim().toLowerCase()));
 
-      if (spot.board.length >= 3) {
-        final flop = spot.board.take(3).join();
-        boardTextures.addAll(_classifier.classify(flop));
+      if (spot.board.isNotEmpty) {
+        boards.add(spot.board.join());
       }
 
-      final actions = <ActionEntry>[];
+      streetCounts[spot.street] = (streetCounts[spot.street] ?? 0) + 1;
+
       final entries = spot.hand.actions.entries.toList()
         ..sort((a, b) => a.key.compareTo(b.key));
+      final line = <String>[];
       for (final kv in entries) {
         for (final a in kv.value) {
-          actions.add(a);
+          line.add(a.action);
         }
       }
-      final line = actions.map((a) => a.action).join('-');
-      if (line.isNotEmpty) actionLines.add(line);
+      if (line.isNotEmpty) actions.add(line.join('-'));
     }
 
-    actionLines.sort();
-    return PackFingerprint(
+    return _PackFingerprint(
       tags: tags,
-      boardTextures: boardTextures,
-      actionLines: actionLines,
-      spotCount: pack.spots.length,
+      boards: boards,
+      actions: actions,
+      streetCounts: streetCounts,
     );
-  }
-
-  /// Computes whether fingerprints [a] and [b] are similar enough.
-  bool areSimilar(PackFingerprint a, PackFingerprint b,
-      {double threshold = 0.8}) {
-    return _similarityScore(a, b) >= threshold;
-  }
-
-  /// Finds similar or duplicate packs within [packs].
-  List<PackSimilarityResult> findDuplicates(List<TrainingPackModel> packs,
-      {double threshold = 0.8}) {
-    final fps = <TrainingPackModel, PackFingerprint>{};
-    for (final p in packs) {
-      fps[p] = generatePackFingerprint(p);
-    }
-    final results = <PackSimilarityResult>[];
-    for (var i = 0; i < packs.length; i++) {
-      for (var j = i + 1; j < packs.length; j++) {
-        final p1 = packs[i];
-        final p2 = packs[j];
-        final sim = _similarityScore(fps[p1]!, fps[p2]!);
-        if (sim >= threshold) {
-          results.add(PackSimilarityResult(p1, p2, sim));
-        }
-      }
-    }
-    return results;
-  }
-
-  double _similarityScore(PackFingerprint a, PackFingerprint b) {
-    final tagScore = _jaccard(a.tags, b.tags);
-    final boardScore = _jaccard(a.boardTextures, b.boardTextures);
-    final actionScore =
-        _jaccard(a.actionLines.toSet(), b.actionLines.toSet());
-    final countScore = _countScore(a.spotCount, b.spotCount);
-    return (tagScore + boardScore + actionScore + countScore) / 4.0;
   }
 
   double _jaccard(Set<String> a, Set<String> b) {
     if (a.isEmpty && b.isEmpty) return 1.0;
     final inter = a.intersection(b).length.toDouble();
     final union = a.union(b).length.toDouble();
-    return union == 0 ? 0 : inter / union;
+    return union == 0 ? 0.0 : inter / union;
   }
 
-  double _countScore(int a, int b) {
-    if (a == 0 && b == 0) return 1.0;
-    final minC = min(a, b).toDouble();
-    final maxC = max(a, b).toDouble();
-    return maxC == 0 ? 0 : minC / maxC;
+  double _structureScore(Map<int, int> a, Map<int, int> b) {
+    final streets = {...a.keys, ...b.keys};
+    if (streets.isEmpty) return 1.0;
+    var minSum = 0;
+    var maxSum = 0;
+    for (final s in streets) {
+      final av = a[s] ?? 0;
+      final bv = b[s] ?? 0;
+      minSum += min(av, bv);
+      maxSum += max(av, bv);
+    }
+    if (maxSum == 0) return 0.0;
+    return minSum / maxSum;
   }
 }
 

--- a/test/services/pack_fingerprint_comparer_service_test.dart
+++ b/test/services/pack_fingerprint_comparer_service_test.dart
@@ -16,7 +16,7 @@ TrainingPackSpot _spot(String id, List<String> board, List<String> actions) {
 }
 
 void main() {
-  test('areSimilar detects near duplicates', () {
+  test('computeSimilarity detects near duplicates', () {
     final service = const PackFingerprintComparerService();
     final pack1 = TrainingPackModel(
       id: 'p1',
@@ -45,18 +45,16 @@ void main() {
       tags: ['tag2'],
     );
 
-    final fp1 = service.generatePackFingerprint(pack1);
-    final fp2 = service.generatePackFingerprint(pack2);
-    final fp3 = service.generatePackFingerprint(pack3);
+    final sim12 = service.computeSimilarity(pack1, pack2);
+    final sim13 = service.computeSimilarity(pack1, pack3);
 
-    expect(service.areSimilar(fp1, fp2), isTrue);
-    expect(service.areSimilar(fp1, fp3), isFalse);
+    expect(sim12, greaterThanOrEqualTo(0.8));
+    expect(sim13, lessThan(0.8));
 
-    final duplicates = service.findDuplicates([pack1, pack2, pack3]);
-    expect(duplicates.length, 1);
-    expect(duplicates.first.a.id, 'p1');
-    expect(duplicates.first.b.id, 'p2');
-    expect(duplicates.first.similarity, greaterThanOrEqualTo(0.8));
+    final matches = service.findSimilarPacks(pack1, [pack1, pack2, pack3]);
+    expect(matches.length, 1);
+    expect(matches.first.pack.id, 'p2');
+    expect(matches.first.similarity, sim12);
   });
 }
 


### PR DESCRIPTION
## Summary
- implement `PackFingerprintComparerService` to score similarity between training packs
- add helper to search for similar packs using a threshold
- test similarity computation and pack matching

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68941c09f934832aad22bbe91fc7073a