### PR TITLE
feat: add training pack quality score calculator

### DIFF
--- a/lib/services/pack_quality_score_calculator_service.dart
+++ b/lib/services/pack_quality_score_calculator_service.dart
@@ -1,0 +1,77 @@
+import 'dart:math' as math;
+
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'spot_fingerprint_generator.dart';
+
+class PackQualityScoreCalculatorService {
+  const PackQualityScoreCalculatorService({
+    SpotFingerprintGenerator? fingerprint,
+  }) : _fingerprint = fingerprint ?? const SpotFingerprintGenerator();
+
+  final SpotFingerprintGenerator _fingerprint;
+
+  double calculateQualityScore(TrainingPackModel pack) {
+    final tags = <String>[];
+    final boards = <String>{};
+    var theoryCount = 0;
+    final seen = <String>{};
+    var duplicates = 0;
+
+    for (final spot in pack.spots) {
+      tags.addAll(spot.tags);
+      if (spot.board.isNotEmpty) {
+        boards.add(spot.board.join());
+      }
+      if (spot.theoryRefs.isNotEmpty) theoryCount++;
+      final fp = _fingerprint.generate(spot);
+      if (!seen.add(fp)) duplicates++;
+    }
+
+    final totalTags = tags.length;
+    final uniqueTags = tags.toSet().length;
+    final tagDiversityScore =
+        totalTags == 0 ? 0.0 : uniqueTags / totalTags;
+
+    final boardDiversityScore = pack.spots.isEmpty
+        ? 0.0
+        : boards.length / pack.spots.length;
+
+    double balanceScore = 0.0;
+    if (uniqueTags > 0) {
+      final counts = <String, int>{};
+      for (final t in tags) {
+        counts[t] = (counts[t] ?? 0) + 1;
+      }
+      final mean = totalTags / uniqueTags;
+      var variance = 0.0;
+      for (final c in counts.values) {
+        variance += math.pow(c - mean, 2) as double;
+      }
+      variance /= uniqueTags;
+      final sd = math.sqrt(variance);
+      final cv = mean == 0 ? 0.0 : sd / mean;
+      balanceScore = 1 / (1 + cv);
+    }
+
+    final theoryRatio =
+        pack.spots.isEmpty ? 0.0 : theoryCount / pack.spots.length;
+    final hasTheoryLinks = theoryRatio >= 0.7
+        ? 1.0
+        : theoryRatio / 0.7;
+
+    final deduplicationScore = pack.spots.isEmpty
+        ? 1.0
+        : 1 - duplicates / pack.spots.length;
+
+    final score = (tagDiversityScore +
+            boardDiversityScore +
+            balanceScore +
+            hasTheoryLinks +
+            deduplicationScore) /
+        5.0;
+
+    pack.metadata['qualityScore'] = score;
+    return score;
+  }
+}

--- a/test/services/pack_quality_score_calculator_service_test.dart
+++ b/test/services/pack_quality_score_calculator_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/pack_quality_score_calculator_service.dart';
+
+void main() {
+  test('calculates and stores quality score', () {
+    final spots = [
+      TrainingPackSpot(
+        id: '1',
+        tags: ['a', 'b'],
+        board: ['Ah', 'Kd', 'Qs'],
+        correctAction: 'fold',
+        theoryRefs: ['T1'],
+      ),
+      TrainingPackSpot(
+        id: '2',
+        tags: ['a'],
+        board: ['2h', '3d', '5c'],
+        correctAction: 'call',
+        theoryRefs: ['T2'],
+      ),
+      TrainingPackSpot(
+        id: '3',
+        tags: ['c'],
+        board: ['Ah', 'Kd', 'Qs'],
+        correctAction: 'fold',
+        theoryRefs: [],
+      ),
+    ];
+
+    final pack = TrainingPackModel(id: 'p', title: 'Test', spots: spots);
+    final service = PackQualityScoreCalculatorService();
+    final score = service.calculateQualityScore(pack);
+
+    expect(score, closeTo(0.7549, 0.0001));
+    expect(pack.metadata['qualityScore'], closeTo(score, 1e-9));
+  });
+}


### PR DESCRIPTION
## Summary
- add `PackQualityScoreCalculatorService` to score pack diversity, theory coverage, and duplicates
- cover service with test verifying computed quality score is stored in metadata

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943278ded0832aa9ce9c0596b77775