### PR TITLE
feat: load template sets by id for scheduler jobs

### DIFF
--- a/lib/services/autogen_pack_generator_service.dart
+++ b/lib/services/autogen_pack_generator_service.dart
@@ -61,7 +61,7 @@ class AutogenPackGeneratorService {
 
     final files = <File>[];
     for (final set in sets) {
-      final spots = _generator.generate(set);
+      final spots = await _generator.generate(set);
       if (spots.isEmpty) continue;
       final base = set.baseSpot;
       final pack = TrainingPackTemplateV2(

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -121,7 +121,7 @@ class AutogenPipelineExecutor {
           ),
         );
         if (generator.shouldAbort) break;
-        var spots = generator.generate(set, theoryIndex: theoryIndex);
+        var spots = await generator.generate(set, theoryIndex: theoryIndex);
         if (generator.shouldAbort) break;
         if (spots.isEmpty) {
           status.update(

--- a/lib/services/training_pack_template_registry_service.dart
+++ b/lib/services/training_pack_template_registry_service.dart
@@ -1,0 +1,24 @@
+import '../models/training_pack_template_set.dart';
+import 'training_pack_template_set_library_service.dart';
+
+/// Provides lookup utilities for [TrainingPackTemplateSet]s.
+class TrainingPackTemplateRegistryService {
+  final TrainingPackTemplateSetLibraryService _library;
+
+  TrainingPackTemplateRegistryService({
+    TrainingPackTemplateSetLibraryService? library,
+  }) : _library = library ?? TrainingPackTemplateSetLibraryService.instance;
+
+  /// Loads a [TrainingPackTemplateSet] by its [templateId].
+  ///
+  /// Throws a [StateError] if no template with the given id exists.
+  Future<TrainingPackTemplateSet> loadTemplateById(String templateId) async {
+    await _library.loadAll();
+    try {
+      return _library.all
+          .firstWhere((s) => s.baseSpot.id == templateId);
+    } catch (_) {
+      throw StateError('Template not found: $templateId');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingPackTemplateRegistryService` for template lookups
- allow `TrainingPackAutoGenerator` to accept template IDs and load sets
- update scheduler to resolve template IDs before generation and log errors

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6894729d1ac4832aa6b0b793061f60b8