### PR TITLE
feat: add autogen realtime stats refresher

### DIFF
--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -173,7 +173,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
             ),
           ),
           Expanded(child: Container()),
-          const SizedBox(
+          SizedBox(
             height: 200,
             child: AutogenHistoryChartWidget(),
           ),

--- a/lib/services/autogen_real_time_stats_refresher_service.dart
+++ b/lib/services/autogen_real_time_stats_refresher_service.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'autogen_run_history_logger_service.dart';
+import 'autogen_status_dashboard_service.dart';
+
+/// Periodically refreshes autogen run history while the pipeline is running.
+class AutogenRealTimeStatsRefresherService {
+  final AutogenRunHistoryLoggerService _historyService;
+  final AutogenStatusDashboardService _statusService;
+  final Duration interval;
+
+  Timer? _timer;
+  final ValueNotifier<DateTime> notifier = ValueNotifier(DateTime.now());
+  List<RunMetricsEntry> _history = const [];
+
+  /// Creates a refresher that polls [AutogenRunHistoryLoggerService] every
+  /// [interval] while the autogen pipeline is running.
+  AutogenRealTimeStatsRefresherService({
+    AutogenRunHistoryLoggerService? historyService,
+    AutogenStatusDashboardService? statusService,
+    this.interval = const Duration(seconds: 10),
+  })  : _historyService = historyService ?? const AutogenRunHistoryLoggerService(),
+        _statusService = statusService ?? AutogenStatusDashboardService.instance {
+    _statusService.notifier.addListener(_statusListener);
+    _statusListener();
+    // Load initial history asynchronously.
+    _refresh();
+  }
+
+  /// Latest cached history entries.
+  List<RunMetricsEntry> get history => _history;
+
+  void _statusListener() {
+    final running = _statusService.getStatus('pipeline')?.isRunning ?? false;
+    if (running) {
+      _startTimer();
+    } else {
+      _stopTimer();
+    }
+  }
+
+  void _startTimer() {
+    if (_timer != null) return;
+    _timer = Timer.periodic(interval, (_) => _refresh());
+    _refresh();
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> _refresh() async {
+    _history = await _historyService.getHistory();
+    notifier.value = DateTime.now();
+  }
+
+  /// Disposes internal resources.
+  void dispose() {
+    _stopTimer();
+    _statusService.notifier.removeListener(_statusListener);
+    notifier.dispose();
+  }
+}
+

--- a/lib/widgets/autogen_history_chart_widget.dart
+++ b/lib/widgets/autogen_history_chart_widget.dart
@@ -1,26 +1,37 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
-import '../services/autogen_run_history_logger_service.dart';
+import '../services/autogen_real_time_stats_refresher_service.dart';
 
 /// Displays historical autogeneration metrics as a time-series chart.
-class AutogenHistoryChartWidget extends StatelessWidget {
-  final AutogenRunHistoryLoggerService service;
+class AutogenHistoryChartWidget extends StatefulWidget {
+  const AutogenHistoryChartWidget({super.key});
 
-  const AutogenHistoryChartWidget({
-    super.key,
-    this.service = const AutogenRunHistoryLoggerService(),
-  });
+  @override
+  State<AutogenHistoryChartWidget> createState() => _AutogenHistoryChartWidgetState();
+}
+
+class _AutogenHistoryChartWidgetState extends State<AutogenHistoryChartWidget> {
+  late final AutogenRealTimeStatsRefresherService _refresher;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresher = AutogenRealTimeStatsRefresherService();
+  }
+
+  @override
+  void dispose() {
+    _refresher.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<RunMetricsEntry>>(
-      future: service.getHistory(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState != ConnectionState.done) {
-          return const Center(child: CircularProgressIndicator());
-        }
-        final history = snapshot.data ?? [];
+    return ValueListenableBuilder<DateTime>(
+      valueListenable: _refresher.notifier,
+      builder: (context, _, __) {
+        final history = _refresher.history;
         if (history.isEmpty) {
           return const Center(child: Text('No history'));
         }

--- a/test/services/autogen_real_time_stats_refresher_service_test.dart
+++ b/test/services/autogen_real_time_stats_refresher_service_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/autogen_real_time_stats_refresher_service.dart';
+import 'package:poker_analyzer/services/autogen_run_history_logger_service.dart';
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+import 'package:poker_analyzer/models/autogen_status.dart';
+
+void main() {
+  test('emits ticks only while running', () async {
+    final dir = await Directory.systemTemp.createTemp('realtime_stats_test');
+    final logger = AutogenRunHistoryLoggerService(
+      filePath: p.join(dir.path, 'history.json'),
+    );
+    await logger.logRun(generated: 1, rejected: 0, avgScore: 0.5);
+
+    final status = AutogenStatusDashboardService.instance;
+    final refresher = AutogenRealTimeStatsRefresherService(
+      historyService: logger,
+      statusService: status,
+      interval: const Duration(milliseconds: 50),
+    );
+
+    final initial = refresher.notifier.value;
+    await Future.delayed(const Duration(milliseconds: 120));
+    expect(refresher.notifier.value, initial);
+
+    status.update('pipeline', const AutogenStatus(isRunning: true));
+    await Future.delayed(const Duration(milliseconds: 120));
+    final runningValue = refresher.notifier.value;
+    expect(runningValue.isAfter(initial), isTrue);
+
+    status.update('pipeline', const AutogenStatus(isRunning: false));
+    final stoppedValue = refresher.notifier.value;
+    await Future.delayed(const Duration(milliseconds: 120));
+    expect(refresher.notifier.value, stoppedValue);
+
+    refresher.dispose();
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `AutogenRealTimeStatsRefresherService` to poll run history and notify listeners
- refresh `AutogenHistoryChartWidget` via `ValueListenableBuilder`
- cover refresher behaviour with unit test

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689441482180832aa35b1972fc589d57