### PR TITLE
feat: add theory ref auto injector

### DIFF
--- a/lib/services/theory_link_auto_injector_service.dart
+++ b/lib/services/theory_link_auto_injector_service.dart
@@ -6,6 +6,7 @@ import '../models/v2/training_pack_spot.dart';
 import 'mini_lesson_library_service.dart';
 import 'theory_mini_lesson_navigator.dart';
 import 'inline_theory_linker.dart';
+import '../models/theory_mini_lesson_node.dart';
 
 /// Injects [InlineTheoryLink]s into [TrainingPackSpot]s based on
 /// underrepresented skill tags.
@@ -13,11 +14,13 @@ class TheoryLinkAutoInjectorService {
   TheoryLinkAutoInjectorService({
     MiniLessonLibraryService? library,
     TheoryMiniLessonNavigator? navigator,
+    this.maxRefsPerSpot = 3,
   })  : _library = library ?? MiniLessonLibraryService.instance,
         _navigator = navigator ?? TheoryMiniLessonNavigator.instance;
 
   final MiniLessonLibraryService _library;
   final TheoryMiniLessonNavigator _navigator;
+  final int maxRefsPerSpot;
 
   /// Scans all [packs] and attaches theory links to spots that contain tags
   /// listed in [report.underrepresentedTags].
@@ -44,5 +47,41 @@ class TheoryLinkAutoInjectorService {
       }
     }
     return packs;
+  }
+
+  /// Injects inline theory references into [spots] based on overlapping tags
+  /// with available mini lessons.
+  ///
+  /// Returns a map of spot ids to the list of injected lesson ids.
+  Future<Map<String, List<String>>> injectTheoryRefs(
+    List<TrainingPackSpot> spots,
+  ) async {
+    final lessons = await _library.getAllLessons();
+    final tagIndex = <String, List<TheoryMiniLessonNode>>{};
+    for (final lesson in lessons) {
+      for (final tag in lesson.tags) {
+        tagIndex.putIfAbsent(tag, () => <TheoryMiniLessonNode>[]).add(lesson);
+      }
+    }
+
+    final result = <String, List<String>>{};
+    for (final spot in spots) {
+      final refs = <String>[];
+      for (final tag in spot.tags) {
+        if (refs.length >= maxRefsPerSpot) break;
+        final lessonsForTag = tagIndex[tag] ?? const [];
+        for (final lesson in lessonsForTag) {
+          if (refs.length >= maxRefsPerSpot) break;
+          if (refs.contains(lesson.id)) continue;
+          refs.add(lesson.id);
+        }
+      }
+      if (refs.isNotEmpty) {
+        spot.meta['theoryRefs'] = refs;
+        spot.theoryRefs = refs;
+      }
+      result[spot.id] = refs;
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- expand TheoryLinkAutoInjectorService with maxRefsPerSpot option
- add injectTheoryRefs to populate theoryRefs based on tag overlap
- test new theory reference injection behaviour

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894310e8d54832abcb02a0988f80456