### PR TITLE
feat: classify auto-generated pack errors

### DIFF
--- a/lib/services/autogen_error_stats_logger.dart
+++ b/lib/services/autogen_error_stats_logger.dart
@@ -1,0 +1,14 @@
+import 'autogen_pack_error_classifier_service.dart';
+
+/// Tracks counts of different [AutogenPackErrorType] occurrences.
+class AutogenErrorStatsLogger {
+  final Map<AutogenPackErrorType, int> _counts = {};
+
+  /// Records an [errorType] occurrence.
+  void log(AutogenPackErrorType errorType) {
+    _counts[errorType] = (_counts[errorType] ?? 0) + 1;
+  }
+
+  /// Returns an immutable view of the recorded counts.
+  Map<AutogenPackErrorType, int> get counts => Map.unmodifiable(_counts);
+}

--- a/lib/services/autogen_pack_error_classifier_service.dart
+++ b/lib/services/autogen_pack_error_classifier_service.dart
@@ -1,0 +1,32 @@
+import '../models/v2/training_pack_template_v2.dart';
+
+/// Enumerates known auto-generation error types for packs.
+enum AutogenPackErrorType {
+  duplicate,
+  emptyOutput,
+  invalidBoard,
+  noSpotsGenerated,
+  templateSyntaxError,
+  unknown,
+}
+
+/// Classifies rejected packs into [AutogenPackErrorType] categories.
+class AutogenPackErrorClassifierService {
+  const AutogenPackErrorClassifierService();
+
+  /// Returns the [AutogenPackErrorType] for a rejected [pack] and optional
+  /// generation [error].
+  AutogenPackErrorType classify(TrainingPackTemplateV2 pack, Exception? error) {
+    final msg = error?.toString().toLowerCase() ?? '';
+    if (msg.contains('duplicate')) return AutogenPackErrorType.duplicate;
+    if (msg.contains('empty')) return AutogenPackErrorType.emptyOutput;
+    if (msg.contains('invalid board')) return AutogenPackErrorType.invalidBoard;
+    if (msg.contains('syntax') || msg.contains('format')) {
+      return AutogenPackErrorType.templateSyntaxError;
+    }
+    if (pack.spots.isEmpty || pack.spotCount == 0) {
+      return AutogenPackErrorType.noSpotsGenerated;
+    }
+    return AutogenPackErrorType.unknown;
+  }
+}

--- a/test/services/autogen_pack_error_classifier_service_test.dart
+++ b/test/services/autogen_pack_error_classifier_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/autogen_pack_error_classifier_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+TrainingPackTemplateV2 _emptyPack() => TrainingPackTemplateV2(
+      id: 'id',
+      name: 'name',
+      trainingType: TrainingType.custom,
+      spots: [],
+      spotCount: 0,
+      tags: [],
+      gameType: GameType.cash,
+      bb: 0,
+      positions: [],
+      meta: {},
+    );
+
+void main() {
+  group('AutogenPackErrorClassifierService', () {
+    const classifier = AutogenPackErrorClassifierService();
+
+    test('detects no spots generated', () {
+      final type = classifier.classify(_emptyPack(), null);
+      expect(type, AutogenPackErrorType.noSpotsGenerated);
+    });
+
+    test('detects duplicate error', () {
+      final type =
+          classifier.classify(_emptyPack(), Exception('duplicate spot'));
+      expect(type, AutogenPackErrorType.duplicate);
+    });
+
+    test('detects invalid board', () {
+      final type = classifier.classify(
+        _emptyPack(),
+        Exception('Invalid board sequence'),
+      );
+      expect(type, AutogenPackErrorType.invalidBoard);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add AutogenPackErrorClassifierService and error type enum
- log error stats for rejected packs
- integrate classifier in TrainingPackAutoGenerator

## Testing
- `dart format lib/services/autogen_pack_error_classifier_service.dart lib/services/autogen_error_stats_logger.dart lib/services/training_pack_auto_generator.dart test/services/autogen_pack_error_classifier_service_test.dart` *(failed: dart: command not found)*
- `dart test` *(failed: dart: command not found)*
- attempted to install Dart SDK via apt but repository had no Release file


------
https://chatgpt.com/codex/tasks/task_e_689442d746c0832a9f674e196d910fb1