### PR TITLE
feat: add autogen pipeline status badge widget

### DIFF
--- a/lib/services/autogen_pipeline_state_service.dart
+++ b/lib/services/autogen_pipeline_state_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+/// Possible statuses for the autogen pipeline.
+enum AutogenPipelineStatus {
+  ready,
+  paused,
+  publishing,
+  error,
+}
+
+/// Service exposing the current state of the autogen pipeline.
+class AutogenPipelineStateService {
+  AutogenPipelineStateService._();
+
+  static final ValueNotifier<AutogenPipelineStatus> _state =
+      ValueNotifier(AutogenPipelineStatus.ready);
+
+  /// Returns a [ValueNotifier] for the current pipeline state.
+  static ValueNotifier<AutogenPipelineStatus> getCurrentState() => _state;
+
+  // Additional methods for updating the state can be added here in future.
+}
+

--- a/lib/widgets/autogen_pipeline_status_badge_widget.dart
+++ b/lib/widgets/autogen_pipeline_status_badge_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../services/autogen_pipeline_state_service.dart';
+
+/// A small badge widget displaying the current autogen pipeline status.
+class AutogenPipelineStatusBadgeWidget extends StatelessWidget {
+  const AutogenPipelineStatusBadgeWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<AutogenPipelineStatus>(
+      valueListenable: AutogenPipelineStateService.getCurrentState(),
+      builder: (context, status, _) {
+        final color = _statusColor(status);
+        final label = _statusLabel(status);
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white),
+          ),
+        );
+      },
+    );
+  }
+
+  Color _statusColor(AutogenPipelineStatus status) {
+    switch (status) {
+      case AutogenPipelineStatus.ready:
+        return Colors.green;
+      case AutogenPipelineStatus.paused:
+        return Colors.orange;
+      case AutogenPipelineStatus.publishing:
+        return Colors.blue;
+      case AutogenPipelineStatus.error:
+        return Colors.red;
+    }
+  }
+
+  String _statusLabel(AutogenPipelineStatus status) {
+    switch (status) {
+      case AutogenPipelineStatus.ready:
+        return 'Ready';
+      case AutogenPipelineStatus.paused:
+        return 'Paused';
+      case AutogenPipelineStatus.publishing:
+        return 'Publishing';
+      case AutogenPipelineStatus.error:
+        return 'Error';
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `AutogenPipelineStateService` to expose pipeline status
- add `AutogenPipelineStatusBadgeWidget` for displaying pipeline state in debug UI

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68949d0a48c8832a84793310ab2dff2d