### PR TITLE
feat: classify board textures for training spots

### DIFF
--- a/lib/services/board_texture_classifier_service.dart
+++ b/lib/services/board_texture_classifier_service.dart
@@ -1,0 +1,47 @@
+import '../models/v2/training_pack_spot.dart';
+import '../models/card_model.dart';
+import 'board_texture_classifier.dart';
+
+/// Service that classifies board textures for [TrainingPackSpot]s.
+class BoardTextureClassifierService {
+  const BoardTextureClassifierService({BoardTextureClassifier? classifier})
+    : _classifier = classifier ?? const BoardTextureClassifier();
+
+  final BoardTextureClassifier _classifier;
+
+  /// Returns a map from spot id to list of texture tags.
+  ///
+  /// Each spot's `board` is analysed and a subset of texture tags is
+  /// produced. Tags include:
+  /// `low`, `aceHigh`, `paired`, `monotone`, `rainbow`, `twoTone`,
+  /// `wet`, and `connected`.
+  ///
+  /// The resulting tags are also cached to `spot.meta['boardTextureTags']`.
+  Map<String, List<String>> classify(List<TrainingPackSpot> spots) {
+    final result = <String, List<String>>{};
+    for (final spot in spots) {
+      final cards = <CardModel>[
+        for (final c in spot.board)
+          if (c.length >= 2) CardModel(rank: c[0], suit: c[1]),
+      ];
+      final tags = _classifier.classifyCards(cards);
+      final filtered = <String>{};
+      if (tags.contains('low')) filtered.add('low');
+      if (tags.contains('aceHigh')) filtered.add('aceHigh');
+      if (tags.contains('paired')) filtered.add('paired');
+      if (tags.contains('monotone')) filtered.add('monotone');
+      if (tags.contains('rainbow')) filtered.add('rainbow');
+      if (tags.contains('wet')) filtered.add('wet');
+      if (tags.contains('connected')) filtered.add('connected');
+
+      // Custom detection for twoTone: exactly two suits present.
+      final suitCount = cards.map((c) => c.suit).toSet().length;
+      if (suitCount == 2) filtered.add('twoTone');
+
+      final tagList = filtered.toList();
+      result[spot.id] = tagList;
+      spot.meta['boardTextureTags'] = tagList;
+    }
+    return result;
+  }
+}

--- a/test/services/board_texture_classifier_service_test.dart
+++ b/test/services/board_texture_classifier_service_test.dart
@@ -1,0 +1,29 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/board_texture_classifier_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+
+void main() {
+  const service = BoardTextureClassifierService();
+
+  test('classifies spots and caches tags', () {
+    final spots = [
+      TrainingPackSpot(id: 's1', board: ['As', 'Ah', 'Td']),
+      TrainingPackSpot(id: 's2', board: ['2c', '3c', '4c']),
+      TrainingPackSpot(id: 's3', board: ['As', 'Ks', '4h']),
+    ];
+    final result = service.classify(spots);
+
+    expect(
+      result['s1']!.toSet(),
+      containsAll({'aceHigh', 'paired', 'rainbow', 'connected', 'wet'}),
+    );
+    expect(
+      result['s2']!.toSet(),
+      containsAll({'low', 'monotone', 'connected', 'wet'}),
+    );
+    expect(result['s3']!.toSet(), containsAll({'aceHigh', 'twoTone', 'wet'}));
+    expect(spots[0].meta['boardTextureTags'], result['s1']);
+    expect(spots[1].meta['boardTextureTags'], result['s2']);
+    expect(spots[2].meta['boardTextureTags'], result['s3']);
+  });
+}


### PR DESCRIPTION
## Summary
- add `BoardTextureClassifierService` to tag board textures for training spots
- add tests covering spot classification and metadata caching

## Testing
- `flutter analyze` *(fails: 4233 issues found)*
- `flutter test test/services/board_texture_classifier_service_test.dart` *(fails: Could not read required files and no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689423bb3c08832a9a787125b9c2d857