### PR TITLE
Add pipeline control panel to inline debug widget

### DIFF
--- a/lib/widgets/autogen_pipeline_control_panel_widget.dart
+++ b/lib/widgets/autogen_pipeline_control_panel_widget.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../services/autogen_pipeline_state_service.dart';
+
+/// Control panel for managing the autogen pipeline state.
+class AutogenPipelineControlPanelWidget extends StatelessWidget {
+  const AutogenPipelineControlPanelWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = AutogenPipelineStateService.getCurrentState();
+    return ValueListenableBuilder<AutogenPipelineStatus>(
+      valueListenable: notifier,
+      builder: (context, status, _) {
+        return Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.grey.shade100,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              ElevatedButton(
+                onPressed: status == AutogenPipelineStatus.ready
+                    ? () => notifier.value = AutogenPipelineStatus.publishing
+                    : null,
+                child: const Text('Start'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: status == AutogenPipelineStatus.publishing
+                    ? () => notifier.value = AutogenPipelineStatus.paused
+                    : null,
+                child: const Text('Pause'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: status != AutogenPipelineStatus.ready
+                    ? () => notifier.value = AutogenPipelineStatus.ready
+                    : null,
+                child: const Text('Reset'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/lib/widgets/inline_autogen_debug_panel_widget.dart
+++ b/lib/widgets/inline_autogen_debug_panel_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../services/autogen_pipeline_debug_stats_service.dart';
 import 'autogen_pipeline_status_badge_widget.dart';
+import 'autogen_pipeline_control_panel_widget.dart';
 
 /// Inline panel showing autogen pipeline status and key metrics.
 class InlineAutogenDebugPanelWidget extends StatelessWidget {
@@ -32,6 +33,10 @@ class InlineAutogenDebugPanelWidget extends StatelessWidget {
             );
           },
         ),
+        const SizedBox(height: 12),
+        const Divider(),
+        const SizedBox(height: 12),
+        const AutogenPipelineControlPanelWidget(),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- integrate `AutogenPipelineControlPanelWidget` into the inline autogen debug panel with divider and spacing
- add a new control panel widget to manage pipeline state via `AutogenPipelineStateService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ae7133b4832aa34374fd8edd8977