### PR TITLE
feat: auto inject theory links for weak tags

### DIFF
--- a/lib/services/theory_link_auto_injector_service.dart
+++ b/lib/services/theory_link_auto_injector_service.dart
@@ -1,57 +1,48 @@
-import 'package:flutter/foundation.dart';
+import 'package:collection/collection.dart';
 
+import '../models/skill_tag_coverage_report.dart';
+import '../models/training_pack_model.dart';
 import '../models/v2/training_pack_spot.dart';
-import '../models/theory_mini_lesson_node.dart';
 import 'mini_lesson_library_service.dart';
+import 'theory_mini_lesson_navigator.dart';
+import 'inline_theory_linker.dart';
 
-/// Automatically links training spots with relevant theory mini lessons based
-/// on shared tags.
+/// Injects [InlineTheoryLink]s into [TrainingPackSpot]s based on
+/// underrepresented skill tags.
 class TheoryLinkAutoInjectorService {
-  final MiniLessonLibraryService library;
+  TheoryLinkAutoInjectorService({
+    MiniLessonLibraryService? library,
+    TheoryMiniLessonNavigator? navigator,
+  })  : _library = library ?? MiniLessonLibraryService.instance,
+        _navigator = navigator ?? TheoryMiniLessonNavigator.instance;
 
-  TheoryLinkAutoInjectorService({MiniLessonLibraryService? library})
-    : library = library ?? MiniLessonLibraryService.instance;
+  final MiniLessonLibraryService _library;
+  final TheoryMiniLessonNavigator _navigator;
 
-  /// Enriches [spots] with a `linkedTheoryLessonId` meta field when a matching
-  /// [TheoryMiniLessonNode] exists.
+  /// Scans all [packs] and attaches theory links to spots that contain tags
+  /// listed in [report.underrepresentedTags].
   ///
-  /// Returns the number of spots that received links.
-  Future<int> injectLinks(
-    List<TrainingPackSpot> spots, {
-    List<TheoryMiniLessonNode>? lessons,
-  }) async {
-    final lessonList = lessons ?? await _loadLessons();
-    int injected = 0;
-    for (final spot in spots) {
-      if (spot.meta.containsKey('linkedTheoryLessonId')) continue;
-      final lesson = _findBestMatch(spot, lessonList);
-      if (lesson == null) continue;
-      spot.meta['linkedTheoryLessonId'] = lesson.id;
-      injected++;
-    }
-    debugPrint('TheoryLinkAutoInjectorService: injected $injected links');
-    return injected;
-  }
-
-  Future<List<TheoryMiniLessonNode>> _loadLessons() async {
-    await library.loadAll();
-    return library.all;
-  }
-
-  TheoryMiniLessonNode? _findBestMatch(
-    TrainingPackSpot spot,
-    List<TheoryMiniLessonNode> lessons,
+  /// Spots with an existing [TrainingPackSpot.theoryLink] remain unchanged.
+  List<TrainingPackModel> injectLinks(
+    SkillTagCoverageReport report,
+    List<TrainingPackModel> packs,
   ) {
-    TheoryMiniLessonNode? best;
-    int bestOverlap = 0;
-    final spotTags = spot.tags.toSet();
-    for (final lesson in lessons) {
-      final overlap = spotTags.intersection(lesson.tags.toSet()).length;
-      if (overlap > bestOverlap) {
-        bestOverlap = overlap;
-        best = lesson;
+    final under = report.underrepresentedTags.toSet();
+    for (final pack in packs) {
+      for (final spot in pack.spots) {
+        if (spot.theoryLink != null) continue;
+        for (final tag in spot.tags) {
+          if (!under.contains(tag)) continue;
+          final lesson = _library.findByTags([tag]).firstOrNull;
+          if (lesson == null) continue;
+          spot.theoryLink = InlineTheoryLink(
+            title: lesson.title,
+            onTap: () => _navigator.openLessonByTag(tag),
+          );
+          break;
+        }
       }
     }
-    return best;
+    return packs;
   }
 }


### PR DESCRIPTION
## Summary
- add TheoryLinkAutoInjectorService to fill underrepresented tags with theory links
- cover service with tests for injection and edge cases

## Testing
- `flutter test` *(fails: flutter: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68942200865c832ab7e2a7f667c8f4a4