### PR TITLE
feat: add pack quality gatekeeper

### DIFF
--- a/lib/services/pack_quality_gatekeeper_service.dart
+++ b/lib/services/pack_quality_gatekeeper_service.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/training_pack_model.dart';
+import 'pack_quality_score_calculator_service.dart';
+
+/// Filters out training packs that do not meet the minimum quality score.
+class PackQualityGatekeeperService {
+  const PackQualityGatekeeperService({
+    PackQualityScoreCalculatorService? scoreCalculator,
+  }) : _scoreCalculator = scoreCalculator ?? const PackQualityScoreCalculatorService();
+
+  final PackQualityScoreCalculatorService _scoreCalculator;
+
+  /// Returns true if the [pack]'s quality score meets or exceeds [minScore].
+  ///
+  /// If the pack does not already have a `qualityScore` stored in its
+  /// metadata, it is calculated and cached before evaluation.
+  bool isQualityAcceptable(TrainingPackModel pack, {double minScore = 0.7}) {
+    var score = pack.metadata['qualityScore'] as double?;
+    if (score == null) {
+      score = _scoreCalculator.calculateQualityScore(pack);
+    }
+    if (score < minScore) {
+      debugPrint(
+          'PackQualityGatekeeperService: rejected pack ${pack.id} with score ${score.toStringAsFixed(2)} < threshold $minScore');
+      return false;
+    }
+    return true;
+  }
+}
+

--- a/test/services/pack_quality_gatekeeper_service_test.dart
+++ b/test/services/pack_quality_gatekeeper_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/pack_quality_gatekeeper_service.dart';
+
+void main() {
+  group('PackQualityGatekeeperService', () {
+    test('rejects packs below threshold', () {
+      final pack = TrainingPackModel(
+        id: 'p1',
+        title: 'Low',
+        spots: const [],
+        metadata: {'qualityScore': 0.5},
+      );
+      const gatekeeper = PackQualityGatekeeperService();
+      final result = gatekeeper.isQualityAcceptable(pack, minScore: 0.7);
+      expect(result, isFalse);
+    });
+
+    test('computes score when missing and accepts above threshold', () {
+      final spots = [
+        TrainingPackSpot(
+          id: '1',
+          tags: ['a', 'b'],
+          board: ['Ah', 'Kd', 'Qs'],
+          correctAction: 'fold',
+          theoryRefs: ['T1'],
+        ),
+        TrainingPackSpot(
+          id: '2',
+          tags: ['a'],
+          board: ['2h', '3d', '5c'],
+          correctAction: 'call',
+          theoryRefs: ['T2'],
+        ),
+      ];
+      final pack = TrainingPackModel(id: 'p2', title: 'High', spots: spots);
+      const gatekeeper = PackQualityGatekeeperService();
+      final result = gatekeeper.isQualityAcceptable(pack, minScore: 0.7);
+      expect(result, isTrue);
+      expect(pack.metadata['qualityScore'], isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add PackQualityGatekeeperService to reject low-quality training packs
- integrate gatekeeper into AutogenPackGeneratorService to skip poor packs and tag quality score
- cover gatekeeper with unit tests

## Testing
- `flutter format lib/services/pack_quality_gatekeeper_service.dart lib/services/autogen_pack_generator_service.dart test/services/pack_quality_gatekeeper_service_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689433ce4d1c832a8104070f76aa72ce