### PR TITLE
feat: add autogen library publisher

### DIFF
--- a/lib/services/autogen_library_publisher_service.dart
+++ b/lib/services/autogen_library_publisher_service.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import '../models/training_pack_model.dart';
+import '../core/training/generation/yaml_writer.dart';
+
+class AutogenLibraryPublisherService {
+  final String baseDir;
+  final YamlWriter _writer;
+
+  AutogenLibraryPublisherService({
+    String? baseDir,
+    YamlWriter? yamlWriter,
+  })  : baseDir = baseDir ?? 'assets/training_packs/generated',
+        _writer = yamlWriter ?? const YamlWriter();
+
+  Future<void> publish(List<TrainingPackModel> curatedPacks) async {
+    final dir = Directory(baseDir);
+    await dir.create(recursive: true);
+
+    final indexFile = File(p.join(baseDir, 'library_autogen_index.yaml'));
+    final index = await _readIndex(indexFile);
+    final existingIds = index.map((e) => e['id'].toString()).toSet();
+
+    var published = 0;
+    var skipped = 0;
+
+    for (final pack in curatedPacks) {
+      if (existingIds.contains(pack.id)) {
+        skipped++;
+        continue;
+      }
+      final fileName = 'pack_${pack.id}.yaml';
+      final filePath = p.join(baseDir, fileName);
+      await _writer.write(_packToYaml(pack), filePath);
+      index.add({
+        'id': pack.id,
+        'file': fileName,
+        'tags': pack.tags,
+        'timestamp': DateTime.now().toIso8601String(),
+      });
+      existingIds.add(pack.id);
+      published++;
+    }
+
+    await _writer.write(index, indexFile.path);
+
+    final logFile = File(p.join(baseDir, 'autogen_publish_log.json'));
+    final logs = await _readLogs(logFile);
+    logs.add({
+      'timestamp': DateTime.now().toIso8601String(),
+      'publishedCount': published,
+      'skippedDuplicates': skipped,
+      'totalCandidates': curatedPacks.length,
+    });
+    await logFile.writeAsString(jsonEncode(logs));
+  }
+
+  Map<String, dynamic> _packToYaml(TrainingPackModel pack) => {
+        'id': pack.id,
+        'title': pack.title,
+        if (pack.tags.isNotEmpty) 'tags': pack.tags,
+        if (pack.metadata.isNotEmpty) 'metadata': pack.metadata,
+        'spots': [for (final s in pack.spots) s.toYaml()],
+      };
+
+  Future<List<Map<String, dynamic>>> _readIndex(File file) async {
+    if (await file.exists()) {
+      final content = await file.readAsString();
+      final data = loadYaml(content);
+      if (data is YamlList) {
+        return data.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+      }
+    }
+    return [];
+  }
+
+  Future<List<dynamic>> _readLogs(File file) async {
+    if (await file.exists()) {
+      try {
+        final data = jsonDecode(await file.readAsString());
+        if (data is List) return List<dynamic>.from(data);
+      } catch (_) {}
+    }
+    return [];
+  }
+}
+

--- a/test/services/autogen_library_publisher_service_test.dart
+++ b/test/services/autogen_library_publisher_service_test.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/services/autogen_library_publisher_service.dart';
+
+void main() {
+  test('publish writes packs and logs duplicates', () async {
+    final tmp = await Directory.systemTemp.createTemp('autogen_pub_test');
+    final service = AutogenLibraryPublisherService(baseDir: tmp.path);
+
+    TrainingPackModel pack(String id, List<String> tags) {
+      return TrainingPackModel(
+        id: id,
+        title: 'Pack$id',
+        spots: [TrainingPackSpot(id: 's$id')],
+        tags: tags,
+      );
+    }
+
+    final p1 = pack('1', ['a']);
+    final p2 = pack('2', ['b']);
+
+    await service.publish([p1, p2]);
+
+    expect(File(p.join(tmp.path, 'pack_1.yaml')).existsSync(), isTrue);
+    expect(File(p.join(tmp.path, 'pack_2.yaml')).existsSync(), isTrue);
+
+    final indexFile = File(p.join(tmp.path, 'library_autogen_index.yaml'));
+    final indexYaml = loadYaml(await indexFile.readAsString()) as YamlList;
+    expect(indexYaml.length, 2);
+
+    await service.publish([p1]);
+
+    final logsFile = File(p.join(tmp.path, 'autogen_publish_log.json'));
+    final logs = jsonDecode(await logsFile.readAsString()) as List;
+    expect(logs.last['skippedDuplicates'], 1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add AutogenLibraryPublisherService for publishing curated packs
- log publications and skip duplicate packs
- tests for publisher service

## Testing
- `dart test test/services/autogen_library_publisher_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689484880dc4832ab6da482684d2ac5a