### PR TITLE
feat: implement live autogen pipeline stats updates

### DIFF
--- a/lib/services/auto_deduplication_engine.dart
+++ b/lib/services/auto_deduplication_engine.dart
@@ -5,6 +5,7 @@ import 'pack_fingerprint_comparer_service.dart';
 import 'training_pack_library_service.dart';
 import 'spot_fingerprint_generator.dart';
 import '../utils/app_logger.dart';
+import 'autogen_pipeline_debug_stats_service.dart';
 
 class AutoDeduplicationReport {
   final List<PackSimilarityResult> duplicates;
@@ -48,6 +49,7 @@ class AutoDeduplicationEngine {
     final fp = _fingerprint.generate(spot);
     if (_seen.contains(fp)) {
       _skipped++;
+      AutogenPipelineDebugStatsService.incrementDeduplicated();
       _log.writeln('Skipped duplicate from ${source ?? 'unknown'}: ${spot.id}');
       return true;
     }
@@ -73,6 +75,7 @@ class AutoDeduplicationEngine {
       final existing = unique[fp];
       if (_seen.contains(fp) && existing == null) {
         _skipped++;
+        AutogenPipelineDebugStatsService.incrementDeduplicated();
         _log.writeln('dropped ${spot.id} from ${source ?? 'memory'}');
         continue;
       }
@@ -93,6 +96,7 @@ class AutoDeduplicationEngine {
         _log.writeln('dropped ${spot.id} duplicate of ${existing.id}');
       }
       _skipped++;
+      AutogenPipelineDebugStatsService.incrementDeduplicated();
     }
 
     _seen.addAll(unique.keys);

--- a/lib/services/autogen_pipeline_debug_stats_service.dart
+++ b/lib/services/autogen_pipeline_debug_stats_service.dart
@@ -13,20 +13,54 @@ class AutogenPipelineStats {
     required this.curated,
     required this.published,
   });
+
+  AutogenPipelineStats copyWith({
+    int? generated,
+    int? deduplicated,
+    int? curated,
+    int? published,
+  }) {
+    return AutogenPipelineStats(
+      generated: generated ?? this.generated,
+      deduplicated: deduplicated ?? this.deduplicated,
+      curated: curated ?? this.curated,
+      published: published ?? this.published,
+    );
+  }
 }
 
-/// Service providing stats for the autogen pipeline.
+/// Service providing live stats for the autogen pipeline.
 class AutogenPipelineDebugStatsService {
   AutogenPipelineDebugStatsService._();
 
-  /// Returns current pipeline stats.
-  static Future<AutogenPipelineStats> getStats() async {
-    // In the future, retrieve real metrics from the pipeline.
-    return const AutogenPipelineStats(
-      generated: 0,
-      deduplicated: 0,
-      curated: 0,
-      published: 0,
-    );
+  static final ValueNotifier<AutogenPipelineStats> _statsNotifier =
+      ValueNotifier(const AutogenPipelineStats(
+    generated: 0,
+    deduplicated: 0,
+    curated: 0,
+    published: 0,
+  ));
+
+  /// Exposes live stats updates.
+  static ValueListenable<AutogenPipelineStats> getLiveStats() => _statsNotifier;
+
+  static void incrementGenerated() {
+    _statsNotifier.value =
+        _statsNotifier.value.copyWith(generated: _statsNotifier.value.generated + 1);
+  }
+
+  static void incrementDeduplicated() {
+    _statsNotifier.value = _statsNotifier.value
+        .copyWith(deduplicated: _statsNotifier.value.deduplicated + 1);
+  }
+
+  static void incrementCurated() {
+    _statsNotifier.value =
+        _statsNotifier.value.copyWith(curated: _statsNotifier.value.curated + 1);
+  }
+
+  static void incrementPublished() {
+    _statsNotifier.value =
+        _statsNotifier.value.copyWith(published: _statsNotifier.value.published + 1);
   }
 }

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -21,6 +21,7 @@ import 'training_pack_fingerprint_generator.dart';
 import 'icm_scenario_library_injector.dart';
 import 'pack_quality_gatekeeper_service.dart';
 import 'autogen_run_history_logger_service.dart';
+import 'autogen_pipeline_debug_stats_service.dart';
 
 /// Centralized orchestrator running the full auto-generation pipeline.
 class AutogenPipelineExecutor {
@@ -134,6 +135,7 @@ class AutogenPipelineExecutor {
           );
           continue;
         }
+        AutogenPipelineDebugStatsService.incrementGenerated();
 
         theoryInjector.injectAll(spots, theoryIndex);
         boardClassifier?.classifyAll(spots);
@@ -176,6 +178,7 @@ class AutogenPipelineExecutor {
           continue;
         }
         generatedCount++;
+        AutogenPipelineDebugStatsService.incrementCurated();
         pack.meta['qualityScore'] = score;
 
         coverage.analyzePack(model);

--- a/lib/services/yaml_pack_exporter.dart
+++ b/lib/services/yaml_pack_exporter.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import '../core/training/export/training_pack_exporter_v2.dart';
 import '../models/v2/training_pack_template_v2.dart';
+import 'autogen_pipeline_debug_stats_service.dart';
 
 /// Exports training packs to YAML files.
 class YamlPackExporter {
@@ -11,8 +12,10 @@ class YamlPackExporter {
       : _delegate = delegate ?? const TrainingPackExporterV2();
 
   /// Writes [pack] to disk as a YAML file and returns the created [File].
-  Future<File> export(TrainingPackTemplateV2 pack) {
-    return _delegate.exportToFile(pack);
+  Future<File> export(TrainingPackTemplateV2 pack) async {
+    final file = await _delegate.exportToFile(pack);
+    AutogenPipelineDebugStatsService.incrementPublished();
+    return file;
   }
 
   /// Converts [pack] to a YAML string.

--- a/lib/widgets/inline_autogen_debug_panel_widget.dart
+++ b/lib/widgets/inline_autogen_debug_panel_widget.dart
@@ -15,20 +15,10 @@ class InlineAutogenDebugPanelWidget extends StatelessWidget {
       children: [
         const AutogenPipelineStatusBadgeWidget(),
         const SizedBox(height: 8),
-        FutureBuilder<AutogenPipelineStats>(
-          future: AutogenPipelineDebugStatsService.getStats(),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              );
-            }
-            final stats = snapshot.data;
-            if (stats == null) {
-              return const Text('No stats');
-            }
+        ValueListenableBuilder<AutogenPipelineStats>(
+          valueListenable:
+              AutogenPipelineDebugStatsService.getLiveStats(),
+          builder: (context, stats, _) {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [


### PR DESCRIPTION
## Summary
- add ValueNotifier-based AutogenPipelineDebugStatsService
- stream live pipeline counters in InlineAutogenDebugPanelWidget
- hook pipeline steps to update generated, deduplicated, curated, and published counts

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894aae77d48832a966df6367cbcac13