### PR TITLE
Add skill tag coverage tracker service

### DIFF
--- a/lib/models/skill_tag_coverage_report.dart
+++ b/lib/models/skill_tag_coverage_report.dart
@@ -1,0 +1,9 @@
+class SkillTagCoverageReport {
+  final Map<String, int> tagCounts;
+  final List<String> underrepresentedTags;
+
+  const SkillTagCoverageReport({
+    required this.tagCounts,
+    required this.underrepresentedTags,
+  });
+}

--- a/lib/services/skill_tag_coverage_tracker_service.dart
+++ b/lib/services/skill_tag_coverage_tracker_service.dart
@@ -1,0 +1,40 @@
+import '../models/skill_tag_coverage_report.dart';
+import 'training_pack_library_service.dart';
+
+/// Evaluates how many spots reference each skill tag across the
+/// training pack library.
+class SkillTagCoverageTrackerService {
+  final TrainingPackLibraryService library;
+  final Set<String> allSkillTags;
+  final int underrepresentedThreshold;
+
+  SkillTagCoverageTrackerService({
+    TrainingPackLibraryService? library,
+    Set<String>? allSkillTags,
+    this.underrepresentedThreshold = 5,
+  }) : library = library ?? TrainingPackLibraryService(),
+       allSkillTags = allSkillTags ?? const {};
+
+  /// Generates a coverage report for all packs in the library.
+  Future<SkillTagCoverageReport> generateReport() async {
+    final packs = await library.getAllPacks();
+    final counts = <String, int>{};
+    for (final pack in packs) {
+      for (final spot in pack.spots) {
+        for (final tag in spot.tags) {
+          final norm = tag.trim().toLowerCase();
+          if (norm.isEmpty) continue;
+          counts[norm] = (counts[norm] ?? 0) + 1;
+        }
+      }
+    }
+    final underrepresented = <String>[
+      for (final tag in allSkillTags)
+        if ((counts[tag] ?? 0) < underrepresentedThreshold) tag,
+    ];
+    return SkillTagCoverageReport(
+      tagCounts: counts,
+      underrepresentedTags: underrepresented,
+    );
+  }
+}

--- a/test/services/skill_tag_coverage_tracker_service_test.dart
+++ b/test/services/skill_tag_coverage_tracker_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/skill_tag_coverage_tracker_service.dart';
+import 'package:poker_analyzer/services/training_pack_library_service.dart';
+
+class _FakeLibraryService extends TrainingPackLibraryService {
+  final List<TrainingPackModel> packs;
+  _FakeLibraryService(this.packs);
+
+  @override
+  Future<List<TrainingPackModel>> getAllPacks() async => packs;
+}
+
+void main() {
+  test('generateReport counts tags and finds underrepresented tags', () async {
+    final library = _FakeLibraryService([
+      TrainingPackModel(
+        id: 'p1',
+        title: 'P1',
+        spots: [
+          TrainingPackSpot(id: 's1', tags: ['a']),
+          TrainingPackSpot(id: 's2', tags: ['b', 'c']),
+        ],
+      ),
+      TrainingPackModel(
+        id: 'p2',
+        title: 'P2',
+        spots: [
+          TrainingPackSpot(id: 's3', tags: ['a']),
+        ],
+      ),
+    ]);
+
+    final service = SkillTagCoverageTrackerService(
+      library: library,
+      allSkillTags: {'a', 'b', 'c', 'd'},
+      underrepresentedThreshold: 2,
+    );
+
+    final report = await service.generateReport();
+    expect(report.tagCounts['a'], 2);
+    expect(report.tagCounts['b'], 1);
+    expect(report.tagCounts['c'], 1);
+    expect(report.underrepresentedTags, containsAll(['b', 'c', 'd']));
+    expect(report.underrepresentedTags, isNot(contains('a')));
+  });
+}


### PR DESCRIPTION
## Summary
- add SkillTagCoverageReport model to hold tag counts and weak tags
- implement SkillTagCoverageTrackerService to analyze tag coverage across the training library
- test coverage tracker for counting and underrepresented tags

## Testing
- `flutter test test/services/skill_tag_coverage_tracker_service_test.dart` *(fails: TheoryBoosterRecommender constant evaluation error)*

------
https://chatgpt.com/codex/tasks/task_e_68941f169560832a97cf428e73ab110c