### PR TITLE
feat: add pack library auto curator service

### DIFF
--- a/lib/services/pack_library_auto_curator_service.dart
+++ b/lib/services/pack_library_auto_curator_service.dart
@@ -1,0 +1,106 @@
+import '../models/training_pack_model.dart';
+import 'auto_deduplication_engine.dart';
+import 'skill_tag_coverage_tracker.dart';
+
+/// Selects a diverse subset of training packs for the library.
+class PackLibraryAutoCuratorService {
+  final AutoDeduplicationEngine _dedup;
+  final SkillTagCoverageTracker? _tagTracker;
+  final dynamic _clusterAnalyzer;
+
+  PackLibraryAutoCuratorService({
+    AutoDeduplicationEngine? dedup,
+    SkillTagCoverageTracker? tagTracker,
+    dynamic clusterAnalyzer,
+  })  : _dedup = dedup ?? AutoDeduplicationEngine(),
+        _tagTracker = tagTracker,
+        _clusterAnalyzer = clusterAnalyzer;
+
+  /// Filters and ranks [input], returning at most [limit] packs.
+  List<TrainingPackModel> curate(List<TrainingPackModel> input,
+      {int limit = 50}) {
+    if (input.isEmpty) return [];
+    final deduped = _dedup.deduplicate(input);
+
+    final bestByCluster = <String, TrainingPackModel>{};
+    final others = <TrainingPackModel>[];
+
+    for (final pack in deduped) {
+      _tagTracker?.analyzePack(pack);
+      final clusterId = _getClusterId(pack);
+      if (clusterId != null && clusterId.isNotEmpty) {
+        final existing = bestByCluster[clusterId];
+        if (existing == null || _comparePacks(pack, existing) > 0) {
+          bestByCluster[clusterId] = pack;
+        }
+      } else {
+        others.add(pack);
+      }
+    }
+
+    final result = <TrainingPackModel>[...bestByCluster.values, ...others];
+
+    result.sort((a, b) {
+      final count = b.spots.length.compareTo(a.spots.length);
+      if (count != 0) return count;
+      final tagsA = _uniqueTags(a).length;
+      final tagsB = _uniqueTags(b).length;
+      final tagComp = tagsB.compareTo(tagsA);
+      if (tagComp != 0) return tagComp;
+      return a.id.compareTo(b.id);
+    });
+
+    return result.length > limit ? result.sublist(0, limit) : result;
+  }
+
+  String? _getClusterId(TrainingPackModel pack) {
+    if (_clusterAnalyzer != null) {
+      try {
+        final cid = _clusterAnalyzer.clusterIdFor(pack);
+        if (cid is String && cid.isNotEmpty) return cid;
+      } catch (_) {}
+      try {
+        final cid = _clusterAnalyzer.analyze(pack);
+        if (cid is String && cid.isNotEmpty) return cid;
+      } catch (_) {}
+    }
+    final metaCluster = pack.metadata['clusterId'] ??
+        pack.metadata['theoryClusterId'] ??
+        pack.metadata['cluster'];
+    if (metaCluster is String && metaCluster.trim().isNotEmpty) {
+      return metaCluster.trim();
+    }
+    for (final spot in pack.spots) {
+      final m = spot.meta;
+      final c = m['cluster'] ??
+          m['theoryCluster'] ??
+          m['clusterId'] ??
+          m['theoryClusterId'];
+      if (c is String && c.trim().isNotEmpty) return c.trim();
+    }
+    return null;
+  }
+
+  int _comparePacks(TrainingPackModel a, TrainingPackModel b) {
+    final bySpots = a.spots.length.compareTo(b.spots.length);
+    if (bySpots != 0) return bySpots;
+    final ta = _uniqueTags(a).length;
+    final tb = _uniqueTags(b).length;
+    return ta.compareTo(tb);
+  }
+
+  Set<String> _uniqueTags(TrainingPackModel pack) {
+    final tags = <String>{};
+    for (final t in pack.tags) {
+      final v = t.trim().toLowerCase();
+      if (v.isNotEmpty) tags.add(v);
+    }
+    for (final s in pack.spots) {
+      for (final t in s.tags) {
+        final v = t.trim().toLowerCase();
+        if (v.isNotEmpty) tags.add(v);
+      }
+    }
+    return tags;
+  }
+}

--- a/test/services/pack_library_auto_curator_service_test.dart
+++ b/test/services/pack_library_auto_curator_service_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/auto_deduplication_engine.dart';
+import 'package:poker_analyzer/services/pack_library_auto_curator_service.dart';
+
+class _NoopDedup extends AutoDeduplicationEngine {
+  _NoopDedup() : super(log: IOSink(StreamController<List<int>>().sink));
+
+  @override
+  List<TrainingPackModel> deduplicate(List<TrainingPackModel> input) => input;
+}
+
+void main() {
+  test('curate selects best pack per cluster and sorts by coverage', () {
+    final curator = PackLibraryAutoCuratorService(dedup: _NoopDedup());
+
+    TrainingPackModel pack(
+      String id, {
+      List<TrainingPackSpot>? spots,
+      List<String>? tags,
+      Map<String, dynamic>? metadata,
+    }) {
+      return TrainingPackModel(
+        id: id,
+        title: id,
+        spots: spots ?? const [],
+        tags: tags,
+        metadata: metadata,
+      );
+    }
+
+    TrainingPackSpot spot(
+      String id, {
+      List<String>? tags,
+      Map<String, dynamic>? meta,
+    }) {
+      return TrainingPackSpot(id: id, tags: tags, meta: meta);
+    }
+
+    final p1 = pack('p1', spots: [
+      spot('s1', meta: {'clusterId': 'c1'}),
+      spot('s2', meta: {'clusterId': 'c1'}),
+    ], tags: ['a']);
+
+    final p2 = pack('p2', spots: [
+      spot('s3', meta: {'clusterId': 'c1'}),
+      spot('s4', meta: {'clusterId': 'c1'}),
+      spot('s5', meta: {'clusterId': 'c1'}),
+    ], tags: ['a', 'b']);
+
+    final p3 = pack('p3', spots: [
+      spot('s6', meta: {'clusterId': 'c2'}),
+    ], tags: ['c']);
+
+    final p4 = pack('p4', spots: [
+      spot('s7'),
+      spot('s8'),
+      spot('s9'),
+      spot('s10'),
+      spot('s11'),
+    ], tags: ['d', 'e', 'f']);
+
+    final p5 = pack('p5', spots: [
+      spot('s12'),
+      spot('s13'),
+      spot('s14'),
+    ], tags: ['x', 'y', 'z']);
+
+    final result = curator.curate([p1, p2, p3, p4, p5], limit: 4);
+
+    expect(result.map((p) => p.id).toList(), ['p4', 'p5', 'p2', 'p3']);
+  });
+}


### PR DESCRIPTION
## Summary
- add PackLibraryAutoCuratorService to deduplicate and select diverse training packs
- cover curator selection with unit test

## Testing
- `dart test test/services/pack_library_auto_curator_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68948259bf7c832a84cabbceed619b2c