### PR TITLE
feat: show autogen error breakdown

### DIFF
--- a/lib/services/autogen_error_stats_logger.dart
+++ b/lib/services/autogen_error_stats_logger.dart
@@ -2,11 +2,27 @@ import 'autogen_pack_error_classifier_service.dart';
 
 /// Tracks counts of different [AutogenPackErrorType] occurrences.
 class AutogenErrorStatsLogger {
+  AutogenErrorStatsLogger._();
+
+  static final AutogenErrorStatsLogger _instance =
+      AutogenErrorStatsLogger._();
+
+  /// Shared singleton instance.
+  factory AutogenErrorStatsLogger() => _instance;
+
+  /// Accessor for the shared singleton instance.
+  static AutogenErrorStatsLogger get instance => _instance;
+
   final Map<AutogenPackErrorType, int> _counts = {};
 
   /// Records an [errorType] occurrence.
   void log(AutogenPackErrorType errorType) {
     _counts[errorType] = (_counts[errorType] ?? 0) + 1;
+  }
+
+  /// Clears all recorded counts.
+  void clear() {
+    _counts.clear();
   }
 
   /// Returns an immutable view of the recorded counts.

--- a/lib/services/training_pack_auto_generator.dart
+++ b/lib/services/training_pack_auto_generator.dart
@@ -28,7 +28,7 @@ class TrainingPackAutoGenerator {
         _dedup = dedup ?? AutoDeduplicationEngine(),
         _errorClassifier =
             errorClassifier ?? const AutogenPackErrorClassifierService(),
-        _errorStats = errorStats;
+        _errorStats = errorStats ?? AutogenErrorStatsLogger();
 
   /// Generates spots from [set] and optionally deduplicates them based on
   /// fingerprints.


### PR DESCRIPTION
## Summary
- add singleton AutogenErrorStatsLogger with count access and clear
- record error stats automatically in TrainingPackAutoGenerator
- surface error breakdown and reset support in AutogenMetricsDashboardScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689444b8ea40832a913a414f75edea4a