### PR TITLE
Add auto linking service and session fingerprint logger

### DIFF
--- a/lib/services/skill_tree_auto_linker_service.dart
+++ b/lib/services/skill_tree_auto_linker_service.dart
@@ -1,0 +1,69 @@
+import '../models/training_pack_model.dart';
+import '../models/theory_mini_lesson_node.dart';
+
+/// Simple representation of a skill tree node with tag metadata.
+class SkillTreeNode {
+  final String id;
+  final List<String> tags;
+  final Map<String, dynamic> meta;
+
+  SkillTreeNode({
+    required this.id,
+    List<String>? tags,
+    Map<String, dynamic>? meta,
+  })  : tags = tags ?? const [],
+        meta = meta ?? <String, dynamic>{};
+}
+
+/// Result of linking a skill node to related packs and lessons.
+class SkillLinkResult {
+  final List<String> packIds;
+  final List<String> lessonIds;
+
+  SkillLinkResult({
+    List<String>? packIds,
+    List<String>? lessonIds,
+  })  : packIds = packIds ?? const [],
+        lessonIds = lessonIds ?? const [];
+}
+
+/// Service linking skill tree nodes to packs and theory lessons based on tags.
+class SkillTreeAutoLinkerService {
+  const SkillTreeAutoLinkerService();
+
+  /// Returns mapping from node id to [SkillLinkResult].
+  Map<String, SkillLinkResult> link(
+    List<SkillTreeNode> nodes,
+    List<TrainingPackModel> packs,
+    List<TheoryMiniLessonNode> lessons,
+  ) {
+    final res = <String, SkillLinkResult>{};
+    for (final node in nodes) {
+      final nodeTags = node.tags.map((t) => t.toLowerCase().trim()).toSet();
+      final pIds = <String>[];
+      for (final pack in packs) {
+        final packTags = <String>{
+          for (final spot in pack.spots)
+            for (final t in spot.tags) t.toLowerCase().trim(),
+          for (final t in pack.tags) t.toLowerCase().trim(),
+        };
+        if (packTags.intersection(nodeTags).isNotEmpty) {
+          pIds.add(pack.id);
+        }
+      }
+      final lIds = <String>[
+        for (final lesson in lessons)
+          if (lesson.tags
+              .map((t) => t.toLowerCase().trim())
+              .toSet()
+              .intersection(nodeTags)
+              .isNotEmpty)
+            lesson.id,
+      ];
+      node.meta['linkedPackIds'] = pIds;
+      node.meta['linkedLessonIds'] = lIds;
+      res[node.id] = SkillLinkResult(packIds: pIds, lessonIds: lIds);
+    }
+    return res;
+  }
+}

--- a/test/services/skill_tree_auto_linker_service_test.dart
+++ b/test/services/skill_tree_auto_linker_service_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/skill_tree_auto_linker_service.dart';
+
+void main() {
+  group('SkillTreeAutoLinkerService', () {
+    test('links nodes to packs and lessons by tags', () {
+      final nodes = [
+        SkillTreeNode(id: 'n1', tags: ['push']),
+        SkillTreeNode(id: 'n2', tags: ['call']),
+      ];
+
+      final packs = [
+        TrainingPackModel(
+          id: 'p1',
+          title: 'Pack1',
+          spots: [
+            TrainingPackSpot(id: 's1', tags: ['push']),
+            TrainingPackSpot(id: 's2', tags: ['call']),
+          ],
+        ),
+        TrainingPackModel(
+          id: 'p2',
+          title: 'Pack2',
+          spots: [TrainingPackSpot(id: 's3', tags: ['raise'])],
+          tags: const ['misc'],
+        ),
+      ];
+
+      final lessons = [
+        TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['push']),
+        TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['raise']),
+      ];
+
+      final service = const SkillTreeAutoLinkerService();
+      final res = service.link(nodes, packs, lessons);
+
+      expect(res['n1']!.packIds, ['p1']);
+      expect(res['n1']!.lessonIds, ['l1']);
+      expect(nodes[0].meta['linkedPackIds'], ['p1']);
+      expect(nodes[0].meta['linkedLessonIds'], ['l1']);
+
+      expect(res['n2']!.packIds, ['p1']);
+      expect(res['n2']!.lessonIds, isEmpty);
+    });
+  });
+}

--- a/test/services/training_session_fingerprint_logger_service_test.dart
+++ b/test/services/training_session_fingerprint_logger_service_test.dart
@@ -8,33 +8,25 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('logs and retrieves sessions', () async {
+  test('logs start and end of sessions', () async {
     final service = TrainingSessionFingerprintLoggerService();
-    final session = TrainingSessionFingerprint(
-      packId: 'pack1',
-      tags: const ['tag1', 'tag2'],
-      totalSpots: 5,
-      correct: 3,
-      incorrect: 2,
-      completedAt: DateTime(2023, 1, 1),
-    );
-    await service.logSession(session);
+    await service.logSessionStart('pack1');
+    await service.logSessionEnd('pack1', ['tag1', 'tag2']);
 
-    final all = await service.getAll();
+    final all = await service.getAllSessions();
     expect(all, hasLength(1));
-    expect(all.first.packId, 'pack1');
-    expect(all.first.tags, containsAll(['tag1', 'tag2']));
-    expect(all.first.totalSpots, 5);
-    expect(all.first.correct, 3);
-    expect(all.first.incorrect, 2);
-    expect(all.first.completedAt, DateTime(2023, 1, 1));
+    final fp = all.first;
+    expect(fp.packId, 'pack1');
+    expect(fp.tagsCovered, containsAll(['tag1', 'tag2']));
+    expect(fp.endTime.isAfter(fp.startTime) || fp.endTime == fp.startTime, isTrue);
   });
 
   test('clear removes all fingerprints', () async {
     final service = TrainingSessionFingerprintLoggerService();
-    await service.logSession(TrainingSessionFingerprint(packId: 'p'));
+    await service.logSessionStart('p');
+    await service.logSessionEnd('p', []);
     await service.clear();
-    final all = await service.getAll();
+    final all = await service.getAllSessions();
     expect(all, isEmpty);
   });
 }


### PR DESCRIPTION
## Summary
- add SkillTreeAutoLinkerService to link skill nodes with packs and lessons by tags
- extend TrainingSessionFingerprintLoggerService with start/end tracking and unique session IDs
- cover new services with unit tests

## Testing
- `flutter test test/services/skill_tree_auto_linker_service_test.dart test/services/training_session_fingerprint_logger_service_test.dart test/services/training_session_fingerprint_timeline_service_test.dart test/services/skill_tag_session_coverage_tracker_service_test.dart` *(failed: command not found)*
- `apt-get install -y dart` *(failed: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68942c29bd20832abbc0a06acb76d026