### PR TITLE
feat: add autogen history chart widget

### DIFF
--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
 import '../widgets/autogen_realtime_stats_panel.dart';
 import '../widgets/inline_report_viewer_widget.dart';
+import '../widgets/autogen_history_chart_widget.dart';
 import '../services/autogen_stats_dashboard_service.dart';
 import '../services/autogen_status_dashboard_service.dart';
 import '../services/autogen_pipeline_executor.dart';
@@ -172,6 +173,10 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
             ),
           ),
           Expanded(child: Container()),
+          const SizedBox(
+            height: 200,
+            child: AutogenHistoryChartWidget(),
+          ),
           const AutogenRealtimeStatsPanel(),
           const SizedBox(
             height: 200,

--- a/lib/widgets/autogen_history_chart_widget.dart
+++ b/lib/widgets/autogen_history_chart_widget.dart
@@ -1,0 +1,114 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../services/autogen_run_history_logger_service.dart';
+
+/// Displays historical autogeneration metrics as a time-series chart.
+class AutogenHistoryChartWidget extends StatelessWidget {
+  final AutogenRunHistoryLoggerService service;
+
+  const AutogenHistoryChartWidget({
+    super.key,
+    this.service = const AutogenRunHistoryLoggerService(),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<RunMetricsEntry>>(
+      future: service.getHistory(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final history = snapshot.data ?? [];
+        if (history.isEmpty) {
+          return const Center(child: Text('No history'));
+        }
+        history.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+        final maxGenerated = history
+            .map((e) => e.generated)
+            .fold<int>(0, (a, b) => b > a ? b : a);
+        final spotsGenerated = history
+            .map((e) => FlSpot(
+                  e.timestamp.millisecondsSinceEpoch.toDouble(),
+                  e.generated.toDouble(),
+                ))
+            .toList();
+        final spotsScore = history
+            .map((e) => FlSpot(
+                  e.timestamp.millisecondsSinceEpoch.toDouble(),
+                  e.avgQualityScore * maxGenerated,
+                ))
+            .toList();
+        return LineChart(
+          LineChartData(
+            minY: 0,
+            maxY: maxGenerated.toDouble(),
+            lineTouchData: LineTouchData(
+              touchTooltipData: LineTouchTooltipData(
+                getTooltipItems: (touchedSpots) {
+                  if (touchedSpots.isEmpty) return [];
+                  final index = touchedSpots.first.spotIndex;
+                  final entry = history[index];
+                  return [
+                    LineTooltipItem(
+                      '${_formatDate(entry.timestamp)}\nGenerated: ${entry.generated}\nRejected: ${entry.rejected}\nAvgScore: ${entry.avgQualityScore.toStringAsFixed(2)}',
+                      const TextStyle(color: Colors.white),
+                    ),
+                  ];
+                },
+              ),
+            ),
+            titlesData: FlTitlesData(
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, _) {
+                    final date =
+                        DateTime.fromMillisecondsSinceEpoch(value.toInt());
+                    return Text('${date.month}/${date.day}',
+                        style: const TextStyle(fontSize: 10));
+                  },
+                ),
+              ),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(showTitles: true),
+              ),
+              rightTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, _) {
+                    if (maxGenerated == 0) return const Text('');
+                    final score = value / maxGenerated;
+                    return Text(score.toStringAsFixed(1),
+                        style: const TextStyle(fontSize: 10));
+                  },
+                ),
+              ),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            ),
+            lineBarsData: [
+              LineChartBarData(
+                spots: spotsGenerated,
+                isCurved: false,
+                barWidth: 2,
+                color: Colors.blue,
+                dotData: const FlDotData(show: false),
+              ),
+              LineChartBarData(
+                spots: spotsScore,
+                isCurved: true,
+                barWidth: 2,
+                color: Colors.orange,
+                dotData: const FlDotData(show: false),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatDate(DateTime d) => '${d.month}/${d.day}';
+}
+


### PR DESCRIPTION
## Summary
- visualize autogen run history with `AutogenHistoryChartWidget`
- show history chart on `AutogenDebugScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943facc8e0832a93b83753a5ba2020